### PR TITLE
Add Favourites toggle button

### DIFF
--- a/packages/lib-classifier/package-lock.json
+++ b/packages/lib-classifier/package-lock.json
@@ -8922,6 +8922,12 @@
 				}
 			}
 		},
+		"sinon-chai": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
+			"integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
+			"dev": true
+		},
 		"slice-ansi": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -78,6 +78,7 @@
     "react": "~16.6.3",
     "react-dom": "~16.6.3",
     "sinon": "~7.1.1",
+    "sinon-chai": "^3.3.0",
     "snazzy": "~8.0.0",
     "standard": "~12.0.1",
     "styled-components": "~4.1.2",

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
@@ -20,6 +20,9 @@ export default class MetaTools extends React.Component {
   constructor () {
     super()
 
+    this.toggleFavourites = this.toggleFavourites.bind(this)
+    this.toggleMetadataModal = this.toggleMetadataModal.bind(this)
+
     this.state = {
       isFavourite: false,
       showMetadataModal: false
@@ -37,7 +40,7 @@ export default class MetaTools extends React.Component {
   render () {
     const { className, isThereMetadata, subject } = this.props
     // Grommet's Button determines disabled state by whether or not onClick is defined
-    const onClick = (isThereMetadata) ? this.toggleMetadataModal.bind(this) : undefined
+    const onClick = (isThereMetadata) ? this.toggleMetadataModal : undefined
     return (
       <Box className={className} direction="row">
         {isThereMetadata &&
@@ -45,12 +48,12 @@ export default class MetaTools extends React.Component {
         {isThereMetadata &&
           <MetadataModal
             active={this.state.showMetadataModal}
-            closeFn={this.toggleMetadataModal.bind(this)}
+            closeFn={this.toggleMetadataModal}
             metadata={subject.metadata}
           />}
         <FavouritesButton
           checked={this.state.isFavourite}
-          onClick={this.toggleFavourites.bind(this)}
+          onClick={this.toggleFavourites}
         />
       </Box>
     )

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
@@ -4,6 +4,7 @@ import { Box } from 'grommet'
 import { inject, observer } from 'mobx-react'
 import MetadataButton from './components/MetadataButton'
 import MetadataModal from './components/MetadataModal'
+import FavouritesButton from './components/FavouritesButton'
 
 function storeMapper(stores) {
   const { active: subject, isThereMetadata } = stores.classifierStore.subjects
@@ -20,12 +21,17 @@ export default class MetaTools extends React.Component {
     super()
 
     this.state = {
+      isFavourite: false,
       showMetadataModal: false
     }
   }
 
   toggleMetadataModal () {
     this.setState((prevState) => { return { showMetadataModal: !prevState.showMetadataModal } })
+  }
+
+  toggleFavourites () {
+    this.setState(prevState => ({ isFavourite: !prevState.isFavourite }))
   }
 
   render () {
@@ -42,6 +48,10 @@ export default class MetaTools extends React.Component {
             closeFn={this.toggleMetadataModal.bind(this)}
             metadata={subject.metadata}
           />}
+        <FavouritesButton
+          checked={this.state.isFavourite}
+          onClick={this.toggleFavourites.bind(this)}
+        />
       </Box>
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.js
@@ -1,0 +1,54 @@
+import counterpart from 'counterpart'
+import PropTypes from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+import theme from 'styled-theming'
+import { Icon } from 'grommet-icons'
+import zooTheme  from '@zooniverse/grommet-theme'
+import { PlainButton } from '@zooniverse/react-components'
+import HeartIcon from './HeartIcon'
+
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
+
+const Favourite = styled(HeartIcon)`
+  fill: none;
+  stroke: ${theme('mode', {
+    dark: zooTheme.dark.colors.font,
+    light: zooTheme.light.colors.font
+  })};
+  width: 1em;
+`
+
+  const IsFavourite = styled(Favourite)`
+  fill: #E45950;
+`
+
+export default function FavouritesButton (props) {
+  const { checked, mode, onClick } = props
+  const Icon = checked ? IsFavourite : Favourite
+  const label = checked ? 'FavouritesButton.remove' : 'FavouritesButton.add'
+  return (
+    <PlainButton
+      aria-checked={checked}
+      icon={<Icon />}
+      margin={{ vertical: 'small', left: 'none', right: 'medium' }}
+      role='checkbox'
+      text={counterpart(label)}
+      onClick={onClick}
+    />
+  )
+}
+
+FavouritesButton.propTypes = {
+  checked: PropTypes.bool,
+  mode: PropTypes.string,
+  onClick: PropTypes.func
+}
+
+FavouritesButton.defaultProps = {
+  checked: false,
+  mode: 'light',
+  onClick: () => false
+}

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.js
@@ -12,7 +12,7 @@ import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
 
-const Favourite = styled(HeartIcon)`
+export const Favourite = styled(HeartIcon)`
   fill: none;
   stroke: ${theme('mode', {
     dark: zooTheme.dark.colors.font,
@@ -21,7 +21,7 @@ const Favourite = styled(HeartIcon)`
   width: 1em;
 `
 
-  const IsFavourite = styled(Favourite)`
+export const IsFavourite = styled(Favourite)`
   fill: #E45950;
 `
 

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.js
@@ -13,7 +13,7 @@ import en from './locales/en'
 counterpart.registerTranslations('en', en)
 
 export const Favourite = styled(HeartIcon)`
-  fill: none;
+  fill: ${props => props.filled ? '#E45950' : 'none'};
   stroke: ${theme('mode', {
     dark: zooTheme.dark.colors.font,
     light: zooTheme.light.colors.font
@@ -21,18 +21,13 @@ export const Favourite = styled(HeartIcon)`
   width: 1em;
 `
 
-export const IsFavourite = styled(Favourite)`
-  fill: #E45950;
-`
-
 export default function FavouritesButton (props) {
   const { checked, mode, onClick } = props
-  const Icon = checked ? IsFavourite : Favourite
   const label = checked ? 'FavouritesButton.remove' : 'FavouritesButton.add'
   return (
     <PlainButton
       aria-checked={checked}
-      icon={<Icon />}
+      icon={<Favourite filled={checked} />}
       margin={{ vertical: 'small', left: 'none', right: 'medium' }}
       role='checkbox'
       text={counterpart(label)}

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.spec.js
@@ -19,7 +19,7 @@ describe('Component > FavouritesButton', function () {
   it('should display an empty icon', function () {
     const button = wrapper.find(PlainButton)
     const { icon } = button.props()
-    expect(icon).to.deep.equal(<Favourite />)
+    expect(icon).to.deep.equal(<Favourite filled={false} />)
   })
 
   it('should not be checked', function () {
@@ -46,7 +46,7 @@ describe('Component > FavouritesButton', function () {
     it('should display a filled icon', function () {
       const button = wrapper.find(PlainButton)
       const { icon } = button.props()
-      expect(icon).to.deep.equal(<IsFavourite />)
+      expect(icon).to.deep.equal(<Favourite filled={true} />)
     })
 
     it('should be checked', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.spec.js
@@ -1,0 +1,16 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import FavouritesButton from './FavouritesButton'
+
+let wrapper
+
+describe('Component > FavouritesButton', function () {
+  before(function () {
+    wrapper = shallow(<FavouritesButton />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.spec.js
@@ -1,7 +1,9 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
+import { PlainButton } from '@zooniverse/react-components'
 
-import FavouritesButton from './FavouritesButton'
+import FavouritesButton, { Favourite, IsFavourite } from './FavouritesButton'
 
 let wrapper
 
@@ -12,5 +14,44 @@ describe('Component > FavouritesButton', function () {
 
   it('should render without crashing', function () {
     expect(wrapper).to.be.ok
+  })
+
+  it('should display an empty icon', function () {
+    const button = wrapper.find(PlainButton)
+    const { icon } = button.props()
+    expect(icon).to.deep.equal(<Favourite />)
+  })
+
+  it('should not be checked', function () {
+    const checked = wrapper.prop('aria-checked')
+    expect(checked).to.be.false
+  })
+
+  describe('on click', function () {
+    const onClickSpy = sinon.spy()
+    before(function () {
+      wrapper = shallow(<FavouritesButton checked={false} onClick={onClickSpy} />)
+    })
+
+    it('should call props.onClick', function () {
+      wrapper.simulate('click')
+      expect(onClickSpy).to.have.been.calledOnce
+    })
+  })
+  describe('when checked', function () {
+    before(function () {
+      wrapper = shallow(<FavouritesButton checked={true} />)
+    })
+
+    it('should display a filled icon', function () {
+      const button = wrapper.find(PlainButton)
+      const { icon } = button.props()
+      expect(icon).to.deep.equal(<IsFavourite />)
+    })
+
+    it('should be checked', function () {
+      const checked = wrapper.prop('aria-checked')
+      expect(checked).to.be.true
+    })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/HeartIcon.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/HeartIcon.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Icon } from 'grommet-icons'
+
+export default function HeartIcon (props) {
+  return (
+    <Icon
+      viewBox='0 0 24 24'
+      {...props}
+    >
+      <path
+        strokeWidth='2' 
+        d='M1,8.4 C1,4 4.5,3 6.5,3 C9,3 11,5 12,6.5 C13,5 15,3 17.5,3 C19.5,3 23,4 23,8.4 C23,15 12,21 12,21 C12,21 1,15 1,8.4 Z'
+      />
+    </Icon>
+  )
+}

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './FavouritesButton'

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/locales/en.json
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/locales/en.json
@@ -1,0 +1,6 @@
+{
+  "FavouritesButton": {
+    "add": "Add to favourites",
+    "remove": "Added to favourites"
+  }
+}

--- a/packages/lib-classifier/test/enzyme-setup.js
+++ b/packages/lib-classifier/test/enzyme-setup.js
@@ -1,4 +1,8 @@
-const { JSDOM } = require('jsdom')
+import chai from 'chai'
+import sinonChai from 'sinon-chai'
+import { JSDOM } from 'jsdom'
+
+chai.use(sinonChai)
 
 const jsdom = new JSDOM('<!doctype html><html><body></body></html>', {
   url: 'https://example.org/'


### PR DESCRIPTION
Package: lib-classifier

Adds a functional toggle button for favourites, plus tests.

Towards #397.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

