### PR TITLE
Auth environment fix and login/logout callback support

### DIFF
--- a/packages/lib-auth/dev/components/App/App.js
+++ b/packages/lib-auth/dev/components/App/App.js
@@ -49,7 +49,9 @@ class App extends React.Component {
         <Box>
           <h2>Auth status:</h2>
           <pre style={{ whiteSpace: 'pre-line', wordBreak: 'break-all' }}>
-            {JSON.stringify(this.auth.getToken(), null, 2)}
+            {this.state.user && this.auth.getToken()
+              ? <Text>Token exists</Text>
+              : <Text>No token</Text>}
           </pre>
           <hr />
           {this.state.user

--- a/packages/lib-auth/dev/components/App/App.js
+++ b/packages/lib-auth/dev/components/App/App.js
@@ -1,5 +1,4 @@
-import { Button, Grommet, Box } from 'grommet'
-import queryString from 'query-string'
+import { Button, Grommet, Box, Text } from 'grommet'
 import React from 'react'
 import zooTheme from '@zooniverse/grommet-theme'
 
@@ -14,28 +13,27 @@ class App extends React.Component {
       redirectUri: 'http://localhost:3000'
     })
     this.state = {
-      loading: false
+      loading: true,
+      user: null
     }
     this.logout = this.logout.bind(this)
   }
 
   componentDidMount () {
-    const { access_token, expires_in } = queryString.parse(window.location.hash)
-    if (access_token && expires_in) {
-      this.setState({ loading: true })
-      this.auth.completeLogin()
-        .then(() => {
-          this.setState({ loading: false })
-          history.replaceState(null, document.title, location.pathname + location.search)
-        })
-    }
+    this.auth.initialize()
+      .then((user) => {
+        this.setState({ loading: false, user })
+        if (location.hash) history.replaceState(null, document.title, location.pathname + location.search)
+      })
+      .catch((error) => {
+        console.error(error)
+        this.setState({ loading: false })
+      })
   }
 
   logout () {
     this.auth.logout()
-
-    // We trigger a forced update to re-render the Auth status content
-    this.forceUpdate()
+      .then(this.setState({ user: null }))
   }
 
   renderApp () {
@@ -43,7 +41,7 @@ class App extends React.Component {
       <Box>
         <Box direction='row' justify='between' pad='small'>
           <div>OAuth Test app</div>
-          {this.auth.getToken()
+          {this.state.user
             ? <Button onClick={this.logout} label='Logout' />
             : <Button onClick={this.auth.startLogin} label='Login' />
           }
@@ -53,6 +51,10 @@ class App extends React.Component {
           <pre style={{ whiteSpace: 'pre-line', wordBreak: 'break-all' }}>
             {JSON.stringify(this.auth.getToken(), null, 2)}
           </pre>
+          <hr />
+          {this.state.user
+            ? <Text>User: {this.state.user.display_name}</Text>
+            : <Text>No user</Text>}
         </Box>
       </Box>
     )

--- a/packages/lib-auth/package-lock.json
+++ b/packages/lib-auth/package-lock.json
@@ -1,14 +1,11 @@
 {
-	"name": "@zooniverse/auth",
-	"version": "0.0.1",
-	"lockfileVersion": 1,
 	"requires": true,
+	"lockfileVersion": 1,
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
 			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.0.0"
 			}
@@ -17,7 +14,6 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.2.tgz",
 			"integrity": "sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/generator": "^7.1.2",
@@ -39,7 +35,6 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -47,8 +42,7 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
@@ -56,7 +50,6 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
 			"integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.1.3",
 				"jsesc": "^2.5.1",
@@ -68,8 +61,7 @@
 				"jsesc": {
 					"version": "2.5.1",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
-					"dev": true
+					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
 				}
 			}
 		},
@@ -77,7 +69,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
 			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			},
@@ -86,7 +77,6 @@
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
 					"integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.10",
@@ -96,8 +86,7 @@
 				"to-fast-properties": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 				}
 			}
 		},
@@ -105,7 +94,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
 			"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-explode-assignable-expression": "^7.1.0",
 				"@babel/types": "^7.0.0"
@@ -115,7 +103,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz",
 			"integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0",
 				"esutils": "^2.0.0"
@@ -125,7 +112,6 @@
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
 					"integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.10",
@@ -135,8 +121,7 @@
 				"to-fast-properties": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 				}
 			}
 		},
@@ -144,7 +129,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
 			"integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.0.0",
 				"@babel/traverse": "^7.1.0",
@@ -155,7 +139,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
 			"integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/types": "^7.0.0",
@@ -166,7 +149,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
 			"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
-			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.1.0",
 				"@babel/types": "^7.0.0"
@@ -176,7 +158,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
 			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "^7.0.0",
 				"@babel/template": "^7.1.0",
@@ -187,7 +168,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
 			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -196,7 +176,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
 			"integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -205,7 +184,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
 			"integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -214,7 +192,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
 			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -223,7 +200,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz",
 			"integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-simple-access": "^7.1.0",
@@ -237,7 +213,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
 			"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -245,14 +220,12 @@
 		"@babel/helper-plugin-utils": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
-			"dev": true
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
 		},
 		"@babel/helper-regex": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
 			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.17.10"
 			}
@@ -261,7 +234,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
 			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"@babel/helper-wrap-function": "^7.1.0",
@@ -274,7 +246,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz",
 			"integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.0.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
@@ -286,7 +257,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
 			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
-			"dev": true,
 			"requires": {
 				"@babel/template": "^7.1.0",
 				"@babel/types": "^7.0.0"
@@ -296,7 +266,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
 			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -305,7 +274,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.1.0.tgz",
 			"integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/template": "^7.1.0",
@@ -317,7 +285,6 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.2.tgz",
 			"integrity": "sha512-Myc3pUE8eswD73aWcartxB16K6CGmHDv9KxOmD2CeOs/FaEAQodr3VYGmlvOmog60vNQ2w8QbatuahepZwrHiA==",
-			"dev": true,
 			"requires": {
 				"@babel/template": "^7.1.2",
 				"@babel/traverse": "^7.1.0",
@@ -328,7 +295,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
 			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
@@ -339,7 +305,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -348,7 +313,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -360,14 +324,12 @@
 		"@babel/parser": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
-			"integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==",
-			"dev": true
+			"integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.1.0.tgz",
 			"integrity": "sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-remap-async-to-generator": "^7.1.0",
@@ -378,7 +340,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
 			"integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-member-expression-to-functions": "^7.0.0",
@@ -392,7 +353,6 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.1.2.tgz",
 			"integrity": "sha512-YooynBO6PmBgHvAd0fl5e5Tq/a0pEC6RqF62ouafme8FzdIVH41Mz/u1dn8fFVm4jzEJ+g/MsOxouwybJPuP8Q==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-replace-supers": "^7.1.0",
@@ -404,7 +364,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz",
 			"integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-json-strings": "^7.0.0"
@@ -414,7 +373,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
 			"integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-object-rest-spread": "^7.0.0"
@@ -424,7 +382,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0.tgz",
 			"integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
@@ -434,7 +391,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0.tgz",
 			"integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0",
@@ -444,14 +400,12 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				},
 				"regexpu-core": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
 					"integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
-					"dev": true,
 					"requires": {
 						"regenerate": "^1.4.0",
 						"regenerate-unicode-properties": "^7.0.0",
@@ -464,14 +418,12 @@
 				"regjsgen": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
-					"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
-					"dev": true
+					"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
 				},
 				"regjsparser": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
 					"integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
-					"dev": true,
 					"requires": {
 						"jsesc": "~0.5.0"
 					}
@@ -482,7 +434,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz",
 			"integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -491,7 +442,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz",
 			"integrity": "sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -500,7 +450,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.1.0.tgz",
 			"integrity": "sha512-uQvRSbgQ0nQg3jsmIixXXDCgSpkBolJ9X7NYThMKCcjvE8dN2uWJUzTUNNAeuKOjARTd+wUQV0ztXpgunZYKzQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -509,7 +458,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz",
 			"integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -518,7 +466,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0.tgz",
 			"integrity": "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -527,7 +474,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
 			"integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -536,7 +482,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
 			"integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -545,7 +490,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
 			"integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -554,7 +498,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.1.0.tgz",
 			"integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -565,7 +508,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0.tgz",
 			"integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -574,7 +516,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
 			"integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"lodash": "^4.17.10"
@@ -584,7 +525,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
 			"integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"@babel/helper-define-map": "^7.1.0",
@@ -599,8 +539,7 @@
 				"globals": {
 					"version": "11.8.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
-					"dev": true
+					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA=="
 				}
 			}
 		},
@@ -608,7 +547,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
 			"integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -617,7 +555,6 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.1.3.tgz",
 			"integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -626,7 +563,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0.tgz",
 			"integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0",
@@ -636,14 +572,12 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				},
 				"regexpu-core": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
 					"integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
-					"dev": true,
 					"requires": {
 						"regenerate": "^1.4.0",
 						"regenerate-unicode-properties": "^7.0.0",
@@ -656,14 +590,12 @@
 				"regjsgen": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
-					"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
-					"dev": true
+					"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
 				},
 				"regjsparser": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
 					"integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
-					"dev": true,
 					"requires": {
 						"jsesc": "~0.5.0"
 					}
@@ -674,7 +606,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0.tgz",
 			"integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -683,7 +614,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.1.0.tgz",
 			"integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -693,7 +623,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz",
 			"integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -702,7 +631,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.1.0.tgz",
 			"integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -712,7 +640,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
 			"integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -721,7 +648,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.1.0.tgz",
 			"integrity": "sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -731,7 +657,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
 			"integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -742,7 +667,6 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.1.3.tgz",
 			"integrity": "sha512-PvTxgjxQAq4pvVUZF3mD5gEtVDuId8NtWkJsZLEJZMZAW3TvgQl1pmydLLN1bM8huHFVVU43lf0uvjQj9FRkKw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -752,7 +676,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.1.0.tgz",
 			"integrity": "sha512-enrRtn5TfRhMmbRwm7F8qOj0qEYByqUvTttPEGimcBH4CJHphjyK1Vg7sdU7JjeEmgSpM890IT/efS2nMHwYig==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -762,7 +685,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
 			"integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -771,7 +693,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.1.0.tgz",
 			"integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-replace-supers": "^7.1.0"
@@ -781,7 +702,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz",
 			"integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-call-delegate": "^7.1.0",
 				"@babel/helper-get-function-arity": "^7.0.0",
@@ -792,7 +712,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0.tgz",
 			"integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -801,7 +720,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0.tgz",
 			"integrity": "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-builder-react-jsx": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -812,7 +730,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0.tgz",
 			"integrity": "sha512-pymy+AK12WO4safW1HmBpwagUQRl9cevNX+82AIAtU1pIdugqcH+nuYP03Ja6B+N4gliAaKWAegIBL/ymALPHA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-jsx": "^7.0.0"
@@ -822,7 +739,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0.tgz",
 			"integrity": "sha512-OSeEpFJEH5dw/TtxTg4nijl4nHBbhqbKL94Xo/Y17WKIf2qJWeIk/QeXACF19lG1vMezkxqruwnTjVizaW7u7w==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-jsx": "^7.0.0"
@@ -832,7 +748,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
 			"integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
-			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.13.3"
 			},
@@ -841,7 +756,6 @@
 					"version": "0.13.3",
 					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
 					"integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
-					"dev": true,
 					"requires": {
 						"private": "^0.1.6"
 					}
@@ -852,7 +766,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
 			"integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -861,7 +774,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz",
 			"integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -870,7 +782,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz",
 			"integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0"
@@ -880,7 +791,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
 			"integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -890,7 +800,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0.tgz",
 			"integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -899,7 +808,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
 			"integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0",
@@ -909,14 +817,12 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				},
 				"regexpu-core": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
 					"integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
-					"dev": true,
 					"requires": {
 						"regenerate": "^1.4.0",
 						"regenerate-unicode-properties": "^7.0.0",
@@ -929,14 +835,12 @@
 				"regjsgen": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
-					"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
-					"dev": true
+					"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
 				},
 				"regjsparser": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
 					"integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
-					"dev": true,
 					"requires": {
 						"jsesc": "~0.5.0"
 					}
@@ -947,7 +851,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0.tgz",
 			"integrity": "sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.5.7",
 				"regenerator-runtime": "^0.11.1"
@@ -957,7 +860,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.0.tgz",
 			"integrity": "sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -1006,7 +908,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
 			"integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-transform-react-display-name": "^7.0.0",
@@ -1019,7 +920,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0.tgz",
 			"integrity": "sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.5.7",
 				"find-cache-dir": "^1.0.0",
@@ -1033,20 +933,17 @@
 				"home-or-tmp": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
-					"integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
-					"dev": true
+					"integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"source-map-support": {
 					"version": "0.5.9",
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
 					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
 						"source-map": "^0.6.0"
@@ -1058,7 +955,6 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
 			"integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
-			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.12.0"
 			},
@@ -1066,8 +962,7 @@
 				"regenerator-runtime": {
 					"version": "0.12.1",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-					"dev": true
+					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
 				}
 			}
 		},
@@ -1075,7 +970,6 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
 			"integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/parser": "^7.1.2",
@@ -1086,7 +980,6 @@
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
 			"integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/generator": "^7.1.3",
@@ -1103,7 +996,6 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1111,14 +1003,12 @@
 				"globals": {
 					"version": "11.8.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
-					"dev": true
+					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA=="
 				},
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
@@ -1126,7 +1016,6 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
 			"integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
-			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.10",
@@ -1136,8 +1025,7 @@
 				"to-fast-properties": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 				}
 			}
 		},
@@ -1145,7 +1033,6 @@
 			"version": "0.6.8",
 			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz",
 			"integrity": "sha512-IMSL7ekYhmFlILXcouA6ket3vV7u9BqStlXzbKOF9HBtpUPMMlHU+bBxrLOa2NvleVwNIxeq/zL8LafLbeUXcA==",
-			"dev": true,
 			"requires": {
 				"@emotion/memoize": "^0.6.6"
 			}
@@ -1153,14 +1040,12 @@
 		"@emotion/memoize": {
 			"version": "0.6.6",
 			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
-			"integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==",
-			"dev": true
+			"integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
 		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
 			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
-			"dev": true,
 			"requires": {
 				"call-me-maybe": "^1.0.1",
 				"glob-to-regexp": "^0.3.0"
@@ -1169,14 +1054,12 @@
 		"@nodelib/fs.stat": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.1.tgz",
-			"integrity": "sha512-KU/VDjC5RwtDUZiz3d+DHXJF2lp5hB9dn552TXIyptj8SH1vXmR40mG0JgGq03IlYsOgGfcv8xrLpSQ0YUMQdA==",
-			"dev": true
+			"integrity": "sha512-KU/VDjC5RwtDUZiz3d+DHXJF2lp5hB9dn552TXIyptj8SH1vXmR40mG0JgGq03IlYsOgGfcv8xrLpSQ0YUMQdA=="
 		},
 		"@samverschueren/stream-to-observable": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
 			"integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
-			"dev": true,
 			"requires": {
 				"any-observable": "^0.3.0"
 			}
@@ -1184,14 +1067,12 @@
 		"@sindresorhus/is": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
-			"dev": true
+			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
 		},
 		"@sinonjs/commons": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
 			"integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
-			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
 			}
@@ -1200,7 +1081,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
 			"integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
-			"dev": true,
 			"requires": {
 				"@sinonjs/samsam": "2.1.0"
 			},
@@ -1209,7 +1089,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
 					"integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
-					"dev": true,
 					"requires": {
 						"array-from": "^2.1.1"
 					}
@@ -1219,20 +1098,17 @@
 		"@sinonjs/samsam": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.2.tgz",
-			"integrity": "sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw==",
-			"dev": true
+			"integrity": "sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw=="
 		},
 		"@types/node": {
 			"version": "10.12.2",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",
-			"integrity": "sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ==",
-			"dev": true
+			"integrity": "sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ=="
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.4.3.tgz",
 			"integrity": "sha512-S6npYhPcTHDYe9nlsKa9CyWByFi8Vj8HovcAgtmMAQZUOczOZbQ8CnwMYKYC5HEZzxEE+oY0jfQk4cVlI3J59Q==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
 				"@webassemblyjs/wast-parser": "1.4.3",
@@ -1244,7 +1120,6 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1252,22 +1127,19 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.4.3.tgz",
-			"integrity": "sha512-3zTkSFswwZOPNHnzkP9ONq4bjJSeKVMcuahGXubrlLmZP8fmTIJ58dW7h/zOVWiFSuG2em3/HH3BlCN7wyu9Rw==",
-			"dev": true
+			"integrity": "sha512-3zTkSFswwZOPNHnzkP9ONq4bjJSeKVMcuahGXubrlLmZP8fmTIJ58dW7h/zOVWiFSuG2em3/HH3BlCN7wyu9Rw=="
 		},
 		"@webassemblyjs/helper-buffer": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.4.3.tgz",
 			"integrity": "sha512-e8+KZHh+RV8MUvoSRtuT1sFXskFnWG9vbDy47Oa166xX+l0dD5sERJ21g5/tcH8Yo95e9IN3u7Jc3NbhnUcSkw==",
-			"dev": true,
 			"requires": {
 				"debug": "^3.1.0"
 			},
@@ -1276,7 +1148,6 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1284,8 +1155,7 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
@@ -1293,7 +1163,6 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.4.3.tgz",
 			"integrity": "sha512-9FgHEtNsZQYaKrGCtsjswBil48Qp1agrzRcPzCbQloCoaTbOXLJ9IRmqT+uEZbenpULLRNFugz3I4uw18hJM8w==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/wast-printer": "1.4.3"
 			}
@@ -1301,20 +1170,17 @@
 		"@webassemblyjs/helper-fsm": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.4.3.tgz",
-			"integrity": "sha512-JINY76U+702IRf7ePukOt037RwmtH59JHvcdWbTTyHi18ixmQ+uOuNhcdCcQHTquDAH35/QgFlp3Y9KqtyJsCQ==",
-			"dev": true
+			"integrity": "sha512-JINY76U+702IRf7ePukOt037RwmtH59JHvcdWbTTyHi18ixmQ+uOuNhcdCcQHTquDAH35/QgFlp3Y9KqtyJsCQ=="
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.4.3.tgz",
-			"integrity": "sha512-I7bS+HaO0K07Io89qhJv+z1QipTpuramGwUSDkwEaficbSvCcL92CUZEtgykfNtk5wb0CoLQwWlmXTwGbNZUeQ==",
-			"dev": true
+			"integrity": "sha512-I7bS+HaO0K07Io89qhJv+z1QipTpuramGwUSDkwEaficbSvCcL92CUZEtgykfNtk5wb0CoLQwWlmXTwGbNZUeQ=="
 		},
 		"@webassemblyjs/helper-wasm-section": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.4.3.tgz",
 			"integrity": "sha512-p0yeeO/h2r30PyjnJX9xXSR6EDcvJd/jC6xa/Pxg4lpfcNi7JUswOpqDToZQ55HMMVhXDih/yqkaywHWGLxqyQ==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/helper-buffer": "1.4.3",
@@ -1327,7 +1193,6 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1335,8 +1200,7 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
@@ -1344,7 +1208,6 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.4.3.tgz",
 			"integrity": "sha512-4u0LJLSPzuRDWHwdqsrThYn+WqMFVqbI2ltNrHvZZkzFPO8XOZ0HFQ5eVc4jY/TNHgXcnwrHjONhPGYuuf//KQ==",
-			"dev": true,
 			"requires": {
 				"leb": "^0.3.0"
 			}
@@ -1353,7 +1216,6 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/validation/-/validation-1.4.3.tgz",
 			"integrity": "sha512-R+rRMKfhd9mq0rj2mhU9A9NKI2l/Rw65vIYzz4lui7eTKPcCu1l7iZNi4b9Gen8D42Sqh/KGiaQNk/x5Tn/iBQ==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3"
 			}
@@ -1362,7 +1224,6 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.4.3.tgz",
 			"integrity": "sha512-qzuwUn771PV6/LilqkXcS0ozJYAeY/OKbXIWU3a8gexuqb6De2p4ya/baBeH5JQ2WJdfhWhSvSbu86Vienttpw==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/helper-buffer": "1.4.3",
@@ -1379,7 +1240,6 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1387,8 +1247,7 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
@@ -1396,7 +1255,6 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.4.3.tgz",
 			"integrity": "sha512-eR394T8dHZfpLJ7U/Z5pFSvxl1L63JdREebpv9gYc55zLhzzdJPAuxjBYT4XqevUdW67qU2s0nNA3kBuNJHbaQ==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
@@ -1407,7 +1265,6 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.4.3.tgz",
 			"integrity": "sha512-7Gp+nschuKiDuAL1xmp4Xz0rgEbxioFXw4nCFYEmy+ytynhBnTeGc9W9cB1XRu1w8pqRU2lbj2VBBA4cL5Z2Kw==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/helper-buffer": "1.4.3",
@@ -1420,7 +1277,6 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1428,8 +1284,7 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
@@ -1437,7 +1292,6 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.4.3.tgz",
 			"integrity": "sha512-KXBjtlwA3BVukR/yWHC9GF+SCzBcgj0a7lm92kTOaa4cbjaTaa47bCjXw6cX4SGQpkncB9PU2hHGYVyyI7wFRg==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
@@ -1450,7 +1304,6 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.4.3.tgz",
 			"integrity": "sha512-QhCsQzqV0CpsEkRYyTzQDilCNUZ+5j92f+g35bHHNqS22FppNTywNFfHPq8ZWZfYCgbectc+PoghD+xfzVFh1Q==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/floating-point-hex-parser": "1.4.3",
@@ -1464,7 +1317,6 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.4.3.tgz",
 			"integrity": "sha512-EgXk4anf8jKmuZJsqD8qy5bz2frEQhBvZruv+bqwNoLWUItjNSFygk8ywL3JTEz9KtxTlAmqTXNrdD1d9gNDtg==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/wast-parser": "1.4.3",
@@ -1474,14 +1326,12 @@
 		"abab": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
-			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
-			"dev": true
+			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
 		},
 		"accepts": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
 			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-			"dev": true,
 			"requires": {
 				"mime-types": "~2.1.18",
 				"negotiator": "0.6.1"
@@ -1490,14 +1340,12 @@
 		"acorn": {
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
-			"integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw==",
-			"dev": true
+			"integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw=="
 		},
 		"acorn-dynamic-import": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
 			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
-			"dev": true,
 			"requires": {
 				"acorn": "^5.0.0"
 			}
@@ -1506,7 +1354,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
 			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
-			"dev": true,
 			"requires": {
 				"acorn": "^6.0.1",
 				"acorn-walk": "^6.0.1"
@@ -1515,8 +1362,7 @@
 				"acorn": {
 					"version": "6.0.4",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-					"integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
-					"dev": true
+					"integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
 				}
 			}
 		},
@@ -1524,7 +1370,6 @@
 			"version": "3.0.1",
 			"resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-			"dev": true,
 			"requires": {
 				"acorn": "^3.0.4"
 			},
@@ -1532,22 +1377,19 @@
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-					"dev": true
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
 				}
 			}
 		},
 		"acorn-walk": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.0.tgz",
-			"integrity": "sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg==",
-			"dev": true
+			"integrity": "sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg=="
 		},
 		"ajv": {
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-			"dev": true,
 			"requires": {
 				"co": "^4.6.0",
 				"fast-deep-equal": "^1.0.0",
@@ -1558,56 +1400,47 @@
 		"ajv-errors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.0.tgz",
-			"integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk=",
-			"dev": true
+			"integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk="
 		},
 		"ajv-keywords": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-			"dev": true
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
 		},
 		"ansi-colors": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.0.5.tgz",
-			"integrity": "sha512-VVjWpkfaphxUBFarydrQ3n26zX5nIK7hcbT3/ielrvwDDyBBjuh2vuSw1P9zkPq0cfqvdw7lkYHnu+OLSfIBsg==",
-			"dev": true
+			"integrity": "sha512-VVjWpkfaphxUBFarydrQ3n26zX5nIK7hcbT3/ielrvwDDyBBjuh2vuSw1P9zkPq0cfqvdw7lkYHnu+OLSfIBsg=="
 		},
 		"ansi-escapes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-			"dev": true
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
 		},
 		"ansi-html": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
-			"dev": true
+			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-			"dev": true
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 		},
 		"any-observable": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-			"integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
-			"dev": true
+			"integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog=="
 		},
 		"anymatch": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-			"dev": true,
 			"requires": {
 				"micromatch": "^3.1.4",
 				"normalize-path": "^2.1.1"
@@ -1616,14 +1449,12 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"dev": true
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			},
@@ -1631,64 +1462,54 @@
 				"sprintf-js": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-					"dev": true
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 				}
 			}
 		},
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-			"dev": true
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-			"dev": true
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
 		},
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-			"dev": true
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
 		"array-differ": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-			"dev": true
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
 		},
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-			"dev": true
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
 		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-			"dev": true
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
 		},
 		"array-flatten": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
-			"dev": true
+			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
 		},
 		"array-from": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
-			"dev": true
+			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
 		},
 		"array-includes": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.7.0"
@@ -1698,7 +1519,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-			"dev": true,
 			"requires": {
 				"array-uniq": "^1.0.1"
 			}
@@ -1706,20 +1526,17 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-			"dev": true
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
 		},
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-			"dev": true
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
 		"array.prototype.flat": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
 			"integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.10.0",
@@ -1729,20 +1546,17 @@
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-			"dev": true
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
 		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-			"dev": true
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -1751,7 +1565,6 @@
 			"version": "4.10.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
 			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
@@ -1762,7 +1575,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
 			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-			"dev": true,
 			"requires": {
 				"util": "0.10.3"
 			},
@@ -1770,14 +1582,12 @@
 				"inherits": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-					"dev": true
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
 				},
 				"util": {
 					"version": "0.10.3",
 					"resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
 					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-					"dev": true,
 					"requires": {
 						"inherits": "2.0.1"
 					}
@@ -1787,44 +1597,37 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-			"dev": true
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-			"dev": true
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
 		},
 		"ast-types": {
 			"version": "0.11.5",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
-			"integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw==",
-			"dev": true
+			"integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw=="
 		},
 		"async": {
 			"version": "1.5.2",
 			"resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-			"dev": true
+			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 		},
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-			"dev": true
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
 		},
 		"async-limiter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-			"dev": true
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -1834,26 +1637,22 @@
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-			"dev": true
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-			"dev": true
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"esutils": "^2.0.2",
@@ -1863,8 +1662,7 @@
 				"js-tokens": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 				}
 			}
 		},
@@ -1872,7 +1670,6 @@
 			"version": "6.26.3",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-generator": "^6.26.0",
@@ -1899,7 +1696,6 @@
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
 			"integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/parser": "^7.0.0",
@@ -1913,7 +1709,6 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-			"dev": true,
 			"requires": {
 				"babel-messages": "^6.23.0",
 				"babel-runtime": "^6.26.0",
@@ -1929,7 +1724,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-traverse": "^6.24.1",
@@ -1940,7 +1734,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1951,7 +1744,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1963,7 +1755,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.26.0",
@@ -1975,7 +1766,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-traverse": "^6.24.1",
@@ -1986,7 +1776,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
-			"dev": true,
 			"requires": {
 				"babel-helper-bindify-decorators": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1998,7 +1787,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2011,7 +1799,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2021,7 +1808,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2031,7 +1817,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2041,7 +1826,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-types": "^6.26.0",
@@ -2052,7 +1836,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2065,7 +1848,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "^6.24.1",
 				"babel-messages": "^6.23.0",
@@ -2079,7 +1861,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-template": "^6.24.1"
@@ -2089,7 +1870,6 @@
 			"version": "8.0.4",
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.4.tgz",
 			"integrity": "sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==",
-			"dev": true,
 			"requires": {
 				"find-cache-dir": "^1.0.0",
 				"loader-utils": "^1.0.2",
@@ -2101,7 +1881,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2110,7 +1889,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2119,7 +1897,6 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.8.0.tgz",
 			"integrity": "sha512-PcrdbXFO/9Plo9JURIj8G0Dsz+Ct8r+NvjoLh6qPt8Y/3EIAj1gHGW1ocPY1IkQbXZLBEZZSRBAxJem1KFdBXg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"lodash": "^4.17.10"
@@ -2128,74 +1905,62 @@
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-			"dev": true
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
-			"dev": true
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
 		},
 		"babel-plugin-syntax-class-constructor-call": {
 			"version": "6.18.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
-			"dev": true
+			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
 		},
 		"babel-plugin-syntax-class-properties": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
-			"dev": true
+			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
 		},
 		"babel-plugin-syntax-decorators": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
-			"dev": true
+			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
 		},
 		"babel-plugin-syntax-dynamic-import": {
 			"version": "6.18.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
-			"dev": true
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-			"dev": true
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
 		},
 		"babel-plugin-syntax-export-extensions": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
-			"dev": true
+			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
-			"dev": true
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-			"dev": true
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-			"dev": true
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
 		},
 		"babel-plugin-transform-async-generator-functions": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
-			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "^6.24.1",
 				"babel-plugin-syntax-async-generators": "^6.5.0",
@@ -2206,7 +1971,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "^6.24.1",
 				"babel-plugin-syntax-async-functions": "^6.8.0",
@@ -2217,7 +1981,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-class-constructor-call": "^6.18.0",
 				"babel-runtime": "^6.22.0",
@@ -2228,7 +1991,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-plugin-syntax-class-properties": "^6.8.0",
@@ -2240,7 +2002,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
-			"dev": true,
 			"requires": {
 				"babel-helper-explode-class": "^6.24.1",
 				"babel-plugin-syntax-decorators": "^6.13.0",
@@ -2253,7 +2014,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2262,7 +2022,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2271,7 +2030,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-template": "^6.26.0",
@@ -2284,7 +2042,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "^6.24.1",
 				"babel-helper-function-name": "^6.24.1",
@@ -2301,7 +2058,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-template": "^6.24.1"
@@ -2311,7 +2067,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2320,7 +2075,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2330,7 +2084,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2339,7 +2092,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2350,7 +2102,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2359,7 +2110,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2370,7 +2120,6 @@
 			"version": "6.26.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
 			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "^6.24.1",
 				"babel-runtime": "^6.26.0",
@@ -2382,7 +2131,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2393,7 +2141,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2404,7 +2151,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "^6.24.1",
 				"babel-runtime": "^6.22.0"
@@ -2414,7 +2160,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "^6.24.1",
 				"babel-helper-get-function-arity": "^6.24.1",
@@ -2428,7 +2173,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2438,7 +2182,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2447,7 +2190,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"dev": true,
 			"requires": {
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2458,7 +2200,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2467,7 +2208,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2476,7 +2216,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"dev": true,
 			"requires": {
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2487,7 +2226,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
@@ -2498,7 +2236,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-export-extensions": "^6.8.0",
 				"babel-runtime": "^6.22.0"
@@ -2508,7 +2245,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "^6.18.0",
 				"babel-runtime": "^6.22.0"
@@ -2518,7 +2254,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
 				"babel-runtime": "^6.26.0"
@@ -2528,7 +2263,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.10.0"
 			}
@@ -2537,7 +2271,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2547,7 +2280,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "^6.22.0",
 				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
@@ -2579,7 +2311,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-class-constructor-call": "^6.24.1",
 				"babel-plugin-transform-export-extensions": "^6.22.0",
@@ -2590,7 +2321,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-dynamic-import": "^6.18.0",
 				"babel-plugin-transform-class-properties": "^6.24.1",
@@ -2602,7 +2332,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
 				"babel-plugin-transform-async-generator-functions": "^6.24.1",
@@ -2615,7 +2344,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-			"dev": true,
 			"requires": {
 				"babel-core": "^6.26.0",
 				"babel-runtime": "^6.26.0",
@@ -2630,7 +2358,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
@@ -2640,7 +2367,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-traverse": "^6.26.0",
@@ -2653,7 +2379,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-messages": "^6.23.0",
@@ -2670,7 +2395,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"esutils": "^2.0.2",
@@ -2681,20 +2405,17 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-			"dev": true
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-			"dev": true,
 			"requires": {
 				"cache-base": "^1.0.1",
 				"class-utils": "^0.3.5",
@@ -2709,7 +2430,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -2718,7 +2438,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -2727,7 +2446,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -2736,7 +2454,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -2748,20 +2465,17 @@
 		"base64-js": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-			"dev": true
+			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
 		},
 		"batch": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
-			"dev": true
+			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"dev": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -2769,38 +2483,32 @@
 		"big.js": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-			"dev": true
+			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
 		},
 		"binary-extensions": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
-			"dev": true
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
 		},
 		"binaryextensions": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.1.tgz",
-			"integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA==",
-			"dev": true
+			"integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA=="
 		},
 		"bluebird": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-			"integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
-			"dev": true
+			"integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
 		},
 		"bn.js": {
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-			"dev": true
+			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
 		},
 		"body-parser": {
 			"version": "1.18.2",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
 			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-			"dev": true,
 			"requires": {
 				"bytes": "3.0.0",
 				"content-type": "~1.0.4",
@@ -2817,14 +2525,12 @@
 				"iconv-lite": {
 					"version": "0.4.19",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-					"dev": true
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
 				},
 				"qs": {
 					"version": "6.5.1",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-					"dev": true
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
 				}
 			}
 		},
@@ -2832,7 +2538,6 @@
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
 			"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
-			"dev": true,
 			"requires": {
 				"array-flatten": "^2.1.0",
 				"deep-equal": "^1.0.1",
@@ -2845,14 +2550,12 @@
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-			"dev": true
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
 		"bower-config": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.1.tgz",
 			"integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.3",
 				"mout": "^1.0.0",
@@ -2865,7 +2568,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2875,7 +2577,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-			"dev": true,
 			"requires": {
 				"arr-flatten": "^1.1.0",
 				"array-unique": "^0.3.2",
@@ -2893,7 +2594,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -2903,26 +2603,22 @@
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-			"dev": true
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
 		},
 		"browser-process-hrtime": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
-			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
-			"dev": true
+			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw=="
 		},
 		"browser-stdout": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-			"dev": true
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
 			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-			"dev": true,
 			"requires": {
 				"buffer-xor": "^1.0.3",
 				"cipher-base": "^1.0.0",
@@ -2936,7 +2632,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
 			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-			"dev": true,
 			"requires": {
 				"browserify-aes": "^1.0.4",
 				"browserify-des": "^1.0.0",
@@ -2947,7 +2642,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
 			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"des.js": "^1.0.0",
@@ -2959,7 +2653,6 @@
 			"version": "4.0.1",
 			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"randombytes": "^2.0.1"
@@ -2969,7 +2662,6 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.1",
 				"browserify-rsa": "^4.0.0",
@@ -2984,7 +2676,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-			"dev": true,
 			"requires": {
 				"pako": "~1.0.5"
 			}
@@ -2993,7 +2684,6 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
 			"integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
-			"dev": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30000899",
 				"electron-to-chromium": "^1.3.82",
@@ -3004,7 +2694,6 @@
 			"version": "4.9.1",
 			"resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-			"dev": true,
 			"requires": {
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4",
@@ -3015,7 +2704,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
 			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"dev": true,
 			"requires": {
 				"buffer-alloc-unsafe": "^1.1.0",
 				"buffer-fill": "^1.0.0"
@@ -3024,14 +2712,12 @@
 		"buffer-alloc-unsafe": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-			"dev": true
+			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
 		},
 		"buffer-fill": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-			"dev": true
+			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
 		},
 		"buffer-from": {
 			"version": "1.1.1",
@@ -3041,38 +2727,32 @@
 		"buffer-indexof": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
-			"dev": true
+			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-			"dev": true
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-			"dev": true
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
-			"dev": true
+			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
 		},
 		"bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-			"dev": true
+			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
 		},
 		"cacache": {
 			"version": "10.0.4",
 			"resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
 			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
-			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.1",
 				"chownr": "^1.0.1",
@@ -3093,7 +2773,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-			"dev": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
 				"component-emitter": "^1.2.1",
@@ -3110,7 +2789,6 @@
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
 			"integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
-			"dev": true,
 			"requires": {
 				"clone-response": "1.0.2",
 				"get-stream": "3.0.0",
@@ -3124,22 +2802,19 @@
 				"lowercase-keys": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-					"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-					"dev": true
+					"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
 				}
 			}
 		},
 		"call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-			"dev": true
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
 		},
 		"caller-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-			"dev": true,
 			"requires": {
 				"callsites": "^0.2.0"
 			}
@@ -3147,14 +2822,12 @@
 		"callsites": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-			"dev": true
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
 		},
 		"camel-case": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
 			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-			"dev": true,
 			"requires": {
 				"no-case": "^2.2.0",
 				"upper-case": "^1.1.1"
@@ -3163,26 +2836,22 @@
 		"camelcase": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-			"dev": true
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000905",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000905.tgz",
-			"integrity": "sha512-cR6ICguvhRrkAjFfBoe54vJQMVOEz7vFmqrV6oor1a7GRg6DdswI40lkiV/QQvAMb4txzTkjSaLaJaiAtSuQzA==",
-			"dev": true
+			"integrity": "sha512-cR6ICguvhRrkAjFfBoe54vJQMVOEz7vFmqrV6oor1a7GRg6DdswI40lkiV/QQvAMb4txzTkjSaLaJaiAtSuQzA=="
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"chai": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
 			"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
-			"dev": true,
 			"requires": {
 				"assertion-error": "^1.0.1",
 				"check-error": "^1.0.1",
@@ -3196,7 +2865,6 @@
 			"version": "1.1.3",
 			"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^2.2.1",
 				"escape-string-regexp": "^1.0.2",
@@ -3208,28 +2876,24 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
 		"change-emitter": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=",
-			"dev": true
+			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
 		},
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-			"dev": true
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
 		},
 		"check-dependencies": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/check-dependencies/-/check-dependencies-1.1.0.tgz",
 			"integrity": "sha512-GDrbGzzJ6Gc6tQh87HBMGhrJ4UWIlR9MKJwgvlrJyj/gWvTYYb2jQetKbajt/EYK5Y8/4g7gH2LEvq8GdUWTag==",
