### PR TITLE
Add project mocks to lib export

### DIFF
--- a/packages/lib-panoptes-js/src/index.js
+++ b/packages/lib-panoptes-js/src/index.js
@@ -1,9 +1,10 @@
 const { config } = require('./config')
 const panoptes = require('./panoptes')
-const projects = require('./resources/projects')
+const { projects, projectMocks } = require('./resources/projects')
 
 module.exports = {
   config,
   panoptes,
-  projects
+  projects,
+  projectMocks
 }


### PR DESCRIPTION
What the description says. Adds the project mocks from the client to the library's exports so it's available for test writing in apps. 