### PR TITLE
Add Statistics box to project app

### DIFF
--- a/packages/app-project/components/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/components/ClassifyPage/ClassifyPage.js
@@ -1,11 +1,13 @@
 import React from 'react'
 
 import FinishedForTheDay from './components/FinishedForTheDay'
+import ProjectStatistics from './components/ProjectStatistics'
 
 function ClassifyPage () {
   return (
     <div>
       <FinishedForTheDay />
+      <ProjectStatistics />
     </div>
   )
 }

--- a/packages/app-project/components/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/components/ClassifyPage/ClassifyPage.js
@@ -1,3 +1,4 @@
+import { Grid } from 'grommet'
 import React from 'react'
 
 import FinishedForTheDay from './components/FinishedForTheDay'
@@ -5,10 +6,10 @@ import ProjectStatistics from './components/ProjectStatistics'
 
 function ClassifyPage () {
   return (
-    <div>
+    <Grid gap='medium' margin='medium'>
       <FinishedForTheDay />
       <ProjectStatistics />
-    </div>
+    </Grid>
   )
 }
 

--- a/packages/app-project/components/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/components/ClassifyPage/ClassifyPage.spec.js
@@ -3,6 +3,7 @@ import React from 'react'
 
 import ClassifyPage from './ClassifyPage'
 import FinishedForTheDay from './components/FinishedForTheDay'
+import ProjectStatistics from './components/ProjectStatistics'
 
 let wrapper
 
