### PR TITLE
Add unit tests for D3 helper functions

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBackgroundLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBackgroundLayer.spec.js
@@ -1,0 +1,27 @@
+import sinon from 'sinon'
+
+import addBackgroundLayer from './addBackgroundLayer'
+
+const selectionFixture = { append: Function.prototype }
+const attrStub = sinon.stub().returnsThis()
+const appendStub = sinon.stub(selectionFixture, 'append')
+  .returns({ attr: attrStub })
+
+describe('LightCurveViewer > d3 > addBackgroundLayer', function () {
+  afterEach(function () {
+    appendStub.resetHistory()
+    attrStub.resetHistory()
+  })
+
+  it('should exist', function () {
+    expect(addBackgroundLayer).to.be.a('function')
+  })
+
+  it('should append a rect with the correct attributes to the selection', function () {
+    addBackgroundLayer(selectionFixture)
+    expect(appendStub.calledWith('rect')).to.be.true
+    expect(attrStub.calledWith('width', '100%')).to.be.true
+    expect(attrStub.calledWith('height', '100%')).to.be.true
+    expect(attrStub.calledWith('fill', '#f8f8f8')).to.be.true
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBorderLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBorderLayer.spec.js
@@ -1,0 +1,29 @@
+import sinon from 'sinon'
+
+import addBorderLayer from './addBorderLayer'
+
+const selectionFixture = { append: Function.prototype }
+const attrStub = sinon.stub().returnsThis()
+const appendStub = sinon.stub(selectionFixture, 'append')
+  .returns({ attr: attrStub })
+
+describe('LightCurveViewer > d3 > addBorderLayer', function () {
+  afterEach(function () {
+    appendStub.resetHistory()
+    attrStub.resetHistory()
+  })
+
+  it('should exist', function () {
+    expect(addBorderLayer).to.be.a('function')
+  })
+
+  it('should append a rect with the correct attributes to the selection', function () {
+    addBorderLayer(selectionFixture)
+    expect(appendStub.calledWith('rect')).to.be.true
+    expect(attrStub.calledWith('width', '100%')).to.be.true
+    expect(attrStub.calledWith('height', '100%')).to.be.true
+    expect(attrStub.calledWith('fill', 'none')).to.be.true
+    expect(attrStub.calledWith('stroke', '#333')).to.be.true
+    expect(attrStub.calledWith('stroke-width', '2')).to.be.true
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addDataLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addDataLayer.spec.js
@@ -1,0 +1,25 @@
+import sinon from 'sinon'
+
+import addDataLayer from './addDataLayer'
+
+const selectionFixture = { append: Function.prototype }
+const attrStub = sinon.stub().returnsThis()
+const appendStub = sinon.stub(selectionFixture, 'append')
+  .returns({ attr: attrStub })
+
+describe('LightCurveViewer > d3 > addDataLayer', function () {
+  afterEach(function () {
+    appendStub.resetHistory()
+    attrStub.resetHistory()
+  })
+
+  it('should exist', function () {
+    expect(addDataLayer).to.be.a('function')
+  })
+
+  it('should append a group with the correct class to the selection', function () {
+    addDataLayer(selectionFixture)
+    expect(appendStub.calledWith('g')).to.be.true
+    expect(attrStub.calledWith('class', 'data-layer')).to.be.true
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addInterfaceLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addInterfaceLayer.spec.js
@@ -1,0 +1,33 @@
+import sinon from 'sinon'
+
+import addInterfaceLayer from './addInterfaceLayer'
+
+const selectionFixture = { append: Function.prototype }
+const attrStub = sinon.stub().returnsThis()
+const styleStub = sinon.stub().returnsThis()
+const appendStub = sinon.stub(selectionFixture, 'append')
+  .returns({
+    attr: attrStub,
+    style: styleStub
+  })
+
+describe('LightCurveViewer > d3 > addInterfaceLayer', function () {
+  afterEach(function () {
+    appendStub.resetHistory()
+    attrStub.resetHistory()
+  })
+
+  it('should exist', function () {
+    expect(addInterfaceLayer).to.be.a('function')
+  })
+
+  it('should append a rect with the correct attributes and style to the selection', function () {
+    addInterfaceLayer(selectionFixture)
+    expect(appendStub.calledWith('rect')).to.be.true
+    expect(attrStub.calledWith('class', 'interface-layer')).to.be.true
+    expect(attrStub.calledWith('width', '100%')).to.be.true
+    expect(attrStub.calledWith('height', '100%')).to.be.true
+    expect(styleStub.calledWith('fill', 'none')).to.be.true
+    expect(styleStub.calledWith('pointer-events', 'all')).to.be.true
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setPointStyle.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setPointStyle.spec.js
@@ -1,0 +1,23 @@
+import sinon from 'sinon'
+
+import setPointStyle from './setPointStyle'
+
+const selectionFixture = { attr: Function.prototype }
+const attrStub = sinon.stub(selectionFixture, 'attr').returnsThis()
+
+describe('LightCurveViewer > d3 > setPointStyle', function () {
+  afterEach(function () {
+    attrStub.resetHistory()
+  })
+
+  it('should exist', function () {
+    expect(setPointStyle).to.be.a('function')
+  })
+
+  it('should add the correct attributes to the selection', function () {
+    setPointStyle(selectionFixture)
+    expect(attrStub.calledWith('r', 1)).to.be.true
+    expect(attrStub.calledWith('class', 'data-point')).to.be.true
+    expect(attrStub.calledWith('fill', '#3cc')).to.be.true
+  })
+})


### PR DESCRIPTION
Package: lib-classifier

Adds a set of tests (and testing strategy) for D3 helper functions.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

