### PR TITLE
Add specific resolution for `styled-components`

### DIFF
--- a/packages/app-project/next.config.js
+++ b/packages/app-project/next.config.js
@@ -1,5 +1,15 @@
+const path = require('path')
+
 module.exports = {
   // Disable file-system routing
   // https://github.com/zeit/next.js#disabling-file-system-routing
-  useFileSystemPublicRoutes: false
+  useFileSystemPublicRoutes: false,
+
+  webpack: (config) => {
+    const modifiedConfig = Object.assign({}, config)
+
+    modifiedConfig.resolve.alias['styled-components'] = path.resolve('.', 'node_modules', 'styled-components')
+
+    return modifiedConfig
+  }
 }


### PR DESCRIPTION
Package: app-project

Modifies webpack config to specify resolution for `styled-components`, fixing the duplicate declaration warning.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

