### PR TITLE
Add buttons review

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButton.js
@@ -12,9 +12,9 @@ function AnnotateButton ({ active, onClick }) {
   return (
     <Button
       active={active}
-      adjustments={{ x: '1', y: '4' }}
       aria-label={counterpart('AnnotateButton.ariaLabel')}
       onClick={onClick}
+      svgAdjustments={{ x: '1', y: '4' }}
     >
       {pointerIcon}
     </Button>

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButton.spec.js
@@ -1,5 +1,6 @@
-import { shallow, mount } from 'enzyme'
+import { shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
 import AnnotateButton from './AnnotateButton'
 
 describe('Component > AnnotateButton', function () {
@@ -8,7 +9,18 @@ describe('Component > AnnotateButton', function () {
   })
 
   it('should have an ARIA label', function () {
-    const wrapper = mount(<AnnotateButton />)
-    expect(wrapper.find('button').prop('aria-label')).to.equal('Annotate')
+    const wrapper = shallow(<AnnotateButton />)
+    expect(wrapper.find('Button').prop('aria-label')).to.equal('Annotate')
+  })
+
+  it('should call the onClick prop function on click', function () {
+    const spy = sinon.spy()
+    const wrapper = shallow(
+      <AnnotateButton
+        onClick={spy}
+      />
+    )
+    wrapper.find('Button').simulate('click')
+    expect(spy.called).to.be.true
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
@@ -39,6 +39,7 @@ class Button extends React.Component {
       focused,
       hovered,
       onBlur,
+      onClick,
       onFocus,
       onMouseOver,
       onMouseOut,
@@ -50,6 +51,7 @@ class Button extends React.Component {
 
     const eventHandlers = {
       onBlur,
+      onClick,
       onFocus,
       onMouseOver,
       onMouseOut,

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
@@ -35,7 +35,6 @@ class Button extends React.Component {
   render () {
     const {
       active,
-      adjustments,
       children,
       focused,
       hovered,
@@ -43,7 +42,8 @@ class Button extends React.Component {
       onFocus,
       onMouseOver,
       onMouseOut,
-      size
+      size,
+      svgAdjustments
     } = this.props
     
     const hoveredOrFocused = hovered || focused
@@ -71,7 +71,7 @@ class Button extends React.Component {
           <IconSVG
             active={active}
             hoveredOrFocused={hoveredOrFocused}
-            {...adjustments}
+            {...svgAdjustments}
           >
             {childrenWithProps}
           </IconSVG>
@@ -84,7 +84,6 @@ class Button extends React.Component {
 
 Button.propTypes = {
   active: PropTypes.bool,
-  adjustments: PropTypes.object,
   children: PropTypes.node,
   focused: PropTypes.bool,
   hovered: PropTypes.bool,
@@ -92,7 +91,8 @@ Button.propTypes = {
   onFocus: PropTypes.func,
   onMouseOver: PropTypes.func,
   onMouseOut: PropTypes.func,
-  siz: PropTypes.string,
+  size: PropTypes.string,
+  svgAdjustments: PropTypes.object
 }
 
 Button.defaultProps = {

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
@@ -90,6 +90,7 @@ Button.propTypes = {
   focused: PropTypes.bool,
   hovered: PropTypes.bool,
   onBlur: PropTypes.func,
+  onClick: PropTypes.func,
   onFocus: PropTypes.func,
   onMouseOver: PropTypes.func,
   onMouseOut: PropTypes.func,
@@ -99,6 +100,11 @@ Button.propTypes = {
 
 Button.defaultProps = {
   active: false,
+  onBlur: () => {},
+  onClick: () => {},
+  onFocus: () => {},
+  onMouseOver: () => {},
+  onMouseOut: () => {},
   size: '46'
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.spec.js
@@ -1,0 +1,9 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import Button from './Button'
+
+describe('Component > Button', function () {
+  it('should render without crashing', function () {
+    shallow(<Button />)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.spec.js
@@ -1,9 +1,70 @@
-import { shallow } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
 import Button from './Button'
 
 describe('Component > Button', function () {
   it('should render without crashing', function () {
     shallow(<Button />)
+  })
+
+  it('should call the onBlur prop function on blur', function () {
+    const spy = sinon.spy()
+    const wrapper = mount(
+      <Button
+        onBlur={spy}
+      />
+    )
+
+    wrapper.find('button').simulate('blur')
+    expect(spy.called).to.be.true
+  })
+
+  it('should call the onClick prop function on click', function () {
+    const spy = sinon.spy()
+    const wrapper = mount(
+      <Button
+        onClick={spy}
+      />
+    )
+
+    wrapper.find('button').simulate('click')
+    expect(spy.called).to.be.true
+  })
+
+  it('should call the onFocus prop function on focus', function () {
+    const spy = sinon.spy()
+    const wrapper = mount(
+      <Button
+        onFocus={spy}
+      />
+    )
+
+    wrapper.find('button').simulate('focus')
+    expect(spy.called).to.be.true
+  })
+
+  it('should call the onMouseOver prop function on mouse over', function () {
+    const spy = sinon.spy()
+    const wrapper = mount(
+      <Button
+        onMouseOver={spy}
+      />
+    )
+
+    wrapper.find('button').simulate('mouseover')
+    expect(spy.called).to.be.true
+  })
+
+  it('should call the onMouseOut prop function on mouse out', function () {
+    const spy = sinon.spy()
+    const wrapper = mount(
+      <Button
+        onMouseOut={spy}
+      />
+    )
+
+    wrapper.find('button').simulate('mouseout')
+    expect(spy.called).to.be.true
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/FullscreenButton/FullscreenButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/FullscreenButton/FullscreenButton.spec.js
@@ -1,4 +1,4 @@
-import { shallow, mount } from 'enzyme'
+import { shallow } from 'enzyme'
 import React from 'react'
 import sinon from 'sinon'
 
@@ -10,18 +10,18 @@ describe('Component > FullscreenButton', function () {
   })
 
   it('should have an ARIA label', function () {
-    const wrapper = mount(<FullscreenButton />)
-    expect(wrapper.find('button').prop('aria-label')).to.equal('View subject in full screen mode')
+    const wrapper = shallow(<FullscreenButton />)
+    expect(wrapper.find('Button').prop('aria-label')).to.equal('View subject in full screen mode')
   })
 
   it('should call the onClick prop function on click', function () {
     const spy = sinon.spy()
-    const wrapper = mount(
+    const wrapper = shallow(
       <FullscreenButton
         onClick={spy}
       />
     )
-    wrapper.find('button').simulate('click')
+    wrapper.find('Button').simulate('click')
     expect(spy.called).to.be.true
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/MoveButton/MoveButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/MoveButton/MoveButton.spec.js
@@ -1,5 +1,6 @@
-import { shallow, mount } from 'enzyme'
+import { shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
 import MoveButton from './MoveButton'
 
 describe('Component > MoveButton', function () {
@@ -8,7 +9,18 @@ describe('Component > MoveButton', function () {
   })
 
   it('should have an ARIA label', function () {
-    const wrapper = mount(<MoveButton />)
-    expect(wrapper.find('button').prop('aria-label')).to.equal('Move subject')
+    const wrapper = shallow(<MoveButton />)
+    expect(wrapper.find('Button').prop('aria-label')).to.equal('Move subject')
+  })
+
+  it('should call the onClick prop function on click', function () {
+    const spy = sinon.spy()
+    const wrapper = shallow(
+      <MoveButton
+        onClick={spy}
+      />
+    )
+    wrapper.find('Button').simulate('click')
+    expect(spy.called).to.be.true
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButton.spec.js
@@ -1,5 +1,6 @@
-import { shallow, mount } from 'enzyme'
+import { shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
 import ResetButton from './ResetButton'
 
 describe('Component > ResetButton', function () {
@@ -8,7 +9,18 @@ describe('Component > ResetButton', function () {
   })
 
   it('should have an ARIA label', function () {
-    const wrapper = mount(<ResetButton />)
-    expect(wrapper.find('button').prop('aria-label')).to.equal('Reset subject view')
+    const wrapper = shallow(<ResetButton />)
+    expect(wrapper.find('Button').prop('aria-label')).to.equal('Reset subject view')
+  })
+
+  it('should call the onClick prop function on click', function () {
+    const spy = sinon.spy()
+    const wrapper = shallow(
+      <ResetButton
+        onClick={spy}
+      />
+    )
+    wrapper.find('Button').simulate('click')
+    expect(spy.called).to.be.true
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButton.js
@@ -11,9 +11,9 @@ counterpart.registerTranslations('en', en)
 function RotateButton ({ onClick }) {
   return (
     <Button
-      adjustments={{ y: '2' }}
       aria-label={counterpart('RotateButton.ariaLabel')}
       onClick={onClick}
+      svgAdjustments={{ y: '2' }}
     >
       {rotateIcon}
     </Button>

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButton.spec.js
@@ -1,5 +1,6 @@
-import { shallow, mount } from 'enzyme'
+import { shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
 import RotateButton from './RotateButton'
 
 describe('Component > RotateButton', function () {
@@ -8,7 +9,18 @@ describe('Component > RotateButton', function () {
   })
 
   it('should have an ARIA label', function () {
-    const wrapper = mount(<RotateButton />)
-    expect(wrapper.find('button').prop('aria-label')).to.equal('Rotate subject')
+    const wrapper = shallow(<RotateButton />)
+    expect(wrapper.find('Button').prop('aria-label')).to.equal('Rotate subject')
+  })
+
+  it('should call the onClick prop function on click', function () {
+    const spy = sinon.spy()
+    const wrapper = shallow(
+      <RotateButton
+        onClick={spy}
+      />
+    )
+    wrapper.find('Button').simulate('click')
+    expect(spy.called).to.be.true
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.spec.js
@@ -1,5 +1,6 @@
-import { shallow, mount } from 'enzyme'
+import { shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
 import ZoomInButton from './ZoomInButton'
 
 describe('Component > ZoomInButton', function () {
@@ -8,7 +9,18 @@ describe('Component > ZoomInButton', function () {
   })
 
   it('should have an ARIA label', function () {
-    const wrapper = mount(<ZoomInButton />)
-    expect(wrapper.find('button').prop('aria-label')).to.equal('Zoom in on subject')
+    const wrapper = shallow(<ZoomInButton />)
+    expect(wrapper.find('Button').prop('aria-label')).to.equal('Zoom in on subject')
+  })
+
+  it('should call the onClick prop function on click', function () {
+    const spy = sinon.spy()
+    const wrapper = shallow(
+      <ZoomInButton
+        onClick={spy}
+      />
+    )
+    wrapper.find('Button').simulate('click')
+    expect(spy.called).to.be.true
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.spec.js
@@ -1,5 +1,6 @@
-import { shallow, mount } from 'enzyme'
+import { shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
 import ZoomOutButton from './ZoomOutButton'
 
 describe('Component > ZoomOutButton', function () {
@@ -8,7 +9,18 @@ describe('Component > ZoomOutButton', function () {
   })
 
   it('should have an ARIA label', function () {
-    const wrapper = mount(<ZoomOutButton />)
-    expect(wrapper.find('button').prop('aria-label')).to.equal('Zoom out from subject')
+    const wrapper = shallow(<ZoomOutButton />)
+    expect(wrapper.find('Button').prop('aria-label')).to.equal('Zoom out from subject')
+  })
+
+  it('should call the onClick prop function on click', function () {
+    const spy = sinon.spy()
+    const wrapper = shallow(
+      <ZoomOutButton
+        onClick={spy}
+      />
+    )
+    wrapper.find('Button').simulate('click')
+    expect(spy.called).to.be.true
   })
 })


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
A few fixes and additional tests for #82. Renamed `adjustments` prop to `svgAdjustments` to make it clear what it is for.

We should consider the styled-components test util or the one from storybook to tests the variable styles depending on props in the `Button` component, but I don't know how to either of those options yet, so it'll have to come in a follow up PR. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

