### PR TITLE
[WIP] Classifier - TESS Light Curve Viewer - add "graphRanges" Workflow Task type

### DIFF
--- a/packages/lib-classifier/src/store/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.js
@@ -2,7 +2,7 @@ import { autorun } from 'mobx'
 import { addDisposer, getRoot, onAction, types } from 'mobx-state-tree'
 
 import Step from './Step'
-import { DrawingTask, MultipleChoiceTask, SingleChoiceTask } from './tasks'
+import { DrawingTask, GraphRangesTask, MultipleChoiceTask, SingleChoiceTask } from './tasks'
 
 const WorkflowStepStore = types
   .model('WorkflowStepStore', {
@@ -12,7 +12,8 @@ const WorkflowStepStore = types
       if (snapshot.type === 'drawing') return DrawingTask
       if (snapshot.type === 'multiple') return MultipleChoiceTask
       if (snapshot.type === 'single') return SingleChoiceTask
-    }}, DrawingTask, MultipleChoiceTask, SingleChoiceTask))
+      if (snapshot.type === 'graphRanges') return GraphRangesTask
+    }}, DrawingTask, GraphRangesTask, MultipleChoiceTask, SingleChoiceTask,))
   })
   .views(self => ({
     get activeStepTasks () {

--- a/packages/lib-classifier/src/store/tasks/GraphRangesTask.js
+++ b/packages/lib-classifier/src/store/tasks/GraphRangesTask.js
@@ -1,0 +1,13 @@
+import { types } from 'mobx-state-tree'
+import Task from './Task'
+
+const GraphRanges = types.model('GraphRanges', {
+  help: types.optional(types.string, ''),
+  instruction: types.string,
+  required: types.maybe(types.boolean), // Should this be an optional type with the default to true?
+  type: types.literal('graphRanges')
+})
+
+const GraphRangesTask = types.compose('GraphRangesTask', Task, GraphRanges)
+
+export default GraphRangesTask

--- a/packages/lib-classifier/src/store/tasks/index.js
+++ b/packages/lib-classifier/src/store/tasks/index.js
@@ -1,4 +1,5 @@
 export { default as DrawingTask } from './DrawingTask'
+export { default as GraphRangesTask } from './GraphRangesTask'
 export { default as MultipleChoiceTask } from './MultipleChoiceTask'
 export { default as SingleChoiceTask } from './SingleChoiceTask'
 export { default as Task } from './Task'


### PR DESCRIPTION
## PR Overview
Package: `lib-classifier`
Requires #279

The goal of this PR is to add a new Workflow Task type called `"graphRanges"` (tm) (feel free to argue about this name) which is used to denote a selection of "ranges" (x-positions, and widths) of interest on a graph.
- [ ] The MobX stores should recognise a new Task called `"graphRanges"`
- [ ] The LightCurveViewer should only allow for annotations to be added/edited/removed when the active current Task is a "graphRanges" task, AND the user is in Annotation mode.
- [ ] The Task Panel on the Classifier should ideally display the instructions of the Graph Ranges Task when said task is active.

In the `workflow` resource, the `"graphRanges"` task would look something like...
```
workflow.tasks =
{
  "T1": {
    "help": "",
    "type": "graphRanges",
    "required":false,
    "instruction":"Mark a transition."
  }
}
```
(Feel free to comment on this structure; I just did a straight rip of the `"text"` annotation task. I'm aware that there's some discussion on standardising how these Tasks should be structured, e.g. should it be 'instruction' or 'question'?)

To be clear, for a Light Curve-type project to work,
- the workflow config must specifically state that it needs to use the TESS Light Curve Viewer as its Subject Viewer. (otherwise, you can't see the light curve)
- One of the workflow's Tasks must be a '"graphRanges"' task (otherwise, you can't place annotations on the light curve)

Note that those two items must be set manually via direct API calls or the Panoptes CLI, not via the project builder. In fact, any workflow that has the "graphRanges" task won't display properly on the PFE Project Builder.

### Status
~~WIP~~
Replaced by #352
