### PR TITLE
Add support for jsonb default for steps

### DIFF
--- a/packages/lib-classifier/src/store/Workflow.js
+++ b/packages/lib-classifier/src/store/Workflow.js
@@ -1,14 +1,16 @@
 import { types } from 'mobx-state-tree'
 import Resource from './Resource'
 
+// The db type for steps is jsonb which is being serialized as an empty object when not defined.
+// Steps will be stored as an array of pairs to preserve order. 
 const Workflow = types
   .model('Workflow', {
     configuration: types.frozen({}),
     display_name: types.string,
     first_task: types.maybe(types.string),
-    steps: types.array(types.array(
+    steps: types.union(types.frozen({}), types.array(types.array(
       types.union(types.string, types.frozen())
-    )),
+    ))),
     tasks: types.maybe(types.frozen()),
     version: types.string
   })


### PR DESCRIPTION
Package: lib-classifier

zooniverse/Panoptes#2963 merged which added the steps attribute. It is defaulted to an empty object, but the db type is jsonb, so we should be able to store an array of pairs when a workflow's steps get defined. This is updating the Workflow model so that the classifier loads. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

