### PR TITLE
Bootstrap script, new component generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,19 @@ This monorepo is managed with [Lerna](https://github.com/lerna/lerna).
 
 Lerna allows us to maintain package modularity for javascript projects that have interdependency. Organizationally, it allows us to track issues, pull requests, and progress for all related packages in one place.
 
-## How to get started
+## Getting started
 
-Installing dependencies for a particular package:
-
-```
-npm install -g lerna
-cd packages/whatever
-lerna bootstrap
+```sh
+git clone git@github.com:zooniverse/front-end-monorepo.git
+cd front-end-monorepo
+./bin/bootstrap.sh
 ```
 
-If you want to contribute a new package and want to use a package in the monorepo, use `lerna add package-name` in the new package folder to get that package added to the `package.json`
+The `bootstrap.sh` script will install the top-level dependencies, build any packages used as dependencies, and finally bootstrap the remaining packages.
 
 ## Helpful Guides
 
+- [Lerna docs](https://github.com/lerna/lerna)
 - [Troubleshooting guide](docs/troubleshooting-guide.md) for developers encountering issues installing or running the Front-End Monorepo.
 
 ## Packages

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -10,6 +10,12 @@ LERNA=$ROOT_DIR/node_modules/.bin/lerna
 printf 'Installing root dependencies...'
 (cd $ROOT_DIR && npm install)
 
+printf 'Bootstrapping `lib-grommet-theme`...'
+$LERNA bootstrap --scope="@zooniverse/grommet-theme"
+printf '\n'
+$LERNA exec --scope="@zooniverse/grommet-theme" -- npm run build
+printf '\n'
+
 printf 'Bootstrapping `lib-react-components`...'
 $LERNA bootstrap --scope="@zooniverse/react-components"
 printf '\n'

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Installs top level dependencies, installs package dependencies for
+# `lib-react-components` and builds the library, then bootstraps the remaining
+# packages.
+
+ROOT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && cd .. && pwd)"
+LERNA=$ROOT_DIR/node_modules/.bin/lerna
+
+printf 'Installing root dependencies...'
+(cd $ROOT_DIR && npm install)
+
+printf 'Bootstrapping `lib-react-components`...'
+$LERNA bootstrap --scope="@zooniverse/react-components"
+printf '\n'
+
+printf 'Building `lib-react-components`...'
+$LERNA exec --scope="@zooniverse/react-components" -- npm run build
+printf '\n'
+
+printf 'Bootstrapping remaining packages...'
+$LERNA bootstrap

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -13,9 +13,13 @@ printf 'Installing root dependencies...'
 printf 'Bootstrapping `lib-react-components`...'
 $LERNA bootstrap --scope="@zooniverse/react-components"
 printf '\n'
-
-printf 'Building `lib-react-components`...'
 $LERNA exec --scope="@zooniverse/react-components" -- npm run build
+printf '\n'
+
+printf 'Bootstrapping `lib-auth`...'
+$LERNA bootstrap --scope="@zooniverse/auth"
+printf '\n'
+$LERNA exec --scope="@zooniverse/auth" -- npm run build
 printf '\n'
 
 printf 'Bootstrapping remaining packages...'

--- a/plop/generators/component.js
+++ b/plop/generators/component.js
@@ -20,11 +20,12 @@ module.exports = function (plop) {
 
       const data = {
         component: render('{{ properCase name }}', answers),
-        container: render('{{ properCase name }}Container', answers),
         shouldCreateContainer: answers.shouldCreateContainer,
       }
       data.path = render('{{ cwd }}/{{ component }}', data)
-      data.entryPoint = data.shouldCreateContainer ? data.container : data.component
+      data.entryPoint = data.shouldCreateContainer
+        ? `${data.component}Container`
+        : data.component
 
       let actions = [
         {
@@ -41,7 +42,7 @@ module.exports = function (plop) {
         },
         {
           type: 'add',
-          templateFile: 'plop/templates/component/Test.js.hbs',
+          templateFile: 'plop/templates/component/Component.spec.js.hbs',
           path: render('{{ path }}/{{ component }}.spec.js', data),
           data
         },
@@ -58,13 +59,13 @@ module.exports = function (plop) {
           {
             type: 'add',
             templateFile: 'plop/templates/component/Container.js.hbs',
-            path: render('{{ path }}/{{ container }}.js', data),
+            path: render('{{ path }}/{{ component }}Container.js', data),
             data
           },
           {
             type: 'add',
-            templateFile: 'plop/templates/component/Test.js.hbs',
-            path: render('{{ path }}/{{ container }}.spec.js', data),
+            templateFile: 'plop/templates/component/Container.spec.js.hbs',
+            path: render('{{ path }}/{{ component }}Container.spec.js', data),
             data
           }
         )

--- a/plop/generators/component.js
+++ b/plop/generators/component.js
@@ -13,6 +13,12 @@ module.exports = function (plop) {
         name: 'shouldCreateContainer',
         message: 'Create a container?'
       },
+      {
+        type: 'confirm',
+        name: 'shouldUseMST',
+        message: 'Connect the container to `mobx-state-tree`?',
+        when: (answers) => answers.shouldCreateContainer
+      }
     ],
 
     actions: function (answers) {
@@ -22,7 +28,9 @@ module.exports = function (plop) {
         component: render('{{ properCase name }}', answers),
         shouldCreateContainer: answers.shouldCreateContainer,
       }
+
       data.path = render('{{ cwd }}/{{ component }}', data)
+
       data.entryPoint = data.shouldCreateContainer
         ? `${data.component}Container`
         : data.component
@@ -54,7 +62,7 @@ module.exports = function (plop) {
         }
       ]
 
-      if (answers.shouldCreateContainer) {
+      if (answers.shouldCreateContainer && !answers.shouldUseMST) {
         actions.push(
           {
             type: 'add',
@@ -65,6 +73,23 @@ module.exports = function (plop) {
           {
             type: 'add',
             templateFile: 'plop/templates/component/Container.spec.js.hbs',
+            path: render('{{ path }}/{{ component }}Container.spec.js', data),
+            data
+          }
+        )
+      }
+
+      if (answers.shouldCreateContainer && answers.shouldUseMST) {
+        actions.push(
+          {
+            type: 'add',
+            templateFile: 'plop/templates/component/MSTContainer.js.hbs',
+            path: render('{{ path }}/{{ component }}Container.js', data),
+            data
+          },
+          {
+            type: 'add',
+            templateFile: 'plop/templates/component/MSTContainer.spec.js.hbs',
             path: render('{{ path }}/{{ component }}Container.spec.js', data),
             data
           }

--- a/plop/templates/component/Component.spec.js.hbs
+++ b/plop/templates/component/Component.spec.js.hbs
@@ -1,9 +1,14 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+
 import {{ properCase name }} from './{{ properCase name }}'
 
+let wrapper
+
 describe('Component > {{ properCase name }}', function () {
-  it('should render without crashing', function () {
-    shallow(<{{ properCase name }} />)
+  before(function () {
+    wrapper = shallow(<{{ properCase name }} />)
   })
+
+  it('should render without crashing', function () {})
 })

--- a/plop/templates/component/Container.spec.js.hbs
+++ b/plop/templates/component/Container.spec.js.hbs
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import {{ properCase name }}Container from './{{ properCase name }}Container'
+import {{ properCase name }} from './{{ properCase name }}'
+
+let wrapper
+
+describe('Component > {{ properCase name }}Container', function () {
+  before(function () {
+    wrapper = shallow(<{{ properCase name }}Container />)
+  })
+
+  it('should render without crashing', function () {})
+
+  it('should render the `{{ properCase name }}` component', function () {
+    expect(wrapper.find({{ properCase name }})).to.have.lengthOf(1)
+  })
+})

--- a/plop/templates/component/MSTContainer.js.hbs
+++ b/plop/templates/component/MSTContainer.js.hbs
@@ -1,0 +1,23 @@
+import { inject, observer } from 'mobx-react'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+import {{ properCase name }} from './{{ properCase name }}'
+
+@inject('store')
+@observer
+class {{ properCase name }}Container extends Component {
+  render () {
+    return (
+      <{{ properCase name }} />
+    )
+  }
+}
+
+{{ properCase name }}Container.propTypes = {
+}
+
+{{ properCase name }}Container.defaultProps = {
+}
+
+export default {{ properCase name }}Container

--- a/plop/templates/component/MSTContainer.spec.js.hbs
+++ b/plop/templates/component/MSTContainer.spec.js.hbs
@@ -9,7 +9,7 @@ let componentWrapper
 
 describe('Component > {{ properCase name }}Container', function () {
   before(function () {
-    wrapper = shallow(<{{ properCase name }}Container />)
+    wrapper = shallow(<{{ properCase name }}Container.wrappedComponent />)
     componentWrapper = wrapper.find({{ properCase name }})
   })
 


### PR DESCRIPTION
Package: all

Closes #269.

Adds a bootstrap script to help get things up and running more smoothly, and updates the `plop` generators to correctly create containers and create MST-connected containers.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

