### PR TITLE
Fix forward refs in tests

### DIFF
--- a/packages/lib-react-components/src/ZooFooter/components/AdminCheckbox/AdminCheckbox.spec.js
+++ b/packages/lib-react-components/src/ZooFooter/components/AdminCheckbox/AdminCheckbox.spec.js
@@ -19,8 +19,8 @@ describe('<AdminCheckbox />', function () {
   it('renders without crashing', function () {})
 
   it('calls onChange prop when clicked', function () {
-    wrapper.find('ForwardRef').simulate('change')
-    expect(onChangeSpy.calledOnce).to.be.true()
+    wrapper.find('CheckBox').simulate('change')
+    expect(onChangeSpy).to.have.been.calledOnce
   })
 
   // Can't test this yet. See comment in component code

--- a/packages/lib-react-components/src/ZooFooter/components/SocialAnchor/SocialAnchor.spec.js
+++ b/packages/lib-react-components/src/ZooFooter/components/SocialAnchor/SocialAnchor.spec.js
@@ -24,12 +24,12 @@ describe('SocialAnchor', function () {
 
     it('should use the service prop as the a11y title', function () {
       wrapper = shallow(<SocialAnchor service='facebook' />)
-      expect(wrapper.find('ForwardRef').props().a11yTitle).to.equal('facebook')
+      expect(wrapper.find('Styled(Anchor)').props().a11yTitle).to.equal('facebook')
     })
 
     it('should use the expected url in the href', function () {
       wrapper = shallow(<SocialAnchor service='facebook' />)
-      expect(wrapper.find('ForwardRef').props().href).to.equal('https://www.facebook.com/therealzooniverse')
+      expect(wrapper.find('Styled(Anchor)').props().href).to.equal('https://www.facebook.com/therealzooniverse')
     })
   })
 
@@ -43,12 +43,12 @@ describe('SocialAnchor', function () {
 
     it('should use the service prop as the a11y title', function () {
       wrapper = shallow(<SocialAnchor service='twitter' />)
-      expect(wrapper.find('ForwardRef').props().a11yTitle).to.equal('twitter')
+      expect(wrapper.find('Styled(Anchor)').props().a11yTitle).to.equal('twitter')
     })
 
     it('should use the expected url in the href', function () {
       wrapper = shallow(<SocialAnchor service='twitter' />)
-      expect(wrapper.find('ForwardRef').props().href).to.equal('https://twitter.com/the_zooniverse')
+      expect(wrapper.find('Styled(Anchor)').props().href).to.equal('https://twitter.com/the_zooniverse')
     })
   })
 
@@ -62,12 +62,12 @@ describe('SocialAnchor', function () {
 
     it('should use the service prop as the a11y title', function () {
       wrapper = shallow(<SocialAnchor service='instagram' />)
-      expect(wrapper.find('ForwardRef').props().a11yTitle).to.equal('instagram')
+      expect(wrapper.find('Styled(Anchor)').props().a11yTitle).to.equal('instagram')
     })
 
     it('should use the expected url in the href', function () {
       wrapper = shallow(<SocialAnchor service='instagram' />)
-      expect(wrapper.find('ForwardRef').props().href).to.equal('https://www.instagram.com/the.zooniverse/')
+      expect(wrapper.find('Styled(Anchor)').props().href).to.equal('https://www.instagram.com/the.zooniverse/')
     })
   })
 })


### PR DESCRIPTION
Removes forward refs from AdminCheckbox and SocialAnchor tests. I think these have been removed from styled components.

Package:
lib-react-components


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

