### PR TITLE
Remove the `marginRight` prop and let Grommet use its own `gap` prop …

### DIFF
--- a/packages/lib-react-components/src/ZooHeader/components/MainNavList/MainNavList.js
+++ b/packages/lib-react-components/src/ZooHeader/components/MainNavList/MainNavList.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import NavListItem from '../NavListItem'
+import { Box } from 'grommet'
 
 export default function MainNavList (props) {
   const {
@@ -15,7 +16,7 @@ export default function MainNavList (props) {
   if (isNarrow) return null
 
   return (
-    <React.Fragment>
+    <Box direction='row' gap='small'>
       {mainHeaderNavListURLs.map((url, i) => (
         <NavListItem
           key={url}
@@ -28,7 +29,7 @@ export default function MainNavList (props) {
           label={adminNavLinkLabel}
           url={adminNavLinkURL}
         />}
-    </React.Fragment>
+    </Box>
   )
 }
 

--- a/packages/lib-react-components/src/ZooHeader/components/NavListItem/NavListItem.js
+++ b/packages/lib-react-components/src/ZooHeader/components/NavListItem/NavListItem.js
@@ -9,8 +9,6 @@ import SpacedText from '../../../SpacedText'
 export const StyledNavListItem = styled(Anchor)`
   border-bottom: 2px solid transparent;
   color: ${props => props.color};
-  display: inline-block;
-  margin-right: ${props => props.marginRight};
   text-decoration: none !important;
   white-space: nowrap;
 
@@ -23,9 +21,9 @@ export const StyledNavListItem = styled(Anchor)`
   }
 `
 
-export default function NavListItem ({ color, label, marginRight, url }) {
+export default function NavListItem ({ color, label, url }) {
   return (
-    <StyledNavListItem color={color} href={url} marginRight={marginRight} >
+    <StyledNavListItem color={color} href={url} >
       <SpacedText
         size='xsmall'
         weight='bold'
@@ -37,13 +35,11 @@ export default function NavListItem ({ color, label, marginRight, url }) {
 }
 
 NavListItem.defaultProps = {
-  color: '#B2B2B2',
-  marginRight: '1.5em'
+  color: '#B2B2B2'
 }
 
 NavListItem.propTypes = {
   color: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
-  marginRight: PropTypes.string,
   url: PropTypes.string.isRequired
 }

--- a/packages/lib-react-components/src/ZooHeader/components/SignedInUserNavigation/SignedInUserNavigation.js
+++ b/packages/lib-react-components/src/ZooHeader/components/SignedInUserNavigation/SignedInUserNavigation.js
@@ -54,6 +54,7 @@ export default function SignedInUserNavigation (props) {
       <Box
         align='center'
         direction='row'
+        gap='small'
         tag='nav'
       >
         <NavListItem
@@ -65,7 +66,6 @@ export default function SignedInUserNavigation (props) {
         <NavListItem
           color={unreadMessages ? zooTheme.global.colors.lightTeal : '#B2B2B2'}
           label={messagesLabel}
-          marginRight='0.75em'
           unread={unreadMessages}
           url={`${host}/inbox`}
         />


### PR DESCRIPTION
Package: lib-react-components

Removes the `marginRight` prop used in the ZooHeader, and uses the Grommet `gap` prop instead.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

