### PR TITLE
Classifier - TESS Light Curve Viewer - add "graph2dRangeX" Workflow Task type

### DIFF
--- a/packages/lib-classifier/src/store/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.js
@@ -2,7 +2,7 @@ import { autorun } from 'mobx'
 import { addDisposer, getRoot, onAction, types } from 'mobx-state-tree'
 
 import Step from './Step'
-import { DrawingTask, MultipleChoiceTask, SingleChoiceTask } from './tasks'
+import { DrawingTask, Graph2dRangeXTask, MultipleChoiceTask, SingleChoiceTask } from './tasks'
 
 const WorkflowStepStore = types
   .model('WorkflowStepStore', {
@@ -12,7 +12,8 @@ const WorkflowStepStore = types
       if (snapshot.type === 'drawing') return DrawingTask
       if (snapshot.type === 'multiple') return MultipleChoiceTask
       if (snapshot.type === 'single') return SingleChoiceTask
-    }}, DrawingTask, MultipleChoiceTask, SingleChoiceTask))
+      if (snapshot.type === 'graph2dRangeX') return Graph2dRangeXTask
+    }}, DrawingTask, Graph2dRangeXTask, MultipleChoiceTask, SingleChoiceTask))
   })
   .views(self => ({
     get activeStepTasks () {

--- a/packages/lib-classifier/src/store/tasks/Graph2dRangeXTask.js
+++ b/packages/lib-classifier/src/store/tasks/Graph2dRangeXTask.js
@@ -1,0 +1,13 @@
+import { types } from 'mobx-state-tree'
+import Task from './Task'
+
+const Graph2dRangeX = types.model('Graph2dRangeX', {
+  help: types.optional(types.string, ''),
+  instruction: types.string,
+  required: types.maybe(types.boolean), // Should this be an optional type with the default to true?
+  type: types.literal('graph2dRangeX')
+})
+
+const Graph2dRangeXTask = types.compose('Graph2dRangeXTask', Task, Graph2dRangeX)
+
+export default Graph2dRangeXTask

--- a/packages/lib-classifier/src/store/tasks/Graph2dRangeXTask.js
+++ b/packages/lib-classifier/src/store/tasks/Graph2dRangeXTask.js
@@ -4,7 +4,7 @@ import Task from './Task'
 const Graph2dRangeX = types.model('Graph2dRangeX', {
   help: types.optional(types.string, ''),
   instruction: types.string,
-  required: types.maybe(types.boolean), // Should this be an optional type with the default to true?
+  required: types.optional(types.boolean, false),
   type: types.literal('graph2dRangeX')
 })
 

--- a/packages/lib-classifier/src/store/tasks/index.js
+++ b/packages/lib-classifier/src/store/tasks/index.js
@@ -1,4 +1,5 @@
 export { default as DrawingTask } from './DrawingTask'
+export { default as Graph2dRangeXTask } from './Graph2dRangeXTask'
 export { default as MultipleChoiceTask } from './MultipleChoiceTask'
 export { default as SingleChoiceTask } from './SingleChoiceTask'
 export { default as Task } from './Task'


### PR DESCRIPTION
## PR Overview
Package: `lib-classifier`
Requires #279
Replaces #319 

The goal of this PR is to add a new Workflow Task type called `"graph2dRangeX"` (tm) which is used to denote a selection of "ranges" (x-positions, and widths) of interest on a graph.
- [x] The MobX stores should recognise a new Task called `"graph2dRangeX"`
- The Task Panel on the Classifier should ideally display the instructions of the Graph Ranges Task when said task is active. (See #309)

### Workflow Setup

In the `workflow` resource, the `"graphRanges"` task would look something like...
```
workflow.tasks =
{
  "T1": {
    "help": "",
    "type": "graph2dRangeX",
    "required":false,
    "instruction":"Mark a transition."
  }
}
```
(Feel free to comment on this structure; I did a straight rip of the `"text"` annotation task. I'm aware that there's some discussion on standardising how these Tasks should be structured, e.g. should it be 'instruction' or 'question'?)

To be clear, for a Light Curve-type project to work,
- the workflow config must specifically state that it needs to use the TESS Light Curve Viewer as its Subject Viewer. (otherwise, you can't see the light curve)
- One of the workflow's Tasks must be a '"graphRanges"' task (otherwise, you can't place annotations on the light curve)

Note that those two items must be set manually via direct API calls or the Panoptes CLI, not via the project builder. In fact, any workflow that has the "graphRanges" task won't display properly on the PFE Project Builder.

### Testing

Note: #309 is required to actually _add_ Annotations on the Light Curve Viewer, as that PR actually renders the "graph2dRangeX" task on the Classifier's Task panel and adds annotations to the submitted Classification.

That said, this PR can _still_ be tested to be functional by checking it using [Staging Project 1862](http://localhost:8080/?project=1862) (Workflow 3280), which has set up the custom `"graph2dRangeX"` task. Without this PR, the Classifier crashes when attempting to comprehend what's a custom "graph2dRangeX" task.

### Status
Ready for review. 
