### PR TITLE
Classifier - TESS Light Curve Viewer - add Graph2dRangeX task (for Task Area)

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Graph2dRangeXTask/Graph2dRangeXTask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Graph2dRangeXTask/Graph2dRangeXTask.js
@@ -5,13 +5,13 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
+export const StyledFieldset = styled.fieldset`
+  border: none;
+`
+
 function storeMapper (stores) {
-  const {
-    addAnnotation
-  } = stores.classifierStore.classifications
   const annotations = stores.classifierStore.classifications.currentAnnotations
   return {
-    addAnnotation,
     annotations
   }
 }
@@ -33,12 +33,21 @@ class Graph2dRangeXTask extends React.Component {
     if (annotations && annotations.size > 0) {
       annotation = annotations.get(task.taskKey)
     }
+    const numberOfAnnotations = (annotation && annotation.value.length) || 0
+    
     return (
-      <Text size='small' tag='legend'>
-        <Markdown>
-          {task.instruction}
-        </Markdown>
-      </Text>
+      <StyledFieldset>
+        <Text size='small' tag='legend'>
+          <Markdown>
+            {task.instruction}
+          </Markdown>
+        </Text>
+      
+        <Text tag='div' size='small' textAlign='center'>
+          {numberOfAnnotations} marks made
+        </Text>
+      
+      </StyledFieldset>
     )
   }
 }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Graph2dRangeXTask/Graph2dRangeXTask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Graph2dRangeXTask/Graph2dRangeXTask.js