-			"dev": true,
 			"requires": {
 				"bower-config": "^1.4.0",
 				"chalk": "^2.1.0",
@@ -3243,7 +2907,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -3252,7 +2915,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -3262,20 +2924,17 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -3285,14 +2944,12 @@
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-			"dev": true
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
 		},
 		"cheerio": {
 			"version": "1.0.0-rc.2",
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
 			"integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
-			"dev": true,
 			"requires": {
 				"css-select": "~1.2.0",
 				"dom-serializer": "~0.1.0",
@@ -3306,7 +2963,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
 			"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
-			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
 				"async-each": "^1.0.0",
@@ -3327,7 +2983,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.1"
 					}
@@ -3337,20 +2992,17 @@
 		"chownr": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
-			"dev": true
+			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
 		},
 		"chrome-trace-event": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-0.1.3.tgz",
-			"integrity": "sha512-sjndyZHrrWiu4RY7AkHgjn80GfAM2ZSzUkZLV/Js59Ldmh6JDThf0SUmOHU53rFu2rVxxfCzJ30Ukcfch3Gb/A==",
-			"dev": true
+			"integrity": "sha512-sjndyZHrrWiu4RY7AkHgjn80GfAM2ZSzUkZLV/Js59Ldmh6JDThf0SUmOHU53rFu2rVxxfCzJ30Ukcfch3Gb/A=="
 		},
 		"cipher-base": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -3359,14 +3011,12 @@
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-			"dev": true
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
 		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"define-property": "^0.2.5",
@@ -3378,7 +3028,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -3389,7 +3038,6 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
 			"integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
-			"dev": true,
 			"requires": {
 				"source-map": "~0.6.0"
 			},
@@ -3397,8 +3045,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -3406,7 +3053,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
 			}
@@ -3414,14 +3060,12 @@
 		"cli-spinners": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
-			"integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
-			"dev": true
+			"integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw="
 		},
 		"cli-table": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
 			"integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-			"dev": true,
 			"requires": {
 				"colors": "1.0.3"
 			},
@@ -3429,8 +3073,7 @@
 				"colors": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-					"dev": true
+					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
 				}
 			}
 		},
@@ -3438,7 +3081,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
 			"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
-			"dev": true,
 			"requires": {
 				"slice-ansi": "0.0.4",
 				"string-width": "^1.0.1"
@@ -3448,7 +3090,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3456,14 +3097,12 @@
 				"slice-ansi": {
 					"version": "0.0.4",
 					"resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-					"dev": true
+					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3475,8 +3114,7 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-			"dev": true
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"client-oauth2": {
 			"version": "4.2.1",
@@ -3491,7 +3129,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-			"dev": true,
 			"requires": {
 				"string-width": "^2.1.1",
 				"strip-ansi": "^4.0.0",
@@ -3501,14 +3138,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -3518,20 +3153,17 @@
 		"clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-			"dev": true
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 		},
 		"clone-buffer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-			"dev": true
+			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
 		},
 		"clone-response": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-			"dev": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
 			}
@@ -3539,14 +3171,12 @@
 		"clone-stats": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-			"dev": true
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
 		},
 		"cloneable-readable": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
 			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"process-nextick-args": "^2.0.0",
@@ -3556,20 +3186,17 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-			"dev": true,
 			"requires": {
 				"map-visit": "^1.0.0",
 				"object-visit": "^1.0.0"
@@ -3579,7 +3206,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -3587,14 +3213,12 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"colors": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-			"integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
-			"dev": true
+			"integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
 		},
 		"combined-stream": {
 			"version": "1.0.6",
@@ -3607,26 +3231,22 @@
 		"commander": {
 			"version": "2.17.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-			"dev": true
+			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
 		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-			"dev": true
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
 		},
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-			"dev": true
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"compressible": {
 			"version": "2.0.14",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
 			"integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
-			"dev": true,
 			"requires": {
 				"mime-db": ">= 1.34.0 < 2"
 			}
@@ -3635,7 +3255,6 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
 			"integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
-			"dev": true,
 			"requires": {
 				"accepts": "~1.3.5",
 				"bytes": "3.0.0",
@@ -3649,8 +3268,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -3666,14 +3284,12 @@
 		"connect-history-api-fallback": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-			"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
-			"dev": true
+			"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
 		},
 		"console-browserify": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-			"dev": true,
 			"requires": {
 				"date-now": "^0.1.4"
 			}
@@ -3681,56 +3297,47 @@
 		"consolidated-events": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
-			"integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ==",
-			"dev": true
+			"integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ=="
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-			"dev": true
+			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
 		},
 		"contains-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-			"dev": true
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
 		},
 		"content-disposition": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-			"dev": true
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
 		},
 		"content-type": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-			"dev": true
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-			"dev": true
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
 		},
 		"cookie": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-			"dev": true
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
 		},
 		"cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-			"dev": true
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"copy-concurrently": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"fs-write-stream-atomic": "^1.0.8",
@@ -3743,14 +3350,12 @@
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-			"dev": true
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-			"dev": true
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -3773,7 +3378,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
 			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.0.0"
@@ -3783,7 +3387,6 @@
 			"version": "1.2.0",
 			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"inherits": "^2.0.1",
@@ -3796,7 +3399,6 @@
 			"version": "1.1.7",
 			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.3",
 				"create-hash": "^1.1.0",
@@ -3810,7 +3412,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-			"dev": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
@@ -3821,7 +3422,6 @@
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-			"dev": true,
 			"requires": {
 				"browserify-cipher": "^1.0.0",
 				"browserify-sign": "^4.0.0",
@@ -3840,7 +3440,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
 			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"source-map": "^0.6.1",
@@ -3851,22 +3450,19 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"css-color-keywords": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-			"integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
-			"dev": true
+			"integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
 		},
 		"css-select": {
 			"version": "1.2.0",
 			"resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-			"dev": true,
 			"requires": {
 				"boolbase": "~1.0.0",
 				"css-what": "2.1",
@@ -3878,7 +3474,6 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.2.2.tgz",
 			"integrity": "sha512-w99Fzop1FO8XKm0VpbQp3y5mnTnaS+rtCvS+ylSEOK76YXO5zoHQx/QMB1N54Cp+Ya9jB9922EHrh14ld4xmmw==",
-			"dev": true,
 			"requires": {
 				"css-color-keywords": "^1.0.0",
 				"fbjs": "^0.8.5",
@@ -3888,20 +3483,17 @@
 		"css-what": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
-			"dev": true
+			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
 		},
 		"cssom": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-			"integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
-			"dev": true
+			"integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog=="
 		},
 		"cssstyle": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
 			"integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
-			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
 			}
@@ -3910,7 +3502,6 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-			"dev": true,
 			"requires": {
 				"array-find-index": "^1.0.1"
 			}
@@ -3918,20 +3509,17 @@
 		"cyclist": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
-			"dev": true
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
 		},
 		"dargs": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
-			"integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk=",
-			"dev": true
+			"integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
 		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -3940,7 +3528,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
 			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
-			"dev": true,
 			"requires": {
 				"abab": "^2.0.0",
 				"whatwg-mimetype": "^2.2.0",
@@ -3950,8 +3537,7 @@
 		"date-fns": {
 			"version": "1.29.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-			"integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
-			"dev": true
+			"integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
 		},
 		"date-names": {
 			"version": "0.1.12",
@@ -3961,20 +3547,17 @@
 		"date-now": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-			"dev": true
+			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
 		},
 		"dateformat": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-			"dev": true
+			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
 		},
 		"debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -3982,14 +3565,12 @@
 		"debug-log": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-			"integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
-			"dev": true
+			"integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8="
 		},
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
@@ -4000,7 +3581,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-			"dev": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
 			}
@@ -4009,7 +3589,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
 			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-			"dev": true,
 			"requires": {
 				"type-detect": "^4.0.0"
 			}
@@ -4017,26 +3596,22 @@
 		"deep-equal": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-			"dev": true
+			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
 		},
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"dev": true
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-			"dev": true
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
 		"default-gateway": {
 			"version": "2.7.2",
 			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
 			"integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
-			"dev": true,
 			"requires": {
 				"execa": "^0.10.0",
 				"ip-regex": "^2.1.0"
@@ -4046,7 +3621,6 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -4059,7 +3633,6 @@
 					"version": "0.10.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
 					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^6.0.0",
 						"get-stream": "^3.0.0",
@@ -4076,7 +3649,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
@@ -4085,7 +3657,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-			"dev": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
 				"isobject": "^3.0.1"
@@ -4095,7 +3666,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -4104,7 +3674,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -4113,7 +3682,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -4126,7 +3694,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
 			"integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
-			"dev": true,
 			"requires": {
 				"find-root": "^1.0.0",
 				"glob": "^7.0.5",
@@ -4140,7 +3707,6 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-			"dev": true,
 			"requires": {
 				"globby": "^5.0.0",
 				"is-path-cwd": "^1.0.0",
@@ -4154,8 +3720,7 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
@@ -4167,14 +3732,12 @@
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-			"dev": true
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
 		},
 		"des.js": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0"
@@ -4183,26 +3746,22 @@
 		"destroy": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-			"dev": true
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
 		"detect-conflict": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
-			"integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24=",
-			"dev": true
+			"integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24="
 		},
 		"detect-file": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
-			"dev": true
+			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
 		},
 		"detect-indent": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-			"dev": true,
 			"requires": {
 				"repeating": "^2.0.0"
 			}
@@ -4210,20 +3769,17 @@
 		"detect-node": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
-			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
-			"dev": true
+			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
 		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-			"dev": true
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
 			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"miller-rabin": "^4.0.0",
@@ -4234,7 +3790,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
 			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"path-type": "^3.0.0"
@@ -4244,7 +3799,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -4254,20 +3808,17 @@
 		"discontinuous-range": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
-			"dev": true
+			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
 		},
 		"dns-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
-			"dev": true
+			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
 		},
 		"dns-packet": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
 			"integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
-			"dev": true,
 			"requires": {
 				"ip": "^1.1.0",
 				"safe-buffer": "^5.0.1"
@@ -4277,7 +3828,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
 			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
-			"dev": true,
 			"requires": {
 				"buffer-indexof": "^1.0.0"
 			}
@@ -4286,7 +3836,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2"
 			}
@@ -4295,7 +3844,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
 			"integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
-			"dev": true,
 			"requires": {
 				"utila": "~0.3"
 			},
@@ -4303,8 +3851,7 @@
 				"utila": {
 					"version": "0.3.3",
 					"resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
-					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
-					"dev": true
+					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY="
 				}
 			}
 		},
@@ -4312,7 +3859,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
 			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-			"dev": true,
 			"requires": {
 				"domelementtype": "~1.1.1",
 				"entities": "~1.1.1"
@@ -4321,28 +3867,24 @@
 				"domelementtype": {
 					"version": "1.1.3",
 					"resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-					"dev": true
+					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
 				}
 			}
 		},
 		"domain-browser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-			"dev": true
+			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
 		},
 		"domelementtype": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-			"dev": true
+			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
 		},
 		"domexception": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-			"dev": true,
 			"requires": {
 				"webidl-conversions": "^4.0.2"
 			}
@@ -4351,7 +3893,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
 			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-			"dev": true,
 			"requires": {
 				"domelementtype": "1"
 			}
@@ -4360,7 +3901,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
 			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-			"dev": true,
 			"requires": {
 				"dom-serializer": "0",
 				"domelementtype": "1"
@@ -4369,14 +3909,12 @@
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-			"dev": true
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 		},
 		"duplexify": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
 			"integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
 				"inherits": "^2.0.1",
@@ -4388,7 +3926,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"dev": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -4397,38 +3934,32 @@
 		"editions": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-			"integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
-			"dev": true
+			"integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
 		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-			"dev": true
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"ejs": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
-			"dev": true
+			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
 		},
 		"electron-to-chromium": {
 			"version": "1.3.83",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.83.tgz",
-			"integrity": "sha512-DqJoDarxq50dcHsOOlMLNoy+qQitlMNbYb6wwbE0oUw2veHdRkpNrhmngiUYKMErdJ8SJ48rpJsZTQgy5SoEAA==",
-			"dev": true
+			"integrity": "sha512-DqJoDarxq50dcHsOOlMLNoy+qQitlMNbYb6wwbE0oUw2veHdRkpNrhmngiUYKMErdJ8SJ48rpJsZTQgy5SoEAA=="
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
-			"dev": true
+			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
 		},
 		"elliptic": {
 			"version": "6.4.1",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
 			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -4442,20 +3973,17 @@
 		"emojis-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-			"dev": true
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
 		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-			"dev": true
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
 		},
 		"encoding": {
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"dev": true,
 			"requires": {
 				"iconv-lite": "~0.4.13"
 			}
@@ -4464,7 +3992,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -4473,7 +4000,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
 			"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"memory-fs": "^0.4.0",
@@ -4483,20 +4009,17 @@
 		"entities": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-			"dev": true
+			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
 		},
 		"envinfo": {
 			"version": "5.10.0",
 			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-5.10.0.tgz",
-			"integrity": "sha512-rXbzXWvnQxy+TcqZlARbWVQwgGVVouVJgFZhLVN5htjLxl1thstrP2ZGi0pXC309AbK7gVOPU+ulz/tmpCI7iw==",
-			"dev": true
+			"integrity": "sha512-rXbzXWvnQxy+TcqZlARbWVQwgGVVouVJgFZhLVN5htjLxl1thstrP2ZGi0pXC309AbK7gVOPU+ulz/tmpCI7iw=="
 		},
 		"enzyme": {
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.7.0.tgz",
 			"integrity": "sha512-QLWx+krGK6iDNyR1KlH5YPZqxZCQaVF6ike1eDJAOg0HvSkSCVImPsdWaNw6v+VrnK92Kg8jIOYhuOSS9sBpyg==",
-			"dev": true,
 			"requires": {
 				"array.prototype.flat": "^1.2.1",
 				"cheerio": "^1.0.0-rc.2",
@@ -4523,7 +4046,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.6.0.tgz",
 			"integrity": "sha512-ay9eGFpChyUDnjTFMMJHzrb681LF3hPWJLEA7RoLFG9jSWAdAm2V50pGmFV9dYGJgh5HfdiqM+MNvle41Yf/PA==",
-			"dev": true,
 			"requires": {
 				"enzyme-adapter-utils": "^1.8.0",
 				"function.prototype.name": "^1.1.0",
@@ -4537,8 +4059,7 @@
 				"react-is": {
 					"version": "16.6.0",
 					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.0.tgz",
-					"integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g==",
-					"dev": true
+					"integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g=="
 				}
 			}
 		},
@@ -4546,7 +4067,6 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.8.1.tgz",
 			"integrity": "sha512-s3QB3xQAowaDS2sHhmEqrT13GJC4+n5bG015ZkLv60n9k5vhxxHTQRIneZmQ4hmdCZEBrvUJ89PG6fRI5OEeuQ==",
-			"dev": true,
 			"requires": {
 				"function.prototype.name": "^1.1.0",
 				"object.assign": "^4.1.0",
@@ -4557,7 +4077,6 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-			"dev": true,
 			"requires": {
 				"prr": "~1.0.1"
 			}
@@ -4566,7 +4085,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
 			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
-			"dev": true,
 			"requires": {
 				"string-template": "~0.2.1",
 				"xtend": "~4.0.0"
@@ -4576,7 +4094,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -4585,7 +4102,6 @@
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
 			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
-			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.1.1",
 				"function-bind": "^1.1.1",
@@ -4598,7 +4114,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.1",
 				"is-date-object": "^1.0.1",
@@ -4608,20 +4123,17 @@
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-			"dev": true
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
 			"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
-			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
 				"estraverse": "^4.2.0",
@@ -4634,7 +4146,6 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
 					"optional": true
 				}
 			}
@@ -4643,7 +4154,6 @@
 			"version": "4.18.2",
 			"resolved": "http://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
 			"integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
-			"dev": true,
 			"requires": {
 				"ajv": "^5.3.0",
 				"babel-code-frame": "^6.22.0",
@@ -4687,14 +4197,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -4703,7 +4211,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -4714,7 +4221,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -4722,20 +4228,17 @@
 				"globals": {
 					"version": "11.7.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-					"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
-					"dev": true
+					"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
 				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -4744,7 +4247,6 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -4754,20 +4256,17 @@
 		"eslint-config-standard": {
 			"version": "11.0.0",
 			"resolved": "http://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz",
-			"integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==",
-			"dev": true
+			"integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw=="
 		},
 		"eslint-config-standard-jsx": {
 			"version": "5.0.0",
 			"resolved": "http://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-5.0.0.tgz",
-			"integrity": "sha512-rLToPAEqLMPBfWnYTu6xRhm2OWziS2n40QFqJ8jAM8NSVzeVKTa3nclhsU4DpPJQRY60F34Oo1wi/71PN/eITg==",
-			"dev": true
+			"integrity": "sha512-rLToPAEqLMPBfWnYTu6xRhm2OWziS2n40QFqJ8jAM8NSVzeVKTa3nclhsU4DpPJQRY60F34Oo1wi/71PN/eITg=="
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
 			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
-			"dev": true,
 			"requires": {
 				"debug": "^2.6.9",
 				"resolve": "^1.5.0"
@@ -4777,7 +4276,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
 			"integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
-			"dev": true,
 			"requires": {
 				"debug": "^2.6.8",
 				"pkg-dir": "^1.0.0"
@@ -4787,7 +4285,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -4797,7 +4294,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -4806,7 +4302,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
 					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0"
 					}
@@ -4817,7 +4312,6 @@
 			"version": "2.9.0",
 			"resolved": "http://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
 			"integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
-			"dev": true,
 			"requires": {
 				"builtin-modules": "^1.1.1",
 				"contains-path": "^0.1.0",
@@ -4835,7 +4329,6 @@
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"isarray": "^1.0.0"
@@ -4847,7 +4340,6 @@
 			"version": "6.0.1",
 			"resolved": "http://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
 			"integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
-			"dev": true,
 			"requires": {
 				"ignore": "^3.3.6",
 				"minimatch": "^3.0.4",
@@ -4858,14 +4350,12 @@
 		"eslint-plugin-promise": {
 			"version": "3.7.0",
 			"resolved": "http://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.7.0.tgz",
-			"integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg==",
-			"dev": true
+			"integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg=="
 		},
 		"eslint-plugin-react": {
 			"version": "7.7.0",
 			"resolved": "http://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
 			"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
-			"dev": true,
 			"requires": {
 				"doctrine": "^2.0.2",
 				"has": "^1.0.1",
@@ -4876,14 +4366,12 @@
 		"eslint-plugin-standard": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
-			"integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
-			"dev": true
+			"integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI="
 		},
 		"eslint-scope": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-			"dev": true,
 			"requires": {
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
@@ -4892,14 +4380,12 @@
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-			"dev": true
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
 		},
 		"espree": {
 			"version": "3.5.4",
 			"resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-			"dev": true,
 			"requires": {
 				"acorn": "^5.5.0",
 				"acorn-jsx": "^3.0.0"
@@ -4908,14 +4394,12 @@
 		"esprima": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-			"dev": true
+			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
 		},
 		"esquery": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
 			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
-			"dev": true,
 			"requires": {
 				"estraverse": "^4.0.0"
 			}
@@ -4924,7 +4408,6 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-			"dev": true,
 			"requires": {
 				"estraverse": "^4.1.0"
 			}
@@ -4932,38 +4415,32 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-			"dev": true
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"etag": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-			"dev": true
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
 		},
 		"eventemitter3": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-			"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
-			"dev": true
+			"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
 		},
 		"events": {
 			"version": "1.1.1",
 			"resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
-			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-			"dev": true
+			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
 		},
 		"eventsource": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
 			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
-			"dev": true,
 			"requires": {
 				"original": ">=0.0.5"
 			}
@@ -4972,7 +4449,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-			"dev": true,
 			"requires": {
 				"md5.js": "^1.3.4",
 				"safe-buffer": "^5.1.1"
@@ -4990,7 +4466,6 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "^5.0.1",
 				"get-stream": "^3.0.0",
@@ -5004,14 +4479,12 @@
 		"exit-hook": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-			"dev": true
+			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
 		},
 		"expand-brackets": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-			"dev": true,
 			"requires": {
 				"debug": "^2.3.3",
 				"define-property": "^0.2.5",
@@ -5026,7 +4499,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -5035,7 +4507,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -5046,7 +4517,6 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
 			"requires": {
 				"fill-range": "^2.1.0"
 			},
@@ -5055,7 +4525,6 @@
 					"version": "2.2.4",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
 					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-					"dev": true,
 					"requires": {
 						"is-number": "^2.1.0",
 						"isobject": "^2.0.0",
@@ -5068,7 +4537,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -5077,7 +4545,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
@@ -5086,7 +4553,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -5097,7 +4563,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
 			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
 			}
@@ -5106,7 +4571,6 @@
 			"version": "4.16.3",
 			"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
 			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
-			"dev": true,
 			"requires": {
 				"accepts": "~1.3.5",
 				"array-flatten": "1.1.1",
@@ -5143,26 +4607,22 @@
 				"array-flatten": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-					"dev": true
+					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 				},
 				"path-to-regexp": {
 					"version": "0.1.7",
 					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-					"dev": true
+					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 				},
 				"qs": {
 					"version": "6.5.1",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-					"dev": true
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-					"dev": true
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 				}
 			}
 		},
@@ -5175,7 +4635,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-			"dev": true,
 			"requires": {
 				"assign-symbols": "^1.0.0",
 				"is-extendable": "^1.0.1"
@@ -5185,7 +4644,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -5196,7 +4654,6 @@
 			"version": "2.2.0",
 			"resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-			"dev": true,
 			"requires": {
 				"chardet": "^0.4.0",
 				"iconv-lite": "^0.4.17",
@@ -5207,7 +4664,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-			"dev": true,
 			"requires": {
 				"array-unique": "^0.3.2",
 				"define-property": "^1.0.0",
@@ -5223,7 +4679,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -5232,7 +4687,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -5241,7 +4695,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -5250,7 +4703,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -5259,7 +4711,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -5271,20 +4722,17 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
 			"version": "1.1.0",
 			"resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-			"dev": true
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 		},
 		"fast-glob": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
 			"integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
-			"dev": true,
 			"requires": {
 				"@mrmlnc/readdir-enhanced": "^2.2.1",
 				"@nodelib/fs.stat": "^1.0.1",
@@ -5298,7 +4746,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.1"
 					}
@@ -5308,20 +4755,17 @@
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-			"dev": true
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"faye-websocket": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
 			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-			"dev": true,
 			"requires": {
 				"websocket-driver": ">=0.5.1"
 			}
@@ -5330,7 +4774,6 @@
 			"version": "0.8.17",
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
 			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-			"dev": true,
 			"requires": {
 				"core-js": "^1.0.0",
 				"isomorphic-fetch": "^2.1.1",
@@ -5344,8 +4787,7 @@
 				"core-js": {
 					"version": "1.2.7",
 					"resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-					"dev": true
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
 				}
 			}
 		},
@@ -5353,7 +4795,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -5362,7 +4803,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-			"dev": true,
 			"requires": {
 				"flat-cache": "^1.2.1",
 				"object-assign": "^4.0.1"
@@ -5371,14 +4811,12 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"dev": true
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
 		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-number": "^3.0.0",
@@ -5390,7 +4828,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -5401,7 +4838,6 @@
 			"version": "1.1.1",
 			"resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
 			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
 				"encodeurl": "~1.0.2",
@@ -5416,7 +4852,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
 				"make-dir": "^1.0.0",
@@ -5426,14 +4861,12 @@
 		"find-root": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-			"dev": true
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
 		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-			"dev": true,
 			"requires": {
 				"locate-path": "^2.0.0"
 			}
@@ -5442,7 +4875,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
 			"integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
-			"dev": true,
 			"requires": {
 				"detect-file": "^1.0.0",
 				"is-glob": "^3.1.0",
@@ -5454,7 +4886,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
 			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.2"
 			}
@@ -5463,7 +4894,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-			"dev": true,
 			"requires": {
 				"circular-json": "^0.3.1",
 				"del": "^2.0.2",
@@ -5474,14 +4904,12 @@
 		"flow-parser": {
 			"version": "0.79.1",
 			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.79.1.tgz",
-			"integrity": "sha512-l6aeT5Ze3RefXiKUtabFNgv1vMp9L2ku+BqLuKCNZytV2ci4f98L47zrSJefwbJWG42sc5dskzcnWy7+ertlLQ==",
-			"dev": true
+			"integrity": "sha512-l6aeT5Ze3RefXiKUtabFNgv1vMp9L2ku+BqLuKCNZytV2ci4f98L47zrSJefwbJWG42sc5dskzcnWy7+ertlLQ=="
 		},
 		"flush-write-stream": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
 			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.4"
@@ -5491,7 +4919,6 @@
 			"version": "1.5.7",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
 			"integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
-			"dev": true,
 			"requires": {
 				"debug": "^3.1.0"
 			},
@@ -5500,7 +4927,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -5510,14 +4936,12 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"dev": true
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
 			"requires": {
 				"for-in": "^1.0.1"
 			}
@@ -5525,8 +4949,7 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
 			"version": "2.3.2",
@@ -5541,14 +4964,12 @@
 		"forwarded": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-			"dev": true
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
@@ -5556,14 +4977,12 @@
 		"fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-			"dev": true
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
 		"from2": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
@@ -5573,7 +4992,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"iferr": "^0.1.5",
@@ -5584,14 +5002,12 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
 			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "^2.9.2",
@@ -5601,24 +5017,20 @@
 				"abbrev": {
 					"version": "1.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"aproba": {
 					"version": "1.2.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -5627,13 +5039,11 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5642,34 +5052,28 @@
 				"chownr": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -5678,25 +5082,21 @@
 				"deep-extend": {
 					"version": "0.5.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -5705,13 +5105,11 @@
 				"fs.realpath": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -5727,7 +5125,6 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -5741,13 +5138,11 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.21",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safer-buffer": "^2.1.0"
@@ -5756,7 +5151,6 @@
 				"ignore-walk": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minimatch": "^3.0.4"
@@ -5765,7 +5159,6 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"once": "^1.3.0",
@@ -5774,19 +5167,16 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ini": {
 					"version": "1.3.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5794,26 +5184,22 @@
 				"isarray": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -5822,7 +5208,6 @@
 				"minizlib": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -5831,7 +5216,6 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5839,13 +5223,11 @@
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "^2.1.2",
@@ -5856,7 +5238,6 @@
 				"node-pre-gyp": {
 					"version": "0.10.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
@@ -5874,7 +5255,6 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1",
@@ -5884,13 +5264,11 @@
 				"npm-bundled": {
 					"version": "1.0.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.1.10",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
@@ -5900,7 +5278,6 @@
 				"npmlog": {
 					"version": "4.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -5911,19 +5288,16 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5931,19 +5305,16 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -5953,19 +5324,16 @@
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.7",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "^0.5.1",
@@ -5977,7 +5345,6 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -5985,7 +5352,6 @@
 				"readable-stream": {
 					"version": "2.3.6",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -6000,7 +5366,6 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"glob": "^7.0.5"
@@ -6008,43 +5373,36 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.5.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -6054,7 +5412,6 @@
 				"string_decoder": {
 					"version": "1.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
@@ -6063,7 +5420,6 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -6071,13 +5427,11 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"chownr": "^1.0.1",
@@ -6092,13 +5446,11 @@
 				"util-deprecate": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "^1.0.2"
@@ -6106,27 +5458,23 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				}
 			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"function.prototype.name": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
 			"integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"function-bind": "^1.1.1",
@@ -6136,44 +5484,37 @@
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-			"dev": true
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
 		},
 		"get-caller-file": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-			"dev": true
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
 		},
 		"get-func-name": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-			"dev": true
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
 		},
 		"get-stdin": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-			"dev": true
+			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
 		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-			"dev": true
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -6182,7 +5523,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
 			"integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
-			"dev": true,
 			"requires": {
 				"got": "^7.0.0",
 				"is-plain-obj": "^1.1.0"
@@ -6192,7 +5532,6 @@
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
 					"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-					"dev": true,
 					"requires": {
 						"decompress-response": "^3.2.0",
 						"duplexer3": "^0.1.4",
@@ -6213,14 +5552,12 @@
 				"p-cancelable": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-					"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-					"dev": true
+					"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
 				},
 				"p-timeout": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
 					"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-					"dev": true,
 					"requires": {
 						"p-finally": "^1.0.0"
 					}
@@ -6228,14 +5565,12 @@
 				"prepend-http": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-					"dev": true
+					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
 				},
 				"url-parse-lax": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-					"dev": true,
 					"requires": {
 						"prepend-http": "^1.0.1"
 					}
@@ -6246,7 +5581,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
 			"integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
-			"dev": true,
 			"requires": {
 				"gh-got": "^6.0.0"
 			}
@@ -6255,7 +5589,6 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -6269,7 +5602,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.1.0.tgz",
 			"integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
-			"dev": true,
 			"requires": {
 				"glob": "^7.0.5",
 				"yargs": "~1.2.6"
@@ -6278,14 +5610,12 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
-					"dev": true
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
 				},
 				"yargs": {
 					"version": "1.2.6",
 					"resolved": "http://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
 					"integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
-					"dev": true,
 					"requires": {
 						"minimist": "^0.1.0"
 					}
@@ -6296,7 +5626,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
 			"requires": {
 				"glob-parent": "^2.0.0",
 				"is-glob": "^2.0.0"
@@ -6306,7 +5635,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-					"dev": true,
 					"requires": {
 						"is-glob": "^2.0.0"
 					}
@@ -6314,14 +5642,12 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -6332,7 +5658,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-			"dev": true,
 			"requires": {
 				"is-glob": "^3.1.0",
 				"path-dirname": "^1.0.0"
@@ -6341,14 +5666,12 @@
 		"glob-to-regexp": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
-			"dev": true
+			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
 		},
 		"global-modules": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
 			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-			"dev": true,
 			"requires": {
 				"global-prefix": "^1.0.1",
 				"is-windows": "^1.0.1",
@@ -6359,7 +5682,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
 			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-			"dev": true,
 			"requires": {
 				"expand-tilde": "^2.0.2",
 				"homedir-polyfill": "^1.0.1",
@@ -6371,14 +5693,12 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-			"dev": true
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
 		},
 		"globby": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-			"dev": true,
 			"requires": {
 				"array-union": "^1.0.1",
 				"arrify": "^1.0.0",
@@ -6391,8 +5711,7 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
@@ -6400,7 +5719,6 @@
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
 			"integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
-			"dev": true,
 			"requires": {
 				"@sindresorhus/is": "^0.7.0",
 				"cacheable-request": "^2.1.1",
@@ -6424,14 +5742,12 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-			"dev": true
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 		},
 		"grommet": {
 			"version": "2.0.0-rc",
 			"resolved": "https://registry.npmjs.org/grommet/-/grommet-2.0.0-rc.tgz",
 			"integrity": "sha512-Pl60m1IPi4fwntt918AnVa/m5TthA4kH8vlX5T7HvqGgNz7rjYqXaXom3pMXCbiJbo54LndWQwwMVHsec0AAkQ==",
-			"dev": true,
 			"requires": {
 				"css": "^2.2.3",
 				"markdown-to-jsx": "^6.6.6",
@@ -6445,14 +5761,12 @@
 		"grommet-icons": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/grommet-icons/-/grommet-icons-3.2.0.tgz",
-			"integrity": "sha512-D4YBzq0VWF+rU3ynviR0EVBCqmobJxqI8+dmgpG+HKOSDyKuUOxTvD91Esb0wcRfTZwX1NVCbhjLak3CGStl9g==",
-			"dev": true
+			"integrity": "sha512-D4YBzq0VWF+rU3ynviR0EVBCqmobJxqI8+dmgpG+HKOSDyKuUOxTvD91Esb0wcRfTZwX1NVCbhjLak3CGStl9g=="
 		},
 		"grouped-queue": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
 			"integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.17.2"
 			}
@@ -6460,26 +5774,22 @@
 		"growl": {
 			"version": "1.10.5",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-			"dev": true
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
 		},
 		"handle-thing": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
-			"dev": true
+			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
 		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.2.tgz",
 			"integrity": "sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==",
-			"dev": true,
 			"requires": {
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
@@ -6489,7 +5799,6 @@
 					"version": "6.5.5",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
 					"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
-					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -6500,14 +5809,12 @@
 				"fast-deep-equal": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-					"dev": true
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
 				},
 				"json-schema-traverse": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-					"dev": true
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 				}
 			}
 		},
@@ -6515,7 +5822,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -6524,7 +5830,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -6532,32 +5837,27 @@
 		"has-color": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-			"dev": true
+			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
 		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-symbol-support-x": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-			"dev": true
+			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
 		},
 		"has-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-			"dev": true
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
 		},
 		"has-to-string-tag-x": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
 			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-			"dev": true,
 			"requires": {
 				"has-symbol-support-x": "^1.4.1"
 			}
@@ -6566,7 +5866,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-			"dev": true,
 			"requires": {
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
@@ -6577,7 +5876,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"kind-of": "^4.0.0"
@@ -6587,7 +5885,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6598,7 +5895,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
 			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -6608,7 +5904,6 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
 			"integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -6617,14 +5912,12 @@
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-			"dev": true
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"dev": true,
 			"requires": {
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
@@ -6634,14 +5927,12 @@
 		"hoist-non-react-statics": {
 			"version": "2.5.5",
 			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-			"dev": true
+			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.1"
@@ -6651,7 +5942,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
 			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-			"dev": true,
 			"requires": {
 				"parse-passwd": "^1.0.0"
 			}
@@ -6659,14 +5949,12 @@
 		"hosted-git-info": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-			"dev": true
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
 		},
 		"hpack.js": {
 			"version": "2.1.6",
 			"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
 			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"obuf": "^1.0.0",
@@ -6678,7 +5966,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-			"dev": true,
 			"requires": {
 				"whatwg-encoding": "^1.0.1"
 			}
@@ -6686,14 +5973,12 @@
 		"html-entities": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
-			"dev": true
+			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
 		},
 		"html-minifier": {
 			"version": "3.5.20",
 			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.20.tgz",
 			"integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
-			"dev": true,
 			"requires": {
 				"camel-case": "3.0.x",
 				"clean-css": "4.2.x",
@@ -6708,7 +5993,6 @@
 			"version": "3.2.0",
 			"resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
 			"integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
-			"dev": true,
 			"requires": {
 				"html-minifier": "^3.2.3",
 				"loader-utils": "^0.2.16",
@@ -6723,7 +6007,6 @@
 					"version": "0.2.17",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"dev": true,
 					"requires": {
 						"big.js": "^3.1.3",
 						"emojis-list": "^2.0.0",
@@ -6737,7 +6020,6 @@
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
 			"integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
-			"dev": true,
 			"requires": {
 				"domelementtype": "^1.3.0",
 				"domhandler": "^2.3.0",
@@ -6751,7 +6033,6 @@
 					"version": "3.0.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
 					"integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
-					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -6763,20 +6044,17 @@
 		"http-cache-semantics": {
 			"version": "3.8.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
-			"dev": true
+			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
 		},
 		"http-deceiver": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
-			"dev": true
+			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
 		},
 		"http-errors": {
 			"version": "1.6.3",
 			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-			"dev": true,
 			"requires": {
 				"depd": "~1.1.2",
 				"inherits": "2.0.3",
@@ -6787,14 +6065,12 @@
 		"http-parser-js": {
 			"version": "0.4.13",
 			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
-			"integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc=",
-			"dev": true
+			"integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc="
 		},
 		"http-proxy": {
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
 			"integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
-			"dev": true,
 			"requires": {
 				"eventemitter3": "^3.0.0",
 				"follow-redirects": "^1.0.0",
@@ -6805,7 +6081,6 @@
 			"version": "0.18.0",
 			"resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
 			"integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
-			"dev": true,
 			"requires": {
 				"http-proxy": "^1.16.2",
 				"is-glob": "^4.0.0",
@@ -6817,7 +6092,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.1"
 					}
@@ -6828,7 +6102,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -6838,14 +6111,12 @@
 		"https-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-			"dev": true
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -6853,26 +6124,22 @@
 		"ieee754": {
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
-			"dev": true
+			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
 		},
 		"iferr": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-			"dev": true
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
 		},
 		"ignore": {
 			"version": "3.3.10",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-			"dev": true
+			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
 		},
 		"import-local": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
-			"dev": true,
 			"requires": {
 				"pkg-dir": "^2.0.0",
 				"resolve-cwd": "^2.0.0"
@@ -6881,14 +6148,12 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
 		"indent-string": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-			"dev": true,
 			"requires": {
 				"repeating": "^2.0.0"
 			}
@@ -6902,7 +6167,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -6916,14 +6180,12 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.0",
@@ -6944,14 +6206,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -6960,7 +6220,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -6970,14 +6229,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -6986,7 +6243,6 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -6997,7 +6253,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
 			"integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
-			"dev": true,
 			"requires": {
 				"default-gateway": "^2.6.0",
 				"ipaddr.js": "^1.5.2"
@@ -7006,14 +6261,12 @@
 		"interpret": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
-			"dev": true
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
 		},
 		"into-stream": {
 			"version": "3.1.0",
 			"resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
 			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
-			"dev": true,
 			"requires": {
 				"from2": "^2.1.1",
 				"p-is-promise": "^1.1.0"
@@ -7023,7 +6276,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -7031,32 +6283,27 @@
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-			"dev": true
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 		},
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-			"dev": true
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
 		},
 		"ip-regex": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
-			"dev": true
+			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
 		},
 		"ipaddr.js": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
-			"dev": true
+			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -7065,7 +6312,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -7075,14 +6321,12 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-			"dev": true
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"dev": true,
 			"requires": {
 				"binary-extensions": "^1.0.0"
 			}
@@ -7090,20 +6334,17 @@
 		"is-boolean-object": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
-			"integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
-			"dev": true
+			"integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M="
 		},
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
 			"requires": {
 				"builtin-modules": "^1.0.0"
 			}
@@ -7111,14 +6352,12 @@
 		"is-callable": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-			"dev": true
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
 		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -7127,7 +6366,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -7137,14 +6375,12 @@
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-			"dev": true
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-			"dev": true,
 			"requires": {
 				"is-accessor-descriptor": "^0.1.6",
 				"is-data-descriptor": "^0.1.4",
@@ -7154,22 +6390,19 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
 			"requires": {
 				"is-primitive": "^2.0.0"
 			}
@@ -7177,20 +6410,17 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-			"dev": true
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -7198,14 +6428,12 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-glob": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.0"
 			}
@@ -7214,7 +6442,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -7223,7 +6450,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -7233,20 +6459,17 @@
 		"is-number-object": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
-			"integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
-			"dev": true
+			"integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k="
 		},
 		"is-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-			"dev": true
+			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
 		},
 		"is-observable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
 			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-			"dev": true,
 			"requires": {
 				"symbol-observable": "^1.1.0"
 			}
@@ -7254,14 +6477,12 @@
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-			"dev": true
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
 			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-			"dev": true,
 			"requires": {
 				"is-path-inside": "^1.0.0"
 			}
@@ -7270,7 +6491,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-			"dev": true,
 			"requires": {
 				"path-is-inside": "^1.0.1"
 			}
@@ -7278,14 +6498,12 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -7293,26 +6511,22 @@
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"dev": true
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
 		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-			"dev": true,
 			"requires": {
 				"has": "^1.0.1"
 			}
@@ -7320,20 +6534,17 @@
 		"is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-			"dev": true
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
 		},
 		"is-retry-allowed": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-			"dev": true
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
 		},
 		"is-scoped": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
 			"integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
-			"dev": true,
 			"requires": {
 				"scoped-regex": "^1.0.0"
 			}
@@ -7341,50 +6552,42 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-string": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-			"integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
-			"dev": true
+			"integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
 		},
 		"is-subset": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-			"dev": true
+			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
 		},
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-			"dev": true
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-			"dev": true
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"is-wsl": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-			"dev": true
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -7395,7 +6598,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
 			"integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
-			"dev": true,
 			"requires": {
 				"buffer-alloc": "^1.2.0"
 			}
@@ -7403,20 +6605,17 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-			"dev": true
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 		},
 		"isomorphic-fetch": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"dev": true,
 			"requires": {
 				"node-fetch": "^1.0.1",
 				"whatwg-fetch": ">=0.10.0"
@@ -7425,14 +6624,12 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"istextorbinary": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
 			"integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
-			"dev": true,
 			"requires": {
 				"binaryextensions": "2",
 				"editions": "^1.3.3",
@@ -7443,7 +6640,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
 			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
-			"dev": true,
 			"requires": {
 				"has-to-string-tag-x": "^1.2.0",
 				"is-object": "^1.0.1"
@@ -7452,20 +6648,17 @@
 		"js-levenshtein": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.4.tgz",
-			"integrity": "sha512-PxfGzSs0ztShKrUYPIn5r0MtyAhYcCwmndozzpz8YObbPnD1jFxzlBGbRnX2mIu6Z13xN6+PTu05TQFnZFlzow==",
-			"dev": true
+			"integrity": "sha512-PxfGzSs0ztShKrUYPIn5r0MtyAhYcCwmndozzpz8YObbPnD1jFxzlBGbRnX2mIu6Z13xN6+PTu05TQFnZFlzow=="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -7474,22 +6667,19 @@
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-					"dev": true
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 				}
 			}
 		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
 		"jscodeshift": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.5.1.tgz",
 			"integrity": "sha512-sRMollbhbmSDrR79JMAnhEjyZJlQQVozeeY9A6/KNuV26DNcuB3mGSCWXp0hks9dcwRNOELbNOiwraZaXXRk5Q==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "^6.8.0",
 				"babel-preset-es2015": "^6.9.0",
@@ -7511,14 +6701,12 @@
 				"ansi-styles": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-					"dev": true
+					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.0.1"
 					}
@@ -7526,20 +6714,17 @@
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 				},
 				"babylon": {
 					"version": "7.0.0-beta.47",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==",
-					"dev": true
+					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
 					"requires": {
 						"expand-range": "^1.8.1",
 						"preserve": "^0.2.0",
@@ -7550,7 +6735,6 @@
 					"version": "0.4.0",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "~1.0.0",
 						"has-color": "~0.1.0",
@@ -7560,14 +6744,12 @@
 				"colors": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-					"integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
-					"dev": true
+					"integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
 				},
 				"expand-brackets": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
 					"requires": {
 						"is-posix-bracket": "^0.1.0"
 					}
@@ -7576,7 +6758,6 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -7584,14 +6765,12 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -7600,7 +6779,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -7609,7 +6787,6 @@
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
 					"requires": {
 						"arr-diff": "^2.0.0",
 						"array-unique": "^0.2.1",
@@ -7630,7 +6807,6 @@
 					"version": "1.8.1",
 					"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
 					"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-					"dev": true,
 					"requires": {
 						"chalk": "~0.4.0",
 						"underscore": "~1.6.0"
@@ -7639,14 +6815,12 @@
 				"strip-ansi": {
 					"version": "0.1.1",
 					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-					"dev": true
+					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
 				},
 				"underscore": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-					"dev": true
+					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
 				}
 			}
 		},
@@ -7654,7 +6828,6 @@
 			"version": "13.0.0",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-13.0.0.tgz",
 			"integrity": "sha512-Kmq4ASMNkgpY+YufE322EnIKoiz0UWY2DRkKlU7d5YrIW4xiVRhWFrZV1fr6w/ZNxQ50wGAH5gGRzydgnmkkvw==",
-			"dev": true,
 			"requires": {
 				"abab": "^2.0.0",
 				"acorn": "^6.0.2",
@@ -7687,76 +6860,64 @@
 				"acorn": {
 					"version": "6.0.4",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-					"integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
-					"dev": true
+					"integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
 				},
 				"parse5": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-					"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
-					"dev": true
+					"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
 				}
 			}
 		},
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-			"dev": true
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
 		},
 		"json-buffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
-			"dev": true
+			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-			"dev": true
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-			"dev": true
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-			"dev": true
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json3": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-			"dev": true
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -7768,7 +6929,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
 			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
-			"dev": true,
 			"requires": {
 				"array-includes": "^3.0.3"
 			}
@@ -7776,14 +6936,12 @@
 		"just-extend": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
-			"integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
-			"dev": true
+			"integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ=="
 		},
 		"keyv": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
 			"integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
-			"dev": true,
 			"requires": {
 				"json-buffer": "3.0.0"
 			}
@@ -7791,20 +6949,17 @@
 		"killable": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
-			"integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms=",
-			"dev": true
+			"integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms="
 		},
 		"kind-of": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-			"dev": true
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 		},
 		"lcid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"dev": true,
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
@@ -7812,14 +6967,12 @@
 		"leb": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/leb/-/leb-0.3.0.tgz",
-			"integrity": "sha1-Mr7p+tFoMo1q6oUi2DP0GA7tHaM=",
-			"dev": true
+			"integrity": "sha1-Mr7p+tFoMo1q6oUi2DP0GA7tHaM="
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
@@ -7829,7 +6982,6 @@
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/listr/-/listr-0.14.1.tgz",
 			"integrity": "sha512-MSMUUVN1f8aRnPi4034RkOqdiUlpYW+FqwFE3aL0uYNPRavkt2S2SsSpDDofn8BDpqv2RNnsdOcCHWsChcq77A==",
-			"dev": true,
 			"requires": {
 				"@samverschueren/stream-to-observable": "^0.3.0",
 				"cli-truncate": "^0.2.1",
@@ -7853,7 +7005,6 @@
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-					"dev": true,
 					"requires": {
 						"escape-string-regexp": "^1.0.5",
 						"object-assign": "^4.1.0"
@@ -7863,7 +7014,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-					"dev": true,
 					"requires": {
 						"chalk": "^1.0.0"
 					}
@@ -7872,7 +7022,6 @@
 					"version": "6.2.2",
 					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
 					"integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
-					"dev": true,
 					"requires": {
 						"tslib": "^1.9.0"
 					}
@@ -7882,14 +7031,12 @@
 		"listr-silent-renderer": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
-			"dev": true
+			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
 		},
 		"listr-update-renderer": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
 			"integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"cli-truncate": "^0.2.1",
@@ -7905,7 +7052,6 @@
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-					"dev": true,
 					"requires": {
 						"escape-string-regexp": "^1.0.5",
 						"object-assign": "^4.1.0"
@@ -7914,14 +7060,12 @@
 				"indent-string": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
 				},
 				"log-symbols": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-					"dev": true,
 					"requires": {
 						"chalk": "^1.0.0"
 					}
@@ -7932,7 +7076,6 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
 			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"cli-cursor": "^1.0.2",
@@ -7944,7 +7087,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-					"dev": true,
 					"requires": {
 						"restore-cursor": "^1.0.1"
 					}
@@ -7953,7 +7095,6 @@
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-					"dev": true,
 					"requires": {
 						"escape-string-regexp": "^1.0.5",
 						"object-assign": "^4.1.0"
@@ -7962,14 +7103,12 @@
 				"onetime": {
 					"version": "1.1.0",
 					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-					"dev": true
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
 				},
 				"restore-cursor": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-					"dev": true,
 					"requires": {
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
@@ -7981,7 +7120,6 @@
 			"version": "2.0.0",
 			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"parse-json": "^2.2.0",
@@ -7992,22 +7130,19 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
 		"loader-runner": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
-			"integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw==",
-			"dev": true
+			"integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw=="
 		},
 		"loader-utils": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-			"dev": true,
 			"requires": {
 				"big.js": "^3.1.3",
 				"emojis-list": "^2.0.0",
@@ -8018,7 +7153,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
 			"requires": {
 				"p-locate": "^2.0.0",
 				"path-exists": "^3.0.0"
@@ -8032,50 +7166,42 @@
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-			"dev": true
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
 		},
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-			"dev": true
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
 		},
 		"lodash.escape": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-			"integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
-			"dev": true
+			"integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-			"dev": true
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
 		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-			"dev": true
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-			"dev": true
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-			"dev": true
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
 		"log-symbols": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1"
 			},
@@ -8084,7 +7210,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -8093,7 +7218,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -8103,14 +7227,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -8121,7 +7243,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
-			"dev": true,
 			"requires": {
 				"ansi-escapes": "^1.0.0",
 				"cli-cursor": "^1.0.2"
@@ -8130,14 +7251,12 @@
 				"ansi-escapes": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-					"dev": true
+					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
 				},
 				"cli-cursor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-					"dev": true,
 					"requires": {
 						"restore-cursor": "^1.0.1"
 					}
@@ -8145,14 +7264,12 @@
 				"onetime": {
 					"version": "1.1.0",
 					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-					"dev": true
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
 				},
 				"restore-cursor": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-					"dev": true,
 					"requires": {
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
@@ -8163,26 +7280,22 @@
 		"loglevel": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
-			"integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
-			"dev": true
+			"integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
 		},
 		"lolex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
-			"integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
-			"dev": true
+			"integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ=="
 		},
 		"long": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-			"integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
-			"dev": true
+			"integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
 		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -8191,7 +7304,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-			"dev": true,
 			"requires": {
 				"currently-unhandled": "^0.4.1",
 				"signal-exit": "^3.0.0"
@@ -8200,20 +7312,17 @@
 		"lower-case": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-			"dev": true
+			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
 		},
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-			"dev": true
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 		},
 		"lru-cache": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
@@ -8228,7 +7337,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-			"dev": true,
 			"requires": {
 				"pify": "^3.0.0"
 			}
@@ -8249,14 +7357,12 @@
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-			"dev": true
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
 		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
@@ -8265,7 +7371,6 @@
 			"version": "6.8.3",
 			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.8.3.tgz",
 			"integrity": "sha512-I/kRZDvHFMEoKCjFS119v6Op4R1wZJEUEwhWSNtsE7WHRVcxKrLZ9vApvNb1j80MAFIY4/e4m1f4vIwSgKUZ8g==",
-			"dev": true,
 			"requires": {
 				"prop-types": "^15.6.2",
 				"unquote": "^1.1.0"
@@ -8274,14 +7379,12 @@
 		"math-random": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-			"dev": true
+			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
 		},
 		"md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
 			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-			"dev": true,
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1",
@@ -8291,14 +7394,12 @@
 		"media-typer": {
 			"version": "0.3.0",
 			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-			"dev": true
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -8307,7 +7408,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
 			"integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
-			"dev": true,
 			"requires": {
 				"through2": "^2.0.0",
 				"vinyl": "^1.1.0",
@@ -8318,7 +7418,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.3.tgz",
 			"integrity": "sha512-tgWmwI/+6vwu6POan82dTjxEpwAoaj0NAFnghtVo/FcLK2/7IhPUtFUUYlwou4MOY6OtjTUJtwpfH1h+eSUziw==",
-			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
 				"deep-extend": "^0.6.0",
@@ -8336,20 +7435,17 @@
 				"clone": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-					"dev": true
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
 				},
 				"clone-stats": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-					"dev": true
+					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
 				},
 				"globby": {
 					"version": "7.1.1",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
 					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
 						"dir-glob": "^2.0.0",
@@ -8362,14 +7458,12 @@
 				"replace-ext": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-					"dev": true
+					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 				},
 				"vinyl": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
 					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-					"dev": true,
 					"requires": {
 						"clone": "^2.1.1",
 						"clone-buffer": "^1.0.0",
@@ -8384,14 +7478,12 @@
 		"memoize-one": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.2.tgz",
-			"integrity": "sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg==",
-			"dev": true
+			"integrity": "sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg=="
 		},
 		"memory-fs": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-			"dev": true,
 			"requires": {
 				"errno": "^0.1.3",
 				"readable-stream": "^2.0.1"
@@ -8400,26 +7492,22 @@
 		"merge-descriptors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-			"dev": true
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
 		},
 		"merge2": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
-			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg==",
-			"dev": true
+			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
 		},
 		"methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-			"dev": true
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"micromatch": {
 			"version": "3.1.10",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -8440,7 +7528,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.0.0",
 				"brorand": "^1.0.1"
@@ -8449,8 +7536,7 @@
 		"mime": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-			"dev": true
+			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
 		},
 		"mime-db": {
 			"version": "1.36.0",
@@ -8468,32 +7554,27 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-			"dev": true
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
 		"mimic-response": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-			"dev": true
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
 		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-			"dev": true
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-			"dev": true
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -8501,14 +7582,12 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mississippi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
 			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
-			"dev": true,
 			"requires": {
 				"concat-stream": "^1.5.0",
 				"duplexify": "^3.4.2",
@@ -8526,7 +7605,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
@@ -8536,7 +7614,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -8547,7 +7624,6 @@
 			"version": "0.5.1",
 			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -8555,20 +7631,17 @@
 		"mobx": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/mobx/-/mobx-5.6.0.tgz",
-			"integrity": "sha512-xrA0tBnSMANXCDjS2W/6YTasesA8mkg9o+v/Bw/OcbXaRVE6/soVwDMWIh7A6TwMDY4tYQprQJZ5WQN1TRSb3A==",
-			"dev": true
+			"integrity": "sha512-xrA0tBnSMANXCDjS2W/6YTasesA8mkg9o+v/Bw/OcbXaRVE6/soVwDMWIh7A6TwMDY4tYQprQJZ5WQN1TRSb3A=="
 		},
 		"mobx-devtools-mst": {
 			"version": "0.9.18",
 			"resolved": "https://registry.npmjs.org/mobx-devtools-mst/-/mobx-devtools-mst-0.9.18.tgz",
-			"integrity": "sha512-HlCcUuKr5aBDGUespXgvwPA9LP2T0dUyx/Ngan8SCF2ywrdB1m+Dz6QISRjUXAJM4Mk9wDyHcrljbxH2QVa0kQ==",
-			"dev": true
+			"integrity": "sha512-HlCcUuKr5aBDGUespXgvwPA9LP2T0dUyx/Ngan8SCF2ywrdB1m+Dz6QISRjUXAJM4Mk9wDyHcrljbxH2QVa0kQ=="
 		},
 		"mobx-react": {
 			"version": "5.3.6",
 			"resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-5.3.6.tgz",
 			"integrity": "sha512-u0ehjkyMllnt+SQ/G5BACxwi4VkJOqDVauA7cL8UvDi4oLO1ID9Z5c/nudTdIAmtsDDhJSxW85mrgsA2Iv/56Q==",
-			"dev": true,
 			"requires": {
 				"hoist-non-react-statics": "^3.0.0",
 				"react-lifecycles-compat": "^3.0.2"
@@ -8578,7 +7651,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz",
 					"integrity": "sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==",
-					"dev": true,
 					"requires": {
 						"react-is": "^16.3.2"
 					}
@@ -8588,14 +7660,12 @@
 		"mobx-state-tree": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-3.7.1.tgz",
-			"integrity": "sha512-XJHT4ldB2eoHBOqTsNLOsJHNsClSkAUwNWQm9njat28Md0ymQIpVPpcKywz9I8tbu2RoWlEm1/U4v6SeQEk/sA==",
-			"dev": true
+			"integrity": "sha512-XJHT4ldB2eoHBOqTsNLOsJHNsClSkAUwNWQm9njat28Md0ymQIpVPpcKywz9I8tbu2RoWlEm1/U4v6SeQEk/sA=="
 		},
 		"mocha": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
 			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-			"dev": true,
 			"requires": {
 				"browser-stdout": "1.3.1",
 				"commander": "2.15.1",
@@ -8613,14 +7683,12 @@
 				"commander": {
 					"version": "2.15.1",
 					"resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-					"dev": true
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -8628,14 +7696,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -8645,20 +7711,17 @@
 		"moo": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
-			"dev": true
+			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
 		},
 		"mout": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mout/-/mout-1.1.0.tgz",
-			"integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw==",
-			"dev": true
+			"integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw=="
 		},
 		"move-concurrently": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"copy-concurrently": "^1.0.0",
@@ -8671,14 +7734,12 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"multicast-dns": {
 			"version": "6.2.3",
 			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
 			"integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
-			"dev": true,
 			"requires": {
 				"dns-packet": "^1.3.1",
 				"thunky": "^1.0.2"
@@ -8687,14 +7748,12 @@
 		"multicast-dns-service-types": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
-			"dev": true
+			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
 		},
 		"multimatch": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-			"dev": true,
 			"requires": {
 				"array-differ": "^1.0.0",
 				"array-union": "^1.0.1",
@@ -8705,21 +7764,18 @@
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-			"dev": true
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
 			"integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
-			"dev": true,
 			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -8737,14 +7793,12 @@
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-			"dev": true
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
 		"nearley": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.15.1.tgz",
 			"integrity": "sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==",
-			"dev": true,
 			"requires": {
 				"moo": "^0.4.3",
 				"nomnom": "~1.6.2",
@@ -8756,26 +7810,22 @@
 		"negotiator": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-			"dev": true
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
 		},
 		"neo-async": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.2.tgz",
-			"integrity": "sha512-vdqTKI9GBIYcAEbFAcpKPErKINfPF5zIuz3/niBfq8WUZjpT2tytLlFVrBgWdOtqI4uaA/Rb6No0hux39XXDuw==",
-			"dev": true
+			"integrity": "sha512-vdqTKI9GBIYcAEbFAcpKPErKINfPF5zIuz3/niBfq8WUZjpT2tytLlFVrBgWdOtqI4uaA/Rb6No0hux39XXDuw=="
 		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-			"dev": true
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
 		"nise": {
 			"version": "1.4.6",
 			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
 			"integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
-			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "3.0.0",
 				"just-extend": "^3.0.0",
@@ -8787,8 +7837,7 @@
 				"lolex": {
 					"version": "2.7.5",
 					"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-					"integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
-					"dev": true
+					"integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q=="
 				}
 			}
 		},
@@ -8796,7 +7845,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
 			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-			"dev": true,
 			"requires": {
 				"lower-case": "^1.1.1"
 			}
@@ -8804,14 +7852,12 @@
 		"node-dir": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.8.tgz",
-			"integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30=",
-			"dev": true
+			"integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30="
 		},
 		"node-fetch": {
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-			"dev": true,
 			"requires": {
 				"encoding": "^0.1.11",
 				"is-stream": "^1.0.1"
@@ -8820,14 +7866,12 @@
 		"node-forge": {
 			"version": "0.7.5",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
-			"integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
-			"dev": true
+			"integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
 		},
 		"node-libs-browser": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
 			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
-			"dev": true,
 			"requires": {
 				"assert": "^1.1.1",
 				"browserify-zlib": "^0.2.0",
@@ -8857,22 +7901,19 @@
 				"process": {
 					"version": "0.11.10",
 					"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-					"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-					"dev": true
+					"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
 				}
 			}
 		},
 		"node-modules-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
-			"dev": true
+			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
 		},
 		"node-releases": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.3.tgz",
 			"integrity": "sha512-ZaZWMsbuDcetpHmYeKWPO6e63pSXLb50M7lJgCbcM2nC/nQC3daNifmtp5a2kp7EWwYfhuvH6zLPWkrF8IiDdw==",
-			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
 			}
@@ -8881,7 +7922,6 @@
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
 			"integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
-			"dev": true,
 			"requires": {
 				"colors": "0.5.x",
 				"underscore": "~1.4.4"
@@ -8891,7 +7931,6 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"is-builtin-module": "^1.0.0",
@@ -8903,7 +7942,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
 			}
@@ -8912,7 +7950,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
 			"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-			"dev": true,
 			"requires": {
 				"prepend-http": "^2.0.0",
 				"query-string": "^5.0.1",
@@ -8923,7 +7960,6 @@
 					"version": "5.1.1",
 					"resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
 					"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-					"dev": true,
 					"requires": {
 						"decode-uri-component": "^0.2.0",
 						"object-assign": "^4.1.0",
@@ -8933,8 +7969,7 @@
 				"strict-uri-encode": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-					"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-					"dev": true
+					"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
 				}
 			}
 		},
@@ -8942,7 +7977,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -8951,7 +7985,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
 			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-			"dev": true,
 			"requires": {
 				"boolbase": "~1.0.0"
 			}
@@ -8959,32 +7992,27 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nwsapi": {
 			"version": "2.0.9",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-			"integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==",
-			"dev": true
+			"integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ=="
 		},
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-			"dev": true
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-			"dev": true,
 			"requires": {
 				"copy-descriptor": "^0.1.0",
 				"define-property": "^0.2.5",
@@ -8995,7 +8023,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -9004,7 +8031,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -9014,26 +8040,22 @@
 		"object-inspect": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
-			"dev": true
+			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
 		},
 		"object-is": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-			"integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
-			"dev": true
+			"integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
 		},
 		"object-keys": {
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
-			"dev": true
+			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
 		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
 			}
@@ -9042,7 +8064,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"function-bind": "^1.1.1",
@@ -9054,7 +8075,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
 			"integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.6.1",
@@ -9066,7 +8086,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.5.1"
@@ -9076,7 +8095,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
 			"requires": {
 				"for-own": "^0.1.4",
 				"is-extendable": "^0.1.1"
@@ -9086,7 +8104,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -9095,7 +8112,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
 			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.6.1",
@@ -9106,14 +8122,12 @@
 		"obuf": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-			"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-			"dev": true
+			"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
 		},
 		"on-finished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
 			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"dev": true,
 			"requires": {
 				"ee-first": "1.1.1"
 			}
@@ -9121,14 +8135,12 @@
 		"on-headers": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
-			"dev": true
+			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
 		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -9137,7 +8149,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -9146,7 +8157,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
 			"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
-			"dev": true,
 			"requires": {
 				"is-wsl": "^1.1.0"
 			}
@@ -9155,7 +8165,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"dev": true,
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
@@ -9165,7 +8174,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-			"dev": true,
 			"requires": {
 				"deep-is": "~0.1.3",
 				"fast-levenshtein": "~2.0.4",
@@ -9178,8 +8186,7 @@
 				"wordwrap": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-					"dev": true
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 				}
 			}
 		},
