### PR TITLE
Add user collections to a project

### DIFF
--- a/packages/app-project/package-lock.json
+++ b/packages/app-project/package-lock.json
@@ -1360,7 +1360,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
             "inherits": "2.0.1"
@@ -1461,7 +1461,7 @@
     },
     "babel-plugin-react-require": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz",
       "integrity": "sha1-Lk57RJa5OmVKHIAEInbeTk7rIOM="
     },
     "babel-plugin-styled-components": {
@@ -3435,8 +3435,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -3457,14 +3456,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3479,20 +3476,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3609,8 +3603,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
@@ -3622,7 +3615,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3637,7 +3629,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3645,14 +3636,12 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3671,7 +3660,6 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3752,8 +3740,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3765,7 +3752,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3851,8 +3837,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "optional": true
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3888,7 +3873,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3908,7 +3892,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3952,14 +3935,12 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "optional": true
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
     },
@@ -4281,7 +4262,7 @@
     },
     "htmlescape": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
     },
     "htmlparser2": {
@@ -4300,7 +4281,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
           "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
           "dev": true
         },
@@ -5845,7 +5826,7 @@
       "dependencies": {
         "http-errors": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
           "integrity": "sha1-bAJC3qaz33r9oVPHEImzHG6Cqr8=",
           "requires": {
             "inherits": "2.0.1",
@@ -6741,6 +6722,12 @@
         "supports-color": "^5.5.0"
       }
     },
+    "sinon-chai": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
+      "integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
+      "dev": true
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -7209,7 +7196,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "requires": {
         "ajv": "^6.0.1",
@@ -7501,7 +7488,7 @@
       "dependencies": {
         "cacache": {
           "version": "10.0.4",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
           "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
           "requires": {
             "bluebird": "^3.5.1",

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -51,7 +51,8 @@
     "enzyme": "~3.7.0",
     "enzyme-adapter-react-16": "~1.7.0",
     "jsdom": "~13.0.0",
-    "mocha": "~5.2.0"
+    "mocha": "~5.2.0",
+    "sinon-chai": "^3.3.0"
   },
   "engines": {
     "node": ">=8"

--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -69,8 +69,6 @@ export default class MyApp extends App {
     const userResource = await auth.checkCurrent()
     if (userResource) {
       this.store.user.set(userResource)
-      const { project } = getSnapshot(this.store)
-      this.store.collections.fetchFavourites(project, userResource)
     }
   }
 

--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -69,6 +69,8 @@ export default class MyApp extends App {
     const userResource = await auth.checkCurrent()
     if (userResource) {
       this.store.user.set(userResource)
+      const { project } = getSnapshot(this.store)
+      this.store.collections.fetchFavourites(project, userResource)
     }
   }
 

--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -35,9 +35,9 @@ const Collections = types
         }
         const projects = [project.id]
         const subjects = []
-        const favourites = yield client.create({ authorization, data, projects, subjects })
+        const response = yield client.create({ authorization, data, projects, subjects })
+        const [ favourites ] = response.body.collections
         self.loadingState = asyncStates.success
-        console.log(favourites)
         self.favourites = Collection.create(favourites)
       }),
 

--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -33,9 +33,8 @@ const Collections = types
           display_name: `Favourites ${project.slug}`,
           favorite: true
         }
-        const projects = [project.id]
         const subjects = []
-        const response = yield client.create({ authorization, data, projects, subjects })
+        const response = yield client.create({ authorization, data, project : project.id, subjects })
         const [ favourites ] = response.body.collections
         self.loadingState = asyncStates.success
         self.favourites = Collection.create(favourites)

--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -8,7 +8,7 @@ export const Collection = types
     display_name: types.maybeNull(types.string),
     favorite: false,
     id: types.identifier,
-    links: types.maybeNull(types.frozen({})),
+    links: types.frozen({}),
     private: true
   })
 
