### PR TITLE
Add error boundary to `ClassifierWrapper`

### DIFF
--- a/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
@@ -17,8 +17,30 @@ function storeMapper (stores) {
 @inject(storeMapper)
 @observer
 export default class ClassifierWrapperContainer extends Component {
+  constructor () {
+    super()
+    this.state = {
+      hasError: false
+    }
+  }
+
+  static getDerivedStateFromError (error) {
+    return {
+      hasError: true
+    }
+  }
+
   render () {
     const { authClient, project } = this.props
+
+    if (this.state.hasError) {
+      return (
+        <Box>
+          There was an error in the classifier :(
+        </Box>
+      )
+    }
+
     if (project.loadingState === 'success') {
       return (
         <Classifier
@@ -29,7 +51,7 @@ export default class ClassifierWrapperContainer extends Component {
     }
 
     return (
-      <div>Loading</div>
+      <div>Loading...</div>
     )
   }
 }

--- a/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
@@ -1,8 +1,10 @@
+import Classifier from '@zooniverse/classifier'
 import { inject, observer } from 'mobx-react'
+import auth from 'panoptes-client/lib/auth'
 import { shape } from 'prop-types'
 import React, { Component } from 'react'
-import auth from 'panoptes-client/lib/auth'
-import Classifier from '@zooniverse/classifier'
+
+import ErrorMessage from './components/ErrorMessage'
 
 function storeMapper (stores) {
   const { project } = stores.store
@@ -20,24 +22,23 @@ export default class ClassifierWrapperContainer extends Component {
   constructor () {
     super()
     this.state = {
-      hasError: false
+      error: null
     }
   }
 
   static getDerivedStateFromError (error) {
     return {
-      hasError: true
+      error
     }
   }
 
   render () {
     const { authClient, project } = this.props
+    const { error } = this.state
 
-    if (this.state.hasError) {
+    if (error) {
       return (
-        <Box>
-          There was an error in the classifier :(
-        </Box>
+        <ErrorMessage error={error} />
       )
     }
 
@@ -51,7 +52,7 @@ export default class ClassifierWrapperContainer extends Component {
     }
 
     return (
-      <div>Loading...</div>
+      <div>Loading…</div>
     )
   }
 }

--- a/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/components/ErrorMessage/ErrorMessage.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/components/ErrorMessage/ErrorMessage.js
@@ -13,6 +13,9 @@ const Pre = styled.pre`
 `
 
 export default function ErrorMessage ({ error }) {
+  const { message, name, stack } = error
+  const errorString = stack ? stack : `${name}: ${message}`
+
   return (
     <Box
       background='#FFF2E9'
@@ -27,21 +30,11 @@ export default function ErrorMessage ({ error }) {
         {counterpart('ErrorMessage.title')}
       </Heading>
 
-      {error.stack && (
-        <Text size='small' margin={{ top: 'medium' }}>
-          <Pre>
-            {error.stack}
-          </Pre>
-        </Text>
-      )}
-
-      {!error.stack && (
-        <Text size='small' margin={{ top: 'medium' }}>
-          <Pre>
-            {error.name}: {error.message}
-          </Pre>
-        </Text>
-      )}
+      <Text size='small' margin={{ top: 'medium' }}>
+        <Pre>
+          {errorString}
+        </Pre>
+      </Text>
     </Box>
   )
 }

--- a/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/components/ErrorMessage/ErrorMessage.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/components/ErrorMessage/ErrorMessage.js
@@ -1,0 +1,55 @@
+import counterpart from 'counterpart'
+import { Box, Heading, Text } from 'grommet'
+import { shape, string } from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
+
+const Pre = styled.pre`
+  margin: 0;
+`
+
+export default function ErrorMessage ({ error }) {
+  return (
+    <Box
+      background='#FFF2E9'
+      border={{ color: 'tomato' }}
+      pad='medium'
+    >
+      <Heading
+        level='3'
+        margin='none'
+        size='small'
+      >
+        {counterpart('ErrorMessage.title')}
+      </Heading>
+
+      {error.stack && (
+        <Text size='small' margin={{ top: 'medium' }}>
+          <Pre>
+            {error.stack}
+          </Pre>
+        </Text>
+      )}
+
+      {!error.stack && (
+        <Text size='small' margin={{ top: 'medium' }}>
+          <Pre>
+            {error.name}: {error.message}
+          </Pre>
+        </Text>
+      )}
+    </Box>
+  )
+}
+
+ErrorMessage.propTypes = {
+  error: shape({
+    message: string.isRequired,
+    name: string.isRequired,
+    stack: string
+  })
+}

--- a/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/components/ErrorMessage/ErrorMessage.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/components/ErrorMessage/ErrorMessage.spec.js
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import ErrorMessage from './ErrorMessage'
+
+let wrapper
+
+const ERROR_WITHOUT_STACK = {
+  message: 'There was some kind of error!',
+  name: 'FoobarError'
+}
+
+const ERROR_WITH_STACK = {
+  ...ERROR_WITHOUT_STACK,
+  stack: 'Foobar foobar foobar foobar foobar foobar foobar foobar.'
+}
+
+describe('Component > ErrorMessage', function () {
+  before(function () {
+    wrapper = shallow(<ErrorMessage error={ERROR_WITH_STACK} />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok
+  })
+
+  it.only('should show the full stack trace if available', function () {
+    const text = wrapper.find('Text').render().text()
+    expect(text).to.equal(ERROR_WITH_STACK.stack)
+  })
+
+  it('should show the error name and message if there is no stack trace', function () {
+    const wrapper = shallow(<ErrorMessage error={ERROR_WITHOUT_TRACE} />)
+    const text = wrapper.find('Text').render().text()
+    expect(text).to.equal(`${ERROR_WITHOUT_TRACE.name}: ${ERROR_WITHOUT_TRACE.essage}`)
+  })
+})

--- a/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/components/ErrorMessage/ErrorMessage.spec.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/components/ErrorMessage/ErrorMessage.spec.js
@@ -24,14 +24,14 @@ describe('Component > ErrorMessage', function () {
     expect(wrapper).to.be.ok
   })
 
-  it.only('should show the full stack trace if available', function () {
+  it('should show the full stack trace if available', function () {
     const text = wrapper.find('Text').render().text()
     expect(text).to.equal(ERROR_WITH_STACK.stack)
   })
 
   it('should show the error name and message if there is no stack trace', function () {
-    const wrapper = shallow(<ErrorMessage error={ERROR_WITHOUT_TRACE} />)
+    const wrapper = shallow(<ErrorMessage error={ERROR_WITHOUT_STACK} />)
     const text = wrapper.find('Text').render().text()
-    expect(text).to.equal(`${ERROR_WITHOUT_TRACE.name}: ${ERROR_WITHOUT_TRACE.essage}`)
+    expect(text).to.equal(`${ERROR_WITHOUT_STACK.name}: ${ERROR_WITHOUT_STACK.message}`)
   })
 })

--- a/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/components/ErrorMessage/index.js
+++ b/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/components/ErrorMessage/index.js
@@ -1,0 +1,1 @@
+export { default } from './ErrorMessage'

--- a/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/components/ErrorMessage/locales/en.json
+++ b/packages/app-project/components/ClassifyPage/components/ClassifierWrapper/components/ErrorMessage/locales/en.json
@@ -1,0 +1,5 @@
+{
+  "ErrorMessage": {
+    "title": "There was an error in the classifier :("
+  }
+}


### PR DESCRIPTION
Package: app-project

Adds an error boundary to the component wrapping the classifier.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

