### PR TITLE
Add jenkinsfile for tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/.next
+**/build
+**/dist
+**/node_modules
+**/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:8
+
+RUN mkdir -p /usr/src
+WORKDIR /usr/src/
+COPY . /usr/src/
+
+RUN npm i -g lerna
+RUN lerna link
+RUN lerna bootstrap

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,3 @@ RUN npm i -g lerna
 RUN mkdir -p /usr/src
 WORKDIR /usr/src/
 COPY . /usr/src/
-
-RUN lerna link
-RUN lerna bootstrap --no-ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM node:8
 
+RUN npm i -g lerna
+
 RUN mkdir -p /usr/src
 WORKDIR /usr/src/
 COPY . /usr/src/
 
-RUN npm i -g lerna
 RUN lerna link
 RUN lerna bootstrap

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /usr/src/
 COPY . /usr/src/
 
 RUN lerna link
-RUN lerna bootstrap
+RUN lerna bootstrap --no-ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,18 @@ RUN npm i -g lerna
 
 RUN mkdir -p /usr/src
 WORKDIR /usr/src/
-COPY . /usr/src/
+
+COPY package*.json lerna.json ./
+
+COPY packages/app-project/package*.json ./packages/app-project/
+COPY packages/lib-async-states/package*.json ./packages/lib-async-states/
+COPY packages/lib-auth/package*.json ./packages/lib-auth/
+COPY packages/lib-classifier/package*.json ./packages/lib-classifier/
+COPY packages/lib-grommet-theme/package*.json ./packages/lib-grommet-theme/
+COPY packages/lib-panoptes-js/package*.json ./packages/lib-panoptes-js/
+COPY packages/lib-react-components/package*.json ./packages/lib-react-components/
+
+RUN lerna link
+RUN lerna bootstrap
+
+COPY ./ .

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node {
 
   stage('Deploy') {
     newImage.inside {
-      sh 'lerna run test'
+      sh 'lerna run --no-bail test'
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ node {
   stage('Test') {
     newImage.inside {
       sh '''
-        lerna run build
+        lerna run build --scope="@zooniverse/react-components"
         lerna run --stream test
       '''
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node {
 
   stage('Deploy') {
     newImage.inside {
-      sh 'lerna run --no-bail test'
+      sh 'lerna run --no-bail --stream test'
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,19 @@
+#!groovy
+
+node {
+  checkout scm
+
+  def dockerRepoName = 'zooniverse/front-end-monorepo'
+  def dockerImageName = "${dockerRepoName}:${env.BUILD_ID}"
+  def newImage = null
+
+  stage('Build Docker image') {
+    newImage = docker.build(dockerImageName)
+  }
+
+  stage('Deploy') {
+    newImage.inside {
+      sh 'lerna run test'
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,11 +9,17 @@ node {
 
   stage('Build Docker image') {
     newImage = docker.build(dockerImageName)
+    newImage.inside {
+      sh '''
+        lerna link
+        lerna bootstrap --no-ci
+      '''
+    }
   }
 
   stage('Deploy') {
     newImage.inside {
-      sh 'lerna run --no-bail --stream test'
+      sh 'lerna run --stream test'
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,17 +9,14 @@ node {
 
   stage('Build Docker image') {
     newImage = docker.build(dockerImageName)
-    newImage.inside {
-      sh '''
-        lerna link
-        lerna bootstrap --no-ci
-      '''
-    }
   }
 
-  stage('Deploy') {
+  stage('Test') {
     newImage.inside {
-      sh 'lerna run --stream test'
+      sh '''
+        lerna run build
+        lerna run --stream test
+      '''
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Zooniverse Front-End Monorepo
 
+[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
+
 ## Requirements
 
 [Browser support](docs/arch/adr-3.md)


### PR DESCRIPTION
Package: all

This adds a basic `Jenkinsfile` for running tests. Currently, it's naive - it creates a Docker image, installs the dependencies, then runs tests for all packages. This is because none of these packages have been published yet - once that's set up, we can start using `lerna changed` etc.

TODO:

- Only run tests for changed packages
- Publish changed packages