@@ -40,12 +40,12 @@ const Collections = types
       },
 
       createFavourites: flow( function * createFavourites () {
-        const project = getRoot(self).project
+        const { project } = getRoot(self)
         self.loadingState = asyncStates.loading
         const token = yield auth.checkBearerToken()
         const authorization = `Bearer ${token}`
         const data = {
-          display_name: `Favourites ${project.slug}`,
+          display_name: `Favorites ${project.slug}`,
           favorite: true
         }
         const subjects = []
@@ -56,8 +56,7 @@ const Collections = types
       }),
 
       fetchFavourites: flow( function * fetchFavourites () {
-        const project = getRoot(self).project
-        const user = getRoot(self).user
+        const { project, user } = getRoot(self)
         self.loadingState = asyncStates.loading
         const token = yield auth.checkBearerToken()
         const authorization = `Bearer ${token}`

--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -37,6 +37,7 @@ const Collections = types
         const subjects = []
         const favourites = yield client.create({ authorization, data, projects, subjects })
         self.loadingState = asyncStates.success
+        console.log(favourites)
         self.favourites = Collection.create(favourites)
       }),
 

--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -1,0 +1,65 @@
+import asyncStates from '@zooniverse/async-states'
+import { flow, getRoot, types } from 'mobx-state-tree'
+import auth from 'panoptes-client/lib/auth'
+
+export const Collection = types
+  .model('Collection', {
+    display_name: types.maybeNull(types.string),
+    favorite: false,
+    id: types.identifier,
+    links: types.maybeNull(types.frozen({})),
+    private: true
+  })
+
+const Collections = types
+  .model('Collections', {
+    error: types.maybeNull(types.frozen({})),
+    favourites: types.maybeNull(Collection),
+    loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.initialized),
+  })
+
+  .actions(self => {
+    let client
+    return {
+      afterAttach () {
+        client = getRoot(self).client.collections
+      },
+
+      createFavourites: flow( function * createFavourites (project) {
+        self.loadingState = asyncStates.loading
+        const token = yield auth.checkBearerToken()
+        const authorization = `Bearer ${token}`
+        const data = {
+          display_name: `Favourites ${project.slug}`,
+          favorite: true
+        }
+        const projects = [project.id]
+        const subjects = []
+        const favourites = yield client.create({ authorization, data, projects, subjects })
+        self.loadingState = asyncStates.success
+        self.favourites = Collection.create(favourites)
+      }),
+
+      fetchFavourites: flow( function * fetchFavourites (project, user) {
+        self.loadingState = asyncStates.loading
+        const token = yield auth.checkBearerToken()
+        const authorization = `Bearer ${token}`
+        const query = {
+          favorite: true,
+          project_ids: [project.id],
+          owner: user.login
+        }
+        const response = yield client.get({ authorization, query })
+        const [ favourites ] = response.body.collections
+        self.loadingState = asyncStates.success
+        if (favourites) {
+          self.favourites = Collection.create(favourites)
+        } else {
+          self.createFavourites(project)
+        }
+      })
+    }
+  })
+
+export default Collections
+  

--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -74,6 +74,32 @@ const Collections = types
         } else {
           self.createFavourites()
         }
+      }),
+      
+      addFavourites: flow( function * addFavourites (subjectIds) {
+        const token = yield auth.checkBearerToken()
+        const authorization = `Bearer ${token}`
+        const params = {
+          authorization,
+          collectionId: self.favourites.id,
+          subjects: subjectIds
+        }
+        const response = yield client.addSubjects(params)
+        const [ favourites ] = response.body.collections
+        self.favourites = Collection.create(favourites)
+      }),
+
+      removeFavourites: flow( function * removeFavourites (subjectIds) {
+        const token = yield auth.checkBearerToken()
+        const authorization = `Bearer ${token}`
+        const params = {
+          authorization,
+          collectionId: self.favourites.id,
+          subjects: subjectIds
+        }
+        const response = yield client.removeSubjects(params)
+        const [ favourites ] = response.body.collections
+        self.favourites = Collection.create(favourites)
       })
     }
   })

