### PR TITLE
[WIP] Smoke test with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,9 @@ WORKDIR /usr/src/
 
 ADD . /usr/src
 
+RUN chown -R node:node .
+
+USER node
+
 RUN npm config set unsafe-perm true
 RUN ./bin/bootstrap.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,8 @@
 FROM node:8
 
-RUN mkdir -p /usr/src
 WORKDIR /usr/src/
 
-COPY ./ .
-RUN chown -R node:node .
+ADD . /usr/src
 
-USER node
-
-RUN npm install
-RUN ./node_modules/.bin/lerna link
-RUN ./node_modules/.bin/lerna bootstrap --no-ci --loglevel verbose
+RUN npm config set unsafe-perm true
+RUN ./bin/bootstrap.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,4 @@ RUN chown -R node:node .
 
 USER node
 
-RUN npm config set unsafe-perm true
 RUN ./bin/bootstrap.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,7 @@ timeout(20) {
       testImage.inside {
         sh '''
           cd /usr/src/
-          ./node_modules/.bin/lerna run build --scope="@zooniverse/grommet-theme"
-          ./node_modules/.bin/lerna run --stream test:ci
+          npx lerna run --stream test:ci
         '''
       }
     }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Lerna allows us to maintain package modularity for javascript projects that have
 
 ## Getting started
 
+#### With your own node setup
+
 ```sh
 git clone git@github.com:zooniverse/front-end-monorepo.git
 cd front-end-monorepo
@@ -23,6 +25,22 @@ cd front-end-monorepo
 ```
 
 The `bootstrap.sh` script will install the top-level dependencies, build any packages used as dependencies, and finally bootstrap the remaining packages.
+
+#### Using docker
+
+```sh
+# Build the image
+docker-compose build
+
+# Run cmds through docker, e.g. run all tests
+docker-compose run --rm front-end npx lerna run --stream test:ci
+
+# Or you can then run tooling using bash session
+docker-compose run --rm front-end bash
+# from within the bash shell
+npx lerna run --stream test:ci
+```
+
 
 ## Helpful Guides
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ docker-compose build
 # Run cmds through docker, e.g. run all tests
 docker-compose run --rm front-end npx lerna run --stream test:ci
 
-# Or you can then run tooling using bash session
+# Or you can then run your dev tooling using a bash session
 docker-compose run --rm front-end bash
 # from within the bash shell
 npx lerna run --stream test:ci

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -14,28 +14,26 @@ set -e
 #   - Install dependencies for remaining packages
 
 ROOT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && cd .. && pwd)"
-LERNA=$ROOT_DIR/node_modules/.bin/lerna
-
 
 printf 'Installing root dependencies...\n'
 (cd $ROOT_DIR && npm install)
 printf '\n'
 
 printf 'Bootstrapping the monorepo!\n\n'
-$LERNA bootstrap
+npx lerna bootstrap
 
 printf 'Building `lib-grommet-theme`...\n'
-$LERNA exec --scope="@zooniverse/grommet-theme" -- npm run build
+npx lerna exec --scope="@zooniverse/grommet-theme" -- npm run build
 printf '\n'
 
 printf 'Building `lib-react-components`...\n'
-$LERNA exec --scope="@zooniverse/react-components" -- npm run build
+npx lerna exec --scope="@zooniverse/react-components" -- npm run build
 printf '\n'
 
 printf 'Building `lib-auth`...\n'
-$LERNA exec --scope="@zooniverse/auth" -- npm run build
+npx lerna exec --scope="@zooniverse/auth" -- npm run build
 printf '\n'
 
 printf 'Building `lib-classifier`...\n'
-$LERNA exec --scope="@zooniverse/classifier" -- npm run build
+npx lerna exec --scope="@zooniverse/classifier" -- npm run build
 printf '\n'

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Script for bootstrapping the monorepo into a working state for development.
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  front-end:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./:/usr/src/


### PR DESCRIPTION
Get started using docker images via docker and compose. this cleans up the dockerfile to rely on the `bootstrap.sh` script and allows dev via the 

It's not optimal in that we copy the src tree into the image before setting up the deps, ideally we'd breakup the bootstrap.sh script to avoid this bulk copy (happy to help on this but might need some direction). 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

