### PR TITLE
Light and dark themes

### DIFF
--- a/packages/lib-grommet-theme/src/dark.js
+++ b/packages/lib-grommet-theme/src/dark.js
@@ -1,0 +1,22 @@
+export default {
+  colors: {
+    background: {
+      border: '#2D2D2D',
+      default: '#333333'
+    },
+    button: {
+      answer: {
+        default: '#5C5C5C',
+        gradient: {
+          top: '#004954',
+          bottom: '#002C31'
+        }
+      },
+      done: {
+        default: '#B8E986',
+        hover: '#345446'
+      }
+    },
+    font: '#E2E5E9'
+  }
+}

--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -1,22 +1,32 @@
 import deepFreeze from 'deep-freeze'
+import light from './light'
+import dark from './dark'
 
 const theme = deepFreeze({
+  dark,
   global: {
     colors: {
+      brand: '#007482',
+      lightBrand: '#16979C',
       black: '#000',
+      lightBlack: '#272727',
       darkGrey: '#5c5c5c',
       teal: '#00979d',
       lightTeal: '#addde0',
+      darkGold: '#CC9200',
       gold: '#f0b200',
       lightGold: '#f6d885',
       tomato: '#e45950',
+      grey: '#CBCCCB',
       lightGrey: '#e2e5e9',
       lighterGrey: '#eff2f5',
       midGrey: '#a6a7a9',
+      darkGrey: '#646464',
       green: '#078f52',
       darkTeal: '#005D69',
-
-      text: '#444444'
+      text: '#444444',
+      navy: '#0C4881',
+      lightNavy: '#6D91B3'
     },
     font: {
       family: "'Karla', Arial, sans-serif",
@@ -43,7 +53,8 @@ const theme = deepFreeze({
         }
       `
     }
-  }
+  },
+  light
 })
 
 export default theme

--- a/packages/lib-grommet-theme/src/light.js
+++ b/packages/lib-grommet-theme/src/light.js
@@ -1,0 +1,75 @@
+export default {
+  // darkTheme: {
+  //   background: {
+  //     border: '#2D2D2D',
+  //     default: '#333333'
+  //   },
+  //   button: {
+  //     answer: {
+  //       default: '#5C5C5C',
+  //       gradient: {
+  //         top: '#004954',
+  //         bottom: '#002C31'
+  //       }
+  //     },
+  //     done: {
+  //       default: '#B8E986',
+  //       hover: '#345446'
+  //     }
+  //   },
+  //   font: '#E2E5E9'
+  // },
+  // lightTheme: {
+  colors: {
+    background: {
+      border: '#ebebeb',
+      default: '#EEF2F5'
+    },
+    button: {
+      answer: {
+        disabled: '#A6A7A9',
+        gradient: {
+          top: '#C0E3E5',
+          bottom: '#8BCED2'
+        }
+      },
+      done: '#078F52',
+      nextHover: '#ea9300'
+    },
+    foreground: '#404040',
+    font: '#000000'    
+  }
+
+  // },
+  // black: {
+  //   default: '#000',
+  //   light: '#272727'
+  // },
+  // brand: {
+  //   default: '#007482',
+  //   light: '#16979C'
+  // },
+  // grey: {
+  //   light: '#CBCCCB',
+  //   mid: '#646464'
+  // },
+  // highlight: {
+  //   dark: '#CC9200',
+  //   default: '#F0B200',
+  //   light: '#F6D885'
+  // },
+  // navy: {
+  //   default: '#0C4881',
+  //   light: '#6D91B3'
+  // },
+  // status: {
+  //   alert: '#E45950',
+  //   disabled: '#C3C5C8',
+  //   success: '#009E0C'
+  // },
+  // teal: {
+  //   dark: '#005D69',
+  //   light: '#ADDDE0',
+  //   mid: '#00979D'
+  // }
+};

--- a/packages/lib-grommet-theme/src/light.js
+++ b/packages/lib-grommet-theme/src/light.js
@@ -1,25 +1,4 @@
 export default {
-  // darkTheme: {
-  //   background: {
-  //     border: '#2D2D2D',
-  //     default: '#333333'
-  //   },
-  //   button: {
-  //     answer: {
-  //       default: '#5C5C5C',
-  //       gradient: {
-  //         top: '#004954',
-  //         bottom: '#002C31'
-  //       }
-  //     },
-  //     done: {
-  //       default: '#B8E986',
-  //       hover: '#345446'
-  //     }
-  //   },
-  //   font: '#E2E5E9'
-  // },
-  // lightTheme: {
   colors: {
     background: {
       border: '#ebebeb',
@@ -39,37 +18,4 @@ export default {
     foreground: '#404040',
     font: '#000000'    
   }
-
-  // },
-  // black: {
-  //   default: '#000',
-  //   light: '#272727'
-  // },
-  // brand: {
-  //   default: '#007482',
-  //   light: '#16979C'
-  // },
-  // grey: {
-  //   light: '#CBCCCB',
-  //   mid: '#646464'
-  // },
-  // highlight: {
-  //   dark: '#CC9200',
-  //   default: '#F0B200',
-  //   light: '#F6D885'
-  // },
-  // navy: {
-  //   default: '#0C4881',
-  //   light: '#6D91B3'
-  // },
-  // status: {
-  //   alert: '#E45950',
-  //   disabled: '#C3C5C8',
-  //   success: '#009E0C'
-  // },
-  // teal: {
-  //   dark: '#005D69',
-  //   light: '#ADDDE0',
-  //   mid: '#00979D'
-  // }
 };


### PR DESCRIPTION
Package: lib-grommet-theme

Closes #24 and #25.

Describe your changes:
This adds a light and dark js file with the defined colors that are unique to those themes. Also adds a few more colors available to the global set. Right now the light and dark theme files are just color variants, not really full fledged themes on their own so they are added to the deep freezed object with the global constants. I removed the `Headings.js` file because it was blank. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