--- a/packages/app-project/stores/Collections.spec.js
+++ b/packages/app-project/stores/Collections.spec.js
@@ -1,0 +1,99 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+import { getSnapshot } from 'mobx-state-tree'
+import asyncStates from '@zooniverse/async-states'
+import { collections } from '@zooniverse/panoptes-js'
+import Collections from './Collections'
+import Store from './Store'
+import placeholderEnv from './helpers/placeholderEnv'
+
+describe('stores > Collections', function () {
+  let rootStore = Store.create({}, placeholderEnv)
+  
+  it('should exist', function () {
+    expect(rootStore.collections).to.be.ok
+  })
+
+  describe('fetchFavourites', function () {
+    let collectionsStore = rootStore.collections
+
+    it('should exist', function () {
+      expect(collectionsStore.fetchFavourites).to.be.a('function')
+    })
+
+    describe('with an existing collection', function () {
+      before(function () {
+        const clientStub = {
+          collections: {
+            get: function () {
+              return Promise.resolve({ body: collections.mocks.responses.get.collection})
+            }
+          }
+        }
+        rootStore = Store.create({}, { client: clientStub })
+        collectionsStore = rootStore.collections
+      })
+
+      it('should fetch a collection', function (done) {
+        expect(collectionsStore.loadingState).to.equal(asyncStates.initialized)
+
+        collectionsStore.fetchFavourites({ id: '2', display_name: 'Hello' }, { login: 'test.user' })
+          .then(function () {
+            expect(collectionsStore.loadingState).to.equal(asyncStates.success)
+            expect(collectionsStore.favourites).to.be.ok
+          })
+          .then(done, done)
+
+        // Since this is run before fetch's thenable resolves, it should test
+        // correctly during the request.
+        expect(collectionsStore.loadingState).to.equal(asyncStates.loading)
+      })
+    })
+
+    describe('without an existing collection', function () {
+      let clientStub
+
+      before(function () {
+        clientStub = {
+          collections: {
+            create: sinon.stub().callsFake(function (payload) {
+              const [ favourites ] = collections.mocks.responses.get.collection.collections
+              const links = {
+                projects: payload.projects,
+                subjects: payload.subjects
+              }
+              const newCollection = Object.assign({}, favourites, payload.data, { links })
+              const body = Object.assign({}, collections.mocks.responses.get.collection, { collections: [newCollection] })
+              return Promise.resolve({ body })
+            }),
+            get: function () {
+              return Promise.resolve({ body: { collections: [] } })
+            }
+          }
+        }
+        rootStore = Store.create({}, { client: clientStub })
+        collectionsStore = rootStore.collections
+      })
+
+      it('should create a new collection', function (done) {
+        expect(collectionsStore.loadingState).to.equal(asyncStates.initialized)
+
+        collectionsStore.fetchFavourites({ id: '2', display_name: 'Hello', slug: 'test/project' }, { login: 'test.user' })
+          .then(function () {
+            const favourites = getSnapshot(collectionsStore.favourites)
+            expect(collectionsStore.loadingState).to.equal(asyncStates.success)
+            expect(clientStub.collections.create).to.have.been.calledOnce
+            expect(collectionsStore.favourites).to.be.ok
+            expect(favourites.display_name).to.equal('Favourites test/project')
+            expect(favourites.links.projects).to.eql(['2'])
+            expect(favourites.links.subjects).to.eql([])
+          })
+          .then(done, done)
+
+        // Since this is run before fetch's thenable resolves, it should test
+        // correctly during the request.
+        expect(collectionsStore.loadingState).to.equal(asyncStates.loading)
+      })
+    })
+  })
+})

--- a/packages/app-project/stores/Collections.spec.js
+++ b/packages/app-project/stores/Collections.spec.js
@@ -5,6 +5,7 @@ import asyncStates from '@zooniverse/async-states'
 import { collections } from '@zooniverse/panoptes-js'
 import Collections from './Collections'
 import Store from './Store'
