### PR TITLE
Use `nock` instead of `superagent-mock`

### DIFF
--- a/packages/lib-panoptes-js/package-lock.json
+++ b/packages/lib-panoptes-js/package-lock.json
@@ -722,6 +722,12 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -2382,6 +2388,40 @@
         "text-encoding": "^0.6.4"
       }
     },
+    "nock": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.1.tgz",
+      "integrity": "sha512-M0aL9IDbUFURmokoXqejZQybZk8EtlYjUBjaoICVbW62uOlyPRsnEsceyOlUik4spCOt50ptwM4BTPt20ITtcQ==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -2783,6 +2823,12 @@
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -3465,12 +3511,6 @@
         "qs": "^6.5.1",
         "readable-stream": "^2.3.5"
       }
-    },
-    "superagent-mock": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/superagent-mock/-/superagent-mock-3.7.0.tgz",
-      "integrity": "sha512-+vWnpMgRw4X0tlN2c4SPbhoVG4RSdYdErJ4AiwCK0r2XqGbHvVNbpZlY0RBfzOy6F5eN5Q1+d1sncmakxnjbiQ==",
-      "dev": true
     },
     "supports-color": {
       "version": "4.4.0",

--- a/packages/lib-panoptes-js/package.json
+++ b/packages/lib-panoptes-js/package.json
@@ -1,15 +1,16 @@
 {
   "name": "@zooniverse/panoptes-js",
-  "version": "0.1.0",
   "description": "A Javascript client for Panoptes API using Superagent",
+  "license": "Apache-2.0",
+  "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
+  "repository": "github:zooniverse/front-end-monorepo",
+  "version": "0.1.0",
   "main": "src/index.js",
   "scripts": {
     "_check": "check-engines && check-dependencies",
     "lint": "npm run _check && standard --env mocha --fix | snazzy; exit 0",
     "test": "npm run _check && NODE_ENV=test mocha"
   },
-  "author": "",
-  "license": "Apache-2.0",
   "dependencies": {
     "check-dependencies": "^1.1.0",
     "check-engines": "^1.5.0",
@@ -21,12 +22,17 @@
     "jsdom": "^11.10.0",
     "mocha": "^5.1.1",
     "mock-local-storage": "^1.0.5",
+    "nock": "^10.0.1",
     "sinon": "^6.0.0",
     "snazzy": "^7.1.1",
-    "standard": "^11.0.1",
-    "superagent-mock": "^3.7.0"
+    "standard": "^11.0.1"
   },
   "engines": {
     "node": ">=8"
+  },
+  "standard": {
+    "env": {
+      "mocha": true
+    }
   }
 }

--- a/packages/lib-panoptes-js/src/panoptes.spec.js
+++ b/packages/lib-panoptes-js/src/panoptes.spec.js
@@ -109,7 +109,6 @@ describe('panoptes.js', function () {
     testNoEndpoint('put')
 
     it('should send any data params if defined', async function () {
-      const params = { display_name: 'My project' }
       const response = await panoptes.put(endpoint, update)
       expect(response.body).to.deep.equal(expectedResponse)
     })

--- a/packages/lib-panoptes-js/src/panoptes.spec.js
+++ b/packages/lib-panoptes-js/src/panoptes.spec.js
@@ -1,82 +1,41 @@
 const { expect } = require('chai')
-const superagent = require('superagent')
-const mockSuperagent = require('superagent-mock')
+const nock = require('nock')
+
 const { config } = require('./config')
 const panoptes = require('./panoptes')
 
 describe('panoptes.js', function () {
+  let scope
+
   describe('get', function () {
-    let superagentMock
-    let actualMatch
-    let actualHeaders
     const endpoint = '/projects'
     const expectedResponse = { id: '2' }
+
     before(function () {
-      superagentMock = mockSuperagent(superagent, [{
-        pattern: endpoint,
-        fixtures: (match, params, header, context) => {
-          actualMatch = match
-          actualHeaders = header
-          return expectedResponse
-        },
-        get: (match, data) => ({ body: data })
-      }])
+      scope = nock(config.host)
+        .persist()
+        .get(uri => uri.includes(endpoint))
+        .query(true)
+        .reply(200, expectedResponse)
     })
 
     after(function () {
-      superagentMock.unset()
+      nock.cleanAll()
     })
 
-    it('should return the expected response', async function () {
-      const response = await panoptes.get(endpoint)
-      expect(response).to.deep.equal({ body: expectedResponse })
-    })
-
-    it('should use the host from the function call if defined', async function () {
-      const mockAPIHost = 'https://my-api.com'
-      const response = await panoptes.get(endpoint, null, null, mockAPIHost)
-      expect(actualMatch.input.includes(mockAPIHost)).to.be.true
-    })
-
-    it('should use the host defined in the config if a host parameter isn\'t defined', async function () {
-      await panoptes.get(endpoint)
-      expect(actualMatch.input.includes(config.host)).to.be.true
-    })
-
-    it('should add Content-Type header to the request', async function () {
-      await panoptes.get(endpoint)
-      expect(actualHeaders['Content-Type']).to.exist
-      expect(actualHeaders['Content-Type']).to.equal('application/json')
-    })
-
-    it('should add Accept header to the request', async function () {
-      await panoptes.get(endpoint)
-      expect(actualHeaders['Accept']).to.exist
-      expect(actualHeaders['Accept']).to.equal('application/vnd.api+json; version=1')
-    })
-
-    it('should add the Authorization header to the request if param is defined', async function () {
-      await panoptes.get(endpoint, null, '12345')
-      expect(actualHeaders['Authorization']).to.exist
-      expect(actualHeaders['Authorization']).to.equal('12345')
-    })
-
-    it('should add the http_cache default query params to the request', async function () {
-      await panoptes.get(endpoint)
-      expect(actualMatch.input.includes('?http_cache=true')).to.be.true
-    })
-
-    it('should add the admin default query param if flag is found in local storage', async function () {
-      localStorage.setItem('adminFlag', true)
-
-      await panoptes.get(endpoint)
-      expect(actualMatch.input.includes('?admin=true')).to.be.true
-      localStorage.removeItem('adminFlag')
-    })
+    testExpectedResponse('get', endpoint, expectedResponse)
+    testHostArg('get', endpoint, expectedResponse)
+    testConfigHost('get', endpoint)
+    testContentTypeHeader('get', endpoint)
+    testAcceptHeader('get', endpoint)
+    testAuthHeader('get', endpoint)
+    testHttpCache('get', endpoint)
+    testAdminParam('get', endpoint)
+    testNoEndpoint('get')
 
     it('should add the query object to the URL if defined', async function () {
-      await panoptes.get(endpoint, { page: '2', page_size: '30' })
-      expect(actualMatch.input.includes('?page=2&page_size=30')).to.be.true
+      const response = await panoptes.get(endpoint, { page: '2', page_size: '30' })
+      expect(response.req.path.includes('?page=2&page_size=30')).to.be.true
     })
 
     it('should error if query params are defined but are not an object', async function () {
@@ -87,267 +46,189 @@ describe('panoptes.js', function () {
         expect(error.message).to.equal('Query must be an object')
       }
     })
-
-    it('should error if request is called without a defined resource endpoint', async function () {
-      try {
-        await panoptes.get()
-        expect.fail()
-      } catch (error) {
-        expect(error.message).to.equal('Request needs a defined resource endpoint')
-      }
-    })
   })
 
   describe('post', function () {
-    let superagentMock
-    let actualMatch
-    let actualParams
-    let actualHeaders
     const endpoint = '/projects'
     const expectedResponse = { id: '3' }
+
     before(function () {
-      superagentMock = mockSuperagent(superagent, [{
-        pattern: endpoint,
-        fixtures: (match, params, header, context) => {
-          actualMatch = match
-          actualParams = params
-          actualHeaders = header
-          return expectedResponse
-        },
-        post: (match, data) => ({ body: data })
-      }])
+      scope = nock(config.host)
+        .persist()
+        .post(uri => uri.includes(endpoint))
+        .query(true)
+        .reply(200, expectedResponse)
     })
 
     after(function () {
-      superagentMock.unset()
+      nock.cleanAll()
     })
 
-    it('should return the expected response', async function () {
-      const response = await panoptes.post(endpoint)
-      expect(response).to.deep.equal({ body: expectedResponse })
-    })
-
-    it('should use the host from the function call if defined', async function () {
-      const mockAPIHost = 'https://my-api.com'
-      const response = panoptes.post(endpoint, null, null, mockAPIHost)
-      expect(actualMatch.input.includes(mockAPIHost)).to.be.true
-    })
-
-    it('should use the host defined in the config if a host parameter isn\'t defined', async function () {
-      await panoptes.post(endpoint)
-      expect(actualMatch.input.includes(config.host)).to.be.true
-    })
-
-    it('should add Content-Type header to the request', async function () {
-      await panoptes.post(endpoint)
-      expect(actualHeaders['Content-Type']).to.exist
-      expect(actualHeaders['Content-Type']).to.equal('application/json')
-    })
-
-    it('should add Accept header to the request', async function () {
-      await panoptes.post(endpoint)
-      expect(actualHeaders['Accept']).to.exist
-      expect(actualHeaders['Accept']).to.equal('application/vnd.api+json; version=1')
-    })
-
-    it('should add the Authorization header to the request if param is defined', async function () {
-      await panoptes.post(endpoint, null, '12345')
-      expect(actualHeaders['Authorization']).to.exist
-      expect(actualHeaders['Authorization']).to.equal('12345')
-    })
-
-    it('should add the http_cache default query params to the request', async function () {
-      await panoptes.post(endpoint)
-      expect(actualMatch.input.includes('?http_cache=true')).to.be.true
-    })
-
-    it('should add the admin default query param if flag is found in local storage', async function () {
-      localStorage.setItem('adminFlag', true)
-
-      await panoptes.post(endpoint)
-      expect(actualMatch.input.includes('?admin=true')).to.be.true
-      localStorage.removeItem('adminFlag')
-    })
+    testExpectedResponse('post', endpoint, expectedResponse)
+    testHostArg('post', endpoint, expectedResponse)
+    testConfigHost('post', endpoint)
+    testContentTypeHeader('post', endpoint)
+    testAcceptHeader('post', endpoint)
+    testAuthHeader('post', endpoint)
+    testHttpCache('post', endpoint)
+    testAdminParam('post', endpoint)
+    testNoEndpoint('post')
 
     it('should send any data params if defined', async function () {
       const params = { display_name: 'My project' }
-      await panoptes.post(endpoint, params)
-      expect(actualParams).to.deep.equal(params)
-    })
-
-    it('should error if request is called without a defined resource endpoint', async function () {
-      try {
-        await panoptes.post()
-        expect.fail()
-      } catch (error) {
-        expect(error.message).to.equal('Request needs a defined resource endpoint')
-      }
+      const response = await panoptes.post(endpoint, params)
+      expect(response.request._data).to.deep.equal(params)
     })
   })
 
   describe('put', function () {
-    let superagentMock
-    let actualMatch
-    let actualParams
-    let actualHeaders
     const endpoint = '/projects/2'
     const update = { display_name: 'My project' }
     const expectedResponse = { id: '3', display_name: 'My project' }
+
     before(function () {
-      superagentMock = mockSuperagent(superagent, [{
-        pattern: '/projects/(\\d+)',
-        fixtures: (match, params, header, context) => {
-          actualMatch = match
-          actualParams = params
-          actualHeaders = header
-          return expectedResponse
-        },
-        put: (match, data) => ({ body: data })
-      }])
+      scope = nock(config.host)
+        .persist()
+        .put(uri => uri.includes(endpoint))
+        .query(true)
+        .reply(200, expectedResponse)
     })
 
     after(function () {
-      superagentMock.unset()
+      nock.cleanAll()
     })
 
-    it('should return the expected response', async function () {
-      const response = await panoptes.put(endpoint, update)
-      expect(response).to.deep.equal({ body: expectedResponse })
-    })
-
-    it('should use the host from the function call if defined', async function () {
-      const mockAPIHost = 'https://my-api.com'
-      await panoptes.put(endpoint, update, null, mockAPIHost)
-      expect(actualMatch.input.includes(mockAPIHost)).to.be.true
-    })
-
-    it('should use the host defined in the config if a host parameter isn\'t defined', async function () {
-      await panoptes.put(endpoint, update)
-      expect(actualMatch.input.includes(config.host)).to.be.true
-    })
-
-    it('should add Content-Type header to the request', async function () {
-      await panoptes.put(endpoint, update)
-      expect(actualHeaders['Content-Type']).to.exist
-      expect(actualHeaders['Content-Type']).to.equal('application/json')
-    })
-
-    it('should add Accept header to the request', async function () {
-      await panoptes.put(endpoint, update)
-      expect(actualHeaders['Accept']).to.exist
-      expect(actualHeaders['Accept']).to.equal('application/vnd.api+json; version=1')
-    })
-
-    it('should add the Authorization header to the request if param is defined', async function () {
-      await panoptes.put(endpoint, update, '12345')
-      expect(actualHeaders['Authorization']).to.exist
-      expect(actualHeaders['Authorization']).to.equal('12345')
-    })
-
-    it('should add the http_cache default query params to the request', async function () {
-      await panoptes.put(endpoint, update)
-      expect(actualMatch.input.includes('?http_cache=true')).to.be.true
-    })
-
-    it('should add the admin default query param if flag is found in local storage', async function () {
-      localStorage.setItem('adminFlag', true)
-
-      await panoptes.put(endpoint, update)
-      expect(actualMatch.input.includes('?admin=true')).to.be.true
-      localStorage.removeItem('adminFlag')
-    })
+    testExpectedResponse('put', endpoint, expectedResponse, update)
+    testHostArg('put', endpoint, expectedResponse, update)
+    testConfigHost('put', endpoint, update)
+    testContentTypeHeader('put', endpoint, update)
+    testAcceptHeader('put', endpoint, update)
+    testAuthHeader('put', endpoint, update)
+    testHttpCache('put', endpoint, update)
+    testAdminParam('put', endpoint, update)
+    testNoEndpoint('put')
 
     it('should send any data params if defined', async function () {
-      await panoptes.put(endpoint, update)
-      expect(actualParams).to.deep.equal(update)
-    })
-
-    it('should error if request is called without a defined resource endpoint', async function () {
-      try {
-        await panoptes.put()
-        expect.fail()
-      } catch (error) {
-        expect(error.message).to.equal('Request needs a defined resource endpoint')
-      }
+      const params = { display_name: 'My project' }
+      const response = await panoptes.put(endpoint, update)
+      expect(response.body).to.deep.equal(expectedResponse)
     })
   })
 
   describe('delete', function () {
-    let superagentMock
-    let actualMatch
-    let actualHeaders
     const endpoint = '/projects'
     const expectedResponse = { status: 204 }
+
     before(function () {
-      superagentMock = mockSuperagent(superagent, [{
-        pattern: endpoint,
-        fixtures: (match, params, header, context) => {
-          actualMatch = match
-          actualHeaders = header
-          return expectedResponse
-        },
-        delete: (match, data) => { return data }
-      }])
+      scope = nock(config.host)
+        .persist()
+        .delete(uri => uri.includes(endpoint))
+        .query(true)
+        .reply(204, { status: 204 })
     })
 
     after(function () {
-      superagentMock.unset()
+      nock.cleanAll()
     })
 
+    testExpectedResponse('del', endpoint, expectedResponse)
+    testHostArg('del', endpoint, expectedResponse)
+    testConfigHost('del', endpoint)
+    testContentTypeHeader('del', endpoint)
+    testAcceptHeader('del', endpoint)
+    testAuthHeader('del', endpoint)
+    testHttpCache('del', endpoint)
+    testAdminParam('del', endpoint)
+    testNoEndpoint('del')
+  })
+
+  function testExpectedResponse (method, endpoint, expectedResponse, update = null) {
     it('should return the expected response', async function () {
-      const response = await panoptes.del(endpoint)
-      expect(response).to.equal(expectedResponse)
+      const response = await panoptes[method](endpoint, update)
+      expect(response.body).to.deep.equal(expectedResponse)
     })
+  }
 
+  function testHostArg (method, endpoint, expectedResponse, update = null) {
     it('should use the host from the function call if defined', async function () {
       const mockAPIHost = 'https://my-api.com'
-      await panoptes.del(endpoint, null, mockAPIHost)
-      expect(actualMatch.input.includes(mockAPIHost)).to.be.true
-    })
 
+      const isDel = method === 'del'
+      // Nock calls it 'delete', panoptes-js calls it 'del'
+      const nockMethod = isDel ? 'delete' : method
+      // There is one less argument for `del`, so to set the correct order we
+      // `apply` an array of arguments
+      const methodArgs = isDel
+        ? [endpoint, null, mockAPIHost]
+        : [endpoint, update, null, mockAPIHost]
+
+      const mockAPIHostScope = nock(mockAPIHost)
+        [nockMethod](uri => uri.includes(endpoint))
+        .query(true)
+        .reply(200, expectedResponse)
+
+      const response = await panoptes[method].apply(this, methodArgs)
+      expect(response.request.url.includes(mockAPIHost)).to.be.true
+    })
+  }
+
+  function testConfigHost (method, endpoint, update = null) {
     it('should use the host defined in the config if a host parameter isn\'t defined', async function () {
-      await panoptes.del(endpoint)
-      expect(actualMatch.input.includes(config.host)).to.be.true
+      const response = await panoptes[method](endpoint, update)
+      expect(response.request.url.includes(config.host)).to.be.true
     })
+  }
 
-    it('should add Content-Type header to the request', async function () {
-      await panoptes.del(endpoint)
-      expect(actualHeaders['Content-Type']).to.exist
-      expect(actualHeaders['Content-Type']).to.equal('application/json')
+  function testContentTypeHeader (method, endpoint, update = null) {
+    it('should add the `Content-Type` header to the request', async function () {
+      const response = await panoptes[method](endpoint, update)
+      expect(response.req.headers['content-type']).to.equal('application/json')
     })
+  }
 
-    it('should add Accept header to the request', async function () {
-      await panoptes.del(endpoint)
-      expect(actualHeaders['Accept']).to.exist
-      expect(actualHeaders['Accept']).to.equal('application/vnd.api+json; version=1')
+  function testAcceptHeader (method, endpoint, update = null) {
+    it('should add the `Accept` header to the request', async function () {
+      const response = await panoptes[method](endpoint, update)
+      expect(response.req.headers['accept']).to.equal('application/vnd.api+json; version=1')
     })
+  }
 
-    it('should add the Authorization header to the request if param is defined', async function () {
-      await panoptes.del(endpoint, '12345')
-      expect(actualHeaders['Authorization']).to.exist
-      expect(actualHeaders['Authorization']).to.equal('12345')
+  function testAuthHeader (method, endpoint, update = null) {
+    it('should add the `Authorization` header to the request if param is defined', async function () {
+      const isDel = method === 'del'
+      const methodArgs = isDel
+        ? [endpoint, '12345']
+        : [endpoint, update, '12345']
+
+      const response = await panoptes[method].apply(this, methodArgs)
+      expect(response.req.headers['authorization']).to.equal('12345')
     })
+  }
 
+  function testHttpCache (method, endpoint, update = null) {
     it('should add the http_cache default query params to the request', async function () {
-      await panoptes.del(endpoint)
-      expect(actualMatch.input.includes('?http_cache=true')).to.be.true
+      const response = await panoptes[method](endpoint, update)
+      expect(response.req.path.includes('?http_cache=true')).to.be.true
     })
+  }
 
+  function testAdminParam (method, endpoint, update = null) {
     it('should add the admin default query param if flag is found in local storage', async function () {
       localStorage.setItem('adminFlag', true)
-
-      await panoptes.del(endpoint)
-      expect(actualMatch.input.includes('?admin=true')).to.be.true
+      const response = await panoptes[method](endpoint, update)
+      expect(response.req.path.includes('?admin=true')).to.be.true
       localStorage.removeItem('adminFlag')
     })
+  }
 
+  function testNoEndpoint (method) {
     it('should error if request is called without a defined resource endpoint', async function () {
       try {
-        await panoptes.del()
+        await panoptes[method]()
         expect.fail()
       } catch (error) {
         expect(error.message).to.equal('Request needs a defined resource endpoint')
       }
     })
-  })
+  }
 })

--- a/packages/lib-panoptes-js/src/resources/projects/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/projects/commonRequests.spec.js
@@ -1,6 +1,5 @@
 const { expect } = require('chai')
-const superagent = require('superagent')
-const mockSuperagent = require('superagent-mock')
+const nock = require('nock')
 
 const projects = require('./index')
 const { endpoint } = require('./helpers')
@@ -8,176 +7,181 @@ const { config } = require('../../config')
 const { resources, responses } = require('./mocks')
 
 describe('Projects resource common requests', function () {
+  let scope
+
   describe('getBySlug', function () {
-    let superagentMock
-    let actualHeaders
     const expectedGetResponse = responses.get.project
     const expectedNotFoundResponse = responses.get.queryNotFound
 
     before(function () {
-      superagentMock = mockSuperagent(superagent, [{
-        pattern: `${config.host}${endpoint}`,
-        fixtures: (match, params, headers) => {
-          actualHeaders = headers
-          const [mockOwner, mockProjectName] = resources.projectOne.slug.split('/')
-          const matchSlug = `${mockOwner}%2F${mockProjectName}`
-
-          if (match.input.includes(matchSlug)) return expectedGetResponse
-
-          return expectedNotFoundResponse
-        },
-        get: (match, data) => ({ body: data })
-      }])
+      scope = nock(config.host)
+        .persist()
+        .get(uri => uri.includes(endpoint))
+        .query(true)
+        .reply(200, (uri, requestBody) =>
+          uri.includes(encodeURIComponent('zooniverse/my-project'))
+            ? expectedNotFoundResponse
+            : expectedGetResponse
+        )
     })
 
     after(function () {
-      superagentMock.unset()
+      nock.cleanAll()
     })
 
-    it('should error if slug param is not a string', function () {
-      return projects.getBySlug({ query: { slug: 1234 }}).catch((error) => {
+    it('should error if slug param is not a string', async function () {
+      try {
+        await projects.getBySlug({ query: { slug: 1234 }})
+        expect.fail()
+      } catch (error) {
         expect(error.message).to.equal('Projects: Get request slug must be a string.')
-      })
+      }
     })
 
-    it('should return the expected response if not found', function () {
-      return projects.getBySlug({ query: { slug: 'zooniverse/my-project' }}).then((response) => {
-        expect(response).to.eql({ body: expectedNotFoundResponse })
-      })
+    it('should return the expected response if not found', async function () {
+      const response = await projects.getBySlug({ query: { slug: 'zooniverse/my-project' }})
+      expect(response.body).to.eql(expectedNotFoundResponse)
     })
 
-    it('should error if slug param is not defined', function () {
-      return projects.getBySlug().catch((error) => {
+    it('should error if slug param is not defined', async function () {
+      try {
+        await projects.getBySlug()
+        expect.fail()
+      } catch (error) {
         expect(error.message).to.equal('Projects: Get by slug request missing required parameter: slug string.')
-      })
+      }
     })
 
-    it('should return the expected response if the slug is defined', function () {
+    it('should return the expected response if the slug is defined', async function () {
       const slug = 'user/untitled-project-2'
-      return projects.getBySlug({ query: { slug }}).then((response) => {
-        expect(response).to.eql({ body: expectedGetResponse })
-      })
+      const response = await projects.getBySlug({ query: { slug }})
+      expect(response.body).to.eql(expectedGetResponse)
     })
 
-    it('should return the expected response if the slug is defined including "projects" in the pathname', function () {
+    it('should return the expected response if the slug is defined including "projects" in the pathname', async function () {
       const slug = 'projects/user/untitled-project-2'
-      return projects.getBySlug({ query: { slug }}).then((response) => {
-        expect(response).to.eql({ body: expectedGetResponse })
-      })
+      const response = await projects.getBySlug({ query: { slug }})
+      expect(response.body).to.eql(expectedGetResponse)
     })
 
-    it('should add the Authorization header to the request if param is defined', function () {
-      return projects.getBySlug({ authorization: '12345', query: { slug: 'zooniverse/my-project' } }).then((response) => {
-        expect(actualHeaders['Authorization']).to.exist
-        expect(actualHeaders['Authorization']).to.equal('12345')
-      })
+    it('should add the Authorization header to the request if param is defined', async function () {
+      const response = await projects.getBySlug({ authorization: '12345', query: { slug: 'zooniverse/my-project' } })
+      expect(response.req.headers.authorization).to.equal('12345')
     })
   })
 
   describe('getWithLinkedResources', function () {
-    let superagentMock
-    let actualHeaders
     const expectedGetResponseWithLinkedResources = responses.get.projectWithLinkedResources
     const expectedNotFoundResponse = responses.get.queryNotFound
 
+    before(function () {
+      scope = nock(config.host)
+        .persist()
+        .get(uri => uri.includes(endpoint))
+        .query(true)
+        .reply(200, expectedGetResponseWithLinkedResources)
+    })
+
     after(function () {
-      superagentMock.unset()
+      nock.cleanAll()
     })
 
-    it('should error if neither a slug or id is defined in query parameters', function () {
-      superagentMock = mockSuperagent(superagent, [{
-        pattern: `${config.host}${endpoint}`,
-        fixtures: (match, params, headers) => {
-          actualHeaders = headers
-          return expectedGetResponseWithLinkedResources
-        },
-        get: (match, data) => ({ body: data })
-      }])
-
-      return projects.getWithLinkedResources().catch((error) => {
+    it('should error if neither a slug or id is defined in query parameters', async function () {
+      try {
+        await projects.getWithLinkedResources()
+        expect.fail()
+      } catch (error) {
         expect(error.message).to.equal('Projects: Get request must have either project id or slug.')
-      })
+      }
     })
 
-    it('should add the Authorization header to the request if param is defined', function () {
-      return projects.getWithLinkedResources({ id: '2', authorization: '12345' }).then((response) => {
-        expect(actualHeaders['Authorization']).to.exist
-        expect(actualHeaders['Authorization']).to.equal('12345')
-      })
+    it('should add the Authorization header to the request if param is defined', async function () {
+      const response = await projects.getWithLinkedResources({ id: '2', authorization: '12345' })
+      expect(response.req.headers.authorization).to.equal('12345')
     })
 
     describe('using project slug query parameter', function () {
       before(function () {
-        superagentMock = mockSuperagent(superagent, [{
-          pattern: `${config.host}${endpoint}`,
-          fixtures: (match, params, headers) => {
-            const [mockOwner, mockProjectName] = expectedGetResponseWithLinkedResources.projects[0].slug.split('/')
-            const matchSlug = `${mockOwner}%2F${mockProjectName}`
-
-            if (match.input.includes(matchSlug)) return expectedGetResponseWithLinkedResources
-            return expectedNotFoundResponse
-          },
-          get: (match, data) => ({ body: data })
-        }])
+        scope = nock(config.host)
+          .persist()
+          .get(uri => uri.includes(endpoint))
+          .query(true)
+          .reply(200, expectedGetResponseWithLinkedResources)
       })
 
-      it('should error if slug is not a string', function () {
-        return projects.getWithLinkedResources({ query: { slug: 1234 }}).catch((error) => {
+      after(function () {
+        nock.cleanAll()
+      })
+
+      it('should error if slug is not a string', async function () {
+        try {
+          await projects.getWithLinkedResources({ query: { slug: 1234 }})
+          expect.fail()
+        } catch (error) {
           expect(error.message).to.equal('Projects: Get request slug must be a string.')
-        })
+        }
       })
 
-      it('should error if the slug is not defined', function () {
-        return projects.getWithLinkedResources().catch((error) => {
+      it('should error if the slug is not defined', async function () {
+        try {
+          await projects.getWithLinkedResources()
+          expect.fail()
+        } catch (error) {
           expect(error.message).to.equal('Projects: Get request must have either project id or slug.')
-        })
+        }
       })
 
-      it('should return the expected response', function () {
-        return projects.getWithLinkedResources({ query: { slug: 'user/untitled-project-2' }}).then((response) => {
-          expect(response).to.eql({ body: expectedGetResponseWithLinkedResources })
-        })
+      it('should return the expected response', async function () {
+        const response = await projects.getWithLinkedResources({ query: { slug: 'user/untitled-project-2' }})
+        expect(response.body).to.eql(expectedGetResponseWithLinkedResources)
       })
     })
 
     describe('using project id', function () {
       before(function () {
-        superagentMock = mockSuperagent(superagent, [{
-          pattern: `${config.host}${endpoint}/(\\d+)`,
-          fixtures: (match, params) => {
-            const projectID = expectedGetResponseWithLinkedResources.projects[0].id
-            const expectedQuery = 'include=avatar%2Cbackground%2Cowners%2Cpages&http_cache=true'
-            const [url, query] = match.input.split('?')
-
-            if (url.includes(projectID) && query === expectedQuery) return expectedGetResponseWithLinkedResources
-            return new Error(404)
-          },
-          get: (match, data) => ({ body: data })
-        }])
+        scope = nock(config.host)
+          .get(uri => uri.includes(endpoint))
+          .query(true)
+          .reply(200, expectedGetResponseWithLinkedResources)
+          .get(uri => uri.includes(endpoint))
+          .query(true)
+          .reply(404)
       })
 
-      it('should error if id is not a string', function () {
-        return projects.getWithLinkedResources({ id: 1234 }).catch((error) => {
+      after(function () {
+        nock.cleanAll()
+      })
+
+      it('should error if id is not a string', async function () {
+        try {
+          await projects.getWithLinkedResources({ id: 1234 })
+          expect.fail()
+        } catch (error) {
           expect(error.message).to.equal('Projects: Get request id must be a string.')
-        })
+        }
       })
 
-      it('should error if the id is not defined', function () {
-        return projects.getWithLinkedResources().catch((error) => {
+      it('should error if the id is not defined', async function () {
+        try {
+          await projects.getWithLinkedResources()
+          expect.fail()
+        } catch (error) {
           expect(error.message).to.equal('Projects: Get request must have either project id or slug.')
-        })
+        }
       })
 
-      it('should return the expected response', function () {
-        return projects.getWithLinkedResources({ id: '2' }).then((response) => {
-          expect(response).to.eql({ body: expectedGetResponseWithLinkedResources })
-        })
+      it('should return the expected response', async function () {
+        const response = await projects.getWithLinkedResources({ id: '2' })
+        expect(response.body).to.eql(expectedGetResponseWithLinkedResources)
       })
 
-      it('should return a 404 if project is not found', function () {
-        return projects.getWithLinkedResources({ id: '3' }).catch((error) => {
-          expect(error.message).to.equal(404)
-        })
+      it('should return a 404 if project is not found', async function () {
+        try {
+          await projects.getWithLinkedResources({ id: '3' })
+          expect.fail()
+        } catch (error) {
+          expect(error.status).to.equal(404)
+        }
       })
     })
   })

--- a/packages/lib-panoptes-js/src/resources/subjects/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/rest.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai')
-const superagent = require('superagent')
-const mockSuperagent = require('superagent-mock')
+const nock = require('nock')
+
 const { config } = require('../../config')
 const { resources, responses } = require('./mocks')
 const { endpoint } = require('./helpers')
@@ -8,51 +8,47 @@ const subjects = require('./index')
 
 describe('Subjects resource REST requests', function () {
   describe('get', function () {
-    let superagentMock
-    let actualHeaders
     const expectedGetResponse = responses.get.subject
-    before(function () {
-      superagentMock = mockSuperagent(superagent, [{
-        pattern: `${config.host}${endpoint}`,
-        fixtures: (match, params, headers, context) => {
-          actualHeaders = headers
-          if (match.input.includes(resources.subject.id)) return expectedGetResponse
+    let scope
 
-          return { status: 404 }
-        },
-        get: (match, data) => {
-          return { body: data }
-        }
-      }])
+    before(function () {
+      scope = nock(config.host)
+        .persist()
+        .get(uri => uri.includes(endpoint))
+        .query(true)
+        .reply(200, expectedGetResponse)
     })
 
     after(function () {
-      superagentMock.unset()
+      nock.cleanAll()
     })
 
-    it('should error if request does not have a subject id', function () {
-      subjects.get().catch((error) => {
+    it('should error if request does not have a subject id', async function () {
+      try {
+        await subjects.get()
+        expect.fail()
+      } catch (error) {
         expect(error.message).to.equal('Subjects: Get request must include a subject id.')
-      })
+      }
     })
 
-    it('should error if the subject id is not a string', function () {
-      subjects.get({ id: 1 }).catch((error) => {
+    it('should error if the subject id is not a string', async function () {
+      try {
+        await subjects.get({ id: 1 })
+        expect.fail()
+      } catch (error) {
         expect(error.message).to.equal('Subjects: Get request id must be a string.')
-      })
+      }
     })
 
-    it('should return the expected response', function () {
-      subjects.get({ id: '10' }).then((response) => {
-        expect(response.body).to.eql(expectedGetResponse)
-      })
+    it('should return the expected response', async function () {
+      const response = await subjects.get({ id: '10' })
+      expect(response.body).to.eql(expectedGetResponse)
     })
 
-    it('should add the Authorization header to the request if param is defined', function () {
-      return subjects.get({ id: '10', authorization: '12345' }).then((response) => {
-        expect(actualHeaders['Authorization']).to.exist
-        expect(actualHeaders['Authorization']).to.equal('12345')
-      })
+    it('should add the Authorization header to the request if param is defined', async function () {
+      const response = await subjects.get({ id: '10', authorization: '12345' })
+      expect(response.req.headers.authorization).to.equal('12345')
     })
   })
 })

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
@@ -35,7 +35,7 @@ function getTutorials (params) {
       // We allow the null value on kind for backwards compatibility
       // These are standard tutorials added prior to the 'kind' field and mini-courses
       response.body.tutorials = response.body.tutorials.filter((tutorial) => {
-        return tutorial.kind === 'tutorial' || null
+        return tutorial.kind === 'tutorial' || tutorial.kind === null
       })
 
       return response

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
@@ -1,6 +1,5 @@
 const { expect } = require('chai')
-const superagent = require('superagent')
-const mockSuperagent = require('superagent-mock')
+const nock = require('nock')
 
 const tutorials = require('./index')
 const { endpoint } = require('./helpers')
@@ -8,214 +7,182 @@ const { config } = require('../../config')
 const { resources, responses } = require('./mocks')
 
 describe('Tutorials resource common requests', function () {
+  let scope
+
   describe('getAttachedImages', function () {
-    let superagentMock
-    let actualMatch
-    let actualHeaders
     const expectedGetResponse = responses.get.attachedImage
 
     before(function () {
-      superagentMock = mockSuperagent(superagent, [{
-        pattern: `${config.host}${endpoint}`,
-        fixtures: (match, params, header) => {
-          actualMatch = match
-          actualHeaders = header
-          return expectedGetResponse
-        },
-        get: (match, data) => ({ body: data })
-      }])
+      scope = nock(config.host)
+        .persist()
+        .get(uri => uri.includes(endpoint))
+        .query(true)
+        .reply(200, expectedGetResponse)
     })
 
     after(function () {
-      superagentMock.unset()
+      nock.cleanAll()
     })
 
-    it('should return an error if there is no tutorial id', function () {
-      return tutorials.getAttachedImages().catch((error) => {
+    it('should return an error if there is no tutorial id', async function () {
+      try {
+        await tutorials.getAttachedImages()
+        expect.fail()
+      } catch (error) {
         expect(error.message).to.equal('Tutorials: getAttachedImages request requires a tutorial id.')
-      })
+      }
     })
 
-    it('should return the expected response', function () {
-      return tutorials.getAttachedImages({ id: '1' }).then((response) => {
-        expect(response.body).to.eql(expectedGetResponse)
-      })
+    it('should return the expected response', async function () {
+      const response = await tutorials.getAttachedImages({ id: '1' })
+      expect(response.body).to.eql(expectedGetResponse)
     })
 
-    it('should use query params if defined', function () {
-      return tutorials.getAttachedImages({ id: '1', query: { page: '2' }}).then((response) => {
-        expect(actualMatch.input.includes('page=2')).to.be.true
-      })
+    it('should use query params if defined', async function () {
+      const response = await tutorials.getAttachedImages({ id: '1', query: { page: '2' }})
+      expect(response.req.path.includes('page=2')).to.be.true
     })
 
-    it('should add the Authorization header to the request if param is defined', function () {
-      return tutorials.getAttachedImages({ id: '1', authorization: '12345' }).then((response) => {
-        expect(actualHeaders['Authorization']).to.exist
-        expect(actualHeaders['Authorization']).to.equal('12345')
-      })
+    it('should add the Authorization header to the request if param is defined', async function () {
+      const response = await tutorials.getAttachedImages({ id: '1', authorization: '12345' })
+      expect(response.req.headers.authorization).to.equal('12345')
     })
   })
 
   describe('getWithImages', function () {
     describe('a single tutorial', function () {
-      let superagentMock
-      let actualMatch
       const expectedGetResponse = responses.get.tutorialWithImages
-      before(function () {
-        superagentMock = mockSuperagent(superagent, [{
-          pattern: `${config.host}${endpoint}`,
-          fixtures: (match, params) => {
-            actualMatch = match
-            if (match.input.includes(resources.tutorialOne.id)) return expectedGetResponse
 
-            return { status: 404 }
-          },
-          get: (match, data) => ({ body: data })
-        }])
+      before(function () {
+        scope = nock(config.host)
+          .persist()
+          .get(uri => uri.includes(endpoint))
+          .query(true)
+          .reply(200, expectedGetResponse)
       })
 
       after(function () {
-        superagentMock.unset()
+        nock.cleanAll()
       })
 
-      it('should use a default include query param', function () {
-        return tutorials.getWithImages({ id: '1' }).then((response) => {
-          expect(actualMatch.input.includes('include=attached_images')).to.be.true
-        })
+      it('should use a default include query param', async function () {
+        const response = await tutorials.getWithImages({ id: '1' })
+        expect(response.req.path.includes('include=attached_images')).to.be.true
       })
 
-      it('should include any other query params if defined', function () {
-        return tutorials.getWithImages({ id: '1', query: { page: '2' }}).then((response) => {
-          expect(actualMatch.input.includes('page=2')).to.be.true
-        })
+      it('should include any other query params if defined', async function () {
+        const response = await tutorials.getWithImages({ id: '1', query: { page: '2' }})
+        expect(response.req.path.includes('page=2')).to.be.true
       })
 
-      it('should return the expected response', function () {
-        return tutorials.getWithImages({ id: '1' }).then((response) => {
-          expect(response.body).to.eql(expectedGetResponse)
-        })
+      it('should return the expected response', async function () {
+        const response = await tutorials.getWithImages({ id: '1' })
+        expect(response.body).to.eql(expectedGetResponse)
       })
     })
 
     describe('many tutorials', function () {
-      let superagentMock
-      let actualMatch
       const expectedGetResponse = responses.get.tutorialsWithImages
+
       before(function () {
-        superagentMock = mockSuperagent(superagent, [{
-          pattern: `${config.host}${endpoint}`,
-          fixtures: (match, params) => {
-            actualMatch = match
-            return expectedGetResponse
-          },
-          get: (match, data) => ({ body: data })
-        }])
+        scope = nock(config.host)
+          .persist()
+          .get(uri => uri.includes(endpoint))
+          .query(true)
+          .reply(200, expectedGetResponse)
       })
 
       after(function () {
-        superagentMock.unset()
+        nock.cleanAll()
       })
 
-      it('should use a default include query param', function () {
-        return tutorials.getWithImages({ workflowId: '10' }).then((response) => {
-          expect(actualMatch.input.includes('include=attached_images')).to.be.true
-        })
+      it('should use a default include query param', async function () {
+        const response = await tutorials.getWithImages({ workflowId: '10' })
+        expect(response.req.path.includes('include=attached_images')).to.be.true
       })
 
-      it('should include any other query params if defined', function () {
-        return tutorials.getWithImages({ workflowId: '10', query: { page: '2' } }).then((response) => {
-          expect(actualMatch.input.includes('page=2')).to.be.true
-        })
+      it('should include any other query params if defined', async function () {
+        const response = await tutorials.getWithImages({ workflowId: '10', query: { page: '2' } })
+        expect(response.req.path.includes('page=2')).to.be.true
       })
 
-      it('should return the expected response', function () {
-        return tutorials.getWithImages({ workflowId: '10' }).then((response) => {
-          expect(response.body).to.eql(expectedGetResponse)
-        })
+      it('should return the expected response', async function () {
+        const response = await tutorials.getWithImages({ workflowId: '10' })
+        expect(response.body).to.eql(expectedGetResponse)
       })
     })
   })
 
   describe('getTutorials', function () {
     describe('by tutorial id', function () {
-      let superagentMock
-
       before(function () {
-        superagentMock = mockSuperagent(superagent, [{
-          pattern: `${config.host}${endpoint}`,
-          fixtures: (match, params) => {
-            if (match.input.includes(resources.tutorialOne.id)) return responses.get.tutorial
-            if (match.input.includes(resources.minicourse.id)) return responses.get.minicourse
-
-            return { status: 404 }
-          },
-          get: (match, data) => ({ body: data })
-        }])
+        scope = nock(config.host)
+          .persist()
+          .get(uri => uri.includes(endpoint))
+          .query(true)
+          .reply(200, (uri, requestBody) => {
+            if (uri.includes(resources.tutorialOne.id)) {
+              return responses.get.tutorial
+            }
+            if (uri.includes(resources.minicourse.id)) {
+              return responses.get.minicourse
+            }
+          })
       })
 
       after(function () {
-        superagentMock.unset()
+        nock.cleanAll()
       })
 
-      it('should return the expected response', function () {
-        return tutorials.getTutorials({ id: '1' }).then((response) => {
-          expect(response.body).to.eql(responses.get.tutorial)
-        })
+      it('should return the expected response', async function () {
+        const response = await tutorials.getTutorials({ id: '1' })
+        expect(response.body).to.eql(responses.get.tutorial)
       })
 
-      it('the expected response should be the tutorial kind', function () {
-        return tutorials.getTutorials({ id: '1' }).then((response) => {
-          const tutorial = response.body.tutorials[0]
-          expect(tutorial.kind).to.equal('tutorial')
-        })
+      it('the expected response should be the tutorial kind', async function () {
+        const response = await tutorials.getTutorials({ id: '1' })
+        const tutorial = response.body.tutorials[0]
+        expect(tutorial.kind).to.equal('tutorial')
       })
 
-      it('should not return a minicourse', function () {
-        return tutorials.getTutorials({ id: '52' }).then((response) => {
-          expect(response.body.tutorials).to.have.lengthOf(0)
-        })
+      it('should not return a minicourse', async function () {
+        const response = await tutorials.getTutorials({ id: '52' })
+        expect(response.body.tutorials).to.have.lengthOf(0)
       })
     })
 
     describe('by workflow id', function () {
-      let superagentMock
-      let actualMatch
       const expectedGetResponse = responses.get.allTutorialsForWorkflow
-      before(function () {
-        superagentMock = mockSuperagent(superagent, [{
-          pattern: `${config.host}${endpoint}`,
-          fixtures: (match, params) => {
-            actualMatch = match
-            if (match.input.includes('workflow_id=10')) return expectedGetResponse
 
-            return { status: 404 }
-          },
-          get: (match, data) => ({ body: data })
-        }])
+      before(function () {
+        scope = nock(config.host)
+          .persist()
+          .get(uri => uri.includes(endpoint))
+          .query(true)
+          .reply(200, expectedGetResponse)
       })
 
       after(function () {
-        superagentMock.unset()
+        nock.cleanAll()
       })
 
-      it('should return the expected response', function () {
-        return tutorials.getTutorials({ workflowId: '10' }).then((response) => {
-          expect(response.body).to.eql(expectedGetResponse)
-        })
+      it('should return the expected response', async function () {
+        const response = await tutorials.getTutorials({ workflowId: '10' })
+        const expectedResponse = Object.assign({}, expectedGetResponse)
+        expectedResponse.tutorials = expectedResponse.tutorials.filter(t => t.kind !== 'mini-course')
+        expect(response.body).to.eql(expectedResponse)
       })
 
-      it('should use the workflow id as the query param', function () {
-        return tutorials.getTutorials({ workflowId: '10' }).then((response) => {
-          expect(actualMatch.input.includes('workflow_id=10')).to.be.true
-        })
+      it('should use the workflow id as the query param', async function () {
+        const response = await tutorials.getTutorials({ workflowId: '10' })
+        expect(response.req.path.includes('workflow_id=10')).to.be.true
       })
 
-      it('should not return minicourse kind tutorials', function () {
-        return tutorials.getTutorials({ workflowId: '10' }).then((response) => {
-          const tutorialsResponse = response.body.tutorials
-          tutorialsResponse.forEach((tutorial) => {
-            expect(tutorial.kind).to.not.equal('mini-course')
-          })
+      it('should not return minicourse kind tutorials', async function () {
+        const response = await tutorials.getTutorials({ workflowId: '10' })
+        const tutorialsResponse = response.body.tutorials
+        tutorialsResponse.forEach((tutorial) => {
+          expect(tutorial.kind).to.not.equal('mini-course')
         })
       })
     })
@@ -223,76 +190,59 @@ describe('Tutorials resource common requests', function () {
 
   describe('getMinicourses', function () {
     describe('by tutorial id', function () {
-      let superagentMock
-      let actualMatch
       const expectedGetResponse = responses.get.minicourse
 
       before(function () {
-        superagentMock = mockSuperagent(superagent, [{
-          pattern: `${config.host}${endpoint}`,
-          fixtures: (match, params) => {
-            actualMatch = match
-            if (match.input.includes(resources.minicourse.id)) return expectedGetResponse
-
-            return { status: 404 }
-          },
-          get: (match, data) => ({ body: data })
-        }])
+        scope = nock(config.host)
+          .persist()
+          .get(uri => uri.includes(endpoint))
+          .query(true)
+          .reply(200, expectedGetResponse)
       })
 
       after(function () {
-        superagentMock.unset()
+        nock.cleanAll()
       })
 
-      it('should return the expected response', function () {
-        return tutorials.getMinicourses({ id: '52' }).then((response) => {
-          expect(response.body).to.eql(expectedGetResponse)
-        })
+      it('should return the expected response', async function () {
+        const response = await tutorials.getMinicourses({ id: '52' })
+        expect(response.body).to.eql(expectedGetResponse)
       })
 
-      it('should set a default query parameter for kind', function () {
-        return tutorials.getMinicourses({ id: '52' }).then((response) => {
-          expect(actualMatch.input.includes('kind=mini-course')).to.be.true
-        })
+      it('should set a default query parameter for kind', async function () {
+        const response = await tutorials.getMinicourses({ id: '52' })
+        expect(response.req.path.includes('kind=mini-course')).to.be.true
       })
     })
 
     describe('by workflow id', function () {
-      let superagentMock
-      let actualMatch
       const expectedGetResponse = responses.get.minicourse
 
       before(function () {
-        superagentMock = mockSuperagent(superagent, [{
-          pattern: `${config.host}${endpoint}`,
-          fixtures: (match, params) => {
-            actualMatch = match
-            return expectedGetResponse
-          },
-          get: (match, data) => ({ body: data })
-        }])
+        scope = nock(config.host)
+          .persist()
+          .get(uri => uri.includes(endpoint))
+          .query(true)
+          .reply(200, expectedGetResponse)
       })
 
       after(function () {
-        superagentMock.unset()
+        nock.cleanAll()
       })
 
-      it('should return the expected response', function () {
-        return tutorials.getMinicourses({ workflowId: '10' }).then((response) => {
-          expect(response.body).to.eql(expectedGetResponse)
-        })
+      it('should return the expected response', async function () {
+        const response = await tutorials.getMinicourses({ workflowId: '10' })
+        expect(response.body).to.eql(expectedGetResponse)
       })
 
-      it('should set a default query parameter for kind', function () {
-        return tutorials.getMinicourses({ workflowId: '10' }).then((response) => {
-          expect(actualMatch.input.includes('kind=mini-course')).to.be.true
-        })
+      it('should set a default query parameter for kind', async function () {
+        const response = await tutorials.getMinicourses({ workflowId: '10' })
+        expect(response.req.path.includes('kind=mini-course')).to.be.true
       })
 
-      it('should use the workflow id as the query param', function () {
-        return tutorials.getTutorials({ workflowId: '10' }).then((response) => {
-          expect(actualMatch.input.includes('workflow_id=10')).to.be.true
-        })
+      it('should use the workflow id as the query param', async function () {
+        const response = await tutorials.getTutorials({ workflowId: '10' })
+        expect(response.req.path.includes('workflow_id=10')).to.be.true
       })
     })
   })

--- a/packages/lib-panoptes-js/src/resources/tutorials/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/rest.spec.js
@@ -1,109 +1,99 @@
 const { expect } = require('chai')
-const superagent = require('superagent')
-const mockSuperagent = require('superagent-mock')
+const nock = require('nock')
+
 const { config } = require('../../config')
 const { resources, responses } = require('./mocks')
 const { endpoint } = require('./helpers')
 const tutorials = require('./index')
 
 describe('Tutorials resource REST requests', function () {
+  let scope
+
   describe('get', function () {
-    let superagentMock
-    let actualHeaders
     const expectedGetAllResponse = responses.get.tutorials
     const expectedGetSingleResponse = responses.get.tutorial
-    const queryNotFound = responses.get.queryNotFound
 
     describe('by workflow id', function () {
       before(function () {
-        superagentMock = mockSuperagent(superagent, [{
-          pattern: `${config.host}${endpoint}`,
-          fixtures: (match, params, headers, context) => {
-            actualHeaders = headers
-            if (match.input.includes('?workflow_id=10')) return expectedGetAllResponse
-
-            return queryNotFound
-          },
-          get: (match, data) => {
-            return { body: data }
-          }
-        }])
+        scope = nock(config.host)
+          .persist()
+          .get(uri => uri.includes(endpoint))
+          .query(true)
+          .reply(200, expectedGetAllResponse)
       })
 
       after(function () {
-        superagentMock.unset()
+        nock.cleanAll()
       })
 
-      it('should error if the workflow id is not defined', function () {
-        return tutorials.get().catch((error) => {
+      it('should error if the workflow id is not defined', async function () {
+        try {
+          await tutorials.get()
+          expect.fail()
+        } catch (error) {
           expect(error.message).to.equal('Tutorials: Get request must include a workflow id or a tutorial id.')
-        })
+        }
       })
 
-      it('should error if the workflow id is not a string', function () {
-        return tutorials.get({ workflowId: 10 }).catch((error) => {
+      it('should error if the workflow id is not a string', async function () {
+        try {
+          await tutorials.get({ workflowId: 10 })
+          expect.fail()
+        } catch (error) {
           expect(error.message).to.equal('Tutorials: Get request workflow id must be a string.')
-        })
+        }
       })
 
-      it('should return the expected response', function () {
-        return tutorials.get({ workflowId: '10' }).then((response) => {
-          expect(response.body).to.eql(expectedGetAllResponse)
-        })
+      it('should return the expected response', async function () {
+        const response = await tutorials.get({ workflowId: '10' })
+        expect(response.body).to.eql(expectedGetAllResponse)
       })
 
-      it('should add the Authorization header to the request if param is defined', function () {
-        return tutorials.get({ workflowId: '1', authorization: '12345' }).then((response) => {
-          expect(actualHeaders['Authorization']).to.exist
-          expect(actualHeaders['Authorization']).to.equal('12345')
-        })
+      it('should add the Authorization header to the request if param is defined', async function () {
+        const response = await tutorials.get({ workflowId: '1', authorization: '12345' })
+        expect(response.req.headers.authorization).to.equal('12345')
       })
     })
 
     describe('by tutorial id', function () {
-      let actualHeaders
       before(function () {
-        superagentMock = mockSuperagent(superagent, [{
-          pattern: `${config.host}${endpoint}`,
-          fixtures: (match, params, headers, context) => {
-            actualHeaders = headers
-            if (match.input.includes(expectedGetSingleResponse.tutorials[0].id)) return expectedGetSingleResponse
-
-            return { status: 404 }
-          },
-          get: (match, data) => {
-            return { body: data }
-          }
-        }])
+        scope = nock(config.host)
+          .persist()
+          .get(uri => uri.includes(endpoint))
+          .query(true)
+          .reply(200, expectedGetSingleResponse)
       })
 
       after(function () {
-        superagentMock.unset()
+        nock.cleanAll()
       })
 
-      it('should error if the tutorial id is not defined', function () {
-        return tutorials.get().catch((error) => {
+      it('should error if the tutorial id is not defined', async function () {
+        try {
+          await tutorials.get()
+          expect.fail()
+        } catch (error) {
           expect(error.message).to.equal('Tutorials: Get request must include a workflow id or a tutorial id.')
-        })
+        }
       })
 
-      it('should error if the tutorial id is not a string', function () {
-        return tutorials.get({ id: 1 }).catch((error) => {
+      it('should error if the tutorial id is not a string', async function () {
+        try {
+          await tutorials.get({ id: 1 })
+          expect.fail()
+        } catch (error) {
           expect(error.message).to.equal('Tutorials: Get request id must be a string.')
-        })
+        }
       })
 
-      it('should return the expected response', function () {
-        return tutorials.get({ id: '1' }).then((response) => {
-          expect(response.body).to.eql(expectedGetSingleResponse)
-        })
+      it('should return the expected response', async function () {
+        const response = await tutorials.get({ id: '1' })
+        expect(response.body).to.eql(expectedGetSingleResponse)
       })
 
-      it('should add the Authorization header to the request if param is defined', function () {
-        return tutorials.get({ id: '1', authorization: '12345' }).then((response) => {
-          expect(actualHeaders['Authorization']).to.exist
-          expect(actualHeaders['Authorization']).to.equal('12345')
-        })
+      it('should add the Authorization header to the request if param is defined', async function () {
+        const response = await tutorials.get({ id: '1', authorization: '12345' })
+        expect(response.req.headers.authorization).to.equal('12345')
       })
     })
   })

--- a/packages/lib-panoptes-js/test/mocha.opts
+++ b/packages/lib-panoptes-js/test/mocha.opts
@@ -4,4 +4,4 @@
 --reporter spec
 --ui bdd
 
-./src/**/**/*.spec.js
+./src/**/*.spec.js


### PR DESCRIPTION
Package: `panoptes-js`

Closes #88.

Rewrites tests to use `nock` instead of `superagent-mock`, which causes the test runner to hang. Also uses `async / await` instead of promises, and a bit of housekeeping.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

