### PR TITLE
Add more sensible smoke test to component templates

### DIFF
--- a/plop/templates/component/Component.spec.js.hbs
+++ b/plop/templates/component/Component.spec.js.hbs
@@ -10,5 +10,7 @@ describe('Component > {{ properCase name }}', function () {
     wrapper = shallow(<{{ properCase name }} />)
   })
 
-  it('should render without crashing', function () {})
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok
+  })
 })

--- a/plop/templates/component/Container.spec.js.hbs
+++ b/plop/templates/component/Container.spec.js.hbs
@@ -13,7 +13,9 @@ describe('Component > {{ properCase name }}Container', function () {
     componentWrapper = wrapper.find({{ properCase name }})
   })
 
-  it('should render without crashing', function () {})
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok
+  })
 
   it('should render the `{{ properCase name }}` component', function () {
     expect(componentWrapper).to.have.lengthOf(1)

--- a/plop/templates/component/MSTContainer.spec.js.hbs
+++ b/plop/templates/component/MSTContainer.spec.js.hbs
@@ -13,7 +13,9 @@ describe('Component > {{ properCase name }}Container', function () {
     componentWrapper = wrapper.find({{ properCase name }})
   })
 
-  it('should render without crashing', function () {})
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok
+  })
 
   it('should render the `{{ properCase name }}` component', function () {
     expect(componentWrapper).to.have.lengthOf(1)


### PR DESCRIPTION
Adds `expect(wrapper).to.be.ok` as the smoke test in plop-generated components.