### PR TITLE
Add layouts

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -8,7 +8,7 @@ import {
   panoptes as panoptesClient,
   projects as projectsClient
 } from '@zooniverse/panoptes-js'
-import SubjectViewer from './components/SubjectViewer'
+import Layout from './components/Layout'
 import RootStore from 'src/store'
 
 const client = {
@@ -39,7 +39,7 @@ class Classifier extends React.Component {
     return (
       <Provider classifierStore={this.classifierStore}>
         <Grommet theme={theme}>
-          <SubjectViewer />
+          <Layout />
         </Grommet>
       </Provider>
     )

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -1,0 +1,22 @@
+import { Box } from 'grommet'
+import React from 'react'
+
+const toolbarStyles = {
+  border: {
+    color: 'lightGrey',
+    side: 'all'
+  },
+  pad: 'small'
+}
+
+function ImageToolbar (props) {
+  return (
+    <aside {...props}>
+      <Box {...toolbarStyles}>
+        Image toolbar
+      </Box>
+    </aside>
+  )
+}
+
+export default ImageToolbar

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.spec.js
@@ -1,0 +1,10 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import ImageToolbar from './ImageToolbar'
+
+describe('Component > ImageToolbar', function () {
+  it('should render without crashing', function () {
+    shallow(<ImageToolbar />)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/README.md
@@ -1,0 +1,5 @@
+# ImageToolbar component
+
+The toolbar used in conjunction with the `SubjectViewer` component to manipulate the subject.
+
+Note - icons are taken from the [Simple Line Icons](http://simplelineicons.com/) set; this is an icon font, but the original SVGs [are available here](https://github.com/orchidsoftware/icons/tree/master/src/svg).

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/index.js
@@ -1,0 +1,1 @@
+export { default } from './ImageToolbar'

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.js
@@ -1,6 +1,7 @@
 import { inject, observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
+
 import getLayout from './helpers/getLayout'
 
 function storeMapper (stores) {
@@ -12,8 +13,9 @@ function storeMapper (stores) {
 @observer
 class Layout extends React.Component {
   render () {
+    // `getLayout()` will always return the default layout as a fallback
     const CurrentLayout = getLayout(this.props.layout)
-    return CurrentLayout ? <CurrentLayout /> : CurrentLayout
+    return <CurrentLayout />
   }
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.js
@@ -1,0 +1,28 @@
+import { inject, observer } from 'mobx-react'
+import PropTypes from 'prop-types'
+import React from 'react'
+import getLayout from './helpers/getLayout'
+
+function storeMapper (stores) {
+  const { layout } = stores.classifierStore.classifier
+  return { layout }
+}
+
+@inject(storeMapper)
+@observer
+class Layout extends React.Component {
+  render () {
+    const CurrentLayout = getLayout(this.props.layout)
+    return CurrentLayout ? <CurrentLayout /> : CurrentLayout
+  }
+}
+
+Layout.propTypes = {
+  layout: PropTypes.string
+}
+
+Layout.defaultProps = {
+  layout: 'default'
+}
+
+export default Layout

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.spec.js
@@ -1,0 +1,10 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import Layout from './Layout'
+
+describe('Component > Layout', function () {
+  it('should render without crashing', function () {
+    shallow(<Layout />)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/DefaultLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/DefaultLayout.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import SubjectViewer from '../../../SubjectViewer'
+import ImageToolbar from '../../../ImageToolbar'
+import styled from 'styled-components'
+import { Box } from 'grommet'
+
+const boxStyles = {
+  pad: 'medium',
+  border: {
+    color: 'lightGrey',
+    side: 'all'
+  }
+}
+
+const ContainerGrid = styled.div`
+  display: grid;
+  grid-gap: 2rem;
+
+  @media (min-width: 700px) {
+    grid-template-columns: 8fr 5fr;
+  }
+`
+
+const ViewerGrid = styled.section`
+  display: grid;
+  grid-template-columns: auto 4.5rem;
+  grid-template-areas: "subject toolbar"
+`
+
+const StyledSubjectViewer = styled(SubjectViewer)`
+  grid-area: subject;
+`
+
+const StyledImageToolbar = styled(ImageToolbar)`
+  grid-area: toolbar;
+`
+
+function DefaultLayout () {
+  return (
+    <ContainerGrid>
+      <ViewerGrid>
+        <StyledSubjectViewer />
+        <StyledImageToolbar />
+      </ViewerGrid>
+      <Box {...boxStyles}>tasks</Box>
+    </ContainerGrid>
+  )
+}
+
+export default DefaultLayout

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/DefaultLayout.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/DefaultLayout.spec.js
@@ -1,0 +1,10 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import DefaultLayout from './DefaultLayout'
+
+describe('Component > DefaultLayout', function () {
+  it('should render without crashing', function () {
+    shallow(<DefaultLayout />)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/index.js
@@ -1,0 +1,1 @@
+export { default } from './DefaultLayout'

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.js
@@ -1,0 +1,11 @@
+import DefaultLayout from '../../components/DefaultLayout'
+
+const layouts = {
+  default: DefaultLayout
+}
+
+function getLayout (layout) {
+  return layouts[layout] || null
+}
+
+export default getLayout

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.js
@@ -1,11 +1,16 @@
 import DefaultLayout from '../../components/DefaultLayout'
 
-const layouts = {
+const layoutsMap = {
   default: DefaultLayout
 }
 
 function getLayout (layout) {
-  return layouts[layout] || null
+  if (layoutsMap[layout]) {
+    return layoutsMap[layout]
+  } else {
+    console.warn(`Couldn't find a layout for '${layout}', falling back to default`)
+    return layoutsMap.default
+  }
 }
 
 export default getLayout

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.spec.js
@@ -7,7 +7,7 @@ describe('Helpers > getLayout', function () {
     expect(getLayout('default')).to.equal(DefaultLayout)
   })
 
-  it('should return null if it can\'t match a layout', function () {
-    expect(getLayout('foobar')).to.equal(null)
+  it('should return the default layout if it can\'t match a layout', function () {
+    expect(getLayout('foobar')).to.equal(DefaultLayout)
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.spec.js
@@ -1,0 +1,13 @@
+import getLayout from './getLayout'
+
+import DefaultLayout from '../../components/DefaultLayout'
+
+describe('Helpers > getLayout', function () {
+  it('should return the `DefaultLayout` component if passed `default`', function () {
+    expect(getLayout('default')).to.equal(DefaultLayout)
+  })
+
+  it('should return null if it can\'t match a layout', function () {
+    expect(getLayout('foobar')).to.equal(null)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/index.js
@@ -1,0 +1,1 @@
+export { default } from './getLayout'

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/index.js
@@ -1,0 +1,1 @@
+export { default } from './Layout'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getViewer/getViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getViewer/getViewer.spec.js
@@ -4,7 +4,10 @@ import SingleImageViewer from '../../components/SingleImageViewer'
 
 describe('Helpers > getViewer', function () {
   it('should return the `SingleImageViewer` component if passed `singleImage`', function () {
-    const single = getViewer('singleImage')
-    expect(single).to.equal(SingleImageViewer)
+    expect(getViewer('singleImage')).to.equal(SingleImageViewer)
+  })
+
+  it('should return null if it can\'t match a viewer', function () {
+    expect(getViewer('foobar')).to.equal(null)
   })
 })

--- a/packages/lib-classifier/src/helpers/layouts/index.js
+++ b/packages/lib-classifier/src/helpers/layouts/index.js
@@ -1,0 +1,1 @@
+export { default } from './layouts'

--- a/packages/lib-classifier/src/helpers/layouts/layouts.js
+++ b/packages/lib-classifier/src/helpers/layouts/layouts.js
@@ -1,0 +1,13 @@
+const layouts = {}
+
+Object.defineProperty(layouts, 'default', {
+  value: 'default',
+  enumerable: true
+})
+
+// helper for returning layouts (e.g. for use in MST enumerable type)
+Object.defineProperty(layouts, 'values', {
+  value: Object.values(layouts)
+})
+
+export default layouts

--- a/packages/lib-classifier/src/helpers/layouts/layouts.spec.js
+++ b/packages/lib-classifier/src/helpers/layouts/layouts.spec.js
@@ -1,0 +1,33 @@
+import layoutsMap from './layouts'
+
+describe('Helpers > layouts', function () {
+  const layouts = [
+    'default'
+  ]
+
+  layouts.forEach(function (layout) {
+    describe(`\`${layout}\` layout`, function () {
+      it('should exist', function () {
+        expect(layoutsMap[layout]).to.equal(layout)
+      })
+
+      it('should be immutable', function () {
+        expect(function () {
+          layoutsMap[layout] = 'foobar'
+        }).to.throw()
+      })
+    })
+  })
+
+  describe('`values` property', function () {
+    it('should return all available layouts', function () {
+      expect(layoutsMap.values).to.deep.equal(layouts)
+    })
+
+    it('should be immutable', function () {
+      expect(function () {
+        layoutsMap.values = 'foobar'
+      }).to.throw()
+    })
+  })
+})

--- a/packages/lib-classifier/src/store/ClassifierStore.js
+++ b/packages/lib-classifier/src/store/ClassifierStore.js
@@ -1,0 +1,16 @@
+import { types } from 'mobx-state-tree'
+import layouts from '../helpers/layouts'
+import subjectViewers from '../helpers/subjectViewers'
+
+const Classifier = types
+  .model('Classifier', {
+    layout: types.optional(types.enumeration('layout', layouts.values), layouts.default),
+  })
+
+  .actions(self => ({
+    setLayout (layout = layouts.DefaultLayout) {
+      self.layout = layout
+    }
+  }))
+
+export default Classifier

--- a/packages/lib-classifier/src/store/ClassifierStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassifierStore.spec.js
@@ -1,0 +1,23 @@
+import ClassifierStore from './ClassifierStore'
+
+let classifierStore
+
+describe('Model > ClassifierStore', function () {
+  before(function () {
+    classifierStore = ClassifierStore.create()
+  })
+
+  it('should exist', function () {
+    expect(ClassifierStore).to.not.equal(undefined)
+  })
+
+  it('should have a `layout` property', function () {
+    expect(classifierStore.layout).to.deep.equal('default')
+  })
+
+  // This can't be tested properly yet as there is only one layout, and the
+  // model uses an enumerable
+  it('should have a `setLayout` method', function () {
+    expect(classifierStore.setLayout).to.be.a('function')
+  })
+})

--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -1,10 +1,12 @@
 import { getEnv, types } from 'mobx-state-tree'
+import ClassifierStore from './ClassifierStore'
 import ProjectStore from './ProjectStore'
 import SubjectStore from './SubjectStore'
 import WorkflowStore from './WorkflowStore'
 
 const RootStore = types
   .model('RootStore', {
+    classifier: types.optional(ClassifierStore, ClassifierStore.create()),
     projects: types.optional(ProjectStore, ProjectStore.create()),
     subjects: types.optional(SubjectStore, SubjectStore.create()),
     workflows: types.optional(WorkflowStore, WorkflowStore.create())

--- a/packages/lib-classifier/src/store/RootStore.spec.js
+++ b/packages/lib-classifier/src/store/RootStore.spec.js
@@ -12,16 +12,17 @@ describe('Model > RootStore', function () {
     expect(RootStore).to.not.equal(undefined)
   })
 
-  it('should have a `projects` property', function () {
-    expect(model.projects).to.not.equal(undefined)
-  })
+  const stores = [
+    'classifier',
+    'projects',
+    'subjects',
+    'workflows'
+  ]
 
-  it('should have a `subjects` property', function () {
-    expect(model.subjects).to.not.equal(undefined)
-  })
-
-  it('should have a `workflows` property', function () {
-    expect(model.workflows).to.not.equal(undefined)
+  stores.forEach(function (store) {
+    it(`should have a \`${store}\` property`, function () {
+      expect(model[store]).to.not.equal(undefined)
+    })
   })
 
   it('should expose the client when passed in', function () {


### PR DESCRIPTION
Package: `lib-classifier`

Adds a default layout for the clasifier UI. Requires #80 merging first.

Originally in #74 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

