### PR TITLE
Add "Finished for the day" component to project app

### DIFF
--- a/packages/app-project/.babelrc
+++ b/packages/app-project/.babelrc
@@ -1,6 +1,7 @@
 {
   "plugins": [
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-optional-chaining",
     "babel-plugin-styled-components"
   ],
   "presets": ["next/babel"]

--- a/packages/app-project/components/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/components/ClassifyPage/ClassifyPage.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import FinishedForTheDay from './components/FinishedForTheDay'
+
+function ClassifyPage () {
+  return (
+    <div>
+      <FinishedForTheDay />
+    </div>
+  )
+}
+
+export default ClassifyPage

--- a/packages/app-project/components/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/components/ClassifyPage/ClassifyPage.spec.js
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme'
 import React from 'react'
 
 import ClassifyPage from './ClassifyPage'
+import FinishedForTheDay from './components/FinishedForTheDay'
 
 let wrapper
 
@@ -13,8 +14,6 @@ describe('Component > ClassifyPage', function () {
   it('should render without crashing', function () {})
 
   it('should render the `FinishedForTheDay` component', function () {
-    // `FinishedForTheDay` is wrapped in a HOC, so we're just asserting on the
-    // text to include the component name.
-    expect(wrapper.text()).to.contain('FinishedForTheDay')
+    expect(wrapper.find(FinishedForTheDay).length).to.equal(1)
   })
 })

--- a/packages/app-project/components/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/components/ClassifyPage/ClassifyPage.spec.js
@@ -1,0 +1,14 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import ClassifyPage from './ClassifyPage'
+
+let wrapper
+
+describe('Component > ClassifyPage', function () {
+  before(function () {
+    wrapper = shallow(<ClassifyPage />)
+  })
+
+  it('should render without crashing', function () {})
+})

--- a/packages/app-project/components/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/components/ClassifyPage/ClassifyPage.spec.js
@@ -11,4 +11,10 @@ describe('Component > ClassifyPage', function () {
   })
 
   it('should render without crashing', function () {})
+
+  it('should render the `FinishedForTheDay` component', function () {
+    // `FinishedForTheDay` is wrapped in a HOC, so we're just asserting on the
+    // text to include the component name.
+    expect(wrapper.text()).to.contain('FinishedForTheDay')
+  })
 })

--- a/packages/app-project/components/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/components/ClassifyPage/ClassifyPage.spec.js
@@ -14,6 +14,6 @@ describe('Component > ClassifyPage', function () {
   it('should render without crashing', function () {})
 
   it('should render the `FinishedForTheDay` component', function () {
-    expect(wrapper.find(FinishedForTheDay).length).to.equal(1)
+    expect(wrapper.find(FinishedForTheDay)).to.have.lengthOf(1)
   })
 })

--- a/packages/app-project/components/ClassifyPage/components/ClassifyBox/ClassifyBox.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifyBox/ClassifyBox.js
@@ -11,6 +11,7 @@ function ClassifyBox ({ children }) {
 }
 
 ClassifyBox.propTypes = {
+  children: PropTypes.node
 }
 
 export default ClassifyBox

--- a/packages/app-project/components/ClassifyPage/components/ClassifyBox/ClassifyBox.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifyBox/ClassifyBox.js
@@ -1,0 +1,16 @@
+import { Box } from 'grommet'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+function ClassifyBox ({ children }) {
+  return (
+    <Box background='white' border='all' pad='medium'>
+      {children}
+    </Box>
+  )
+}
+
+ClassifyBox.propTypes = {
+}
+
+export default ClassifyBox

