### PR TITLE
Auth param

### DIFF
--- a/packages/lib-panoptes-js/docs/README.md
+++ b/packages/lib-panoptes-js/docs/README.md
@@ -74,7 +74,7 @@ A base set of HTTP request functions are available from the `panoptes.js` file t
 - `Content-Type: application/json`
 - `Accept: application/vnd.api+json; version=1`
 
-TODO: Add doc about Authentication header.
+All of the base helpers will take an `authorization` string parameter that will set as the `Authorization` header. This string should include the type and token, i.e. `Bearer 12345abcde`. See the docs for the specific helper you want to use for exact usage. The resource specific helpers may or may not take an `authorization` parameter depending on if it should or could be an authenticated request.
 
 Request functions available:
 
@@ -90,13 +90,14 @@ This library also provides a set of helper functions per Panoptes resource, so i
 **Function**
 
 ``` javascript
-panoptes.get(endpoint, query, host)
+panoptes.get(endpoint, query, authorization, host)
 ```
 
 **Arguments**
 
 - endpoint _(string)_ - the API endpoint for the request. Required.
 - query _(object)_ - an object of request query parameters. Optional.
+- authorization _(string)_ - a string of the authorization type and token, i.e. `'Bearer 12345abcde'`. Optional.
 - host _(string)_ - available to specifiy a different API host. Defaults to the hosts defined in the `config.js` file. Optional.
 
 **Returns**