+import initStore from './initStore'
 import placeholderEnv from './helpers/placeholderEnv'
 
 describe('stores > Collections', function () {
@@ -23,6 +24,15 @@ describe('stores > Collections', function () {
 
     describe('with an existing collection', function () {
       before(function () {
+        const project = {
+          id: '2',
+          display_name: 'Hello',
+          slug: 'test/project'
+        }
+        const user = {
+          login: 'test.user'
+        }
+        const snapshot = { project, user }
         const clientStub = {
           collections: {
             get: function () {
@@ -30,14 +40,14 @@ describe('stores > Collections', function () {
             }
           }
         }
-        rootStore = Store.create({}, { client: clientStub })
+        rootStore = initStore(true, snapshot, clientStub)
         collectionsStore = rootStore.collections
       })
 
       it('should fetch a collection', function (done) {
         expect(collectionsStore.loadingState).to.equal(asyncStates.initialized)
 
-        collectionsStore.fetchFavourites({ id: '2', display_name: 'Hello' }, { login: 'test.user' })
+        collectionsStore.fetchFavourites()
           .then(function () {
             expect(collectionsStore.loadingState).to.equal(asyncStates.success)
             expect(collectionsStore.favourites).to.be.ok
@@ -54,6 +64,15 @@ describe('stores > Collections', function () {
       let clientStub
 
       before(function () {
+        const project = {
+          id: '2',
+          display_name: 'Hello',
+          slug: 'test/project'
+        }
+        const user = {
+          login: 'test.user'
+        }
+        const snapshot = { project, user }
         clientStub = {
           collections: {
             create: sinon.stub().callsFake(function (payload) {
@@ -71,14 +90,14 @@ describe('stores > Collections', function () {
             }
           }
         }
-        rootStore = Store.create({}, { client: clientStub })
+        rootStore = initStore(true, snapshot, clientStub)
         collectionsStore = rootStore.collections
       })
 
       it('should create a new collection', function (done) {
         expect(collectionsStore.loadingState).to.equal(asyncStates.initialized)
 
-        collectionsStore.fetchFavourites({ id: '2', display_name: 'Hello', slug: 'test/project' }, { login: 'test.user' })
+        collectionsStore.fetchFavourites()
           .then(function () {
             const favourites = getSnapshot(collectionsStore.favourites)
             expect(collectionsStore.loadingState).to.equal(asyncStates.success)

--- a/packages/app-project/stores/Collections.spec.js
+++ b/packages/app-project/stores/Collections.spec.js
@@ -59,7 +59,7 @@ describe('stores > Collections', function () {
             create: sinon.stub().callsFake(function (payload) {
               const [ favourites ] = collections.mocks.responses.get.collection.collections
               const links = {
-                projects: payload.projects,
+                project: payload.project,
                 subjects: payload.subjects
               }
               const newCollection = Object.assign({}, favourites, payload.data, { links })
@@ -85,7 +85,7 @@ describe('stores > Collections', function () {
             expect(clientStub.collections.create).to.have.been.calledOnce
             expect(collectionsStore.favourites).to.be.ok
             expect(favourites.display_name).to.equal('Favourites test/project')
-            expect(favourites.links.projects).to.eql(['2'])
+            expect(favourites.links.project).to.equal('2')
             expect(favourites.links.subjects).to.eql([])
           })
           .then(done, done)

--- a/packages/app-project/stores/Store.js
+++ b/packages/app-project/stores/Store.js
@@ -1,10 +1,12 @@
 import { getEnv, types } from 'mobx-state-tree'
 
+import Collections from './Collections'
 import Project from './Project'
 import User from './User'
 
 const Store = types
   .model('Store', {
+    collections: types.optional(Collections, {}),
     project: types.optional(Project, {}),
     user: types.optional(User, {})
   })

--- a/packages/app-project/stores/User.js
+++ b/packages/app-project/stores/User.js
@@ -7,7 +7,8 @@ const User = types
   .model('User', {
     avatar_src: types.maybeNull(types.string),
     display_name: types.maybeNull(types.string),
-    id: types.maybeNull(numberString)
+    id: types.maybeNull(numberString),
+    login: types.maybeNull(types.string)
   })
 
   .views(self => ({
@@ -28,6 +29,7 @@ const User = types
     set (user) {
       self.id = user.id
       self.display_name = user.display_name
+      self.login = user.login
     }
   }))
 

--- a/packages/app-project/stores/initStore.js
+++ b/packages/app-project/stores/initStore.js
@@ -1,5 +1,6 @@
 import { applySnapshot } from 'mobx-state-tree'
 import {
+  collections as collectionsClient,
   panoptes as panoptesClient,
   projects as projectsClient
 } from '@zooniverse/panoptes-js'
@@ -8,6 +9,7 @@ import Store from './Store'
 let store = null
 
 const defaultClient = {
+  collections: collectionsClient,
   panoptes: panoptesClient,
   projects: projectsClient
 }

--- a/packages/app-project/test/chai-config.js
+++ b/packages/app-project/test/chai-config.js
@@ -1,0 +1,4 @@
+import chai from 'chai'
+import sinonChai from 'sinon-chai'
+
+chai.use(sinonChai)

--- a/packages/app-project/test/mocha.opts
+++ b/packages/app-project/test/mocha.opts
@@ -4,5 +4,6 @@
 --ui bdd
 --file ./test/create-enzyme-adapter.js
 --file ./test/create-global-document.js
+--file ./test/chai-config.js
 
 ./{components,pages,stores}/**/*.spec.js


### PR DESCRIPTION
Package:
app-project

Depends on #430 

Adds a collections store, which holds your project favourites. Loads favourites, or creates them if they don't exist yet, on log in. Adds actions to add or remove a list of subject IDs as favourites.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