@@ -9187,7 +8194,6 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
 			"integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.1",
 				"cli-cursor": "^1.0.2",
@@ -9199,7 +8205,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-					"dev": true,
 					"requires": {
 						"restore-cursor": "^1.0.1"
 					}
@@ -9207,14 +8212,12 @@
 				"onetime": {
 					"version": "1.1.0",
 					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-					"dev": true
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
 				},
 				"restore-cursor": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-					"dev": true,
 					"requires": {
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
@@ -9226,7 +8229,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
 			"integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-			"dev": true,
 			"requires": {
 				"url-parse": "^1.4.3"
 			}
@@ -9234,20 +8236,17 @@
 		"os-browserify": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-			"dev": true
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
 		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"dev": true
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-			"dev": true,
 			"requires": {
 				"execa": "^0.7.0",
 				"lcid": "^1.0.0",
@@ -9257,14 +8256,12 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"osenv": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.0"
@@ -9273,14 +8270,12 @@
 		"p-cancelable": {
 			"version": "0.4.1",
 			"resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-			"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
-			"dev": true
+			"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
 		},
 		"p-each-series": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
 			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
-			"dev": true,
 			"requires": {
 				"p-reduce": "^1.0.0"
 			}
@@ -9288,26 +8283,22 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-is-promise": {
 			"version": "1.1.0",
 			"resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
-			"dev": true
+			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
 		},
 		"p-lazy": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-lazy/-/p-lazy-1.0.0.tgz",
-			"integrity": "sha1-7FPIAvLuOsKPFmzILQsrAt4nqDU=",
-			"dev": true
+			"integrity": "sha1-7FPIAvLuOsKPFmzILQsrAt4nqDU="
 		},
 		"p-limit": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-			"dev": true,
 			"requires": {
 				"p-try": "^1.0.0"
 			}
@@ -9316,7 +8307,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
 			"requires": {
 				"p-limit": "^1.1.0"
 			}
@@ -9324,20 +8314,17 @@
 		"p-map": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
-			"dev": true
+			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
 		},
 		"p-reduce": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
-			"dev": true
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
 		},
 		"p-timeout": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
 			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-			"dev": true,
 			"requires": {
 				"p-finally": "^1.0.0"
 			}
@@ -9345,20 +8332,17 @@
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-			"dev": true
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 		},
 		"pako": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
-			"dev": true
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
 		},
 		"parallel-transform": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
 			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-			"dev": true,
 			"requires": {
 				"cyclist": "~0.2.2",
 				"inherits": "^2.0.3",
@@ -9369,7 +8353,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
 			"integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-			"dev": true,
 			"requires": {
 				"no-case": "^2.2.0"
 			}
@@ -9378,7 +8361,6 @@
 			"version": "5.1.1",
 			"resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
 			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
-			"dev": true,
 			"requires": {
 				"asn1.js": "^4.0.0",
 				"browserify-aes": "^1.0.0",
@@ -9391,7 +8373,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
 			"requires": {
 				"glob-base": "^0.3.0",
 				"is-dotfile": "^1.0.0",
@@ -9402,14 +8383,12 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -9420,7 +8399,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-			"dev": true,
 			"requires": {
 				"error-ex": "^1.2.0"
 			}
@@ -9428,14 +8406,12 @@
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-			"dev": true
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
 		},
 		"parse5": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
 			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -9443,62 +8419,52 @@
 		"parseurl": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-			"dev": true
+			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
 		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-			"dev": true
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
 		},
 		"path-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
-			"dev": true
+			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
 		},
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-			"dev": true
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
 		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-			"dev": true
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"path-to-regexp": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-			"dev": true,
 			"requires": {
 				"isarray": "0.0.1"
 			},
@@ -9506,8 +8472,7 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				}
 			}
 		},
@@ -9515,7 +8480,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-			"dev": true,
 			"requires": {
 				"pify": "^2.0.0"
 			},
@@ -9523,22 +8487,19 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
 		"pathval": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-			"dev": true
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
 		},
 		"pbkdf2": {
 			"version": "3.0.17",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
 			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
-			"dev": true,
 			"requires": {
 				"create-hash": "^1.1.2",
 				"create-hmac": "^1.1.4",
@@ -9550,26 +8511,22 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-			"dev": true
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-			"dev": true
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"dev": true,
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
@@ -9578,7 +8535,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
 			"integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
-			"dev": true,
 			"requires": {
 				"node-modules-regexp": "^1.0.0"
 			}
@@ -9587,7 +8543,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
 			"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
-			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
 				"load-json-file": "^4.0.0"
@@ -9597,7 +8552,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -9609,7 +8563,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -9621,7 +8574,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
 			"integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
-			"dev": true,
 			"requires": {
 				"debug-log": "^1.0.0",
 				"find-root": "^1.0.0",
@@ -9632,7 +8584,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-			"dev": true,
 			"requires": {
 				"find-up": "^2.1.0"
 			}
@@ -9640,8 +8591,7 @@
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-			"dev": true
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
 		},
 		"pluralizers": {
 			"version": "0.1.7",
@@ -9651,14 +8601,12 @@
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-			"dev": true
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
 		},
 		"polished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/polished/-/polished-2.3.0.tgz",
 			"integrity": "sha512-G2yD9LhJy5HBuU+Im5qe70ubaJI/ZTTOIJO6GRMwJ2WSoAiPzlm8+LjAXMnm9/K0E0NumRVHvQu2HHPKQSYQjw==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.0.0"
 			}
@@ -9678,7 +8626,6 @@
 			"version": "1.0.17",
 			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.17.tgz",
 			"integrity": "sha512-syFcRIRzVI1BoEFOCaAiizwDolh1S1YXSodsVhncbhjzjZQulhczNRbqnUl9N31Q4dKGOXsNDqxC2BWBgSMqeQ==",
-			"dev": true,
 			"requires": {
 				"async": "^1.5.2",
 				"debug": "^2.2.0",
@@ -9688,50 +8635,42 @@
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-			"dev": true
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"postcss-value-parser": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-			"dev": true
+			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
 		"prepend-http": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-			"dev": true
+			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"dev": true
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
 		},
 		"prettier": {
 			"version": "1.14.2",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.2.tgz",
-			"integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==",
-			"dev": true
+			"integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg=="
 		},
 		"pretty-bytes": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
-			"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
-			"dev": true
+			"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
 		},
 		"pretty-error": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
 			"integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
-			"dev": true,
 			"requires": {
 				"renderkid": "^2.0.1",
 				"utila": "~0.4"
@@ -9740,8 +8679,7 @@
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-			"dev": true
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
@@ -9751,14 +8689,12 @@
 		"progress": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-			"dev": true
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
 		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"dev": true,
 			"requires": {
 				"asap": "~2.0.3"
 			}
@@ -9766,14 +8702,12 @@
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-			"dev": true
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
 		},
 		"prop-types": {
 			"version": "15.6.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
 			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.3.1",
 				"object-assign": "^4.1.1"
@@ -9783,7 +8717,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
 			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
-			"dev": true,
 			"requires": {
 				"forwarded": "~0.1.2",
 				"ipaddr.js": "1.8.0"
@@ -9792,14 +8725,12 @@
 		"prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-			"dev": true
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"psl": {
 			"version": "1.1.29",
@@ -9810,7 +8741,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
 			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"browserify-rsa": "^4.0.0",
@@ -9824,7 +8754,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
 			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -9834,7 +8763,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
 			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-			"dev": true,
 			"requires": {
 				"duplexify": "^3.6.0",
 				"inherits": "^2.0.3",
@@ -9849,8 +8777,7 @@
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-			"dev": true
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
 		"query-string": {
 			"version": "6.1.0",
@@ -9864,26 +8791,22 @@
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-			"dev": true
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
 		},
 		"querystring-es3": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-			"dev": true
+			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
 		},
 		"querystringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
-			"integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
-			"dev": true
+			"integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
 		},
 		"raf": {
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
 			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-			"dev": true,
 			"requires": {
 				"performance-now": "^2.1.0"
 			}
@@ -9891,14 +8814,12 @@
 		"railroad-diagrams": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
-			"dev": true
+			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
 		},
 		"randexp": {
 			"version": "0.4.6",
 			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
 			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"dev": true,
 			"requires": {
 				"discontinuous-range": "1.0.0",
 				"ret": "~0.1.10"
@@ -9908,7 +8829,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
 			"integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
-			"dev": true,
 			"requires": {
 				"is-number": "^4.0.0",
 				"kind-of": "^6.0.0",
@@ -9918,8 +8838,7 @@
 				"is-number": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
 				}
 			}
 		},
@@ -9927,7 +8846,6 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
 			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -9936,7 +8854,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-			"dev": true,
 			"requires": {
 				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
@@ -9945,14 +8862,12 @@
 		"range-parser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-			"dev": true
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
 		},
 		"raw-body": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
 			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-			"dev": true,
 			"requires": {
 				"bytes": "3.0.0",
 				"http-errors": "1.6.2",
@@ -9963,14 +8878,12 @@
 				"depd": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-					"dev": true
+					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
 				},
 				"http-errors": {
 					"version": "1.6.2",
 					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
 					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-					"dev": true,
 					"requires": {
 						"depd": "1.1.1",
 						"inherits": "2.0.3",
@@ -9981,14 +8894,12 @@
 				"iconv-lite": {
 					"version": "0.4.19",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-					"dev": true
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
 				},
 				"setprototypeof": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-					"dev": true
+					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
 				}
 			}
 		},
@@ -9996,7 +8907,6 @@
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-16.6.0.tgz",
 			"integrity": "sha512-zJPnx/jKtuOEXCbQ9BKaxDMxR0001/hzxXwYxG8septeyYGfsgAei6NgfbVgOhbY1WOP2o3VPs/E9HaN+9hV3Q==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -10007,14 +8917,12 @@
 		"react-desc": {
 			"version": "3.6.5",
 			"resolved": "https://registry.npmjs.org/react-desc/-/react-desc-3.6.5.tgz",
-			"integrity": "sha512-fI3JbWRQdRmQ3pBFscULdmJnKceSgK5Ug6BdFS/G/+9/6hle16sOQYEeELIu053uhhSuwK59aBex0UaeTJWnpw==",
-			"dev": true
+			"integrity": "sha512-fI3JbWRQdRmQ3pBFscULdmJnKceSgK5Ug6BdFS/G/+9/6hle16sOQYEeELIu053uhhSuwK59aBex0UaeTJWnpw=="
 		},
 		"react-dom": {
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.0.tgz",
 			"integrity": "sha512-Stm2D9dXEUUAQdvpvhvFj/DEXwC2PAL/RwEMhoN4dvvD2ikTlJegEXf97xryg88VIAU22ZAP7n842l+9BTz6+w==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -10025,20 +8933,17 @@
 		"react-is": {
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.0.tgz",
-			"integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g==",
-			"dev": true
+			"integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g=="
 		},
 		"react-lifecycles-compat": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-			"dev": true
+			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
 		"react-test-renderer": {
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.6.0.tgz",
 			"integrity": "sha512-w+Y3YT7OX1LP5KO7HCd0YR34Ol1qmISHaooPNMRYa6QzmwtcWhEGuZPr34wO8UCBIokswuhyLQUq7rjPDcEtJA==",
-			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
@@ -10049,8 +8954,7 @@
 				"react-is": {
 					"version": "16.6.0",
 					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.0.tgz",
-					"integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g==",
-					"dev": true
+					"integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g=="
 				}
 			}
 		},
@@ -10058,7 +8962,6 @@
 			"version": "8.0.3",
 			"resolved": "https://registry.npmjs.org/react-waypoint/-/react-waypoint-8.0.3.tgz",
 			"integrity": "sha512-2tfq6PU8meAOpZ+ZqyGO1YCa9n2kEhq6+UI5tOpgMUra2iJmpva9QvwReamO3eozVMxFQ495wR9pkMbLnXvI/w==",
-			"dev": true,
 			"requires": {
 				"consolidated-events": "^1.1.0 || ^2.0.0",
 				"prop-types": "^15.0.0"
@@ -10068,7 +8971,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
 			"integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
-			"dev": true,
 			"requires": {
 				"pify": "^3.0.0",
 				"safe-buffer": "^5.1.1"
@@ -10078,7 +8980,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-			"dev": true,
 			"requires": {
 				"load-json-file": "^2.0.0",
 				"normalize-package-data": "^2.3.2",
@@ -10089,7 +8990,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
 				"read-pkg": "^2.0.0"
@@ -10113,7 +9013,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"minimatch": "^3.0.2",
@@ -10125,7 +9024,6 @@
 			"version": "0.15.3",
 			"resolved": "https://registry.npmjs.org/recast/-/recast-0.15.3.tgz",
 			"integrity": "sha512-xqnagxQH7mL4+UpcCVMObPPdjCEE2dmfGcTwcdpyNgZOd9W0rfdLRF3+smoA+AQqMw6xK6G4021dAQK8XfPYIQ==",
-			"dev": true,
 			"requires": {
 				"ast-types": "0.11.5",
 				"esprima": "~4.0.0",
@@ -10136,14 +9034,12 @@
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-					"dev": true
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -10151,7 +9047,6 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-			"dev": true,
 			"requires": {
 				"resolve": "^1.1.6"
 			}
@@ -10160,7 +9055,6 @@
 			"version": "0.30.0",
 			"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
 			"integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.0.0",
 				"change-emitter": "^0.1.2",
@@ -10173,14 +9067,12 @@
 		"regenerate": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-			"dev": true
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
 		},
 		"regenerate-unicode-properties": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
 			"integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
-			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0"
 			}
@@ -10188,14 +9080,12 @@
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-			"dev": true
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.18.0",
 				"babel-types": "^6.19.0",
@@ -10206,7 +9096,6 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"dev": true,
 			"requires": {
 				"is-equal-shallow": "^0.1.3"
 			}
@@ -10215,7 +9104,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
@@ -10225,7 +9113,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-			"dev": true,
 			"requires": {
 				"regenerate": "^1.2.1",
 				"regjsgen": "^0.2.0",
@@ -10235,14 +9122,12 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-			"dev": true
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
 			},
@@ -10250,28 +9135,24 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
 			}
 		},
 		"relateurl": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
-			"dev": true
+			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"renderkid": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
 			"integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
-			"dev": true,
 			"requires": {
 				"css-select": "^1.1.0",
 				"dom-converter": "~0.1",
@@ -10284,7 +9165,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
 					"integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
-					"dev": true,
 					"requires": {
 						"domelementtype": "1"
 					}
@@ -10293,7 +9173,6 @@
 					"version": "1.1.6",
 					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
 					"integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-					"dev": true,
 					"requires": {
 						"domelementtype": "1"
 					}
@@ -10302,7 +9181,6 @@
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
 					"integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
-					"dev": true,
 					"requires": {
 						"domelementtype": "1",
 						"domhandler": "2.1",
@@ -10313,14 +9191,12 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -10331,34 +9207,29 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"utila": {
 					"version": "0.3.3",
 					"resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
-					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
-					"dev": true
+					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY="
 				}
 			}
 		},
 		"repeat-element": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-			"dev": true
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
@@ -10366,14 +9237,12 @@
 		"replace-ext": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-			"dev": true
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
 		},
 		"request": {
 			"version": "2.88.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -10401,7 +9270,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.13.1"
 			}
