### PR TITLE
Classifier - TESS Light Curve Viewer - add 'Remove Annotation' buttons

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -508,18 +508,29 @@ class LightCurveViewer extends Component {
       .data(annotationBrushes, (d) => d.id)
     
     function addRemoveAnnotationButton(selection, onClick = null) {
-      const width = 20
-      const height = 20
+      const size = 20  // Width and height
       
       const g = selection.append('g')
         .attr('class', 'remove-button')
         .attr('transform', `translate(0, 0)`)
+        .style('cursor', 'pointer')
+        .on('click', onClick)
       
       g.append('circle')
-        .attr('fill', '#fff')
-        .attr('r', width/2)
+        .attr('fill', '#4cc')
+        .attr('r', size / 2)
         .attr('cx', 0)
-        .attr('cy', height/2)
+        .attr('cy', size / 2)
+      
+      const lx = size * -0.2
+      const rx = size * 0.2
+      const uy = size * 0.3
+      const dy = size * 0.7
+      
+      g.append('path')  // A big ol' X
+        .attr('stroke', '#eee')
+        .attr('stroke-width', '3')
+        .attr('d', `M ${lx} ${uy} L ${rx} ${dy} M ${rx} ${uy} L ${lx} ${dy} `)
       
       return g
     }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -247,13 +247,16 @@ class LightCurveViewer extends Component {
   http://bl.ocks.org/ludwigschubert/0236fa8594c4b02711b2606a8f95f605
    */
   createAnnotationBrush () {
+    const defaultBrush = this.getDefaultBrush() // a.k.a. the latest brush
+    const nextAvailableId = (defaultBrush && defaultBrush.id + 1) || 0
+    
     const brush = d3.brushX()
       .on('start', this.onAnnotationBrushStart.bind(this))
       .on('brush', this.onAnnotationBrushBrushed.bind(this))
       .on('end', this.onAnnotationBrushEnd.bind(this))
 
     this.annotationBrushes.push({
-      id: this.annotationBrushes.length,
+      id: nextAvailableId,
       brush: brush,
       minX: undefined, // x, relative to the data range (not the SVG dimensions)
       maxX: undefined
@@ -503,27 +506,27 @@ class LightCurveViewer extends Component {
     const brushSelection = this.d3annotationsLayer
       .selectAll('.brush')
       .data(annotationBrushes, (d) => d.id)
-
+    
     // Set up new brushes
     brushSelection.enter()
       .insert('g', '.brush')
       .attr('class', 'brush')
       .attr('id', (brush) => (`brush-${brush.id}`))
-      .each(function applyBrushLogic (brushObject) { // Don't use ()=>{}
-        brushObject.brush(d3.select(this)) // Apply the brush logic to the <g.brush> element (i.e. 'this')
+      .each(function applyBrushLogic (annotationBrush) { // Don't use ()=>{}
+        annotationBrush.brush(d3.select(this)) // Apply the brush logic to the <g.brush> element (i.e. 'this')
       })
 
     // Modify brushes so that their invisible overlays don't overlap and
     // accidentally block events from the brushes below them. The 'default'
     // brush - aka the interface for creating new brushes - is the exception.
     brushSelection
-      .each(function disableInvisibleBrushOverlay (brushObject) { // Don't use ()=>{}
+      .each(function disableInvisibleBrushOverlay (annotationBrush) { // Don't use ()=>{}
         d3.select(this)
           .attr('class', 'brush')
           .selectAll('.overlay')
           .style('pointer-events', () => {
-            const brush = brushObject.brush
-            if (brushObject.id === defaultBrush.id && brush !== undefined) return 'all'
+            const brush = annotationBrush.brush
+            if (annotationBrush.id === defaultBrush.id && brush !== undefined) return 'all'
             return 'none'
           })
       })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -265,6 +265,11 @@ class LightCurveViewer extends Component {
   
   removeAnnotationBrush (annotationBrush) {
     console.log('+++ REMOVE: ', annotationBrush)
+    
+    this.annotationBrushes = this.annotationBrushes.filter((ab) => ab.id !== annotationBrush.id)
+    
+    this.updateAnnotationBrushes()
+    this.saveBrushesToAnnotations()
   }
 
   // Helper function to prevent infinite loops
@@ -523,7 +528,7 @@ class LightCurveViewer extends Component {
       .each(function applyBrushLogic (annotationBrush) { // Don't use ()=>{}
         annotationBrush.brush(d3.select(this)) // Apply the brush logic to the <g.brush> element (i.e. 'this')
       })
-      .call(addRemoveAnnotationButton, this.removeAnnotationBrush)
+      .call(addRemoveAnnotationButton, this.removeAnnotationBrush.bind(this))
 
     // Modify brushes so that their invisible overlays don't overlap and
     // accidentally block events from the brushes below them. The 'default'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -5,6 +5,7 @@ import ReactResizeDetector from 'react-resize-detector'
 import { inject, observer } from 'mobx-react'
 
 import addAxisLabel from './d3/addAxisLabel'
+import addRemoveAnnotationButton from './d3/addRemoveAnnotationButton'
 import addBackgroundLayer from './d3/addBackgroundLayer'
 import addBorderLayer from './d3/addBorderLayer'
 import addDataLayer from './d3/addDataLayer'
@@ -264,10 +265,7 @@ class LightCurveViewer extends Component {
   }
   
   removeAnnotationBrush (annotationBrush) {
-    console.log('+++ REMOVE: ', annotationBrush)
-    
     this.annotationBrushes = this.annotationBrushes.filter((ab) => ab.id !== annotationBrush.id)
-    
     this.updateAnnotationBrushes()
     this.saveBrushesToAnnotations()
   }
@@ -298,13 +296,11 @@ class LightCurveViewer extends Component {
     return (this.annotationBrushes.length) && this.annotationBrushes[this.annotationBrushes.length - 1]
   }
 
-  onAnnotationBrushStart () { console.log('+++ onAnnotationBrushStart') }
+  onAnnotationBrushStart () {}
 
-  onAnnotationBrushBrushed () { console.log('+++ onAnnotationBrushBrushed') }
+  onAnnotationBrushBrushed () {}
 
   onAnnotationBrushEnd (annotationBrush, index, domElements) {
-    console.log('+++ onAnnotationBrushEnd')
-    
     const props = this.props
     const brushSelection = d3.event.selection // Returns [xMin, xMax] or null, where x is relative to the SVG (not the data)
     const defaultBrush = this.getDefaultBrush()
@@ -510,8 +506,6 @@ class LightCurveViewer extends Component {
   Updates and re-draws the Annotation Brushes.
    */
   updateAnnotationBrushes () {
-    console.log('+++ updateAnnotationBrushes')
-    
     const annotationBrushes = this.annotationBrushes
     const defaultBrush = this.getDefaultBrush()
 
@@ -528,7 +522,7 @@ class LightCurveViewer extends Component {
       .each(function applyBrushLogic (annotationBrush) { // Don't use ()=>{}
         annotationBrush.brush(d3.select(this)) // Apply the brush logic to the <g.brush> element (i.e. 'this')
       })
-      .call(addRemoveAnnotationButton, this.removeAnnotationBrush.bind(this))
+      .call(addRemoveAnnotationButton, this.removeAnnotationBrush.bind(this))  // Note: the datum (the Annotation Brush) is passed as an argument to removeAnnotationBrush() due to the way that the data is joined by `.data()` above
 
     // Modify brushes so that their invisible overlays don't overlap and
     // accidentally block events from the brushes below them. The 'default'
@@ -718,34 +712,3 @@ LightCurveViewer.wrappedComponent.defaultProps = {
 }
 
 export default LightCurveViewer
-
-function addRemoveAnnotationButton (selection, onClick = null) {
-  const size = 20  // Width and height
-
-  const g = selection.append('g')
-    .attr('class', 'remove-button')
-    .attr('transform', `translate(0, 0)`)
-    .style('cursor', 'pointer')
-  
-  const lx = size * -0.2
-  const rx = size * 0.2
-  const uy = size * 0.3
-  const dy = size * 0.7
-  
-  g.append('circle')
-    .attr('fill', '#4cc')
-    .attr('r', size / 2)
-    .attr('cx', 0)
-    .attr('cy', size / 2)
-    .style('pointer-events', 'all')
-    .on('mousedown touchstart', () => { d3.event && d3.event.stopPropagation() })  // Prevent parent's brush events from triggering 
-    .on('click', onClick)
-
-  g.append('path')  // A big ol' X
-    .attr('stroke', '#eee')
-    .attr('stroke-width', '3')
-    .attr('d', `M ${lx} ${uy} L ${rx} ${dy} M ${rx} ${uy} L ${lx} ${dy} `)
-    .style('pointer-events', 'none')
-
-  return g
-}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addAxisLabel.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addAxisLabel.js
@@ -1,8 +1,9 @@
-export default function addAxisLabel (selection, className, text, axisLabelStyle) {
+export default function addAxisLabel (selection, className, text, axisStyle) {
   return selection
     .append('text')
     .attr('class', className)
-    .style('font-size', axisLabelStyle.fontSize)
-    .style('font-family', axisLabelStyle.fontFamily)
+    .style('font-size', axisStyle.fontSize)
+    .style('font-family', axisStyle.fontFamily)
+    .style('fill', axisStyle.color)
     .text(text)
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addAxisLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addAxisLayer.js
@@ -1,0 +1,37 @@
+/*
+Adds the Axis Layer to the chart.
+
+Structure is:
+```
+<g.axis-layer>
+  <g.x-axis>
+  <g.y-axis>
+  <text.x-axis-label>
+  <text.y-axis-label>
+```
+ */
+
+import addAxisLabel from './addAxisLabel'
+
+export default function addAxis (selection, chartStyle, xAxis, yAxis, axisXLabel, axisYLabel) {
+  const axisLayer = selection
+    .append('g')
+    .attr('class', 'axis-layer')
+  
+  axisLayer
+    .append('g')
+    .attr('class', 'x-axis')
+    .attr('color', chartStyle.color)
+    .call(xAxis)
+
+  axisLayer
+    .append('g')
+    .attr('class', 'y-axis')
+    .attr('color', chartStyle.color)
+    .call(yAxis)
+  
+  axisLayer.call(addAxisLabel, 'x-axis-label', axisXLabel, chartStyle)
+  axisLayer.call(addAxisLabel, 'y-axis-label', axisYLabel, chartStyle)
+
+  return axisLayer
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addAxisLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addAxisLayer.spec.js
@@ -1,0 +1,7 @@
+import addAxisLayer from './addAxisLayer'
+
+describe('LightCurveViewer > d3 > addAxisLayer', function () {
+  it('should exist', function () {
+    expect(addAxisLayer).to.be.a('function')
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBackgroundLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBackgroundLayer.js
@@ -1,8 +1,8 @@
-export default function addBackgroundLayer (selection) {
+export default function addBackgroundLayer (selection, chartStyle) {
   return selection
     .append('rect')
     .attr('class', 'deco background-layer')
     .attr('width', '100%')
     .attr('height', '100%')
-    .attr('fill', '#f8f8f8')
+    .attr('fill', chartStyle.background)
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBorderLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBorderLayer.js
@@ -5,6 +5,6 @@ export default function addBorderLayer (selection) {
     .attr('width', '100%')
     .attr('height', '100%')
     .attr('fill', 'none')
-    .attr('stroke', '#333')
+    .attr('stroke', '#444')
     .attr('stroke-width', '2')
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addRemoveAnnotationButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addRemoveAnnotationButton.js
@@ -1,0 +1,37 @@
+/*
+Clarification: this is a function for adding a "Remove Annotation" button. A
+button that removes an Annotation when it's clicked.
+ */
+
+import * as d3 from 'd3'
+
+export default function addRemoveAnnotationButton (selection, onClick = null) {
+  const size = 20  // Width and height
+
+  const g = selection.append('g')
+    .attr('class', 'remove-button')
+    .attr('transform', `translate(0, 0)`)
+    .style('cursor', 'pointer')
+  
+  const lx = size * -0.2
+  const rx = size * 0.2
+  const uy = size * 0.3
+  const dy = size * 0.7
+  
+  g.append('circle')
+    .attr('fill', '#4cc')
+    .attr('r', size / 2)
+    .attr('cx', 0)
+    .attr('cy', size / 2)
+    .style('pointer-events', 'all')
+    .on('mousedown touchstart', () => { d3.event && d3.event.stopPropagation() })  // Prevent parent's brush events from triggering 
+    .on('click', onClick)
+
+  g.append('path')  // A big ol' X
+    .attr('stroke', '#eee')
+    .attr('stroke-width', '3')
+    .attr('d', `M ${lx} ${uy} L ${rx} ${dy} M ${rx} ${uy} L ${lx} ${dy} `)
+    .style('pointer-events', 'none')
+
+  return g
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addRemoveAnnotationButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addRemoveAnnotationButton.js
@@ -1,33 +1,29 @@
-/*
-Clarification: this is a function for adding a "Remove Annotation" button. A
-button that removes an Annotation when it's clicked.
- */
-
 import * as d3 from 'd3'
 
 export default function addRemoveAnnotationButton (selection, onClick = null) {
-  const size = 20  // Width and height
+  const size = 20 // Width and height
+
+  const lx = size * -0.2
+  const rx = size * 0.2
+  const uy = size * 0.3
+  const dy = size * 0.7
 
   const g = selection.append('g')
     .attr('class', 'remove-button')
     .attr('transform', `translate(0, 0)`)
     .style('cursor', 'pointer')
-  
-  const lx = size * -0.2
-  const rx = size * 0.2
-  const uy = size * 0.3
-  const dy = size * 0.7
-  
+
   g.append('circle')
     .attr('fill', '#4cc')
     .attr('r', size / 2)
     .attr('cx', 0)
     .attr('cy', size / 2)
     .style('pointer-events', 'all')
-    .on('mousedown touchstart', () => { d3.event && d3.event.stopPropagation() })  // Prevent parent's brush events from triggering 
+    // Prevent parent's brush events from triggering
+    .on('mousedown touchstart', d3.event.stopPropagation)
     .on('click', onClick)
 
-  g.append('path')  // A big ol' X
+  g.append('path')
     .attr('stroke', '#eee')
     .attr('stroke-width', '3')
     .attr('d', `M ${lx} ${uy} L ${rx} ${dy} M ${rx} ${uy} L ${lx} ${dy} `)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addRemoveAnnotationButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addRemoveAnnotationButton.spec.js
@@ -1,0 +1,7 @@
+import addRemoveAnnotationButton from './addRemoveAnnotationButton'
+
+describe('LightCurveViewer > d3 > addRemoveAnnotationButton', function () {
+  it('should exist', function () {
+    expect(addRemoveAnnotationButton).to.be.a('function')
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setDataPointStyle.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setDataPointStyle.js
@@ -1,6 +1,6 @@
-export default function setDataPointStyle (selection) {
+export default function setDataPointStyle (selection, chartStyle) {
   return selection
     .attr('class', 'data-point')
-    .attr('r', 1.25)
-    .attr('fill', '#488')
+    .attr('r', chartStyle.dataPointSize)
+    .attr('fill', chartStyle.color)
 }


### PR DESCRIPTION
## PR Overview
package: lib-classifier
Requires / targets #385

This PR allows each Annotation to be deleted.
- This was done by modifying the standard D3 Brush with a 'Remove Annotation' button that does exactly that.

![screen shot 2019-01-25 at 20 25 49](https://user-images.githubusercontent.com/13952701/51770980-7721a400-20df-11e9-8ed1-14c818b29461.png)
_Two Annotations (annotation-brushes) with a teal 'X' button on each_

### Status
Ready for review.

This PR targets #385 for ease of review.
- If #385 hasn't been merged to master, this PR should continue to target that PR.
- If #385 _has_ been merged to master, this PR should be re-targeted to master.