### PR TITLE
Add height and width to subject image

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -12,7 +12,11 @@ const SVG = styled.svg`
 function SingleImageViewer ({ url }) {
   return (
     <SVG>
-      <image xlinkHref={url} />
+      <image
+        height='100%'
+        width='100%'
+        xlinkHref={url}
+      />
       <InteractionLayer />
     </SVG>
   )


### PR DESCRIPTION
Explicitly specify height and width 100% on the subject image. Fixes a bug where Firefox renders the image with height and width 0.

Package: lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

