### PR TITLE
Use pluralization instead of ternary expression

### DIFF
--- a/packages/lib-react-components/src/ZooHeader/components/SignedInUserNavigation/SignedInUserNavigation.js
+++ b/packages/lib-react-components/src/ZooHeader/components/SignedInUserNavigation/SignedInUserNavigation.js
@@ -33,14 +33,14 @@ export default function SignedInUserNavigation (props) {
     user
   } = props
 
-  const notificationLabelString = (unreadNotifications)
-    ? `${counterpart('SignedInUserNavigation.navListLabels.notifications')} (${unreadNotifications})`
-    : counterpart('SignedInUserNavigation.navListLabels.notifications')
+  const notificationLabelString = counterpart('SignedInUserNavigation.navListLabels.notifications', {
+    count: unreadNotifications
+  })
 
-  const messagesLabelString = (unreadMessages)
-    ? `${counterpart('SignedInUserNavigation.navListLabels.messages')} (${unreadMessages})`
-    : counterpart('SignedInUserNavigation.navListLabels.messages')
-  
+  const messagesLabelString = counterpart('SignedInUserNavigation.navListLabels.messages', {
+    count: unreadMessages
+  })
+
   const notificationLabel = (isNarrow)
     ? <FontAwesomeIcon icon={(unreadNotifications) ? fasBell : farBell} />
     : notificationLabelString

--- a/packages/lib-react-components/src/ZooHeader/components/SignedInUserNavigation/locales/en.json
+++ b/packages/lib-react-components/src/ZooHeader/components/SignedInUserNavigation/locales/en.json
@@ -1,8 +1,16 @@
 {
   "SignedInUserNavigation": {
     "navListLabels": {
-      "messages": "Messages",
-      "notifications": "Notifications"
+      "messages": {
+        "zero": "Messages",
+        "one": "Messages (%(count)s)",
+        "other": "Messages (%(count)s)"
+      },
+      "notifications": {
+        "zero": "Notifications",
+        "one": "Notifications (%(count)s)",
+        "other": "Notifications (%(count)s)"
+      }
     }
   }
 }


### PR DESCRIPTION
Package: lib-classifier

Removes an unnecessary ternary in favour of using counterpart's pluralization method.

Thanks to @eatyourgreens for the tip

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