@@ -10410,7 +9278,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
 			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
 				"stealthy-require": "^1.1.0",
@@ -10420,20 +9287,17 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-			"dev": true
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"require-uncached": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-			"dev": true,
 			"requires": {
 				"caller-path": "^0.1.0",
 				"resolve-from": "^1.0.0"
@@ -10442,14 +9306,12 @@
 		"requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-			"dev": true
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resolve": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
 			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.5"
 			}
@@ -10458,7 +9320,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-			"dev": true,
 			"requires": {
 				"resolve-from": "^3.0.0"
 			},
@@ -10466,8 +9327,7 @@
 				"resolve-from": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-					"dev": true
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 				}
 			}
 		},
@@ -10475,7 +9335,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
 			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-			"dev": true,
 			"requires": {
 				"expand-tilde": "^2.0.0",
 				"global-modules": "^1.0.0"
@@ -10484,20 +9343,17 @@
 		"resolve-from": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-			"dev": true
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
 		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-			"dev": true
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
 		"responselike": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
 			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-			"dev": true,
 			"requires": {
 				"lowercase-keys": "^1.0.0"
 			}
@@ -10506,7 +9362,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-			"dev": true,
 			"requires": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
@@ -10515,14 +9370,12 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"dev": true
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"rimraf": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.0.5"
 			}
@@ -10531,7 +9384,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
 			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-			"dev": true,
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
@@ -10541,7 +9393,6 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
 			"integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
-			"dev": true,
 			"requires": {
 				"lodash.flattendeep": "^4.4.0",
 				"nearley": "^2.7.10"
@@ -10551,7 +9402,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
 			}
@@ -10559,14 +9409,12 @@
 		"run-parallel": {
 			"version": "1.1.9",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-			"dev": true
+			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
 		},
 		"run-queue": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1"
 			}
@@ -10574,14 +9422,12 @@
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-			"dev": true
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"dev": true,
 			"requires": {
 				"rx-lite": "*"
 			}
@@ -10590,7 +9436,6 @@
 			"version": "5.5.11",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
 			"integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
-			"dev": true,
 			"requires": {
 				"symbol-observable": "1.0.1"
 			},
@@ -10598,8 +9443,7 @@
 				"symbol-observable": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-					"dev": true
+					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
 				}
 			}
 		},
@@ -10612,7 +9456,6 @@
 			"version": "1.1.0",
 			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-			"dev": true,
 			"requires": {
 				"ret": "~0.1.10"
 			}
@@ -10620,14 +9463,12 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"saxes": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.3.tgz",
 			"integrity": "sha512-Nc5DXc5A+m3rUDtkS+vHlBWKT7mCKjJPyia7f8YMW773hsXVv2wEHQZGE0zs4+5PLwz9U5Sbl/94Cnd9vHV7Bg==",
-			"dev": true,
 			"requires": {
 				"xmlchars": "^1.3.1"
 			}
@@ -10636,7 +9477,6 @@
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.10.0.tgz",
 			"integrity": "sha512-+TSTVTCBAA3h8Anei3haDc1IRwMeDmtI/y/o3iBe3Mjl2vwYF9DtPDt929HyRmV/e7au7CLu8sc4C4W0VOs29w==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -10646,7 +9486,6 @@
 			"version": "0.4.7",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
 			"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-			"dev": true,
 			"requires": {
 				"ajv": "^6.1.0",
 				"ajv-keywords": "^3.1.0"
@@ -10656,7 +9495,6 @@
 					"version": "6.5.5",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
 					"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
-					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -10667,40 +9505,34 @@
 				"ajv-keywords": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
-					"dev": true
+					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
 				},
 				"fast-deep-equal": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-					"dev": true
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
 				},
 				"json-schema-traverse": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-					"dev": true
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 				}
 			}
 		},
 		"scoped-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
-			"integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=",
-			"dev": true
+			"integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
 		},
 		"select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
-			"dev": true
+			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
 		},
 		"selfsigned": {
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
 			"integrity": "sha512-vmZenZ+8Al3NLHkWnhBQ0x6BkML1eCP2xEi3JE+f3D9wW9fipD9NNJHYtE9XJM4TsPaHGZJIamrSI6MTg1dU2Q==",
-			"dev": true,
 			"requires": {
 				"node-forge": "0.7.5"
 			}
@@ -10708,14 +9540,12 @@
 		"semver": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-			"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
-			"dev": true
+			"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
 		},
 		"send": {
 			"version": "0.16.2",
 			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
 			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
@@ -10735,14 +9565,12 @@
 		"serialize-javascript": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
-			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
-			"dev": true
+			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
 		},
 		"serve-index": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
 			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
-			"dev": true,
 			"requires": {
 				"accepts": "~1.3.4",
 				"batch": "0.6.1",
@@ -10757,7 +9585,6 @@
 			"version": "1.13.2",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
 			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-			"dev": true,
 			"requires": {
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
@@ -10768,20 +9595,17 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-			"dev": true
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -10793,7 +9617,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -10803,20 +9626,17 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"setprototypeof": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-			"dev": true
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
 		},
 		"sha.js": {
 			"version": "2.4.11",
 			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -10826,7 +9646,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -10834,14 +9653,12 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
 		"shelljs": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
 			"integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
@@ -10851,14 +9668,12 @@
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-			"dev": true
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"sinon": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.1.1.tgz",
 			"integrity": "sha512-iYagtjLVt1vN3zZY7D8oH7dkjNJEjLjyuzy8daX5+3bbQl8gaohrheB9VfH1O3L6LKuue5WTJvFluHiuZ9y3nQ==",
-			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.2.0",
 				"@sinonjs/formatio": "^3.0.0",
@@ -10874,14 +9689,12 @@
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-			"dev": true
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
 		"slice-ansi": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0"
 			}
@@ -10889,14 +9702,12 @@
 		"slide": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-			"dev": true
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
 		},
 		"snapdragon": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-			"dev": true,
 			"requires": {
 				"base": "^0.11.1",
 				"debug": "^2.2.0",
@@ -10912,7 +9723,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -10921,7 +9731,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -10932,7 +9741,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-			"dev": true,
 			"requires": {
 				"define-property": "^1.0.0",
 				"isobject": "^3.0.0",
@@ -10943,7 +9751,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -10952,7 +9759,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -10961,7 +9767,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -10970,7 +9775,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -10983,7 +9787,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
 			},
@@ -10992,7 +9795,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -11003,7 +9805,6 @@
 			"version": "7.1.1",
 			"resolved": "http://registry.npmjs.org/snazzy/-/snazzy-7.1.1.tgz",
 			"integrity": "sha512-gJ46s+jcwOeRhO9uEkTyzcREFZ0c5LZOgcVakLxTPIvhRIywKvbvArvMg5e8bBbpWe4InC/8eyEQOGXgJVNOfw==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.3.0",
 				"inherits": "^2.0.1",
@@ -11017,14 +9818,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -11033,7 +9832,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -11043,20 +9841,17 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -11065,7 +9860,6 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -11076,7 +9870,6 @@
 			"version": "0.3.19",
 			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
 			"integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
-			"dev": true,
 			"requires": {
 				"faye-websocket": "^0.10.0",
 				"uuid": "^3.0.1"
@@ -11086,7 +9879,6 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
 			"integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
-			"dev": true,
 			"requires": {
 				"debug": "^2.6.6",
 				"eventsource": "0.1.6",
@@ -11100,7 +9892,6 @@
 					"version": "0.11.1",
 					"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
 					"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-					"dev": true,
 					"requires": {
 						"websocket-driver": ">=0.5.1"
 					}
@@ -11111,7 +9902,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-			"dev": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
 			}
@@ -11119,20 +9909,17 @@
 		"source-list-map": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-			"dev": true
+			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
 		},
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"source-map-resolve": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-			"dev": true,
 			"requires": {
 				"atob": "^2.1.1",
 				"decode-uri-component": "^0.2.0",
@@ -11145,7 +9932,6 @@
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-			"dev": true,
 			"requires": {
 				"source-map": "^0.5.6"
 			}
@@ -11153,14 +9939,12 @@
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-			"dev": true
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"spdx-correct": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
-			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -11169,14 +9953,12 @@
 		"spdx-exceptions": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
-			"dev": true
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
@@ -11185,14 +9967,12 @@
 		"spdx-license-ids": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
-			"dev": true
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
 		},
 		"spdy": {
 			"version": "3.4.7",
 			"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
 			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
-			"dev": true,
 			"requires": {
 				"debug": "^2.6.8",
 				"handle-thing": "^1.2.5",
@@ -11206,7 +9986,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
 			"integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
-			"dev": true,
 			"requires": {
 				"debug": "^2.6.8",
 				"detect-node": "^2.0.3",
@@ -11221,7 +10000,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
 			}
@@ -11235,7 +10013,6 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
 			"integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
-			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -11252,7 +10029,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
 			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.1"
 			}
@@ -11261,7 +10037,6 @@
 			"version": "11.0.1",
 			"resolved": "http://registry.npmjs.org/standard/-/standard-11.0.1.tgz",
 			"integrity": "sha512-nu0jAcHiSc8H+gJCXeiziMVZNDYi8MuqrYJKxTgjP4xKXZMKm311boqQIzDrYI/ktosltxt2CbDjYQs9ANC8IA==",
-			"dev": true,
 			"requires": {
 				"eslint": "~4.18.0",
 				"eslint-config-standard": "11.0.0",
@@ -11278,7 +10053,6 @@
 			"version": "8.0.1",
 			"resolved": "http://registry.npmjs.org/standard-engine/-/standard-engine-8.0.1.tgz",
 			"integrity": "sha512-LA531C3+nljom/XRvdW/hGPXwmilRkaRkENhO3FAGF1Vtq/WtCXzgmnc5S6vUHHsgv534MRy02C1ikMwZXC+tw==",
-			"dev": true,
 			"requires": {
 				"deglob": "^2.1.0",
 				"get-stdin": "^6.0.0",
@@ -11289,8 +10063,7 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
 		},
@@ -11298,7 +10071,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/standard-json/-/standard-json-1.0.3.tgz",
 			"integrity": "sha512-lhMP+KREBcfyyMe2ObJlEjJ0lc0ItA9uny83d9ZL6ggYtB79DuaAKCxJVoiflg5EV3D2rpuWn+n4+zXjWXk0sQ==",
-			"dev": true,
 			"requires": {
 				"concat-stream": "^1.5.0"
 			}
@@ -11307,7 +10079,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-			"dev": true,
 			"requires": {
 				"define-property": "^0.2.5",
 				"object-copy": "^0.1.0"
@@ -11317,7 +10088,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -11327,20 +10097,17 @@
 		"statuses": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-			"dev": true
+			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-			"dev": true
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
 		},
 		"stream-browserify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-			"dev": true,
 			"requires": {
 				"inherits": "~2.0.1",
 				"readable-stream": "^2.0.2"
@@ -11350,7 +10117,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
 			"integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"stream-shift": "^1.0.0"
@@ -11360,7 +10126,6 @@
 			"version": "2.8.3",
 			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
 			"integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
-			"dev": true,
 			"requires": {
 				"builtin-status-codes": "^3.0.0",
 				"inherits": "^2.0.1",
@@ -11372,8 +10137,7 @@
 		"stream-shift": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-			"dev": true
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
 		},
 		"strict-uri-encode": {
 			"version": "2.0.0",
@@ -11383,14 +10147,12 @@
 		"string-template": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
-			"dev": true
+			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
 		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
@@ -11399,14 +10161,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -11417,7 +10177,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
 			"integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.5.0",
@@ -11436,7 +10195,6 @@
 			"version": "3.0.1",
 			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -11444,14 +10202,12 @@
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-			"dev": true
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 		},
 		"strip-bom-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
 			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
-			"dev": true,
 			"requires": {
 				"first-chunk-stream": "^2.0.0",
 				"strip-bom": "^2.0.0"
@@ -11461,7 +10217,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -11471,20 +10226,17 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"styled-components": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.0.3.tgz",
 			"integrity": "sha512-oEZovK4xMGAMhOA9h74dCYJsp3IwUFhEvtYe4gwTy0cBZ3a17YMxBfM2oXsEoED9f+HCM5UQZW2h297n4u8hUw==",
-			"dev": true,
 			"requires": {
 				"@emotion/is-prop-valid": "^0.6.8",
 				"babel-plugin-styled-components": ">= 1",
@@ -11500,20 +10252,17 @@
 		"stylis": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.3.tgz",
-			"integrity": "sha512-TxU0aAscJghF9I3V9q601xcK3Uw1JbXvpsBGj/HULqexKOKlOEzzlIpLFRbKkCK990ccuxfXUqmPbIIo7Fq/cQ==",
-			"dev": true
+			"integrity": "sha512-TxU0aAscJghF9I3V9q601xcK3Uw1JbXvpsBGj/HULqexKOKlOEzzlIpLFRbKkCK990ccuxfXUqmPbIIo7Fq/cQ=="
 		},
 		"stylis-rule-sheet": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-			"integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
-			"dev": true
+			"integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
 		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -11521,20 +10270,17 @@
 		"symbol-observable": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-			"dev": true
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
-			"dev": true
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
 		},
 		"table": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-			"dev": true,
 			"requires": {
 				"ajv": "^5.2.3",
 				"ajv-keywords": "^2.1.0",
@@ -11548,7 +10294,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -11557,7 +10302,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -11567,14 +10311,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -11584,14 +10326,12 @@
 		"tapable": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",
-			"integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg==",
-			"dev": true
+			"integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg=="
 		},
 		"temp": {
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
 			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "^1.0.0",
 				"rimraf": "~2.2.6"
@@ -11600,40 +10340,34 @@
 				"rimraf": {
 					"version": "2.2.8",
 					"resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-					"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-					"dev": true
+					"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
 				}
 			}
 		},
 		"text-encoding": {
 			"version": "0.6.4",
 			"resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-			"dev": true
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
 		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-			"dev": true
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
 		},
 		"textextensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
-			"integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA==",
-			"dev": true
+			"integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA=="
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.1.5",
 				"xtend": "~4.0.1"
@@ -11642,20 +10376,17 @@
 		"thunky": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
-			"integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E=",
-			"dev": true
+			"integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E="
 		},
 		"timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-			"dev": true
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"timers-browserify": {
 			"version": "2.0.10",
 			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
 			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
-			"dev": true,
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
@@ -11664,7 +10395,6 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
@@ -11672,20 +10402,17 @@
 		"to-arraybuffer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
-			"dev": true
+			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-			"dev": true
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -11694,7 +10421,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -11705,7 +10431,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-			"dev": true,
 			"requires": {
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
@@ -11717,7 +10442,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
@@ -11726,8 +10450,7 @@
 		"toposort": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
-			"integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
-			"dev": true
+			"integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk="
 		},
 		"tough-cookie": {
 			"version": "2.4.3",
@@ -11742,7 +10465,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			},
@@ -11750,34 +10472,29 @@
 				"punycode": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-					"dev": true
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 				}
 			}
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-			"dev": true
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
 		"tslib": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-			"dev": true
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
-			"dev": true
+			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -11785,14 +10502,12 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
@@ -11800,14 +10515,12 @@
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
 		},
 		"type-is": {
 			"version": "1.6.16",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
 			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-			"dev": true,
 			"requires": {
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.18"
@@ -11821,14 +10534,12 @@
 		"ua-parser-js": {
 			"version": "0.7.19",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==",
-			"dev": true
+			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
 		},
 		"uglify-es": {
 			"version": "3.3.9",
 			"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
 			"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-			"dev": true,
 			"requires": {
 				"commander": "~2.13.0",
 				"source-map": "~0.6.1"
@@ -11837,14 +10548,12 @@
 				"commander": {
 					"version": "2.13.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-					"dev": true
+					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -11852,7 +10561,6 @@
 			"version": "3.4.8",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.8.tgz",
 			"integrity": "sha512-WatYTD84gP/867bELqI2F/2xC9PQBETn/L+7RGq9MQOA/7yFBNvY1UwXqvtILeE6n0ITwBXxp34M0/o70dzj6A==",
-			"dev": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -11861,8 +10569,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -11870,7 +10577,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
 			"integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
-			"dev": true,
 			"requires": {
 				"cacache": "^10.0.4",
 				"find-cache-dir": "^1.0.0",
@@ -11885,28 +10591,24 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"underscore": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
-			"dev": true
+			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-			"dev": true
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
 		},
 		"unicode-match-property-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
 			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-			"dev": true,
 			"requires": {
 				"unicode-canonical-property-names-ecmascript": "^1.0.4",
 				"unicode-property-aliases-ecmascript": "^1.0.4"
@@ -11915,20 +10617,17 @@
 		"unicode-match-property-value-ecmascript": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-			"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
-			"dev": true
+			"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
 		},
 		"unicode-property-aliases-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
-			"dev": true
+			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
 		},
 		"union-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
@@ -11940,7 +10639,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -11949,7 +10647,6 @@
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-extendable": "^0.1.1",
@@ -11962,14 +10659,12 @@
 		"uniq": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-			"dev": true
+			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
 		},
 		"unique-filename": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
 			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-			"dev": true,
 			"requires": {
 				"unique-slug": "^2.0.0"
 			}
@@ -11978,7 +10673,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
 			"integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
-			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
@@ -11986,20 +10680,17 @@
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-			"dev": true
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
 		"unquote": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
-			"dev": true
+			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
 		},
 		"unset-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-			"dev": true,
 			"requires": {
 				"has-value": "^0.3.1",
 				"isobject": "^3.0.0"
@@ -12009,7 +10700,6 @@
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-					"dev": true,
 					"requires": {
 						"get-value": "^2.0.3",
 						"has-values": "^0.1.4",
@@ -12020,7 +10710,6 @@
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-							"dev": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -12030,8 +10719,7 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-					"dev": true
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
 				}
 			}
 		},
@@ -12039,7 +10727,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
 			"integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
-			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0"
 			}
@@ -12047,20 +10734,17 @@
 		"upath": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
-			"dev": true
+			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
 		},
 		"upper-case": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
-			"dev": true
+			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
 		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			},
@@ -12068,22 +10752,19 @@
 				"punycode": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-					"dev": true
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 				}
 			}
 		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-			"dev": true
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
 		"url": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
 			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-			"dev": true,
 			"requires": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
@@ -12092,22 +10773,19 @@
 				"punycode": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-					"dev": true
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
 				}
 			}
 		},
 		"url-join": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
-			"integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=",
-			"dev": true
+			"integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo="
 		},
 		"url-parse": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
 			"integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
-			"dev": true,
 			"requires": {
 				"querystringify": "^2.0.0",
 				"requires-port": "^1.0.0"
@@ -12117,7 +10795,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
 			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-			"dev": true,
 			"requires": {
 				"prepend-http": "^2.0.0"
 			}
@@ -12125,20 +10802,17 @@
 		"url-to-options": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-			"dev": true
+			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
 		},
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-			"dev": true
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
 		"util": {
 			"version": "0.10.4",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
 			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-			"dev": true,
 			"requires": {
 				"inherits": "2.0.3"
 			}
@@ -12152,7 +10826,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"object.getownpropertydescriptors": "^2.0.3"
@@ -12161,32 +10834,27 @@
 		"utila": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
-			"integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
-			"dev": true
+			"integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
 		},
 		"utils-merge": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-			"dev": true
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-			"dev": true
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"v8-compile-cache": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
-			"integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==",
-			"dev": true
+			"integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw=="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-			"dev": true,
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
@@ -12195,14 +10863,12 @@
 		"vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-			"dev": true
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -12213,7 +10879,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-			"dev": true,
 			"requires": {
 				"clone": "^1.0.0",
 				"clone-stats": "^0.0.1",
@@ -12224,7 +10889,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
 			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"pify": "^2.3.0",
@@ -12237,14 +10901,12 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -12255,7 +10917,6 @@
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
 			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-			"dev": true,
 			"requires": {
 				"indexof": "0.0.1"
 			}
@@ -12264,7 +10925,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
-			"dev": true,
 			"requires": {
 				"browser-process-hrtime": "^0.1.2"
 			}
@@ -12273,7 +10933,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.0.0.tgz",
 			"integrity": "sha512-0et1+9uXYiIRAecx1D5Z1nk60+vimniGdIKl4XjeqkWi6acoHNlXMv1VR5jV+jF4ooeO08oWbYxeAJOcon1oMA==",
-			"dev": true,
 			"requires": {
 				"domexception": "^1.0.1",
 				"webidl-conversions": "^4.0.2",
@@ -12284,7 +10943,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
 			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
-			"dev": true,
 			"requires": {
 				"chokidar": "^2.0.2",
 				"graceful-fs": "^4.1.2",
@@ -12295,7 +10953,6 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
 			"integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
-			"dev": true,
 			"requires": {
 				"minimalistic-assert": "^1.0.0"
 			}
@@ -12304,7 +10961,6 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/webassemblyjs/-/webassemblyjs-1.4.3.tgz",
 			"integrity": "sha512-4lOV1Lv6olz0PJkDGQEp82HempAn147e6BXijWDzz9g7/2nSebVP9GVg62Fz5ZAs55mxq13GA0XLyvY8XkyDjg==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/validation": "1.4.3",
@@ -12316,14 +10972,12 @@
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-			"dev": true
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
 			"version": "4.8.3",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.8.3.tgz",
 			"integrity": "sha512-/hfAjBISycdK597lxONjKEFX7dSIU1PsYwC3XlXUXoykWBlv9QV5HnO+ql3HvrrgfBJ7WXdnjO9iGPR2aAc5sw==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/wasm-edit": "1.4.3",
@@ -12353,7 +11007,6 @@
 					"version": "6.5.5",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
 					"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
-					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -12364,20 +11017,17 @@
 				"ajv-keywords": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
-					"dev": true
+					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
 				},
 				"fast-deep-equal": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-					"dev": true
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
 				},
 				"json-schema-traverse": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-					"dev": true
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 				}
 			}
 		},
@@ -12385,7 +11035,6 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/webpack-addons/-/webpack-addons-1.1.5.tgz",
 			"integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
-			"dev": true,
 			"requires": {
 				"jscodeshift": "^0.4.0"
 			},
@@ -12393,14 +11042,12 @@
 				"ansi-styles": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-					"dev": true
+					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.0.1"
 					}
@@ -12408,20 +11055,17 @@
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 				},
 				"ast-types": {
 					"version": "0.10.1",
 					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
-					"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
-					"dev": true
+					"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
 					"requires": {
 						"expand-range": "^1.8.1",
 						"preserve": "^0.2.0",
@@ -12432,7 +11076,6 @@
 					"version": "0.4.0",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "~1.0.0",
 						"has-color": "~0.1.0",
@@ -12442,20 +11085,17 @@
 				"colors": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-					"integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
-					"dev": true
+					"integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
 				},
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-					"dev": true
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 				},
 				"expand-brackets": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
 					"requires": {
 						"is-posix-bracket": "^0.1.0"
 					}
@@ -12464,7 +11104,6 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -12472,14 +11111,12 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -12488,7 +11125,6 @@
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.4.1.tgz",
 					"integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
-					"dev": true,
 					"requires": {
 						"async": "^1.5.0",
 						"babel-plugin-transform-flow-strip-types": "^6.8.0",
@@ -12511,7 +11147,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -12520,7 +11155,6 @@
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
 					"requires": {
 						"arr-diff": "^2.0.0",
 						"array-unique": "^0.2.1",
@@ -12541,7 +11175,6 @@
 					"version": "1.8.1",
 					"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
 					"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-					"dev": true,
 					"requires": {
 						"chalk": "~0.4.0",
 						"underscore": "~1.6.0"
@@ -12551,7 +11184,6 @@
 					"version": "0.12.9",
 					"resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
 					"integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
-					"dev": true,
 					"requires": {
 						"ast-types": "0.10.1",
 						"core-js": "^2.4.1",
@@ -12563,20 +11195,17 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"strip-ansi": {
 					"version": "0.1.1",
 					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-					"dev": true
+					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
 				},
 				"underscore": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-					"dev": true
+					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
 				}
 			}
 		},
@@ -12584,7 +11213,6 @@
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.1.5.tgz",
 			"integrity": "sha512-CiWQR+1JS77rmyiO6y1q8Kt/O+e8nUUC9YfJ25JtSmzDwbqJV7vIsh3+QKRHVTbTCa0DaVh8iY1LBiagUIDB3g==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.4.1",
 				"cross-spawn": "^6.0.5",
@@ -12617,14 +11245,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -12633,7 +11259,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -12644,7 +11269,6 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -12656,14 +11280,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"inquirer": {
 					"version": "5.2.0",
 					"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
 					"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
-					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
 						"chalk": "^2.0.0",
@@ -12684,7 +11306,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -12693,7 +11314,6 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -12704,7 +11324,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.2.0.tgz",
 			"integrity": "sha512-YJLMF/96TpKXaEQwaLEo+Z4NDK8aV133ROF6xp9pe3gQoS7sxfpXh4Rv9eC+8vCvWfmDjRQaMSlRPbO+9G6jgA==",
-			"dev": true,
 			"requires": {
 				"loud-rejection": "^1.6.0",
 				"memory-fs": "~0.4.1",
@@ -12718,8 +11337,7 @@
 				"mime": {
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-					"integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
-					"dev": true
+					"integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
 				}
 			}
 		},
@@ -12727,7 +11345,6 @@
 			"version": "3.1.7",
 			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.7.tgz",
 			"integrity": "sha512-KagFrNHf3QKndS61cXqzkQ4gpdXo0d1LZTTplAJzNK1Ev2ZyJiu+BzerW/2dixYYfpnGzp0AcvCXpmYXIOkFOA==",
-			"dev": true,
 			"requires": {
 				"ansi-html": "0.0.7",
 				"bonjour": "^3.5.0",
@@ -12763,7 +11380,6 @@
 					"version": "6.5.3",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
 					"integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
-					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -12774,14 +11390,12 @@
 				"ajv-keywords": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
-					"dev": true
+					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -12790,7 +11404,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
 					"integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-					"dev": true,
 					"requires": {
 						"xregexp": "4.0.0"
 					}
@@ -12799,7 +11412,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
 					"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-					"dev": true,
 					"requires": {
 						"globby": "^6.1.0",
 						"is-path-cwd": "^1.0.0",
@@ -12812,14 +11424,12 @@
 				"fast-deep-equal": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-					"dev": true
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
 				},
 				"find-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
 					}
@@ -12828,7 +11438,6 @@
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
 						"glob": "^7.0.3",
@@ -12840,28 +11449,24 @@
 						"pify": {
 							"version": "2.3.0",
 							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-							"dev": true
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 						}
 					}
 				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"json-schema-traverse": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-					"dev": true
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 				},
 				"locate-path": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
@@ -12871,7 +11476,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
 					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
-					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
@@ -12880,7 +11484,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
 					"requires": {
 						"p-limit": "^2.0.0"
 					}
@@ -12888,14 +11491,12 @@
 				"p-try": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
-					"dev": true
+					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
 				},
 				"schema-utils": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
 					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-					"dev": true,
 					"requires": {
 						"ajv": "^6.1.0",
 						"ajv-errors": "^1.0.0",
@@ -12906,7 +11507,6 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -12915,7 +11515,6 @@
 					"version": "12.0.1",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
 					"integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
-					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^2.0.0",
@@ -12935,7 +11534,6 @@
 					"version": "10.1.0",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
 					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					}
@@ -12946,7 +11544,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
 			"integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
-			"dev": true,
 			"requires": {
 				"ansi-colors": "^3.0.0",
 				"uuid": "^3.3.2"
@@ -12956,7 +11553,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
 			"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
-			"dev": true,
 			"requires": {
 				"source-list-map": "^2.0.0",
 				"source-map": "~0.6.1"
@@ -12965,8 +11561,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -12974,7 +11569,6 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
 			"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
-			"dev": true,
 			"requires": {
 				"http-parser-js": ">=0.4.0",
 				"websocket-extensions": ">=0.1.1"
@@ -12983,14 +11577,12 @@
 		"websocket-extensions": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
-			"dev": true
+			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
 		},
 		"whatwg-encoding": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
 			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
-			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
@@ -12998,20 +11590,17 @@
 		"whatwg-fetch": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
-			"dev": true
+			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
 		},
 		"whatwg-mimetype": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz",
-			"integrity": "sha512-5YSO1nMd5D1hY3WzAQV3PzZL83W3YeyR1yW9PcH26Weh1t+Vzh9B6XkDh7aXm83HBZ4nSMvkjvN2H2ySWIvBgw==",
-			"dev": true
+			"integrity": "sha512-5YSO1nMd5D1hY3WzAQV3PzZL83W3YeyR1yW9PcH26Weh1t+Vzh9B6XkDh7aXm83HBZ4nSMvkjvN2H2ySWIvBgw=="
 		},
 		"whatwg-url": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
 			"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
-			"dev": true,
 			"requires": {
 				"lodash.sortby": "^4.7.0",
 				"tr46": "^1.0.1",
@@ -13022,7 +11611,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -13030,20 +11618,17 @@
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"wordwrap": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-			"dev": true
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 		},
 		"worker-farm": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
 			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
-			"dev": true,
 			"requires": {
 				"errno": "~0.1.7"
 			}
@@ -13052,7 +11637,6 @@
 			"version": "2.1.0",
 			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"dev": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
@@ -13062,7 +11646,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -13071,7 +11654,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -13083,14 +11665,12 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-			"dev": true,
 			"requires": {
 				"mkdirp": "^0.5.1"
 			}
@@ -13099,7 +11679,6 @@
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
 			"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
@@ -13110,7 +11689,6 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.0.tgz",
 			"integrity": "sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==",
-			"dev": true,
 			"requires": {
 				"async-limiter": "~1.0.0"
 			}
@@ -13118,44 +11696,37 @@
 		"xml-name-validator": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
-			"dev": true
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
 		},
 		"xmlchars": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-1.3.1.tgz",
-			"integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw==",
-			"dev": true
+			"integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw=="
 		},
 		"xregexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
-			"dev": true
+			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
 		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-			"dev": true
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-			"dev": true
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
 			"version": "11.1.0",
 			"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 			"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
-			"dev": true,
 			"requires": {
 				"cliui": "^4.0.0",
 				"decamelize": "^1.1.1",
@@ -13174,8 +11745,7 @@
 				"y18n": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-					"dev": true
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 				}
 			}
 		},
@@ -13183,7 +11753,6 @@
 			"version": "9.0.2",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
 			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0"
 			}
@@ -13192,7 +11761,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.3.3.tgz",
 			"integrity": "sha512-HBpXdNw8V66EwqIFt01rNhSgX33BOzgVb9CxpIvESvCI4ELeOSniB6gV6RXwrBur8kmHZCIAkYQYpib7Qxx8FQ==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.4.1",
 				"cross-spawn": "^6.0.5",
@@ -13214,14 +11782,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -13230,7 +11796,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -13240,14 +11805,12 @@
 				"chardet": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.5.0.tgz",
-					"integrity": "sha512-9ZTaoBaePSCFvNlNGrsyI8ZVACP2svUtq0DkM7t4K2ClAa96sqOIRjAzDTc8zXzFt1cZR46rRzLTiHFSJ+Qw0g==",
-					"dev": true
+					"integrity": "sha512-9ZTaoBaePSCFvNlNGrsyI8ZVACP2svUtq0DkM7t4K2ClAa96sqOIRjAzDTc8zXzFt1cZR46rRzLTiHFSJ+Qw0g=="
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -13260,7 +11823,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -13269,7 +11831,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.1.tgz",
 					"integrity": "sha512-e1neqvSt5pSwQcFnYc6yfGuJD2Q4336cdbHs5VeUO0zTkqPbrHMyw2q1r47fpfLWbvIG8H8A6YO3sck7upTV6Q==",
-					"dev": true,
 					"requires": {
 						"chardet": "^0.5.0",
 						"iconv-lite": "^0.4.22",
@@ -13280,7 +11841,6 @@
 					"version": "8.0.1",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
 					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
-					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
 						"dir-glob": "^2.0.0",
@@ -13294,14 +11854,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"inquirer": {
 					"version": "6.2.0",
 					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
 					"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
-					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
 						"chalk": "^2.0.0",
@@ -13322,7 +11880,6 @@
 					"version": "6.2.2",
 					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
 					"integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
-					"dev": true,
 					"requires": {
 						"tslib": "^1.9.0"
 					}
@@ -13331,7 +11888,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -13340,7 +11896,6 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -13348,8 +11903,7 @@
 				"untildify": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-					"integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
-					"dev": true
+					"integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
 				}
 			}
 		},
@@ -13357,7 +11911,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
 			"integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
-			"dev": true,
 			"requires": {
 				"async": "^2.6.0",
 				"chalk": "^2.3.0",
@@ -13390,7 +11943,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -13399,7 +11951,6 @@
 					"version": "2.6.1",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
 					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-					"dev": true,
 					"requires": {
 						"lodash": "^4.17.10"
 					}
@@ -13408,7 +11959,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -13419,7 +11969,6 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -13432,7 +11981,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -13440,14 +11988,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"load-json-file": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -13458,14 +12004,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -13475,7 +12019,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -13484,7 +12027,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -13495,7 +12037,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -13505,7 +12046,6 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}

--- a/packages/lib-auth/package-lock.json
+++ b/packages/lib-auth/package-lock.json
@@ -1,11 +1,14 @@
 {
-	"requires": true,
+	"name": "@zooniverse/auth",
+	"version": "0.0.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
 			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.0.0"
 			}
@@ -14,6 +17,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.2.tgz",
 			"integrity": "sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/generator": "^7.1.2",
@@ -35,6 +39,7 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -42,7 +47,8 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
 				}
 			}
 		},
@@ -50,6 +56,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
 			"integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.1.3",
 				"jsesc": "^2.5.1",
@@ -61,7 +68,8 @@
 				"jsesc": {
 					"version": "2.5.1",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+					"dev": true
 				}
 			}
 		},
@@ -69,6 +77,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
 			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			},
@@ -77,6 +86,7 @@
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
 					"integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
+					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.10",
@@ -86,7 +96,8 @@
 				"to-fast-properties": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
 				}
 			}
 		},
@@ -94,6 +105,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
 			"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-explode-assignable-expression": "^7.1.0",
 				"@babel/types": "^7.0.0"
@@ -103,6 +115,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz",
 			"integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0",
 				"esutils": "^2.0.0"
@@ -112,6 +125,7 @@
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
 					"integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
+					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.10",
@@ -121,7 +135,8 @@
 				"to-fast-properties": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
 				}
 			}
 		},
@@ -129,6 +144,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
 			"integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.0.0",
 				"@babel/traverse": "^7.1.0",
