### PR TITLE
Panoptes.js: Tutorials resource

### DIFF
--- a/packages/lib-panoptes-js/.travis.yml
+++ b/packages/lib-panoptes-js/.travis.yml
@@ -1,2 +1,0 @@
-language: node_js
-node_js: "8"

--- a/packages/lib-panoptes-js/docs/tutorials.md
+++ b/packages/lib-panoptes-js/docs/tutorials.md
@@ -1,0 +1,246 @@
+# Tutorials request helpers
+
+[CRUD REST request helpers](#crud-rest)
+
+- [Get](#get)
+
+[Other common requests](#common-requests)
+
+- [Get Attached Images](#get-attached-images)
+- [Get with Images](#get-with-images)
+- [Get Tutorials](#get-tutorials)
+- [Get Mini-courses](#get-mini-courses)
+
+[Testing](#testing)
+
+- [Mocks](#mocks)
+
+## CRUD REST
+
+The tutorials endpoint is available in the module exports.
+
+``` javascript
+import { tutorials } from '@zooniverse/panoptes-js';
+
+tutorials.endpoint
+```
+
+### Get
+
+**Function**
+
+``` javascript
+// By tutorial id
+const params = { id: tutorialId, query: query };
+
+tutorials.get(params)
+
+// By workflow id
+const params = { workflowId: workflowId, query: query };
+
+tutorials.get(params)
+```
+
+**Arguments**
+
+- params _(object)_ - An object that should include a tutorial id _(string)_ or workflow id _(string)_ and/or query _(object)_ properties. The get request requires either a tutorial id or workflow id. Query params are optional.
+
+**Returns**
+
+- Promise _(object)_ resolves to the API response with the resource(s), meta, links, and linked properties or the request error.
+
+**Example**
+
+``` javascript
+// Get request
+tutorials.get({ id: '1' }).then((response) => {
+  this.setState({ tutorial: response.body.tutorials[0] });
+}).catch((error) => { 
+  if (error.statusCode === 404) return null; // If you don't care about catching a 404
+});
+
+// or by workflow id, maybe this workflow has a standard tutorial and mini-course
+// the lab currently doesn't allow more than one standard tutorial or mini-course to be linked
+// to a workflow at a time.
+tutorials.get({ workflow_id: '2334' }).then((response) => {
+  this.setState({
+    tutorials: response.body.tutorials
+  });
+});
+```
+
+## Common requests
+
+### Get Attached Images
+
+A tutorials get request that validates for the presence of the tutorial id. The id is used to create the tutorials attached images endpoint for the request. Allows for optional query params.
+
+**Function**
+
+``` javascript
+const params = { id: '1' };
+
+tutorials.getAttachedImages(params)
+
+// or with additional query params
+const params = { id: '1', query: { page: '2' } }
+
+tutorials.getAttachedImages(params)
+```
+
+**Arguments**
+
+- params _(object)_ - An object that should include the tutorial id _(string)_ and optionally additional query params.
+
+**Returns**
+
+- Promise _(object)_ resolves to the API response with the resource(s), meta, links, and linked properties or the request error.
+
+**Example**
+
+``` javascript
+// Get request using id
+tutorials.getAttachedImages({ id: '10' }).then((response) => {
+  this.setState({ tutorialMedia: response.body.media[0] });
+}).catch((error) => { 
+  if (error.statusCode === 404) return null; // If you don't care about catching a 404
+});
+```
+
+### Get with Images
+
+A tutorials get request uses a default include query param for attached images. It then uses the tutorials' [`get`](#get request helper so this also requires either a tutorial id or workflow id. Note, there is a known bug with the include request, so this will not return what we expect at the moment:
+
+https://github.com/zooniverse/Panoptes/issues/2279
+
+**Function**
+
+``` javascript
+const params = { id: '1' };
+
+tutorials.getWithImages(params)
+
+// or with additional query params
+const params = { workflowId: '1000', query: { page: '2' } }
+
+tutorials.getWithImages(params)
+```
+
+**Arguments**
+
+- params _(object)_ - An object that should include the tutorial id _(string)_ or workflow id _(string)_ and optionally additional query params.
+
+**Returns**
+
+- Promise _(object)_ resolves to the API response with the resource, meta, links, and linked media resources or the request error.
+
+**Example**
+
+``` javascript
+// Get request
+tutorials.getWithImages({ id: '1' }).then((response) => {
+  // The media will have to be matched up with the step it is for...
+  this.setState({ 
+    tutorial: response.body.tutorials[0],
+    tutorialMedia: response.body.linked
+  });
+}).catch((error) => { 
+  if (error.statusCode === 404) return null; // If you don't care about catching a 404
+});
+```
+
+### Get Tutorials
+
+A tutorials get request that filters the response to only be tutorials with the property `kind` set to `tutorial` or null values (for backwards compatibility). It then uses the tutorials' [`get`](#get) request helper so this also requires either a tutorial id or workflow id.
+
+**Function**
+
+``` javascript
+const params = { id: '1' };
+
+tutorials.getTutorials(params)
+
+// or with additional query params, This is illustrative. Requesting for a second page doesn't actually make sense...
+const params = { workflowId: '10', query: { page: '2' } }
+
+tutorials.getTutorials(params)
+```
+
+**Arguments**
+
+- params _(object)_ - An object that should include the tutorial id _(string)_ or workflow id _(string)_ and optionally additional query params.
+
+**Returns**
+
+- Promise _(object)_ resolves to the API response with the filtered resource(s), meta, links, and linked media resources or the request error.
+
+**Example**
+
+``` javascript
+// Get request
+tutorials.getWithImages({ id: '1' }).then((response) => {
+  this.setState({ 
+    tutorial: response.body.tutorials[0]
+  });
+}).catch((error) => { console.error(error) });
+```
+
+### Get Mini-courses
+
+A tutorials get request uses a default kind query param for `mini-course`. It then uses the [`get`](#get) request helper so this also requires either a tutorial id or workflow id.
+
+**Function**
+
+``` javascript
+const params = { id: '45' };
+
+tutorials.getMinicourses(params)
+
+// or with additional query params. This is illustrative. Requesting for a second page doesn't actually make sense...
+const params = { workflowId: '455', query: { page: '2' } }
+
+tutorials.getMinicourses(params)
+```
+
+**Arguments**
+
+- params _(object)_ - An object that should include the tutorial id _(string)_ or workflow id _(string)_ and optionally additional query params.
+
+**Returns**
+
+- Promise _(object)_ resolves to the API response with the resource, meta, links, and linked media resources or the request error.
+
+**Example**
+
+``` javascript
+// Get request
+tutorials.getMinicourses({ id: '45' }).then((response) => {
+  this.setState({ 
+    tutorial: response.body.tutorials[0]
+  });
+})
+```
+
+## Testing
+
+### Mocks
+
+For your convenience, the mocks used in testing are exported and made available to use in any app tests. The available mocks are and how to access them:
+
+- resources
+  - tutorialOne - `tutorials.mocks.resources.tutorialOne`
+  - tutorialTwo - `tutorials.mocks.resources.tutorialTwo`
+  - tutorialWithNullKind - `tutorials.mocks.resources.tutorialWithNullKind`
+  - minicourse - `tutorials.mocks.resources.minicourse`
+  - attachedImageOne - `tutorials.mocks.resources.attachedImageOne`
+  - attachedImageTwo - `tutorials.mocks.resources.attachedImageTwo`
+- responses
+  - get
+    - allTutorialsForWorkflow - `tutorials.mocks.responses.get.allTutorialsForWorkflow`
+    - tutorial - `tutorials.mocks.responses.get.tutorial`
+    - tutorials - `tutorials.mocks.responses.get.tutorials`
+    - tutorialWithImages - `tutorials.mocks.responses.get.tutorialWithImages`
+    - tutorialsWithImages - `tutorials.mocks.responses.get.tutorialsWithImages`
+    - minicourse - `tutorials.mocks.responses.get.minicourse`
+    - attachedImage - `tutorials.mocks.responses.get.attachedImage`
+    - queryNotFound - `tutorials.mocks.responses.get.queryNotFound`

--- a/packages/lib-panoptes-js/src/index.js
+++ b/packages/lib-panoptes-js/src/index.js
@@ -1,7 +1,9 @@
 const { config, env } = require('./config')
 const panoptes = require('./panoptes')
-const projects = require('./resources/projects')
+
 const media = require('./resources/media')
+const projects = require('./resources/projects')
+const tutorials = require('./resources/tutorials')
 const users = require('./resources/users')
 
 module.exports = {
@@ -10,5 +12,6 @@ module.exports = {
   media,
   panoptes,
   projects,
+  tutorials,
   users
 }

--- a/packages/lib-panoptes-js/src/resources/media/mocks.js
+++ b/packages/lib-panoptes-js/src/resources/media/mocks.js
@@ -14,11 +14,11 @@ const mediaResourceTypes = {
 }
 
 const resourcesThatCanHaveMedia = {
-  field_guides: 'field_guides',
-  organizations: 'organizations',
-  projects: 'projects',
-  tutorials: 'tutorials',
-  users: 'users'
+  field_guide: 'field_guide',
+  organization: 'organization',
+  project: 'project',
+  tutorial: 'tutorial',
+  user: 'user'
 }
 
 function getRandomID (min, max) {

--- a/packages/lib-panoptes-js/src/resources/projects/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/projects/commonRequests.spec.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const superagent = require('superagent')
 const mockSuperagent = require('superagent-mock')
 
-const { projects } = require('./index')
+const projects = require('./index')
 const { endpoint } = require('./helpers')
 const { config } = require('../../config')
 const { resources, responses } = require('./mocks')

--- a/packages/lib-panoptes-js/src/resources/projects/index.js
+++ b/packages/lib-panoptes-js/src/resources/projects/index.js
@@ -3,7 +3,7 @@ const { getBySlug, getWithLinkedResources } = require('./commonRequests')
 const { endpoint } = require('./helpers')
 const mocks = require('./mocks')
 
-const projects = {
+module.exports = {
   create,
   get,
   update,
@@ -13,5 +13,3 @@ const projects = {
   getWithLinkedResources,
   mocks
 }
-
-module.exports = { projects }

--- a/packages/lib-panoptes-js/src/resources/projects/index.js
+++ b/packages/lib-panoptes-js/src/resources/projects/index.js
@@ -1,7 +1,7 @@
 const { create, get, update, del } = require('./rest')
 const { getBySlug, getWithLinkedResources } = require('./commonRequests')
 const { endpoint } = require('./helpers')
-const { mocks } = require('./mocks')
+const mocks = require('./mocks')
 
 const projects = {
   create,

--- a/packages/lib-panoptes-js/src/resources/projects/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/projects/rest.spec.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const superagent = require('superagent')
 const mockSuperagent = require('superagent-mock')
 
-const { projects } = require('./index')
+const projects = require('./index')
 const { endpoint } = require('./helpers')
 const { config } = require('../../config')
 const { responses } = require('./mocks')

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
@@ -1,0 +1,40 @@
+const panoptes = require('../../panoptes')
+const { get } = require('./rest')
+const { endpoint } = require('./helpers')
+
+function getAttachedImages(params) {
+  const tutorialId = (params && params.id) ? params.id : ''
+  const tutorialAttachedImagesEndpoint = `${endpoint}/${tutorialId}/attached_images`
+
+  return panoptes.get(tutorialAttachedImagesEndpoint)
+}
+
+function getWithImages (params) {
+  const defaultInclude = { include: 'attached_images' }
+  const queryParams = (params && params.query) ? Object.assign({}, params.query, defaultInclude) : defaultInclude
+
+  return get(queryParams)
+}
+
+function getTutorials (params) {
+  return get(queryParams).then((response) => {
+    const { tutorials } = response.body
+
+    if (tutorials && tutorials.length > 0) {
+      // We allow the null value on kind for backwards compatibility
+      // These are standard tutorials added prior to the 'kind' field and mini-courses
+      return tutorials.filter((tutorial) => {
+        return tutorial.kind === 'tutorial' || null;
+      })
+    }
+  })
+}
+
+function getMinicourses (params) {
+  const defaultKindParam = { kind: 'mini-course' }
+  const queryParams = (params && params.query) ? Object.assign({}, params.query, defaultKindParam) : defaultKindParam
+
+  return get(queryParams)
+}
+
+module.exports = { getAttachedImages, getMinicourses, getTutorials, getWithImages }

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
@@ -46,9 +46,9 @@ function getTutorials (params) {
 
 function getMinicourses (params) {
   const defaultKindParam = { kind: 'mini-course' }
-  const queryParams = (params && params.query) ? Object.assign({}, params.query, defaultKindParam) : defaultKindParam
+  params.query = (params && params.query) ? Object.assign({}, params.query, defaultKindParam) : defaultKindParam
 
-  return get(queryParams)
+  return get(params)
 }
 
 module.exports = { getAttachedImages, getMinicourses, getTutorials, getWithImages }

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
@@ -1,5 +1,5 @@
 const panoptes = require('../../panoptes')
-const tutorials = require('./index')
+const { get } = require('./rest')
 const { endpoint } = require('./helpers')
 const { raiseError } = require('../../utilityFunctions')
 
@@ -23,12 +23,15 @@ function getWithImages (params) {
   // include request doesn't go past page one
   // tutorials shoudn't have more than 20 steps, so, this is a way to enforce that.
   const defaultInclude = { include: 'attached_images' }
-  const queryParams = (params && params.query) ? Object.assign({}, params.query, defaultInclude) : defaultInclude
-  return tutorials.get(queryParams)
+  params.query = (params && params.query) ? Object.assign({}, params.query, defaultInclude) : defaultInclude
+
+  return get(params)
 }
 
 function getTutorials (params) {
-  return tutorials.get(queryParams).then((response) => {
+  const queryParams = (params && params.query) ? params.query : {}
+
+  return get(queryParams).then((response) => {
     const tutorialsResponse = response.body.tutorials
 
     if (tutorialsResponse && tutorialsResponse.length > 0) {
@@ -45,7 +48,7 @@ function getMinicourses (params) {
   const defaultKindParam = { kind: 'mini-course' }
   const queryParams = (params && params.query) ? Object.assign({}, params.query, defaultKindParam) : defaultKindParam
 
-  return tutorials.get(queryParams)
+  return get(queryParams)
 }
 
 module.exports = { getAttachedImages, getMinicourses, getTutorials, getWithImages }

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
@@ -10,6 +10,11 @@ function getAttachedImages(params) {
 }
 
 function getWithImages (params) {
+  // We probably always want the attached_images when requesting a tutorial.
+  // There is a known Panoptes bug with the include param returning unrelated attached_images
+  // https://github.com/zooniverse/Panoptes/issues/2279
+  // include request doesn't go past page one
+  // tutorials shoudn't have more than 20 steps, so, this is a way to enforce that.
   const defaultInclude = { include: 'attached_images' }
   const queryParams = (params && params.query) ? Object.assign({}, params.query, defaultInclude) : defaultInclude
 

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
@@ -29,18 +29,18 @@ function getWithImages (params) {
 }
 
 function getTutorials (params) {
-  const queryParams = (params && params.query) ? params.query : {}
-
-  return get(queryParams).then((response) => {
-    const tutorialsResponse = response.body.tutorials
-
-    if (tutorialsResponse && tutorialsResponse.length > 0) {
+  return get(params).then((response) => {
+    if (response.body.tutorials && response.body.tutorials.length > 0) {
       // We allow the null value on kind for backwards compatibility
       // These are standard tutorials added prior to the 'kind' field and mini-courses
-      return tutorialsResponse.filter((tutorial) => {
+      response.body.tutorials = response.body.tutorials.filter((tutorial) => {
         return tutorial.kind === 'tutorial' || null;
       })
+
+      return response
     }
+
+    return response
   })
 }
 

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
@@ -2,3 +2,91 @@ const { expect } = require('chai')
 const superagent = require('superagent')
 const mockSuperagent = require('superagent-mock')
 const { JSDOM } = require('jsdom')
+
+const tutorials = require('./index')
+const { endpoint } = require('./helpers')
+const { config } = require('../../config')
+const { resources, responses } = require('./mocks')
+
+describe('Tutorials resource common requests', function () {
+  describe('getAttachedImages', function () {
+    let superagentMock
+    let actualMatch
+    const expectedGetResponse = responses.get.attachedImage
+
+    before(function () {
+      superagentMock = mockSuperagent(superagent, [{
+        pattern: `${config.host}${endpoint}`,
+        fixtures: (match, params) => {
+          actualMatch = match
+          return expectedGetResponse
+        },
+        get: (match, data) => ({ body: data })
+      }])
+    })
+
+    after(function () {
+      superagentMock.unset()
+    })
+
+    it('should return an error if there is no tutorial id', function () {
+      return tutorials.getAttachedImages().catch((error) => {
+        expect(error.message).to.equal('Tutorials: getAttachedImages request requires a tutorial id.')
+      })
+    })
+
+    it('should return the expected response', function () {
+      return tutorials.getAttachedImages({ id: '1' }).then((response) => {
+        expect(response.body).to.eql(expectedGetResponse)
+      })
+    })
+
+    it('should use query params if defined', function () {
+      return tutorials.getAttachedImages({ id: '1', query: { page: '2' }}).then((response) => {
+        expect(actualMatch.input.includes('page=2')).to.be.true
+      })
+    })
+  })
+
+  describe('getWithImages', function () {
+    describe('a single tutorial', function () {
+      let superagentMock
+      let actualMatch
+      const expectedGetResponse = responses.get.tutorialWithImages
+      before(function () {
+        superagentMock = mockSuperagent(superagent, [{
+          pattern: `${config.host}${endpoint}`,
+          fixtures: (match, params) => {
+            actualMatch = match
+            if (match.input.includes(resources.tutorialOne.id)) return expectedGetResponse
+
+            return { status: 404 }
+          },
+          get: (match, data) => ({ body: data })
+        }])
+      })
+
+      after(function () {
+        superagentMock.unset()
+      })
+
+      it('should use a default include query param', function () {
+        return tutorials.getWithImages({ id: '1' }).then((response) => { 
+          expect(actualMatch.input.include('include=attached_images')).to.be.true
+        })
+      })
+
+      it('should include any other query params if defined', function () {
+        return tutorials.getWithImages({ id: '1', query: { page: '2' }}).then((response) => {
+          expect(actualMatch.input.includes('page=2')).to.be.true
+        })
+      })
+
+      it('should return the expected response', function() {
+        return tutorials.getWithImages({ id: '1' }).then((response) => {
+          expect(response.body).to.eql(expectedGetResponse)
+        })
+      })
+    })
+  })
+})

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
@@ -72,7 +72,7 @@ describe('Tutorials resource common requests', function () {
 
       it('should use a default include query param', function () {
         return tutorials.getWithImages({ id: '1' }).then((response) => { 
-          expect(actualMatch.input.include('include=attached_images')).to.be.true
+          expect(actualMatch.input.includes('include=attached_images')).to.be.true
         })
       })
 
@@ -84,6 +84,44 @@ describe('Tutorials resource common requests', function () {
 
       it('should return the expected response', function() {
         return tutorials.getWithImages({ id: '1' }).then((response) => {
+          expect(response.body).to.eql(expectedGetResponse)
+        })
+      })
+    })
+
+    describe('many tutorials', function () {
+      let superagentMock
+      let actualMatch
+      const expectedGetResponse = responses.get.tutorialsWithImages
+      before(function () {
+        superagentMock = mockSuperagent(superagent, [{
+          pattern: `${config.host}${endpoint}`,
+          fixtures: (match, params) => {
+            actualMatch = match
+            return expectedGetResponse
+          },
+          get: (match, data) => ({ body: data })
+        }])
+      })
+
+      after(function () {
+        superagentMock.unset()
+      })
+
+      it('should use a default include query param', function () {
+        return tutorials.getWithImages({ workflowId: '10' }).then((response) => {
+          expect(actualMatch.input.includes('include=attached_images')).to.be.true
+        })
+      })
+
+      it('should include any other query params if defined', function () {
+        return tutorials.getWithImages({ workflowId: '10', query: { page: '2' } }).then((response) => {
+          expect(actualMatch.input.includes('page=2')).to.be.true
+        })
+      })
+
+      it('should return the expected response', function() {
+        return tutorials.getWithImages({ workflowId: '10' }).then((response) => {
           expect(response.body).to.eql(expectedGetResponse)
         })
       })

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
@@ -1,0 +1,4 @@
+const { expect } = require('chai')
+const superagent = require('superagent')
+const mockSuperagent = require('superagent-mock')
+const { JSDOM } = require('jsdom')

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
@@ -127,4 +127,74 @@ describe('Tutorials resource common requests', function () {
       })
     })
   })
+
+  describe.only('getTutorials', function () {
+    describe('by tutorial id', function () {
+      let superagentMock
+
+      before(function () {
+        superagentMock = mockSuperagent(superagent, [{
+          pattern: `${config.host}${endpoint}`,
+          fixtures: (match, params) => {
+            if (match.input.includes(resources.tutorialOne.id)) return responses.get.tutorial
+            if (match.input.includes(resources.minicourse.id)) return responses.get.minicourse
+
+            return { status: 404 }
+          },
+          get: (match, data) => ({ body: data })
+        }])
+      })
+
+      after(function () {
+        superagentMock.unset()
+      })
+
+      it('should return the expected response', function () {
+        return tutorials.getTutorials({ id: '1' }).then((response) => {
+          expect(response.body).to.eql(responses.get.tutorial)
+        })
+      })
+
+      it('the expected response should be the tutorial kind', function () {
+        return tutorials.getTutorials({ id: '1' }).then((response) => {
+          const tutorial = response.body.tutorials[0]
+          expect(tutorial.kind).to.equal('tutorial')
+        })
+      })
+
+      it('should not return a minicourse', function () {
+        return tutorials.getTutorials({ id: '52' }).then((response) => {
+          expect(response.body.tutorials).to.have.lengthOf(0)
+        })
+      })
+    })
+
+    describe('by workflow id', function () {
+      let superagentMock
+      let actualMatch
+      const expectedGetResponse = responses.get.allTutorialsForWorkflow
+      before(function () {
+        superagentMock = mockSuperagent(superagent, [{
+          pattern: `${config.host}${endpoint}`,
+          fixtures: (match, params) => {
+            actualMatch = match
+            if (match.input.includes('workflow_id=10')) return expectedGetResponse
+
+            return { status: 404 }
+          },
+          get: (match, data) => ({ body: data })
+        }])
+      })
+
+      after(function () {
+        superagentMock.unset()
+      })
+
+      it('should return the expected response', function () {
+        return tutorials.getTutorials({ workflowId: '10' }).then((response) => {
+          expect(response.body).to.eql(expectedGetResponse)
+        })
+      })
+    })
+  })
 })

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
@@ -128,7 +128,7 @@ describe('Tutorials resource common requests', function () {
     })
   })
 
-  describe.only('getTutorials', function () {
+  describe('getTutorials', function () {
     describe('by tutorial id', function () {
       let superagentMock
 
@@ -193,6 +193,97 @@ describe('Tutorials resource common requests', function () {
       it('should return the expected response', function () {
         return tutorials.getTutorials({ workflowId: '10' }).then((response) => {
           expect(response.body).to.eql(expectedGetResponse)
+        })
+      })
+
+      it('should use the workflow id as the query param', function () {
+        return tutorials.getTutorials({ workflowId: '10' }).then((response) => {
+          expect(actualMatch.input.includes('workflow_id=10')).to.be.true
+        })
+      })
+
+      it('should not return minicourse kind tutorials', function () {
+        return tutorials.getTutorials({ workflowId: '10' }).then((response) => {
+          const tutorialsResponse = response.body.tutorials
+          tutorialsResponse.forEach((tutorial) => {
+            expect(tutorial.kind).to.not.equal('mini-course')
+          })
+        })
+      })
+    })
+  })
+
+  describe('getMinicourses', function () {
+    describe('by tutorial id', function () {
+      let superagentMock
+      let actualMatch
+      const expectedGetResponse = responses.get.minicourse
+
+      before(function () {
+        superagentMock = mockSuperagent(superagent, [{
+          pattern: `${config.host}${endpoint}`,
+          fixtures: (match, params) => {
+            actualMatch = match
+            if (match.input.includes(resources.minicourse.id)) return expectedGetResponse
+
+            return { status: 404 }
+          },
+          get: (match, data) => ({ body: data })
+        }])
+      })
+
+      after(function () {
+        superagentMock.unset()
+      })
+
+      it('should return the expected response', function () {
+        return tutorials.getMinicourses({ id: '52' }).then((response) => {
+          expect(response.body).to.eql(expectedGetResponse)
+        })
+      })
+
+      it('should set a default query parameter for kind', function () {
+        return tutorials.getMinicourses({ id: '52' }).then((response) => {
+          expect(actualMatch.input.includes('kind=mini-course')).to.be.true
+        })
+      })
+    })
+
+    describe('by workflow id', function () {
+      let superagentMock
+      let actualMatch
+      const expectedGetResponse = responses.get.minicourse
+
+      before(function () {
+        superagentMock = mockSuperagent(superagent, [{
+          pattern: `${config.host}${endpoint}`,
+          fixtures: (match, params) => {
+            actualMatch = match
+            return expectedGetResponse
+          },
+          get: (match, data) => ({ body: data })
+        }])
+      })
+
+      after(function () {
+        superagentMock.unset()
+      })
+
+      it('should return the expected response', function () {
+        return tutorials.getMinicourses({ workflowId: '10' }).then((response) => {
+          expect(response.body).to.eql(expectedGetResponse)
+        })
+      })
+
+      it('should set a default query parameter for kind', function () {
+        return tutorials.getMinicourses({ workflowId: '10' }).then((response) => {
+          expect(actualMatch.input.includes('kind=mini-course')).to.be.true
+        })
+      })
+
+      it('should use the workflow id as the query param', function () {
+        return tutorials.getTutorials({ workflowId: '10' }).then((response) => {
+          expect(actualMatch.input.includes('workflow_id=10')).to.be.true
         })
       })
     })

--- a/packages/lib-panoptes-js/src/resources/tutorials/helpers.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/helpers.js
@@ -1,14 +1,3 @@
-function handleError (error) {
-  if (console && process.env.NODE_ENV !== 'test') console.error(error)
-  return Promise.reject(error)
-}
-
-function isParamTypeInvalid (param, type) {
-  if (param && typeof param !== type) return true
-
-  return false
-}
-
 const endpoint = '/tutorials'
 
-module.exports = { endpoint, handleError, isParamTypeInvalid }
+module.exports = { endpoint, isParamTypeInvalid }

--- a/packages/lib-panoptes-js/src/resources/tutorials/helpers.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/helpers.js
@@ -1,3 +1,3 @@
 const endpoint = '/tutorials'
 
-module.exports = { endpoint, isParamTypeInvalid }
+module.exports = { endpoint }

--- a/packages/lib-panoptes-js/src/resources/tutorials/helpers.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/helpers.js
@@ -1,0 +1,14 @@
+function handleError (error) {
+  if (console && process.env.NODE_ENV !== 'test') console.error(error)
+  return Promise.reject(error)
+}
+
+function isParamTypeInvalid (param, type) {
+  if (param && typeof param !== type) return true
+
+  return false
+}
+
+const endpoint = '/tutorials'
+
+module.exports = { endpoint, handleError, isParamTypeInvalid }

--- a/packages/lib-panoptes-js/src/resources/tutorials/index.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/index.js
@@ -1,0 +1,13 @@
+const { create, get, update, del } = require('./rest')
+const { endpoint } = require('./helpers')
+
+const tutorials = {
+  create,
+  get,
+  update,
+  delete: del,
+  endpoint,
+  mocks
+}
+
+module.exports = { tutorials }

--- a/packages/lib-panoptes-js/src/resources/tutorials/index.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/index.js
@@ -1,14 +1,17 @@
 const { create, get, update, del } = require('./rest')
+const { getAttachedImages, getMinicourses, getTutorials, getWithImages } = require('./commonRequests')
 const { endpoint } = require('./helpers')
 const mocks = require('./mocks')
 
-const tutorials = {
+module.exports = {
   create,
   get,
   update,
   delete: del,
+  getAttachedImages,
+  getMinicourses,
+  getTutorials,
+  getWithImages,
   endpoint,
   mocks
 }
-
-module.exports = { tutorials }

--- a/packages/lib-panoptes-js/src/resources/tutorials/index.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/index.js
@@ -1,5 +1,6 @@
 const { create, get, update, del } = require('./rest')
 const { endpoint } = require('./helpers')
+const mocks = require('./mocks')
 
 const tutorials = {
   create,

--- a/packages/lib-panoptes-js/src/resources/tutorials/mocks.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/mocks.js
@@ -3,18 +3,35 @@ const { buildResponse } = require('../../utilityFunctions')
 const { buildMockedMediumResource } = media.mocks
 
 // Resources
-const tutorial = {
+const tutorialOne = {
   created_at: "2016-08-02T17:59:44.132Z",
   display_name: "Survey Task Tutorial",
   href: "/tutorials/1",
   id: "1",
   kind: "tutorial",
   language: "en",
-  links: { },
+  links: { workflow_id: '10' },
   steps: [
     {
       content: "Welcome to Animal Snapshots!",
       media: "1"
+    }
+  ],
+  updated_at: "2017-03-27T19:00:56.369Z"
+}
+
+const tutorialTwo = {
+  created_at: "2016-08-02T17:59:44.132Z",
+  display_name: "Drawing Task Tutorial",
+  href: "/tutorials/2",
+  id: "2",
+  kind: "tutorial",
+  language: "en",
+  links: { workflow_id: '10' },
+  steps: [
+    {
+      content: "Welcome to Draw a Square!",
+      media: "3"
     }
   ],
   updated_at: "2017-03-27T19:00:56.369Z"
@@ -27,7 +44,7 @@ const minicourse = {
   id: "52",
   kind: "mini-course",
   language: "en",
-  links: { },
+  links: { workflow_id: '10' },
   steps: [{
     content: "Here's a fun fact",
     media: "50"
@@ -38,24 +55,31 @@ const minicourse = {
 const attachedImage = buildMockedMediumResource('attached_images', 'tutorial')
 
 const resources = {
-  tutorial,
+  tutorialOne,
+  tutorialTwo,
   minicourse,
   attachedImage
 }
 
 // Responses
 
-const tutorialResponse = buildResponse('get', 'tutorials', [resources.tutorial], {})
+const tutorialResponse = buildResponse('get', 'tutorials', [resources.tutorialOne], {})
 
-const minicourseResponse = buildResponse('get', 'tutorials', [response.minicourse], {})
+const tutorials = buildResponse('get', 'tutorials', [resources.tutorialOne, resources.tutorialTwo], {})
 
-const attachedImageResponse = build('get', 'media', [response.attachedImage], {})
+const minicourseResponse = buildResponse('get', 'tutorials', [resources.minicourse], {})
+
+const attachedImageResponse = buildResponse('get', 'media', [resources.attachedImage])
+
+const queryNotFound = buildResponse('get', 'tutorials', [])
 
 const responses = {
   get: {
     tutorial: tutorialResponse,
+    tutorials,
     minicourse: minicourseResponse,
-    attachedImage: attachedImageResponse
+    attachedImage: attachedImageResponse,
+    queryNotFound
   }
 }
 

--- a/packages/lib-panoptes-js/src/resources/tutorials/mocks.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/mocks.js
@@ -37,6 +37,23 @@ const tutorialTwo = {
   updated_at: "2017-03-27T19:00:56.369Z"
 }
 
+const tutorialWithNullKind = {
+  created_at: "2016-08-02T17:59:44.132Z",
+  display_name: "Question Task Tutorial",
+  href: "/tutorials/3",
+  id: "3",
+  kind: null,
+  language: "en",
+  links: { workflow_id: '10' },
+  steps: [
+    {
+      content: "Welcome to my survey!",
+      media: "8"
+    }
+  ],
+  updated_at: "2017-03-27T19:00:56.369Z"
+}
+
 const minicourse = {
   created_at: "2016-06-01T20:08:07.898Z",
   display_name: "",
@@ -59,6 +76,7 @@ const attachedImageTwo = buildMockedMediumResource('attached_image', 'tutorial')
 const resources = {
   tutorialOne,
   tutorialTwo,
+  tutorialWithNullKind,
   minicourse,
   attachedImageOne,
   attachedImageTwo
@@ -78,10 +96,13 @@ const tutorialWithImagesResponse = buildResponse('get', 'tutorials', [resources.
 
 const tutorialsWithImagesResponse = buildResponse('get', 'tutorials', [resources.tutorialOne, resources.tutorialTwo], { media: [resources.attachedImageOne, resources.attachedImageTwo] })
 
+const allTutorialsForWorkflowResponse = buildResponse('get', 'tutorials', [resources.tutorialWithNullKind, resources.tutorialOne, resources.tutorialTwo, resources.minicourse], {})
+
 const queryNotFound = buildResponse('get', 'tutorials', [])
 
 const responses = {
   get: {
+    allTutorialsForWorkflow: allTutorialsForWorkflowResponse,
     tutorial: tutorialResponse,
     tutorials,
     tutorialWithImages: tutorialWithImagesResponse,

--- a/packages/lib-panoptes-js/src/resources/tutorials/mocks.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/mocks.js
@@ -1,0 +1,65 @@
+const media = require('../media')
+const { buildResponse } = require('../../utilityFunctions')
+const { buildMockedMediumResource } = media.mocks
+
+// Resources
+const tutorial = {
+  created_at: "2016-08-02T17:59:44.132Z",
+  display_name: "Survey Task Tutorial",
+  href: "/tutorials/1",
+  id: "1",
+  kind: "tutorial",
+  language: "en",
+  links: { },
+  steps: [
+    {
+      content: "Welcome to Animal Snapshots!",
+      media: "1"
+    }
+  ],
+  updated_at: "2017-03-27T19:00:56.369Z"
+}
+
+const minicourse = {
+  created_at: "2016-06-01T20:08:07.898Z",
+  display_name: "",
+  href: "/tutorials/52",
+  id: "52",
+  kind: "mini-course",
+  language: "en",
+  links: { },
+  steps: [{
+    content: "Here's a fun fact",
+    media: "50"
+  }],
+  updated_at: "2017-03-27T18:34:24.488Z"
+}
+
+const attachedImage = buildMockedMediumResource('attached_images', 'tutorial')
+
+const resources = {
+  tutorial,
+  minicourse,
+  attachedImage
+}
+
+// Responses
+
+const tutorialResponse = buildResponse('get', 'tutorials', [resources.tutorial], {})
+
+const minicourseResponse = buildResponse('get', 'tutorials', [response.minicourse], {})
+
+const attachedImageResponse = build('get', 'media', [response.attachedImage], {})
+
+const responses = {
+  get: {
+    tutorial: tutorialResponse,
+    minicourse: minicourseResponse,
+    attachedImage: attachedImageResponse
+  }
+}
+
+module.exports = {
+  resources,
+  responses
+}

--- a/packages/lib-panoptes-js/src/resources/tutorials/mocks.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/mocks.js
@@ -96,6 +96,9 @@ const tutorialWithImagesResponse = buildResponse('get', 'tutorials', [resources.
 
 const tutorialsWithImagesResponse = buildResponse('get', 'tutorials', [resources.tutorialOne, resources.tutorialTwo], { media: [resources.attachedImageOne, resources.attachedImageTwo] })
 
+// The Lab UI doesn't actually allow project builders to link more than one tutorial of each kind to a workflow
+// But this mock has both a tutorial with `tutorial` and `null` in addition to a `mini-course` kind
+// To test the getTutorials function return value
 const allTutorialsForWorkflowResponse = buildResponse('get', 'tutorials', [resources.tutorialWithNullKind, resources.tutorialOne, resources.tutorialTwo, resources.minicourse], {})
 
 const queryNotFound = buildResponse('get', 'tutorials', [])

--- a/packages/lib-panoptes-js/src/resources/tutorials/mocks.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/mocks.js
@@ -52,13 +52,16 @@ const minicourse = {
   updated_at: "2017-03-27T18:34:24.488Z"
 }
 
-const attachedImage = buildMockedMediumResource('attached_images', 'tutorial')
+const attachedImageOne = buildMockedMediumResource('attached_images', 'tutorial')
+
+const attachedImageTwo = buildMockedMediumResource('attached_image', 'tutorial')
 
 const resources = {
   tutorialOne,
   tutorialTwo,
   minicourse,
-  attachedImage
+  attachedImageOne,
+  attachedImageTwo
 }
 
 // Responses
@@ -69,7 +72,11 @@ const tutorials = buildResponse('get', 'tutorials', [resources.tutorialOne, reso
 
 const minicourseResponse = buildResponse('get', 'tutorials', [resources.minicourse], {})
 
-const attachedImageResponse = buildResponse('get', 'media', [resources.attachedImage])
+const attachedImageResponse = buildResponse('get', 'media', [resources.attachedImageOne])
+
+const tutorialWithImagesResponse = buildResponse('get', 'tutorials', [resources.tutorialOne], { media: [resources.attachedImageOne] })
+
+const tutorialsWithImagesResponse = buildResponse('get', 'tutorials', [resources.tutorialOne, resources.tutorialTwo], { media: [resources.attachedImageOne, resources.attachedImageTwo] })
 
 const queryNotFound = buildResponse('get', 'tutorials', [])
 
@@ -77,6 +84,8 @@ const responses = {
   get: {
     tutorial: tutorialResponse,
     tutorials,
+    tutorialWithImages: tutorialWithImagesResponse,
+    tutorialsWithImages: tutorialsWithImagesResponse,
     minicourse: minicourseResponse,
     attachedImage: attachedImageResponse,
     queryNotFound

--- a/packages/lib-panoptes-js/src/resources/tutorials/rest.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/rest.js
@@ -11,7 +11,6 @@ function get (params) {
   const tutorialId = (params && params.id) ? params.id : ''
   const workflowId = (params && params.workflowId) ? params.workflowId : ''
 
-
   if (isParamTypeInvalid(tutorialId, 'string')) return raiseError('Tutorials: Get request id must be a string.', 'typeError')
   if (isParamTypeInvalid(workflowId, 'string')) return raiseError('Tutorials: Get request workflow id must be a string.', 'typeError')
 

--- a/packages/lib-panoptes-js/src/resources/tutorials/rest.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/rest.js
@@ -20,7 +20,11 @@ function get (params) {
     return panoptes.get(`${endpoint}/${tutorialId}`, queryParams)
   }
   
-  if (workflowId) return panoptes.get(endpoint, queryParams)
+  if (workflowId) {
+    queryParams.workflow_id = workflowId
+    delete queryParams.workflowId
+    return panoptes.get(endpoint, queryParams)
+  }
   
   return raiseError('Tutorials: Get request must include a workflow id or a tutorial id.', 'typeError')
 }

--- a/packages/lib-panoptes-js/src/resources/tutorials/rest.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/rest.js
@@ -1,24 +1,19 @@
 const panoptes = require('../../panoptes')
-const { endpoint, handleError, isParamTypeInvalid } = require('./helpers')
+const { endpoint } = require('./helpers')
+const { isParamTypeInvalid, raiseError } = require('../../utilityFunctions')
 
 function create (params) {
   console.log('todo')
 }
 
 function get (params) {
-  // We probably always want the attached_images
-  // There is a known Panoptes bug with the include param returning unrelated attached_images
-  // https://github.com/zooniverse/Panoptes/issues/2279
-  // include request doesn't go past page one
-  // tutorials shoudn't have more than 20 steps, so, this is a way to enforce that.
-  // const defaultQuery = { include: 'attached_images' }
   const queryParams = (params && params.query) ? params.query : {}
   const tutorialId = (params && params.id) ? params.id : ''
   const workflowId = (params && params.workflowId) ? params.workflowId : ''
 
 
-  if (isParamTypeInvalid(tutorialId, 'string')) return handleError('Tutorials: Get request id must be a string.')
-  if (isParamTypeInvalid(workflowId, 'string')) return handleError('Tutorials: Get request workflow id must be a string.')
+  if (isParamTypeInvalid(tutorialId, 'string')) return raiseError('Tutorials: Get request id must be a string.', 'typeError')
+  if (isParamTypeInvalid(workflowId, 'string')) return raiseError('Tutorials: Get request workflow id must be a string.', 'typeError')
 
   if (tutorialId) {
     delete queryParams.id
@@ -27,7 +22,7 @@ function get (params) {
   
   if (workflowId) return panoptes.get(endpoint, queryParams)
   
-  return handleError('Tutorials: Get request must include a workflow id or a tutorial id.')
+  return raiseError('Tutorials: Get request must include a workflow id or a tutorial id.', 'typeError')
 }
 
 function update () {

--- a/packages/lib-panoptes-js/src/resources/tutorials/rest.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/rest.js
@@ -25,7 +25,7 @@ function get (params) {
     return panoptes.get(endpoint, queryParams)
   }
   
-  return raiseError('Tutorials: Get request must include a workflow id or a tutorial id.', 'typeError')
+  return raiseError('Tutorials: Get request must include a workflow id or a tutorial id.', 'error')
 }
 
 function update () {

--- a/packages/lib-panoptes-js/src/resources/tutorials/rest.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/rest.js
@@ -1,0 +1,41 @@
+const panoptes = require('../../panoptes')
+const { endpoint, handleError, isParamTypeInvalid } = require('./helpers')
+
+function create (params) {
+  console.log('todo')
+}
+
+function get (params) {
+  // We probably always want the attached_images
+  // There is a known Panoptes bug with the include param returning unrelated attached_images
+  // https://github.com/zooniverse/Panoptes/issues/2279
+  // include request doesn't go past page one
+  // tutorials shoudn't have more than 20 steps, so, this is a way to enforce that.
+  // const defaultQuery = { include: 'attached_images' }
+  const queryParams = (params && params.query) ? params.query : {}
+  const tutorialId = (params && params.id) ? params.id : ''
+  const workflowId = (params && params.workflowId) ? params.workflowId : ''
+
+
+  if (isParamTypeInvalid(tutorialId, 'string')) return handleError('Tutorials: Get request id must be a string.')
+  if (isParamTypeInvalid(workflowId, 'string')) return handleError('Tutorials: Get request workflow id must be a string.')
+
+  if (tutorialId) {
+    delete queryParams.id
+    return panoptes.get(`${endpoint}/${tutorialId}`, queryParams)
+  }
+  
+  if (workflowId) return panoptes.get(endpoint, queryParams)
+  
+  return handleError('Tutorials: Get request must include a workflow id or a tutorial id.')
+}
+
+function update () {
+  console.log('todo')
+}
+
+function del () {
+  console.log('todo')
+}
+
+module.exports = { create, get, update, del }

--- a/packages/lib-panoptes-js/src/resources/tutorials/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/rest.spec.js
@@ -29,7 +29,7 @@ describe('Tutorials resource REST requests', function () {
         superagentMock.unset()
       })
 
-      it('should error if the tutorial id or the workflow id is not defined', function () {
+      it('should error if the workflow id is not defined', function () {
         return tutorials.get().catch((error) => {
           expect(error).to.equal('Tutorials: Get request must include a workflow id or a tutorial id.')
         })
@@ -46,6 +46,8 @@ describe('Tutorials resource REST requests', function () {
           expect(error).to.equal('Tutorials: Get request workflow id must be a string.')
         })
       })
+
+      it('should return the expected response')
     })
 
     describe('a single tutorial', function () {

--- a/packages/lib-panoptes-js/src/resources/tutorials/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/rest.spec.js
@@ -4,9 +4,9 @@ const mockSuperagent = require('superagent-mock')
 const { config } = require('../../config')
 const { resources, responses } = require('./mocks')
 const { endpoint } = require('./helpers')
-const { tutorials } = require('./index')
+const tutorials = require('./index')
 
-describe.only('Tutorials resource REST requests', function () {
+describe('Tutorials resource REST requests', function () {
   describe('get', function () {
     let superagentMock
     const expectedGetAllResponse = responses.get.tutorials

--- a/packages/lib-panoptes-js/src/resources/tutorials/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/rest.spec.js
@@ -1,0 +1,69 @@
+const { expect } = require('chai')
+const superagent = require('superagent')
+const mockSuperagent = require('superagent-mock')
+const { config } = require('../../config')
+const { resources, responses } = require('./mocks')
+const { endpoint } = require('./helpers')
+const { tutorials } = require('./index')
+
+describe('Tutorials resource REST requests', function () {
+  describe('get', function () {
+    let superagentMock
+    const expectedGetAllResponse = responses.get.tutorials
+    const expectedGetSingleResponse = responses.get.tutorial
+    
+    describe('many tutorials', function () {
+      before(function () {
+        superagentMock = mockSuperagent(superagent, [{
+          pattern: `${config.host}${endpoint}`,
+          fixtures: (match, params, headers, context) => {
+            return expectedGetAllResponse
+          },
+          get: (match, data) => {
+            return { body: data }
+          }
+        }])
+      })
+
+      after(function () {
+        superagentMock.unset()
+      })
+
+      it('should error if the tutorial id or the workflow id is not defined', function () {
+        return tutorials.get().catch((error) => {
+          expect(error).to.equal('Tutorials: Get request must include a workflow id or a tutorial id.')
+        })
+      })
+
+      it('should error if the tutorial id is not a string', function () {
+        return tutorials.get({ id: 1 }).catch((error) => {
+          expect(error).to.equal('Tutorials: Get request id must be a string.')
+        })
+      })
+
+      it('should error if the workflow id is not a string', function () {
+        return tutorials.get({ workflowId: 10 }).catch((error) => {
+          expect(error).to.equal('Tutorials: Get request workflow id must be a string.')
+        })
+      })
+    })
+
+    describe('a single tutorial', function () {
+      before(function () {
+        superagentMock = mockSuperagent(superagent, [{
+          pattern: `${config.host}${endpoint}`,
+          fixtures: (match, params, headers, context) => {
+            return expectedGetSingleResponse
+          },
+          get: (match, data) => {
+            return { body: data }
+          }
+        }])
+      })
+
+      after(function () {
+        superagentMock.unset()
+      })
+    })
+  })
+})

--- a/packages/lib-panoptes-js/src/utilityFunctions/index.js
+++ b/packages/lib-panoptes-js/src/utilityFunctions/index.js
@@ -33,4 +33,10 @@ function raiseError(errorMessage, errorClass) {
   return Promise.reject(error[errorClass])
 }
 
-module.exports = { isBrowser, isNode, buildResponse, raiseError }
+function isParamTypeInvalid(param, type) {
+  if (param && typeof param !== type) return true
+
+  return false
+}
+
+module.exports = { isBrowser, isNode, buildResponse, isParamTypeInvalid, raiseError }

--- a/packages/lib-panoptes-js/src/utilityFunctions/index.js
+++ b/packages/lib-panoptes-js/src/utilityFunctions/index.js
@@ -22,7 +22,7 @@ function buildResponse (httpMethod, resourceType, resources, linked, params) {
   return response
 }
 
-function raiseError(errorMessage, errorClass) {
+function raiseError (errorMessage, errorClass) {
   const error = {
     error: new Error(errorMessage),
     typeError: new TypeError(errorMessage)
@@ -33,7 +33,7 @@ function raiseError(errorMessage, errorClass) {
   return Promise.reject(error[errorClass])
 }
 
-function isParamTypeInvalid(param, type) {
+function isParamTypeInvalid (param, type) {
   if (param && typeof param !== type) return true
 
   return false


### PR DESCRIPTION
Package: lib-panoptes-js

Closes #63.

Describe your changes:
This adds the helper functions for `GET` requests for the tutorial resource.

I also snuck in a fix for the exports for the projects resource helpers too. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

