### PR TITLE
Security fix: upgrade webpack-dev-server

### DIFF
--- a/packages/lib-classifier/package-lock.json
+++ b/packages/lib-classifier/package-lock.json
@@ -1423,7 +1423,7 @@
 		"acorn-jsx": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+			"integrity": "sha1-MqBk/ZJUKSFqCbFBECv90YX65A4=",
 			"dev": true
 		},
 		"acorn-walk": {
@@ -1457,9 +1457,9 @@
 			"dev": true
 		},
 		"ansi-colors": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.1.tgz",
-			"integrity": "sha512-Xt+zb6nqgvV9SWAVp0EG3lRsHcbq5DDgqjPPz6pwgtj6RKz65zGXMNa82oJfOSBA/to6GmRP7Dr+6o+kbApTzQ==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+			"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
 			"dev": true
 		},
 		"ansi-escapes": {
@@ -1508,7 +1508,7 @@
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
 			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
@@ -1539,9 +1539,9 @@
 			"dev": true
 		},
 		"array-flatten": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+			"integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
 			"dev": true
 		},
 		"array-from": {
@@ -1664,7 +1664,7 @@
 		},
 		"async": {
 			"version": "1.5.2",
-			"resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
 			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
 			"dev": true
 		},
@@ -2422,7 +2422,7 @@
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
 			"dev": true
 		},
 		"class-utils": {
@@ -2583,9 +2583,9 @@
 			},
 			"dependencies": {
 				"mime-db": {
-					"version": "1.37.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-					"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+					"version": "1.38.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+					"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
 					"dev": true
 				}
 			}