@@ -1,0 +1,62 @@
+import { Markdown, Text } from 'grommet'
+import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
+import { observable } from 'mobx'
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+function storeMapper (stores) {
+  const {
+    addAnnotation
+  } = stores.classifierStore.classifications
+  const annotations = stores.classifierStore.classifications.currentAnnotations
+  return {
+    addAnnotation,
+    annotations
+  }
+}
+
+@inject(storeMapper)
+@observer
+class Graph2dRangeXTask extends React.Component {
+  onChange (index, event) {
+    const { addAnnotation, task } = this.props
+    if (event.target.checked) addAnnotation(index, task)
+  }
+
+  render () {
+    const {
+      annotations,
+      task
+    } = this.props
+    let annotation
+    if (annotations && annotations.size > 0) {
+      annotation = annotations.get(task.taskKey)
+    }
+    return (
+      <Text size='small' tag='legend'>
+        <Markdown>
+          {task.instruction}
+        </Markdown>
+      </Text>
+    )
+  }
+}
+
+Graph2dRangeXTask.wrappedComponent.defaultProps = {
+  addAnnotation: () => {},
+  annotations: observable.map(),
+  task: {}
+}
+
+Graph2dRangeXTask.wrappedComponent.propTypes = {
+  addAnnotation: PropTypes.func,
+  annotations: MobXPropTypes.observableMap,
+  task: PropTypes.shape({
+    help: PropTypes.string,
+    instruction: PropTypes.string,
+    required: PropTypes.bool
+  })
+}
+
+export default Graph2dRangeXTask

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Graph2dRangeXTask/Graph2dRangeXTask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Graph2dRangeXTask/Graph2dRangeXTask.js
@@ -19,11 +19,6 @@ function storeMapper (stores) {
 @inject(storeMapper)
 @observer
 class Graph2dRangeXTask extends React.Component {
-  onChange (index, event) {
-    const { addAnnotation, task } = this.props
-    if (event.target.checked) addAnnotation(index, task)
-  }
-
   render () {
     const {
       annotations,
@@ -53,13 +48,11 @@ class Graph2dRangeXTask extends React.Component {
 }
 
 Graph2dRangeXTask.wrappedComponent.defaultProps = {
-  addAnnotation: () => {},
   annotations: observable.map(),
   task: {}
 }
 
 Graph2dRangeXTask.wrappedComponent.propTypes = {
-  addAnnotation: PropTypes.func,
   annotations: MobXPropTypes.observableMap,
   task: PropTypes.shape({
     help: PropTypes.string,

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Graph2dRangeXTask/Graph2dRangeXTask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Graph2dRangeXTask/Graph2dRangeXTask.js
@@ -1,9 +1,13 @@
+import counterpart from 'counterpart'
 import { Markdown, Text } from 'grommet'
 import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
 import { observable } from 'mobx'
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+
+import en from './locales/en'
+counterpart.registerTranslations('en', en)
 
 export const StyledFieldset = styled.fieldset`
   border: none;
@@ -39,7 +43,7 @@ class Graph2dRangeXTask extends React.Component {
         </Text>
       
         <Text tag='div' size='small' textAlign='center'>
-          {numberOfAnnotations} marks made
+          {counterpart('Graph2dRangeXTask.marksMade')} : {numberOfAnnotations}
         </Text>
       
       </StyledFieldset>

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Graph2dRangeXTask/Graph2dRangeXTask.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Graph2dRangeXTask/Graph2dRangeXTask.spec.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { expect } from 'chai'
+import sinon from 'sinon'
+import Graph2dRangeXTask from './Graph2dRangeXTask'
+
+// TODO: move this into a factory
+const task = {
+  instruction: 'Mark an area of the graph that is interesting.',
+  taskKey: 'T101',
+  type: 'graph2dRangeX'
+}
+
+describe('Graph2dRangeXTask', function () {
+  describe('when it renders', function () {
+    let wrapper
+    before(function () {
+      wrapper = shallow(<Graph2dRangeXTask.wrappedComponent addAnnotation={() => {}} task={task} />)
+    })
+
+    it('should render without crashing', function () {
+      expect(wrapper).to.be.ok
+    })
+
+    it('should have instructions', function () {
+      expect(wrapper.find('GrommetMarkdown').text()).to.equal(task.instruction)
+    })
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Graph2dRangeXTask/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Graph2dRangeXTask/index.js
@@ -1,0 +1,1 @@
+export { default } from './Graph2dRangeXTask'

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Graph2dRangeXTask/locales/en.json
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Graph2dRangeXTask/locales/en.json
@@ -1,0 +1,5 @@
+{
+  "Graph2dRangeXTask": {
+    "marksMade": "Marks made"
+  }
+}

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/helpers/getTaskComponent.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/helpers/getTaskComponent.js
@@ -1,9 +1,11 @@
 import DrawingTask from '../components/DrawingTask'
+import Graph2dRangeXTask from '../components/Graph2dRangeXTask'
 import SingleChoiceTask from '../components/SingleChoiceTask'
 import MultipleChoiceTask from '../components/MultipleChoiceTask'
 
 const taskTypes = {
   drawing: DrawingTask,
+  graph2dRangeX: Graph2dRangeXTask,
   single: SingleChoiceTask,
   multiple: MultipleChoiceTask
 }

--- a/packages/lib-classifier/src/store/tasks/Graph2dRangeXTask.spec.js
+++ b/packages/lib-classifier/src/store/tasks/Graph2dRangeXTask.spec.js
@@ -1,0 +1,15 @@
+import Graph2dRangeXTask from './Graph2dRangeXTask'
+
+const graphTask = {
+  instruction: 'Mark an area of the graph that is interesting.',
+  taskKey: 'T101',
+  type: 'graph2dRangeX'
+}
+
+describe('Model > Graph2dRangeXTask', function () {
+  it('should exist', function () {
+    const graphTaskInstance = Graph2dRangeXTask.create(graphTask)
+    expect(graphTaskInstance).to.exist
+    expect(graphTaskInstance).to.be.an('object')
+  })
+})


### PR DESCRIPTION
## PR Overview
package: `lib-classifier`

This PR adds the Graph2dRangeX task to the Classifier's Task Area.

![screen shot 2019-01-18 at 14 21 12](https://user-images.githubusercontent.com/13952701/51392265-634ccf80-1b2c-11e9-80d6-7bd3c971239c.png)
_The Graph2dRangeX task can be seen on the right side. Yes, that bit of text. That's all._

This task area is currently a very simple copy of the Drawing Task placeholder, which only has space for `instructions`, and nothing more. The Task (in the Task Area) has _no interactive bits._

There is currently no intention to improve this Task any further (save maybe for some styling updates?), at least until we get a design review on the UX.

### Testing
The Task can be tested on any project workflow with the custom `graph2dRangeX` task. For convenience, try `http://localhost:8080/?project=1862` on staging.

### Status
Ready for review.