@@ -15,5 +16,9 @@ describe('Component > ClassifyPage', function () {
 
   it('should render the `FinishedForTheDay` component', function () {
     expect(wrapper.find(FinishedForTheDay)).to.have.lengthOf(1)
+  })
+
+  it('should render the `ProjectStatistics` component', function () {
+    expect(wrapper.find(ProjectStatistics)).to.have.lengthOf(1)
   })
 })

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/ProjectStatistics.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/ProjectStatistics.js
@@ -1,0 +1,93 @@
+import counterpart from 'counterpart'
+import { base as baseTheme, Text, Paragraph } from 'grommet'
+import PropTypes from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+
+import en from './locales/en'
+import ClassifyBox from '../ClassifyBox'
+import CompletionBar from './components/CompletionBar'
+import MainGrid from './components/MainGrid'
+import Stat from './components/Stat'
+import Subtitle from './components/Subtitle'
+
+counterpart.registerTranslations('en', en)
+
+const NumbersGrid = styled.div`
+  display: grid;
+  grid-template-rows: 1fr 1fr;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 12px;
+`
+
+const StyledParagraph = styled(Paragraph)`
+  max-width: 100%;
+`
+
+function ProjectStatistics ({
+  classifications,
+  completedSubjects,
+  subjects,
+  volunteers
+}) {
+  return (
+    <ClassifyBox>
+      <MainGrid>
+        <section>
+          <Subtitle text={counterpart('ProjectStatistics.subtitle')} />
+          <StyledParagraph margin={{ top: 'none' }} size='small'>
+            {counterpart('ProjectStatistics.text')}
+          </StyledParagraph>
+          <CompletionBar />
+          <Text
+            margin={{ top: 'small' }}
+            size='small'
+            weight='bold'
+          >
+            {counterpart('ProjectStatistics.percentComplete')}
+          </Text>
+        </section>
+        <section>
+          <Subtitle
+            text={counterpart('ProjectStatistics.byTheNumbers')}
+            margin={{ bottom: 'small', top: 'none' }}
+          />
+          <NumbersGrid>
+            <Stat
+              value={volunteers}
+              label={counterpart('ProjectStatistics.volunteers')}
+            />
+            <Stat
+              value={classifications}
+              label={counterpart('ProjectStatistics.classifications')}
+            />
+            <Stat
+              value={subjects}
+              label={counterpart('ProjectStatistics.subjects')}
+            />
+            <Stat
+              value={completedSubjects}
+              label={counterpart('ProjectStatistics.completedSubjects')}
+            />
+          </NumbersGrid>
+        </section>
+      </MainGrid>
+    </ClassifyBox>
+  )
+}
+
+ProjectStatistics.propTypes = {
+  classifications: PropTypes.number.isRequired,
+  completedSubjects: PropTypes.number.isRequired,
+  subjects: PropTypes.number.isRequired,
+  volunteers: PropTypes.number.isRequired
+}
+
+ProjectStatistics.defaultProps = {
+  classifications: 0,
+  completedSubjects: 0,
+  subjects: 0,
+  volunteers: 0
+}
+
+export default ProjectStatistics

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/ProjectStatistics.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/ProjectStatistics.spec.js
@@ -1,0 +1,22 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import ProjectStatistics from './ProjectStatistics'
+import CompletionBar from './components/CompletionBar'
+import Stat from './components/Stat'
+
+let wrapper
+
+describe('Component > ProjectStatistics', function () {
+  it('should render without crashing', function () {
+    wrapper = shallow(<ProjectStatistics />)
+  })
+
+  it('should render the Completion Bar', function () {
+    expect(wrapper.find(CompletionBar)).to.have.lengthOf(1)
+  })
+
+  it('should render four Stat boxes', function () {
+    expect(wrapper.find(Stat)).to.have.lengthOf(4)
+  })
+})

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/ProjectStatisticsContainer.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/ProjectStatisticsContainer.js
@@ -1,0 +1,53 @@
+import { inject, observer } from 'mobx-react'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+import ProjectStatistics from './ProjectStatistics'
+
+function storeMapper (stores) {
+  const { project } = stores.store
+  return {
+    classifications: project.classificationsCount,
+    completedSubjects: project.retiredSubjectsCount,
+    subjects: project.subjectsCount,
+    volunteers: project.classifiersCount
+  }
+}
+
+@inject(storeMapper)
+@observer
+class ProjectStatisticsContainer extends Component {
+  render () {
+    const {
+      classifications,
+      completedSubjects,
+      subjects,
+      volunteers
+    } = this.props
+
+    return (
+      <ProjectStatistics
+        classifications={classifications}
+        completedSubjects={completedSubjects}
+        subjects={subjects}
+        volunteers={volunteers}
+      />
+    )
+  }
+}
+
+ProjectStatisticsContainer.propTypes = {
+  classifications: PropTypes.number,
+  completedSubjects: PropTypes.number,
+  subjects: PropTypes.number,
+  volunteers: PropTypes.number
+}
+
+ProjectStatisticsContainer.defaultProps = {
+  classifications: 0,
+  completedSubjects: 0,
+  subjects: 0,
+  volunteers: 0
+}
+
+export default ProjectStatisticsContainer

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/ProjectStatisticsContainer.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/ProjectStatisticsContainer.spec.js
@@ -1,0 +1,47 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import ProjectStatistics from './ProjectStatistics'
+import ProjectStatisticsContainer from './ProjectStatisticsContainer'
+
+let wrapper
+let projectStatisticsWrapper
+
+const CLASSIFICATIONS = 1
+const COMPLETEDSUBJECTS = 2
+const SUBJECTS = 3
+const VOLUNTEERS = 4
+
+describe('Component > CompletionBarContainer', function () {
+  before(function () {
+    wrapper = shallow(<ProjectStatisticsContainer.wrappedComponent
+      classifications={CLASSIFICATIONS}
+      completedSubjects={COMPLETEDSUBJECTS}
+      subjects={SUBJECTS}
+      volunteers={VOLUNTEERS}
+    />)
+    projectStatisticsWrapper = wrapper.find(ProjectStatistics)
+  })
+
+  it('should render without crashing', function () {})
+
+  it('should render the `ProjectStatistics` component', function () {
+    expect(projectStatisticsWrapper).to.have.lengthOf(1)
+  })
+
+  it('should pass through a `classifications` prop', function () {
+    expect(projectStatisticsWrapper.prop('classifications')).to.equal(CLASSIFICATIONS)
+  })
+
+  it('should pass through a `completedSubjects` prop', function () {
+    expect(projectStatisticsWrapper.prop('completedSubjects')).to.equal(COMPLETEDSUBJECTS)
+  })
+
+  it('should pass through a `subjects` prop', function () {
+    expect(projectStatisticsWrapper.prop('subjects')).to.equal(SUBJECTS)
+  })
+
+  it('should pass through a `volunteers` prop', function () {
+    expect(projectStatisticsWrapper.prop('volunteers')).to.equal(VOLUNTEERS)
+  })
+})

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/CompletionBar.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/CompletionBar.js
@@ -2,20 +2,21 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import * as d3 from 'd3'
 import theme from '@zooniverse/grommet-theme'
+import styled from 'styled-components'
 
 import addBackgroundLayer from './d3/addBackgroundLayer'
 import createBar from './d3/createBar'
 import createLabel from './d3/createLabel'
 
