### PR TITLE
Clear user project preferences on logout

### DIFF
--- a/packages/lib-auth/src/controllers/oauth/createOAuthClient.js
+++ b/packages/lib-auth/src/controllers/oauth/createOAuthClient.js
@@ -94,8 +94,7 @@ function createOAuthClient ({
   }
 
   function getUser () {
-    const snapshot = getSnapshot(store.user)
-    return snapshot.active || null
+    return (store.user.active) ? getSnapshot(store.user.active) : null
   }
 
   function logout (beforeLogout, afterLogout) {
@@ -103,6 +102,7 @@ function createOAuthClient ({
         if (beforeLogout) beforeLogout()
       })
       .then(() => store.credentials.logout())
+      .then(getUser())
       .then(() => {
         if (afterLogout) afterLogout()
       })

--- a/packages/lib-auth/src/models/oauth/UserStore.js
+++ b/packages/lib-auth/src/models/oauth/UserStore.js
@@ -26,9 +26,9 @@ const UserStore = types
           if (user) {
             self.setUser(user)
             self.loadingState = asyncStates.success
+            console.log('Got user', user.display_name, user.id)
             return user
           }
-          console.log('Got user', user.display_name, user.id)
         } catch (error) {
           console.error('Could not get user:', error)
           console.log('Resetting auth store and localStorage')

--- a/packages/lib-classifier/dev/components/App/App.js
+++ b/packages/lib-classifier/dev/components/App/App.js
@@ -85,8 +85,8 @@ class App extends React.Component {
 
   logout() {
     this.authClient.logout()
-      .then(() => {
-        this.setState({ user: null })
+      .then((user) => {
+        this.setState({ user })
       })
   }
 

--- a/packages/lib-classifier/dev/components/App/App.js
+++ b/packages/lib-classifier/dev/components/App/App.js
@@ -29,9 +29,9 @@ class App extends React.Component {
     })
 
     this.state = {
-      authenticated: false,
       loading: false,
-      project: null
+      project: null,
+      user: null
     }
   }
 
@@ -41,17 +41,12 @@ class App extends React.Component {
   }
 
   initAuthorization() {
-    const { access_token, expires_in } = queryString.parse(window.location.hash)
-    if (access_token && expires_in) {
-      this.setState({ loading: true })
-      return this.authClient.completeLogin()
-        .then(() => {
-          this.setState({ authenticated: !!this.authClient.getUser(), loading: false })
+    this.setState({ loading: true })
+      return this.authClient.initialize()
+        .then((user) => {
+          this.setState({ loading: false, user })
           history.replaceState(null, document.title, location.pathname + location.search)
         })
-    }
-
-    return Promise.resolve(null)
   }
 
   getBearerToken() {
@@ -90,9 +85,9 @@ class App extends React.Component {
 
   logout() {
     this.authClient.logout()
-
-    // We trigger a forced update to re-render the Auth status content
-    this.setState({ authenticated: false })
+      .then(() => {
+        this.setState({ user: null })
+      })
   }
 
   render() {
@@ -105,13 +100,17 @@ class App extends React.Component {
     return (
       <Grommet theme={theme}>
         <Box tag='header' pad='medium' align='end'>
-          {this.state.authenticated
+          {this.state.user
             ? <Button onClick={this.logout.bind(this)} label='Logout' />
             : <Button onClick={this.login.bind(this)} label='Login' />
           }
         </Box>
         <Box tag='section'>
-          <Classifier authClient={this.authClient} project={this.state.project} />
+          <Classifier 
+            authClient={this.authClient}
+            project={this.state.project}
+            user={this.state.user}
+          />
         </Box>
       </Grommet>
 

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -36,10 +36,12 @@ class Classifier extends React.Component {
   }
 
   componentDidUpdate (prevProps) {
-    const { project } = this.props
+    const { project, user } = this.props
     if (project.id !== prevProps.project.id) {
       this.setProject(project)
     }
+
+    if (!user) this.classifierStore.userProjectPreferences.reset()
   }
 
   setProject (project) {

--- a/packages/lib-classifier/src/store/utils/getBearerToken.js
+++ b/packages/lib-classifier/src/store/utils/getBearerToken.js
@@ -1,0 +1,6 @@
+export default function getBearerToken (authClient) {
+  const authToken = authClient.getToken() || {}
+  if (authToken && authToken.token) return `Bearer ${authToken.token}` 
+
+  return ''
+}

--- a/packages/lib-classifier/src/store/utils/index.js
+++ b/packages/lib-classifier/src/store/utils/index.js
@@ -1,3 +1,4 @@
 export { default as ClassificationQueue } from './ClassificationQueue'
 export { default as convertMapToArray } from './convertMapToArray'
 export { default as sessionUtils } from './session'
+export { default as getBearerToken } from './getBearerToken'


### PR DESCRIPTION
Package: lib-classifier, lib-auth

Closes #288

Describe your changes:
Refactors the use of the auth lib by the classifier based on the latest refactor. Classifier expects a user prop and when it's falsey, then UPP is cleared. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