@@ -139,6 +155,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
 			"integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/types": "^7.0.0",
@@ -149,6 +166,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
 			"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.1.0",
 				"@babel/types": "^7.0.0"
@@ -158,6 +176,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
 			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "^7.0.0",
 				"@babel/template": "^7.1.0",
@@ -168,6 +187,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
 			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -176,6 +196,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
 			"integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -184,6 +205,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
 			"integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -192,6 +214,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
 			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -200,6 +223,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz",
 			"integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-simple-access": "^7.1.0",
@@ -213,6 +237,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
 			"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -220,12 +245,14 @@
 		"@babel/helper-plugin-utils": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+			"dev": true
 		},
 		"@babel/helper-regex": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
 			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+			"dev": true,
 			"requires": {
 				"lodash": "^4.17.10"
 			}
@@ -234,6 +261,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
 			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"@babel/helper-wrap-function": "^7.1.0",
@@ -246,6 +274,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz",
 			"integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.0.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
@@ -257,6 +286,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
 			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.1.0",
 				"@babel/types": "^7.0.0"
@@ -266,6 +296,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
 			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -274,6 +305,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.1.0.tgz",
 			"integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/template": "^7.1.0",
@@ -285,6 +317,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.2.tgz",
 			"integrity": "sha512-Myc3pUE8eswD73aWcartxB16K6CGmHDv9KxOmD2CeOs/FaEAQodr3VYGmlvOmog60vNQ2w8QbatuahepZwrHiA==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.1.2",
 				"@babel/traverse": "^7.1.0",
@@ -295,6 +328,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
 			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
@@ -305,6 +339,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -313,6 +348,7 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -324,12 +360,14 @@
 		"@babel/parser": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
-			"integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w=="
+			"integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==",
+			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.1.0.tgz",
 			"integrity": "sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-remap-async-to-generator": "^7.1.0",
@@ -340,6 +378,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
 			"integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-member-expression-to-functions": "^7.0.0",
@@ -353,6 +392,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.1.2.tgz",
 			"integrity": "sha512-YooynBO6PmBgHvAd0fl5e5Tq/a0pEC6RqF62ouafme8FzdIVH41Mz/u1dn8fFVm4jzEJ+g/MsOxouwybJPuP8Q==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-replace-supers": "^7.1.0",
@@ -364,6 +404,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz",
 			"integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-json-strings": "^7.0.0"
@@ -373,6 +414,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
 			"integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-object-rest-spread": "^7.0.0"
@@ -382,6 +424,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0.tgz",
 			"integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
@@ -391,6 +434,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0.tgz",
 			"integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0",
@@ -400,12 +444,14 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				},
 				"regexpu-core": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
 					"integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+					"dev": true,
 					"requires": {
 						"regenerate": "^1.4.0",
 						"regenerate-unicode-properties": "^7.0.0",
@@ -418,12 +464,14 @@
 				"regjsgen": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
-					"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
+					"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+					"dev": true
 				},
 				"regjsparser": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
 					"integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+					"dev": true,
 					"requires": {
 						"jsesc": "~0.5.0"
 					}
@@ -434,6 +482,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz",
 			"integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -442,6 +491,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz",
 			"integrity": "sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -450,6 +500,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.1.0.tgz",
 			"integrity": "sha512-uQvRSbgQ0nQg3jsmIixXXDCgSpkBolJ9X7NYThMKCcjvE8dN2uWJUzTUNNAeuKOjARTd+wUQV0ztXpgunZYKzQ==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -458,6 +509,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz",
 			"integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -466,6 +518,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0.tgz",
 			"integrity": "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -474,6 +527,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
 			"integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -482,6 +536,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
 			"integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -490,6 +545,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
 			"integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -498,6 +554,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.1.0.tgz",
 			"integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -508,6 +565,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0.tgz",
 			"integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -516,6 +574,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
 			"integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"lodash": "^4.17.10"
@@ -525,6 +584,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
 			"integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"@babel/helper-define-map": "^7.1.0",
@@ -539,7 +599,8 @@
 				"globals": {
 					"version": "11.8.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA=="
+					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+					"dev": true
 				}
 			}
 		},
@@ -547,6 +608,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
 			"integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -555,6 +617,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.1.3.tgz",
 			"integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -563,6 +626,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0.tgz",
 			"integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0",
@@ -572,12 +636,14 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				},
 				"regexpu-core": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
 					"integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+					"dev": true,
 					"requires": {
 						"regenerate": "^1.4.0",
 						"regenerate-unicode-properties": "^7.0.0",
@@ -590,12 +656,14 @@
 				"regjsgen": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
-					"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
+					"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+					"dev": true
 				},
 				"regjsparser": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
 					"integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+					"dev": true,
 					"requires": {
 						"jsesc": "~0.5.0"
 					}
@@ -606,6 +674,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0.tgz",
 			"integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -614,6 +683,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.1.0.tgz",
 			"integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -623,6 +693,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz",
 			"integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -631,6 +702,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.1.0.tgz",
 			"integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -640,6 +712,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
 			"integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -648,6 +721,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.1.0.tgz",
 			"integrity": "sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -657,6 +731,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
 			"integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -667,6 +742,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.1.3.tgz",
 			"integrity": "sha512-PvTxgjxQAq4pvVUZF3mD5gEtVDuId8NtWkJsZLEJZMZAW3TvgQl1pmydLLN1bM8huHFVVU43lf0uvjQj9FRkKw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -676,6 +752,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.1.0.tgz",
 			"integrity": "sha512-enrRtn5TfRhMmbRwm7F8qOj0qEYByqUvTttPEGimcBH4CJHphjyK1Vg7sdU7JjeEmgSpM890IT/efS2nMHwYig==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -685,6 +762,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
 			"integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -693,6 +771,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.1.0.tgz",
 			"integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-replace-supers": "^7.1.0"
@@ -702,6 +781,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz",
 			"integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-call-delegate": "^7.1.0",
 				"@babel/helper-get-function-arity": "^7.0.0",
@@ -712,6 +792,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0.tgz",
 			"integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -720,6 +801,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0.tgz",
 			"integrity": "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-builder-react-jsx": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -730,6 +812,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.0.0.tgz",
 			"integrity": "sha512-pymy+AK12WO4safW1HmBpwagUQRl9cevNX+82AIAtU1pIdugqcH+nuYP03Ja6B+N4gliAaKWAegIBL/ymALPHA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-jsx": "^7.0.0"
@@ -739,6 +822,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.0.0.tgz",
 			"integrity": "sha512-OSeEpFJEH5dw/TtxTg4nijl4nHBbhqbKL94Xo/Y17WKIf2qJWeIk/QeXACF19lG1vMezkxqruwnTjVizaW7u7w==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-jsx": "^7.0.0"
@@ -748,6 +832,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
 			"integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.13.3"
 			},
@@ -756,6 +841,7 @@
 					"version": "0.13.3",
 					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
 					"integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+					"dev": true,
 					"requires": {
 						"private": "^0.1.6"
 					}
@@ -766,6 +852,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
 			"integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -774,6 +861,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz",
 			"integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -782,6 +870,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz",
 			"integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0"
@@ -791,6 +880,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
 			"integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -800,6 +890,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0.tgz",
 			"integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -808,6 +899,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
 			"integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0",
@@ -817,12 +909,14 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				},
 				"regexpu-core": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
 					"integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+					"dev": true,
 					"requires": {
 						"regenerate": "^1.4.0",
 						"regenerate-unicode-properties": "^7.0.0",
@@ -835,12 +929,14 @@
 				"regjsgen": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
-					"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
+					"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+					"dev": true
 				},
 				"regjsparser": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
 					"integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+					"dev": true,
 					"requires": {
 						"jsesc": "~0.5.0"
 					}
@@ -851,6 +947,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0.tgz",
 			"integrity": "sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==",
+			"dev": true,
 			"requires": {
 				"core-js": "^2.5.7",
 				"regenerator-runtime": "^0.11.1"
@@ -860,6 +957,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.0.tgz",
 			"integrity": "sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -908,6 +1006,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
 			"integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-transform-react-display-name": "^7.0.0",
@@ -920,6 +1019,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0.tgz",
 			"integrity": "sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==",
+			"dev": true,
 			"requires": {
 				"core-js": "^2.5.7",
 				"find-cache-dir": "^1.0.0",
@@ -933,17 +1033,20 @@
 				"home-or-tmp": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
-					"integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs="
+					"integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				},
 				"source-map-support": {
 					"version": "0.5.9",
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
 					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
 						"source-map": "^0.6.0"
@@ -955,6 +1058,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
 			"integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
+			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.12.0"
 			},
@@ -962,7 +1066,8 @@
 				"regenerator-runtime": {
 					"version": "0.12.1",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+					"dev": true
 				}
 			}
 		},
@@ -970,6 +1075,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
 			"integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/parser": "^7.1.2",
@@ -980,6 +1086,7 @@
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
 			"integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/generator": "^7.1.3",
@@ -996,6 +1103,7 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1003,12 +1111,14 @@
 				"globals": {
 					"version": "11.8.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA=="
+					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+					"dev": true
 				},
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
 				}
 			}
 		},
@@ -1016,6 +1126,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
 			"integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.10",
@@ -1025,7 +1136,8 @@
 				"to-fast-properties": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
 				}
 			}
 		},
@@ -1033,6 +1145,7 @@
 			"version": "0.6.8",
 			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz",
 			"integrity": "sha512-IMSL7ekYhmFlILXcouA6ket3vV7u9BqStlXzbKOF9HBtpUPMMlHU+bBxrLOa2NvleVwNIxeq/zL8LafLbeUXcA==",
+			"dev": true,
 			"requires": {
 				"@emotion/memoize": "^0.6.6"
 			}
@@ -1040,12 +1153,14 @@
 		"@emotion/memoize": {
 			"version": "0.6.6",
 			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
-			"integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
+			"integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==",
+			"dev": true
 		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
 			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+			"dev": true,
 			"requires": {
 				"call-me-maybe": "^1.0.1",
 				"glob-to-regexp": "^0.3.0"
@@ -1054,12 +1169,14 @@
 		"@nodelib/fs.stat": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.1.tgz",
-			"integrity": "sha512-KU/VDjC5RwtDUZiz3d+DHXJF2lp5hB9dn552TXIyptj8SH1vXmR40mG0JgGq03IlYsOgGfcv8xrLpSQ0YUMQdA=="
+			"integrity": "sha512-KU/VDjC5RwtDUZiz3d+DHXJF2lp5hB9dn552TXIyptj8SH1vXmR40mG0JgGq03IlYsOgGfcv8xrLpSQ0YUMQdA==",
+			"dev": true
 		},
 		"@samverschueren/stream-to-observable": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
 			"integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+			"dev": true,
 			"requires": {
 				"any-observable": "^0.3.0"
 			}
@@ -1067,12 +1184,14 @@
 		"@sindresorhus/is": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+			"dev": true
 		},
 		"@sinonjs/commons": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
 			"integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
 			}
@@ -1081,6 +1200,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
 			"integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/samsam": "2.1.0"
 			},
@@ -1089,6 +1209,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
 					"integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+					"dev": true,
 					"requires": {
 						"array-from": "^2.1.1"
 					}
@@ -1098,17 +1219,20 @@
 		"@sinonjs/samsam": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.2.tgz",
-			"integrity": "sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw=="
+			"integrity": "sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw==",
+			"dev": true
 		},
 		"@types/node": {
 			"version": "10.12.2",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",
-			"integrity": "sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ=="
+			"integrity": "sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ==",
+			"dev": true
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.4.3.tgz",
 			"integrity": "sha512-S6npYhPcTHDYe9nlsKa9CyWByFi8Vj8HovcAgtmMAQZUOczOZbQ8CnwMYKYC5HEZzxEE+oY0jfQk4cVlI3J59Q==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
 				"@webassemblyjs/wast-parser": "1.4.3",
@@ -1120,6 +1244,7 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1127,19 +1252,22 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
 				}
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.4.3.tgz",
-			"integrity": "sha512-3zTkSFswwZOPNHnzkP9ONq4bjJSeKVMcuahGXubrlLmZP8fmTIJ58dW7h/zOVWiFSuG2em3/HH3BlCN7wyu9Rw=="
+			"integrity": "sha512-3zTkSFswwZOPNHnzkP9ONq4bjJSeKVMcuahGXubrlLmZP8fmTIJ58dW7h/zOVWiFSuG2em3/HH3BlCN7wyu9Rw==",
+			"dev": true
 		},
 		"@webassemblyjs/helper-buffer": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.4.3.tgz",
 			"integrity": "sha512-e8+KZHh+RV8MUvoSRtuT1sFXskFnWG9vbDy47Oa166xX+l0dD5sERJ21g5/tcH8Yo95e9IN3u7Jc3NbhnUcSkw==",
+			"dev": true,
 			"requires": {
 				"debug": "^3.1.0"
 			},
@@ -1148,6 +1276,7 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1155,7 +1284,8 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
 				}
 			}
 		},
@@ -1163,6 +1293,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.4.3.tgz",
 			"integrity": "sha512-9FgHEtNsZQYaKrGCtsjswBil48Qp1agrzRcPzCbQloCoaTbOXLJ9IRmqT+uEZbenpULLRNFugz3I4uw18hJM8w==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/wast-printer": "1.4.3"
 			}
@@ -1170,17 +1301,20 @@
 		"@webassemblyjs/helper-fsm": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.4.3.tgz",
-			"integrity": "sha512-JINY76U+702IRf7ePukOt037RwmtH59JHvcdWbTTyHi18ixmQ+uOuNhcdCcQHTquDAH35/QgFlp3Y9KqtyJsCQ=="
+			"integrity": "sha512-JINY76U+702IRf7ePukOt037RwmtH59JHvcdWbTTyHi18ixmQ+uOuNhcdCcQHTquDAH35/QgFlp3Y9KqtyJsCQ==",
+			"dev": true
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.4.3.tgz",
-			"integrity": "sha512-I7bS+HaO0K07Io89qhJv+z1QipTpuramGwUSDkwEaficbSvCcL92CUZEtgykfNtk5wb0CoLQwWlmXTwGbNZUeQ=="
+			"integrity": "sha512-I7bS+HaO0K07Io89qhJv+z1QipTpuramGwUSDkwEaficbSvCcL92CUZEtgykfNtk5wb0CoLQwWlmXTwGbNZUeQ==",
+			"dev": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.4.3.tgz",
 			"integrity": "sha512-p0yeeO/h2r30PyjnJX9xXSR6EDcvJd/jC6xa/Pxg4lpfcNi7JUswOpqDToZQ55HMMVhXDih/yqkaywHWGLxqyQ==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/helper-buffer": "1.4.3",
@@ -1193,6 +1327,7 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1200,7 +1335,8 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
 				}
 			}
 		},
@@ -1208,6 +1344,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.4.3.tgz",
 			"integrity": "sha512-4u0LJLSPzuRDWHwdqsrThYn+WqMFVqbI2ltNrHvZZkzFPO8XOZ0HFQ5eVc4jY/TNHgXcnwrHjONhPGYuuf//KQ==",
+			"dev": true,
 			"requires": {
 				"leb": "^0.3.0"
 			}
@@ -1216,6 +1353,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/validation/-/validation-1.4.3.tgz",
 			"integrity": "sha512-R+rRMKfhd9mq0rj2mhU9A9NKI2l/Rw65vIYzz4lui7eTKPcCu1l7iZNi4b9Gen8D42Sqh/KGiaQNk/x5Tn/iBQ==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3"
 			}
@@ -1224,6 +1362,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.4.3.tgz",
 			"integrity": "sha512-qzuwUn771PV6/LilqkXcS0ozJYAeY/OKbXIWU3a8gexuqb6De2p4ya/baBeH5JQ2WJdfhWhSvSbu86Vienttpw==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/helper-buffer": "1.4.3",
@@ -1240,6 +1379,7 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1247,7 +1387,8 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
 				}
 			}
 		},
@@ -1255,6 +1396,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.4.3.tgz",
 			"integrity": "sha512-eR394T8dHZfpLJ7U/Z5pFSvxl1L63JdREebpv9gYc55zLhzzdJPAuxjBYT4XqevUdW67qU2s0nNA3kBuNJHbaQ==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
@@ -1265,6 +1407,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.4.3.tgz",
 			"integrity": "sha512-7Gp+nschuKiDuAL1xmp4Xz0rgEbxioFXw4nCFYEmy+ytynhBnTeGc9W9cB1XRu1w8pqRU2lbj2VBBA4cL5Z2Kw==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/helper-buffer": "1.4.3",
@@ -1277,6 +1420,7 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1284,7 +1428,8 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
 				}
 			}
 		},
@@ -1292,6 +1437,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.4.3.tgz",
 			"integrity": "sha512-KXBjtlwA3BVukR/yWHC9GF+SCzBcgj0a7lm92kTOaa4cbjaTaa47bCjXw6cX4SGQpkncB9PU2hHGYVyyI7wFRg==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
@@ -1304,6 +1450,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.4.3.tgz",
 			"integrity": "sha512-QhCsQzqV0CpsEkRYyTzQDilCNUZ+5j92f+g35bHHNqS22FppNTywNFfHPq8ZWZfYCgbectc+PoghD+xfzVFh1Q==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/floating-point-hex-parser": "1.4.3",
@@ -1317,6 +1464,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.4.3.tgz",
 			"integrity": "sha512-EgXk4anf8jKmuZJsqD8qy5bz2frEQhBvZruv+bqwNoLWUItjNSFygk8ywL3JTEz9KtxTlAmqTXNrdD1d9gNDtg==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/wast-parser": "1.4.3",
@@ -1326,12 +1474,14 @@
 		"abab": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
-			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
+			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+			"dev": true
 		},
 		"accepts": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
 			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+			"dev": true,
 			"requires": {
 				"mime-types": "~2.1.18",
 				"negotiator": "0.6.1"
@@ -1340,12 +1490,14 @@
 		"acorn": {
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
-			"integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw=="
+			"integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw==",
+			"dev": true
 		},
 		"acorn-dynamic-import": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
 			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+			"dev": true,
 			"requires": {
 				"acorn": "^5.0.0"
 			}
@@ -1354,6 +1506,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
 			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+			"dev": true,
 			"requires": {
 				"acorn": "^6.0.1",
 				"acorn-walk": "^6.0.1"
@@ -1362,7 +1515,8 @@
 				"acorn": {
 					"version": "6.0.4",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-					"integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
+					"integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
+					"dev": true
 				}
 			}
 		},
@@ -1370,6 +1524,7 @@
 			"version": "3.0.1",
 			"resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
 			"requires": {
 				"acorn": "^3.0.4"
 			},
@@ -1377,19 +1532,22 @@
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
 				}
 			}
 		},
 		"acorn-walk": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.0.tgz",
-			"integrity": "sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg=="
+			"integrity": "sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg==",
+			"dev": true
 		},
 		"ajv": {
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
 			"requires": {
 				"co": "^4.6.0",
 				"fast-deep-equal": "^1.0.0",
@@ -1400,47 +1558,56 @@
 		"ajv-errors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.0.tgz",
-			"integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk="
+			"integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk=",
+			"dev": true
 		},
 		"ajv-keywords": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"dev": true
 		},
 		"ansi-colors": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.0.5.tgz",
-			"integrity": "sha512-VVjWpkfaphxUBFarydrQ3n26zX5nIK7hcbT3/ielrvwDDyBBjuh2vuSw1P9zkPq0cfqvdw7lkYHnu+OLSfIBsg=="
+			"integrity": "sha512-VVjWpkfaphxUBFarydrQ3n26zX5nIK7hcbT3/ielrvwDDyBBjuh2vuSw1P9zkPq0cfqvdw7lkYHnu+OLSfIBsg==",
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+			"dev": true
 		},
 		"ansi-html": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"any-observable": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-			"integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog=="
+			"integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+			"dev": true
 		},
 		"anymatch": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"dev": true,
 			"requires": {
 				"micromatch": "^3.1.4",
 				"normalize-path": "^2.1.1"
@@ -1449,12 +1616,14 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
 		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			},
@@ -1462,54 +1631,64 @@
 				"sprintf-js": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+					"dev": true
 				}
 			}
 		},
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"dev": true
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
 		},
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
 		},
 		"array-differ": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+			"dev": true
 		},
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
 		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+			"dev": true
 		},
 		"array-flatten": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
+			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
+			"dev": true
 		},
 		"array-from": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
+			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+			"dev": true
 		},
 		"array-includes": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.7.0"
@@ -1519,6 +1698,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
 			"requires": {
 				"array-uniq": "^1.0.1"
 			}
@@ -1526,17 +1706,20 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"dev": true
 		},
 		"array.prototype.flat": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
 			"integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.10.0",
@@ -1546,17 +1729,20 @@
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+			"dev": true
 		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -1565,6 +1751,7 @@
 			"version": "4.10.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
 			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+			"dev": true,
 			"requires": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
@@ -1575,6 +1762,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
 			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+			"dev": true,
 			"requires": {
 				"util": "0.10.3"
 			},
@@ -1582,12 +1770,14 @@
 				"inherits": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+					"dev": true
 				},
 				"util": {
 					"version": "0.10.3",
 					"resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
 					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+					"dev": true,
 					"requires": {
 						"inherits": "2.0.1"
 					}
@@ -1597,37 +1787,44 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
 		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
 		},
 		"ast-types": {
 			"version": "0.11.5",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
-			"integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw=="
+			"integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw==",
+			"dev": true
 		},
 		"async": {
 			"version": "1.5.2",
 			"resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+			"dev": true
 		},
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true
 		},
 		"async-limiter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"dev": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -1637,22 +1834,26 @@
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+			"dev": true
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"esutils": "^2.0.2",
@@ -1662,7 +1863,8 @@
 				"js-tokens": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
 				}
 			}
 		},
@@ -1670,6 +1872,7 @@
 			"version": "6.26.3",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-generator": "^6.26.0",
@@ -1696,6 +1899,7 @@
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
 			"integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/parser": "^7.0.0",
@@ -1709,6 +1913,7 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true,
 			"requires": {
 				"babel-messages": "^6.23.0",
 				"babel-runtime": "^6.26.0",
@@ -1724,6 +1929,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-traverse": "^6.24.1",
@@ -1734,6 +1940,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1744,6 +1951,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1755,6 +1963,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.26.0",
@@ -1766,6 +1975,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-traverse": "^6.24.1",
@@ -1776,6 +1986,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+			"dev": true,
 			"requires": {
 				"babel-helper-bindify-decorators": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1787,6 +1998,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1799,6 +2011,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -1808,6 +2021,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -1817,6 +2031,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -1826,6 +2041,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-types": "^6.26.0",
@@ -1836,6 +2052,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1848,6 +2065,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "^6.24.1",
 				"babel-messages": "^6.23.0",
@@ -1861,6 +2079,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-template": "^6.24.1"
@@ -1870,6 +2089,7 @@
 			"version": "8.0.4",
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.4.tgz",
 			"integrity": "sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==",
+			"dev": true,
 			"requires": {
 				"find-cache-dir": "^1.0.0",
 				"loader-utils": "^1.0.2",
@@ -1881,6 +2101,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -1889,6 +2110,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -1897,6 +2119,7 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.8.0.tgz",
 			"integrity": "sha512-PcrdbXFO/9Plo9JURIj8G0Dsz+Ct8r+NvjoLh6qPt8Y/3EIAj1gHGW1ocPY1IkQbXZLBEZZSRBAxJem1KFdBXg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"lodash": "^4.17.10"
@@ -1905,62 +2128,74 @@
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+			"dev": true
 		},
 		"babel-plugin-syntax-class-constructor-call": {
 			"version": "6.18.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
+			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-class-properties": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+			"dev": true
 		},
 		"babel-plugin-syntax-decorators": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
+			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
+			"dev": true
 		},
 		"babel-plugin-syntax-dynamic-import": {
 			"version": "6.18.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
 		},
 		"babel-plugin-syntax-export-extensions": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
+			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
 		},
 		"babel-plugin-transform-async-generator-functions": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "^6.24.1",
 				"babel-plugin-syntax-async-generators": "^6.5.0",
@@ -1971,6 +2206,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "^6.24.1",
 				"babel-plugin-syntax-async-functions": "^6.8.0",
@@ -1981,6 +2217,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-class-constructor-call": "^6.18.0",
 				"babel-runtime": "^6.22.0",
@@ -1991,6 +2228,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-plugin-syntax-class-properties": "^6.8.0",
@@ -2002,6 +2240,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-class": "^6.24.1",
 				"babel-plugin-syntax-decorators": "^6.13.0",
@@ -2014,6 +2253,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2022,6 +2262,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2030,6 +2271,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-template": "^6.26.0",
@@ -2042,6 +2284,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "^6.24.1",
 				"babel-helper-function-name": "^6.24.1",
@@ -2058,6 +2301,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-template": "^6.24.1"
@@ -2067,6 +2311,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2075,6 +2320,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2084,6 +2330,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2092,6 +2339,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2102,6 +2350,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2110,6 +2359,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2120,6 +2370,7 @@
 			"version": "6.26.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
 			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "^6.24.1",
 				"babel-runtime": "^6.26.0",
@@ -2131,6 +2382,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2141,6 +2393,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2151,6 +2404,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "^6.24.1",
 				"babel-runtime": "^6.22.0"
@@ -2160,6 +2414,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "^6.24.1",
 				"babel-helper-get-function-arity": "^6.24.1",
@@ -2173,6 +2428,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2182,6 +2438,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2190,6 +2447,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2200,6 +2458,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2208,6 +2467,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2216,6 +2476,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2226,6 +2487,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
@@ -2236,6 +2498,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-export-extensions": "^6.8.0",
 				"babel-runtime": "^6.22.0"
@@ -2245,6 +2508,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "^6.18.0",
 				"babel-runtime": "^6.22.0"
@@ -2254,6 +2518,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
 				"babel-runtime": "^6.26.0"
@@ -2263,6 +2528,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.10.0"
 			}
@@ -2271,6 +2537,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2280,6 +2547,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "^6.22.0",
 				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
@@ -2311,6 +2579,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-class-constructor-call": "^6.24.1",
 				"babel-plugin-transform-export-extensions": "^6.22.0",
@@ -2321,6 +2590,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-dynamic-import": "^6.18.0",
 				"babel-plugin-transform-class-properties": "^6.24.1",
@@ -2332,6 +2602,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
 				"babel-plugin-transform-async-generator-functions": "^6.24.1",
@@ -2344,6 +2615,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "^6.26.0",
 				"babel-runtime": "^6.26.0",
@@ -2358,6 +2630,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
@@ -2367,6 +2640,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-traverse": "^6.26.0",
@@ -2379,6 +2653,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-messages": "^6.23.0",
@@ -2395,6 +2670,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"esutils": "^2.0.2",
@@ -2405,17 +2681,20 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"dev": true,
 			"requires": {
 				"cache-base": "^1.0.1",
 				"class-utils": "^0.3.5",
@@ -2430,6 +2709,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -2438,6 +2718,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -2446,6 +2727,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -2454,6 +2736,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -2465,17 +2748,20 @@
 		"base64-js": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+			"dev": true
 		},
 		"batch": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
+			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"dev": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -2483,32 +2769,38 @@
 		"big.js": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+			"dev": true
 		},
 		"binary-extensions": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"dev": true
 		},
 		"binaryextensions": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.1.tgz",
-			"integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA=="
+			"integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA==",
+			"dev": true
 		},
 		"bluebird": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-			"integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
+			"integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
+			"dev": true
 		},
 		"bn.js": {
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+			"dev": true
 		},
 		"body-parser": {
 			"version": "1.18.2",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
 			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+			"dev": true,
 			"requires": {
 				"bytes": "3.0.0",
 				"content-type": "~1.0.4",
@@ -2525,12 +2817,14 @@
 				"iconv-lite": {
 					"version": "0.4.19",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+					"dev": true
 				},
 				"qs": {
 					"version": "6.5.1",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+					"dev": true
 				}
 			}
 		},
@@ -2538,6 +2832,7 @@
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
 			"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+			"dev": true,
 			"requires": {
 				"array-flatten": "^2.1.0",
 				"deep-equal": "^1.0.1",
@@ -2550,12 +2845,14 @@
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+			"dev": true
 		},
 		"bower-config": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.1.tgz",
 			"integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.3",
 				"mout": "^1.0.0",
@@ -2568,6 +2865,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2577,6 +2875,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"dev": true,
 			"requires": {
 				"arr-flatten": "^1.1.0",
 				"array-unique": "^0.3.2",
@@ -2594,6 +2893,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -2603,22 +2903,26 @@
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+			"dev": true
 		},
 		"browser-process-hrtime": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
-			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw=="
+			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+			"dev": true
 		},
 		"browser-stdout": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
 			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+			"dev": true,
 			"requires": {
 				"buffer-xor": "^1.0.3",
 				"cipher-base": "^1.0.0",
@@ -2632,6 +2936,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
 			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+			"dev": true,
 			"requires": {
 				"browserify-aes": "^1.0.4",
 				"browserify-des": "^1.0.0",
@@ -2642,6 +2947,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
 			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"des.js": "^1.0.0",
@@ -2653,6 +2959,7 @@
 			"version": "4.0.1",
 			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"randombytes": "^2.0.1"
@@ -2662,6 +2969,7 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.1",
 				"browserify-rsa": "^4.0.0",
@@ -2676,6 +2984,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+			"dev": true,
 			"requires": {
 				"pako": "~1.0.5"
 			}
@@ -2684,6 +2993,7 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
 			"integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
+			"dev": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30000899",
 				"electron-to-chromium": "^1.3.82",
@@ -2694,6 +3004,7 @@
 			"version": "4.9.1",
 			"resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+			"dev": true,
 			"requires": {
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4",
@@ -2704,6 +3015,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
 			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+			"dev": true,
 			"requires": {
 				"buffer-alloc-unsafe": "^1.1.0",
 				"buffer-fill": "^1.0.0"
@@ -2712,12 +3024,14 @@
 		"buffer-alloc-unsafe": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+			"dev": true
 		},
 		"buffer-fill": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+			"dev": true
 		},
 		"buffer-from": {
 			"version": "1.1.1",
@@ -2727,32 +3041,38 @@
 		"buffer-indexof": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
+			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
+			"dev": true
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+			"dev": true
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
 		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+			"dev": true
 		},
 		"bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+			"dev": true
 		},
 		"cacache": {
 			"version": "10.0.4",
 			"resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
 			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.1",
 				"chownr": "^1.0.1",
@@ -2773,6 +3093,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
 				"component-emitter": "^1.2.1",
@@ -2789,6 +3110,7 @@
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
 			"integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+			"dev": true,
 			"requires": {
 				"clone-response": "1.0.2",
 				"get-stream": "3.0.0",
@@ -2802,19 +3124,22 @@
 				"lowercase-keys": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-					"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+					"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+					"dev": true
 				}
 			}
 		},
 		"call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+			"dev": true
 		},
 		"caller-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
 			"requires": {
 				"callsites": "^0.2.0"
 			}
@@ -2822,12 +3147,14 @@
 		"callsites": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
 		},
 		"camel-case": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
 			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+			"dev": true,
 			"requires": {
 				"no-case": "^2.2.0",
 				"upper-case": "^1.1.1"
@@ -2836,22 +3163,26 @@
 		"camelcase": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+			"dev": true
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000905",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000905.tgz",
-			"integrity": "sha512-cR6ICguvhRrkAjFfBoe54vJQMVOEz7vFmqrV6oor1a7GRg6DdswI40lkiV/QQvAMb4txzTkjSaLaJaiAtSuQzA=="
+			"integrity": "sha512-cR6ICguvhRrkAjFfBoe54vJQMVOEz7vFmqrV6oor1a7GRg6DdswI40lkiV/QQvAMb4txzTkjSaLaJaiAtSuQzA==",
+			"dev": true
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
 		},
 		"chai": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
 			"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+			"dev": true,
 			"requires": {
 				"assertion-error": "^1.0.1",
 				"check-error": "^1.0.1",
@@ -2865,6 +3196,7 @@
 			"version": "1.1.3",
 			"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "^2.2.1",
 				"escape-string-regexp": "^1.0.2",
@@ -2876,24 +3208,28 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				}
 			}
 		},
 		"change-emitter": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=",
+			"dev": true
 		},
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
 		},
 		"check-dependencies": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/check-dependencies/-/check-dependencies-1.1.0.tgz",
 			"integrity": "sha512-GDrbGzzJ6Gc6tQh87HBMGhrJ4UWIlR9MKJwgvlrJyj/gWvTYYb2jQetKbajt/EYK5Y8/4g7gH2LEvq8GdUWTag==",
+			"dev": true,
 			"requires": {
 				"bower-config": "^1.4.0",
 				"chalk": "^2.1.0",
@@ -2907,6 +3243,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -2915,6 +3252,7 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -2924,17 +3262,20 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -2944,12 +3285,14 @@
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
 		},
 		"cheerio": {
 			"version": "1.0.0-rc.2",
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
 			"integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+			"dev": true,
 			"requires": {
 				"css-select": "~1.2.0",
 				"dom-serializer": "~0.1.0",
@@ -2963,6 +3306,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
 			"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
 				"async-each": "^1.0.0",
@@ -2983,6 +3327,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.1"
 					}
@@ -2992,17 +3337,20 @@
 		"chownr": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+			"dev": true
 		},
 		"chrome-trace-event": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-0.1.3.tgz",
-			"integrity": "sha512-sjndyZHrrWiu4RY7AkHgjn80GfAM2ZSzUkZLV/Js59Ldmh6JDThf0SUmOHU53rFu2rVxxfCzJ30Ukcfch3Gb/A=="
+			"integrity": "sha512-sjndyZHrrWiu4RY7AkHgjn80GfAM2ZSzUkZLV/Js59Ldmh6JDThf0SUmOHU53rFu2rVxxfCzJ30Ukcfch3Gb/A==",
+			"dev": true
 		},
 		"cipher-base": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -3011,12 +3359,14 @@
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
 		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"define-property": "^0.2.5",
@@ -3028,6 +3378,7 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -3038,6 +3389,7 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
 			"integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+			"dev": true,
 			"requires": {
 				"source-map": "~0.6.0"
 			},
@@ -3045,7 +3397,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -3053,6 +3406,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
 			}
@@ -3060,12 +3414,14 @@
 		"cli-spinners": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
-			"integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw="
+			"integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+			"dev": true
 		},
 		"cli-table": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
 			"integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+			"dev": true,
 			"requires": {
 				"colors": "1.0.3"
 			},
@@ -3073,7 +3429,8 @@
 				"colors": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+					"dev": true
 				}
 			}
 		},
@@ -3081,6 +3438,7 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
 			"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+			"dev": true,
 			"requires": {
 				"slice-ansi": "0.0.4",
 				"string-width": "^1.0.1"
@@ -3090,6 +3448,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3097,12 +3456,14 @@
 				"slice-ansi": {
 					"version": "0.0.4",
 					"resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3114,7 +3475,8 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
 		},
 		"client-oauth2": {
 			"version": "4.2.1",
@@ -3129,6 +3491,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"dev": true,
 			"requires": {
 				"string-width": "^2.1.1",
 				"strip-ansi": "^4.0.0",
@@ -3138,12 +3501,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -3153,17 +3518,20 @@
 		"clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+			"dev": true
 		},
 		"clone-buffer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
+			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+			"dev": true
 		},
 		"clone-response": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+			"dev": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
 			}
@@ -3171,12 +3539,14 @@
 		"clone-stats": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+			"dev": true
 		},
 		"cloneable-readable": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
 			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"process-nextick-args": "^2.0.0",
@@ -3186,17 +3556,20 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
 		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"dev": true,
 			"requires": {
 				"map-visit": "^1.0.0",
 				"object-visit": "^1.0.0"
@@ -3206,6 +3579,7 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -3213,12 +3587,14 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"colors": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-			"integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
+			"integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.6",
@@ -3231,22 +3607,26 @@
 		"commander": {
 			"version": "2.17.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
 		},
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"dev": true
 		},
 		"compressible": {
 			"version": "2.0.14",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
 			"integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
+			"dev": true,
 			"requires": {
 				"mime-db": ">= 1.34.0 < 2"
 			}
@@ -3255,6 +3635,7 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
 			"integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+			"dev": true,
 			"requires": {
 				"accepts": "~1.3.5",
 				"bytes": "3.0.0",
@@ -3268,7 +3649,8 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -3284,12 +3666,14 @@
 		"connect-history-api-fallback": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-			"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+			"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
+			"dev": true
 		},
 		"console-browserify": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+			"dev": true,
 			"requires": {
 				"date-now": "^0.1.4"
 			}
@@ -3297,47 +3681,56 @@
 		"consolidated-events": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
-			"integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ=="
+			"integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ==",
+			"dev": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+			"dev": true
 		},
 		"contains-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"dev": true
 		},
 		"content-disposition": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+			"dev": true
 		},
 		"content-type": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"dev": true
 		},
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"dev": true
 		},
 		"cookie": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+			"dev": true
 		},
 		"cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+			"dev": true
 		},
 		"copy-concurrently": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"fs-write-stream-atomic": "^1.0.8",
@@ -3350,12 +3743,14 @@
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
 		},
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -3378,6 +3773,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
 			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.0.0"
@@ -3387,6 +3783,7 @@
 			"version": "1.2.0",
 			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"inherits": "^2.0.1",
@@ -3399,6 +3796,7 @@
 			"version": "1.1.7",
 			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.3",
 				"create-hash": "^1.1.0",