@@ -2623,9 +2623,9 @@
 			}
 		},
 		"connect-history-api-fallback": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-			"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+			"integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
 			"dev": true
 		},
 		"console-browserify": {
@@ -3443,7 +3443,7 @@
 		"doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2"
@@ -3857,7 +3857,7 @@
 				"eslint-scope": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-					"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+					"integrity": "sha1-UL8wcekzi83EMzF5Sgy1M/ATYXI=",
 					"dev": true,
 					"requires": {
 						"esrecurse": "^4.1.0",
@@ -3867,7 +3867,7 @@
 				"ms": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
 					"dev": true
 				},
 				"strip-ansi": {
@@ -3896,7 +3896,7 @@
 		"eslint-import-resolver-node": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+			"integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
 			"dev": true,
 			"requires": {
 				"debug": "^2.6.9",
@@ -4019,7 +4019,7 @@
 				"prop-types": {
 					"version": "15.6.2",
 					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-					"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+					"integrity": "sha1-BdXKd7RFPphdYPx/+MhZCUpJcQI=",
 					"dev": true,
 					"requires": {
 						"loose-envify": "^1.3.1",
@@ -4076,7 +4076,7 @@
 		"esquery": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+			"integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
 			"dev": true,
 			"requires": {
 				"estraverse": "^4.0.0"
@@ -4467,7 +4467,7 @@
 		},
 		"finalhandler": {
 			"version": "1.1.1",
-			"resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
 			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
 			"dev": true,
 			"requires": {
@@ -4521,7 +4521,7 @@
 		"flat-cache": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-			"integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+			"integrity": "sha1-LC73dSXMKSkAff/6HdMUqpyd7m8=",
 			"dev": true,
 			"requires": {
 				"circular-json": "^0.3.1",
@@ -5308,7 +5308,7 @@
 		},
 		"globby": {
 			"version": "6.1.0",
-			"resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 			"dev": true,
 			"requires": {
@@ -5321,7 +5321,7 @@
 			"dependencies": {
 				"pify": {
 					"version": "2.3.0",
-					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				}
@@ -5360,9 +5360,9 @@
 			"dev": true
 		},
 		"handle-thing": {
-			"version": "1.2.5",
-			"resolved": "http://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
+			"integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
 			"dev": true
 		},
 		"har-schema": {
@@ -5502,7 +5502,7 @@
 		"hosted-git-info": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
 			"dev": true
 		},
 		"hpack.js": {
@@ -5598,7 +5598,7 @@
 		},
 		"http-errors": {
 			"version": "1.6.3",
-			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"dev": true,
 			"requires": {
@@ -5627,7 +5627,7 @@
 		},
 		"http-proxy-middleware": {
 			"version": "0.18.0",
-			"resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
 			"integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
 			"dev": true,
 			"requires": {
@@ -6125,7 +6125,7 @@
 		"is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
 			"dev": true
 		},
 		"is-stream": {
@@ -6246,7 +6246,7 @@
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
 					"dev": true
 				}
 			}
@@ -6656,7 +6656,7 @@
 		},
 		"media-typer": {
 			"version": "0.3.0",
-			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
 			"dev": true
 		},
@@ -7760,7 +7760,7 @@
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
 			"dev": true
 		},
 		"pluralizers": {
@@ -7784,9 +7784,9 @@
 			}
 		},
 		"portfinder": {
-			"version": "1.0.19",
-			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.19.tgz",
-			"integrity": "sha512-23aeQKW9KgHe6citUrG3r9HjeX6vls0h713TAa+CwTKZwNIr/pD2ApaxYF4Um3ZZyq4ar+Siv3+fhoHaIwSOSw==",
+			"version": "1.0.20",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
+			"integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
 			"dev": true,
 			"requires": {
 				"async": "^1.5.2",
@@ -9199,13 +9199,13 @@
 		"spdx-exceptions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
 			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
 			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
@@ -9219,32 +9219,75 @@
 			"dev": true
 		},
 		"spdy": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
-			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.0.tgz",
+			"integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.8",
-				"handle-thing": "^1.2.5",
+				"debug": "^4.1.0",
+				"handle-thing": "^2.0.0",
 				"http-deceiver": "^1.2.7",
-				"safe-buffer": "^5.0.1",
 				"select-hose": "^2.0.0",
-				"spdy-transport": "^2.0.18"
+				"spdy-transport": "^3.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
 			}
 		},
 		"spdy-transport": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.1.tgz",
-			"integrity": "sha512-q7D8c148escoB3Z7ySCASadkegMmUZW8Wb/Q1u0/XBgDKMO880rLQDj8Twiew/tYi7ghemKUi/whSYOwE17f5Q==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+			"integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.8",
-				"detect-node": "^2.0.3",
+				"debug": "^4.1.0",
+				"detect-node": "^2.0.4",
 				"hpack.js": "^2.1.6",
-				"obuf": "^1.1.1",
-				"readable-stream": "^2.2.9",
-				"safe-buffer": "^5.0.1",
-				"wbuf": "^1.7.2"
+				"obuf": "^1.1.2",
+				"readable-stream": "^3.0.6",
+				"wbuf": "^1.7.3"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+					"integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"split-string": {
@@ -9779,7 +9822,7 @@
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
 			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
@@ -10239,7 +10282,7 @@
 		"validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
 			"dev": true,
 			"requires": {
 				"spdx-correct": "^3.0.0",
@@ -10413,9 +10456,9 @@
 			}
 		},
 		"webpack-dev-server": {
-			"version": "3.1.10",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.10.tgz",
-			"integrity": "sha512-RqOAVjfqZJtQcB0LmrzJ5y4Jp78lv9CK0MZ1YJDTaTmedMZ9PU9FLMQNrMCfVu8hHzaVLVOJKBlGEHMN10z+ww==",
+			"version": "3.1.14",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz",
+			"integrity": "sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==",
 			"dev": true,
 			"requires": {
 				"ansi-html": "0.0.7",
@@ -10437,12 +10480,14 @@
 				"portfinder": "^1.0.9",
 				"schema-utils": "^1.0.0",
 				"selfsigned": "^1.9.1",
+				"semver": "^5.6.0",
 				"serve-index": "^1.7.2",
 				"sockjs": "0.3.19",
 				"sockjs-client": "1.3.0",
-				"spdy": "^3.4.1",
+				"spdy": "^4.0.0",
 				"strip-ansi": "^3.0.0",
 				"supports-color": "^5.1.0",
+				"url": "^0.11.0",
 				"webpack-dev-middleware": "3.4.0",
 				"webpack-log": "^2.0.0",
 				"yargs": "12.0.2"
@@ -10498,9 +10543,9 @@
 					"dev": true
 				},
 				"p-limit": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-					"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -10531,6 +10576,12 @@
 						"ajv-errors": "^1.0.0",
 						"ajv-keywords": "^3.1.0"
 					}
+				},
+				"semver": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+					"dev": true
 				},
 				"yargs": {
 					"version": "12.0.2",

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -85,7 +85,7 @@
     "superagent": "~3.8.3",
     "webpack": "~4.26.1",
     "webpack-cli": "~3.1.2",
-    "webpack-dev-server": "~3.1.10"
+    "webpack-dev-server": "^3.1.14"
   },
   "standard": {
     "env": {


### PR DESCRIPTION
Package: lib-classifier

Security patch for webpack-dev-server.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

