### PR TITLE
Add collections to the API client

### DIFF
--- a/packages/lib-panoptes-js/src/index.js
+++ b/packages/lib-panoptes-js/src/index.js
@@ -1,6 +1,7 @@
 const { config, env } = require('./config')
 const panoptes = require('./panoptes')
 
+const collections = require('./resources/collections')
 const media = require('./resources/media')
 const projects = require('./resources/projects')
 const subjects = require('./resources/subjects')
@@ -8,6 +9,7 @@ const tutorials = require('./resources/tutorials')
 const users = require('./resources/users')
 
 module.exports = {
+  collections,
   config,
   env,
   media,

--- a/packages/lib-panoptes-js/src/resources/collections/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/collections/commonRequests.js
@@ -19,7 +19,7 @@ function removeSubjects (params) {
   if (!collectionId) return raiseError('Collections remove subject: collections ID is required.', 'error')
   const authorization = (params && params.authorization) ? params.authorization : ''
   const subjects = params && params.subjects
-  if (!subjects || !Array.isArray(subjects)) return raiseError('Collections removesubjects: subjects array is required.', 'error')
+  if (!subjects || !Array.isArray(subjects)) return raiseError('Collections remove subjects: subjects array is required.', 'error')
 
   if (typeof collectionId !== 'string') return raiseError('Collections remove link: collections id must be a string.', 'typeError')
 

--- a/packages/lib-panoptes-js/src/resources/collections/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/collections/commonRequests.js
@@ -1,0 +1,29 @@
+const panoptes = require('../../panoptes')
+const { endpoint } = require('./helpers')
+const { raiseError } = require('../../utilityFunctions')
+
+function addSubjects (params) {
+  const collectionId = params && params.id
+  if (!collectionId) return raiseError('Collections add subject: collections ID is required.', 'error')
+  const authorization = (params && params.authorization) ? params.authorization : ''
+  const subjects = params && params.subjects
+  if (!subjects || !Array.isArray(subjects)) return raiseError('Collections add subjects: subjects array is required.', 'error')
+
+  if (typeof collectionId !== 'string') return raiseError('Collections add link: collections id must be a string.', 'typeError')
+
+  return panoptes.post(`${endpoint}/${collectionId}/links/subjects`, { subjects }, authorization)
+}
+
+function removeSubjects (params) {
+  const collectionId = params && params.id
+  if (!collectionId) return raiseError('Collections remove subject: collections ID is required.', 'error')
+  const authorization = (params && params.authorization) ? params.authorization : ''
+  const subjects = params && params.subjects
+  if (!subjects || !Array.isArray(subjects)) return raiseError('Collections removesubjects: subjects array is required.', 'error')
+
+  if (typeof collectionId !== 'string') return raiseError('Collections remove link: collections id must be a string.', 'typeError')
+
+  return panoptes.del(`${endpoint}/${collectionId}/links/subjects/${subjects.join(',')}`, authorization)
+}
+
+module.exports = { addSubjects, removeSubjects }

--- a/packages/lib-panoptes-js/src/resources/collections/helpers.js
+++ b/packages/lib-panoptes-js/src/resources/collections/helpers.js
@@ -1,0 +1,3 @@
+const endpoint = '/collections'
+
+module.exports = { endpoint }

--- a/packages/lib-panoptes-js/src/resources/collections/index.js
+++ b/packages/lib-panoptes-js/src/resources/collections/index.js
@@ -1,0 +1,13 @@
+const { create, get, update, del } = require('./rest')
+const { addSubjects, removeSubjects } = require('./commonRequests')
+const { endpoint } = require('./helpers')
+
+module.exports = {
+  create,
+  get,
+  delete: del,
+  update,
+  endpoint,
+  addSubjects,
+  removeSubjects
+}

--- a/packages/lib-panoptes-js/src/resources/collections/index.js
+++ b/packages/lib-panoptes-js/src/resources/collections/index.js
@@ -1,6 +1,7 @@
 const { create, get, update, del } = require('./rest')
 const { addSubjects, removeSubjects } = require('./commonRequests')
 const { endpoint } = require('./helpers')
+const mocks = require('./mocks')
 
 module.exports = {
   create,
@@ -9,5 +10,6 @@ module.exports = {
   update,
   endpoint,
   addSubjects,
-  removeSubjects
+  removeSubjects,
+  mocks
 }

--- a/packages/lib-panoptes-js/src/resources/collections/mocks.js
+++ b/packages/lib-panoptes-js/src/resources/collections/mocks.js
@@ -1,0 +1,42 @@
+const { buildResponse } = require('../../utilityFunctions')
+
+const collection = {
+  created_at: '2015-03-17T13:45:40.297Z',
+  description: '',
+  display_name: 'test collection',
+  external_id: null,
+  favorite: false,
+  href: '/collections/1',
+  id: '1',
+  links: {
+    projects: ['1'],
+    subjects: ['1']
+  },
+  private: true,
+  updated_at: '2015-03-17T13:45:40.297Z'
+}
+
+const collections = [
+  collection,
+  Object.assign({}, collection, { id: '2' })
+]
+
+const resources = {
+  collection,
+  collections
+}
+
+const collectionResponse = buildResponse('get', 'collections', [resources.collection], {})
+const collectionsResponse = buildResponse('get', 'collections', resources.collections, {})
+
+const responses = {
+  get: {
+    collection: collectionResponse,
+    collections: collectionsResponse
+  }
+}
+
+module.exports = {
+  resources,
+  responses
+}

--- a/packages/lib-panoptes-js/src/resources/collections/rest.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.js
@@ -5,11 +5,12 @@ const { raiseError } = require('../../utilityFunctions')
 function create (params) {
   const newCollectionData = (params && params.data) || {}
   const authorization = (params && params.authorization) ? params.authorization : ''
-  const projects = (params && params.projects) || []
   const subjects = (params && params.subjects) || []
   const links = {
-    projects,
     subjects
+  }
+  if (params && params.project) {
+    links.project = params.project
   }
   const collectionData = Object.assign({}, newCollectionData, { links })
 

--- a/packages/lib-panoptes-js/src/resources/collections/rest.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.js
@@ -3,12 +3,10 @@ const { endpoint } = require('./helpers')
 const { raiseError } = require('../../utilityFunctions')
 
 function create (params) {
-  const newCollectionData = (params && params.data) ? params.data : {}
+  const newCollectionData = (params && params.data) || {}
   const authorization = (params && params.authorization) ? params.authorization : ''
-  const projects = params && params.projects
-  const subjects = (params && params.subjects) ? params.subjects : []
-  if (!projects || !Array.isArray(projects)) return raiseError('Collection create: projects array is required.', 'error')
-  // TODO: project and subject links
+  const projects = (params && params.projects) || []
+  const subjects = (params && params.subjects) || []
   const links = {
     projects,
     subjects

--- a/packages/lib-panoptes-js/src/resources/collections/rest.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.js
@@ -12,9 +12,9 @@ function create (params) {
   if (params && params.project) {
     links.project = params.project
   }
-  const collectionData = Object.assign({}, newCollectionData, { links })
+  const collections = Object.assign({}, newCollectionData, { links })
 
-  return panoptes.post(endpoint, collectionData, authorization)
+  return panoptes.post(endpoint, { collections }, authorization)
 }
 
 function get (params) {

--- a/packages/lib-panoptes-js/src/resources/collections/rest.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.js
@@ -31,10 +31,12 @@ function get (params) {
 
 function update (params) {
   const changes = (params && params.data) ? params.data : null
+  const collectionId = params && params.id
   const authorization = (params && params.authorization) ? params.authorization : ''
+  if (!collectionId) return raiseError('Collections: Update request id must be present.', 'typeError')
   if (!changes) return raiseError('Collection update: payload not supplied.', 'error')
 
-  return panoptes.put(endpoint, changes, authorization)
+  return panoptes.put(`${endpoint}/${collectionId}`, { collections: changes }, authorization)
 }
 
 function del (params) {

--- a/packages/lib-panoptes-js/src/resources/collections/rest.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.js
@@ -5,10 +5,13 @@ const { raiseError } = require('../../utilityFunctions')
 function create (params) {
   const newCollectionData = (params && params.data) ? params.data : {}
   const authorization = (params && params.authorization) ? params.authorization : ''
+  const projects = params && params.projects
+  const subjects = (params && params.subjects) ? params.subjects : []
+  if (!projects || !Array.isArray(projects)) return raiseError('Collection create: projects array is required.', 'error')
   // TODO: project and subject links
   const links = {
-    projects: [],
-    subjects: []
+    projects,
+    subjects
   }
   const collectionData = Object.assign({}, newCollectionData, { links })
 

--- a/packages/lib-panoptes-js/src/resources/collections/rest.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.js
@@ -1,0 +1,47 @@
+const panoptes = require('../../panoptes')
+const { endpoint } = require('./helpers')
+const { raiseError } = require('../../utilityFunctions')
+
+function create (params) {
+  const newCollectionData = (params && params.data) ? params.data : {}
+  const authorization = (params && params.authorization) ? params.authorization : ''
+  // TODO: project and subject links
+  const links = {
+    projects: [],
+    subjects: []
+  }
+  const collectionData = Object.assign({}, newCollectionData, { links })
+
+  return panoptes.post(endpoint, collectionData, authorization)
+}
+
+function get (params) {
+  const queryParams = (params && params.query) ? params.query : {}
+  const collectionId = (params && params.id) ? params.id : ''
+  const authorization = (params && params.authorization) ? params.authorization : ''
+
+  if (!collectionId) return panoptes.get(endpoint, queryParams, authorization)
+  if (collectionId && typeof collectionId !== 'string') return raiseError('Collections: Get request id must be a string.', 'typeError')
+
+  return panoptes.get(`${endpoint}/${collectionId}`, {}, authorization)
+}
+
+function update (params) {
+  const changes = (params && params.data) ? params.data : null
+  const authorization = (params && params.authorization) ? params.authorization : ''
+  if (!changes) return raiseError('Collection update: payload not supplied.', 'error')
+
+  return panoptes.put(endpoint, changes, authorization)
+}
+
+function del (params) {
+  const collectionId = (params && params.id) ? params.id : ''
+  const authorization = (params && params.authorization) ? params.authorization : ''
+
+  if (!collectionId) return raiseError('Collections: Delete request id must be present.', 'typeError')
+  if (collectionId && typeof collectionId !== 'string') return raiseError('Collections: Delete request id must be a string.', 'typeError')
+
+  return panoptes.del(`${endpoint}/${collectionId}`, authorization)
+}
+
+module.exports = { create, get, update, del }

--- a/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
@@ -89,4 +89,48 @@ describe('Collections resource REST requests', function () {
       })
     })
   })
+
+  describe('update', function () {
+    const data = {
+      display_name: 'my test collection'
+    }
+    const expectedPutResponse = Object.assign({}, responses.get.collection, data)
+    const requestBody = { collections : data }
+    let scope
+
+    before(function () {
+      scope = nock(config.host)
+        .persist()
+        .put(`${endpoint}/10`, requestBody)
+        .query(true)
+        .reply(200, expectedPutResponse)
+    })
+
+    after(function () {
+      nock.cleanAll()
+    })
+
+    it('should raise an error if a collection is not specified', async function () {
+      try {
+        await collections.update({})
+        expect.fail()
+      } catch (error) {
+        expect(error.message).to.equal('Collections: Update request id must be present.')
+      }
+    })
+
+    it('should raise an error if no changes are specified', async function () {
+      try {
+        await collections.update({ id: '10' })
+        expect.fail()
+      } catch (error) {
+        expect(error.message).to.equal('Collection update: payload not supplied.')
+      }
+    })
+
+    it('should update the specified collection', async function () {
+      const response = await collections.update({ id: '10', data })
+      expect(response.body).to.eql(expectedPutResponse)
+    })
+  })
 })

--- a/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
@@ -164,4 +164,85 @@ describe('Collections resource REST requests', function () {
       expect(response.body).to.eql(expectedDeleteResponse)
     })
   })
+
+  describe('add subjects', function () {
+    const expectedAddResponse = responses.get.collection
+    const subjects = ['2']
+    let scope
+
+    before(function () {
+      scope = nock(config.host)
+        .persist()
+        .post(`${endpoint}/10/links/subjects`, { subjects })
+        .query(true)
+        .reply(200, expectedAddResponse)
+    })
+
+    after(function () {
+      nock.cleanAll()
+    })
+
+    it('should raise an error if a collection is not specified', async function () {
+      try {
+        await collections.addSubjects({})
+        expect.fail()
+      } catch (error) {
+        expect(error.message).to.equal('Collections add subject: collections ID is required.')
+      }
+    })
+
+    it('should raise an error if subjects is not an array', async function () {
+      try {
+        await collections.addSubjects({ id: '10', subjects: '2'})
+        expect.fail()
+      } catch (error) {
+        expect(error.message).to.equal('Collections add subjects: subjects array is required.')
+      }
+    })
+
+    it('should add subjects to the specified collection', async function () {
+      const response = await collections.addSubjects({ id: '10', subjects })
+      expect(response).to.be.ok
+    })
+  })
+
+  describe('remove subjects', function () {
+    const expectedDeleteResponse = {}
+    let scope
+
+    before(function () {
+      scope = nock(config.host)
+        .persist()
+        .delete(`${endpoint}/10/links/subjects/2`)
+        .query(true)
+        .reply(200, expectedDeleteResponse)
+    })
+
+    after(function () {
+      nock.cleanAll()
+    })
+
+    it('should raise an error if a collection is not specified', async function () {
+      try {
+        await collections.removeSubjects({})
+        expect.fail()
+      } catch (error) {
+        expect(error.message).to.equal('Collections remove subject: collections ID is required.')
+      }
+    })
+
+    it('should raise an error if subjects is not an array', async function () {
+      try {
+        await collections.removeSubjects({ id: '10', subjects: '2'})
+        expect.fail()
+      } catch (error) {
+        expect(error.message).to.equal('Collections remove subjects: subjects array is required.')
+      }
+    })
+
+    it('should unlink the specified subjects', async function () {
+      const response = await collections.removeSubjects({ id: '10', subjects: ['2'] })
+      expect(response).to.be.ok
+    })
+  })
 })