@@ -3412,6 +3810,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"dev": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
@@ -3422,6 +3821,7 @@
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+			"dev": true,
 			"requires": {
 				"browserify-cipher": "^1.0.0",
 				"browserify-sign": "^4.0.0",
@@ -3440,6 +3840,7 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
 			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"source-map": "^0.6.1",
@@ -3450,19 +3851,22 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
 		"css-color-keywords": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-			"integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+			"integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
+			"dev": true
 		},
 		"css-select": {
 			"version": "1.2.0",
 			"resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+			"dev": true,
 			"requires": {
 				"boolbase": "~1.0.0",
 				"css-what": "2.1",
@@ -3474,6 +3878,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.2.2.tgz",
 			"integrity": "sha512-w99Fzop1FO8XKm0VpbQp3y5mnTnaS+rtCvS+ylSEOK76YXO5zoHQx/QMB1N54Cp+Ya9jB9922EHrh14ld4xmmw==",
+			"dev": true,
 			"requires": {
 				"css-color-keywords": "^1.0.0",
 				"fbjs": "^0.8.5",
@@ -3483,17 +3888,20 @@
 		"css-what": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
+			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+			"dev": true
 		},
 		"cssom": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-			"integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog=="
+			"integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+			"dev": true
 		},
 		"cssstyle": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
 			"integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
+			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
 			}
@@ -3502,6 +3910,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"dev": true,
 			"requires": {
 				"array-find-index": "^1.0.1"
 			}
@@ -3509,17 +3918,20 @@
 		"cyclist": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+			"dev": true
 		},
 		"dargs": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
-			"integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
+			"integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk=",
+			"dev": true
 		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -3528,6 +3940,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
 			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"dev": true,
 			"requires": {
 				"abab": "^2.0.0",
 				"whatwg-mimetype": "^2.2.0",
@@ -3537,7 +3950,8 @@
 		"date-fns": {
 			"version": "1.29.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-			"integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
+			"integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+			"dev": true
 		},
 		"date-names": {
 			"version": "0.1.12",
@@ -3547,17 +3961,20 @@
 		"date-now": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+			"dev": true
 		},
 		"dateformat": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
+			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+			"dev": true
 		},
 		"debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -3565,12 +3982,14 @@
 		"debug-log": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-			"integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8="
+			"integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+			"dev": true
 		},
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
@@ -3581,6 +4000,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"dev": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
 			}
@@ -3589,6 +4009,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
 			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"dev": true,
 			"requires": {
 				"type-detect": "^4.0.0"
 			}
@@ -3596,22 +4017,26 @@
 		"deep-equal": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+			"dev": true
 		},
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"dev": true
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"default-gateway": {
 			"version": "2.7.2",
 			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
 			"integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
+			"dev": true,
 			"requires": {
 				"execa": "^0.10.0",
 				"ip-regex": "^2.1.0"
@@ -3621,6 +4046,7 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -3633,6 +4059,7 @@
 					"version": "0.10.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
 					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+					"dev": true,
 					"requires": {
 						"cross-spawn": "^6.0.0",
 						"get-stream": "^3.0.0",
@@ -3649,6 +4076,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
@@ -3657,6 +4085,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"dev": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
 				"isobject": "^3.0.1"
@@ -3666,6 +4095,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -3674,6 +4104,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -3682,6 +4113,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -3694,6 +4126,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
 			"integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
+			"dev": true,
 			"requires": {
 				"find-root": "^1.0.0",
 				"glob": "^7.0.5",
@@ -3707,6 +4140,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
 			"requires": {
 				"globby": "^5.0.0",
 				"is-path-cwd": "^1.0.0",
@@ -3720,7 +4154,8 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
 				}
 			}
 		},
@@ -3732,12 +4167,14 @@
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+			"dev": true
 		},
 		"des.js": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0"
@@ -3746,22 +4183,26 @@
 		"destroy": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+			"dev": true
 		},
 		"detect-conflict": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
-			"integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24="
+			"integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24=",
+			"dev": true
 		},
 		"detect-file": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+			"dev": true
 		},
 		"detect-indent": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
 			"requires": {
 				"repeating": "^2.0.0"
 			}
@@ -3769,17 +4210,20 @@
 		"detect-node": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
-			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
+			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
+			"dev": true
 		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
 			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"miller-rabin": "^4.0.0",
@@ -3790,6 +4234,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
 			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"path-type": "^3.0.0"
@@ -3799,6 +4244,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -3808,17 +4254,20 @@
 		"discontinuous-range": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+			"dev": true
 		},
 		"dns-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
+			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+			"dev": true
 		},
 		"dns-packet": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
 			"integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+			"dev": true,
 			"requires": {
 				"ip": "^1.1.0",
 				"safe-buffer": "^5.0.1"
@@ -3828,6 +4277,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
 			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+			"dev": true,
 			"requires": {
 				"buffer-indexof": "^1.0.0"
 			}
@@ -3836,6 +4286,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2"
 			}
@@ -3844,6 +4295,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
 			"integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
+			"dev": true,
 			"requires": {
 				"utila": "~0.3"
 			},
@@ -3851,7 +4303,8 @@
 				"utila": {
 					"version": "0.3.3",
 					"resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
-					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY="
+					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
+					"dev": true
 				}
 			}
 		},
@@ -3859,6 +4312,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
 			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+			"dev": true,
 			"requires": {
 				"domelementtype": "~1.1.1",
 				"entities": "~1.1.1"
@@ -3867,24 +4321,28 @@
 				"domelementtype": {
 					"version": "1.1.3",
 					"resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+					"dev": true
 				}
 			}
 		},
 		"domain-browser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
+			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+			"dev": true
 		},
 		"domelementtype": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+			"dev": true
 		},
 		"domexception": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"dev": true,
 			"requires": {
 				"webidl-conversions": "^4.0.2"
 			}
@@ -3893,6 +4351,7 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
 			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+			"dev": true,
 			"requires": {
 				"domelementtype": "1"
 			}
@@ -3901,6 +4360,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
 			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+			"dev": true,
 			"requires": {
 				"dom-serializer": "0",
 				"domelementtype": "1"
@@ -3909,12 +4369,14 @@
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+			"dev": true
 		},
 		"duplexify": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
 			"integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
 				"inherits": "^2.0.1",
@@ -3926,6 +4388,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"dev": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -3934,32 +4397,38 @@
 		"editions": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-			"integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+			"integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+			"dev": true
 		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+			"dev": true
 		},
 		"ejs": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
+			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
+			"dev": true
 		},
 		"electron-to-chromium": {
 			"version": "1.3.83",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.83.tgz",
-			"integrity": "sha512-DqJoDarxq50dcHsOOlMLNoy+qQitlMNbYb6wwbE0oUw2veHdRkpNrhmngiUYKMErdJ8SJ48rpJsZTQgy5SoEAA=="
+			"integrity": "sha512-DqJoDarxq50dcHsOOlMLNoy+qQitlMNbYb6wwbE0oUw2veHdRkpNrhmngiUYKMErdJ8SJ48rpJsZTQgy5SoEAA==",
+			"dev": true
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
+			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+			"dev": true
 		},
 		"elliptic": {
 			"version": "6.4.1",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
 			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -3973,17 +4442,20 @@
 		"emojis-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+			"dev": true
 		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+			"dev": true
 		},
 		"encoding": {
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "~0.4.13"
 			}
@@ -3992,6 +4464,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -4000,6 +4473,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
 			"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"memory-fs": "^0.4.0",
@@ -4009,17 +4483,20 @@
 		"entities": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+			"dev": true
 		},
 		"envinfo": {
 			"version": "5.10.0",
 			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-5.10.0.tgz",
-			"integrity": "sha512-rXbzXWvnQxy+TcqZlARbWVQwgGVVouVJgFZhLVN5htjLxl1thstrP2ZGi0pXC309AbK7gVOPU+ulz/tmpCI7iw=="
+			"integrity": "sha512-rXbzXWvnQxy+TcqZlARbWVQwgGVVouVJgFZhLVN5htjLxl1thstrP2ZGi0pXC309AbK7gVOPU+ulz/tmpCI7iw==",
+			"dev": true
 		},
 		"enzyme": {
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.7.0.tgz",
 			"integrity": "sha512-QLWx+krGK6iDNyR1KlH5YPZqxZCQaVF6ike1eDJAOg0HvSkSCVImPsdWaNw6v+VrnK92Kg8jIOYhuOSS9sBpyg==",
+			"dev": true,
 			"requires": {
 				"array.prototype.flat": "^1.2.1",
 				"cheerio": "^1.0.0-rc.2",
@@ -4046,6 +4523,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.6.0.tgz",
 			"integrity": "sha512-ay9eGFpChyUDnjTFMMJHzrb681LF3hPWJLEA7RoLFG9jSWAdAm2V50pGmFV9dYGJgh5HfdiqM+MNvle41Yf/PA==",
+			"dev": true,
 			"requires": {
 				"enzyme-adapter-utils": "^1.8.0",
 				"function.prototype.name": "^1.1.0",
@@ -4059,7 +4537,8 @@
 				"react-is": {
 					"version": "16.6.0",
 					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.0.tgz",
-					"integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g=="
+					"integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g==",
+					"dev": true
 				}
 			}
 		},
@@ -4067,6 +4546,7 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.8.1.tgz",
 			"integrity": "sha512-s3QB3xQAowaDS2sHhmEqrT13GJC4+n5bG015ZkLv60n9k5vhxxHTQRIneZmQ4hmdCZEBrvUJ89PG6fRI5OEeuQ==",
+			"dev": true,
 			"requires": {
 				"function.prototype.name": "^1.1.0",
 				"object.assign": "^4.1.0",
@@ -4077,6 +4557,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+			"dev": true,
 			"requires": {
 				"prr": "~1.0.1"
 			}
@@ -4085,6 +4566,7 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
 			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+			"dev": true,
 			"requires": {
 				"string-template": "~0.2.1",
 				"xtend": "~4.0.0"
@@ -4094,6 +4576,7 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -4102,6 +4585,7 @@
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
 			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.1.1",
 				"function-bind": "^1.1.1",
@@ -4114,6 +4598,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.1",
 				"is-date-object": "^1.0.1",
@@ -4123,17 +4608,20 @@
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escodegen": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
 			"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
 				"estraverse": "^4.2.0",
@@ -4146,6 +4634,7 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
 					"optional": true
 				}
 			}
@@ -4154,6 +4643,7 @@
 			"version": "4.18.2",
 			"resolved": "http://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
 			"integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+			"dev": true,
 			"requires": {
 				"ajv": "^5.3.0",
 				"babel-code-frame": "^6.22.0",
@@ -4197,12 +4687,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -4211,6 +4703,7 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -4221,6 +4714,7 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -4228,17 +4722,20 @@
 				"globals": {
 					"version": "11.7.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-					"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
+					"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+					"dev": true
 				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -4247,6 +4744,7 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -4256,17 +4754,20 @@
 		"eslint-config-standard": {
 			"version": "11.0.0",
 			"resolved": "http://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz",
-			"integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw=="
+			"integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==",
+			"dev": true
 		},
 		"eslint-config-standard-jsx": {
 			"version": "5.0.0",
 			"resolved": "http://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-5.0.0.tgz",
-			"integrity": "sha512-rLToPAEqLMPBfWnYTu6xRhm2OWziS2n40QFqJ8jAM8NSVzeVKTa3nclhsU4DpPJQRY60F34Oo1wi/71PN/eITg=="
+			"integrity": "sha512-rLToPAEqLMPBfWnYTu6xRhm2OWziS2n40QFqJ8jAM8NSVzeVKTa3nclhsU4DpPJQRY60F34Oo1wi/71PN/eITg==",
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
 			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+			"dev": true,
 			"requires": {
 				"debug": "^2.6.9",
 				"resolve": "^1.5.0"
@@ -4276,6 +4777,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
 			"integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+			"dev": true,
 			"requires": {
 				"debug": "^2.6.8",
 				"pkg-dir": "^1.0.0"
@@ -4285,6 +4787,7 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -4294,6 +4797,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -4302,6 +4806,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
 					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0"
 					}
@@ -4312,6 +4817,7 @@
 			"version": "2.9.0",
 			"resolved": "http://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
 			"integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
+			"dev": true,
 			"requires": {
 				"builtin-modules": "^1.1.1",
 				"contains-path": "^0.1.0",
@@ -4329,6 +4835,7 @@
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"isarray": "^1.0.0"
@@ -4340,6 +4847,7 @@
 			"version": "6.0.1",
 			"resolved": "http://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
 			"integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+			"dev": true,
 			"requires": {
 				"ignore": "^3.3.6",
 				"minimatch": "^3.0.4",
@@ -4350,12 +4858,14 @@
 		"eslint-plugin-promise": {
 			"version": "3.7.0",
 			"resolved": "http://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.7.0.tgz",
-			"integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg=="
+			"integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg==",
+			"dev": true
 		},
 		"eslint-plugin-react": {
 			"version": "7.7.0",
 			"resolved": "http://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
 			"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+			"dev": true,
 			"requires": {
 				"doctrine": "^2.0.2",
 				"has": "^1.0.1",
@@ -4366,12 +4876,14 @@
 		"eslint-plugin-standard": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
-			"integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI="
+			"integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
+			"dev": true
 		},
 		"eslint-scope": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"dev": true,
 			"requires": {
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
@@ -4380,12 +4892,14 @@
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
 		},
 		"espree": {
 			"version": "3.5.4",
 			"resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"dev": true,
 			"requires": {
 				"acorn": "^5.5.0",
 				"acorn-jsx": "^3.0.0"
@@ -4394,12 +4908,14 @@
 		"esprima": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+			"dev": true
 		},
 		"esquery": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
 			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+			"dev": true,
 			"requires": {
 				"estraverse": "^4.0.0"
 			}
@@ -4408,6 +4924,7 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"dev": true,
 			"requires": {
 				"estraverse": "^4.1.0"
 			}
@@ -4415,32 +4932,38 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"etag": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+			"dev": true
 		},
 		"eventemitter3": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-			"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+			"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+			"dev": true
 		},
 		"events": {
 			"version": "1.1.1",
 			"resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
-			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+			"dev": true
 		},
 		"eventsource": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
 			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+			"dev": true,
 			"requires": {
 				"original": ">=0.0.5"
 			}
@@ -4449,6 +4972,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"dev": true,
 			"requires": {
 				"md5.js": "^1.3.4",
 				"safe-buffer": "^5.1.1"
@@ -4466,6 +4990,7 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "^5.0.1",
 				"get-stream": "^3.0.0",
@@ -4479,12 +5004,14 @@
 		"exit-hook": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"dev": true,
 			"requires": {
 				"debug": "^2.3.3",
 				"define-property": "^0.2.5",
@@ -4499,6 +5026,7 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -4507,6 +5035,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -4517,6 +5046,7 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
 			"requires": {
 				"fill-range": "^2.1.0"
 			},
@@ -4525,6 +5055,7 @@
 					"version": "2.2.4",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
 					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+					"dev": true,
 					"requires": {
 						"is-number": "^2.1.0",
 						"isobject": "^2.0.0",
@@ -4537,6 +5068,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -4545,6 +5077,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
@@ -4553,6 +5086,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -4563,6 +5097,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
 			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
 			}
@@ -4571,6 +5106,7 @@
 			"version": "4.16.3",
 			"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
 			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+			"dev": true,
 			"requires": {
 				"accepts": "~1.3.5",
 				"array-flatten": "1.1.1",
@@ -4607,22 +5143,26 @@
 				"array-flatten": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+					"dev": true
 				},
 				"path-to-regexp": {
 					"version": "0.1.7",
 					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+					"dev": true
 				},
 				"qs": {
 					"version": "6.5.1",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+					"dev": true
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+					"dev": true
 				}
 			}
 		},
@@ -4635,6 +5175,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
 			"requires": {
 				"assign-symbols": "^1.0.0",
 				"is-extendable": "^1.0.1"
@@ -4644,6 +5185,7 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -4654,6 +5196,7 @@
 			"version": "2.2.0",
 			"resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+			"dev": true,
 			"requires": {
 				"chardet": "^0.4.0",
 				"iconv-lite": "^0.4.17",
@@ -4664,6 +5207,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"dev": true,
 			"requires": {
 				"array-unique": "^0.3.2",
 				"define-property": "^1.0.0",
@@ -4679,6 +5223,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -4687,6 +5232,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -4695,6 +5241,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -4703,6 +5250,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -4711,6 +5259,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -4722,17 +5271,20 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "1.1.0",
 			"resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
 		},
 		"fast-glob": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
 			"integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
+			"dev": true,
 			"requires": {
 				"@mrmlnc/readdir-enhanced": "^2.2.1",
 				"@nodelib/fs.stat": "^1.0.1",
@@ -4746,6 +5298,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.1"
 					}
@@ -4755,17 +5308,20 @@
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"faye-websocket": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
 			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+			"dev": true,
 			"requires": {
 				"websocket-driver": ">=0.5.1"
 			}
@@ -4774,6 +5330,7 @@
 			"version": "0.8.17",
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
 			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+			"dev": true,
 			"requires": {
 				"core-js": "^1.0.0",
 				"isomorphic-fetch": "^2.1.1",
@@ -4787,7 +5344,8 @@
 				"core-js": {
 					"version": "1.2.7",
 					"resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+					"dev": true
 				}
 			}
 		},
@@ -4795,6 +5353,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -4803,6 +5362,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
 			"requires": {
 				"flat-cache": "^1.2.1",
 				"object-assign": "^4.0.1"
@@ -4811,12 +5371,14 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
 		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-number": "^3.0.0",
@@ -4828,6 +5390,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -4838,6 +5401,7 @@
 			"version": "1.1.1",
 			"resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
 			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
 				"encodeurl": "~1.0.2",
@@ -4852,6 +5416,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
 				"make-dir": "^1.0.0",
@@ -4861,12 +5426,14 @@
 		"find-root": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+			"dev": true
 		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"dev": true,
 			"requires": {
 				"locate-path": "^2.0.0"
 			}
@@ -4875,6 +5442,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
 			"integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+			"dev": true,
 			"requires": {
 				"detect-file": "^1.0.0",
 				"is-glob": "^3.1.0",
@@ -4886,6 +5454,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
 			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.2"
 			}
@@ -4894,6 +5463,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"dev": true,
 			"requires": {
 				"circular-json": "^0.3.1",
 				"del": "^2.0.2",
@@ -4904,12 +5474,14 @@
 		"flow-parser": {
 			"version": "0.79.1",
 			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.79.1.tgz",
-			"integrity": "sha512-l6aeT5Ze3RefXiKUtabFNgv1vMp9L2ku+BqLuKCNZytV2ci4f98L47zrSJefwbJWG42sc5dskzcnWy7+ertlLQ=="
+			"integrity": "sha512-l6aeT5Ze3RefXiKUtabFNgv1vMp9L2ku+BqLuKCNZytV2ci4f98L47zrSJefwbJWG42sc5dskzcnWy7+ertlLQ==",
+			"dev": true
 		},
 		"flush-write-stream": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
 			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.4"
@@ -4919,6 +5491,7 @@
 			"version": "1.5.7",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
 			"integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
+			"dev": true,
 			"requires": {
 				"debug": "^3.1.0"
 			},
@@ -4927,6 +5500,7 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -4936,12 +5510,14 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"requires": {
 				"for-in": "^1.0.1"
 			}
@@ -4949,7 +5525,8 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
 			"version": "2.3.2",
@@ -4964,12 +5541,14 @@
 		"forwarded": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+			"dev": true
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
@@ -4977,12 +5556,14 @@
 		"fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+			"dev": true
 		},
 		"from2": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
@@ -4992,6 +5573,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"iferr": "^0.1.5",
@@ -5002,12 +5584,14 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
 			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "^2.9.2",
@@ -5017,20 +5601,24 @@
 				"abbrev": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -5039,11 +5627,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5052,28 +5642,34 @@
 				"chownr": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -5082,21 +5678,25 @@
 				"deep-extend": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -5105,11 +5705,13 @@
 				"fs.realpath": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -5125,6 +5727,7 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -5138,11 +5741,13 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.21",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safer-buffer": "^2.1.0"
@@ -5151,6 +5756,7 @@
 				"ignore-walk": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minimatch": "^3.0.4"
@@ -5159,6 +5765,7 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"once": "^1.3.0",
@@ -5167,16 +5774,19 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5184,22 +5794,26 @@
 				"isarray": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -5208,6 +5822,7 @@
 				"minizlib": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -5216,6 +5831,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5223,11 +5839,13 @@
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "^2.1.2",
@@ -5238,6 +5856,7 @@
 				"node-pre-gyp": {
 					"version": "0.10.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
@@ -5255,6 +5874,7 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1",
@@ -5264,11 +5884,13 @@
 				"npm-bundled": {
 					"version": "1.0.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.1.10",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
@@ -5278,6 +5900,7 @@
 				"npmlog": {
 					"version": "4.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -5288,16 +5911,19 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5305,16 +5931,19 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -5324,16 +5953,19 @@
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.7",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "^0.5.1",
@@ -5345,6 +5977,7 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -5352,6 +5985,7 @@
 				"readable-stream": {
 					"version": "2.3.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -5366,6 +6000,7 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"glob": "^7.0.5"
@@ -5373,36 +6008,43 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.5.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5412,6 +6054,7 @@
 				"string_decoder": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
@@ -5420,6 +6063,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5427,11 +6071,13 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"chownr": "^1.0.1",
@@ -5446,11 +6092,13 @@
 				"util-deprecate": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "^1.0.2"
@@ -5458,23 +6106,27 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				}
 			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"function.prototype.name": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
 			"integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"function-bind": "^1.1.1",
@@ -5484,37 +6136,44 @@
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
 		},
 		"get-caller-file": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+			"dev": true
 		},
 		"get-func-name": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"dev": true
 		},
 		"get-stdin": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
+			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+			"dev": true
 		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+			"dev": true
 		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -5523,6 +6182,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
 			"integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
+			"dev": true,
 			"requires": {
 				"got": "^7.0.0",
 				"is-plain-obj": "^1.1.0"
@@ -5532,6 +6192,7 @@
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
 					"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+					"dev": true,
 					"requires": {
 						"decompress-response": "^3.2.0",
 						"duplexer3": "^0.1.4",
@@ -5552,12 +6213,14 @@
 				"p-cancelable": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-					"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+					"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+					"dev": true
 				},
 				"p-timeout": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
 					"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+					"dev": true,
 					"requires": {
 						"p-finally": "^1.0.0"
 					}
@@ -5565,12 +6228,14 @@
 				"prepend-http": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+					"dev": true
 				},
 				"url-parse-lax": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+					"dev": true,
 					"requires": {
 						"prepend-http": "^1.0.1"
 					}
@@ -5581,6 +6246,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
 			"integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
+			"dev": true,
 			"requires": {
 				"gh-got": "^6.0.0"
 			}
@@ -5589,6 +6255,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -5602,6 +6269,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.1.0.tgz",
 			"integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
+			"dev": true,
 			"requires": {
 				"glob": "^7.0.5",
 				"yargs": "~1.2.6"
@@ -5610,12 +6278,14 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
+					"dev": true
 				},
 				"yargs": {
 					"version": "1.2.6",
 					"resolved": "http://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
 					"integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
+					"dev": true,
 					"requires": {
 						"minimist": "^0.1.0"
 					}
@@ -5626,6 +6296,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"requires": {
 				"glob-parent": "^2.0.0",
 				"is-glob": "^2.0.0"
@@ -5635,6 +6306,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
 					"requires": {
 						"is-glob": "^2.0.0"
 					}
@@ -5642,12 +6314,14 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -5658,6 +6332,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"dev": true,
 			"requires": {
 				"is-glob": "^3.1.0",
 				"path-dirname": "^1.0.0"
@@ -5666,12 +6341,14 @@
 		"glob-to-regexp": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
+			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+			"dev": true
 		},
 		"global-modules": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
 			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+			"dev": true,
 			"requires": {
 				"global-prefix": "^1.0.1",
 				"is-windows": "^1.0.1",
@@ -5682,6 +6359,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
 			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+			"dev": true,
 			"requires": {
 				"expand-tilde": "^2.0.2",
 				"homedir-polyfill": "^1.0.1",
@@ -5693,12 +6371,14 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globby": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"dev": true,
 			"requires": {
 				"array-union": "^1.0.1",
 				"arrify": "^1.0.0",
@@ -5711,7 +6391,8 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
 				}
 			}
 		},
@@ -5719,6 +6400,7 @@
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
 			"integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+			"dev": true,
 			"requires": {
 				"@sindresorhus/is": "^0.7.0",
 				"cacheable-request": "^2.1.1",
@@ -5742,12 +6424,14 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"grommet": {
 			"version": "2.0.0-rc",
 			"resolved": "https://registry.npmjs.org/grommet/-/grommet-2.0.0-rc.tgz",
 			"integrity": "sha512-Pl60m1IPi4fwntt918AnVa/m5TthA4kH8vlX5T7HvqGgNz7rjYqXaXom3pMXCbiJbo54LndWQwwMVHsec0AAkQ==",
+			"dev": true,
 			"requires": {
 				"css": "^2.2.3",
 				"markdown-to-jsx": "^6.6.6",
@@ -5761,12 +6445,14 @@
 		"grommet-icons": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/grommet-icons/-/grommet-icons-3.2.0.tgz",
-			"integrity": "sha512-D4YBzq0VWF+rU3ynviR0EVBCqmobJxqI8+dmgpG+HKOSDyKuUOxTvD91Esb0wcRfTZwX1NVCbhjLak3CGStl9g=="
+			"integrity": "sha512-D4YBzq0VWF+rU3ynviR0EVBCqmobJxqI8+dmgpG+HKOSDyKuUOxTvD91Esb0wcRfTZwX1NVCbhjLak3CGStl9g==",
+			"dev": true
 		},
 		"grouped-queue": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
 			"integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
+			"dev": true,
 			"requires": {
 				"lodash": "^4.17.2"
 			}
@@ -5774,22 +6460,26 @@
 		"growl": {
 			"version": "1.10.5",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
 		},
 		"handle-thing": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
+			"dev": true
 		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
 		},
 		"har-validator": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.2.tgz",
 			"integrity": "sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==",
+			"dev": true,
 			"requires": {
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
@@ -5799,6 +6489,7 @@
 					"version": "6.5.5",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
 					"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -5809,12 +6500,14 @@
 				"fast-deep-equal": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+					"dev": true
 				},
 				"json-schema-traverse": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+					"dev": true
 				}
 			}
 		},
@@ -5822,6 +6515,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -5830,6 +6524,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -5837,27 +6532,32 @@
 		"has-color": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+			"dev": true
 		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"has-symbol-support-x": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+			"dev": true
 		},
 		"has-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"dev": true
 		},
 		"has-to-string-tag-x": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
 			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+			"dev": true,
 			"requires": {
 				"has-symbol-support-x": "^1.4.1"
 			}
@@ -5866,6 +6566,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"dev": true,
 			"requires": {
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
@@ -5876,6 +6577,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"kind-of": "^4.0.0"
@@ -5885,6 +6587,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -5895,6 +6598,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
 			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -5904,6 +6608,7 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
 			"integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -5912,12 +6617,14 @@
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"dev": true,
 			"requires": {
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
@@ -5927,12 +6634,14 @@
 		"hoist-non-react-statics": {
 			"version": "2.5.5",
 			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+			"dev": true
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.1"
@@ -5942,6 +6651,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
 			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+			"dev": true,
 			"requires": {
 				"parse-passwd": "^1.0.0"
 			}
@@ -5949,12 +6659,14 @@
 		"hosted-git-info": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"dev": true
 		},
 		"hpack.js": {
 			"version": "2.1.6",
 			"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
 			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"obuf": "^1.0.0",
@@ -5966,6 +6678,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"dev": true,
 			"requires": {
 				"whatwg-encoding": "^1.0.1"
 			}
@@ -5973,12 +6686,14 @@
 		"html-entities": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
+			"dev": true
 		},
 		"html-minifier": {
 			"version": "3.5.20",
 			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.20.tgz",
 			"integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
+			"dev": true,
 			"requires": {
 				"camel-case": "3.0.x",
 				"clean-css": "4.2.x",
@@ -5993,6 +6708,7 @@
 			"version": "3.2.0",
 			"resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
 			"integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
+			"dev": true,
 			"requires": {
 				"html-minifier": "^3.2.3",
 				"loader-utils": "^0.2.16",
@@ -6007,6 +6723,7 @@
 					"version": "0.2.17",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+					"dev": true,
 					"requires": {
 						"big.js": "^3.1.3",
 						"emojis-list": "^2.0.0",
@@ -6020,6 +6737,7 @@
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
 			"integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+			"dev": true,
 			"requires": {
 				"domelementtype": "^1.3.0",
 				"domhandler": "^2.3.0",
@@ -6033,6 +6751,7 @@
 					"version": "3.0.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
 					"integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -6044,17 +6763,20 @@
 		"http-cache-semantics": {
 			"version": "3.8.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
+			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+			"dev": true
 		},
 		"http-deceiver": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
+			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+			"dev": true
 		},
 		"http-errors": {
 			"version": "1.6.3",
 			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+			"dev": true,
 			"requires": {
 				"depd": "~1.1.2",
 				"inherits": "2.0.3",
@@ -6065,12 +6787,14 @@
 		"http-parser-js": {
 			"version": "0.4.13",
 			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
-			"integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc="
+			"integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc=",
+			"dev": true
 		},
 		"http-proxy": {
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
 			"integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+			"dev": true,
 			"requires": {
 				"eventemitter3": "^3.0.0",
 				"follow-redirects": "^1.0.0",
@@ -6081,6 +6805,7 @@
 			"version": "0.18.0",
 			"resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
 			"integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
+			"dev": true,
 			"requires": {
 				"http-proxy": "^1.16.2",
 				"is-glob": "^4.0.0",
@@ -6092,6 +6817,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.1"
 					}
@@ -6102,6 +6828,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -6111,12 +6838,14 @@
 		"https-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+			"dev": true
 		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -6124,22 +6853,26 @@
 		"ieee754": {
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+			"dev": true
 		},
 		"iferr": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+			"dev": true
 		},
 		"ignore": {
 			"version": "3.3.10",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
+			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+			"dev": true
 		},
 		"import-local": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+			"dev": true,
 			"requires": {
 				"pkg-dir": "^2.0.0",
 				"resolve-cwd": "^2.0.0"
@@ -6148,12 +6881,14 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"indent-string": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+			"dev": true,
 			"requires": {
 				"repeating": "^2.0.0"
 			}
@@ -6167,6 +6902,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -6180,12 +6916,14 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.0",
@@ -6206,12 +6944,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -6220,6 +6960,7 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -6229,12 +6970,14 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -6243,6 +6986,7 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -6253,6 +6997,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
 			"integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
+			"dev": true,
 			"requires": {
 				"default-gateway": "^2.6.0",
 				"ipaddr.js": "^1.5.2"
@@ -6261,12 +7006,14 @@
 		"interpret": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+			"dev": true
 		},
 		"into-stream": {
 			"version": "3.1.0",
 			"resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
 			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+			"dev": true,
 			"requires": {
 				"from2": "^2.1.1",
 				"p-is-promise": "^1.1.0"
@@ -6276,6 +7023,7 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -6283,27 +7031,32 @@
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
 		},
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+			"dev": true
 		},
 		"ip-regex": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+			"dev": true
 		},
 		"ipaddr.js": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
+			"dev": true
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -6312,6 +7065,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6321,12 +7075,14 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"requires": {
 				"binary-extensions": "^1.0.0"
 			}
@@ -6334,17 +7090,20 @@
 		"is-boolean-object": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
-			"integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M="
+			"integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
+			"dev": true
 		},
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"dev": true,
 			"requires": {
 				"builtin-modules": "^1.0.0"
 			}
@@ -6352,12 +7111,14 @@
 		"is-callable": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"dev": true
 		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -6366,6 +7127,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6375,12 +7137,14 @@
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"dev": true,
 			"requires": {
 				"is-accessor-descriptor": "^0.1.6",
 				"is-data-descriptor": "^0.1.4",
@@ -6390,19 +7154,22 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
 				}
 			}
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"requires": {
 				"is-primitive": "^2.0.0"
 			}
@@ -6410,17 +7177,20 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
 		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -6428,12 +7198,14 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
 		},
 		"is-glob": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.0"
 			}
@@ -6442,6 +7214,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -6450,6 +7223,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6459,17 +7233,20 @@
 		"is-number-object": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
-			"integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k="
+			"integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
+			"dev": true
 		},
 		"is-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+			"dev": true
 		},
 		"is-observable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
 			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+			"dev": true,
 			"requires": {
 				"symbol-observable": "^1.1.0"
 			}
@@ -6477,12 +7254,14 @@
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
 			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+			"dev": true,
 			"requires": {
 				"is-path-inside": "^1.0.0"
 			}
@@ -6491,6 +7270,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
 			"requires": {
 				"path-is-inside": "^1.0.1"
 			}
@@ -6498,12 +7278,14 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+			"dev": true
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -6511,22 +7293,26 @@
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
 		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
 			"requires": {
 				"has": "^1.0.1"
 			}
@@ -6534,17 +7320,20 @@
 		"is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
 		},
 		"is-retry-allowed": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+			"dev": true
 		},
 		"is-scoped": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
 			"integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
+			"dev": true,
 			"requires": {
 				"scoped-regex": "^1.0.0"
 			}
@@ -6552,42 +7341,50 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-string": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-			"integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
+			"integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+			"dev": true
 		},
 		"is-subset": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
+			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+			"dev": true
 		},
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+			"dev": true
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
 		},
 		"is-wsl": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -6598,6 +7395,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
 			"integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
+			"dev": true,
 			"requires": {
 				"buffer-alloc": "^1.2.0"
 			}
@@ -6605,17 +7403,20 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true
 		},
 		"isomorphic-fetch": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"dev": true,
 			"requires": {
 				"node-fetch": "^1.0.1",
 				"whatwg-fetch": ">=0.10.0"
@@ -6624,12 +7425,14 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"istextorbinary": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
 			"integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
+			"dev": true,
 			"requires": {
 				"binaryextensions": "2",
 				"editions": "^1.3.3",
@@ -6640,6 +7443,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
 			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+			"dev": true,
 			"requires": {
 				"has-to-string-tag-x": "^1.2.0",
 				"is-object": "^1.0.1"
@@ -6648,17 +7452,20 @@
 		"js-levenshtein": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.4.tgz",
-			"integrity": "sha512-PxfGzSs0ztShKrUYPIn5r0MtyAhYcCwmndozzpz8YObbPnD1jFxzlBGbRnX2mIu6Z13xN6+PTu05TQFnZFlzow=="
+			"integrity": "sha512-PxfGzSs0ztShKrUYPIn5r0MtyAhYcCwmndozzpz8YObbPnD1jFxzlBGbRnX2mIu6Z13xN6+PTu05TQFnZFlzow==",
+			"dev": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -6667,19 +7474,22 @@
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
 				}
 			}
 		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true
 		},
 		"jscodeshift": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.5.1.tgz",
 			"integrity": "sha512-sRMollbhbmSDrR79JMAnhEjyZJlQQVozeeY9A6/KNuV26DNcuB3mGSCWXp0hks9dcwRNOELbNOiwraZaXXRk5Q==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "^6.8.0",
 				"babel-preset-es2015": "^6.9.0",
@@ -6701,12 +7511,14 @@
 				"ansi-styles": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.0.1"
 					}
@@ -6714,17 +7526,20 @@
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"dev": true
 				},
 				"babylon": {
 					"version": "7.0.0-beta.47",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
+					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==",
+					"dev": true
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true,
 					"requires": {
 						"expand-range": "^1.8.1",
 						"preserve": "^0.2.0",
@@ -6735,6 +7550,7 @@
 					"version": "0.4.0",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "~1.0.0",
 						"has-color": "~0.1.0",
@@ -6744,12 +7560,14 @@
 				"colors": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-					"integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
+					"integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
+					"dev": true
 				},
 				"expand-brackets": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true,
 					"requires": {
 						"is-posix-bracket": "^0.1.0"
 					}
@@ -6758,6 +7576,7 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -6765,12 +7584,14 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -6779,6 +7600,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6787,6 +7609,7 @@
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true,
 					"requires": {
 						"arr-diff": "^2.0.0",
 						"array-unique": "^0.2.1",
@@ -6807,6 +7630,7 @@
 					"version": "1.8.1",
 					"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
 					"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+					"dev": true,
 					"requires": {
 						"chalk": "~0.4.0",
 						"underscore": "~1.6.0"
@@ -6815,12 +7639,14 @@
 				"strip-ansi": {
 					"version": "0.1.1",
 					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+					"dev": true
 				},
 				"underscore": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+					"dev": true
 				}
 			}
 		},
@@ -6828,6 +7654,7 @@
 			"version": "13.0.0",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-13.0.0.tgz",
 			"integrity": "sha512-Kmq4ASMNkgpY+YufE322EnIKoiz0UWY2DRkKlU7d5YrIW4xiVRhWFrZV1fr6w/ZNxQ50wGAH5gGRzydgnmkkvw==",
+			"dev": true,
 			"requires": {
 				"abab": "^2.0.0",
 				"acorn": "^6.0.2",
@@ -6860,64 +7687,76 @@
 				"acorn": {
 					"version": "6.0.4",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-					"integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
+					"integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
+					"dev": true
 				},
 				"parse5": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-					"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
+					"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+					"dev": true
 				}
 			}
 		},
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
 		},
 		"json-buffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+			"dev": true
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"json3": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+			"dev": true
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -6929,6 +7768,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
 			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+			"dev": true,
 			"requires": {
 				"array-includes": "^3.0.3"
 			}