+const SVG = styled.svg`
+  display: block;
+`
+
 class CompletionBar extends Component {
   constructor () {
     super()
-    this.svgContainer = React.createRef()
+    this.svgRef = React.createRef()
     this.d3svg = null
-  }
-
-  getData () {
-    return [this.props.completeness]
   }
 
   componentDidMount () {
@@ -24,18 +25,11 @@ class CompletionBar extends Component {
   }
 
   initChart () {
-    const container = this.svgContainer.current
-    this.d3svg = d3.select(container)
-      .append('svg')
-      .attr('class', 'completion-bar')
-      .attr('height', '40px')
-      .attr('width', '100%')
-      .style('display', 'block')
-      .call(addBackgroundLayer, theme.global.colors.lightTeal)
+    this.d3svg = d3.select(this.svgRef.current)
 
     this.d3svg
       .selectAll('.bar')
-      .data(this.getData())
+      .data([this.props.completeness])
       .enter()
       .append('g')
       .attr('class', 'bar')
@@ -77,7 +71,9 @@ class CompletionBar extends Component {
 
   render () {
     return (
-      <div ref={this.svgContainer} />
+      <SVG ref={this.svgRef} height='40px' width='100%'>
+        <rect height='100%' width='100%' fill={theme.global.colors.lightTeal} />
+      </SVG>
     )
   }
 }

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/CompletionBar.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/CompletionBar.js
@@ -1,0 +1,93 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import * as d3 from 'd3'
+import theme from '@zooniverse/grommet-theme'
+
+import addBackgroundLayer from './d3/addBackgroundLayer'
+import createBar from './d3/createBar'
+import createLabel from './d3/createLabel'
+
+class CompletionBar extends Component {
+  constructor () {
+    super()
+    this.svgContainer = React.createRef()
+    this.d3svg = null
+  }
+
+  getData () {
+    return [this.props.completeness]
+  }
+
+  componentDidMount () {
+    this.initChart()
+    this.drawChart()
+  }
+
+  initChart () {
+    const container = this.svgContainer.current
+    this.d3svg = d3.select(container)
+      .append('svg')
+      .attr('class', 'completion-bar')
+      .attr('height', '40px')
+      .attr('width', '100%')
+      .style('display', 'block')
+      .call(addBackgroundLayer, theme.global.colors.lightTeal)
+
+    this.d3svg
+      .selectAll('.bar')
+      .data(this.getData())
+      .enter()
+      .append('g')
+      .attr('class', 'bar')
+      .call(createBar, theme.global.colors.teal)
+      .call(createLabel, theme.global.colors.teal)
+  }
+
+  drawChart () {
+    const bar = this.d3svg.selectAll('.bar')
+
+    // TODO: see if this looks better when using a scale transform instead of
+    // manipulating the width.
+    bar.selectAll('rect')
+      .transition()
+      .duration(1000)
+      .attr('width', d => `${d * 100}%`)
+
+    bar.selectAll('text')
+      .transition()
+      .duration(1000)
+      .tween('text', (d, i, elements) => {
+        // `this` _should_ be bound to the element, but in React is already
+        // bound to the component instance, so we define it here as `node`.
+        const node = d3.select(elements[i])
+        const interpolator = d3.interpolate(0, d)
+        return t => {
+          const value = interpolator(t)
+          const percent = d3.format('.0%')(value)
+          node.text(percent)
+            .attr('x', percent)
+          if (value > 0.5) {
+            node.attr('dx', '-12px')
+              .attr('text-anchor', 'end')
+              .attr('fill', '#fff')
+          }
+        }
+      })
+  }
+
+  render () {
+    return (
+      <div ref={this.svgContainer} />
+    )
+  }
+}
+
+CompletionBar.propTypes = {
+  completeness: PropTypes.number.isRequired
+}
+
+CompletionBar.defaultProps = {
+  completeness: 0.60
+}
+
+export default CompletionBar

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/CompletionBar.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/CompletionBar.js
@@ -50,10 +50,8 @@ class CompletionBar extends Component {
     bar.selectAll('text')
       .transition()
       .duration(1000)
-      .tween('text', (d, i, elements) => {
-        // `this` _should_ be bound to the element, but in React is already
-        // bound to the component instance, so we define it here as `node`.
-        const node = d3.select(elements[i])
+      .tween('text', function (d, i, elements) {
+        const node = d3.select(this)
         const interpolator = d3.interpolate(0, d)
         return t => {
           const value = interpolator(t)
@@ -83,7 +81,7 @@ CompletionBar.propTypes = {
 }
 
 CompletionBar.defaultProps = {
-  completeness: 0.60
+  completeness: 0
 }
 
 export default CompletionBar

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/CompletionBar.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/CompletionBar.spec.js
@@ -1,0 +1,9 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import CompletionBar from './CompletionBar'
+
+describe('Component > CompletionBar', function () {
+  it('should render without crashing', function () {
+    shallow(<CompletionBar />)
+  })
+})

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/CompletionBarContainer.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/CompletionBarContainer.js
@@ -1,0 +1,34 @@
+import { inject, observer } from 'mobx-react'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+import CompletionBar from './CompletionBar'
+
+function storeMapper (stores) {
+  return {
+    completeness: stores.store.project.completeness
+  }
+}
+
+@inject(storeMapper)
+@observer
+class CompletionBarContainer extends Component {
+  render () {
+    const { completeness } = this.props
+    return (
+      <CompletionBar
+        completeness={completeness}
+      />
+    )
+  }
+}
+
+CompletionBarContainer.propTypes = {
+  completeness: PropTypes.number.isRequired
+}
+
+CompletionBarContainer.defaultProps = {
+  completeness: 0
+}
+
+export default CompletionBarContainer

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/CompletionBarContainer.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/CompletionBarContainer.spec.js
@@ -1,0 +1,29 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import CompletionBar from './CompletionBar'
+import CompletionBarContainer from './CompletionBarContainer'
+
+let wrapper
+let completionBarWrapper
+
+const COMPLETENESS = 0.4
+
+describe('Component > CompletionBarContainer', function () {
+  before(function () {
+    wrapper = shallow(<CompletionBarContainer.wrappedComponent
+      completeness={COMPLETENESS}
+    />)
+    completionBarWrapper = wrapper.find(CompletionBar)
+  })
+
+  it('should render without crashing', function () {})
+
+  it('should render the `CompletionBar` component', function () {
+    expect(completionBarWrapper).to.have.lengthOf(1)
+  })
+
+  it('should pass through a `completeness` prop', function () {
+    expect(completionBarWrapper.prop('completeness')).to.equal(COMPLETENESS)
+  })
+})

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/d3/addBackgroundLayer.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/d3/addBackgroundLayer.js
@@ -1,0 +1,7 @@
+export default function addBackgroundLayer (selection, fill) {
+  return selection
+    .append('rect')
+    .attr('height', '100%')
+    .attr('width', '100%')
+    .style('fill', fill)
+}

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/d3/createBar.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/d3/createBar.js
@@ -1,0 +1,7 @@
+export default function createBar (selection, fill) {
+  return selection
+    .append('rect')
+    .attr('width', '0%')
+    .attr('height', '100%')
+    .attr('fill', fill)
+}

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/d3/createLabel.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/d3/createLabel.js
@@ -1,0 +1,11 @@
+export default function createBar (selection, fill) {
+  return selection
+    .append('text')
+    .text('0%')
+    .attr('x', '0%')
+    .attr('y', '50%')
+    .attr('alignment-baseline', 'middle')
+    .attr('dx', '12px')
+    .attr('text-anchor', 'start')
+    .attr('fill', fill)
+}

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/index.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/CompletionBar/index.js
@@ -1,0 +1,1 @@
+export { default } from './CompletionBarContainer'

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/MainGrid/MainGrid.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/MainGrid/MainGrid.js
@@ -1,0 +1,41 @@
+import { base as baseTheme } from 'grommet'
+import theme from '@zooniverse/grommet-theme'
+import styled from 'styled-components'
+
+const { breakpoints } = baseTheme.global
+
+const MainGrid = styled.div`
+  display: grid;
+  grid-template-rows: auto auto;
+  grid-template-columns: 100%;
+
+  section {
+    &:nth-of-type(1) {
+      padding-bottom: 12px;
+      border-bottom: solid 1px rgba(0,0,0,0.33);
+    }
+    &:nth-of-type(2) {
+      margin-top: 12px;
+    }
+  }
+
+  @media (min-width: ${breakpoints.small.value}px) {
+    grid-template-rows: 1fr;
+    grid-template-columns: 61.8% auto;
+
+    section {
+      &:nth-of-type(1) {
+        padding-bottom: 0;
+        padding-right: 24px;
+        border-bottom: 0;
+        border-right: solid 1px rgba(0,0,0,0.33);
+      }
+      &:nth-of-type(2) {
+        margin-top: 0;
+        margin-left: 24px;
+      }
+    }
+  }
+`
+
+export default MainGrid

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/MainGrid/MainGrid.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/MainGrid/MainGrid.spec.js
@@ -1,0 +1,9 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import MainGrid from './MainGrid'
+
+describe('Component > MainGrid', function () {
+  it('should render without crashing', function () {
+    shallow(<MainGrid />)
+  })
+})

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/MainGrid/index.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/MainGrid/index.js
@@ -1,0 +1,1 @@
+export { default } from './MainGrid'

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Stat/Stat.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Stat/Stat.js
@@ -1,0 +1,25 @@
+import { Text } from 'grommet'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+import AnimatedNumber from './components/AnimatedNumber'
+
+function Stat ({ label, value }) {
+  return (
+    <div>
+      <Text size='xxlarge' color='#E2E5E9' tag='div'>
+        <AnimatedNumber value={value} />
+      </Text>
+      <Text size='small' color='#A6A7A9' weight='bold' tag='div'>
+        {label}
+      </Text>
+    </div>
+  )
+}
+
+Stat.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.number.isRequired
+}
+
+export default Stat

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Stat/Stat.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Stat/Stat.spec.js
@@ -1,0 +1,27 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import Stat from './Stat'
+import AnimatedNumber from './components/AnimatedNumber'
+
+let wrapper
+const value = 123456
+const label = 'Text label'
+
+describe('Component > Stat', function () {
+  before(function () {
+    wrapper = shallow(<Stat value={value} label={label} />)
+  })
+
+  it('should render without crashing', function () {})
+
+  it('should pass the `value` prop to an `AnimatedNumber`', function () {
+    const animatedNumber = wrapper.find(AnimatedNumber)
+    expect(animatedNumber.length).to.equal(1)
+    expect(animatedNumber.prop('value')).to.equal(value)
+  })
+
+  it('should render the `label` prop', function () {
+    expect(wrapper.text()).to.contain(label)
+  })
+})

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Stat/components/AnimatedNumber/AnimatedNumber.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Stat/components/AnimatedNumber/AnimatedNumber.js
@@ -1,0 +1,49 @@
+import * as d3 from 'd3'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+class AnimatedNumber extends Component {
+  constructor () {
+    super()
+    this.ref = React.createRef()
+  }
+
+  componentDidMount () {
+    this.animateValue()
+  }
+
+  animateValue () {
+    d3.select(this.ref.current)
+      .data([this.props.value])
+      .transition()
+      .duration(this.props.duration)
+      .tween('text', (d, i, elements) => {
+        // `this` _should_ be bound to the element, but in React is already
+        // bound to the component instance, so we define it here as `node`.
+        const node = d3.select(elements[i])
+        const interpolator = d3.interpolate(0, d)
+        return t => {
+          const value = interpolator(t)
+          const niceValue = d3.format(',d')(value)
+          node.text(niceValue)
+        }
+      })
+  }
+
+  render () {
+    return (
+      <span ref={this.ref}>0</span>
+    )
+  }
+}
+
+AnimatedNumber.propTypes = {
+  duration: PropTypes.number,
+  value: PropTypes.number.isRequired
+}
+
+AnimatedNumber.defaultProps = {
+  duration: 1000
+}
+
+export default AnimatedNumber

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Stat/components/AnimatedNumber/AnimatedNumber.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Stat/components/AnimatedNumber/AnimatedNumber.js
@@ -17,10 +17,8 @@ class AnimatedNumber extends Component {
       .data([this.props.value])
       .transition()
       .duration(this.props.duration)
-      .tween('text', (d, i, elements) => {
-        // `this` _should_ be bound to the element, but in React is already
-        // bound to the component instance, so we define it here as `node`.
-        const node = d3.select(elements[i])
+      .tween('text', function (d, i, elements) {
+        const node = d3.select(this)
         const interpolator = d3.interpolate(0, d)
         return t => {
           const value = interpolator(t)

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Stat/components/AnimatedNumber/AnimatedNumber.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Stat/components/AnimatedNumber/AnimatedNumber.spec.js
@@ -1,0 +1,10 @@
+import { render } from 'enzyme'
+import React from 'react'
+
+import AnimatedNumber from './AnimatedNumber'
+
+describe('Component > AnimatedNumber', function () {
+  it('should render without crashing', function () {
+    render(<AnimatedNumber value={1000} />)
+  })
+})

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Stat/components/AnimatedNumber/index.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Stat/components/AnimatedNumber/index.js
@@ -1,0 +1,1 @@
+export { default } from './AnimatedNumber'

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Stat/index.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Stat/index.js
@@ -1,0 +1,1 @@
+export { default } from './Stat'

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Subtitle/Subtitle.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Subtitle/Subtitle.js
@@ -1,0 +1,21 @@
+import { Box, Text } from 'grommet'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+function Subtitle ({ text, ...props }) {
+  return (
+    <Text {...props}>
+      {text}
+    </Text>
+  )
+}
+
+Subtitle.defaultProps = {
+  color: 'black',
+  margin: 'none',
+  size: 'small',
+  tag: 'h5',
+  weight: 'bold'
+}
+
+export default Subtitle

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Subtitle/Subtitle.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Subtitle/Subtitle.spec.js
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import Subtitle from './Subtitle'
+
+let wrapper
+const TEXT = 'Foobar'
+
+describe('Component > Subtitle', function () {
+  before(function () {
+    wrapper = shallow(<Subtitle text={TEXT} />)
+  })
+
+  it('should render without crashing', function () {})
+
+  it('should render the `text` prop', function () {
+    expect(wrapper.text()).to.equal(TEXT)
+  })
+})

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Subtitle/index.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/components/Subtitle/index.js
@@ -1,0 +1,1 @@
+export { default } from './Subtitle'

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/index.js
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/index.js
@@ -1,0 +1,1 @@
+export { default } from './ProjectStatisticsContainer'

--- a/packages/app-project/components/ClassifyPage/components/ProjectStatistics/locales/en.json
+++ b/packages/app-project/components/ClassifyPage/components/ProjectStatistics/locales/en.json
@@ -1,0 +1,12 @@
+{
+  "ProjectStatistics": {
+    "byTheNumbers": "By the numbers",
+    "classifications": "Classifications",
+    "completedSubjects": "Completed subjects",
+    "subjects": "Subjects",
+    "percentComplete": "Percent complete",
+    "subtitle": "Keep track of the progress you and your fellow volunteers have made on this project.",
+    "text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
+    "volunteers": "Volunteers"
+  }
+}

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -22,6 +22,7 @@
     "@zooniverse/panoptes-js": "~0.0.1",
     "@zooniverse/react-components": "~0.7.1",
     "counterpart": "^0.18.6",
+    "d3": "^5.7.0",
     "grommet": "~2.0.0-rc",
     "grommet-icons": "~3.1.0",
     "lodash": "~4.17.11",

--- a/packages/app-project/stores/Project.js
+++ b/packages/app-project/stores/Project.js
@@ -1,15 +1,19 @@
 import asyncStates from '@zooniverse/async-states'
 import { flow, getRoot, types } from 'mobx-state-tree'
-import { get } from 'lodash'
 import numberString from './types/numberString'
 
 const Project = types
   .model('Project', {
     backgrounds: types.frozen([]),
+    classificationsCount: types.optional(types.number, 0),
+    classifiersCount: types.optional(types.number, 0),
+    completeness: types.optional(types.number, 0),
     displayName: types.maybeNull(types.string),
     error: types.maybeNull(types.frozen({})),
     id: types.maybeNull(numberString),
-    loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.initialized)
+    loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.initialized),
+    retiredSubjectsCount: types.optional(types.number, 0),
+    subjectsCount: types.optional(types.number, 0)
   })
 
   .actions(self => {
@@ -25,13 +29,18 @@ const Project = types
         try {
           const query = { slug }
           const response = yield client.getWithLinkedResources({ query })
-          const project = get(response, 'body.projects[0]')
-          const linked = get(response, 'body.linked')
+          const project = response.body.projects[0]
+          const linked = response.body.linked
 
+          self.backgrounds = linked.backgrounds
+          self.classificationsCount = project.classifications_count
+          self.classifiersCount = project.classifiers_count
+          self.completeness = project.completeness
           self.displayName = project.display_name
           self.id = project.id
           self.slug = project.slug
-          self.backgrounds = linked.backgrounds
+          self.retiredSubjectsCount = project.retired_subjects_count
+          self.subjectsCount = project.subjects_count
 
           self.loadingState = asyncStates.success
         } catch (error) {


### PR DESCRIPTION
Package: `app-project`

Adds the Project Statistics box to the classifier page.

![untitled2](https://user-images.githubusercontent.com/2725841/48364677-f1c25200-e6a0-11e8-8846-7b8e344286a8.gif)

~~requires #232 merging first~~

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

