### PR TITLE
Panoptes.js Subjects requests

### DIFF
--- a/packages/lib-panoptes-js/docs/README.md
+++ b/packages/lib-panoptes-js/docs/README.md
@@ -209,6 +209,8 @@ panoptes.del('/projects/1104').then((response) => {
 Using helper functions for a defined Panoptes resource in a React component. These resources have functions defined:
 
 - [Projects](projects.md)
+- [Subjects](subjects.md)
+- [Tutorials](tutorials.md)
 
 The API for resource helpers will include:
 

--- a/packages/lib-panoptes-js/docs/subjects.md
+++ b/packages/lib-panoptes-js/docs/subjects.md
@@ -1,0 +1,107 @@
+# Subjects request helpers
+
+[CRUD REST request helpers](#crud-rest)
+
+- [Get](#get)
+
+[Other common requests](#common-requests)
+
+- [Get Subject Queue](#get-subject-queue)
+
+[Testing](#testing)
+
+- [Mocks](#mocks)
+
+## CRUD REST
+
+The subjects endpoint is available in the module exports.
+
+``` javascript
+import { subjects } from '@zooniverse/panoptes-js';
+
+subjects.endpoint
+```
+
+### Get
+
+**Function**
+
+``` javascript
+// By subject id
+const params = { id: subjectId, query: query };
+
+subjects.get(params)
+```
+
+**Arguments**
+
+- params _(object)_ - An object that should include a subject id _(string)_ and/or query _(object)_ properties. If you're requesting a subject queue for classification, use [subjects.getSubjectQueue](#get-subject-queue). Query params are optional.
+
+**Returns**
+
+- Promise _(object)_ resolves to the API response with the resource(s), meta, links, and linked properties or the request error.
+
+**Example**
+
+``` javascript
+// Get request
+subjects.get({ id: '9' }).then((response) => {
+  this.setState({ subject: response.body.subjects[0] });
+}).catch((error) => { 
+  if (error.statusCode === 404) return null; // If you don't care about catching a 404
+});
+```
+
+## Common requests
+
+### Get Subjects Queue
+
+A subjects get request that validates for the presence of a workflow id and optionally the subject set id. Allows for optional query params.
+
+**Function**
+
+``` javascript
+const params = { workflowId: '50' };
+
+subjects.getSubjectQueue(params)
+
+// or with optional subject set id
+const params = { workflowId: '50', subjectSetId: '403' }
+
+subjects.getSubjectQueue(params)
+
+// or with optional additional query params
+const params = { workflowId: '50', query: { page_size: '2' } }
+
+subjects.getSubjectQueue(params)
+```
+
+**Arguments**
+
+- params _(object)_ - An object that should include the workflow id _(string)_, optionally the subject set id _(string)_,and optionally additional query params.
+
+**Returns**
+
+- Promise _(object)_ resolves to the API response with the resources, meta, links, and linked properties or the request error.
+
+**Example**
+
+``` javascript
+subjects.getSubjectQueue({ workflowId: '10' }).then((response) => {
+  this.setState({ queue: response.body.subjects });
+})
+```
+
+## Testing
+
+### Mocks
+
+For your convenience, the mocks used in testing are exported and made available to use in any app tests. The available mocks are and how to access them:
+
+- resources
+  - subject - `subjects.mocks.resources.subject`
+  - subjectQueue - `subjects.mocks.resources.subjectQueue`
+- responses
+  - get
+    - subject - `subjects.mocks.responses.get.subject`
+    - subjectQueue - `subjects.mocks.responses.get.subjectQueue`

--- a/packages/lib-panoptes-js/src/index.js
+++ b/packages/lib-panoptes-js/src/index.js
@@ -3,6 +3,7 @@ const panoptes = require('./panoptes')
 
 const media = require('./resources/media')
 const projects = require('./resources/projects')
+const subjects = require('./resources/subjects')
 const tutorials = require('./resources/tutorials')
 const users = require('./resources/users')
 
@@ -12,6 +13,7 @@ module.exports = {
   media,
   panoptes,
   projects,
+  subjects,
   tutorials,
   users
 }

--- a/packages/lib-panoptes-js/src/resources/projects/helpers.spec.js
+++ b/packages/lib-panoptes-js/src/resources/projects/helpers.spec.js
@@ -12,7 +12,7 @@ const invalidUrls = [
   '//projects/foo/bar'
 ]
 
-describe('Helpers', function () {
+describe('Projects Helpers', function () {
   describe('getProjectSlugFromURL', function () {
     it('should return the correct slug from a URL', function () {
       validUrls.forEach(function (url) {

--- a/packages/lib-panoptes-js/src/resources/subjects/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/commonRequests.js
@@ -2,7 +2,7 @@ const panoptes = require('../../panoptes')
 const { endpoint, queuedEndpoint } = require('./helpers')
 const { isParamTypeInvalid, raiseError } = require('../../utilityFunctions')
 
-function getSubjectsQueue(params) {
+function getSubjectQueue(params) {
   const queryParams = (params && params.query) ? params.query : {}
   const workflowId = (params && params.workflowId) ? params.workflowId : ''
   const subjectSetId = (params && params.subjectSetId) ? params.subjectSetId : ''
@@ -21,5 +21,5 @@ function getSubjectsQueue(params) {
 }
 
 module.exports = {
-  getSubjectsQueue
+  getSubjectQueue
 }

--- a/packages/lib-panoptes-js/src/resources/subjects/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/commonRequests.js
@@ -1,0 +1,21 @@
+const panoptes = require('../../panoptes')
+const { endpoint, queuedEndpoint } = require('./helpers')
+const { isParamTypeInvalid, raiseError } = require('../../utilityFunctions')
+
+function getSubjectsQueue(params) {
+  const queryParams = (params && params.query) ? params.query : {}
+  const workflowId = (params && params.workflowId) ? params.workflowId : ''
+  const subjectSetId = (params && params.subjectSetId) ? params.subjectSetId : ''
+
+  if (isParamTypeInvalid(workflowId, 'string')) return raiseError('Subjects: Get request workflow id must be a string.', 'typeError')
+  if (isParamTypeInvalid(subjectSetId, 'string')) return raiseError('Subjects: Get request subject set id must be a string.', 'typeError')
+
+  if (workflowId) {
+    queryParams.workflow_id = workflowId
+    if (subjectSetId) queryParams.subject_set_id = subjectSetId
+
+    return panoptes.get(queuedEndpoint, queryParams)
+  }
+
+  return raiseError('Subjects: Get request must include a workflow id.', 'Error')
+}

--- a/packages/lib-panoptes-js/src/resources/subjects/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/commonRequests.js
@@ -17,7 +17,7 @@ function getSubjectsQueue(params) {
     return panoptes.get(queuedEndpoint, queryParams)
   }
 
-  return raiseError('Subjects: Get request must include a workflow id.', 'Error')
+  return raiseError('Subjects: Get request must include a workflow id.', 'error')
 }
 
 module.exports = {

--- a/packages/lib-panoptes-js/src/resources/subjects/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/commonRequests.js
@@ -19,3 +19,7 @@ function getSubjectsQueue(params) {
 
   return raiseError('Subjects: Get request must include a workflow id.', 'Error')
 }
+
+module.exports = {
+  getSubjectsQueue
+}

--- a/packages/lib-panoptes-js/src/resources/subjects/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/commonRequests.spec.js
@@ -7,7 +7,7 @@ const { endpoint } = require('./helpers')
 const subjects = require('./index')
 
 describe('Subjects resource common requests', function () {
-  describe('getSubjectsQueue', function () {
+  describe('getSubjectQueue', function () {
     let superagentMock
     let actualMatch
     const expectedGetResponse = responses.get.subjectsQueue
@@ -29,31 +29,31 @@ describe('Subjects resource common requests', function () {
     })
 
     it('should return a error if the request does not have a workflow id', function () {
-      subjects.getSubjectsQueue().catch((error) => {
+      subjects.getSubjectQueue().catch((error) => {
         expect(error.message).to.equal('Subjects: Get request must include a workflow id.')
       })
     })
 
     it('should error if the workflow id is not a string', function () {
-      subjects.getSubjectsQueue({ workflowId: 10 }).catch((error) => {
+      subjects.getSubjectQueue({ workflowId: 10 }).catch((error) => {
         expect(error.message).to.equal('Subjects: Get request workflow id must be a string.')
       })
     })
 
     it('should error if the subject set id is not a string', function () {
-      subjects.getSubjectsQueue({ subjectSetId: 40, workflowId: '10' }).catch((error) => {
+      subjects.getSubjectQueue({ subjectSetId: 40, workflowId: '10' }).catch((error) => {
         expect(error.message).to.equal('Subjects: Get request subject set id must be a string.')
       })
     })
 
     it('should return the expected response', function () {
-      subjects.getSubjectsQueue({ workflowId: '10' }).then((response) => {
+      subjects.getSubjectQueue({ workflowId: '10' }).then((response) => {
         expect(response.body).to.eql(expectedGetResponse)
       })
     })
 
     it('should use the subject set id in the request query params if defined', function () {
-      subjects.getSubjectsQueue({ subjectSetId: '40', workflowId: '10' }).then(() => {
+      subjects.getSubjectQueue({ subjectSetId: '40', workflowId: '10' }).then(() => {
         expect(actualMatch.input.includes('subject_set_id=40')).to.be.true
       })
     })

--- a/packages/lib-panoptes-js/src/resources/subjects/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/commonRequests.spec.js
@@ -1,0 +1,61 @@
+const { expect } = require('chai')
+const superagent = require('superagent')
+const mockSuperagent = require('superagent-mock')
+const { config } = require('../../config')
+const { resources, responses } = require('./mocks')
+const { endpoint } = require('./helpers')
+const subjects = require('./index')
+
+describe('Subjects resource common requests', function () {
+  describe('getSubjectsQueue', function () {
+    let superagentMock
+    let actualMatch
+    const expectedGetResponse = responses.get.subjectsQueue
+    before(function () {
+      superagentMock = mockSuperagent(superagent, [{
+        pattern: `${config.host}${endpoint}`,
+        fixtures: (match, params, headers, context) => {
+          actualMatch = match
+          return expectedGetResponse
+        },
+        get: (match, data) => {
+          return { body: data }
+        }
+      }])
+    })
+
+    after(function () {
+      superagentMock.unset()
+    })
+
+    it('should return a error if the request does not have a workflow id', function () {
+      subjects.getSubjectsQueue().catch((error) => {
+        expect(error.message).to.equal('Subjects: Get request must include a workflow id.')
+      })
+    })
+
+    it('should error if the workflow id is not a string', function () {
+      subjects.getSubjectsQueue({ workflowId: 10 }).catch((error) => {
+        expect(error.message).to.equal('Subjects: Get request workflow id must be a string.')
+      })
+    })
+
+    it('should error if the subject set id is not a string', function () {
+      subjects.getSubjectsQueue({ subjectSetId: 40, workflowId: '10' }).catch((error) => {
+        expect(error.message).to.equal('Subjects: Get request subject set id must be a string.')
+      })
+    })
+
+    it('should return the expected response', function () {
+      subjects.getSubjectsQueue({ workflowId: '10' }).then((response) => {
+        expect(response.body).to.eql(expectedGetResponse)
+      })
+    })
+
+    it('should use the subject set id in the request query params if defined', function () {
+      subjects.getSubjectsQueue({ subjectSetId: '40', workflowId: '10' }).then(() => {
+        expect(actualMatch.input.includes('subject_set_id=40')).to.be.true
+      })
+    })
+  })
+})

--- a/packages/lib-panoptes-js/src/resources/subjects/helpers.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/helpers.js
@@ -27,15 +27,15 @@ function buildQueuedSubjectResource () {
   }
 }
 
-function buildSubjectsQueue () {
+function buildSubjectQueue () {
   const times = 10
-  const subjectsQueue = []
+  const subjectQueue = []
   for (var i = 0; i < times; i++) {
     const subject = buildQueuedSubjectResource()
-    subjectsQueue.push(subject)
+    subjectQueue.push(subject)
   }
 
-  return subjectsQueue
+  return subjectQueue
 }
 
-module.exports = { buildQueuedSubjectResource, buildSubjectsQueue, endpoint, queuedEndpoint }
+module.exports = { buildQueuedSubjectResource, buildSubjectQueue, endpoint, queuedEndpoint }

--- a/packages/lib-panoptes-js/src/resources/subjects/helpers.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/helpers.js
@@ -1,0 +1,4 @@
+const endpoint = '/subjects'
+const queuedEndpoint = '/subjects/queued'
+
+module.exports = { endpoint, queuedEndpoint }

--- a/packages/lib-panoptes-js/src/resources/subjects/helpers.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/helpers.js
@@ -1,4 +1,41 @@
 const endpoint = '/subjects'
 const queuedEndpoint = '/subjects/queued'
 
-module.exports = { endpoint, queuedEndpoint }
+function getRandomID (min, max) {
+  return (Math.floor(Math.random() * (max - min + 1)) + min).toString()
+}
+
+function buildQueuedSubjectResource () {
+  const randomId = getRandomID(0, 100)
+
+  return {
+    already_seen: false,
+    created_at: '2018-01-23T15:22:55.810Z',
+    favorite: false,
+    finished_workflow: false,
+    href: `/subjects/${randomId}`,
+    id:  `${randomId}`,
+    locations: [{
+      'image/jpeg': 'https://placekitten.com/408/287'
+    }],
+    metadata: {},
+    retired: false,
+    selection_state: 'normal',
+    updated_at: '2018-01-23T15:22:55.810Z',
+    user_has_finished_workflow: false,
+    zooniverse_id: null
+  }
+}
+
+function buildSubjectsQueue () {
+  const times = 10
+  const subjectsQueue = []
+  for (var i = 0; i < times; i++) {
+    const subject = buildQueuedSubjectResource()
+    subjectsQueue.push(subject)
+  }
+
+  return subjectsQueue
+}
+
+module.exports = { buildQueuedSubjectResource, buildSubjectsQueue, endpoint, queuedEndpoint }

--- a/packages/lib-panoptes-js/src/resources/subjects/helpers.spec.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/helpers.spec.js
@@ -1,4 +1,4 @@
-const { buildQueuedSubjectResource, buildSubjectsQueue } = require('./helpers')
+const { buildQueuedSubjectResource, buildSubjectQueue } = require('./helpers')
 
 describe('Subjects Helpers', function () {
   describe('buildQueuedSubjectResource', function () {
@@ -16,7 +16,7 @@ describe('Subjects Helpers', function () {
 
   describe('buildSubjectQueue', function () {
     it('should return an array with ten objects', function () {
-      const queue = buildSubjectsQueue()
+      const queue = buildSubjectQueue()
       expect(queue).to.have.lengthOf(10)
       queue.forEach((subject) => {
         expect(subject).to.be.an.instanceOf(Object)

--- a/packages/lib-panoptes-js/src/resources/subjects/helpers.spec.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/helpers.spec.js
@@ -1,0 +1,26 @@
+const { buildQueuedSubjectResource, buildSubjectsQueue } = require('./helpers')
+
+describe('Subjects Helpers', function () {
+  describe('buildQueuedSubjectResource', function () {
+    it('should return a mocked subject resource object', function () {
+      const subject = buildQueuedSubjectResource()
+      expect(subject).to.exist
+      expect(subject).to.be.an.instanceOf(Object)
+    })
+
+    it('should return a mocked subject with a random id > 0 and <= 100', function () {
+      const subject = buildQueuedSubjectResource()
+      expect(Number(subject.id)).to.be.within(1, 100)
+    })
+  })
+
+  describe('buildSubjectQueue', function () {
+    it('should return an array with ten objects', function () {
+      const queue = buildSubjectsQueue()
+      expect(queue).to.have.lengthOf(10)
+      queue.forEach((subject) => {
+        expect(subject).to.be.an.instanceOf(Object)
+      })
+    })
+  })
+})

--- a/packages/lib-panoptes-js/src/resources/subjects/index.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/index.js
@@ -1,5 +1,5 @@
 const { create, get, update, del } = require('./rest')
-const { getSubjectsQueue } = require('./commonRequests')
+const { getSubjectQueue } = require('./commonRequests')
 const { endpoint } = require('./helpers')
 const mocks = require('./mocks')
 
@@ -9,6 +9,6 @@ module.exports = {
   update,
   delete: del,
   endpoint,
-  getSubjectsQueue,
+  getSubjectQueue,
   mocks
 }

--- a/packages/lib-panoptes-js/src/resources/subjects/index.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/index.js
@@ -1,5 +1,5 @@
 const { create, get, update, del } = require('./rest')
-// const { getAttachedImages, getMinicourses, getTutorials, getWithImages } = require('./commonRequests')
+const { getSubjectsQueue } = require('./commonRequests')
 const { endpoint } = require('./helpers')
 const mocks = require('./mocks')
 
@@ -9,5 +9,6 @@ module.exports = {
   update,
   delete: del,
   endpoint,
+  getSubjectsQueue,
   mocks
 }

--- a/packages/lib-panoptes-js/src/resources/subjects/index.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/index.js
@@ -1,0 +1,13 @@
+const { create, get, update, del } = require('./rest')
+// const { getAttachedImages, getMinicourses, getTutorials, getWithImages } = require('./commonRequests')
+const { endpoint } = require('./helpers')
+const mocks = require('./mocks')
+
+module.exports = {
+  create,
+  get,
+  update,
+  delete: del,
+  endpoint,
+  mocks
+}

--- a/packages/lib-panoptes-js/src/resources/subjects/mocks.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/mocks.js
@@ -1,28 +1,34 @@
 const { buildResponse } = require('../../utilityFunctions')
+const { buildSubjectsQueue } = require('./helpers')
 
 const subject = {
-  created_at: "2015-03-17T13:45:53.402Z",
+  created_at: '2015-03-17T13:45:40.297Z',
   external_id: null,
-  href: "/subjects/10",
-  id: "10",
+  href: "/subjects/1",
+  id: "1",
   links: { project: "1" },
-  locations:[{
+  locations: [{
     'image/png': 'https://placekitten.com/408/287'
   }],
   metadata: {},
-  updated_at: "2015-03-17T13:45:53.402Z",
+  updated_at: '2015-03-17T13:45:40.297Z',
   zooniverse_id: null
 }
 
+const subjectsQueue = buildSubjectsQueue()
+
 const resources = {
-  subject
+  subject,
+  subjectsQueue
 }
 
 const subjectResponse = buildResponse('get', 'subjects', [resources.subject], {})
+const subjectsQueueResponse = buildResponse('get', 'subjects', subjectsQueue, {})
 
 const responses = {
   get: {
-    subject: subjectResponse
+    subject: subjectResponse,
+    subjectsQueue: subjectsQueueResponse
   }
 }
 

--- a/packages/lib-panoptes-js/src/resources/subjects/mocks.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/mocks.js
@@ -15,20 +15,20 @@ const subject = {
   zooniverse_id: null
 }
 
-const subjectsQueue = buildSubjectsQueue()
+const subjectQueue = buildSubjectQueue()
 
 const resources = {
   subject,
-  subjectsQueue
+  subjectQueue
 }
 
 const subjectResponse = buildResponse('get', 'subjects', [resources.subject], {})
-const subjectsQueueResponse = buildResponse('get', 'subjects', subjectsQueue, {})
+const subjectQueueResponse = buildResponse('get', 'subjects', subjectQueue, {})
 
 const responses = {
   get: {
     subject: subjectResponse,
-    subjectsQueue: subjectsQueueResponse
+    subjectQueue: subjectQueueResponse
   }
 }
 

--- a/packages/lib-panoptes-js/src/resources/subjects/mocks.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/mocks.js
@@ -1,0 +1,32 @@
+const { buildResponse } = require('../../utilityFunctions')
+
+const subject = {
+  created_at: "2015-03-17T13:45:53.402Z",
+  external_id: null,
+  href: "/subjects/10",
+  id: "10",
+  links: { project: "1" },
+  locations:[{
+    'image/png': 'https://placekitten.com/408/287'
+  }],
+  metadata: {},
+  updated_at: "2015-03-17T13:45:53.402Z",
+  zooniverse_id: null
+}
+
+const resources = {
+  subject
+}
+
+const subjectResponse = buildResponse('get', 'subjects', [resources.subject], {})
+
+const responses = {
+  get: {
+    subject: subjectResponse
+  }
+}
+
+module.exports = {
+  resources,
+  responses
+}

--- a/packages/lib-panoptes-js/src/resources/subjects/rest.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/rest.js
@@ -17,8 +17,11 @@ function get(params) {
     return panoptes.get(`${endpoint}/${subjectId}`, queryParams)
   }
 
-  if (console) console.warn('Subjects: Are you trying to request subjects for classification? If so, use the helper `getSubjectsQueue` instead.')
-  return panoptes.get(endpoint, queryParams)
+  if (console && !subjectId && process.env.NODE_ENV !== 'test') {
+    console.warn('Subjects: Are you trying to request subjects for classification? If so, use the helper `getSubjectsQueue` instead.')
+    console.warn('Subjects: To request a page of subjects linked to a subject set, use the SetMemberSubjects Panoptes resource instead.')
+  }
+  return raiseError('Subjects: Get request must include a subject id.', 'error')
 }
 
 function update() {

--- a/packages/lib-panoptes-js/src/resources/subjects/rest.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/rest.js
@@ -1,0 +1,32 @@
+const panoptes = require('../../panoptes')
+const { endpoint } = require('./helpers')
+const { isParamTypeInvalid, raiseError } = require('../../utilityFunctions')
+
+function create(params) {
+  console.log('todo')
+}
+
+function get(params) {
+  const queryParams = (params && params.query) ? params.query : {}
+  const subjectId = (params && params.id) ? params.id : ''
+
+  if (isParamTypeInvalid(subjectId, 'string')) return raiseError('Subjects: Get request id must be a string.', 'typeError')
+
+  if (subjectId) {
+    delete queryParams.id
+    return panoptes.get(`${endpoint}/${subjectId}`, queryParams)
+  }
+
+  if (console) console.warn('Subjects: Are you trying to request subjects for classification? If so, use the helper `getSubjectsQueue` instead.')
+  return panoptes.get(endpoint, queryParams)
+}
+
+function update() {
+  console.log('todo')
+}
+
+function del() {
+  console.log('todo')
+}
+
+module.exports = { create, get, update, del }

--- a/packages/lib-panoptes-js/src/resources/subjects/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/rest.spec.js
@@ -1,0 +1,49 @@
+const { expect } = require('chai')
+const superagent = require('superagent')
+const mockSuperagent = require('superagent-mock')
+const { config } = require('../../config')
+const { resources, responses } = require('./mocks')
+const { endpoint } = require('./helpers')
+const subjects = require('./index')
+
+describe('Subjects resource REST requests', function () {
+  describe('get', function () {
+    let superagentMock
+    const expectedGetResponse = responses.get.subject
+    before(function () {
+      superagentMock = mockSuperagent(superagent, [{
+        pattern: `${config.host}${endpoint}`,
+        fixtures: (match, params, headers, context) => {
+          if (match.input.includes(resources.subject.id)) return expectedGetResponse
+
+          return { status: 404 }
+        },
+        get: (match, data) => {
+          return { body: data }
+        }
+      }])
+    })
+
+    after(function () {
+      superagentMock.unset()
+    })
+
+    it('should error if request does not have a subject id', function () {
+      subjects.get().catch((error) => {
+        expect(error.message).to.equal('Subjects: Get request must include a subject id.')
+      })
+    })
+
+    it('should error if the subject id is not a string', function () {
+      subjects.get({ id: 1 }).catch((error) => {
+        expect(error.message).to.equal('Subjects: Get request id must be a string.')
+      })
+    })
+
+    it('should return the expected response', function () {
+      subjects.get({ id: '10' }).then((response) => {
+        expect(response.body).to.eql(expectedGetResponse)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Package: lib-panoptes-js

Closes #64.

Describe your changes:
Adds subjects resource request helpers for HTTP GET requests. The others can be filled out when needed since they're only used by the lab.

~WIP because I still need to write docs.~ Docs are updated.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