@@ -126,13 +127,14 @@ panoptes.get('/projects/1104', { include: 'avatar,background,owners' }).then((re
 **Function**
 
 ``` javascript
-panoptes.post(endpoint, data, host)
+panoptes.post(endpoint, data, authorization, host)
 ```
 
 **Arguments**
 
 - endpoint _(string)_ - the API endpoint for the request. Required.
 - data _(object)_ - an object of data to send with the request. Optional.
+- authorization _(string)_ - a string of the authorization type and token, i.e. `'Bearer 12345abcde'`. Optional.
 - host _(string)_ - available to specify a different API host. Defaults to the hosts defined in the `config.js` file. Optional.
 
 **Returns**
@@ -154,13 +156,14 @@ panoptes.get('/projects', { private: true }).then((response) => {
 **Function**
 
 ``` javascript
-panoptes.post(endpoint, data, host)
+panoptes.post(endpoint, data, authorization, host)
 ```
 
 **Arguments**
 
 - endpoint _(string)_ - the API endpoint for the request. Required.
 - data _(object)_ - an object of data to send with the request. Optional.
+- authorization _(string)_ - a string of the authorization type and token, i.e. `'Bearer 12345abcde'`. Optional.
 - host _(string)_ - available to specify a different API host. Defaults to the hosts defined in the `config.js` file. Optional.
 
 **Returns**
@@ -182,12 +185,13 @@ panoptes.put('/projects/1104', { display_name: 'Super Zoo' }).then((response) =>
 **Function**
 
 ``` javascript
-panoptes.del(endpoint, host)
+panoptes.del(endpoint, authorization, host)
 ```
 
 **Arguments**
 
 - endpoint _(string)_ - the API endpoint for the request. Required.
+- authorization _(string)_ - a string of the authorization type and token, i.e. `'Bearer 12345abcde'`. Optional.
 - host _(string)_ - available to specify a different API host. Defaults to the hosts defined in the `config.js` file. Optional.
 
 **Returns**

--- a/packages/lib-panoptes-js/docs/projects.md
+++ b/packages/lib-panoptes-js/docs/projects.md
@@ -23,14 +23,14 @@
 **Function**
 
 ``` javascript
-const params = { id: projectID, query: query };
+const params = { id: projectID, query: query, authorization: authorization };
 
 projects.get(params)
 ```
 
 **Arguments**
 
-- params _(object)_ - An object that should include id _(string)_ and/or query _(object)_ properties. If undefined, the get request defaults to request the first page of the projects resource. Optional.
+- params _(object)_ - An object that should include id _(string)_ and/or query _(object)_ properties. Also can take an authorization _(string)_ property that must be set to a string including type and token, i.e. `{ authorization: 'Bearer 12345' }`. If undefined, the get request defaults to request the first page of the projects resource. Optional.
 
 **Returns**
 
@@ -60,14 +60,14 @@ projects.get().then((response) => {
 **Function**
 
 ``` javascript
-const params = { data: data };
+const params = { data: data, authorization: authorization };
 
 projects.post(params)
 ```
 
 **Arguments**
 
-- params _(object)_ - An object with a data _(object)_ property to send as params with the POST request. Optional.
+- params _(object)_ - An object with a data _(object)_ property to send as params with the POST request. Also can take an authorization _(string)_ property that must be set to a string including type and token, i.e. `{ authorization: 'Bearer 12345' }`. Optional.
 
 **Returns**
 
@@ -87,14 +87,14 @@ projects.create().then((response) => {
 **Function**
 
 ``` javascript
-const params = { id: projectID, data: data };
+const params = { id: projectID, data: data, authorization: authorization };
 
 projects.post(params)
 ```
 
 **Arguments**
 
-- params _(object)_ - An object with an id _(string)_ to include in the request endpoint and data _(object)_ property to send as params with the PUT request. Required.
+- params _(object)_ - An object with an id _(string)_ to include in the request endpoint and data _(object)_ property to send as params with the PUT request. Also can take an authorization _(string)_ property that must be set to a string including type and token, i.e. `{ authorization: 'Bearer 12345' }`. Required.
 
 **Returns**
 
@@ -114,14 +114,14 @@ projects.update({ id: '1104', data: { display_name: 'Super Zoo' } }).then((respo
 **Function**
 
 ``` javascript
-const params = { id: projectID };
+const params = { id: projectID, authorization: authorization };
 
 projects.delete(params);
 ```
 
 **Arguments**
 
-- params _(object)_ - An object with an id _(string)_ property to include in the request endpoint. Required.
+- params _(object)_ - An object with an id _(string)_ property to include in the request endpoint. Also can take an authorization _(string)_ property that must be set to a string including type and token, i.e. `{ authorization: 'Bearer 12345' }`. Required.
 
 **Returns**
 
@@ -146,19 +146,19 @@ A project get request that validates for the presence of the slug in the query p
 **Function**
 
 ``` javascript
-const params = { slug: 'zooniverse/galaxy-zoo' };
+const params = { slug: 'zooniverse/galaxy-zoo', authorization: authorization };
 
 projects.getBySlug(params)
 
 // or with additional query params
-const params = { slug: 'zooniverse/galaxy-zoo', cards: true }
+const params = { slug: 'zooniverse/galaxy-zoo', cards: true, authorization: authorization }
 
 projects.getBySlug(params)
 ```
 
 **Arguments**
 
-- params _(object)_ - An object that should include the project's slug _(string)_ and optionally additional query params.
+- params _(object)_ - An object that should include the project's slug _(string)_ and optionally additional query params. Also can take an authorization _(string)_ property that must be set to a string including type and token, i.e. `{ authorization: 'Bearer 12345' }`.
 
 **Returns**
 
@@ -189,7 +189,7 @@ The request can be done with either project ID or project slug.
 
 ``` javascript
 // Using project id
-const params = { id: '1' }
+const params = { id: '1', authorization: authorization }
 
 projects.getWithLinkedResources(params)
 
@@ -209,7 +209,7 @@ projects.getWithLinkedResources(params)
 
 **Arguments**
 
-- params _(object)_ - An object that should include the project's slug _(string)_ or the project's id _(string)_ and optionally additional query params. If the slug is undefined and in a browser environment, the get request uses the window's location pathname and transforms it to the correct format. Slug param is optional if in browser, but the slug or the project id is required in node.js.
+- params _(object)_ - An object that should include the project's slug _(string)_ or the project's id _(string)_ and optionally additional query params. Also can take an authorization _(string)_ property that must be set to a string including type and token, i.e. `{ authorization: 'Bearer 12345' }`. This helper method uses a private internal function to get the project slug if the location pathname, like `'projects/zooniverse/gravity-spy'` is passed in as the slug into the request call. 
 
 **Returns**
 

--- a/packages/lib-panoptes-js/docs/subjects.md
+++ b/packages/lib-panoptes-js/docs/subjects.md
@@ -28,14 +28,14 @@ subjects.endpoint
 
 ``` javascript
 // By subject id
-const params = { id: subjectId, query: query };
+const params = { id: subjectId, query: query, authorization: authorization };
 
 subjects.get(params)
 ```
 
 **Arguments**
 
-- params _(object)_ - An object that should include a subject id _(string)_ and/or query _(object)_ properties. If you're requesting a subject queue for classification, use [subjects.getSubjectQueue](#get-subject-queue). Query params are optional.
+- params _(object)_ - An object that should include a subject id _(string)_ and/or query _(object)_ properties. Also can take an authorization _(string)_ property that must be set to a string including type and token, i.e. `{ authorization: 'Bearer 12345' }`. If you're requesting a subject queue for classification, use [subjects.getSubjectQueue](#get-subject-queue). Query params are optional.
 
 **Returns**
 
@@ -61,7 +61,7 @@ A subjects get request that validates for the presence of a workflow id and opti
 **Function**
 
 ``` javascript
-const params = { workflowId: '50' };
+const params = { workflowId: '50', authorization: authorization };
 
 subjects.getSubjectQueue(params)
 
@@ -78,7 +78,7 @@ subjects.getSubjectQueue(params)
 
 **Arguments**
 
-- params _(object)_ - An object that should include the workflow id _(string)_, optionally the subject set id _(string)_,and optionally additional query params.
+- params _(object)_ - An object that should include the workflow id _(string)_, optionally the subject set id _(string)_, and optionally additional query params. Also can take an authorization _(string)_ property that must be set to a string including type and token, i.e. `{ authorization: 'Bearer 12345' }`.
 
 **Returns**
 

--- a/packages/lib-panoptes-js/docs/tutorials.md
+++ b/packages/lib-panoptes-js/docs/tutorials.md
@@ -31,7 +31,7 @@ tutorials.endpoint
 
 ``` javascript
 // By tutorial id
-const params = { id: tutorialId, query: query };
+const params = { id: tutorialId, query: query, authorization: authorization };
 
 tutorials.get(params)
 
@@ -43,7 +43,7 @@ tutorials.get(params)
 
 **Arguments**
 
-- params _(object)_ - An object that should include a tutorial id _(string)_ or workflow id _(string)_ and/or query _(object)_ properties. The get request requires either a tutorial id or workflow id. Query params are optional.
+- params _(object)_ - An object that should include a tutorial id _(string)_ or workflow id _(string)_ and/or query _(object)_ properties. The get request requires either a tutorial id or workflow id. Also can take an authorization _(string)_ property that must be set to a string including type and token, i.e. `{ authorization: 'Bearer 12345' }`. Query params are optional.
 
 **Returns**
 
@@ -78,7 +78,7 @@ A tutorials get request that validates for the presence of the tutorial id. The 
 **Function**
 
 ``` javascript
-const params = { id: '1' };
+const params = { id: '1', authorization: authorization };
 
 tutorials.getAttachedImages(params)
 
@@ -90,7 +90,7 @@ tutorials.getAttachedImages(params)
 
 **Arguments**
 
-- params _(object)_ - An object that should include the tutorial id _(string)_ and optionally additional query params.
+- params _(object)_ - An object that should include the tutorial id _(string)_ and optionally additional query params. Also can take an authorization _(string)_ property that must be set to a string including type and token, i.e. `{ authorization: 'Bearer 12345' }`.
 
 **Returns**
 
@@ -116,7 +116,7 @@ https://github.com/zooniverse/Panoptes/issues/2279
 **Function**
 
 ``` javascript
-const params = { id: '1' };
+const params = { id: '1', authorization: authorization };
 
 tutorials.getWithImages(params)
 
@@ -128,7 +128,7 @@ tutorials.getWithImages(params)
 
 **Arguments**
 
-- params _(object)_ - An object that should include the tutorial id _(string)_ or workflow id _(string)_ and optionally additional query params.
+- params _(object)_ - An object that should include the tutorial id _(string)_ or workflow id _(string)_ and optionally additional query params. Also can take an authorization _(string)_ property that must be set to a string including type and token, i.e. `{ authorization: 'Bearer 12345' }`.
 
 **Returns**
 
@@ -156,7 +156,7 @@ A tutorials get request that filters the response to only be tutorials with the 
 **Function**
 
 ``` javascript
-const params = { id: '1' };
+const params = { id: '1', authorization: authorization };
 
 tutorials.getTutorials(params)
 
@@ -168,7 +168,7 @@ tutorials.getTutorials(params)
 
 **Arguments**
 
-- params _(object)_ - An object that should include the tutorial id _(string)_ or workflow id _(string)_ and optionally additional query params.
+- params _(object)_ - An object that should include the tutorial id _(string)_ or workflow id _(string)_ and optionally additional query params. Also can take an authorization _(string)_ property that must be set to a string including type and token, i.e. `{ authorization: 'Bearer 12345' }`.
 
 **Returns**
 
@@ -192,7 +192,7 @@ A tutorials get request uses a default kind query param for `mini-course`. It th
 **Function**
 
 ``` javascript
-const params = { id: '45' };
+const params = { id: '45', authorization: authorization };
 
 tutorials.getMinicourses(params)
 
@@ -204,7 +204,7 @@ tutorials.getMinicourses(params)
 
 **Arguments**
 
-- params _(object)_ - An object that should include the tutorial id _(string)_ or workflow id _(string)_ and optionally additional query params.
+- params _(object)_ - An object that should include the tutorial id _(string)_ or workflow id _(string)_ and optionally additional query params. Also can take an authorization _(string)_ property that must be set to a string including type and token, i.e. `{ authorization: 'Bearer 12345' }`.
 
 **Returns**
 

--- a/packages/lib-panoptes-js/src/panoptes.js
+++ b/packages/lib-panoptes-js/src/panoptes.js
@@ -15,9 +15,8 @@ function checkForAdminFlag () {
   return undefined
 }
 
-// TODO: Write auth client
 // TODO: Consider how to integrate a GraphQL option
-function get (endpoint, query, host) {
+function get (endpoint, query, authorization = null, host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
 
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
@@ -25,7 +24,8 @@ function get (endpoint, query, host) {
   const request = superagent.get(`${apiHost}${endpoint}`)
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/vnd.api+json; version=1')
-  // .set('Authorization', apiClient.headers.Authorization);
+
+  if (authorization) request.set('Authorization', authorization)
 
   if (query && Object.keys(query).length > 0) {
     if (typeof query !== 'object') return Promise.reject(new TypeError('Query must be an object'))
@@ -34,51 +34,58 @@ function get (endpoint, query, host) {
   } else {
     request.query(defaultParams)
   }
+
   return request.then(response => response)
 }
 
-function post (endpoint, data, host) {
+function post (endpoint, data, authorization = null, host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
 
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
   const apiHost = host || config.host
 
-  return superagent.post(`${apiHost}${endpoint}`)
+  const request = superagent.post(`${apiHost}${endpoint}`)
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/vnd.api+json; version=1')
-    // .set('Authorization', apiClient.headers.Authorization)
-    .query(defaultParams)
+
+  if (authorization) request.set('Authorization', authorization)
+
+  return request.query(defaultParams)
     .send(data)
     .then(response => response)
 }
 
-function put (endpoint, data, host) {
+function put (endpoint, data, authorization = null, host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
 
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
   if (!data) return handleMissingParameter('Request needs a defined data for update')
   const apiHost = host || config.host
 
-  return superagent.put(`${apiHost}${endpoint}`)
+  const request = superagent.put(`${apiHost}${endpoint}`)
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/vnd.api+json; version=1')
-    // .set('Authorization', apiClient.headers.Authorization)
-    .query(defaultParams)
+
+  if (authorization) request.set('Authorization', authorization)
+
+  return request.query(defaultParams)
     .send(data)
     .then(response => response)
 }
 
-function del (endpoint, host) {
+function del (endpoint, authorization = null, host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
 
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
   const apiHost = host || config.host
 
-  return superagent.delete(`${apiHost}${endpoint}`)
+  const request = superagent.delete(`${apiHost}${endpoint}`)
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/vnd.api+json; version=1')
-    // .set('Authorization', apiClient.headers.Authorization)
-    .query(defaultParams)
+
+  if (authorization) request.set('Authorization', authorization)
+
+  return request.query(defaultParams)
     .then(response => response)
 }
 

--- a/packages/lib-panoptes-js/src/panoptes.js
+++ b/packages/lib-panoptes-js/src/panoptes.js
@@ -16,7 +16,7 @@ function checkForAdminFlag () {
 }
 
 // TODO: Consider how to integrate a GraphQL option
-function get (endpoint, query, authorization = null, host) {
+function get (endpoint, query, authorization = '', host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
 
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
@@ -38,7 +38,7 @@ function get (endpoint, query, authorization = null, host) {
   return request.then(response => response)
 }
 
-function post (endpoint, data, authorization = null, host) {
+function post (endpoint, data, authorization = '', host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
 
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
@@ -55,7 +55,7 @@ function post (endpoint, data, authorization = null, host) {
     .then(response => response)
 }
 
-function put (endpoint, data, authorization = null, host) {
+function put (endpoint, data, authorization = '', host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
 
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
@@ -73,7 +73,7 @@ function put (endpoint, data, authorization = null, host) {
     .then(response => response)
 }
 
-function del (endpoint, authorization = null, host) {
+function del (endpoint, authorization = '', host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
 
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')

--- a/packages/lib-panoptes-js/src/panoptes.spec.js
+++ b/packages/lib-panoptes-js/src/panoptes.spec.js
@@ -1,5 +1,3 @@
-/* global localStorage */
-
 const { expect } = require('chai')
 const superagent = require('superagent')
 const mockSuperagent = require('superagent-mock')
@@ -37,22 +35,19 @@ describe('panoptes.js', function () {
 
     it('should use the host from the function call if defined', function () {
       const mockAPIHost = 'https://my-api.com'
-      return panoptes.get(endpoint, null, mockAPIHost).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
+      return panoptes.get(endpoint, null, null, mockAPIHost).then((response) => {
         expect(actualMatch.input.includes(mockAPIHost)).to.be.true
       })
     })
 
     it('should use the host defined in the config if a host parameter isn\'t defined', function () {
       return panoptes.get(endpoint).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualMatch.input.includes(config.host)).to.be.true
       })
     })
 
     it('should add Content-Type header to the request', function () {
       return panoptes.get(endpoint).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualHeader['Content-Type']).to.exist
         expect(actualHeader['Content-Type']).to.equal('application/json')
       })
@@ -60,7 +55,6 @@ describe('panoptes.js', function () {
 
     it('should add Accept header to the request', function () {
       return panoptes.get(endpoint).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualHeader['Accept']).to.exist
         expect(actualHeader['Accept']).to.equal('application/vnd.api+json; version=1')
       })
@@ -68,7 +62,6 @@ describe('panoptes.js', function () {
 
     it('should add the http_cache default query params to the request', function () {
       return panoptes.get(endpoint).then(() => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualMatch.input.includes('?http_cache=true')).to.be.true
       })
     })
@@ -77,7 +70,6 @@ describe('panoptes.js', function () {
       localStorage.setItem('adminFlag', true)
 
       return panoptes.get(endpoint).then(() => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualMatch.input.includes('?admin=true')).to.be.true
         localStorage.removeItem('adminFlag')
       })
@@ -85,7 +77,6 @@ describe('panoptes.js', function () {
 
     it('should add the query object to the URL if defined', function () {
       return panoptes.get(endpoint, { page: '2', page_size: '30' }).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualMatch.input.includes('?page=2&page_size=30')).to.be.true
       })
     })
@@ -135,22 +126,19 @@ describe('panoptes.js', function () {
 
     it('should use the host from the function call if defined', function () {
       const mockAPIHost = 'https://my-api.com'
-      return panoptes.post(endpoint, null, mockAPIHost).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
+      return panoptes.post(endpoint, null, null, mockAPIHost).then((response) => {
         expect(actualMatch.input.includes(mockAPIHost)).to.be.true
       })
     })
 
     it('should use the host defined in the config if a host parameter isn\'t defined', function () {
       return panoptes.post(endpoint).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualMatch.input.includes(config.host)).to.be.true
       })
     })
 
     it('should add Content-Type header to the request', function () {
       return panoptes.post(endpoint).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualHeader['Content-Type']).to.exist
         expect(actualHeader['Content-Type']).to.equal('application/json')
       })
@@ -158,7 +146,6 @@ describe('panoptes.js', function () {
 
     it('should add Accept header to the request', function () {
       return panoptes.post(endpoint).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualHeader['Accept']).to.exist
         expect(actualHeader['Accept']).to.equal('application/vnd.api+json; version=1')
       })
@@ -166,7 +153,6 @@ describe('panoptes.js', function () {
 
     it('should add the http_cache default query params to the request', function () {
       return panoptes.post(endpoint).then(() => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualMatch.input.includes('?http_cache=true')).to.be.true
       })
     })
@@ -175,7 +161,6 @@ describe('panoptes.js', function () {
       localStorage.setItem('adminFlag', true)
 
       return panoptes.post(endpoint).then(() => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualMatch.input.includes('?admin=true')).to.be.true
         localStorage.removeItem('adminFlag')
       })
@@ -228,22 +213,19 @@ describe('panoptes.js', function () {
 
     it('should use the host from the function call if defined', function () {
       const mockAPIHost = 'https://my-api.com'
-      return panoptes.put(endpoint, update, mockAPIHost).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
+      return panoptes.put(endpoint, update, null, mockAPIHost).then((response) => {
         expect(actualMatch.input.includes(mockAPIHost)).to.be.true
       })
     })
 
     it('should use the host defined in the config if a host parameter isn\'t defined', function () {
       return panoptes.put(endpoint, update).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualMatch.input.includes(config.host)).to.be.true
       })
     })
 
     it('should add Content-Type header to the request', function () {
       return panoptes.put(endpoint, update).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualHeader['Content-Type']).to.exist
         expect(actualHeader['Content-Type']).to.equal('application/json')
       })
@@ -251,7 +233,6 @@ describe('panoptes.js', function () {
 
     it('should add Accept header to the request', function () {
       return panoptes.put(endpoint, update).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualHeader['Accept']).to.exist
         expect(actualHeader['Accept']).to.equal('application/vnd.api+json; version=1')
       })
@@ -259,7 +240,6 @@ describe('panoptes.js', function () {
 
     it('should add the http_cache default query params to the request', function () {
       return panoptes.put(endpoint, update).then(() => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualMatch.input.includes('?http_cache=true')).to.be.true
       })
     })
@@ -268,7 +248,6 @@ describe('panoptes.js', function () {
       localStorage.setItem('adminFlag', true)
 
       return panoptes.put(endpoint, update).then(() => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualMatch.input.includes('?admin=true')).to.be.true
         localStorage.removeItem('adminFlag')
       })
@@ -317,22 +296,19 @@ describe('panoptes.js', function () {
 
     it('should use the host from the function call if defined', function () {
       const mockAPIHost = 'https://my-api.com'
-      return panoptes.del(endpoint, mockAPIHost).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
+      return panoptes.del(endpoint, null, mockAPIHost).then((response) => {
         expect(actualMatch.input.includes(mockAPIHost)).to.be.true
       })
     })
 
     it('should use the host defined in the config if a host parameter isn\'t defined', function () {
       return panoptes.del(endpoint).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualMatch.input.includes(config.host)).to.be.true
       })
     })
 
     it('should add Content-Type header to the request', function () {
       return panoptes.del(endpoint).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualHeader['Content-Type']).to.exist
         expect(actualHeader['Content-Type']).to.equal('application/json')
       })
@@ -340,7 +316,6 @@ describe('panoptes.js', function () {
 
     it('should add Accept header to the request', function () {
       return panoptes.del(endpoint).then((response) => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualHeader['Accept']).to.exist
         expect(actualHeader['Accept']).to.equal('application/vnd.api+json; version=1')
       })
@@ -348,7 +323,6 @@ describe('panoptes.js', function () {
 
     it('should add the http_cache default query params to the request', function () {
       return panoptes.del(endpoint).then(() => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualMatch.input.includes('?http_cache=true')).to.be.true
       })
     })
@@ -357,7 +331,6 @@ describe('panoptes.js', function () {
       localStorage.setItem('adminFlag', true)
 
       return panoptes.del(endpoint).then(() => {
-        // eslint-disable-next-line no-unused-expressions
         expect(actualMatch.input.includes('?admin=true')).to.be.true
         localStorage.removeItem('adminFlag')
       })

--- a/packages/lib-panoptes-js/src/panoptes.spec.js
+++ b/packages/lib-panoptes-js/src/panoptes.spec.js
@@ -4,11 +4,11 @@ const mockSuperagent = require('superagent-mock')
 const { config } = require('./config')
 const panoptes = require('./panoptes')
 
-describe.only('panoptes.js', function () {
+describe('panoptes.js', function () {
   describe('get', function () {
     let superagentMock
     let actualMatch
-    let actualHeader
+    let actualHeaders
     const endpoint = '/projects'
     const expectedResponse = { id: '2' }
     before(function () {
@@ -16,7 +16,7 @@ describe.only('panoptes.js', function () {
         pattern: endpoint,
         fixtures: (match, params, header, context) => {
           actualMatch = match
-          actualHeader = header
+          actualHeaders = header
           return expectedResponse
         },
         get: (match, data) => ({ body: data })
@@ -48,22 +48,22 @@ describe.only('panoptes.js', function () {
 
     it('should add Content-Type header to the request', function () {
       return panoptes.get(endpoint).then((response) => {
-        expect(actualHeader['Content-Type']).to.exist
-        expect(actualHeader['Content-Type']).to.equal('application/json')
+        expect(actualHeaders['Content-Type']).to.exist
+        expect(actualHeaders['Content-Type']).to.equal('application/json')
       })
     })
 
     it('should add Accept header to the request', function () {
       return panoptes.get(endpoint).then((response) => {
-        expect(actualHeader['Accept']).to.exist
-        expect(actualHeader['Accept']).to.equal('application/vnd.api+json; version=1')
+        expect(actualHeaders['Accept']).to.exist
+        expect(actualHeaders['Accept']).to.equal('application/vnd.api+json; version=1')
       })
     })
 
     it('should add the Authorization header to the request if param is defined', function () {
       return panoptes.get(endpoint, null, '12345').then((response) => {
-        expect(actualHeader['Authorization']).to.exist
-        expect(actualHeader['Authorization']).to.equal('12345')
+        expect(actualHeaders['Authorization']).to.exist
+        expect(actualHeaders['Authorization']).to.equal('12345')
       })
     })
 
@@ -105,7 +105,7 @@ describe.only('panoptes.js', function () {
     let superagentMock
     let actualMatch
     let actualParams
-    let actualHeader
+    let actualHeaders
     const endpoint = '/projects'
     const expectedResponse = { id: '3' }
     before(function () {
@@ -114,7 +114,7 @@ describe.only('panoptes.js', function () {
         fixtures: (match, params, header, context) => {
           actualMatch = match
           actualParams = params
-          actualHeader = header
+          actualHeaders = header
           return expectedResponse
         },
         post: (match, data) => ({ body: data })
@@ -146,22 +146,22 @@ describe.only('panoptes.js', function () {
 
     it('should add Content-Type header to the request', function () {
       return panoptes.post(endpoint).then((response) => {
-        expect(actualHeader['Content-Type']).to.exist
-        expect(actualHeader['Content-Type']).to.equal('application/json')
+        expect(actualHeaders['Content-Type']).to.exist
+        expect(actualHeaders['Content-Type']).to.equal('application/json')
       })
     })
 
     it('should add Accept header to the request', function () {
       return panoptes.post(endpoint).then((response) => {
-        expect(actualHeader['Accept']).to.exist
-        expect(actualHeader['Accept']).to.equal('application/vnd.api+json; version=1')
+        expect(actualHeaders['Accept']).to.exist
+        expect(actualHeaders['Accept']).to.equal('application/vnd.api+json; version=1')
       })
     })
 
     it('should add the Authorization header to the request if param is defined', function () {
       return panoptes.post(endpoint, null, '12345').then((response) => {
-        expect(actualHeader['Authorization']).to.exist
-        expect(actualHeader['Authorization']).to.equal('12345')
+        expect(actualHeaders['Authorization']).to.exist
+        expect(actualHeaders['Authorization']).to.equal('12345')
       })
     })
 
@@ -198,7 +198,7 @@ describe.only('panoptes.js', function () {
     let superagentMock
     let actualMatch
     let actualParams
-    let actualHeader
+    let actualHeaders
     const endpoint = '/projects/2'
     const update = { display_name: 'My project' }
     const expectedResponse = { id: '3', display_name: 'My project' }
@@ -208,7 +208,7 @@ describe.only('panoptes.js', function () {
         fixtures: (match, params, header, context) => {
           actualMatch = match
           actualParams = params
-          actualHeader = header
+          actualHeaders = header
           return expectedResponse
         },
         put: (match, data) => ({ body: data })
@@ -240,22 +240,22 @@ describe.only('panoptes.js', function () {
 
     it('should add Content-Type header to the request', function () {
       return panoptes.put(endpoint, update).then((response) => {
-        expect(actualHeader['Content-Type']).to.exist
-        expect(actualHeader['Content-Type']).to.equal('application/json')
+        expect(actualHeaders['Content-Type']).to.exist
+        expect(actualHeaders['Content-Type']).to.equal('application/json')
       })
     })
 
     it('should add Accept header to the request', function () {
       return panoptes.put(endpoint, update).then((response) => {
-        expect(actualHeader['Accept']).to.exist
-        expect(actualHeader['Accept']).to.equal('application/vnd.api+json; version=1')
+        expect(actualHeaders['Accept']).to.exist
+        expect(actualHeaders['Accept']).to.equal('application/vnd.api+json; version=1')
       })
     })
 
     it('should add the Authorization header to the request if param is defined', function () {
       return panoptes.put(endpoint, update, '12345').then((response) => {
-        expect(actualHeader['Authorization']).to.exist
-        expect(actualHeader['Authorization']).to.equal('12345')
+        expect(actualHeaders['Authorization']).to.exist
+        expect(actualHeaders['Authorization']).to.equal('12345')
       })
     })
 
@@ -290,7 +290,7 @@ describe.only('panoptes.js', function () {
   describe('delete', function () {
     let superagentMock
     let actualMatch
-    let actualHeader
+    let actualHeaders
     const endpoint = '/projects'
     const expectedResponse = { status: 204 }
     before(function () {
@@ -298,7 +298,7 @@ describe.only('panoptes.js', function () {
         pattern: endpoint,
         fixtures: (match, params, header, context) => {
           actualMatch = match
-          actualHeader = header
+          actualHeaders = header
           return expectedResponse
         },
         delete: (match, data) => { return data }
@@ -330,22 +330,22 @@ describe.only('panoptes.js', function () {
 
     it('should add Content-Type header to the request', function () {
       return panoptes.del(endpoint).then((response) => {
-        expect(actualHeader['Content-Type']).to.exist
-        expect(actualHeader['Content-Type']).to.equal('application/json')
+        expect(actualHeaders['Content-Type']).to.exist
+        expect(actualHeaders['Content-Type']).to.equal('application/json')
       })
     })
 
     it('should add Accept header to the request', function () {
       return panoptes.del(endpoint).then((response) => {
-        expect(actualHeader['Accept']).to.exist
-        expect(actualHeader['Accept']).to.equal('application/vnd.api+json; version=1')
+        expect(actualHeaders['Accept']).to.exist
+        expect(actualHeaders['Accept']).to.equal('application/vnd.api+json; version=1')
       })
     })
 
     it('should add the Authorization header to the request if param is defined', function () {
       return panoptes.del(endpoint, '12345').then((response) => {
-        expect(actualHeader['Authorization']).to.exist
-        expect(actualHeader['Authorization']).to.equal('12345')
+        expect(actualHeaders['Authorization']).to.exist
+        expect(actualHeaders['Authorization']).to.equal('12345')
       })
     })
 

--- a/packages/lib-panoptes-js/src/panoptes.spec.js
+++ b/packages/lib-panoptes-js/src/panoptes.spec.js
@@ -4,7 +4,7 @@ const mockSuperagent = require('superagent-mock')
 const { config } = require('./config')
 const panoptes = require('./panoptes')
 
-describe('panoptes.js', function () {
+describe.only('panoptes.js', function () {
   describe('get', function () {
     let superagentMock
     let actualMatch
@@ -57,6 +57,13 @@ describe('panoptes.js', function () {
       return panoptes.get(endpoint).then((response) => {
         expect(actualHeader['Accept']).to.exist
         expect(actualHeader['Accept']).to.equal('application/vnd.api+json; version=1')
+      })
+    })
+
+    it('should add the Authorization header to the request if param is defined', function () {
+      return panoptes.get(endpoint, null, '12345').then((response) => {
+        expect(actualHeader['Authorization']).to.exist
+        expect(actualHeader['Authorization']).to.equal('12345')
       })
     })
 
@@ -151,6 +158,13 @@ describe('panoptes.js', function () {
       })
     })
 
+    it('should add the Authorization header to the request if param is defined', function () {
+      return panoptes.post(endpoint, null, '12345').then((response) => {
+        expect(actualHeader['Authorization']).to.exist
+        expect(actualHeader['Authorization']).to.equal('12345')
+      })
+    })
+
     it('should add the http_cache default query params to the request', function () {
       return panoptes.post(endpoint).then(() => {
         expect(actualMatch.input.includes('?http_cache=true')).to.be.true
@@ -238,6 +252,13 @@ describe('panoptes.js', function () {
       })
     })
 
+    it('should add the Authorization header to the request if param is defined', function () {
+      return panoptes.put(endpoint, update, '12345').then((response) => {
+        expect(actualHeader['Authorization']).to.exist
+        expect(actualHeader['Authorization']).to.equal('12345')
+      })
+    })
+
     it('should add the http_cache default query params to the request', function () {
       return panoptes.put(endpoint, update).then(() => {
         expect(actualMatch.input.includes('?http_cache=true')).to.be.true
@@ -318,6 +339,13 @@ describe('panoptes.js', function () {
       return panoptes.del(endpoint).then((response) => {
         expect(actualHeader['Accept']).to.exist
         expect(actualHeader['Accept']).to.equal('application/vnd.api+json; version=1')
+      })
+    })
+
+    it('should add the Authorization header to the request if param is defined', function () {
+      return panoptes.del(endpoint, '12345').then((response) => {
+        expect(actualHeader['Authorization']).to.exist
+        expect(actualHeader['Authorization']).to.equal('12345')
       })
     })
 

--- a/packages/lib-panoptes-js/src/resources/projects/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/projects/commonRequests.js
@@ -3,15 +3,16 @@ const { raiseError } = require('../../utilityFunctions')
 const panoptes = require('../../panoptes')
 
 function getBySlug (params) {
-  const queryParams = params || {}
+  const queryParams = (params && params.query) ? params.query : {}
+  const authorization = (params && params.authorization) ? params.authorization : ''
 
   if (queryParams.slug && typeof queryParams.slug !== 'string') return raiseError('Projects: Get request slug must be a string.', 'typeError')
   if (queryParams.slug && queryParams.slug.includes('projects')) {
     queryParams.slug = getProjectSlugFromURL(queryParams.slug)
   }
 
-  if (queryParams && queryParams.slug) {
-    return panoptes.get(endpoint, queryParams)
+  if (queryParams.slug) {
+    return panoptes.get(endpoint, queryParams, authorization)
   }
 
   return raiseError('Projects: Get by slug request missing required parameter: slug string.', 'error')
@@ -19,25 +20,23 @@ function getBySlug (params) {
 
 function getWithLinkedResources (params) {
   const include = { include: 'avatar,background,owners,pages' }
+  const projectId = (params && params.id) ? params.id : ''
+  const authorization = (params && params.authorization) ? params.authorization : ''
 
   if (params && typeof params !== 'object') return raiseError('Projects: Get request params must be an object.', 'error')
 
-  const queryParams = params ? Object.assign({}, params, include) : include
+  const queryParams = (params && params.query) ? Object.assign({}, params.query, include) : include
   if (queryParams.slug && typeof queryParams.slug !== 'string') return raiseError('Projects: Get request slug must be a string.', 'typeError')
-  if (queryParams.id && typeof queryParams.id !== 'string') return raiseError('Projects: Get request id must be a string.', 'typeError')
-  if (!queryParams.slug && !queryParams.id) return raiseError('Projects: Get request must have either project id or slug.', 'typeError')
+  if (projectId && typeof projectId !== 'string') return raiseError('Projects: Get request id must be a string.', 'typeError')
+  if (!queryParams.slug && !projectId) return raiseError('Projects: Get request must have either project id or slug.', 'typeError')
 
-  if (queryParams.id) {
-    const projectID = queryParams.id
-    delete queryParams.id
-    return panoptes.get(`${endpoint}/${projectID}`, queryParams)
-  }
+  if (projectId) return panoptes.get(`${endpoint}/${projectId}`, queryParams, authorization)
 
   if (queryParams.slug && queryParams.slug.includes('projects')) {
     queryParams.slug = getProjectSlugFromURL(queryParams.slug)
   }
 
-  return panoptes.get(endpoint, queryParams)
+  return panoptes.get(endpoint, queryParams, authorization)
 }
 
 module.exports = { getBySlug, getWithLinkedResources }

--- a/packages/lib-panoptes-js/src/resources/projects/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/projects/commonRequests.spec.js
@@ -33,13 +33,13 @@ describe('Projects resource common requests', function () {
     })
 
     it('should error if slug param is not a string', function () {
-      return projects.getBySlug({ slug: 1234 }).catch((error) => {
+      return projects.getBySlug({ query: { slug: 1234 }}).catch((error) => {
         expect(error.message).to.equal('Projects: Get request slug must be a string.')
       })
     })
 
     it('should return the expected response if not found', function () {
-      return projects.getBySlug({ slug: 'zooniverse/my-project' }).then((response) => {
+      return projects.getBySlug({ query: { slug: 'zooniverse/my-project' }}).then((response) => {
         expect(response).to.eql({ body: expectedNotFoundResponse })
       })
     })
@@ -52,14 +52,14 @@ describe('Projects resource common requests', function () {
 
     it('should return the expected response if the slug is defined', function () {
       const slug = 'user/untitled-project-2'
-      return projects.getBySlug({ slug }).then((response) => {
+      return projects.getBySlug({ query: { slug }}).then((response) => {
         expect(response).to.eql({ body: expectedGetResponse })
       })
     })
 
     it('should return the expected response if the slug is defined including "projects" in the pathname', function () {
       const slug = 'projects/user/untitled-project-2'
-      return projects.getBySlug({ slug }).then((response) => {
+      return projects.getBySlug({ query: { slug }}).then((response) => {
         expect(response).to.eql({ body: expectedGetResponse })
       })
     })
@@ -104,7 +104,7 @@ describe('Projects resource common requests', function () {
       })
 
       it('should error if slug is not a string', function () {
-        return projects.getWithLinkedResources({ slug: 1234 }).catch((error) => {
+        return projects.getWithLinkedResources({ query: { slug: 1234 }}).catch((error) => {
           expect(error.message).to.equal('Projects: Get request slug must be a string.')
         })
       })
@@ -116,7 +116,7 @@ describe('Projects resource common requests', function () {
       })
 
       it('should return the expected response', function () {
-        return projects.getWithLinkedResources({ slug: 'user/untitled-project-2' }).then((response) => {
+        return projects.getWithLinkedResources({ query: { slug: 'user/untitled-project-2' }}).then((response) => {
           expect(response).to.eql({ body: expectedGetResponseWithLinkedResources })
         })
       })

--- a/packages/lib-panoptes-js/src/resources/projects/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/projects/commonRequests.spec.js
@@ -10,13 +10,15 @@ const { resources, responses } = require('./mocks')
 describe('Projects resource common requests', function () {
   describe('getBySlug', function () {
     let superagentMock
+    let actualHeaders
     const expectedGetResponse = responses.get.project
     const expectedNotFoundResponse = responses.get.queryNotFound
 
     before(function () {
       superagentMock = mockSuperagent(superagent, [{
         pattern: `${config.host}${endpoint}`,
-        fixtures: (match, params) => {
+        fixtures: (match, params, headers) => {
+          actualHeaders = headers
           const [mockOwner, mockProjectName] = resources.projectOne.slug.split('/')
           const matchSlug = `${mockOwner}%2F${mockProjectName}`
 
@@ -63,10 +65,18 @@ describe('Projects resource common requests', function () {
         expect(response).to.eql({ body: expectedGetResponse })
       })
     })
+
+    it('should add the Authorization header to the request if param is defined', function () {
+      return projects.getBySlug({ authorization: '12345', query: { slug: 'zooniverse/my-project' } }).then((response) => {
+        expect(actualHeaders['Authorization']).to.exist
+        expect(actualHeaders['Authorization']).to.equal('12345')
+      })
+    })
   })
 
   describe('getWithLinkedResources', function () {
     let superagentMock
+    let actualHeaders
     const expectedGetResponseWithLinkedResources = responses.get.projectWithLinkedResources
     const expectedNotFoundResponse = responses.get.queryNotFound
 
@@ -77,7 +87,8 @@ describe('Projects resource common requests', function () {
     it('should error if neither a slug or id is defined in query parameters', function () {
       superagentMock = mockSuperagent(superagent, [{
         pattern: `${config.host}${endpoint}`,
-        fixtures: (match, params) => {
+        fixtures: (match, params, headers) => {
+          actualHeaders = headers
           return expectedGetResponseWithLinkedResources
         },
         get: (match, data) => ({ body: data })
@@ -88,11 +99,18 @@ describe('Projects resource common requests', function () {
       })
     })
 
+    it('should add the Authorization header to the request if param is defined', function () {
+      return projects.getWithLinkedResources({ id: '2', authorization: '12345' }).then((response) => {
+        expect(actualHeaders['Authorization']).to.exist
+        expect(actualHeaders['Authorization']).to.equal('12345')
+      })
+    })
+
     describe('using project slug query parameter', function () {
       before(function () {
         superagentMock = mockSuperagent(superagent, [{
           pattern: `${config.host}${endpoint}`,
-          fixtures: (match, params) => {
+          fixtures: (match, params, headers) => {
             const [mockOwner, mockProjectName] = expectedGetResponseWithLinkedResources.projects[0].slug.split('/')
             const matchSlug = `${mockOwner}%2F${mockProjectName}`
 

--- a/packages/lib-panoptes-js/src/resources/projects/rest.js
+++ b/packages/lib-panoptes-js/src/resources/projects/rest.js
@@ -15,17 +15,20 @@ function create (params) {
 function get (params) {
   const queryParams = (params && params.query) ? params.query : {}
   const projectId = (params && params.id) ? params.id : ''
+  const authorization = (params && params.authorization) ? params.authorization : ''
 
   if (!projectId) return panoptes.get(endpoint, queryParams)
   if (projectId && typeof projectId !== 'string') return raiseError('Projects: Get request id must be a string.', 'typeError')
 
-  return panoptes.get(`${endpoint}/${projectId}`, queryParams)
+  return panoptes.get(`${endpoint}/${projectId}`, queryParams, authorization)
 }
 
 function update (params) {
   const { id, data } = params
+  const authorization = (params && params.authorization) ? params.authorization : ''
+
   if (id && typeof id !== 'string') return raiseError('Projects: Update request id must be a string.', 'typeError')
-  if (id && data) return panoptes.put(`${endpoint}/${id}`, data)
+  if (id && data) return panoptes.put(`${endpoint}/${id}`, data, authorization)
   if (!id) return raiseError('Projects: Update request missing project id.', 'error')
   if (!data) return raiseError('Projects: Update request missing data to post.', 'error')
 
@@ -34,8 +37,10 @@ function update (params) {
 
 function del (params) {
   const id = (params) ? params.id : ''
+  const authorization = (params && params.authorization) ? params.authorization : ''
+
   if (id && typeof id !== 'string') return raiseError('Projects: Delete request id must be a string.', 'typeError')
-  if (id) return panoptes.del(`${endpoint}/${id}`)
+  if (id) return panoptes.del(`${endpoint}/${id}`, authorization)
   return raiseError('Projects: Delete request missing project id.', 'error')
 }
 

--- a/packages/lib-panoptes-js/src/resources/projects/rest.js
+++ b/packages/lib-panoptes-js/src/resources/projects/rest.js
@@ -4,12 +4,13 @@ const { raiseError } = require('../../utilityFunctions')
 
 function create (params) {
   const newProjectData = (params && params.data) ? params.data : {}
+  const authorization = (params && params.authorization) ? params.authorization : ''
 
   const allProjectData = Object.assign({
     private: true
   }, newProjectData)
 
-  return panoptes.post(endpoint, allProjectData)
+  return panoptes.post(endpoint, allProjectData, authorization)
 }
 
 function get (params) {
@@ -17,7 +18,7 @@ function get (params) {
   const projectId = (params && params.id) ? params.id : ''
   const authorization = (params && params.authorization) ? params.authorization : ''
 
-  if (!projectId) return panoptes.get(endpoint, queryParams)
+  if (!projectId) return panoptes.get(endpoint, queryParams, authorization)
   if (projectId && typeof projectId !== 'string') return raiseError('Projects: Get request id must be a string.', 'typeError')
 
   return panoptes.get(`${endpoint}/${projectId}`, queryParams, authorization)

--- a/packages/lib-panoptes-js/src/resources/projects/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/projects/rest.spec.js
@@ -11,12 +11,14 @@ describe('Projects resource REST requests', function () {
   describe('create', function () {
     let superagentMock
     let actualParams
+    let actualHeaders
     const expectedResponse = responses.post.createdProject
     before(function () {
       superagentMock = mockSuperagent(superagent, [{
         pattern: `${config.host}${endpoint}`,
-        fixtures: (match, params, header, context) => {
+        fixtures: (match, params, headers, context) => {
           actualParams = params
+          actualHeaders = headers
           return expectedResponse
         },
         post: (match, data) => ({ body: data })
@@ -39,17 +41,26 @@ describe('Projects resource REST requests', function () {
         expect(actualParams).to.eql(Object.assign({}, { private: true }, projectDisplayName))
       })
     })
+
+    it('should add the Authorization header to the request if param is defined', function () {
+      return projects.create({ authorization: '12345' }).then((response) => {
+        expect(actualHeaders['Authorization']).to.exist
+        expect(actualHeaders['Authorization']).to.equal('12345')
+      })
+    })
   })
 
   describe('get', function () {
     describe('many projects', function () {
       let superagentMock
+      let actualHeaders
       const expectedGetAllResponse = responses.get.projects
 
       before(function () {
         superagentMock = mockSuperagent(superagent, [{
           pattern: `${config.host}${endpoint}`,
           fixtures: (match, params, headers, context) => {
+            actualHeaders = headers
             return expectedGetAllResponse
           },
           get: (match, data) => {
@@ -67,11 +78,19 @@ describe('Projects resource REST requests', function () {
           expect(response).to.eql({ body: expectedGetAllResponse })
         })
       })
+
+      it('should add the Authorization header to the request if param is defined', function () {
+        return projects.get({ authorization: '12345' }).then((response) => {
+          expect(actualHeaders['Authorization']).to.exist
+          expect(actualHeaders['Authorization']).to.equal('12345')
+        })
+      })
     })
 
     describe('a single project', function () {
       let superagentMock
       let actualMatch
+      let actualHeaders
       const expectedGetSingleResponse = responses.get.project
 
       before(function () {
@@ -79,6 +98,7 @@ describe('Projects resource REST requests', function () {
           pattern: `${config.host}${endpoint}/(\\d+)`,
           fixtures: (match, params, headers, context) => {
             actualMatch = match
+            actualHeaders = headers
             return expectedGetSingleResponse
           },
           get: (match, data) => {
@@ -91,6 +111,13 @@ describe('Projects resource REST requests', function () {
         superagentMock.unset()
       })
 
+      it('should add the Authorization header to the request if param is defined', function () {
+        return projects.get({ authorization: '12345', id: '2' }).then((response) => {
+          expect(actualHeaders['Authorization']).to.exist
+          expect(actualHeaders['Authorization']).to.equal('12345')
+        })
+      })
+
       it('should return the expected response with a defined id argument', function () {
         return projects.get({ id: '2' }).then(response => {
           expect(response).to.eql({ body: expectedGetSingleResponse })
@@ -101,7 +128,6 @@ describe('Projects resource REST requests', function () {
         const queryParams = { page: '2' }
 
         return projects.get({ id: '2', query: queryParams }).then(response => {
-          // eslint-disable-next-line no-unused-expressions
           expect(actualMatch.input.includes('?page=2')).to.be.true
         })
       })
@@ -116,13 +142,15 @@ describe('Projects resource REST requests', function () {
 
   describe('update', function () {
     let superagentMock
+    let actualHeaders
     const expectedPutResponse = responses.updatedProject
     const update = { researcher_quote: 'Try my project!' }
 
     before(function () {
       superagentMock = mockSuperagent(superagent, [{
         pattern: `${config.host}${endpoint}/(\\d+)`,
-        fixtures: (match, params) => {
+        fixtures: (match, params, headers) => {
+          actualHeaders = headers
           return expectedPutResponse
         },
         put: (match, data) => ({ body: data })
@@ -151,6 +179,13 @@ describe('Projects resource REST requests', function () {
       })
     })
 
+    it('should add the Authorization header to the request if param is defined', function () {
+      return projects.update({ id: '2', data: update, authorization: '12345' }).then((response) => {
+        expect(actualHeaders['Authorization']).to.exist
+        expect(actualHeaders['Authorization']).to.equal('12345')
+      })
+    })
+
     it('should return the expected response', function () {
       return projects.update({ id: '2', data: update }).then((response) => {
         expect(response).to.eql({ body: expectedPutResponse })
@@ -160,11 +195,13 @@ describe('Projects resource REST requests', function () {
 
   describe('delete', function () {
     let superagentMock
+    let actualHeaders
     const responseStatus = { status: 204 }
     before(function () {
       superagentMock = mockSuperagent(superagent, [{
         pattern: `${config.host}${endpoint}/(\\d+)`,
-        fixtures: (match, params) => {
+        fixtures: (match, params, headers) => {
+          actualHeaders = headers
           return responseStatus
         },
         delete: (match, data) => { return data }
@@ -190,6 +227,13 @@ describe('Projects resource REST requests', function () {
     it('should error if the request\'s project id is not a string', function () {
       return projects.delete({ id: 2 }).catch((error) => {
         expect(error.message).to.equal('Projects: Delete request id must be a string.')
+      })
+    })
+
+    it('should add the Authorization header to the request if param is defined', function () {
+      return projects.delete({ id: '2', authorization: '12345' }).then((response) => {
+        expect(actualHeaders['Authorization']).to.exist
+        expect(actualHeaders['Authorization']).to.equal('12345')
       })
     })
 

--- a/packages/lib-panoptes-js/src/resources/subjects/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/commonRequests.js
@@ -1,11 +1,12 @@
 const panoptes = require('../../panoptes')
-const { endpoint, queuedEndpoint } = require('./helpers')
+const { queuedEndpoint } = require('./helpers')
 const { isParamTypeInvalid, raiseError } = require('../../utilityFunctions')
 
 function getSubjectQueue (params) {
   const queryParams = (params && params.query) ? params.query : {}
   const workflowId = (params && params.workflowId) ? params.workflowId : ''
   const subjectSetId = (params && params.subjectSetId) ? params.subjectSetId : ''
+  const authorization = (params && params.authorization) ? params.authorization : ''
 
   if (isParamTypeInvalid(workflowId, 'string')) return raiseError('Subjects: Get request workflow id must be a string.', 'typeError')
   if (isParamTypeInvalid(subjectSetId, 'string')) return raiseError('Subjects: Get request subject set id must be a string.', 'typeError')
@@ -14,7 +15,7 @@ function getSubjectQueue (params) {
     queryParams.workflow_id = workflowId
     if (subjectSetId) queryParams.subject_set_id = subjectSetId
 
-    return panoptes.get(queuedEndpoint, queryParams)
+    return panoptes.get(queuedEndpoint, queryParams, authorization)
   }
 
   return raiseError('Subjects: Get request must include a workflow id.', 'error')

--- a/packages/lib-panoptes-js/src/resources/subjects/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/commonRequests.spec.js
@@ -10,12 +10,14 @@ describe('Subjects resource common requests', function () {
   describe('getSubjectQueue', function () {
     let superagentMock
     let actualMatch
+    let autualHeaders
     const expectedGetResponse = responses.get.subjectsQueue
     before(function () {
       superagentMock = mockSuperagent(superagent, [{
         pattern: `${config.host}${endpoint}`,
         fixtures: (match, params, headers, context) => {
           actualMatch = match
+          actualHeaders = headers
           return expectedGetResponse
         },
         get: (match, data) => {
@@ -55,6 +57,13 @@ describe('Subjects resource common requests', function () {
     it('should use the subject set id in the request query params if defined', function () {
       subjects.getSubjectQueue({ subjectSetId: '40', workflowId: '10' }).then(() => {
         expect(actualMatch.input.includes('subject_set_id=40')).to.be.true
+      })
+    })
+
+    it('should add the Authorization header to the request if param is defined', function () {
+      return subjects.getSubjectQueue({ workflowId: '10', authorization: '12345' }).then((response) => {
+        expect(actualHeaders['Authorization']).to.exist
+        expect(actualHeaders['Authorization']).to.equal('12345')
       })
     })
   })

--- a/packages/lib-panoptes-js/src/resources/subjects/rest.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/rest.js
@@ -9,12 +9,12 @@ function create (params) {
 function get (params) {
   const queryParams = (params && params.query) ? params.query : {}
   const subjectId = (params && params.id) ? params.id : ''
+  const authorization = (params && params.authorization) ? params.authorization : ''
 
   if (isParamTypeInvalid(subjectId, 'string')) return raiseError('Subjects: Get request id must be a string.', 'typeError')
 
   if (subjectId) {
-    delete queryParams.id
-    return panoptes.get(`${endpoint}/${subjectId}`, queryParams)
+    return panoptes.get(`${endpoint}/${subjectId}`, queryParams, authorization)
   }
 
   if (console && !subjectId && process.env.NODE_ENV !== 'test') {

--- a/packages/lib-panoptes-js/src/resources/subjects/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/rest.spec.js
@@ -9,11 +9,13 @@ const subjects = require('./index')
 describe('Subjects resource REST requests', function () {
   describe('get', function () {
     let superagentMock
+    let actualHeaders
     const expectedGetResponse = responses.get.subject
     before(function () {
       superagentMock = mockSuperagent(superagent, [{
         pattern: `${config.host}${endpoint}`,
         fixtures: (match, params, headers, context) => {
+          actualHeaders = headers
           if (match.input.includes(resources.subject.id)) return expectedGetResponse
 
           return { status: 404 }
@@ -43,6 +45,13 @@ describe('Subjects resource REST requests', function () {
     it('should return the expected response', function () {
       subjects.get({ id: '10' }).then((response) => {
         expect(response.body).to.eql(expectedGetResponse)
+      })
+    })
+
+    it('should add the Authorization header to the request if param is defined', function () {
+      return subjects.get({ id: '10', authorization: '12345' }).then((response) => {
+        expect(actualHeaders['Authorization']).to.exist
+        expect(actualHeaders['Authorization']).to.equal('12345')
       })
     })
   })

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
@@ -5,12 +5,13 @@ const { raiseError } = require('../../utilityFunctions')
 
 function getAttachedImages (params) {
   const tutorialId = (params && params.id) ? params.id : ''
+  const authorization = (params && params.authorization) ? params.authorization : ''
 
   if (tutorialId) {
     const queryParams = (params && params.query) ? params.query : {}
     const tutorialAttachedImagesEndpoint = `${endpoint}/${tutorialId}/attached_images`
 
-    return panoptes.get(tutorialAttachedImagesEndpoint, queryParams)
+    return panoptes.get(tutorialAttachedImagesEndpoint, queryParams, authorization)
   }
 
   return raiseError('Tutorials: getAttachedImages request requires a tutorial id.', 'error')

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
@@ -1,7 +1,6 @@
 const { expect } = require('chai')
 const superagent = require('superagent')
 const mockSuperagent = require('superagent-mock')
-const { JSDOM } = require('jsdom')
 
 const tutorials = require('./index')
 const { endpoint } = require('./helpers')
@@ -12,13 +11,15 @@ describe('Tutorials resource common requests', function () {
   describe('getAttachedImages', function () {
     let superagentMock
     let actualMatch
+    let actualHeaders
     const expectedGetResponse = responses.get.attachedImage
 
     before(function () {
       superagentMock = mockSuperagent(superagent, [{
         pattern: `${config.host}${endpoint}`,
-        fixtures: (match, params) => {
+        fixtures: (match, params, header) => {
           actualMatch = match
+          actualHeaders = header
           return expectedGetResponse
         },
         get: (match, data) => ({ body: data })
@@ -44,6 +45,13 @@ describe('Tutorials resource common requests', function () {
     it('should use query params if defined', function () {
       return tutorials.getAttachedImages({ id: '1', query: { page: '2' }}).then((response) => {
         expect(actualMatch.input.includes('page=2')).to.be.true
+      })
+    })
+
+    it('should add the Authorization header to the request if param is defined', function () {
+      return tutorials.getAttachedImages({ id: '1', authorization: '12345' }).then((response) => {
+        expect(actualHeaders['Authorization']).to.exist
+        expect(actualHeaders['Authorization']).to.equal('12345')
       })
     })
   })

--- a/packages/lib-panoptes-js/src/resources/tutorials/rest.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/rest.js
@@ -10,19 +10,18 @@ function get (params) {
   const queryParams = (params && params.query) ? params.query : {}
   const tutorialId = (params && params.id) ? params.id : ''
   const workflowId = (params && params.workflowId) ? params.workflowId : ''
+  const authorization = (params && params.authorization) ? params.authorization : ''
 
   if (isParamTypeInvalid(tutorialId, 'string')) return raiseError('Tutorials: Get request id must be a string.', 'typeError')
   if (isParamTypeInvalid(workflowId, 'string')) return raiseError('Tutorials: Get request workflow id must be a string.', 'typeError')
 
   if (tutorialId) {
-    delete queryParams.id
-    return panoptes.get(`${endpoint}/${tutorialId}`, queryParams)
+    return panoptes.get(`${endpoint}/${tutorialId}`, queryParams, authorization)
   }
 
   if (workflowId) {
     queryParams.workflow_id = workflowId
-    delete queryParams.workflowId
-    return panoptes.get(endpoint, queryParams)
+    return panoptes.get(endpoint, queryParams, authorization)
   }
 
   return raiseError('Tutorials: Get request must include a workflow id or a tutorial id.', 'error')

--- a/packages/lib-panoptes-js/src/resources/tutorials/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/rest.spec.js
@@ -9,15 +9,17 @@ const tutorials = require('./index')
 describe('Tutorials resource REST requests', function () {
   describe('get', function () {
     let superagentMock
+    let actualHeaders
     const expectedGetAllResponse = responses.get.tutorials
     const expectedGetSingleResponse = responses.get.tutorial
     const queryNotFound = responses.get.queryNotFound
 
-    describe('many tutorials', function () {
+    describe('by workflow id', function () {
       before(function () {
         superagentMock = mockSuperagent(superagent, [{
           pattern: `${config.host}${endpoint}`,
           fixtures: (match, params, headers, context) => {
+            actualHeaders = headers
             if (match.input.includes('?workflow_id=10')) return expectedGetAllResponse
 
             return queryNotFound
@@ -49,13 +51,22 @@ describe('Tutorials resource REST requests', function () {
           expect(response.body).to.eql(expectedGetAllResponse)
         })
       })
+
+      it('should add the Authorization header to the request if param is defined', function () {
+        return tutorials.get({ workflowId: '1', authorization: '12345' }).then((response) => {
+          expect(actualHeaders['Authorization']).to.exist
+          expect(actualHeaders['Authorization']).to.equal('12345')
+        })
+      })
     })
 
-    describe('a single tutorial', function () {
+    describe('by tutorial id', function () {
+      let actualHeaders
       before(function () {
         superagentMock = mockSuperagent(superagent, [{
           pattern: `${config.host}${endpoint}`,
           fixtures: (match, params, headers, context) => {
+            actualHeaders = headers
             if (match.input.includes(expectedGetSingleResponse.tutorials[0].id)) return expectedGetSingleResponse
 
             return { status: 404 }
@@ -85,6 +96,13 @@ describe('Tutorials resource REST requests', function () {
       it('should return the expected response', function () {
         return tutorials.get({ id: '1' }).then((response) => {
           expect(response.body).to.eql(expectedGetSingleResponse)
+        })
+      })
+
+      it('should add the Authorization header to the request if param is defined', function () {
+        return tutorials.get({ id: '1', authorization: '12345' }).then((response) => {
+          expect(actualHeaders['Authorization']).to.exist
+          expect(actualHeaders['Authorization']).to.equal('12345')
         })
       })
     })


### PR DESCRIPTION
Package: lib-panoptes-js

Describe your changes:
Adds an `authentication` parameter to the various requests in anticipation of the auth clients. When defined, it'll add the `Authentication` header. I also fixed the projects' common requests helpers to be consistent with the other requests' expected parameters so that the API is consistent. 

As always, WIP because docs need updating.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [x] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

