### PR TITLE
Wait on user before rendering the classifier

### DIFF
--- a/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
@@ -35,9 +35,10 @@ export default class ClassifierWrapperContainer extends Component {
 
   render () {
     const { authClient, project, user } = this.props
-    const { error } = this.state
+    const somethingWentWrong = this.state.error || project.loadingState === asyncStates.error
 
-    if (error) {
+    if (somethingWentWrong) {
+      const { error } = this.state || project
       return (
         <ErrorMessage error={error} />
       )
@@ -57,14 +58,6 @@ export default class ClassifierWrapperContainer extends Component {
           authClient={authClient}
           project={project}
         />
-      )
-    }
-
-    if (project.loadingState === asyncStates.error) {
-      return (
-        <p>
-          {project.error}
-        </p>
       )
     }
 

--- a/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
@@ -7,12 +7,13 @@ import React, { Component } from 'react'
 import ErrorMessage from './components/ErrorMessage'
 
 function storeMapper (stores) {
-  const { project } = stores.store
+  const { project, user } = stores.store
   // We return a POJO here, as the `project` resource is also stored in a
   // `mobx-state-tree` store in the classifier and an MST node can't be in two
   // stores at the same time.
   return {
-    project: project.toJSON()
+    project: project.toJSON(),
+    user
   }
 }
 
@@ -33,12 +34,20 @@ export default class ClassifierWrapperContainer extends Component {
   }
 
   render () {
-    const { authClient, project } = this.props
+    const { authClient, project, user } = this.props
     const { error } = this.state
 
     if (error) {
       return (
         <ErrorMessage error={error} />
+      )
+    }
+
+    if (user.pending) {
+      return (
+        <p>
+          Signing in…
+        </p>
       )
     }
 

--- a/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
@@ -43,7 +43,7 @@ export default class ClassifierWrapperContainer extends Component {
       )
     }
 
-    if (user.pending) {
+    if (user.loadingState === asyncStates.loading) {
       return (
         <p>
           Signing in…

--- a/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
@@ -3,7 +3,7 @@ import { inject, observer } from 'mobx-react'
 import auth from 'panoptes-client/lib/auth'
 import { shape } from 'prop-types'
 import React, { Component } from 'react'
-
+import asyncStates from '@zooniverse/async-states'
 import ErrorMessage from './components/ErrorMessage'
 
 function storeMapper (stores) {
@@ -51,12 +51,20 @@ export default class ClassifierWrapperContainer extends Component {
       )
     }
 
-    if (project.loadingState === 'success') {
+    if (project.loadingState === asyncStates.success) {
       return (
         <Classifier
           authClient={authClient}
           project={project}
         />
+      )
+    }
+
+    if (project.loadingState === asyncStates.error) {
+      return (
+        <p>
+          {project.error}
+        </p>
       )
     }
 

--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -51,7 +51,7 @@ export default class MyApp extends App {
   }
 
   componentDidMount () {
-    this.getUser()
+    this.store.user.checkCurrent()
   }
 
   componentDidUpdate () {
@@ -63,13 +63,6 @@ export default class MyApp extends App {
 
     if (slugFromUrl && currentSlug !== slugFromUrl) {
       this.store.project.fetch(slugFromUrl)
-    }
-  }
-
-  async getUser () {
-    const userResource = await auth.checkCurrent()
-    if (userResource) {
-      this.store.user.set(userResource)
     }
   }
 

--- a/packages/app-project/stores/User.js
+++ b/packages/app-project/stores/User.js
@@ -8,9 +8,10 @@ const User = types
   .model('User', {
     avatar_src: types.maybeNull(types.string),
     display_name: types.maybeNull(types.string),
+    error: types.maybeNull(types.frozen({})),
     id: types.maybeNull(numberString),
     login: types.maybeNull(types.string),
-    pending: true
+    loadingState: asyncStates.loading
   })
 
   .views(self => ({
@@ -25,10 +26,18 @@ const User = types
 
   .actions(self => ({
     checkCurrent: flow(function * checkCurrent () {
-      const userResource = yield auth.checkCurrent()
-      self.pending = false
-      if (userResource) {
-        self.set(userResource)
+      self.loadingState = asyncStates.loading
+      try {
+        const userResource = yield auth.checkCurrent()
+        self.loadingState = asyncStates.success
+        if (userResource) {
+          self.set(userResource)
+        }
+      }
+      catch(error) {
+        console.log(error)
+        self.loadingState = asyncStates.error
+        self.error = error
       }
     }),
 

--- a/packages/app-project/stores/User.js
+++ b/packages/app-project/stores/User.js
@@ -9,7 +9,8 @@ const User = types
     avatar_src: types.maybeNull(types.string),
     display_name: types.maybeNull(types.string),
     id: types.maybeNull(numberString),
-    login: types.maybeNull(types.string)
+    login: types.maybeNull(types.string),
+    pending: true
   })
 
   .views(self => ({
@@ -25,6 +26,7 @@ const User = types
   .actions(self => ({
     checkCurrent: flow(function * checkCurrent () {
       const userResource = yield auth.checkCurrent()
+      self.pending = false
       if (userResource) {
         self.set(userResource)
       }

--- a/packages/app-project/stores/User.js
+++ b/packages/app-project/stores/User.js
@@ -1,5 +1,6 @@
 import asyncStates from '@zooniverse/async-states'
 import { flow, getRoot, types } from 'mobx-state-tree'
+import auth from 'panoptes-client/lib/auth'
 
 import numberString from './types/numberString'
 
@@ -22,6 +23,13 @@ const User = types
   }))
 
   .actions(self => ({
+    checkCurrent: flow(function * checkCurrent () {
+      const userResource = yield auth.checkCurrent()
+      if (userResource) {
+        self.set(userResource)
+      }
+    }),
+
     clear () {
       self.id = null
     },


### PR DESCRIPTION
Package:
app-project

Adds user.checkCurrent() to the User store, and adds `user.loadingState` flag, which is set to `loading` while we run the initial check for a logged-in user. Displays a 'logging in' message while we check for a user.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

