### PR TITLE
Docs

### DIFF
--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+**Package**
+
+
+**Feature or Issue Description**
+
+
+**To Dos**
+
+- [ ] Example

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+Package:
+
+Closes # .
+
+Describe your changes:
+
+
+# Review Checklist
+
+## General
+
+- [ ] Are the tests passing locally and on Travis?
+- [ ] Is the documentation up to date?
+- [ ] Is the changelog updated?
+
+## Apps
+
+- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
+- [ ] Does it work on mobile?
+- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
+

--- a/docs/arch/adr-1.md
+++ b/docs/arch/adr-1.md
@@ -1,0 +1,21 @@
+# ADR 1: Adopting Architecture Decision Records
+
+July 19, 2018
+
+## Context
+
+The current generation of API, front-end apps and clients, and libraries were initially designed and programmed by very small group of people. Most of the architecture decisions were not documented or documented in an easily discoverable place. Now that it's been nearly four years since the launch Panoptes API and Panoptes Front End, we have decided to do a significant rewrite of the front-end apps and clients. Part of this motiviation is to have a more collaborative architecture and design of the code using lessons learned in maintaining PFE and the javascript client. 
+
+The ADRs are inspired by [this blog post](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) and should be used to document architecture decisions in the rewrite process.
+
+## Decision
+
+We will adopt ADRs to document app or library structure, conventions, dependency and technology choices. We will use the conventions outlined in the blog post linked to in the Context section.
+
+## Status
+
+Proposed
+
+## Consequences
+
+Adopting this documentation style should provide structure, documentation, and process to the architecture decisions made in the rewrite in an easily discoverable way. 

--- a/docs/arch/adr-1.md
+++ b/docs/arch/adr-1.md
@@ -4,7 +4,7 @@ July 19, 2018
 
 ## Context
 
-The current generation of API, front-end apps and clients, and libraries were initially designed and programmed by very small group of people. Most of the architecture decisions were not documented or documented in an easily discoverable place. Now that it's been nearly four years since the launch Panoptes API and Panoptes Front End, we have decided to do a significant rewrite of the front-end apps and clients. Part of this motiviation is to have a more collaborative architecture and design of the code using lessons learned in maintaining PFE and the javascript client. 
+The current generation of API, front-end apps and clients, and libraries were initially designed and programmed by very small group of people. Most of the architecture decisions were not documented or documented in an easily discoverable place. Now that it's been three years since the launch Panoptes API and Panoptes Front End, we have decided to do a significant rewrite of the front-end apps and clients. Part of this motiviation is to have a more collaborative architecture and design of the code using lessons learned in maintaining PFE and the javascript client. 
 
 The ADRs are inspired by [this blog post](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) and should be used to document architecture decisions in the rewrite process.
 


### PR DESCRIPTION
This adds a github docs folder at the top level that include our standard contributing info as well as a issue and PR templates.

I also included a proposed Architecture Decision Record (ADR) about adding ADRs! Read this [blog post](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) about it. Let me know if there are concerns about the ADR and I can update any one of the sections. If we're all for it, I'll update its status to `Accepted` before merging. 