### PR TITLE
Do not define custom npm install script

### DIFF
--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -11,7 +11,6 @@
     "_test": "npm run _check && BABEL_ENV=test mocha",
     "build": "npm run _check && PANOPTES_ENV=production next build",
     "dev": "npm run _check && PANOPTES_ENV=staging npm run _serve",
-    "install": "lerna bootstrap --scope=@zooniverse/fe-project",
     "start": "npm run _check && NODE_ENV=production npm run _serve",
     "test": "npm run _test && exit 0",
     "test:ci": "npm run _test"

--- a/packages/lib-async-states/package.json
+++ b/packages/lib-async-states/package.json
@@ -18,7 +18,6 @@
     "_compress": "minify src/async-states.js -d dist",
     "_test": "mocha",
     "build": "npm run _clean && npm run _compress",
-    "install": "lerna bootstrap --scope=@zooniverse/async-states",
     "lint": "standard src --fix | snazzy; exit 0",
     "prepare": "npm run build",
     "test": "npm run _test && exit 0",

--- a/packages/lib-auth/package.json
+++ b/packages/lib-auth/package.json
@@ -13,7 +13,6 @@
     "build:dev": "export PANOPTES_ENV=staging && npm run build",
     "build:production": "export PANOPTES_ENV=production && npm run build",
     "dev": "npm run _check && webpack-dev-server --port 3000 --config webpack.dev.js",
-    "install": "lerna bootstrap --scope=@zooniverse/auth",
     "lint": "npm run _check && standard --fix | snazzy; exit 0",
     "start": "export PANOPTES_ENV=production && npm run _check && npm run dev",
     "test": "npm run _test && exit 0",


### PR DESCRIPTION
Package: lib-auth, lib-async-states, app-project

The latest version of lerna has changes to the bootstrap command and having a custom defined npm install script that calls bootstrap was causing an infinite loop of bootstrap commands being called. This update removes the custom defined npm install script for these packages and let's lerna do its thing. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

