### PR TITLE
Run app-project store tests

### DIFF
--- a/packages/app-project/stores/Project.js
+++ b/packages/app-project/stores/Project.js
@@ -15,9 +15,16 @@ const Project = types
     links: types.maybeNull(types.frozen({})),
     loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.initialized),
     retired_subjects_count: types.optional(types.number, 0),
+    slug: types.optional(types.string, ''),
     urls: types.frozen([]),
     subjects_count: types.optional(types.number, 0)
   })
+
+  .views(self => ({
+    get displayName () {
+      return self.display_name
+    }
+  }))
 
   .actions(self => {
     let client

--- a/packages/app-project/stores/Project.spec.js
+++ b/packages/app-project/stores/Project.spec.js
@@ -58,7 +58,7 @@ describe('Stores > Project', function () {
     before(function () {
       clientStub = {
         projects: {
-          get: function () {
+          getWithLinkedResources: function () {
             return Promise.resolve({ body: mocks.responses.get.projectWithLinkedResources })
           }
         }
@@ -78,14 +78,13 @@ describe('Stores > Project', function () {
         .then(function () {
           const { projectBackground, projectTwo } = mocks.resources
 
-          expect(projectStore.background).to.eql(projectTwo.projectBackground)
+          expect(projectStore.background).to.eql(projectBackground)
           expect(projectStore.displayName).to.equal(projectTwo.display_name)
           expect(projectStore.id).to.equal(projectTwo.id)
           expect(projectStore.loadingState).to.equal(asyncStates.success)
           expect(projectStore.slug).to.equal(projectTwo.slug)
-
-          done()
         })
+        .then(done, done)
 
       // Since this is run before fetch's thenable resolves, it should test
       // correctly during the request.

--- a/packages/app-project/stores/Project.spec.js
+++ b/packages/app-project/stores/Project.spec.js
@@ -1,3 +1,4 @@
+import { expect } from 'chai'
 import asyncStates from '@zooniverse/async-states'
 import { projects } from '@zooniverse/panoptes-js'
 
@@ -14,7 +15,7 @@ describe('Stores > Project', function () {
   it('should exist', function () {
     rootStore = Store.create({}, placeholderEnv)
     projectStore = rootStore.project
-    projectStore.should.not.be.undefined
+    expect(projectStore).to.be.ok
   })
 
   describe('default model properties', function () {
@@ -40,11 +41,11 @@ describe('Stores > Project', function () {
     })
 
     it('should have a `slug` property', function () {
-      projectStore.slug.should.equal('')
+      expect(projectStore.slug).to.equal('')
     })
 
     it('should have a `state` property', function () {
-      projectStore.loadingState.should.equal(asyncStates.initialized)
+      expect(projectStore.loadingState).to.equal(asyncStates.initialized)
     })
 
     after(function () {
@@ -67,28 +68,28 @@ describe('Stores > Project', function () {
     })
 
     it('should exist', function () {
-      projectStore.fetch.should.be.a('function')
+      expect(projectStore.fetch).to.be.a('function')
     })
 
     it('should fetch a valid project resource', function (done) {
-      projectStore.loadingState.should.equal(asyncStates.initialized)
+      expect(projectStore.loadingState).to.equal(asyncStates.initialized)
 
       projectStore.fetch('foo/bar')
         .then(function () {
           const { projectBackground, projectTwo } = mocks.resources
 
-          projectStore.background.should.eql(projectTwo.projectBackground)
-          projectStore.displayName.should.equal(projectTwo.display_name)
-          projectStore.id.should.equal(projectTwo.id)
-          projectStore.loadingState.should.equal(asyncStates.success)
-          projectStore.slug.should.equal(projectTwo.slug)
+          expect(projectStore.background).to.eql(projectTwo.projectBackground)
+          expect(projectStore.displayName).to.equal(projectTwo.display_name)
+          expect(projectStore.id).to.equal(projectTwo.id)
+          expect(projectStore.loadingState).to.equal(asyncStates.success)
+          expect(projectStore.slug).to.equal(projectTwo.slug)
 
           done()
         })
 
       // Since this is run before fetch's thenable resolves, it should test
       // correctly during the request.
-      projectStore.loadingState.should.equal(asyncStates.loading)
+      expect(projectStore.loadingState).to.equal(asyncStates.loading)
     })
 
     after(function () {

--- a/packages/app-project/stores/Store.spec.js
+++ b/packages/app-project/stores/Store.spec.js
@@ -1,13 +1,14 @@
+import { expect } from 'chai'
 import Store from './Store'
 import placeholderEnv from './helpers/placeholderEnv'
 
 describe('Stores > Store', function () {
   it('should export an object', function () {
-    Store.should.be.an('object')
+    expect(Store).to.be.an('object')
   })
 
   it('should contain a project store', function () {
     const store = Store.create({}, placeholderEnv)
-    store.project.should.exist
+    expect(store.project).to.be.ok
   })
 })

--- a/packages/app-project/stores/initStore.spec.js
+++ b/packages/app-project/stores/initStore.spec.js
@@ -1,3 +1,4 @@
+import { expect } from 'chai'
 import asyncStates from '@zooniverse/async-states'
 import { panoptes, projects } from '@zooniverse/panoptes-js'
 
@@ -5,24 +6,24 @@ import initStore from './initStore'
 
 describe('Stores > initStore', function () {
   it('should export a function', function () {
-    initStore.should.be.a('function')
+    expect(initStore).to.be.a('function')
   })
 
   it('should create a new store when running on the server', function () {
     const store1 = initStore(true)
     const store2 = initStore(true)
-    store2.should.not.equal(store1)
+    expect(store2).to.not.eql(store1)
   })
 
   it('should reuse a store when running on the server', function () {
     const store1 = initStore(false)
     const store2 = initStore(false)
-    store2.should.equal(store1)
+    expect(store2).to.eql(store1)
   })
 
   it('should contain a project store', function () {
     const store = initStore()
-    store.project.should.exist
+    expect(store.project).to.be.ok
   })
 
   it('should apply a snapshot when provided', function () {
@@ -35,18 +36,18 @@ describe('Stores > initStore', function () {
       }
     }
     const store = initStore(true, snapshot)
-    store.should.deep.equal(snapshot)
+    expect(store.project).to.deep.equal(snapshot.project)
   })
 
   it('should use PanoptesJS if there is no client argument', function () {
     const store = initStore()
-    store.client.panoptes.should.deep.equal(panoptes)
-    store.client.projects.should.deep.equal(projects)
+    expect(store.client.panoptes).to.deep.equal(panoptes)
+    expect(store.client.projects).to.deep.equal(projects)
   })
 
   it('should use the client argument if defined', function () {
     const client = {}
     const store = initStore({}, {}, client)
-    store.client.should.equal(client)
+    expect(store.client).to.equal(client)
   })
 })

--- a/packages/app-project/stores/initStore.spec.js
+++ b/packages/app-project/stores/initStore.spec.js
@@ -12,13 +12,13 @@ describe('Stores > initStore', function () {
   it('should create a new store when running on the server', function () {
     const store1 = initStore(true)
     const store2 = initStore(true)
-    expect(store2).to.not.eql(store1)
+    expect(store2).to.not.equal(store1)
   })
 
-  it('should reuse a store when running on the server', function () {
-    const store1 = initStore(false)
+  it('should reuse a store when not running on the server', function () {
+    const store1 = initStore(true)
     const store2 = initStore(false)
-    expect(store2).to.eql(store1)
+    expect(store2).to.equal(store1)
   })
 
   it('should contain a project store', function () {
@@ -30,13 +30,14 @@ describe('Stores > initStore', function () {
     const snapshot = {
       project: {
         loadingState: asyncStates.initialized,
-        displayName: 'foobar',
+        display_name: 'foobar',
         error: null,
         id: '12345'
       }
     }
     const store = initStore(true, snapshot)
-    expect(store.project).to.deep.equal(snapshot.project)
+    expect(store.project.displayName).to.equal('foobar')
+    expect(store.project.id).to.equal('12345')
   })
 
   it('should use PanoptesJS if there is no client argument', function () {

--- a/packages/app-project/test/mocha.opts
+++ b/packages/app-project/test/mocha.opts
@@ -5,4 +5,4 @@
 --file ./test/create-enzyme-adapter.js
 --file ./test/create-global-document.js
 
-./{components,pages}/**/*.spec.js
+./{components,pages,stores}/**/*.spec.js


### PR DESCRIPTION
Package:
app-project

Runs the app-project store tests and fixes failing tests.
Overlaps with #437, so there may be small merge conflicts with that PR. This one should probably merge first.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

