### PR TITLE
Remove cruft accidentally left in project helpers file

### DIFF
--- a/packages/lib-panoptes-js/src/resources/projects/helpers.js
+++ b/packages/lib-panoptes-js/src/resources/projects/helpers.js
@@ -13,17 +13,6 @@ function getProjectSlugFromURL (urlArg) {
   }
 }
 
-function raiseError (errorMessage, errorClass) {
-  const error = {
-    error: new Error(errorMessage),
-    typeError: new TypeError(errorMessage)
-  }
-
-  if (console && process.env.NODE_ENV !== 'test') console.error(error[errorClass])
-
-  return Promise.reject(error[errorClass])
-}
-
 const endpoint = '/projects'
 
-module.exports = { getProjectSlugFromURL, raiseError, endpoint }
+module.exports = { getProjectSlugFromURL, endpoint }


### PR DESCRIPTION
Package: panoptes-js

Describe your changes:

Removes cruft accidentally left in the project helpers file.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