--- a/packages/app-project/components/ClassifyPage/components/ClassifyBox/ClassifyBox.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifyBox/ClassifyBox.spec.js
@@ -1,5 +1,6 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+
 import ClassifyBox from './ClassifyBox'
 
 describe('Component > ClassifyBox', function () {

--- a/packages/app-project/components/ClassifyPage/components/ClassifyBox/ClassifyBox.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifyBox/ClassifyBox.spec.js
@@ -3,8 +3,21 @@ import React from 'react'
 
 import ClassifyBox from './ClassifyBox'
 
+let wrapper
+const Foobar = () => <div>Foobar</div>
+
 describe('Component > ClassifyBox', function () {
-  it('should render without crashing', function () {
-    shallow(<ClassifyBox />)
+  before(function () {
+    wrapper = shallow(
+      <ClassifyBox>
+        <Foobar />
+      </ClassifyBox>
+    )
+  })
+
+  it('should render without crashing', function () {})
+
+  it('should render its children', function () {
+    expect(wrapper.find(Foobar).length).to.equal(1)
   })
 })

--- a/packages/app-project/components/ClassifyPage/components/ClassifyBox/ClassifyBox.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifyBox/ClassifyBox.spec.js
@@ -18,6 +18,6 @@ describe('Component > ClassifyBox', function () {
   it('should render without crashing', function () {})
 
   it('should render its children', function () {
-    expect(wrapper.find(Foobar).length).to.equal(1)
+    expect(wrapper.find(Foobar)).to.have.lengthOf(1)
   })
 })

--- a/packages/app-project/components/ClassifyPage/components/ClassifyBox/ClassifyBox.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifyBox/ClassifyBox.spec.js
@@ -1,0 +1,9 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import ClassifyBox from './ClassifyBox'
+
+describe('Component > ClassifyBox', function () {
+  it('should render without crashing', function () {
+    shallow(<ClassifyBox />)
+  })
+})

--- a/packages/app-project/components/ClassifyPage/components/ClassifyBox/README.md
+++ b/packages/app-project/components/ClassifyPage/components/ClassifyBox/README.md
@@ -1,0 +1,3 @@
+# ClassifyBox
+
+A common box component for widgets on the Classify page.

--- a/packages/app-project/components/ClassifyPage/components/ClassifyBox/index.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifyBox/index.js
@@ -1,0 +1,1 @@
+export { default } from './ClassifyBox'

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
@@ -24,7 +24,7 @@ function FinishedForTheDay ({ imageSrc, projectName }) {
   return (
     <Grid columns={columns}>
       {imageSrc && <ProjectImage imageSrc={imageSrc} projectName={projectName} />}
-      <Box border='all' pad='medium'>
+      <Box background='white' border='all' pad='medium'>
         <Heading level='3' margin='none' color='#5C5C5C'>
           {counterpart('FinishedForTheDay.title')}
         </Heading>

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
@@ -1,5 +1,5 @@
 import counterpart from 'counterpart'
-import { Box, Button, Grid, Heading, Paragraph } from 'grommet'
+import { Box, Button, Grid, Heading, Paragraph, Text } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
@@ -21,6 +21,7 @@ const StyledParagraph = styled(Paragraph)`
 
 function FinishedForTheDay ({ imageSrc, projectName }) {
   const columns = (imageSrc) ? ['1/4', 'auto'] : ['auto']
+
   return (
     <Grid columns={columns}>
       {imageSrc && <ProjectImage imageSrc={imageSrc} projectName={projectName} />}

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
@@ -12,7 +12,6 @@ counterpart.registerTranslations('en', en)
 
 const StyledButton = styled(Button)`
   border-width: 1px;
-  font-size: 14px;
   min-width: 300px;
 `
 
@@ -34,13 +33,21 @@ function FinishedForTheDay ({ imageSrc, projectName }) {
         </StyledParagraph>
         <Box gap='small' direction='row-responsive'>
           <StyledButton
-            label={counterpart('FinishedForTheDay.buttons.stats')}
+            label={(
+              <Text size='small'>
+                {counterpart('FinishedForTheDay.buttons.stats')}
+              </Text>
+            )}
             onClick={() => console.info('click')}
             primary
           />
           <StyledButton
             onClick={() => console.info('click')}
-            label={counterpart('FinishedForTheDay.buttons.anotherProject')}
+            label={(
+              <Text size='small'>
+                {counterpart('FinishedForTheDay.buttons.anotherProject')}
+              </Text>
+            )}
           />
         </Box>
       </ClassifyBox>

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
@@ -61,4 +61,8 @@ FinishedForTheDay.propTypes = {
   projectName: PropTypes.string.isRequired
 }
 
+FinishedForTheDay.defaultProps = {
+  imageSrc: ''
+}
+
 export default FinishedForTheDay

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 
 import en from './locales/en'
 import ProjectImage from './components/ProjectImage'
+import ClassifyBox from '../ClassifyBox'
 
 counterpart.registerTranslations('en', en)
 
@@ -24,7 +25,7 @@ function FinishedForTheDay ({ imageSrc, projectName }) {
   return (
     <Grid columns={columns}>
       {imageSrc && <ProjectImage imageSrc={imageSrc} projectName={projectName} />}
-      <Box background='white' border='all' pad='medium'>
+      <ClassifyBox>
         <Heading level='3' margin='none' color='#5C5C5C'>
           {counterpart('FinishedForTheDay.title')}
         </Heading>
@@ -42,7 +43,7 @@ function FinishedForTheDay ({ imageSrc, projectName }) {
             label={counterpart('FinishedForTheDay.buttons.anotherProject')}
           />
         </Box>
-      </Box>
+      </ClassifyBox>
     </Grid>
   )
 }

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
@@ -1,0 +1,55 @@
+import counterpart from 'counterpart'
+import { Box, Button, Grid, Heading, Paragraph } from 'grommet'
+import PropTypes from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+
+import en from './locales/en'
+import ProjectImage from './components/ProjectImage'
+
+counterpart.registerTranslations('en', en)
+
+const StyledButton = styled(Button)`
+  border-width: 1px;
+  font-size: 14px;
+  min-width: 300px;
+`
+
+const StyledParagraph = styled(Paragraph)`
+  max-width: 100%;
+`
+
+function FinishedForTheDay ({ imageSrc, projectName }) {
+  const columns = (imageSrc) ? ['1/4', 'auto'] : ['auto']
+  return (
+    <Grid columns={columns} margin="medium">
+      {imageSrc && <ProjectImage imageSrc={imageSrc} projectName={projectName} />}
+      <Box border='all' pad='medium'>
+        <Heading level='3' margin='none' color='#5C5C5C'>
+          {counterpart('FinishedForTheDay.title')}
+        </Heading>
+        <StyledParagraph margin={{ vertical: 'small' }} size='small'>
+          {counterpart('FinishedForTheDay.text', { projectName })}
+        </StyledParagraph>
+        <Box gap='small' direction='row-responsive'>
+          <StyledButton
+            label={counterpart('FinishedForTheDay.buttons.stats')}
+            onClick={() => console.info('click')}
+            primary
+          />
+          <StyledButton
+            onClick={() => console.info('click')}
+            label={counterpart('FinishedForTheDay.buttons.anotherProject')}
+          />
+        </Box>
+      </Box>
+    </Grid>
+  )
+}
+
+FinishedForTheDay.propTypes = {
+  imageSrc: PropTypes.string,
+  projectName: PropTypes.string.isRequired
+}
+
+export default FinishedForTheDay

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
@@ -22,7 +22,7 @@ const StyledParagraph = styled(Paragraph)`
 function FinishedForTheDay ({ imageSrc, projectName }) {
   const columns = (imageSrc) ? ['1/4', 'auto'] : ['auto']
   return (
-    <Grid columns={columns} margin="medium">
+    <Grid columns={columns}>
       {imageSrc && <ProjectImage imageSrc={imageSrc} projectName={projectName} />}
       <Box border='all' pad='medium'>
         <Heading level='3' margin='none' color='#5C5C5C'>

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
@@ -1,0 +1,46 @@
+import { shallow, render } from 'enzyme'
+import React from 'react'
+import FinishedForTheDay from './FinishedForTheDay'
+
+const projectName = 'Foobar'
+const imageSrc = 'foobar.jpg'
+
+let wrapper
+
+describe('Component > FinishedForTheDay', function () {
+  before(function () {
+    wrapper = render(<FinishedForTheDay projectName={projectName} />)
+  })
+
+  it('should render without crashing', function () {})
+
+  it('should contain a title', function () {
+    expect(wrapper.find('h3').first().length).to.equal(1)
+  })
+
+  it('should contain some text', function () {
+    const para = wrapper.find('p').first()
+    expect(para.length).to.equal(1)
+    expect(para.text().length).to.be.ok
+  })
+
+  xit('should contain a stats button', function () {
+    // We'll test this by link, and that link isn't hooked up yet
+  })
+
+  xit('should contain an other projects button', function () {
+    // We'll test this by link, and that link isn't hooked up yet
+  })
+
+  it('should not contain a `ProjectImage` if there\'s no `imgSrc` prop', function () {
+    const image = wrapper.find('ProjectImage')
+    expect(image.length).to.equal(0)
+  })
+
+  it('should contain a `ProjectImage` if an `imageSrc` prop is present', function () {
+    const wrapper = shallow(<FinishedForTheDay projectName={projectName} imageSrc={imageSrc} />)
+    const projectImageWrapper = wrapper.find('ProjectImage')
+    expect(projectImageWrapper.length).to.equal(1)
+    expect(projectImageWrapper.prop('imageSrc')).to.equal(imageSrc)
+  })
+})

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
@@ -17,12 +17,12 @@ describe('Component > FinishedForTheDay', function () {
   it('should render without crashing', function () {})
 
   it('should contain a title', function () {
-    expect(wrapper.find('h3').first().length).to.equal(1)
+    expect(wrapper.find('h3')).to.have.lengthOf(1)
   })
 
   it('should contain some text', function () {
-    const para = wrapper.find('p').first()
-    expect(para.length).to.equal(1)
+    const para = wrapper.find('p')
+    expect(para).to.have.lengthOf(1)
     expect(para.text().length).to.be.ok
   })
 
@@ -35,14 +35,13 @@ describe('Component > FinishedForTheDay', function () {
   })
 
   it('should not contain a `ProjectImage` if there\'s no `imgSrc` prop', function () {
-    const image = wrapper.find(ProjectImage)
-    expect(image.length).to.equal(0)
+    expect(wrapper.find(ProjectImage)).to.have.lengthOf(0)
   })
 
   it('should contain a `ProjectImage` if an `imageSrc` prop is present', function () {
     const wrapper = shallow(<FinishedForTheDay projectName={projectName} imageSrc={imageSrc} />)
     const projectImageWrapper = wrapper.find(ProjectImage)
-    expect(projectImageWrapper.length).to.equal(1)
+    expect(projectImageWrapper).to.have.lengthOf(1)
     expect(projectImageWrapper.prop('imageSrc')).to.equal(imageSrc)
   })
 })

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
@@ -1,6 +1,8 @@
 import { shallow, render } from 'enzyme'
 import React from 'react'
+
 import FinishedForTheDay from './FinishedForTheDay'
+import ProjectImage from './components/ProjectImage'
 
 const projectName = 'Foobar'
 const imageSrc = 'foobar.jpg'
@@ -33,13 +35,13 @@ describe('Component > FinishedForTheDay', function () {
   })
 
   it('should not contain a `ProjectImage` if there\'s no `imgSrc` prop', function () {
-    const image = wrapper.find('ProjectImage')
+    const image = wrapper.find(ProjectImage)
     expect(image.length).to.equal(0)
   })
 
   it('should contain a `ProjectImage` if an `imageSrc` prop is present', function () {
     const wrapper = shallow(<FinishedForTheDay projectName={projectName} imageSrc={imageSrc} />)
-    const projectImageWrapper = wrapper.find('ProjectImage')
+    const projectImageWrapper = wrapper.find(ProjectImage)
     expect(projectImageWrapper.length).to.equal(1)
     expect(projectImageWrapper.prop('imageSrc')).to.equal(imageSrc)
   })

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.js
@@ -8,11 +8,11 @@ import FinishedForTheDay from './FinishedForTheDay'
 @observer
 class FinishedForTheDayContainer extends Component {
   getProjectName () {
-    return this.props.store.project?.displayName || ''
+    return this.props.store.project?.displayName
   }
 
   getImageSrc () {
-    return this.props.store.project?.backgrounds[0].src || ''
+    return this.props.store.project?.backgrounds?[0]?.src
   }
 
   render () {

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.js
@@ -1,27 +1,26 @@
-import { get } from 'lodash'
+import { inject, observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { inject, observer } from 'mobx-react'
 
 import FinishedForTheDay from './FinishedForTheDay'
 
 @inject('store')
 @observer
 class FinishedForTheDayContainer extends Component {
-  getComponentProps () {
-    const { props } = this
-    const projectName = get(props, 'store.project.displayName', '')
-    const imageSrc = get(props, 'store.project.backgrounds[0].src', '')
-    return {
-      imageSrc,
-      projectName
-    }
+  getProjectName () {
+    return this.props.store.project?.displayName || ''
+  }
+
+  getImageSrc () {
+    return this.props.store.project?.backgrounds[0].src || ''
   }
 
   render () {
-    const componentProps = this.getComponentProps()
     return (
-      <FinishedForTheDay {...componentProps} />
+      <FinishedForTheDay
+        projectName={this.getProjectName()}
+        imageSrc={this.getImageSrc()}
+      />
     )
   }
 }

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.js
@@ -12,7 +12,7 @@ class FinishedForTheDayContainer extends Component {
   }
 
   getImageSrc () {
-    return this.props.store.project?.backgrounds?[0]?.src
+    return this.props.store.project?.backgrounds[0]?.src
   }
 
   render () {

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.js
@@ -1,0 +1,40 @@
+import { get } from 'lodash'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import { inject, observer } from 'mobx-react'
+
+import FinishedForTheDay from './FinishedForTheDay'
+
+@inject('store')
+@observer
+class FinishedForTheDayContainer extends Component {
+  getComponentProps () {
+    const { props } = this
+    const projectName = get(props, 'store.project.displayName', '')
+    const imageSrc = get(props, 'store.project.backgrounds[0].src', '')
+    return {
+      imageSrc,
+      projectName
+    }
+  }
+
+  render () {
+    const componentProps = this.getComponentProps()
+    return (
+      <FinishedForTheDay {...componentProps} />
+    )
+  }
+}
+
+FinishedForTheDayContainer.propTypes = {
+  store: PropTypes.shape({
+    project: PropTypes.shape({
+      backgrounds: PropTypes.arrayOf(PropTypes.shape({
+        src: PropTypes.string
+      })),
+      displayName: PropTypes.string
+    })
+  })
+}
+
+export default FinishedForTheDayContainer

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.spec.js
@@ -1,5 +1,7 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+
+import FinishedForTheDay from './FinishedForTheDay'
 import FinishedForTheDayContainer from './FinishedForTheDayContainer'
 
 const mockStore = {
@@ -23,7 +25,7 @@ describe('Component > FinishedForTheDayContainer', function () {
   it('should render without crashing', function () {})
 
   it('should render the `FinishedForTheDay` component', function () {
-    expect(wrapper.find('FinishedForTheDay').first().length).to.equal(1)
+    expect(wrapper.find(FinishedForTheDay).length).to.equal(1)
   })
 
   it('should pass the correct props to the `FinishedForTheDay` component', function () {

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.spec.js
@@ -25,7 +25,7 @@ describe('Component > FinishedForTheDayContainer', function () {
   it('should render without crashing', function () {})
 
   it('should render the `FinishedForTheDay` component', function () {
-    expect(wrapper.find(FinishedForTheDay).length).to.equal(1)
+    expect(wrapper.find(FinishedForTheDay)).to.have.lengthOf(1)
   })
 
   it('should pass the correct props to the `FinishedForTheDay` component', function () {

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.spec.js
@@ -1,0 +1,33 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import FinishedForTheDayContainer from './FinishedForTheDayContainer'
+
+const mockStore = {
+  project: {
+    backgrounds: [
+      {
+        src: 'foobar.jpg'
+      }
+    ],
+    displayName: 'Foobar'
+  }
+}
+
+describe('Component > FinishedForTheDayContainer', function () {
+  let wrapper
+
+  before(function () {
+    wrapper = shallow(<FinishedForTheDayContainer.wrappedComponent store={mockStore} />)
+  })
+
+  it('should render without crashing', function () {})
+
+  it('should render the `FinishedForTheDay` component', function () {
+    expect(wrapper.find('FinishedForTheDay').first().length).to.equal(1)
+  })
+
+  it('should pass the correct props to the `FinishedForTheDay` component', function () {
+    expect(wrapper.prop('imageSrc')).to.equal(mockStore.project.backgrounds[0].src)
+    expect(wrapper.prop('projectName')).to.equal(mockStore.project.displayName)
+  })
+})

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import ProgressiveImage from 'react-progressive-image'
 import posed from 'react-pose'
-import styled from 'styled-components'
 import { Stack } from 'grommet'
 
 import en from './locales/en'

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.js
@@ -30,8 +30,9 @@ function ProjectImage ({ imageSrc, projectName }) {
               style={{
                 display: loading ? 'none' : 'block',
                 height: '100%',
-                width: '100%',
-                objectFit: 'cover'
+                objectFit: 'cover',
+                objectPosition: '50% 0%',
+                width: '100%'
               }}
               src={src}
               alt={alt}

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.js
@@ -1,3 +1,4 @@
+import counterpart from 'counterpart'
 import PropTypes from 'prop-types'
 import React from 'react'
 import ProgressiveImage from 'react-progressive-image'
@@ -8,12 +9,15 @@ import { Stack } from 'grommet'
 import en from './locales/en'
 import Placeholder from './components/Placeholder'
 
+counterpart.registerTranslations('en', en)
+
 const Img = posed.img({
   hidden: { opacity: 0 },
   visible: { opacity: 1 }
 })
 
 function ProjectImage ({ imageSrc, projectName }) {
+  const alt = counterpart('ProjectImage.alt', { projectName })
   return (
     <ProgressiveImage
       src={imageSrc}
@@ -31,12 +35,12 @@ function ProjectImage ({ imageSrc, projectName }) {
                 objectFit: 'cover'
               }}
               src={src}
-              alt={`Background image for ${projectName}`}
+              alt={alt}
               pose={loading ? 'hidden' : 'visible'}
             />
           </Stack>
           <noscript>
-            <img src={imageSrc} />
+            <img src={imageSrc} alt={alt} />
           </noscript>
         </>
       )}

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.js
@@ -1,0 +1,52 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import ProgressiveImage from 'react-progressive-image'
+import posed from 'react-pose'
+import styled from 'styled-components'
+import { Stack } from 'grommet'
+
+import en from './locales/en'
+import Placeholder from './components/Placeholder'
+
+const Img = posed.img({
+  hidden: { opacity: 0 },
+  visible: { opacity: 1 }
+})
+
+function ProjectImage ({ imageSrc, projectName }) {
+  return (
+    <ProgressiveImage
+      src={imageSrc}
+      placeholder=''
+    >
+      {(src, loading) => (
+        <>
+          <Stack fill>
+            <Placeholder />
+            <Img
+              style={{
+                display: loading ? 'none' : 'block',
+                height: '100%',
+                width: '100%',
+                objectFit: 'cover'
+              }}
+              src={src}
+              alt={`Background image for ${projectName}`}
+              pose={loading ? 'hidden' : 'visible'}
+            />
+          </Stack>
+          <noscript>
+            <img src={imageSrc} />
+          </noscript>
+        </>
+      )}
+    </ProgressiveImage>
+  )
+}
+
+ProjectImage.propTypes = {
+  imageSrc: PropTypes.string.isRequired,
+  projectName: PropTypes.string.isRequired
+}
+
+export default ProjectImage

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.spec.js
@@ -26,4 +26,11 @@ describe('Component > ProjectImage', function () {
     expect(noscriptWrapper.length).to.equal(1)
     expect(imageWrapper.length).to.equal(1)
   })
+
+  it('should have an alt', function () {
+    const imgsWrapper = wrapper.find('img')
+    imgsWrapper.forEach(imgWrapper =>
+      expect(imgWrapper.prop('alt')).to.equal(`Image for ${projectName}`)
+    )
+  })
 })

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.spec.js
@@ -16,15 +16,13 @@ describe('Component > ProjectImage', function () {
   it('should render without crashing', function () {})
 
   it('should contain a `Placeholder` component', function () {
-    const placeholderWrapper = wrapper.find('Placeholder')
-    expect(placeholderWrapper.length).to.equal(1)
+    expect(wrapper.find('Placeholder')).to.have.lengthOf(1)
   })
 
   it('should have a `<noscript />` image for SSR', function () {
     const noscriptWrapper = wrapper.find('noscript')
-    const imageWrapper = noscriptWrapper.find('img')
-    expect(noscriptWrapper.length).to.equal(1)
-    expect(imageWrapper.length).to.equal(1)
+    expect(noscriptWrapper).to.have.lengthOf(1)
+    expect(noscriptWrapper.find('img')).to.have.lengthOf(1)
   })
 
   it('should have an alt', function () {

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.spec.js
@@ -1,0 +1,29 @@
+import { mount } from 'enzyme'
+import React from 'react'
+
+import ProjectImage from './ProjectImage'
+
+let wrapper
+
+const projectName = 'Foobar'
+const imageSrc = 'foobar.jpg'
+
+describe('Component > ProjectImage', function () {
+  before(function () {
+    wrapper = mount(<ProjectImage imageSrc={imageSrc} projectName={projectName} />)
+  })
+
+  it('should render without crashing', function () {})
+
+  it('should contain a `Placeholder` component', function () {
+    const placeholderWrapper = wrapper.find('Placeholder')
+    expect(placeholderWrapper.length).to.equal(1)
+  })
+
+  it('should have a `<noscript />` image for SSR', function () {
+    const noscriptWrapper = wrapper.find('noscript')
+    const imageWrapper = noscriptWrapper.find('img')
+    expect(noscriptWrapper.length).to.equal(1)
+    expect(imageWrapper.length).to.equal(1)
+  })
+})

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/components/Placeholder/Placeholder.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/components/Placeholder/Placeholder.js
@@ -1,0 +1,23 @@
+import { Box } from 'grommet'
+import React from 'react'
+import styled from 'styled-components'
+
+// Width is derived from the golden ratio 👑
+const SVG = styled.svg`
+  width: 38%;
+`
+
+function Placeholder () {
+  return (
+    <Box background='#007482' fill justify='center' align='center'>
+      <SVG preserveAspectRatio='xMidYMid meet' role='img' viewBox='0 0 100 100' >
+        <g fill='currentColor' stroke='none' transform='translate(50, 50)'>
+          <path d='M 0 -45 A 45 45 0 0 1 0 45 A 45 45 0 0 1 0 -45 Z M 0 -30 A 30 30 0 0 0 0 30 A 30 30 0 0 0 0 -30 Z'></path><path d='M 0 -14 A 14 14 0 0 1 0 14 A 14 14 0 0 1 0 -14 Z'></path>
+          <ellipse cx='0' cy='0' rx='6' ry='65' transform='rotate(50)'></ellipse>
+        </g>
+      </SVG>
+    </Box>
+  )
+}
+
+export default Placeholder

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/components/Placeholder/Placeholder.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/components/Placeholder/Placeholder.js
@@ -12,8 +12,8 @@ function Placeholder () {
     <Box background='#007482' fill justify='center' align='center'>
       <SVG preserveAspectRatio='xMidYMid meet' role='img' viewBox='0 0 100 100' >
         <g fill='currentColor' stroke='none' transform='translate(50, 50)'>
-          <path d='M 0 -45 A 45 45 0 0 1 0 45 A 45 45 0 0 1 0 -45 Z M 0 -30 A 30 30 0 0 0 0 30 A 30 30 0 0 0 0 -30 Z'></path><path d='M 0 -14 A 14 14 0 0 1 0 14 A 14 14 0 0 1 0 -14 Z'></path>
-          <ellipse cx='0' cy='0' rx='6' ry='65' transform='rotate(50)'></ellipse>
+          <path d='M 0 -45 A 45 45 0 0 1 0 45 A 45 45 0 0 1 0 -45 Z M 0 -30 A 30 30 0 0 0 0 30 A 30 30 0 0 0 0 -30 Z' /><path d='M 0 -14 A 14 14 0 0 1 0 14 A 14 14 0 0 1 0 -14 Z' />
+          <ellipse cx='0' cy='0' rx='6' ry='65' transform='rotate(50)' />
         </g>
       </SVG>
     </Box>

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/components/Placeholder/Placeholder.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/components/Placeholder/Placeholder.spec.js
@@ -1,0 +1,14 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import Placeholder from './Placeholder'
+
+let wrapper
+
+describe('Component > Placeholder', function () {
+  before(function () {
+    wrapper = shallow(<Placeholder />)
+  })
+
+  it('should render without crashing', function () {})
+})

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/components/Placeholder/index.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/components/Placeholder/index.js
@@ -1,0 +1,1 @@
+export { default } from './Placeholder'

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/index.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/index.js
@@ -1,0 +1,1 @@
+export { default } from './ProjectImage'

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/locales/en.json
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/locales/en.json
@@ -1,4 +1,5 @@
 {
   "ProjectImage": {
+    "alt": "Image for %(projectName)s"
   }
 }

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/locales/en.json
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/locales/en.json
@@ -1,0 +1,4 @@
+{
+  "ProjectImage": {
+  }
+}

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/index.js
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/index.js
@@ -1,0 +1,1 @@
+export { default } from './FinishedForTheDayContainer'

--- a/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/locales/en.json
+++ b/packages/app-project/components/ClassifyPage/components/FinishedForTheDay/locales/en.json
@@ -1,0 +1,10 @@
+{
+  "FinishedForTheDay": {
+    "buttons": {
+      "anotherProject": "Find another project",
+      "stats": "See your stats"
+    },
+    "text": "Your answers are saved for the research team while you're working. See your stats and return to the %(projectName)s home page, or find another project to contribute to.",
+    "title": "Finished for the day?"
+  }
+}

--- a/packages/app-project/components/ClassifyPage/index.js
+++ b/packages/app-project/components/ClassifyPage/index.js
@@ -1,0 +1,1 @@
+export { default } from './ClassifyPage'

--- a/packages/app-project/components/Head/Head.spec.js
+++ b/packages/app-project/components/Head/Head.spec.js
@@ -1,6 +1,7 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import Head from './head'
+
+import Head from './Head'
 
 describe('Component > Head', function () {
   it('should render without crashing', function () {

--- a/packages/app-project/components/Navigation/Navigation.spec.js
+++ b/packages/app-project/components/Navigation/Navigation.spec.js
@@ -1,9 +1,10 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import Nav from './nav'
 
-describe('Component > Nav', function () {
+import Navigation from './Navigation'
+
+describe('Component > Navigation', function () {
   it('should render without crashing', function () {
-    shallow(<Nav />)
+    shallow(<Navigation />)
   })
 })

--- a/packages/app-project/package-lock.json
+++ b/packages/app-project/package-lock.json
@@ -386,6 +386,16 @@
         "@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
       }
     },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.0.0.tgz",
+      "integrity": "sha512-7x8HLa71OzNiofbQUVakS0Kmg++6a+cXNfS7QKHbbv03SuSaumJyaWsfNgw+T7aqrJlqurYpZqrkPgXu0iZK0w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.0.0"
+      }
+    },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0.tgz",
@@ -457,6 +467,15 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
       "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.0.0.tgz",
+      "integrity": "sha512-QXedQsZf8yua1nNrXSePT0TsGSQH9A1iK08m9dhCMdZeJaaxYcQfXdgHWVV6Cp7WE/afPVvSKIsAHK5wP+yxDA==",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }

--- a/packages/app-project/package-lock.json
+++ b/packages/app-project/package-lock.json
@@ -900,11 +900,31 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
       "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
     },
+    "@popmotion/easing": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@popmotion/easing/-/easing-1.0.1.tgz",
+      "integrity": "sha512-NbIEz9mZAem0F0sjg2v57LbU9Y2Xc50QEX434jYrwEQzXJuJipyUV48Qz4hjHqbB/8xiUj0JMQfRvP8K9nUbxg=="
+    },
+    "@popmotion/popcorn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@popmotion/popcorn/-/popcorn-0.1.1.tgz",
+      "integrity": "sha512-VDCOmpMzc4tkcspwn4zEiuR8RqHjFKYjW7Ky6A5JlVAfK6HnLrYxtJbLaCzXJQI29YbeYr7BbbNno+OpI7z04w==",
+      "requires": {
+        "@popmotion/easing": "^1.0.1",
+        "framesync": "^4.0.1",
+        "hey-listen": "^1.0.5",
+        "style-value-types": "^3.0.7"
+      }
+    },
+    "@types/invariant": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.29.tgz",
+      "integrity": "sha512-lRVw09gOvgviOfeUrKc/pmTiRZ7g7oDOU6OAutyuSHpm1/o2RaBQvRhgK8QEdu+FFuw/wnWb29A/iuxv9i8OpQ=="
+    },
     "@types/node": {
       "version": "10.11.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.3.tgz",
-      "integrity": "sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ==",
-      "dev": true
+      "integrity": "sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ=="
     },
     "@webassemblyjs/ast": {
       "version": "1.7.8",
@@ -2053,6 +2073,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "counterpart": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/counterpart/-/counterpart-0.18.6.tgz",
+      "integrity": "sha512-cAIDAYbC3x8S2DDbvFEJ4TzPtPYXma25/kfAkfmprNLlkPWeX4SdUp1c2xklfphqCU3HnDaivR4R3BrAYf5OMA==",
+      "requires": {
+        "date-names": "^0.1.11",
+        "except": "^0.1.3",
+        "extend": "^3.0.0",
+        "pluralizers": "^0.1.7",
+        "sprintf-js": "^1.0.3"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -2205,6 +2237,11 @@
         "whatwg-mimetype": "^2.1.0",
         "whatwg-url": "^7.0.0"
       }
+    },
+    "date-names": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/date-names/-/date-names-0.1.12.tgz",
+      "integrity": "sha512-HYc4+Rl53sOHh9R0pgpgqzZy471E4cFXLOjJDQImGOAeacbAV87+RUO70iE1Mfvnp1yuS2V8Y+/n1nS7OoMYiw=="
     },
     "date-now": {
       "version": "0.1.4",
@@ -2688,6 +2725,14 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "except": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/except/-/except-0.1.3.tgz",
+      "integrity": "sha1-mCYckZWFUVNrREgiOOl4P7c9KSo=",
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -2745,8 +2790,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2997,6 +3041,14 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
         "map-cache": "^0.2.2"
+      }
+    },
+    "framesync": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.0.1.tgz",
+      "integrity": "sha512-7dF3SXz/xMdwSHFHgj8PV2dAUCFclXWhasAb06rFvAM2pX24m9eDs6X+ikK0kx92w/uIljUi0sBINwcbl0rT2Q==",
+      "requires": {
+        "hey-listen": "^1.0.5"
       }
     },
     "fresh": {
@@ -3647,13 +3699,12 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "grommet": {
-      "version": "2.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.0.0-beta.7.tgz",
-      "integrity": "sha512-OpBtwwyHtYrxHFANvprLfxT3d+SNUvEQbexoo2J1e2Q9wD2Jaxb5gmj/CD4NtMKGUlrGtk3PsbI2JQpa/axOYA==",
+      "version": "2.0.0-rc",
+      "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.0.0-rc.tgz",
+      "integrity": "sha512-Pl60m1IPi4fwntt918AnVa/m5TthA4kH8vlX5T7HvqGgNz7rjYqXaXom3pMXCbiJbo54LndWQwwMVHsec0AAkQ==",
       "requires": {
         "css": "^2.2.3",
         "markdown-to-jsx": "^6.6.6",
-        "node-emoji": "^1.8.1",
         "polished": "^2.2.0",
         "prop-types": "^15.5.10",
         "react-desc": "^3.5.0",
@@ -3792,6 +3843,11 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
+    },
+    "hey-listen": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.5.tgz",
+      "integrity": "sha512-O2iCNxBBGb4hOxL9tUdnoPwDYmZhQ29t5xKV74BVZNdvwCDXCpVYTJ4yoaibc1V0I8Yw3K3nwmvDpoyjnCqUaw=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -4420,11 +4476,6 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
-    },
     "log-update": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
@@ -4474,11 +4525,11 @@
       }
     },
     "markdown-to-jsx": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.7.4.tgz",
-      "integrity": "sha512-3mStPW6KBMvm0M5icmy7zu63L41dl2Gg9WL6+gqSFhTec9n6SNUbt6xgB9zVL/qz/Nzwn/MCum6c8xGv8TOPFw==",
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.8.3.tgz",
+      "integrity": "sha512-I/kRZDvHFMEoKCjFS119v6Op4R1wZJEUEwhWSNtsE7WHRVcxKrLZ9vApvNb1j80MAFIY4/e4m1f4vIwSgKUZ8g==",
       "requires": {
-        "prop-types": "^15.5.10",
+        "prop-types": "^15.6.2",
         "unquote": "^1.1.0"
       }
     },
@@ -4863,14 +4914,6 @@
         "webpack-sources": "1.2.0",
         "webpackbar": "2.6.3",
         "write-file-webpack-plugin": "4.3.2"
-      }
-    },
-    "node-emoji": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
-      "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
-      "requires": {
-        "lodash.toarray": "^4.4.0"
       }
     },
     "node-fetch": {
@@ -5412,6 +5455,11 @@
         "find-up": "^2.1.0"
       }
     },
+    "pluralizers": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/pluralizers/-/pluralizers-0.1.7.tgz",
+      "integrity": "sha512-mw6AejUiCaMQ6uPN9ObjJDTnR5AnBSmnHHy3uVTbxrSFSxO5scfwpTs8Dxyb6T2v7GSulhvOq+pm9y+hXUvtOA=="
+    },
     "pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
@@ -5419,11 +5467,49 @@
       "dev": true
     },
     "polished": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-2.2.0.tgz",
-      "integrity": "sha512-GEKeNET1XIri53xKpFwGZX4fh2k3b5GE5fxwLWYYR2sGWkMAHJVcb7bK1g6QHIDcoIEEGC8CzHOQgl2qFByd3w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-2.3.0.tgz",
+      "integrity": "sha512-G2yD9LhJy5HBuU+Im5qe70ubaJI/ZTTOIJO6GRMwJ2WSoAiPzlm8+LjAXMnm9/K0E0NumRVHvQu2HHPKQSYQjw==",
       "requires": {
         "@babel/runtime": "^7.0.0"
+      }
+    },
+    "popmotion": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-8.5.0.tgz",
+      "integrity": "sha512-H/r0vbQO+Zgr4x4zmwiP2GFOCkp7UMd6A4jV66KDXenaH7+qDs+1raC+4QIEAOke/QigJaJ/W39om8vgr0pTOw==",
+      "requires": {
+        "@popmotion/easing": "^1.0.1",
+        "@popmotion/popcorn": "^0.1.0",
+        "framesync": "^4.0.0",
+        "hey-listen": "^1.0.5",
+        "style-value-types": "^3.0.6",
+        "stylefire": "^2.0.7",
+        "tslib": "^1.9.1"
+      }
+    },
+    "popmotion-pose": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/popmotion-pose/-/popmotion-pose-3.4.0.tgz",
+      "integrity": "sha512-fRnzNuLRjicMrIeZBlL1Y1mdsXCpOwWeJcQzWFXj7T9lQ3j/fEDCZCE+TWCB4DHClXH+P/xPiJeIKfG+6gZeKA==",
+      "requires": {
+        "@popmotion/easing": "^1.0.1",
+        "hey-listen": "^1.0.5",
+        "popmotion": "^8.5.0",
+        "pose-core": "^2.0.0",
+        "style-value-types": "^3.0.6",
+        "tslib": "^1.9.1"
+      }
+    },
+    "pose-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pose-core/-/pose-core-2.0.0.tgz",
+      "integrity": "sha512-RJcDqYADmuXKQ+uP59oh+EIeRhsuAkKLeVrT25ak57q8TXkEKh8pjL99AHNQLktLUI97erpdNnOp+McK3d/CUQ==",
+      "requires": {
+        "@types/invariant": "^2.2.29",
+        "@types/node": "^10.0.5",
+        "hey-listen": "^1.0.5",
+        "tslib": "^1.9.1"
       }
     },
     "posix-character-classes": {
@@ -5637,9 +5723,9 @@
       }
     },
     "react-desc": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/react-desc/-/react-desc-3.5.0.tgz",
-      "integrity": "sha512-w54YB1JUBRS9w4lBFuPQo5Fq/eao65iwH6XeSmpHOmfGl4SP/1xEhhvxtNpbQR9bhqXvkQlhIEUSo8wyn3u5zA=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/react-desc/-/react-desc-3.6.5.tgz",
+      "integrity": "sha512-fI3JbWRQdRmQ3pBFscULdmJnKceSgK5Ug6BdFS/G/+9/6hle16sOQYEeELIu053uhhSuwK59aBex0UaeTJWnpw=="
     },
     "react-dom": {
       "version": "16.5.2",
@@ -5666,6 +5752,23 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-pose": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/react-pose/-/react-pose-3.4.0.tgz",
+      "integrity": "sha512-4dBScQIyaBenYg+Z+bdKj539rVIAmJDRO4uyn1gofrI+YWozBzYIfYuAz3PtCqTvBCyX9Tm0vo3pIRmTvY85Vw==",
+      "requires": {
+        "@emotion/is-prop-valid": "^0.6.5",
+        "hey-listen": "^1.0.5",
+        "popmotion-pose": "^3.4.0",
+        "react-is": "^16.5.1",
+        "tslib": "^1.9.1"
+      }
+    },
+    "react-progressive-image": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/react-progressive-image/-/react-progressive-image-0.6.0.tgz",
+      "integrity": "sha512-/yc8N3lHskPQkubm+QH5RIQHA89Sigv7p9UkvbHzKVE2OBb6njhmquk7GW/f2Y//mzk5DesFHN/hV5RWhd6IXA=="
     },
     "react-test-renderer": {
       "version": "16.5.2",
@@ -6365,6 +6468,11 @@
         "extend-shallow": "^3.0.0"
       }
     },
+    "sprintf-js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+    },
     "sshpk": {
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
@@ -6529,6 +6637,11 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
+    "style-value-types": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.0.7.tgz",
+      "integrity": "sha512-7vzeicDiPNnJjvTYfJbQhZ7P3OCkXfvkJOJQ+ifFnXNTA/7KBxMZacHLvlRjM5/TtXbVdrZE6u+2nzSUSPrbSQ=="
+    },
     "styled-components": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.0.0.tgz",
@@ -6569,6 +6682,17 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
+      }
+    },
+    "stylefire": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/stylefire/-/stylefire-2.1.0.tgz",
+      "integrity": "sha512-DeO5v4w4xwvSoatWkfD++tpPqoolSxZtmrL7mFwxHp70AXJuzvwDVlTkpaXwPXvfevXwiGXA224gOnIk2pLiRA==",
+      "requires": {
+        "framesync": "^4.0.0",
+        "hey-listen": "^1.0.4",
+        "style-value-types": "^3.0.6",
+        "tslib": "^1.9.1"
       }
     },
     "stylis": {

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "~7.1.2",
+    "@babel/plugin-proposal-optional-chaining": "^7.0.0",
     "@babel/register": "~7.0.0",
     "babel-plugin-styled-components": "~1.8.0",
     "chai": "~4.2.0",

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -21,6 +21,7 @@
     "@zooniverse/grommet-theme": "~2.0.0",
     "@zooniverse/panoptes-js": "~0.0.1",
     "@zooniverse/react-components": "~0.7.1",
+    "counterpart": "^0.18.6",
     "grommet": "~2.0.0-rc",
     "grommet-icons": "~3.1.0",
     "lodash": "~4.17.11",
@@ -31,6 +32,8 @@
     "path-match": "~1.2.4",
     "react": "~16.5.2",
     "react-dom": "~16.5.2",
+    "react-pose": "^3.4.0",
+    "react-progressive-image": "^0.6.0",
     "styled-components": "~4.0.0",
     "url-parse": "~1.4.3"
   },

