### PR TITLE
Fix LCV not loading next subject

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
@@ -33,7 +33,7 @@ class SubjectViewer extends React.Component {
     const { subject } = this.props
     const Viewer = getViewer(subject.viewer)
     return (
-      <Viewer subject={subject} />
+      <Viewer subject={subject} subjectId={subject.id} />
     )
   }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -44,7 +44,6 @@ class LightCurveViewer extends Component {
   }
 
   clearChart () {
-    console.info('clearing')
     this.d3dataLayer.selectAll('circle')
       .remove()
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -25,20 +25,31 @@ class LightCurveViewer extends Component {
   }
 
   componentDidUpdate (prevProps) {
-    const isFirstDraw = !prevProps.points.length && this.props.points.length
-    if (isFirstDraw) {
-      const container = this.svgContainer.current
-      const height = container.offsetHeight || 0
-      const width = container.offsetWidth || 0
-      this.drawChart(width, height, isFirstDraw)
+    const points = this.props.points
+    const prevPoints = prevProps.points
+    const sameSubject = (points === prevPoints)
+
+    if (!sameSubject) {
+      this.clearChart()
     }
+
+    const container = this.svgContainer.current
+    const height = container.offsetHeight || 0
+    const width = container.offsetWidth || 0
+    this.drawChart(width, height, sameSubject)
   }
 
   componentWillUnmount () {
     this.d3interfaceLayer.on('.zoom', null)
   }
 
-  drawChart (width, height, isFirstDraw = false) {
+  clearChart () {
+    console.info('clearing')
+    this.d3dataLayer.selectAll('circle')
+      .remove()
+  }
+
+  drawChart (width, height, shouldAnimate = false) {
     if (!height || !width) {
       return false
     }
@@ -58,18 +69,18 @@ class LightCurveViewer extends Component {
       .attr('cx', d => this.xScale(d[0]))
       .attr('cy', d => this.yScale(d[1]))
 
-    if (isFirstDraw) {
+    if (shouldAnimate) {
       points.enter()
         .append('circle')
         .call(setPointStyle)
         .merge(points)
+        .transition()
         .call(setPointCoords)
     } else {
       points.enter()
         .append('circle')
         .call(setPointStyle)
         .merge(points)
-        .transition()
         .call(setPointCoords)
     }
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
@@ -28,9 +28,9 @@ class LightCurveViewerContainer extends Component {
   }
 
   componentDidUpdate (prevProps) {
-    const prevSubject = prevProps.subject
-    const { subject } = this.props
-
+    const prevSubject = prevProps.subject.toJSON()
+    const subject = this.props.subject.toJSON()
+    console.info(prevSubject.id, subject.id)
     if (subject && (!prevSubject || prevSubject.id !== subject.id)) {
       this.handleSubject()
     }
@@ -92,6 +92,7 @@ class LightCurveViewerContainer extends Component {
     if (!subject) {
       return null
     }
+
     return (
       <LightCurveViewer
         extent={this.state.extent}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
@@ -28,10 +28,11 @@ class LightCurveViewerContainer extends Component {
   }
 
   componentDidUpdate (prevProps) {
-    const prevSubject = prevProps.subject.toJSON()
-    const subject = this.props.subject.toJSON()
-    console.info(prevSubject.id, subject.id)
-    if (subject && (!prevSubject || prevSubject.id !== subject.id)) {
+    const { subject, subjectId } = this.props
+    const prevSubject = prevProps.subject
+    const prevSubjectId = prevProps.subjectId
+
+    if (subject && (!prevSubject || prevSubjectId !== subjectId)) {
       this.handleSubject()
     }
   }
@@ -105,9 +106,8 @@ class LightCurveViewerContainer extends Component {
 LightCurveViewerContainer.propTypes = {
   subject: PropTypes.shape({
     locations: PropTypes.arrayOf(locationValidator)
-  })
+  }),
+  subjectId: PropTypes.string
 }
-
-LightCurveViewerContainer.defaultProps = {}
 
 export default LightCurveViewerContainer

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -1,12 +1,25 @@
+import zooTheme from '@zooniverse/grommet-theme'
+import asyncStates from '@zooniverse/async-states'
+import { Box } from 'grommet'
 import { inject, observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Box } from 'grommet'
+import styled, { ThemeProvider } from 'styled-components'
+import theme from 'styled-theming'
 
-import asyncStates from '@zooniverse/async-states'
 import getTaskComponent from './helpers/getTaskComponent'
 import TaskHelpButton from './components/TaskHelpButton'
 import { default as TaskNavButtons } from './components/TaskNavButtons'
+
+const StyledBox = styled(Box)`
+  border-bottom: 1px solid;
+  border-left: 1px solid;
+  border-right: 1px solid;
+  border-color: ${theme('mode', {
+    dark: zooTheme.dark.colors.tabs.border,
+    light: zooTheme.light.colors.tabs.border
+  })};
+`
 
 function storeMapper (stores) {
   const { loadingState } = stores.classifierStore.workflows
@@ -39,23 +52,25 @@ export class Tasks extends React.Component {
     const { tasks } = this.props
     if (tasks.length > 0) {
       return (
-        <Box tag='form'>
-          {tasks.map((task) => {
-            const TaskComponent = getTaskComponent(task.type)
-            if (TaskComponent) {
-              return (
-                <Box key={task.taskKey}>
-                  <TaskComponent task={task} {...this.props} />
-                  {task.help &&
-                    <TaskHelpButton />}
-                </Box>
-              )
-            }
+        <ThemeProvider theme={{ mode: this.props.theme }}>
+          <StyledBox tag='form' pad={{ top: 'medium' }}>
+            {tasks.map((task) => {
+              const TaskComponent = getTaskComponent(task.type)
+              if (TaskComponent) {
+                return (
+                  <Box key={task.taskKey}>
+                    <TaskComponent task={task} {...this.props} />
+                    {task.help &&
+                      <TaskHelpButton />}
+                  </Box>
+                )
+              }
 
-            return (<div>Task component could not be rendered.</div>)
-          })}
-          <TaskNavButtons />
-        </Box>
+              return (<div>Task component could not be rendered.</div>)
+            })}
+            <TaskNavButtons />
+          </StyledBox>
+      </ThemeProvider>
       )
     }
 
@@ -70,12 +85,16 @@ export class Tasks extends React.Component {
 
 Tasks.wrappedComponent.propTypes = {
   loadingState: PropTypes.oneOf(asyncStates.values),
-  tasks: PropTypes.arrayOf(PropTypes.object)
+  tasks: PropTypes.arrayOf(PropTypes.object),
+  theme: PropTypes.string,
+
 }
 
 Tasks.wrappedComponent.defaultProps = {
   loadingState: asyncStates.initialized,
-  tasks: []
+  tasks: [],
+  theme: 'light',
+
 }
 
 export default Tasks

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/DrawingTask/DrawingTask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/DrawingTask/DrawingTask.js
@@ -1,0 +1,62 @@
+import { Markdown, Text } from 'grommet'
+import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
+import { observable } from 'mobx'
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+function storeMapper (stores) {
+  const {
+    addAnnotation
+  } = stores.classifierStore.classifications
+  const annotations = stores.classifierStore.classifications.currentAnnotations
+  return {
+    addAnnotation,
+    annotations
+  }
+}
+
+@inject(storeMapper)
+@observer
+class DrawingTask extends React.Component {
+  onChange (index, event) {
+    const { addAnnotation, task } = this.props
+    if (event.target.checked) addAnnotation(index, task)
+  }
+
+  render () {
+    const {
+      annotations,
+      task
+    } = this.props
+    let annotation
+    if (annotations && annotations.size > 0) {
+      annotation = annotations.get(task.taskKey)
+    }
+    return (
+      <Text size='small' tag='legend'>
+        <Markdown>
+          {task.instruction}
+        </Markdown>
+      </Text>
+    )
+  }
+}
+
+DrawingTask.wrappedComponent.defaultProps = {
+  addAnnotation: () => {},
+  annotations: observable.map(),
+  task: {}
+}
+
+DrawingTask.wrappedComponent.propTypes = {
+  addAnnotation: PropTypes.func,
+  annotations: MobXPropTypes.observableMap,
+  task: PropTypes.shape({
+    help: PropTypes.string,
+    instruction: PropTypes.string,
+    required: PropTypes.bool
+  })
+}
+
+export default DrawingTask

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/DrawingTask/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/DrawingTask/index.js
@@ -1,0 +1,1 @@
+export { default } from './DrawingTask'

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/helpers/getTaskComponent.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/helpers/getTaskComponent.js
@@ -1,7 +1,9 @@
+import DrawingTask from '../components/DrawingTask'
 import SingleChoiceTask from '../components/SingleChoiceTask'
 import MultipleChoiceTask from '../components/MultipleChoiceTask'
 
 const taskTypes = {
+  drawing: DrawingTask,
   single: SingleChoiceTask,
   multiple: MultipleChoiceTask
 }


### PR DESCRIPTION
Package: lib-classifier

Closes #238 

Ensures a new subject is plotted on the chart, adds a placeholder drawing task for the tasks area.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