@@ -6936,12 +7776,14 @@
 		"just-extend": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
-			"integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ=="
+			"integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
+			"dev": true
 		},
 		"keyv": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
 			"integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+			"dev": true,
 			"requires": {
 				"json-buffer": "3.0.0"
 			}
@@ -6949,17 +7791,20 @@
 		"killable": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
-			"integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms="
+			"integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms=",
+			"dev": true
 		},
 		"kind-of": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"dev": true
 		},
 		"lcid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"dev": true,
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
@@ -6967,12 +7812,14 @@
 		"leb": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/leb/-/leb-0.3.0.tgz",
-			"integrity": "sha1-Mr7p+tFoMo1q6oUi2DP0GA7tHaM="
+			"integrity": "sha1-Mr7p+tFoMo1q6oUi2DP0GA7tHaM=",
+			"dev": true
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
@@ -6982,6 +7829,7 @@
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/listr/-/listr-0.14.1.tgz",
 			"integrity": "sha512-MSMUUVN1f8aRnPi4034RkOqdiUlpYW+FqwFE3aL0uYNPRavkt2S2SsSpDDofn8BDpqv2RNnsdOcCHWsChcq77A==",
+			"dev": true,
 			"requires": {
 				"@samverschueren/stream-to-observable": "^0.3.0",
 				"cli-truncate": "^0.2.1",
@@ -7005,6 +7853,7 @@
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+					"dev": true,
 					"requires": {
 						"escape-string-regexp": "^1.0.5",
 						"object-assign": "^4.1.0"
@@ -7014,6 +7863,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+					"dev": true,
 					"requires": {
 						"chalk": "^1.0.0"
 					}
@@ -7022,6 +7872,7 @@
 					"version": "6.2.2",
 					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
 					"integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
+					"dev": true,
 					"requires": {
 						"tslib": "^1.9.0"
 					}
@@ -7031,12 +7882,14 @@
 		"listr-silent-renderer": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
+			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+			"dev": true
 		},
 		"listr-update-renderer": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
 			"integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"cli-truncate": "^0.2.1",
@@ -7052,6 +7905,7 @@
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+					"dev": true,
 					"requires": {
 						"escape-string-regexp": "^1.0.5",
 						"object-assign": "^4.1.0"
@@ -7060,12 +7914,14 @@
 				"indent-string": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
 				},
 				"log-symbols": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+					"dev": true,
 					"requires": {
 						"chalk": "^1.0.0"
 					}
@@ -7076,6 +7932,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
 			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"cli-cursor": "^1.0.2",
@@ -7087,6 +7944,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+					"dev": true,
 					"requires": {
 						"restore-cursor": "^1.0.1"
 					}
@@ -7095,6 +7953,7 @@
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+					"dev": true,
 					"requires": {
 						"escape-string-regexp": "^1.0.5",
 						"object-assign": "^4.1.0"
@@ -7103,12 +7962,14 @@
 				"onetime": {
 					"version": "1.1.0",
 					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+					"dev": true
 				},
 				"restore-cursor": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+					"dev": true,
 					"requires": {
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
@@ -7120,6 +7981,7 @@
 			"version": "2.0.0",
 			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"parse-json": "^2.2.0",
@@ -7130,19 +7992,22 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
 				}
 			}
 		},
 		"loader-runner": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
-			"integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw=="
+			"integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw==",
+			"dev": true
 		},
 		"loader-utils": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"dev": true,
 			"requires": {
 				"big.js": "^3.1.3",
 				"emojis-list": "^2.0.0",
@@ -7153,6 +8018,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"dev": true,
 			"requires": {
 				"p-locate": "^2.0.0",
 				"path-exists": "^3.0.0"
@@ -7166,42 +8032,50 @@
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+			"dev": true
 		},
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+			"dev": true
 		},
 		"lodash.escape": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-			"integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
+			"integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
+			"dev": true
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+			"dev": true
 		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+			"dev": true
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+			"dev": true
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
 		},
 		"log-symbols": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1"
 			},
@@ -7210,6 +8084,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -7218,6 +8093,7 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -7227,12 +8103,14 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -7243,6 +8121,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+			"dev": true,
 			"requires": {
 				"ansi-escapes": "^1.0.0",
 				"cli-cursor": "^1.0.2"
@@ -7251,12 +8130,14 @@
 				"ansi-escapes": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+					"dev": true
 				},
 				"cli-cursor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+					"dev": true,
 					"requires": {
 						"restore-cursor": "^1.0.1"
 					}
@@ -7264,12 +8145,14 @@
 				"onetime": {
 					"version": "1.1.0",
 					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+					"dev": true
 				},
 				"restore-cursor": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+					"dev": true,
 					"requires": {
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
@@ -7280,22 +8163,26 @@
 		"loglevel": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
-			"integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
+			"integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
+			"dev": true
 		},
 		"lolex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
-			"integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ=="
+			"integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
+			"dev": true
 		},
 		"long": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-			"integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+			"integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -7304,6 +8191,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+			"dev": true,
 			"requires": {
 				"currently-unhandled": "^0.4.1",
 				"signal-exit": "^3.0.0"
@@ -7312,17 +8200,20 @@
 		"lower-case": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+			"dev": true
 		},
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"dev": true
 		},
 		"lru-cache": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
@@ -7337,6 +8228,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+			"dev": true,
 			"requires": {
 				"pify": "^3.0.0"
 			}
@@ -7357,12 +8249,14 @@
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true
 		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
@@ -7371,6 +8265,7 @@
 			"version": "6.8.3",
 			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.8.3.tgz",
 			"integrity": "sha512-I/kRZDvHFMEoKCjFS119v6Op4R1wZJEUEwhWSNtsE7WHRVcxKrLZ9vApvNb1j80MAFIY4/e4m1f4vIwSgKUZ8g==",
+			"dev": true,
 			"requires": {
 				"prop-types": "^15.6.2",
 				"unquote": "^1.1.0"
@@ -7379,12 +8274,14 @@
 		"math-random": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+			"dev": true
 		},
 		"md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
 			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"dev": true,
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1",
@@ -7394,12 +8291,14 @@
 		"media-typer": {
 			"version": "0.3.0",
 			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+			"dev": true
 		},
 		"mem": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -7408,6 +8307,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
 			"integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
+			"dev": true,
 			"requires": {
 				"through2": "^2.0.0",
 				"vinyl": "^1.1.0",
@@ -7418,6 +8318,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.3.tgz",
 			"integrity": "sha512-tgWmwI/+6vwu6POan82dTjxEpwAoaj0NAFnghtVo/FcLK2/7IhPUtFUUYlwou4MOY6OtjTUJtwpfH1h+eSUziw==",
+			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
 				"deep-extend": "^0.6.0",
@@ -7435,17 +8336,20 @@
 				"clone": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
 				},
 				"clone-stats": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+					"dev": true
 				},
 				"globby": {
 					"version": "7.1.1",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
 					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
 						"dir-glob": "^2.0.0",
@@ -7458,12 +8362,14 @@
 				"replace-ext": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+					"dev": true
 				},
 				"vinyl": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
 					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+					"dev": true,
 					"requires": {
 						"clone": "^2.1.1",
 						"clone-buffer": "^1.0.0",
@@ -7478,12 +8384,14 @@
 		"memoize-one": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.2.tgz",
-			"integrity": "sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg=="
+			"integrity": "sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg==",
+			"dev": true
 		},
 		"memory-fs": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+			"dev": true,
 			"requires": {
 				"errno": "^0.1.3",
 				"readable-stream": "^2.0.1"
@@ -7492,22 +8400,26 @@
 		"merge-descriptors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+			"dev": true
 		},
 		"merge2": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
-			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
+			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg==",
+			"dev": true
 		},
 		"methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+			"dev": true
 		},
 		"micromatch": {
 			"version": "3.1.10",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -7528,6 +8440,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+			"dev": true,
 			"requires": {
 				"bn.js": "^4.0.0",
 				"brorand": "^1.0.1"
@@ -7536,7 +8449,8 @@
 		"mime": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+			"dev": true
 		},
 		"mime-db": {
 			"version": "1.36.0",
@@ -7554,27 +8468,32 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
 		},
 		"mimic-response": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true
 		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+			"dev": true
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -7582,12 +8501,14 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"mississippi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
 			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+			"dev": true,
 			"requires": {
 				"concat-stream": "^1.5.0",
 				"duplexify": "^3.4.2",
@@ -7605,6 +8526,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
@@ -7614,6 +8536,7 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -7624,6 +8547,7 @@
 			"version": "0.5.1",
 			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -7631,17 +8555,20 @@
 		"mobx": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/mobx/-/mobx-5.6.0.tgz",
-			"integrity": "sha512-xrA0tBnSMANXCDjS2W/6YTasesA8mkg9o+v/Bw/OcbXaRVE6/soVwDMWIh7A6TwMDY4tYQprQJZ5WQN1TRSb3A=="
+			"integrity": "sha512-xrA0tBnSMANXCDjS2W/6YTasesA8mkg9o+v/Bw/OcbXaRVE6/soVwDMWIh7A6TwMDY4tYQprQJZ5WQN1TRSb3A==",
+			"dev": true
 		},
 		"mobx-devtools-mst": {
 			"version": "0.9.18",
 			"resolved": "https://registry.npmjs.org/mobx-devtools-mst/-/mobx-devtools-mst-0.9.18.tgz",
-			"integrity": "sha512-HlCcUuKr5aBDGUespXgvwPA9LP2T0dUyx/Ngan8SCF2ywrdB1m+Dz6QISRjUXAJM4Mk9wDyHcrljbxH2QVa0kQ=="
+			"integrity": "sha512-HlCcUuKr5aBDGUespXgvwPA9LP2T0dUyx/Ngan8SCF2ywrdB1m+Dz6QISRjUXAJM4Mk9wDyHcrljbxH2QVa0kQ==",
+			"dev": true
 		},
 		"mobx-react": {
 			"version": "5.3.6",
 			"resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-5.3.6.tgz",
 			"integrity": "sha512-u0ehjkyMllnt+SQ/G5BACxwi4VkJOqDVauA7cL8UvDi4oLO1ID9Z5c/nudTdIAmtsDDhJSxW85mrgsA2Iv/56Q==",
+			"dev": true,
 			"requires": {
 				"hoist-non-react-statics": "^3.0.0",
 				"react-lifecycles-compat": "^3.0.2"
@@ -7651,6 +8578,7 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz",
 					"integrity": "sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==",
+					"dev": true,
 					"requires": {
 						"react-is": "^16.3.2"
 					}
@@ -7660,12 +8588,14 @@
 		"mobx-state-tree": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-3.7.1.tgz",
-			"integrity": "sha512-XJHT4ldB2eoHBOqTsNLOsJHNsClSkAUwNWQm9njat28Md0ymQIpVPpcKywz9I8tbu2RoWlEm1/U4v6SeQEk/sA=="
+			"integrity": "sha512-XJHT4ldB2eoHBOqTsNLOsJHNsClSkAUwNWQm9njat28Md0ymQIpVPpcKywz9I8tbu2RoWlEm1/U4v6SeQEk/sA==",
+			"dev": true
 		},
 		"mocha": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
 			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+			"dev": true,
 			"requires": {
 				"browser-stdout": "1.3.1",
 				"commander": "2.15.1",
@@ -7683,12 +8613,14 @@
 				"commander": {
 					"version": "2.15.1",
 					"resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -7696,12 +8628,14 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -7711,17 +8645,20 @@
 		"moo": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
+			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+			"dev": true
 		},
 		"mout": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mout/-/mout-1.1.0.tgz",
-			"integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw=="
+			"integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw==",
+			"dev": true
 		},
 		"move-concurrently": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"copy-concurrently": "^1.0.0",
@@ -7734,12 +8671,14 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"multicast-dns": {
 			"version": "6.2.3",
 			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
 			"integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+			"dev": true,
 			"requires": {
 				"dns-packet": "^1.3.1",
 				"thunky": "^1.0.2"
@@ -7748,12 +8687,14 @@
 		"multicast-dns-service-types": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+			"dev": true
 		},
 		"multimatch": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+			"dev": true,
 			"requires": {
 				"array-differ": "^1.0.0",
 				"array-union": "^1.0.1",
@@ -7764,18 +8705,21 @@
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"nan": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
 			"integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+			"dev": true,
 			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -7793,12 +8737,14 @@
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"nearley": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.15.1.tgz",
 			"integrity": "sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==",
+			"dev": true,
 			"requires": {
 				"moo": "^0.4.3",
 				"nomnom": "~1.6.2",
@@ -7810,22 +8756,26 @@
 		"negotiator": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+			"dev": true
 		},
 		"neo-async": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.2.tgz",
-			"integrity": "sha512-vdqTKI9GBIYcAEbFAcpKPErKINfPF5zIuz3/niBfq8WUZjpT2tytLlFVrBgWdOtqI4uaA/Rb6No0hux39XXDuw=="
+			"integrity": "sha512-vdqTKI9GBIYcAEbFAcpKPErKINfPF5zIuz3/niBfq8WUZjpT2tytLlFVrBgWdOtqI4uaA/Rb6No0hux39XXDuw==",
+			"dev": true
 		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
 		},
 		"nise": {
 			"version": "1.4.6",
 			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
 			"integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "3.0.0",
 				"just-extend": "^3.0.0",
@@ -7837,7 +8787,8 @@
 				"lolex": {
 					"version": "2.7.5",
 					"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-					"integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q=="
+					"integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+					"dev": true
 				}
 			}
 		},
@@ -7845,6 +8796,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
 			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+			"dev": true,
 			"requires": {
 				"lower-case": "^1.1.1"
 			}
@@ -7852,12 +8804,14 @@
 		"node-dir": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.8.tgz",
-			"integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30="
+			"integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30=",
+			"dev": true
 		},
 		"node-fetch": {
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"dev": true,
 			"requires": {
 				"encoding": "^0.1.11",
 				"is-stream": "^1.0.1"
@@ -7866,12 +8820,14 @@
 		"node-forge": {
 			"version": "0.7.5",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
-			"integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
+			"integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
+			"dev": true
 		},
 		"node-libs-browser": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
 			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+			"dev": true,
 			"requires": {
 				"assert": "^1.1.1",
 				"browserify-zlib": "^0.2.0",
@@ -7901,19 +8857,22 @@
 				"process": {
 					"version": "0.11.10",
 					"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-					"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+					"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+					"dev": true
 				}
 			}
 		},
 		"node-modules-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
+			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+			"dev": true
 		},
 		"node-releases": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.3.tgz",
 			"integrity": "sha512-ZaZWMsbuDcetpHmYeKWPO6e63pSXLb50M7lJgCbcM2nC/nQC3daNifmtp5a2kp7EWwYfhuvH6zLPWkrF8IiDdw==",
+			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
 			}
@@ -7922,6 +8881,7 @@
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
 			"integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+			"dev": true,
 			"requires": {
 				"colors": "0.5.x",
 				"underscore": "~1.4.4"
@@ -7931,6 +8891,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"is-builtin-module": "^1.0.0",
@@ -7942,6 +8903,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
 			}
@@ -7950,6 +8912,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
 			"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+			"dev": true,
 			"requires": {
 				"prepend-http": "^2.0.0",
 				"query-string": "^5.0.1",
@@ -7960,6 +8923,7 @@
 					"version": "5.1.1",
 					"resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
 					"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+					"dev": true,
 					"requires": {
 						"decode-uri-component": "^0.2.0",
 						"object-assign": "^4.1.0",
@@ -7969,7 +8933,8 @@
 				"strict-uri-encode": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-					"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+					"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+					"dev": true
 				}
 			}
 		},
@@ -7977,6 +8942,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -7985,6 +8951,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
 			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+			"dev": true,
 			"requires": {
 				"boolbase": "~1.0.0"
 			}
@@ -7992,27 +8959,32 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nwsapi": {
 			"version": "2.0.9",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-			"integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ=="
+			"integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==",
+			"dev": true
 		},
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
 			"requires": {
 				"copy-descriptor": "^0.1.0",
 				"define-property": "^0.2.5",
@@ -8023,6 +8995,7 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -8031,6 +9004,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -8040,22 +9014,26 @@
 		"object-inspect": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+			"dev": true
 		},
 		"object-is": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-			"integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+			"integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+			"dev": true
 		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
 			}
@@ -8064,6 +9042,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"function-bind": "^1.1.1",
@@ -8075,6 +9054,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
 			"integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.6.1",
@@ -8086,6 +9066,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.5.1"
@@ -8095,6 +9076,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"requires": {
 				"for-own": "^0.1.4",
 				"is-extendable": "^0.1.1"
@@ -8104,6 +9086,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -8112,6 +9095,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
 			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.6.1",
@@ -8122,12 +9106,14 @@
 		"obuf": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-			"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
+			"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+			"dev": true
 		},
 		"on-finished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
 			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"dev": true,
 			"requires": {
 				"ee-first": "1.1.1"
 			}
@@ -8135,12 +9121,14 @@
 		"on-headers": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+			"dev": true
 		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -8149,6 +9137,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -8157,6 +9146,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
 			"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+			"dev": true,
 			"requires": {
 				"is-wsl": "^1.1.0"
 			}
@@ -8165,6 +9155,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
@@ -8174,6 +9165,7 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
 			"requires": {
 				"deep-is": "~0.1.3",
 				"fast-levenshtein": "~2.0.4",
@@ -8186,7 +9178,8 @@
 				"wordwrap": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
 				}
 			}
 		},
@@ -8194,6 +9187,7 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
 			"integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+			"dev": true,
 			"requires": {
 				"chalk": "^1.1.1",
 				"cli-cursor": "^1.0.2",
@@ -8205,6 +9199,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+					"dev": true,
 					"requires": {
 						"restore-cursor": "^1.0.1"
 					}
@@ -8212,12 +9207,14 @@
 				"onetime": {
 					"version": "1.1.0",
 					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+					"dev": true
 				},
 				"restore-cursor": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+					"dev": true,
 					"requires": {
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
@@ -8229,6 +9226,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
 			"integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+			"dev": true,
 			"requires": {
 				"url-parse": "^1.4.3"
 			}
@@ -8236,17 +9234,20 @@
 		"os-browserify": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+			"dev": true
 		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-locale": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"dev": true,
 			"requires": {
 				"execa": "^0.7.0",
 				"lcid": "^1.0.0",
@@ -8256,12 +9257,14 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"osenv": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.0"
@@ -8270,12 +9273,14 @@
 		"p-cancelable": {
 			"version": "0.4.1",
 			"resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-			"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+			"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
+			"dev": true
 		},
 		"p-each-series": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
 			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+			"dev": true,
 			"requires": {
 				"p-reduce": "^1.0.0"
 			}
@@ -8283,22 +9288,26 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
 		},
 		"p-is-promise": {
 			"version": "1.1.0",
 			"resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+			"dev": true
 		},
 		"p-lazy": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-lazy/-/p-lazy-1.0.0.tgz",
-			"integrity": "sha1-7FPIAvLuOsKPFmzILQsrAt4nqDU="
+			"integrity": "sha1-7FPIAvLuOsKPFmzILQsrAt4nqDU=",
+			"dev": true
 		},
 		"p-limit": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"dev": true,
 			"requires": {
 				"p-try": "^1.0.0"
 			}
@@ -8307,6 +9316,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"dev": true,
 			"requires": {
 				"p-limit": "^1.1.0"
 			}
@@ -8314,17 +9324,20 @@
 		"p-map": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+			"dev": true
 		},
 		"p-reduce": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+			"dev": true
 		},
 		"p-timeout": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
 			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+			"dev": true,
 			"requires": {
 				"p-finally": "^1.0.0"
 			}
@@ -8332,17 +9345,20 @@
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+			"dev": true
 		},
 		"pako": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+			"dev": true
 		},
 		"parallel-transform": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
 			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"dev": true,
 			"requires": {
 				"cyclist": "~0.2.2",
 				"inherits": "^2.0.3",
@@ -8353,6 +9369,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
 			"integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+			"dev": true,
 			"requires": {
 				"no-case": "^2.2.0"
 			}
@@ -8361,6 +9378,7 @@
 			"version": "5.1.1",
 			"resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
 			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+			"dev": true,
 			"requires": {
 				"asn1.js": "^4.0.0",
 				"browserify-aes": "^1.0.0",
@@ -8373,6 +9391,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"requires": {
 				"glob-base": "^0.3.0",
 				"is-dotfile": "^1.0.0",
@@ -8383,12 +9402,14 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -8399,6 +9420,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"dev": true,
 			"requires": {
 				"error-ex": "^1.2.0"
 			}
@@ -8406,12 +9428,14 @@
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+			"dev": true
 		},
 		"parse5": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
 			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -8419,52 +9443,62 @@
 		"parseurl": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+			"dev": true
 		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
 		},
 		"path-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+			"dev": true
 		},
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+			"dev": true
 		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"dev": true,
 			"requires": {
 				"isarray": "0.0.1"
 			},
@@ -8472,7 +9506,8 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
 				}
 			}
 		},
@@ -8480,6 +9515,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"dev": true,
 			"requires": {
 				"pify": "^2.0.0"
 			},
@@ -8487,19 +9523,22 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
 				}
 			}
 		},
 		"pathval": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+			"dev": true
 		},
 		"pbkdf2": {
 			"version": "3.0.17",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
 			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+			"dev": true,
 			"requires": {
 				"create-hash": "^1.1.2",
 				"create-hmac": "^1.1.4",
@@ -8511,22 +9550,26 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
 		},
 		"pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
@@ -8535,6 +9578,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
 			"integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
+			"dev": true,
 			"requires": {
 				"node-modules-regexp": "^1.0.0"
 			}
@@ -8543,6 +9587,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
 			"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
 				"load-json-file": "^4.0.0"
@@ -8552,6 +9597,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -8563,6 +9609,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -8574,6 +9621,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
 			"integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+			"dev": true,
 			"requires": {
 				"debug-log": "^1.0.0",
 				"find-root": "^1.0.0",
@@ -8584,6 +9632,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"dev": true,
 			"requires": {
 				"find-up": "^2.1.0"
 			}
@@ -8591,7 +9640,8 @@
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"dev": true
 		},
 		"pluralizers": {
 			"version": "0.1.7",
@@ -8601,12 +9651,14 @@
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"dev": true
 		},
 		"polished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/polished/-/polished-2.3.0.tgz",
 			"integrity": "sha512-G2yD9LhJy5HBuU+Im5qe70ubaJI/ZTTOIJO6GRMwJ2WSoAiPzlm8+LjAXMnm9/K0E0NumRVHvQu2HHPKQSYQjw==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.0.0"
 			}
@@ -8626,6 +9678,7 @@
 			"version": "1.0.17",
 			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.17.tgz",
 			"integrity": "sha512-syFcRIRzVI1BoEFOCaAiizwDolh1S1YXSodsVhncbhjzjZQulhczNRbqnUl9N31Q4dKGOXsNDqxC2BWBgSMqeQ==",
+			"dev": true,
 			"requires": {
 				"async": "^1.5.2",
 				"debug": "^2.2.0",
@@ -8635,42 +9688,50 @@
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
 		},
 		"postcss-value-parser": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"prepend-http": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
 		},
 		"prettier": {
 			"version": "1.14.2",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.2.tgz",
-			"integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg=="
+			"integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==",
+			"dev": true
 		},
 		"pretty-bytes": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
-			"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
+			"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
+			"dev": true
 		},
 		"pretty-error": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
 			"integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+			"dev": true,
 			"requires": {
 				"renderkid": "^2.0.1",
 				"utila": "~0.4"
@@ -8679,7 +9740,8 @@
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
@@ -8689,12 +9751,14 @@
 		"progress": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+			"dev": true
 		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dev": true,
 			"requires": {
 				"asap": "~2.0.3"
 			}
@@ -8702,12 +9766,14 @@
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+			"dev": true
 		},
 		"prop-types": {
 			"version": "15.6.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
 			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.3.1",
 				"object-assign": "^4.1.1"
@@ -8717,6 +9783,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
 			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+			"dev": true,
 			"requires": {
 				"forwarded": "~0.1.2",
 				"ipaddr.js": "1.8.0"
@@ -8725,12 +9792,14 @@
 		"prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+			"dev": true
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"psl": {
 			"version": "1.1.29",
@@ -8741,6 +9810,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
 			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"browserify-rsa": "^4.0.0",
@@ -8754,6 +9824,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
 			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -8763,6 +9834,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
 			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+			"dev": true,
 			"requires": {
 				"duplexify": "^3.6.0",
 				"inherits": "^2.0.3",
@@ -8777,7 +9849,8 @@
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
 		},
 		"query-string": {
 			"version": "6.1.0",
@@ -8791,22 +9864,26 @@
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+			"dev": true
 		},
 		"querystring-es3": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+			"dev": true
 		},
 		"querystringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
-			"integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
+			"integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
+			"dev": true
 		},
 		"raf": {
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
 			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+			"dev": true,
 			"requires": {
 				"performance-now": "^2.1.0"
 			}
@@ -8814,12 +9891,14 @@
 		"railroad-diagrams": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
+			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+			"dev": true
 		},
 		"randexp": {
 			"version": "0.4.6",
 			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
 			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+			"dev": true,
 			"requires": {
 				"discontinuous-range": "1.0.0",
 				"ret": "~0.1.10"
@@ -8829,6 +9908,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
 			"integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+			"dev": true,
 			"requires": {
 				"is-number": "^4.0.0",
 				"kind-of": "^6.0.0",
@@ -8838,7 +9918,8 @@
 				"is-number": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+					"dev": true
 				}
 			}
 		},
@@ -8846,6 +9927,7 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
 			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -8854,6 +9936,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+			"dev": true,
 			"requires": {
 				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
@@ -8862,12 +9945,14 @@
 		"range-parser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+			"dev": true
 		},
 		"raw-body": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
 			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+			"dev": true,
 			"requires": {
 				"bytes": "3.0.0",
 				"http-errors": "1.6.2",
@@ -8878,12 +9963,14 @@
 				"depd": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+					"dev": true
 				},
 				"http-errors": {
 					"version": "1.6.2",
 					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
 					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+					"dev": true,
 					"requires": {
 						"depd": "1.1.1",
 						"inherits": "2.0.3",
@@ -8894,12 +9981,14 @@
 				"iconv-lite": {
 					"version": "0.4.19",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+					"dev": true
 				},
 				"setprototypeof": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+					"dev": true
 				}
 			}
 		},
@@ -8907,6 +9996,7 @@
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-16.6.0.tgz",
 			"integrity": "sha512-zJPnx/jKtuOEXCbQ9BKaxDMxR0001/hzxXwYxG8septeyYGfsgAei6NgfbVgOhbY1WOP2o3VPs/E9HaN+9hV3Q==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -8917,12 +10007,14 @@
 		"react-desc": {
 			"version": "3.6.5",
 			"resolved": "https://registry.npmjs.org/react-desc/-/react-desc-3.6.5.tgz",
-			"integrity": "sha512-fI3JbWRQdRmQ3pBFscULdmJnKceSgK5Ug6BdFS/G/+9/6hle16sOQYEeELIu053uhhSuwK59aBex0UaeTJWnpw=="
+			"integrity": "sha512-fI3JbWRQdRmQ3pBFscULdmJnKceSgK5Ug6BdFS/G/+9/6hle16sOQYEeELIu053uhhSuwK59aBex0UaeTJWnpw==",
+			"dev": true
 		},
 		"react-dom": {
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.0.tgz",
 			"integrity": "sha512-Stm2D9dXEUUAQdvpvhvFj/DEXwC2PAL/RwEMhoN4dvvD2ikTlJegEXf97xryg88VIAU22ZAP7n842l+9BTz6+w==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -8933,17 +10025,20 @@
 		"react-is": {
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.0.tgz",
-			"integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g=="
+			"integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g==",
+			"dev": true
 		},
 		"react-lifecycles-compat": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+			"dev": true
 		},
 		"react-test-renderer": {
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.6.0.tgz",
 			"integrity": "sha512-w+Y3YT7OX1LP5KO7HCd0YR34Ol1qmISHaooPNMRYa6QzmwtcWhEGuZPr34wO8UCBIokswuhyLQUq7rjPDcEtJA==",
+			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
@@ -8954,7 +10049,8 @@
 				"react-is": {
 					"version": "16.6.0",
 					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.0.tgz",
-					"integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g=="
+					"integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g==",
+					"dev": true
 				}
 			}
 		},
@@ -8962,6 +10058,7 @@
 			"version": "8.0.3",
 			"resolved": "https://registry.npmjs.org/react-waypoint/-/react-waypoint-8.0.3.tgz",
 			"integrity": "sha512-2tfq6PU8meAOpZ+ZqyGO1YCa9n2kEhq6+UI5tOpgMUra2iJmpva9QvwReamO3eozVMxFQ495wR9pkMbLnXvI/w==",
+			"dev": true,
 			"requires": {
 				"consolidated-events": "^1.1.0 || ^2.0.0",
 				"prop-types": "^15.0.0"
@@ -8971,6 +10068,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
 			"integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
+			"dev": true,
 			"requires": {
 				"pify": "^3.0.0",
 				"safe-buffer": "^5.1.1"
@@ -8980,6 +10078,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"dev": true,
 			"requires": {
 				"load-json-file": "^2.0.0",
 				"normalize-package-data": "^2.3.2",
@@ -8990,6 +10089,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
 				"read-pkg": "^2.0.0"
@@ -9013,6 +10113,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"minimatch": "^3.0.2",
@@ -9024,6 +10125,7 @@
 			"version": "0.15.3",
 			"resolved": "https://registry.npmjs.org/recast/-/recast-0.15.3.tgz",
 			"integrity": "sha512-xqnagxQH7mL4+UpcCVMObPPdjCEE2dmfGcTwcdpyNgZOd9W0rfdLRF3+smoA+AQqMw6xK6G4021dAQK8XfPYIQ==",
+			"dev": true,
 			"requires": {
 				"ast-types": "0.11.5",
 				"esprima": "~4.0.0",
@@ -9034,12 +10136,14 @@
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -9047,6 +10151,7 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
 			"requires": {
 				"resolve": "^1.1.6"
 			}
@@ -9055,6 +10160,7 @@
 			"version": "0.30.0",
 			"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
 			"integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.0.0",
 				"change-emitter": "^0.1.2",
@@ -9067,12 +10173,14 @@
 		"regenerate": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+			"dev": true
 		},
 		"regenerate-unicode-properties": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
 			"integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0"
 			}
@@ -9080,12 +10188,14 @@
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.18.0",
 				"babel-types": "^6.19.0",
@@ -9096,6 +10206,7 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
 			"requires": {
 				"is-equal-shallow": "^0.1.3"
 			}
@@ -9104,6 +10215,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
@@ -9113,6 +10225,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"dev": true,
 			"requires": {
 				"regenerate": "^1.2.1",
 				"regjsgen": "^0.2.0",
@@ -9122,12 +10235,14 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
 			},
@@ -9135,24 +10250,28 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				}
 			}
 		},
 		"relateurl": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+			"dev": true
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
 		},
 		"renderkid": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
 			"integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
+			"dev": true,
 			"requires": {
 				"css-select": "^1.1.0",
 				"dom-converter": "~0.1",
@@ -9165,6 +10284,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
 					"integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
+					"dev": true,
 					"requires": {
 						"domelementtype": "1"
 					}
@@ -9173,6 +10293,7 @@
 					"version": "1.1.6",
 					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
 					"integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
+					"dev": true,
 					"requires": {
 						"domelementtype": "1"
 					}
@@ -9181,6 +10302,7 @@
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
 					"integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
+					"dev": true,
 					"requires": {
 						"domelementtype": "1",
 						"domhandler": "2.1",
@@ -9191,12 +10313,14 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
 				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -9207,29 +10331,34 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
 				},
 				"utila": {
 					"version": "0.3.3",
 					"resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
-					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY="
+					"integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
+					"dev": true
 				}
 			}
 		},
 		"repeat-element": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
@@ -9237,12 +10366,14 @@
 		"replace-ext": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+			"dev": true
 		},
 		"request": {
 			"version": "2.88.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -9270,6 +10401,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"dev": true,
 			"requires": {
 				"lodash": "^4.13.1"
 			}
@@ -9278,6 +10410,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
 			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
 				"stealthy-require": "^1.1.0",
@@ -9287,17 +10420,20 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
 		},
 		"require-uncached": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
 			"requires": {
 				"caller-path": "^0.1.0",
 				"resolve-from": "^1.0.0"
@@ -9306,12 +10442,14 @@
 		"requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+			"dev": true
 		},
 		"resolve": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
 			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.5"
 			}
@@ -9320,6 +10458,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"dev": true,
 			"requires": {
 				"resolve-from": "^3.0.0"
 			},
@@ -9327,7 +10466,8 @@
 				"resolve-from": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
 				}
 			}
 		},
@@ -9335,6 +10475,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
 			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+			"dev": true,
 			"requires": {
 				"expand-tilde": "^2.0.0",
 				"global-modules": "^1.0.0"
@@ -9343,17 +10484,20 @@
 		"resolve-from": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
 		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true
 		},
 		"responselike": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
 			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"dev": true,
 			"requires": {
 				"lowercase-keys": "^1.0.0"
 			}
@@ -9362,6 +10506,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"requires": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
@@ -9370,12 +10515,14 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
 		},
 		"rimraf": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.0.5"
 			}
@@ -9384,6 +10531,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
 			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"dev": true,
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
@@ -9393,6 +10541,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
 			"integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
+			"dev": true,
 			"requires": {
 				"lodash.flattendeep": "^4.4.0",
 				"nearley": "^2.7.10"
@@ -9402,6 +10551,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
 			}
@@ -9409,12 +10559,14 @@
 		"run-parallel": {
 			"version": "1.1.9",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
+			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+			"dev": true
 		},
 		"run-queue": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1"
 			}
@@ -9422,12 +10574,14 @@
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
 			"requires": {
 				"rx-lite": "*"
 			}
@@ -9436,6 +10590,7 @@
 			"version": "5.5.11",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
 			"integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
+			"dev": true,
 			"requires": {
 				"symbol-observable": "1.0.1"
 			},
@@ -9443,7 +10598,8 @@
 				"symbol-observable": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+					"dev": true
 				}
 			}
 		},
@@ -9456,6 +10612,7 @@
 			"version": "1.1.0",
 			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
 			"requires": {
 				"ret": "~0.1.10"
 			}
@@ -9463,12 +10620,14 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"saxes": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.3.tgz",
 			"integrity": "sha512-Nc5DXc5A+m3rUDtkS+vHlBWKT7mCKjJPyia7f8YMW773hsXVv2wEHQZGE0zs4+5PLwz9U5Sbl/94Cnd9vHV7Bg==",
+			"dev": true,
 			"requires": {
 				"xmlchars": "^1.3.1"
 			}
@@ -9477,6 +10636,7 @@
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.10.0.tgz",
 			"integrity": "sha512-+TSTVTCBAA3h8Anei3haDc1IRwMeDmtI/y/o3iBe3Mjl2vwYF9DtPDt929HyRmV/e7au7CLu8sc4C4W0VOs29w==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -9486,6 +10646,7 @@
 			"version": "0.4.7",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
 			"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+			"dev": true,
 			"requires": {
 				"ajv": "^6.1.0",
 				"ajv-keywords": "^3.1.0"
@@ -9495,6 +10656,7 @@
 					"version": "6.5.5",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
 					"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -9505,34 +10667,40 @@
 				"ajv-keywords": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+					"dev": true
 				},
 				"fast-deep-equal": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+					"dev": true
 				},
 				"json-schema-traverse": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+					"dev": true
 				}
 			}
 		},
 		"scoped-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
-			"integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
+			"integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=",
+			"dev": true
 		},
 		"select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
+			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+			"dev": true
 		},
 		"selfsigned": {
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
 			"integrity": "sha512-vmZenZ+8Al3NLHkWnhBQ0x6BkML1eCP2xEi3JE+f3D9wW9fipD9NNJHYtE9XJM4TsPaHGZJIamrSI6MTg1dU2Q==",
+			"dev": true,
 			"requires": {
 				"node-forge": "0.7.5"
 			}
@@ -9540,12 +10708,14 @@
 		"semver": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-			"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+			"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+			"dev": true
 		},
 		"send": {
 			"version": "0.16.2",
 			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
 			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
@@ -9565,12 +10735,14 @@
 		"serialize-javascript": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
-			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
+			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
+			"dev": true
 		},
 		"serve-index": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
 			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+			"dev": true,
 			"requires": {
 				"accepts": "~1.3.4",
 				"batch": "0.6.1",
@@ -9585,6 +10757,7 @@
 			"version": "1.13.2",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
 			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"dev": true,
 			"requires": {
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
@@ -9595,17 +10768,20 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true
 		},
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -9617,6 +10793,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -9626,17 +10803,20 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
 		},
 		"setprototypeof": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+			"dev": true
 		},
 		"sha.js": {
 			"version": "2.4.11",
 			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -9646,6 +10826,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -9653,12 +10834,14 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
 		},
 		"shelljs": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
 			"integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