--- a/packages/app-project/pages/Classify.js
+++ b/packages/app-project/pages/Classify.js
@@ -1,3 +1,5 @@
 import React from 'react'
 
-export default () => <div>Project classify</div>
+import ClassifyPage from '../components/ClassifyPage'
+
+export default () => <ClassifyPage />

--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -1,5 +1,4 @@
 import zooTheme from '@zooniverse/grommet-theme'
-import { ZooFooter } from '@zooniverse/react-components'
 import { Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
 import * as mst from 'mobx-state-tree'
@@ -68,7 +67,6 @@ export default class MyApp extends App {
             <Head />
             <Navigation />
             <Component {...pageProps} />
-            <ZooFooter />
           </Grommet>
         </Provider>
       </Container>

--- a/packages/app-project/server/server.js
+++ b/packages/app-project/server/server.js
@@ -45,10 +45,9 @@ app.prepare()
 
       // Finally handle any non-matching routes
       handle(req, res)
-      return
     })
-    .listen(port, (err) => {
-      if (err) throw err
-      console.log(`> Ready on http://localhost:${port}`)
-    })
+      .listen(port, (err) => {
+        if (err) throw err
+        console.log(`> Ready on http://localhost:${port}`)
+      })
   })

--- a/packages/app-project/stores/Project.js
+++ b/packages/app-project/stores/Project.js
@@ -5,6 +5,7 @@ import numberString from './types/numberString'
 
 const Project = types
   .model('Project', {
+    backgrounds: types.frozen([]),
     displayName: types.maybeNull(types.string),
     error: types.maybeNull(types.frozen({})),
     id: types.maybeNull(numberString),
@@ -22,11 +23,16 @@ const Project = types
       fetch: flow(function * fetch (slug) {
         self.loadingState = asyncStates.loading
         try {
-          const response = yield client.getBySlug({ query: { slug } })
+          const query = { slug }
+          const response = yield client.getWithLinkedResources({ query })
           const project = get(response, 'body.projects[0]')
+          const linked = get(response, 'body.linked')
+
           self.displayName = project.display_name
           self.id = project.id
           self.slug = project.slug
+          self.backgrounds = linked.backgrounds
+
           self.loadingState = asyncStates.success
         } catch (error) {
           self.error = error.message

--- a/packages/app-project/stores/Project.spec.js
+++ b/packages/app-project/stores/Project.spec.js
@@ -1,7 +1,8 @@
+import asyncStates from '@zooniverse/async-states'
+import { projects } from '@zooniverse/panoptes-js'
+
 import Project from './Project'
 import Store from './Store'
-import asyncStates from '../helpers/asyncStates'
-import { projects } from '@zooniverse/panoptes-js'
 import placeholderEnv from './helpers/placeholderEnv'
 
 let clientStub

--- a/packages/app-project/stores/initStore.spec.js
+++ b/packages/app-project/stores/initStore.spec.js
@@ -1,6 +1,7 @@
-import initStore from './initStore'
-import asyncStates from '../helpers/asyncStates'
+import asyncStates from '@zooniverse/async-states'
 import { panoptes, projects } from '@zooniverse/panoptes-js'
+
+import initStore from './initStore'
 
 describe('Stores > initStore', function () {
   it('should export a function', function () {

--- a/packages/app-project/test/mocha.opts
+++ b/packages/app-project/test/mocha.opts
@@ -5,4 +5,4 @@
 --file ./test/create-enzyme-adapter.js
 --file ./test/create-global-document.js
 
-./pages/*.spec.js
+./{components,pages}/**/*.spec.js


### PR DESCRIPTION
Package: fe-project

Adds a "Finished for the day?" component to the classify page. Image is taken from the project background, and loads progressively ❤️ 

I'm not sure it quite works at phone sizes - I might need to delve into the button styles in the grommet theme for why.

![untitled](https://user-images.githubusercontent.com/2725841/47940883-fe49ec00-dee3-11e8-8a87-d09a76970ef8.gif)

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

