### PR TITLE
Classifier - TESS Light Curve Viewer - lock Annotate mode to only Graph2dRangeX task

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -189,9 +189,9 @@ class LightCurveViewer extends Component {
 
   getAnnotationValues () {
     const props = this.props
-    const annotations = (props.annotations && props.annotations.toJSON()) || {}
-    if (this.isCurrentTaskValidForAnnotation()) {
-      return (annotations[props.currentTask.taskKey] && [...annotations[props.currentTask.taskKey].value]) || []
+    const annotations = (props.annotations && props.annotations.get(props.currentTask.taskKey))
+    if (annotations && this.isCurrentTaskValidForAnnotation()) {
+      return annotations.toJSON().value || []
     } else {
       return []
     }
@@ -348,7 +348,7 @@ class LightCurveViewer extends Component {
     // Figure out where the user clicked on the graph, then add a new annotation
     // to the array of annotations.
     const clickCoords = getClickCoords(this.d3svg.node(), this.xScale, this.yScale, t)
-    const values = this.getAnnotationValues()
+    const values = this.getAnnotationValues().slice()  // Create a copy
     values.push({ x: clickCoords[0], width: STARTING_WIDTH })
 
     props.addAnnotation(values, props.currentTask)
@@ -357,7 +357,7 @@ class LightCurveViewer extends Component {
   }
   
   isCurrentTaskValidForAnnotation () {
-    return !!this.props.currentTask && this.props.currentTask.type === 'graph2dRangeX'
+    return this.props.currentTask.type === 'graph2dRangeX'
   }
 
   /*

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -188,13 +188,10 @@ class LightCurveViewer extends Component {
   }
 
   getAnnotationValues () {
-    const props = this.props
-    const annotations = (props.annotations && props.annotations.get(props.currentTask.taskKey))
-    if (annotations && this.isCurrentTaskValidForAnnotation()) {
-      return annotations.toJSON().value || []
-    } else {
-      return []
-    }
+    const { annotations, currentTask } = this.props
+    const annotation = annotations.get(currentTask.taskKey)
+    if (annotation && this.isCurrentTaskValidForAnnotation()) return Array.from(annotation.value) || []
+    return []
   }
 
   getCurrentTransform () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -183,7 +183,11 @@ class LightCurveViewer extends Component {
   getAnnotationValues () {
     const props = this.props
     const annotations = (props.annotations && props.annotations.toJSON()) || {}
-    return (annotations[props.currentTask.taskKey] && [...annotations[props.currentTask.taskKey].value]) || []
+    if (this.isCurrentTaskValidForAnnotation()) {
+      return (annotations[props.currentTask.taskKey] && [...annotations[props.currentTask.taskKey].value]) || []
+    } else {
+      return []
+    }
   }
 
   getCurrentTransform () {
@@ -329,7 +333,7 @@ class LightCurveViewer extends Component {
     const props = this.props
     const t = this.getCurrentTransform()
     
-    if (props.currentTask && props.currentTask.type !== 'graph2dRangeX') {
+    if (!this.isCurrentTaskValidForAnnotation()) {
       props.enableMove && props.enableMove()
       return
     }
@@ -343,6 +347,10 @@ class LightCurveViewer extends Component {
     props.addAnnotation(values, props.currentTask)
 
     this.updateUserAnnotations()
+  }
+  
+  isCurrentTaskValidForAnnotation () {
+    return !!this.props.currentTask && this.props.currentTask.type === 'graph2dRangeX'
   }
 
   /*

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -21,7 +21,8 @@ const ZOOMING_TIME = 100 // milliseconds
 
 function storeMapper (stores) {
   const {
-    interactionMode, // strong: indicates if the Classifier is in 'annotate' (default) mode or 'move' mode
+    enableMove,
+    interactionMode, // string: indicates if the Classifier is in 'annotate' (default) mode or 'move' mode
     setOnZoom // func: sets onZoom event handler
   } = stores.classifierStore.subjectViewer
 
@@ -30,26 +31,18 @@ function storeMapper (stores) {
   } = stores.classifierStore.classifications
   const annotations = stores.classifierStore.classifications.currentAnnotations
   const { active: step } = stores.classifierStore.workflowSteps
-  const tasks = stores.classifierStore.workflowSteps.activeStepTasks
-
-  // WIP
-  // We currently have no corresponding "graphRanges" task in the Panoptes
-  // Project Builder, so this is jimmied in.
-  // NOTE: There are two things that need to be done:
-  // - We need to create a workflow with the custom "graphRanges" task
-  // - We need to consider how the LCV reacts when the current active task is
-  //   NOT a graphRanges task.
-  const currentTask = {
-    type: 'graph2dRangeX',
-    taskKey: 'T100'
-  }
-
+  
+  const currentTask =
+    (stores.classifierStore.workflowSteps.activeStepTasks
+     && stores.classifierStore.workflowSteps.activeStepTasks[0])
+    || {}
+  
   return {
     addAnnotation,
     annotations,
     currentTask,
+    enableMove,
     interactionMode,
-    tasks,
     setOnZoom
   }
 }
@@ -335,6 +328,11 @@ class LightCurveViewer extends Component {
     const STARTING_WIDTH = 0.4
     const props = this.props
     const t = this.getCurrentTransform()
+    
+    if (props.currentTask && props.currentTask.type !== 'graph2dRangeX') {
+      props.enableMove && props.enableMove()
+      return
+    }
 
     // Figure out where the user clicked on the graph, then add a new annotation
     // to the array of annotations.

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -100,14 +100,21 @@ class LightCurveViewer extends Component {
     const points = this.props.dataPoints
     const prevPoints = prevProps.dataPoints
     const sameSubject = (points === prevPoints)
+    
+    const currentTaskKey = (this.props.currentTask && this.props.currentTask.taskKey) || ''
+    const prevTaskKey = (prevProps.currentTask && prevProps.currentTask.taskKey) || ''
+    const sameTask = (currentTaskKey === prevTaskKey)
 
-    if (!sameSubject) {
+    if (!sameSubject) {  // Triggers when changing between Subjects
       this.clearChart()
 
       const container = this.svgContainer.current
       const height = container.offsetHeight || 0
       const width = container.offsetWidth || 0
       this.drawChart(width, height, sameSubject)
+      
+    } else if (!sameTask) {  // Triggers when changing between Workflow tasks.
+      this.updateUserAnnotations()
     }
 
     if (prevProps.interactionMode !== this.props.interactionMode) {


### PR DESCRIPTION
## PR Overview
package: `lib-classifier`
Parallel to #376

When using the Light Curve subject viewer, if a user attempts to _add Annotations_ while the current workflow task is NOT a `graph2dRangeX` task, the subject viewer mode will automatically switch to Move mode.

This behaviour mimics the current behaviour on the [PFE Classifier component](https://master.pfe-preview.zooniverse.org/dev/classifier) - Annotate mode only matters (to the subject viewer and/or annotation pane) when the current active task is a drawing task.

### Dev Notes
Based on discussions with @srallen and @eatyourgreens on Slack (`#frontend-rewrite`) on Fri 18 Jan 2019,
- The "current active step" in a Workflow _can have multiple tasks,_ such as with the Notes from Nature combo which features two text inputs and a dropdown menu on the screen for a transcription project.
  - _(I was initially confused as to why I kept getting an array of Tasks when I was expecting a single Task, so this helps explain the model.)_
- `stores.classifierStore.workflowSteps.activeStepTasks` returns the list of all Tasks in a given step as an **array**, but in the case of the LCV, we expect this to only be an **array of one task.**
- There are certain combinations of tasks and subjects that don't make sense (e.g. two survey tasks simultaneously) but we're not accounting for that... _yet._

For the moment, the logic in the LCV that checks for the current task looks like...
```
const currentTask =
  (stores.classifierStore.workflowSteps.activeStepTasks
   && stores.classifierStore.workflowSteps.activeStepTasks[0])
  || {}
```
...though there may be merit moving this to the Subject Viewer store (`views: get firstTask()`) for other components.

### Status
Ready for review.