### PR TITLE
Fix main entry point in Classifier's package.json

### DIFF
--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -2,7 +2,7 @@
   "name": "@zooniverse/classifier",
   "version": "0.0.1",
   "description": "",
-  "main": "dist/index.js",
+  "main": "dist/main.js",
   "scripts": {
     "_check": "check-dependencies",
     "build": "npm run _check && webpack --config webpack.dist.js",


### PR DESCRIPTION
Package: **Classifier**

## PR Overview
This fixes a small issue in the Classifier package, where the main entry point in `package.json` didn't match where the file was.

`package.json` specifies that `package.main` is `dist/index.js`, but the `npm run build` command (see webpack.dist.js) compiles to `dist/main.js` instead.

### Review Checklist

#### General
n/a

#### Apps
n/a

### Status
Ready for review.