### PR TITLE
Fix a couple of errors in plop component generator

### DIFF
--- a/plop/generators/component.js
+++ b/plop/generators/component.js
@@ -30,22 +30,26 @@ module.exports = function (plop) {
         {
           type: 'add',
           templateFile: 'plop/templates/component/locales/en.json.hbs',
-          path: render('{{ path }}/locales/en.json', data)
+          path: render('{{ path }}/locales/en.json', data),
+          data
         },
         {
           type: 'add',
           templateFile: 'plop/templates/component/Component.js.hbs',
-          path: render('{{ path }}/{{ component }}.js', data)
+          path: render('{{ path }}/{{ component }}.js', data),
+          data
         },
         {
           type: 'add',
           templateFile: 'plop/templates/component/Test.js.hbs',
-          path: render('{{ path }}/{{ component }}.spec.js', data)
+          path: render('{{ path }}/{{ component }}.spec.js', data),
+          data
         },
         {
           type: 'add',
           templateFile: 'plop/templates/component/index.js.hbs',
-          path: render('{{ path }}/index.js', data)
+          path: render('{{ path }}/index.js', data),
+          data
         }
       ]
 
@@ -54,12 +58,14 @@ module.exports = function (plop) {
           {
             type: 'add',
             templateFile: 'plop/templates/component/Container.js.hbs',
-            path: render('{{ path }}/{{ container }}.js', data)
+            path: render('{{ path }}/{{ container }}.js', data),
+            data
           },
           {
             type: 'add',
             templateFile: 'plop/templates/component/Test.js.hbs',
-            path: render('{{ path }}/{{ container }}.spec.js', data)
+            path: render('{{ path }}/{{ container }}.spec.js', data),
+            data
           }
         )
       }

--- a/plop/generators/component.js
+++ b/plop/generators/component.js
@@ -44,8 +44,8 @@ module.exports = function (plop) {
         },
         {
           type: 'add',
-          templateFile: 'plop/templates/component/Index.js.hbs',
-          path: render('{{ path }}/Index.js', data)
+          templateFile: 'plop/templates/component/index.js.hbs',
+          path: render('{{ path }}/index.js', data)
         }
       ]
 

--- a/plop/plopfile.js
+++ b/plop/plopfile.js
@@ -3,6 +3,6 @@ const componentGenerator = require('./generators/component')
 
 module.exports = function (plop) {
   plop.addHelper('cwd', p => process.cwd())
-  plop.setGenerator('App', appGenerator(plop))
   plop.setGenerator('Component', componentGenerator(plop))
+  plop.setGenerator('App', appGenerator(plop))
 }


### PR DESCRIPTION
Fixes an error where the entryPoint wasn't being correctly set, and fixes the case of the `index.js` file for new components.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