--- a/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
@@ -133,4 +133,35 @@ describe('Collections resource REST requests', function () {
       expect(response.body).to.eql(expectedPutResponse)
     })
   })
+
+  describe('delete', function () {
+    const expectedDeleteResponse = {}
+    let scope
+
+    before(function () {
+      scope = nock(config.host)
+        .persist()
+        .delete(`${endpoint}/10`)
+        .query(true)
+        .reply(200, expectedDeleteResponse)
+    })
+
+    after(function () {
+      nock.cleanAll()
+    })
+
+    it('should raise an error if a collection is not specified', async function () {
+      try {
+        await collections.delete({})
+        expect.fail()
+      } catch (error) {
+        expect(error.message).to.equal('Collections: Delete request id must be present.')
+      }
+    })
+
+    it('should delete the specified collection', async function () {
+      const response = await collections.delete({ id: '10' })
+      expect(response.body).to.eql(expectedDeleteResponse)
+    })
+  })
 })

--- a/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
@@ -142,7 +142,8 @@ describe('Collections resource REST requests', function () {
       project: '2',
       subjects: []
     }
-    const payload = Object.assign({}, data, { links })
+    const changes = Object.assign({}, data, { links })
+    const payload = { collections: changes }
     let scope
 
     before(function () {

--- a/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
@@ -8,7 +8,6 @@ const collections = require('./index')
 
 describe('Collections resource REST requests', function () {
   describe('get', function () {
-
     describe('with a collection ID', function () {
       const expectedGetResponse = responses.get.collection
       let scope
@@ -39,7 +38,7 @@ describe('Collections resource REST requests', function () {
         expect(response.body).to.eql(expectedGetResponse)
       })
     })
- 
+
     describe('without a collection ID', function () {
       const expectedGetResponse = responses.get.collections
       const query = {
@@ -95,7 +94,7 @@ describe('Collections resource REST requests', function () {
       display_name: 'my test collection'
     }
     const expectedPutResponse = Object.assign({}, responses.get.collection, data)
-    const requestBody = { collections : data }
+    const requestBody = { collections: data }
     let scope
 
     before(function () {
@@ -131,6 +130,36 @@ describe('Collections resource REST requests', function () {
     it('should update the specified collection', async function () {
       const response = await collections.update({ id: '10', data })
       expect(response.body).to.eql(expectedPutResponse)
+    })
+  })
+
+  describe('create', function () {
+    const expectedCreateResponse = responses.get.collection
+    const data = {
+      display_name: 'test collection'
+    }
+    const links = {
+      projects: [],
+      subjects: []
+    }
+    const payload = Object.assign({}, data, { links })
+    let scope
+
+    before(function () {
+      scope = nock(config.host)
+        .persist()
+        .post(`${endpoint}`, payload)
+        .query(true)
+        .reply(201, expectedCreateResponse)
+    })
+
+    after(function () {
+      nock.cleanAll()
+    })
+
+    it('should create a new collection', async function () {
+      const response = await collections.create({ data })
+      expect(response.body).to.eql(expectedCreateResponse)
     })
   })
 

--- a/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
@@ -1,0 +1,92 @@
+const { expect } = require('chai')
+const nock = require('nock')
+
+const { config } = require('../../config')
+const { resources, responses } = require('./mocks')
+const { endpoint } = require('./helpers')
+const collections = require('./index')
+
+describe('Collections resource REST requests', function () {
+  describe('get', function () {
+
+    describe('with a collection ID', function () {
+      const expectedGetResponse = responses.get.collection
+      let scope
+
+      before(function () {
+        scope = nock(config.host)
+          .persist()
+          .get(`${endpoint}/10`)
+          .query(true)
+          .reply(200, expectedGetResponse)
+      })
+
+      after(function () {
+        nock.cleanAll()
+      })
+
+      it('should error if the collection ID is not a string', async function () {
+        try {
+          await collections.get({ id: 1 })
+          expect.fail()
+        } catch (error) {
+          expect(error.message).to.equal('Collections: Get request id must be a string.')
+        }
+      })
+
+      it('should return a collection', async function () {
+        const response = await collections.get({ id: '10' })
+        expect(response.body).to.eql(expectedGetResponse)
+      })
+    })
+ 
+    describe('without a collection ID', function () {
+      const expectedGetResponse = responses.get.collections
+      const query = {
+        project_ids: '1',
+        owner: 'test',
+        http_cache: 'true'
+      }
+      let scope
+
+      before(function () {
+        scope = nock(config.host)
+          .persist()
+          .get(`${endpoint}`)
+          .query(query)
+          .reply(200, expectedGetResponse)
+      })
+
+      after(function () {
+        nock.cleanAll()
+      })
+
+      it('should query the API for a list of collections', async function () {
+        const response = await collections.get({ query })
+        expect(response.body).to.eql(expectedGetResponse)
+      })
+    })
+
+    describe('with an authorization param', function () {
+      const expectedGetResponse = responses.get.collection
+      let scope
+
+      before(function () {
+        scope = nock(config.host)
+          .persist()
+          .get(uri => uri.includes(endpoint))
+          .query(true)
+          .reply(200, expectedGetResponse)
+      })
+
+      after(function () {
+        nock.cleanAll()
+      })
+
+      it('should add the Authorization header to the request', async function () {
+        const response = await collections.get({ id: '10', authorization: '12345' })
+        expect(response.req.headers.authorization).to.equal('12345')
+      })
+    })
+  })
+})

--- a/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
@@ -139,7 +139,7 @@ describe('Collections resource REST requests', function () {
       display_name: 'test collection'
     }
     const links = {
-      projects: [],
+      project: '2',
       subjects: []
     }
     const payload = Object.assign({}, data, { links })
@@ -158,7 +158,7 @@ describe('Collections resource REST requests', function () {
     })
 
     it('should create a new collection', async function () {
-      const response = await collections.create({ data })
+      const response = await collections.create({ data, project: '2' })
       expect(response.body).to.eql(expectedCreateResponse)
     })
   })


### PR DESCRIPTION
Package: lib-panoptes-js

Add collections to the API client, so that we can wire up the classifier favourites and collections buttons to the API.

Adds `collections.create|get|update|delete` and a couple of helpers to link and unlink subjects.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

