### PR TITLE
Classifier - TESS Light Curve Viewer - allow adding Annotations (ver 2)

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -24,7 +24,7 @@ function storeMapper (stores) {
     interactionMode, // strong: indicates if the Classifier is in 'annotate' (default) mode or 'move' mode
     setOnZoom // func: sets onZoom event handler
   } = stores.classifierStore.subjectViewer
-  
+
   const {
     addAnnotation
   } = stores.classifierStore.classifications
@@ -41,7 +41,7 @@ function storeMapper (stores) {
   //   NOT a graphRanges task.
   const currentTask = {
     type: 'graph2dRangeX',
-    taskKey: 'T100',
+    taskKey: 'T100'
   }
 
   return {
@@ -172,21 +172,21 @@ class LightCurveViewer extends Component {
     // Add the data points
     const points = this.d3dataLayer.selectAll('.data-point')
       .data(this.props.dataPoints)
-    
+
     // For each new and existing data point, add (append) a new SVG circle.
     points.enter()
-      .append('circle')  // Note: all circles are of class '.data-point'
+      .append('circle') // Note: all circles are of class '.data-point'
       .call(setDataPointStyle)
 
     // For each SVG circle old/deleted data point, remove the corresponding SVG circle.
     points.exit().remove()
-    
+
     // Update visual elements
     this.updateDataPoints(shouldAnimate)
     this.updateUserAnnotations()
     this.updatePresentation(width, height)
   }
-  
+
   getAnnotationValues () {
     const props = this.props
     const annotations = (props.annotations && props.annotations.toJSON()) || {}
@@ -194,9 +194,9 @@ class LightCurveViewer extends Component {
   }
 
   getCurrentTransform () {
-    return (d3.event && d3.event.transform)
-      || (this.d3interfaceLayer && d3.zoomTransform(this.d3interfaceLayer.node()))
-      || d3.zoomIdentity
+    return (d3.event && d3.event.transform) ||
+      (this.d3interfaceLayer && d3.zoomTransform(this.d3interfaceLayer.node())) ||
+      d3.zoomIdentity
   }
 
   /*
@@ -296,7 +296,7 @@ class LightCurveViewer extends Component {
     // Annotations/markings layer
     this.d3svg
       .append('g')
-        .attr('class', 'annotations-layer')
+      .attr('class', 'annotations-layer')
     this.d3annotationsLayer = this.d3svg.select('.annotations-layer')
 
     /*
@@ -318,7 +318,7 @@ class LightCurveViewer extends Component {
 
     if (interactionMode === 'annotate') {
       this.d3svg.on('click', this.doInsertAnnotation.bind(this))
-      this.d3interfaceLayer.style('display', 'none')    
+      this.d3interfaceLayer.style('display', 'none')
     } else if (interactionMode === 'move') {
       this.d3svg.on('click', null)
       this.d3interfaceLayer.style('display', 'inline')
@@ -346,7 +346,7 @@ class LightCurveViewer extends Component {
 
     this.updateUserAnnotations()
   }
-  
+
   /*
   Re-draw the data points to fit the new view
   We don't don't add/remove data points at this step (no enter() or exit())
@@ -394,8 +394,8 @@ class LightCurveViewer extends Component {
     this.yAxis.scale(this.yScale) // Do NOT rescale the y-axis
     this.d3axisY.call(this.yAxis)
   }
-  
-    /*
+
+  /*
   Re-draw the user annotations to fit the new view
   Note: users can only zoom & pan in the x-direction
    */
@@ -412,24 +412,24 @@ class LightCurveViewer extends Component {
 
     const getRightEdgeOfAnnotation = (x, width, xScale, transform) =>
       transform.rescaleX(this.xScale)(x + width / 2)
-    
+
     const getWidthOfAnnotation = (x, width, xScale, transform) => {
       const left = getLeftEdgeOfAnnotation(x, width, xScale, transform)
       const right = getRightEdgeOfAnnotation(x, width, xScale, transform)
       return Math.max(right - left, 0)
     }
-    
+
     // For each newly added annotation value, create a new corresponding annotation SVG element.
     annotations.enter()
-      .append('rect')  // Class: '.user-annotation'
-        .call(setUserAnnotationAttr)
+      .append('rect') // Class: '.user-annotation'
+      .call(setUserAnnotationAttr)
 
       // And for all current annotations, update their annotation SVG element
       .merge(annotations)
-        .attr('x', d => getLeftEdgeOfAnnotation(d.x, d.width, this.xScale, t))
-        .attr('width', d => getWidthOfAnnotation(d.x, d.width, this.xScale, t))
-        .attr('y', d => 0)
-        .attr('height', d => '100%')
+      .attr('x', d => getLeftEdgeOfAnnotation(d.x, d.width, this.xScale, t))
+      .attr('width', d => getWidthOfAnnotation(d.x, d.width, this.xScale, t))
+      .attr('y', d => 0)
+      .attr('height', d => '100%')
 
     // For each annotation SVG element that no longer has an annotation value
     // (e.g. the annotation value was deleted, or this is a fresh new Subject)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -407,13 +407,11 @@ class LightCurveViewer extends Component {
     const annotations = this.d3annotationsLayer.selectAll('.user-annotation')
       .data(annotationValues)
 
-    const getLeftEdgeOfAnnotation = (x, width = 0, xScale, transform) => {
-      return transform.rescaleX(this.xScale)(x - width / 2)
-    }
+    const getLeftEdgeOfAnnotation = (x, width = 0, xScale, transform) =>
+      transform.rescaleX(this.xScale)(x - width / 2)
 
-    const getRightEdgeOfAnnotation = (x, width, xScale, transform) => {
-      return transform.rescaleX(this.xScale)(x + width / 2)
-    }
+    const getRightEdgeOfAnnotation = (x, width, xScale, transform) =>
+      transform.rescaleX(this.xScale)(x + width / 2)
     
     const getWidthOfAnnotation = (x, width, xScale, transform) => {
       const left = getLeftEdgeOfAnnotation(x, width, xScale, transform)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.spec.js
@@ -17,7 +17,7 @@ describe('Component > LightCurveViewer', function () {
     }
 
     // Use mount() instead of shallow() since d3 logic exists outside of render()
-    wrapper = render(<LightCurveViewer.wrappedComponent points={dataPoints} extent={dataExtent} />)
+    wrapper = render(<LightCurveViewer.wrappedComponent dataPoints={dataPoints} dataExtent={dataExtent} />)
   })
 
   it('should render without crashing', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/getClickCoords.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/getClickCoords.js
@@ -10,6 +10,6 @@ export default function getClickCoords (svgNode, xScale, yScale, transform) {
   const coords = d3.mouse(svgNode)
   return [
     transform.rescaleX(xScale).invert(coords[0]),
-    yScale.invert(coords[1])  // For the LightCurveViewer, only the x-axis is rescaled
+    yScale.invert(coords[1]) // For the LightCurveViewer, only the x-axis is rescaled
   ]
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/getClickCoords.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/getClickCoords.js
@@ -10,6 +10,6 @@ export default function getClickCoords (svgNode, xScale, yScale, transform) {
   const coords = d3.mouse(svgNode)
   return [
     transform.rescaleX(xScale).invert(coords[0]),
-    yScale.invert(coords[1]) // For the LightCurveViewer, only the x-axis is rescaled
+    yScale.invert(coords[1])  // For the LightCurveViewer, only the x-axis is rescaled
   ]
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/preventDefaultAction.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/preventDefaultAction.js
@@ -1,0 +1,6 @@
+import * as d3 from 'd3'
+
+export default function preventDefaultAction () {
+  d3.event.stopPropagation()
+  d3.event.preventDefault()
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setDataPointStyle.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setDataPointStyle.js
@@ -1,6 +1,6 @@
-export default function setPointStyle (selection) {
+export default function setDataPointStyle (selection) {
   return selection
-    .attr('r', 1.25)
     .attr('class', 'data-point')
+    .attr('r', 1.25)
     .attr('fill', '#488')
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setDataPointStyle.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setDataPointStyle.spec.js
@@ -1,21 +1,21 @@
 import sinon from 'sinon'
 
-import setPointStyle from './setPointStyle'
+import setDataPointStyle from './setDataPointStyle'
 
 const selectionFixture = { attr: Function.prototype }
 const attrStub = sinon.stub(selectionFixture, 'attr').returnsThis()
 
-describe('LightCurveViewer > d3 > setPointStyle', function () {
+describe('LightCurveViewer > d3 > setDataPointStyle', function () {
   afterEach(function () {
     attrStub.resetHistory()
   })
 
   it('should exist', function () {
-    expect(setPointStyle).to.be.a('function')
+    expect(setDataPointStyle).to.be.a('function')
   })
 
   it('should add the correct attributes to the selection', function () {
-    setPointStyle(selectionFixture)
+    setDataPointStyle(selectionFixture)
     expect(attrStub.calledWith('r', 1.25)).to.be.true
     expect(attrStub.calledWith('class', 'data-point')).to.be.true
     expect(attrStub.calledWith('fill', '#488')).to.be.true

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setUserAnnotationAttr.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setUserAnnotationAttr.js
@@ -1,4 +1,5 @@
 import * as d3 from 'd3'
+import preventDefaultAction from './preventDefaultAction'
 
 export default function setUserAnnotationAttr (selection) {
   return selection
@@ -7,12 +8,11 @@ export default function setUserAnnotationAttr (selection) {
     .attr('fill-opacity', '0.5')
     .style('cursor', 'pointer')
     .on('click', function () {
-      console.log('+++ Example Annotation clicked')
+      alert('+++ Example Annotation clicked')
       
       // Prevents clicks on the parent d3annotationsLayer, which add new annotations.
-      d3.event.stopPropagation()
-      d3.event.preventDefault()
+      preventDefaultAction()
     })
-    .on('mousedown', function () { d3.event.stopPropagation() ; d3.event.preventDefault() })  // Prevents "drag selection"
-    .on('touchstart', function () { d3.event.stopPropagation() ; d3.event.preventDefault() })
+    .on('mousedown', preventDefaultAction)  // Prevents "drag selection"
+    .on('touchstart', preventDefaultAction)
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setUserAnnotationAttr.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setUserAnnotationAttr.js
@@ -1,4 +1,3 @@
-import * as d3 from 'd3'
 import preventDefaultAction from './preventDefaultAction'
 
 export default function setUserAnnotationAttr (selection) {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setUserAnnotationAttr.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setUserAnnotationAttr.js
@@ -1,0 +1,18 @@
+import * as d3 from 'd3'
+
+export default function setUserAnnotationAttr (selection) {
+  return selection
+    .attr('class', 'user-annotation')
+    .attr('fill', '#c44')
+    .attr('fill-opacity', '0.5')
+    .style('cursor', 'pointer')
+    .on('click', function () {
+      console.log('+++ Example Annotation clicked')
+      
+      // Prevents clicks on the parent d3annotationsLayer, which add new annotations.
+      d3.event.stopPropagation()
+      d3.event.preventDefault()
+    })
+    .on('mousedown', function () { d3.event.stopPropagation() ; d3.event.preventDefault() })  // Prevents "drag selection"
+    .on('touchstart', function () { d3.event.stopPropagation() ; d3.event.preventDefault() })
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setUserAnnotationAttr.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setUserAnnotationAttr.js
@@ -9,10 +9,10 @@ export default function setUserAnnotationAttr (selection) {
     .style('cursor', 'pointer')
     .on('click', function () {
       alert('+++ Example Annotation clicked')
-      
+
       // Prevents clicks on the parent d3annotationsLayer, which add new annotations.
       preventDefaultAction()
     })
-    .on('mousedown', preventDefaultAction)  // Prevents "drag selection"
+    .on('mousedown', preventDefaultAction) // Prevents "drag selection"
     .on('touchstart', preventDefaultAction)
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setUserAnnotationAttr.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setUserAnnotationAttr.spec.js
@@ -1,0 +1,30 @@
+import sinon from 'sinon'
+
+import setUserAnnotationAttr from './setUserAnnotationAttr'
+
+const selectionFixture = {
+  attr: Function.prototype,
+  style: Function.prototype,
+  on: Function.prototype
+}
+const attrStub = sinon.stub(selectionFixture, 'attr').returnsThis()
+const styleStub = sinon.stub(selectionFixture, 'style').returnsThis()
+const onStub = sinon.stub(selectionFixture, 'on').returnsThis()
+
+describe('LightCurveViewer > d3 > setUserAnnotationAttr', function () {
+  afterEach(function () {
+    attrStub.resetHistory()
+  })
+
+  it('should exist', function () {
+    expect(setUserAnnotationAttr).to.be.a('function')
+  })
+
+  it('should add the correct attributes to the selection', function () {
+    setUserAnnotationAttr(selectionFixture)
+    expect(attrStub.calledWith('class', 'user-annotation')).to.be.true
+    expect(attrStub.calledWith('fill', '#c44')).to.be.true
+    expect(attrStub.calledWith('fill-opacity', '0.5')).to.be.true
+    expect(styleStub.calledWith('cursor', 'pointer')).to.be.true
+  })
+})

--- a/packages/lib-classifier/src/store/Classification.js
+++ b/packages/lib-classifier/src/store/Classification.js
@@ -1,6 +1,6 @@
 import { types, getType } from 'mobx-state-tree'
 import Resource from './Resource'
-import { SingleChoiceAnnotation, MultipleChoiceAnnotation } from './annotations'
+import { SingleChoiceAnnotation, MultipleChoiceAnnotation, Graph2dRangeXAnnotation } from './annotations'
 
 const ClassificationMetadata = types.model('ClassificationMetadata', {
   finishedAt: types.maybe(types.string),
@@ -30,8 +30,9 @@ const Classification = types
         const snapshotType = getType(snapshot)
         if (snapshotType.name === 'SingleChoiceAnnotation') return SingleChoiceAnnotation
         if (snapshotType.name === 'MultipleChoiceAnnotation') return MultipleChoiceAnnotation
+        if (snapshotType.name === 'Graph2dRangeXAnnotation') return Graph2dRangeXAnnotation
       }
-    }, SingleChoiceAnnotation, MultipleChoiceAnnotation)),
+    }, SingleChoiceAnnotation, MultipleChoiceAnnotation, Graph2dRangeXAnnotation)),
     completed: types.optional(types.boolean, false),
     links: types.frozen({
       project: types.string,

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -8,7 +8,7 @@ import { Split } from 'seven-ten'
 
 import Classification, { ClassificationMetadata } from './Classification'
 import ResourceStore from './ResourceStore'
-import { SingleChoiceAnnotation, MultipleChoiceAnnotation } from './annotations'
+import { SingleChoiceAnnotation, MultipleChoiceAnnotation, Graph2dRangeXAnnotation } from './annotations'
 import {
   ClassificationQueue,
   convertMapToArray,
@@ -82,7 +82,8 @@ const ClassificationStore = types
     function getAnnotationType (taskType) {
       const taskTypes = {
         single: SingleChoiceAnnotation,
-        multiple: MultipleChoiceAnnotation
+        multiple: MultipleChoiceAnnotation,
+        graph2dRangeX: Graph2dRangeXAnnotation
       }
 
       return taskTypes[taskType] || undefined

--- a/packages/lib-classifier/src/store/annotations/Graph2dRangeXAnnotation.js
+++ b/packages/lib-classifier/src/store/annotations/Graph2dRangeXAnnotation.js
@@ -1,0 +1,13 @@
+import { types } from 'mobx-state-tree'
+import Annotation from './Annotation'
+
+const Graph2dRangeX = types.model('Graph2dRangeX', {
+  value: types.array(types.model({
+    x: types.number,
+    width: types.number
+  }))
+})
+
+const Graph2dRangeXAnnotation = types.compose('Graph2dRangeXAnnotation', Annotation, Graph2dRangeX)
+
+export default Graph2dRangeXAnnotation

--- a/packages/lib-classifier/src/store/annotations/Graph2dRangeXAnnotation.spec.js
+++ b/packages/lib-classifier/src/store/annotations/Graph2dRangeXAnnotation.spec.js
@@ -1,0 +1,19 @@
+import Graph2dRangeXAnnotation from './Graph2dRangeXAnnotation'
+
+const annotation = {
+  task: 'T0',
+  value: [
+    {
+      x: 100,
+      width: 10
+    }
+  ]
+}
+
+describe('Model > Graph2dRangeXAnnotation', function () {
+  it('should exist', function () {
+    const annotationInstance = Graph2dRangeXAnnotation.create(annotation)
+    expect(annotationInstance).to.exist
+    expect(annotationInstance).to.be.an('object')
+  })
+})

--- a/packages/lib-classifier/src/store/annotations/index.js
+++ b/packages/lib-classifier/src/store/annotations/index.js
@@ -1,3 +1,4 @@
 export { default as Annotation } from './Annotation'
 export { default as SingleChoiceAnnotation } from './SingleChoiceAnnotation'
 export { default as MultipleChoiceAnnotation } from './MultipleChoiceAnnotation'
+export { default as Graph2dRangeXAnnotation } from './Graph2dRangeXAnnotation'


### PR DESCRIPTION
## PR Overview
Package: `lib-classifier`
~~Requires (and is a sequel to) #279 and #352~~ 👌 (Merged!)
Replaces #309 (309 has gone waaay off base)
Closes #241 

The goal of this PR is to let users add annotations via the LCV
- [x] Users should be able to add new annotations in Annotate Mode.
  - [x] When in Annotate Mode, mouse click should add an annotation at the point of click.
  - [x] Mouse drag and wheel scroll should be ignored. 

![screen shot 2018-12-04 at 15 45 09](https://user-images.githubusercontent.com/13952701/49453972-1b702400-f7dc-11e8-8b47-865cda4bd5fa.png)
_When in Annotation mode (selected from the Classifier page toolbar), users can click on the light curve to plonk down a "Graph Range"-type annotation (with a fixed width), which indicates the range where a dip in the brightness has been detected_

NOTE: the annotation data should be in the form of: `{ x: number, width: number }`
- `x` marks the centre of a selection range (aka a column) indicating a dip in the light curve.
- `width` marks the total range of the, er, selection range.

NOTE: not covered in this PR -
- ability to edit or remove existing Annotations.

### Dev Notes

See https://github.com/zooniverse/front-end-monorepo/pull/309#issuecomment-444182527 for full, rambling dev notes on...
1. Connecting the LightCurveViewer to the MobX stores
2. Using the "graph2dRangeX" workflow task

TL;DR: I need to make the LCV ignore any attempted annotation actions (e.g. adding/removing annotations) UNLESS the Current Workflow Task is "graph2dRangeX"

### Status
WIP - I still need to address a few comments from @rogerhutchings from #309 and check on the Current Workflow Task === 'graph2dRangeX'