@@ -9668,12 +10851,14 @@
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"sinon": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.1.1.tgz",
 			"integrity": "sha512-iYagtjLVt1vN3zZY7D8oH7dkjNJEjLjyuzy8daX5+3bbQl8gaohrheB9VfH1O3L6LKuue5WTJvFluHiuZ9y3nQ==",
+			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.2.0",
 				"@sinonjs/formatio": "^3.0.0",
@@ -9689,12 +10874,14 @@
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0"
 			}
@@ -9702,12 +10889,14 @@
 		"slide": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+			"dev": true
 		},
 		"snapdragon": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"dev": true,
 			"requires": {
 				"base": "^0.11.1",
 				"debug": "^2.2.0",
@@ -9723,6 +10912,7 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -9731,6 +10921,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -9741,6 +10932,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
 			"requires": {
 				"define-property": "^1.0.0",
 				"isobject": "^3.0.0",
@@ -9751,6 +10943,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -9759,6 +10952,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -9767,6 +10961,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -9775,6 +10970,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -9787,6 +10983,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
 			},
@@ -9795,6 +10992,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -9805,6 +11003,7 @@
 			"version": "7.1.1",
 			"resolved": "http://registry.npmjs.org/snazzy/-/snazzy-7.1.1.tgz",
 			"integrity": "sha512-gJ46s+jcwOeRhO9uEkTyzcREFZ0c5LZOgcVakLxTPIvhRIywKvbvArvMg5e8bBbpWe4InC/8eyEQOGXgJVNOfw==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.3.0",
 				"inherits": "^2.0.1",
@@ -9818,12 +11017,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -9832,6 +11033,7 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -9841,17 +11043,20 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -9860,6 +11065,7 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -9870,6 +11076,7 @@
 			"version": "0.3.19",
 			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
 			"integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+			"dev": true,
 			"requires": {
 				"faye-websocket": "^0.10.0",
 				"uuid": "^3.0.1"
@@ -9879,6 +11086,7 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
 			"integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
+			"dev": true,
 			"requires": {
 				"debug": "^2.6.6",
 				"eventsource": "0.1.6",
@@ -9892,6 +11100,7 @@
 					"version": "0.11.1",
 					"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
 					"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+					"dev": true,
 					"requires": {
 						"websocket-driver": ">=0.5.1"
 					}
@@ -9902,6 +11111,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+			"dev": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
 			}
@@ -9909,17 +11119,20 @@
 		"source-list-map": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
+			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+			"dev": true
 		},
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
 		},
 		"source-map-resolve": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"dev": true,
 			"requires": {
 				"atob": "^2.1.1",
 				"decode-uri-component": "^0.2.0",
@@ -9932,6 +11145,7 @@
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"dev": true,
 			"requires": {
 				"source-map": "^0.5.6"
 			}
@@ -9939,12 +11153,14 @@
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"dev": true
 		},
 		"spdx-correct": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -9953,12 +11169,14 @@
 		"spdx-exceptions": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
@@ -9967,12 +11185,14 @@
 		"spdx-license-ids": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+			"dev": true
 		},
 		"spdy": {
 			"version": "3.4.7",
 			"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
 			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+			"dev": true,
 			"requires": {
 				"debug": "^2.6.8",
 				"handle-thing": "^1.2.5",
@@ -9986,6 +11206,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
 			"integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
+			"dev": true,
 			"requires": {
 				"debug": "^2.6.8",
 				"detect-node": "^2.0.3",
@@ -10000,6 +11221,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
 			}
@@ -10013,6 +11235,7 @@
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
 			"integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -10029,6 +11252,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
 			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.1"
 			}
@@ -10037,6 +11261,7 @@
 			"version": "11.0.1",
 			"resolved": "http://registry.npmjs.org/standard/-/standard-11.0.1.tgz",
 			"integrity": "sha512-nu0jAcHiSc8H+gJCXeiziMVZNDYi8MuqrYJKxTgjP4xKXZMKm311boqQIzDrYI/ktosltxt2CbDjYQs9ANC8IA==",
+			"dev": true,
 			"requires": {
 				"eslint": "~4.18.0",
 				"eslint-config-standard": "11.0.0",
@@ -10053,6 +11278,7 @@
 			"version": "8.0.1",
 			"resolved": "http://registry.npmjs.org/standard-engine/-/standard-engine-8.0.1.tgz",
 			"integrity": "sha512-LA531C3+nljom/XRvdW/hGPXwmilRkaRkENhO3FAGF1Vtq/WtCXzgmnc5S6vUHHsgv534MRy02C1ikMwZXC+tw==",
+			"dev": true,
 			"requires": {
 				"deglob": "^2.1.0",
 				"get-stdin": "^6.0.0",
@@ -10063,7 +11289,8 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				}
 			}
 		},
@@ -10071,6 +11298,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/standard-json/-/standard-json-1.0.3.tgz",
 			"integrity": "sha512-lhMP+KREBcfyyMe2ObJlEjJ0lc0ItA9uny83d9ZL6ggYtB79DuaAKCxJVoiflg5EV3D2rpuWn+n4+zXjWXk0sQ==",
+			"dev": true,
 			"requires": {
 				"concat-stream": "^1.5.0"
 			}
@@ -10079,6 +11307,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
 			"requires": {
 				"define-property": "^0.2.5",
 				"object-copy": "^0.1.0"
@@ -10088,6 +11317,7 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -10097,17 +11327,20 @@
 		"statuses": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+			"dev": true
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"dev": true
 		},
 		"stream-browserify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+			"dev": true,
 			"requires": {
 				"inherits": "~2.0.1",
 				"readable-stream": "^2.0.2"
@@ -10117,6 +11350,7 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
 			"integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"stream-shift": "^1.0.0"
@@ -10126,6 +11360,7 @@
 			"version": "2.8.3",
 			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
 			"integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+			"dev": true,
 			"requires": {
 				"builtin-status-codes": "^3.0.0",
 				"inherits": "^2.0.1",
@@ -10137,7 +11372,8 @@
 		"stream-shift": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+			"dev": true
 		},
 		"strict-uri-encode": {
 			"version": "2.0.0",
@@ -10147,12 +11383,14 @@
 		"string-template": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
+			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
+			"dev": true
 		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
@@ -10161,12 +11399,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -10177,6 +11417,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
 			"integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.5.0",
@@ -10195,6 +11436,7 @@
 			"version": "3.0.1",
 			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -10202,12 +11444,14 @@
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
 		},
 		"strip-bom-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
 			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
+			"dev": true,
 			"requires": {
 				"first-chunk-stream": "^2.0.0",
 				"strip-bom": "^2.0.0"
@@ -10217,6 +11461,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -10226,17 +11471,20 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"styled-components": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.0.3.tgz",
 			"integrity": "sha512-oEZovK4xMGAMhOA9h74dCYJsp3IwUFhEvtYe4gwTy0cBZ3a17YMxBfM2oXsEoED9f+HCM5UQZW2h297n4u8hUw==",
+			"dev": true,
 			"requires": {
 				"@emotion/is-prop-valid": "^0.6.8",
 				"babel-plugin-styled-components": ">= 1",
@@ -10252,17 +11500,20 @@
 		"stylis": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.3.tgz",
-			"integrity": "sha512-TxU0aAscJghF9I3V9q601xcK3Uw1JbXvpsBGj/HULqexKOKlOEzzlIpLFRbKkCK990ccuxfXUqmPbIIo7Fq/cQ=="
+			"integrity": "sha512-TxU0aAscJghF9I3V9q601xcK3Uw1JbXvpsBGj/HULqexKOKlOEzzlIpLFRbKkCK990ccuxfXUqmPbIIo7Fq/cQ==",
+			"dev": true
 		},
 		"stylis-rule-sheet": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-			"integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
+			"integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -10270,17 +11521,20 @@
 		"symbol-observable": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+			"dev": true
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"dev": true
 		},
 		"table": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"dev": true,
 			"requires": {
 				"ajv": "^5.2.3",
 				"ajv-keywords": "^2.1.0",
@@ -10294,6 +11548,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -10302,6 +11557,7 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -10311,12 +11567,14 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -10326,12 +11584,14 @@
 		"tapable": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",
-			"integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg=="
+			"integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg==",
+			"dev": true
 		},
 		"temp": {
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
 			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "^1.0.0",
 				"rimraf": "~2.2.6"
@@ -10340,34 +11600,40 @@
 				"rimraf": {
 					"version": "2.2.8",
 					"resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-					"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+					"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+					"dev": true
 				}
 			}
 		},
 		"text-encoding": {
 			"version": "0.6.4",
 			"resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+			"dev": true
 		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"textextensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
-			"integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA=="
+			"integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA==",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"through2": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"dev": true,
 			"requires": {
 				"readable-stream": "^2.1.5",
 				"xtend": "~4.0.1"
@@ -10376,17 +11642,20 @@
 		"thunky": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
-			"integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E="
+			"integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E=",
+			"dev": true
 		},
 		"timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+			"dev": true
 		},
 		"timers-browserify": {
 			"version": "2.0.10",
 			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
 			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+			"dev": true,
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
@@ -10395,6 +11664,7 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
@@ -10402,17 +11672,20 @@
 		"to-arraybuffer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+			"dev": true
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
 		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -10421,6 +11694,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -10431,6 +11705,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
 			"requires": {
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
@@ -10442,6 +11717,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
@@ -10450,7 +11726,8 @@
 		"toposort": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
-			"integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk="
+			"integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
+			"dev": true
 		},
 		"tough-cookie": {
 			"version": "2.4.3",
@@ -10465,6 +11742,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			},
@@ -10472,29 +11750,34 @@
 				"punycode": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"dev": true
 				}
 			}
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"tslib": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+			"dev": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -10502,12 +11785,14 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
@@ -10515,12 +11800,14 @@
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"type-is": {
 			"version": "1.6.16",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
 			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"dev": true,
 			"requires": {
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.18"
@@ -10534,12 +11821,14 @@
 		"ua-parser-js": {
 			"version": "0.7.19",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
+			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==",
+			"dev": true
 		},
 		"uglify-es": {
 			"version": "3.3.9",
 			"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
 			"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+			"dev": true,
 			"requires": {
 				"commander": "~2.13.0",
 				"source-map": "~0.6.1"
@@ -10548,12 +11837,14 @@
 				"commander": {
 					"version": "2.13.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -10561,6 +11852,7 @@
 			"version": "3.4.8",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.8.tgz",
 			"integrity": "sha512-WatYTD84gP/867bELqI2F/2xC9PQBETn/L+7RGq9MQOA/7yFBNvY1UwXqvtILeE6n0ITwBXxp34M0/o70dzj6A==",
+			"dev": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -10569,7 +11861,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -10577,6 +11870,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
 			"integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
+			"dev": true,
 			"requires": {
 				"cacache": "^10.0.4",
 				"find-cache-dir": "^1.0.0",
@@ -10591,24 +11885,28 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
 		"underscore": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
+			"dev": true
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+			"dev": true
 		},
 		"unicode-match-property-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
 			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+			"dev": true,
 			"requires": {
 				"unicode-canonical-property-names-ecmascript": "^1.0.4",
 				"unicode-property-aliases-ecmascript": "^1.0.4"
@@ -10617,17 +11915,20 @@
 		"unicode-match-property-value-ecmascript": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-			"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
+			"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+			"dev": true
 		},
 		"unicode-property-aliases-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
+			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
+			"dev": true
 		},
 		"union-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
@@ -10639,6 +11940,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -10647,6 +11949,7 @@
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-extendable": "^0.1.1",
@@ -10659,12 +11962,14 @@
 		"uniq": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+			"dev": true
 		},
 		"unique-filename": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
 			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+			"dev": true,
 			"requires": {
 				"unique-slug": "^2.0.0"
 			}
@@ -10673,6 +11978,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
 			"integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
@@ -10680,17 +11986,20 @@
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+			"dev": true
 		},
 		"unquote": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
+			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+			"dev": true
 		},
 		"unset-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"dev": true,
 			"requires": {
 				"has-value": "^0.3.1",
 				"isobject": "^3.0.0"
@@ -10700,6 +12009,7 @@
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
 					"requires": {
 						"get-value": "^2.0.3",
 						"has-values": "^0.1.4",
@@ -10710,6 +12020,7 @@
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -10719,7 +12030,8 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
 				}
 			}
 		},
@@ -10727,6 +12039,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
 			"integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0"
 			}
@@ -10734,17 +12047,20 @@
 		"upath": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
+			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+			"dev": true
 		},
 		"upper-case": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+			"dev": true
 		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			},
@@ -10752,19 +12068,22 @@
 				"punycode": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"dev": true
 				}
 			}
 		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true
 		},
 		"url": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
 			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+			"dev": true,
 			"requires": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
@@ -10773,19 +12092,22 @@
 				"punycode": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+					"dev": true
 				}
 			}
 		},
 		"url-join": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
-			"integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo="
+			"integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=",
+			"dev": true
 		},
 		"url-parse": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
 			"integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+			"dev": true,
 			"requires": {
 				"querystringify": "^2.0.0",
 				"requires-port": "^1.0.0"
@@ -10795,6 +12117,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
 			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+			"dev": true,
 			"requires": {
 				"prepend-http": "^2.0.0"
 			}
@@ -10802,17 +12125,20 @@
 		"url-to-options": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+			"dev": true
 		},
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
 		},
 		"util": {
 			"version": "0.10.4",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
 			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.3"
 			}
@@ -10826,6 +12152,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"object.getownpropertydescriptors": "^2.0.3"
@@ -10834,27 +12161,32 @@
 		"utila": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
-			"integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
+			"integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
+			"dev": true
 		},
 		"utils-merge": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+			"dev": true
 		},
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"dev": true
 		},
 		"v8-compile-cache": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
-			"integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw=="
+			"integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==",
+			"dev": true
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
@@ -10863,12 +12195,14 @@
 		"vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -10879,6 +12213,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+			"dev": true,
 			"requires": {
 				"clone": "^1.0.0",
 				"clone-stats": "^0.0.1",
@@ -10889,6 +12224,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
 			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"pify": "^2.3.0",
@@ -10901,12 +12237,14 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -10917,6 +12255,7 @@
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
 			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+			"dev": true,
 			"requires": {
 				"indexof": "0.0.1"
 			}
@@ -10925,6 +12264,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"dev": true,
 			"requires": {
 				"browser-process-hrtime": "^0.1.2"
 			}
@@ -10933,6 +12273,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.0.0.tgz",
 			"integrity": "sha512-0et1+9uXYiIRAecx1D5Z1nk60+vimniGdIKl4XjeqkWi6acoHNlXMv1VR5jV+jF4ooeO08oWbYxeAJOcon1oMA==",
+			"dev": true,
 			"requires": {
 				"domexception": "^1.0.1",
 				"webidl-conversions": "^4.0.2",
@@ -10943,6 +12284,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
 			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+			"dev": true,
 			"requires": {
 				"chokidar": "^2.0.2",
 				"graceful-fs": "^4.1.2",
@@ -10953,6 +12295,7 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
 			"integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+			"dev": true,
 			"requires": {
 				"minimalistic-assert": "^1.0.0"
 			}
@@ -10961,6 +12304,7 @@
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/webassemblyjs/-/webassemblyjs-1.4.3.tgz",
 			"integrity": "sha512-4lOV1Lv6olz0PJkDGQEp82HempAn147e6BXijWDzz9g7/2nSebVP9GVg62Fz5ZAs55mxq13GA0XLyvY8XkyDjg==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/validation": "1.4.3",
@@ -10972,12 +12316,14 @@
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"dev": true
 		},
 		"webpack": {
 			"version": "4.8.3",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.8.3.tgz",
 			"integrity": "sha512-/hfAjBISycdK597lxONjKEFX7dSIU1PsYwC3XlXUXoykWBlv9QV5HnO+ql3HvrrgfBJ7WXdnjO9iGPR2aAc5sw==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/wasm-edit": "1.4.3",
@@ -11007,6 +12353,7 @@
 					"version": "6.5.5",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
 					"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -11017,17 +12364,20 @@
 				"ajv-keywords": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+					"dev": true
 				},
 				"fast-deep-equal": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+					"dev": true
 				},
 				"json-schema-traverse": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+					"dev": true
 				}
 			}
 		},
@@ -11035,6 +12385,7 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/webpack-addons/-/webpack-addons-1.1.5.tgz",
 			"integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
+			"dev": true,
 			"requires": {
 				"jscodeshift": "^0.4.0"
 			},
@@ -11042,12 +12393,14 @@
 				"ansi-styles": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.0.1"
 					}
@@ -11055,17 +12408,20 @@
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"dev": true
 				},
 				"ast-types": {
 					"version": "0.10.1",
 					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
-					"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
+					"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
+					"dev": true
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true,
 					"requires": {
 						"expand-range": "^1.8.1",
 						"preserve": "^0.2.0",
@@ -11076,6 +12432,7 @@
 					"version": "0.4.0",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "~1.0.0",
 						"has-color": "~0.1.0",
@@ -11085,17 +12442,20 @@
 				"colors": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-					"integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
+					"integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
+					"dev": true
 				},
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
 				},
 				"expand-brackets": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true,
 					"requires": {
 						"is-posix-bracket": "^0.1.0"
 					}
@@ -11104,6 +12464,7 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -11111,12 +12472,14 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -11125,6 +12488,7 @@
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.4.1.tgz",
 					"integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
+					"dev": true,
 					"requires": {
 						"async": "^1.5.0",
 						"babel-plugin-transform-flow-strip-types": "^6.8.0",
@@ -11147,6 +12511,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -11155,6 +12520,7 @@
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true,
 					"requires": {
 						"arr-diff": "^2.0.0",
 						"array-unique": "^0.2.1",
@@ -11175,6 +12541,7 @@
 					"version": "1.8.1",
 					"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
 					"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+					"dev": true,
 					"requires": {
 						"chalk": "~0.4.0",
 						"underscore": "~1.6.0"
@@ -11184,6 +12551,7 @@
 					"version": "0.12.9",
 					"resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
 					"integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
+					"dev": true,
 					"requires": {
 						"ast-types": "0.10.1",
 						"core-js": "^2.4.1",
@@ -11195,17 +12563,20 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "0.1.1",
 					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+					"dev": true
 				},
 				"underscore": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+					"dev": true
 				}
 			}
 		},
@@ -11213,6 +12584,7 @@
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.1.5.tgz",
 			"integrity": "sha512-CiWQR+1JS77rmyiO6y1q8Kt/O+e8nUUC9YfJ25JtSmzDwbqJV7vIsh3+QKRHVTbTCa0DaVh8iY1LBiagUIDB3g==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.4.1",
 				"cross-spawn": "^6.0.5",
@@ -11245,12 +12617,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -11259,6 +12633,7 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -11269,6 +12644,7 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -11280,12 +12656,14 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"inquirer": {
 					"version": "5.2.0",
 					"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
 					"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
 						"chalk": "^2.0.0",
@@ -11306,6 +12684,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -11314,6 +12693,7 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -11324,6 +12704,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.2.0.tgz",
 			"integrity": "sha512-YJLMF/96TpKXaEQwaLEo+Z4NDK8aV133ROF6xp9pe3gQoS7sxfpXh4Rv9eC+8vCvWfmDjRQaMSlRPbO+9G6jgA==",
+			"dev": true,
 			"requires": {
 				"loud-rejection": "^1.6.0",
 				"memory-fs": "~0.4.1",
@@ -11337,7 +12718,8 @@
 				"mime": {
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-					"integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+					"integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+					"dev": true
 				}
 			}
 		},
@@ -11345,6 +12727,7 @@
 			"version": "3.1.7",
 			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.7.tgz",
 			"integrity": "sha512-KagFrNHf3QKndS61cXqzkQ4gpdXo0d1LZTTplAJzNK1Ev2ZyJiu+BzerW/2dixYYfpnGzp0AcvCXpmYXIOkFOA==",
+			"dev": true,
 			"requires": {
 				"ansi-html": "0.0.7",
 				"bonjour": "^3.5.0",
@@ -11380,6 +12763,7 @@
 					"version": "6.5.3",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
 					"integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -11390,12 +12774,14 @@
 				"ajv-keywords": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+					"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+					"dev": true
 				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -11404,6 +12790,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
 					"integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+					"dev": true,
 					"requires": {
 						"xregexp": "4.0.0"
 					}
@@ -11412,6 +12799,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
 					"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+					"dev": true,
 					"requires": {
 						"globby": "^6.1.0",
 						"is-path-cwd": "^1.0.0",
@@ -11424,12 +12812,14 @@
 				"fast-deep-equal": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+					"dev": true
 				},
 				"find-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
 					}
@@ -11438,6 +12828,7 @@
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
 						"glob": "^7.0.3",
@@ -11449,24 +12840,28 @@
 						"pify": {
 							"version": "2.3.0",
 							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"json-schema-traverse": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+					"dev": true
 				},
 				"locate-path": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
@@ -11476,6 +12871,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
 					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
@@ -11484,6 +12880,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
 					"requires": {
 						"p-limit": "^2.0.0"
 					}
@@ -11491,12 +12888,14 @@
 				"p-try": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+					"dev": true
 				},
 				"schema-utils": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
 					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"dev": true,
 					"requires": {
 						"ajv": "^6.1.0",
 						"ajv-errors": "^1.0.0",
@@ -11507,6 +12906,7 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -11515,6 +12915,7 @@
 					"version": "12.0.1",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
 					"integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
+					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^2.0.0",
@@ -11534,6 +12935,7 @@
 					"version": "10.1.0",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
 					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					}
@@ -11544,6 +12946,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
 			"integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+			"dev": true,
 			"requires": {
 				"ansi-colors": "^3.0.0",
 				"uuid": "^3.3.2"
@@ -11553,6 +12956,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
 			"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+			"dev": true,
 			"requires": {
 				"source-list-map": "^2.0.0",
 				"source-map": "~0.6.1"
@@ -11561,7 +12965,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -11569,6 +12974,7 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
 			"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+			"dev": true,
 			"requires": {
 				"http-parser-js": ">=0.4.0",
 				"websocket-extensions": ">=0.1.1"
@@ -11577,12 +12983,14 @@
 		"websocket-extensions": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+			"dev": true
 		},
 		"whatwg-encoding": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
 			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
@@ -11590,17 +12998,20 @@
 		"whatwg-fetch": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+			"dev": true
 		},
 		"whatwg-mimetype": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz",
-			"integrity": "sha512-5YSO1nMd5D1hY3WzAQV3PzZL83W3YeyR1yW9PcH26Weh1t+Vzh9B6XkDh7aXm83HBZ4nSMvkjvN2H2ySWIvBgw=="
+			"integrity": "sha512-5YSO1nMd5D1hY3WzAQV3PzZL83W3YeyR1yW9PcH26Weh1t+Vzh9B6XkDh7aXm83HBZ4nSMvkjvN2H2ySWIvBgw==",
+			"dev": true
 		},
 		"whatwg-url": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
 			"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+			"dev": true,
 			"requires": {
 				"lodash.sortby": "^4.7.0",
 				"tr46": "^1.0.1",
@@ -11611,6 +13022,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -11618,17 +13030,20 @@
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
 		},
 		"wordwrap": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"dev": true
 		},
 		"worker-farm": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
 			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+			"dev": true,
 			"requires": {
 				"errno": "~0.1.7"
 			}
@@ -11637,6 +13052,7 @@
 			"version": "2.1.0",
 			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
@@ -11646,6 +13062,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -11654,6 +13071,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -11665,12 +13083,14 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
 			"requires": {
 				"mkdirp": "^0.5.1"
 			}
@@ -11679,6 +13099,7 @@
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
 			"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
@@ -11689,6 +13110,7 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.0.tgz",
 			"integrity": "sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==",
+			"dev": true,
 			"requires": {
 				"async-limiter": "~1.0.0"
 			}
@@ -11696,37 +13118,44 @@
 		"xml-name-validator": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
 		},
 		"xmlchars": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-1.3.1.tgz",
-			"integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw=="
+			"integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw==",
+			"dev": true
 		},
 		"xregexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
+			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
+			"dev": true
 		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"dev": true
 		},
 		"y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"dev": true
 		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		},
 		"yargs": {
 			"version": "11.1.0",
 			"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 			"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+			"dev": true,
 			"requires": {
 				"cliui": "^4.0.0",
 				"decamelize": "^1.1.1",
@@ -11745,7 +13174,8 @@
 				"y18n": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+					"dev": true
 				}
 			}
 		},
@@ -11753,6 +13183,7 @@
 			"version": "9.0.2",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
 			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0"
 			}
@@ -11761,6 +13192,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.3.3.tgz",
 			"integrity": "sha512-HBpXdNw8V66EwqIFt01rNhSgX33BOzgVb9CxpIvESvCI4ELeOSniB6gV6RXwrBur8kmHZCIAkYQYpib7Qxx8FQ==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.4.1",
 				"cross-spawn": "^6.0.5",
@@ -11782,12 +13214,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -11796,6 +13230,7 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -11805,12 +13240,14 @@
 				"chardet": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.5.0.tgz",
-					"integrity": "sha512-9ZTaoBaePSCFvNlNGrsyI8ZVACP2svUtq0DkM7t4K2ClAa96sqOIRjAzDTc8zXzFt1cZR46rRzLTiHFSJ+Qw0g=="
+					"integrity": "sha512-9ZTaoBaePSCFvNlNGrsyI8ZVACP2svUtq0DkM7t4K2ClAa96sqOIRjAzDTc8zXzFt1cZR46rRzLTiHFSJ+Qw0g==",
+					"dev": true
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -11823,6 +13260,7 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -11831,6 +13269,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.1.tgz",
 					"integrity": "sha512-e1neqvSt5pSwQcFnYc6yfGuJD2Q4336cdbHs5VeUO0zTkqPbrHMyw2q1r47fpfLWbvIG8H8A6YO3sck7upTV6Q==",
+					"dev": true,
 					"requires": {
 						"chardet": "^0.5.0",
 						"iconv-lite": "^0.4.22",
@@ -11841,6 +13280,7 @@
 					"version": "8.0.1",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
 					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
 						"dir-glob": "^2.0.0",
@@ -11854,12 +13294,14 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"inquirer": {
 					"version": "6.2.0",
 					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
 					"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
 						"chalk": "^2.0.0",
@@ -11880,6 +13322,7 @@
 					"version": "6.2.2",
 					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
 					"integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
+					"dev": true,
 					"requires": {
 						"tslib": "^1.9.0"
 					}
@@ -11888,6 +13331,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -11896,6 +13340,7 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -11903,7 +13348,8 @@
 				"untildify": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-					"integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
+					"integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
+					"dev": true
 				}
 			}
 		},
@@ -11911,6 +13357,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
 			"integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
+			"dev": true,
 			"requires": {
 				"async": "^2.6.0",
 				"chalk": "^2.3.0",
@@ -11943,6 +13390,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -11951,6 +13399,7 @@
 					"version": "2.6.1",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
 					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"dev": true,
 					"requires": {
 						"lodash": "^4.17.10"
 					}
@@ -11959,6 +13408,7 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -11969,6 +13419,7 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -11981,6 +13432,7 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -11988,12 +13440,14 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
 				},
 				"load-json-file": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -12004,12 +13458,14 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -12019,6 +13475,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -12027,6 +13484,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -12037,6 +13495,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -12046,6 +13505,7 @@
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}

--- a/packages/lib-auth/package.json
+++ b/packages/lib-auth/package.json
@@ -10,10 +10,12 @@
     "_check": "check-dependencies",
     "_test": "npm run _check && NODE_PATH=. NODE_ENV=test mocha",
     "build": "npm run _check && npm run _clean && webpack --config webpack.dist.js",
+    "build:dev": "export PANOPTES_ENV=staging && npm run build",
+    "build:production": "export PANOPTES_ENV=production && npm run build",
     "dev": "npm run _check && webpack-dev-server --port 3000 --config webpack.dev.js",
     "install": "lerna bootstrap --scope=@zooniverse/auth",
     "lint": "npm run _check && standard --fix | snazzy; exit 0",
-    "start": "npm run _check && PANOPTES_ENV=production npm run dev",
+    "start": "export PANOPTES_ENV=production && npm run _check && npm run dev",
     "test": "npm run _test && exit 0",
     "test:ci": "npm run _test"
   },

--- a/packages/lib-auth/src/controllers/oauth/createOAuthClient.js
+++ b/packages/lib-auth/src/controllers/oauth/createOAuthClient.js
@@ -70,11 +70,20 @@ function createOAuthClient ({
       })
   }
 
-  function destroy () {
-    store.credentials.logout()
-    ReactDOM.unmountComponentAtNode(element)
-    element.parentNode.removeChild(element)
-    element = null
+  function destroy (beforeDestroy, afterDestroy) {
+    return Promise.resolve(() => {
+        if (beforeDestroy) beforeDestroy()
+      })
+      .then(() => {
+        store.credentials.logout()
+        ReactDOM.unmountComponentAtNode(element)
+        element.parentNode.removeChild(element)
+        element = null
+      })
+      .then(() => {
+        if (afterDestroy) afterDestroy()
+      })
+
   }
 
   function getToken () {
@@ -89,17 +98,23 @@ function createOAuthClient ({
     return snapshot.active || null
   }
 
-  function logout (onLogout) {
-    return Promise.resolve(store.credentials.logout())
+  function logout (beforeLogout, afterLogout) {
+    return Promise.resolve(() => {
+        if (beforeLogout) beforeLogout()
+      })
+      .then(() => store.credentials.logout())
       .then(() => {
-        if (onLogout) onLogout()
+        if (afterLogout) afterLogout()
       })
   }
 
-  function startLogin (onStartLogin) {
-    return Promise.resolve(store.ui.openLoginPopup())
+  function startLogin (beforeStartLogin, afterStartLogin) {
+    return Promise.resolve(() => {
+        if (beforeStartLoging) beforeStartLogin()
+      })
+      .then(() => store.ui.openLoginPopup())
       .then(() => {
-        if (onStartLogin) onStartLogin()
+        if (afterStartLogin) afterStartLogin()
       })
   }
 

--- a/packages/lib-auth/src/controllers/oauth/createOAuthClient.js
+++ b/packages/lib-auth/src/controllers/oauth/createOAuthClient.js
@@ -28,7 +28,7 @@ function createOAuthClient ({
   let element = createElement()
 
   // Functions
-  function initialize() {
+  function initialize () {
     const { expiresAt, token } = store.credentials
     const { access_token, expires_in } = queryString.parse(window.location.hash)
 
@@ -89,7 +89,7 @@ function createOAuthClient ({
     return snapshot.active || null
   }
 
-  function logout(onLogout) {
+  function logout (onLogout) {
     return Promise.resolve(store.credentials.logout())
       .then(() => {
         if (onLogout) onLogout()
@@ -101,7 +101,6 @@ function createOAuthClient ({
       .then(() => {
         if (onStartLogin) onStartLogin()
       })
-
   }
 
   // Init

--- a/packages/lib-auth/src/models/oauth/CredentialsStore.spec.js
+++ b/packages/lib-auth/src/models/oauth/CredentialsStore.spec.js
@@ -53,7 +53,7 @@ describe('Model > CredentialsStore', function () {
     it('should be a function', function () {
       expect(credentialsStore.set).to.be.a('function')
     })
-    
+
     it('should set the expiresAt and token properties', function () {
       credentialsStore.set(CREDENTIALS)
       expect(credentialsStore.expiresAt).to.equal(CREDENTIALS.expiresAt)
@@ -131,7 +131,6 @@ describe('Model > CredentialsStore', function () {
     afterEach(function () {
       credentialsStore.reset() // Make sure timeouts and localStorage are cleared
     })
-
 
     it('should be a function', function () {
       expect(credentialsStore.logout).to.be.a('function')

--- a/packages/lib-auth/src/models/oauth/UserResource.js
+++ b/packages/lib-auth/src/models/oauth/UserResource.js
@@ -2,31 +2,31 @@ import { types } from 'mobx-state-tree'
 
 const UserResource = types
   .model('UserResource', {
-    admin: types.boolean,
+    admin: types.maybeNull(types.boolean),
     avatar_src: types.maybeNull(types.string),
-    banned: types.boolean,
-    beta_email_communication: types.boolean,
+    banned: types.maybeNull(types.boolean),
+    beta_email_communication: types.maybeNull(types.boolean),
     created_at: types.string,
-    credited_name: types.string,
-    display_name: types.string,
+    credited_name: types.maybeNull(types.string),
+    display_name: types.maybeNull(types.string),
     email: types.string,
-    global_email_communication: types.boolean,
+    global_email_communication: types.maybeNull(types.boolean),
     href: types.string,
     id: types.identifier,
-    intervention_notifications: types.boolean,
+    intervention_notifications: types.maybeNull(types.boolean),
     languages: types.array(types.string),
     login: types.string,
-    login_prompt: types.boolean,
-    private_profile: types.boolean,
-    project_email_communication: types.boolean,
+    login_prompt: types.maybeNull(types.boolean),
+    private_profile: types.maybeNull(types.boolean),
+    project_email_communication: types.maybeNull(types.boolean),
     subject_limit: types.number,
     type: types.literal('users'),
     updated_at: types.string,
-    upload_whitelist: types.boolean,
+    upload_whitelist: types.maybeNull(types.boolean),
     uploaded_subjects_count: types.number,
-    ux_testing_email_communication: types.boolean,
-    valid_email: types.boolean,
-    zooniverse_id: types.string
+    ux_testing_email_communication: types.maybeNull(types.boolean),
+    valid_email: types.maybeNull(types.boolean),
+    zooniverse_id: types.maybeNull(types.string)
   })
 
 export default UserResource

--- a/packages/lib-auth/src/models/oauth/UserStore.js
+++ b/packages/lib-auth/src/models/oauth/UserStore.js
@@ -1,5 +1,4 @@
-import { autorun } from 'mobx'
-import { addDisposer, flow, getRoot, types } from 'mobx-state-tree'
+import { flow, getRoot, types } from 'mobx-state-tree'
 import asyncStates from '@zooniverse/async-states'
 import { panoptes } from '@zooniverse/panoptes-js'
 import UserResource from './UserResource'
@@ -13,23 +12,6 @@ const UserStore = types
   })
 
   .actions(self => {
-    function afterAttach () {
-      createCredentialsObserver()
-    }
-
-    function createCredentialsObserver () {
-      const credentialsDisposer = autorun(() => {
-        const { token } = getRoot(self).credentials
-        if (token) {
-          self.reset()
-          self.fetchResource(token)
-        }
-
-        self.reset()
-      })
-      addDisposer(self, credentialsDisposer)
-    }
-
     function * fetchResource (token) {
       console.log('Getting user')
 
@@ -43,6 +25,7 @@ const UserStore = types
           if (user) {
             self.setUser(user)
             self.loadingState = asyncStates.success
+            return user
           }
           console.log('Got user', user.display_name, user.id)
         } catch (error) {
@@ -67,7 +50,6 @@ const UserStore = types
     }
 
     return {
-      afterAttach,
       fetchResource: flow(fetchResource),
       reset,
       setUser

--- a/packages/lib-auth/src/models/oauth/UserStore.js
+++ b/packages/lib-auth/src/models/oauth/UserStore.js
@@ -1,6 +1,7 @@
 import { flow, getRoot, types } from 'mobx-state-tree'
 import asyncStates from '@zooniverse/async-states'
 import { panoptes } from '@zooniverse/panoptes-js'
+
 import UserResource from './UserResource'
 
 const UserStore = types
@@ -31,8 +32,7 @@ const UserStore = types
         } catch (error) {
           console.error('Could not get user:', error)
           console.log('Resetting auth store and localStorage')
-          const credentials = getRoot(self).credentials
-          credentials.reset()
+          getRoot(self).credentials.reset()
           self.loadingState = asyncStates.error
         }
       }

--- a/packages/lib-auth/webpack.dev.js
+++ b/packages/lib-auth/webpack.dev.js
@@ -5,7 +5,7 @@ const webpack = require('webpack')
 const EnvironmentWebpackPlugin = new webpack.EnvironmentPlugin({
   DEBUG: false,
   NODE_ENV: 'development',
-  PANOPTES_ENV: 'staging'
+  PANOPTES_ENV: process.env.PANOPTES_ENV || 'staging'
 })
 
 const HtmlWebpackPluginConfig = new HtmlWebpackPlugin({

--- a/packages/lib-auth/webpack.dist.js
+++ b/packages/lib-auth/webpack.dist.js
@@ -4,7 +4,7 @@ const webpack = require('webpack')
 const EnvironmentWebpackPlugin = new webpack.EnvironmentPlugin({
   DEBUG: false,
   NODE_ENV: 'production',
-  PANOPTES_ENV: 'production'
+  PANOPTES_ENV: process.env.PANOPTES_ENV || 'production'
 })
 
 // TODO: get optimization config working


### PR DESCRIPTION
Package: lib-auth

Closes #267

Describe your changes:
This is a continued refactor on the auth lib. This PR includes the following changes:
- Use the `PANOPTES_ENV` environmental variable with the webpack builds if defined otherwise use a default avlue. Add a npm script to build using staging under `build:dev`. Use this script when developing against staging.
- Add the `initialize` function to the public API. This will determine whether to load stored credentials or to grab them from the url and then fetch and return the user. If there are no credentials, just return a promise with null value. I tried to be more clever and use some kind onAction or onSnapshot MST method, but this was really the wrong way to go and I couldn't get it to work quite right with waiting for the user resource fetch as well as returning the user, so I refactored to explicitly call the async action to fetch the user rather than use the observer in the stores.
- Return promises for the `startLogin` and `logout` functions and add callback support.

I'd like to update the docs and write tests for the controller in a separate PR if that's alright.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

