### PR TITLE
Fix create new favourites test

### DIFF
--- a/packages/app-project/stores/Collections.spec.js
+++ b/packages/app-project/stores/Collections.spec.js
@@ -103,7 +103,7 @@ describe('stores > Collections', function () {
             expect(collectionsStore.loadingState).to.equal(asyncStates.success)
             expect(clientStub.collections.create).to.have.been.calledOnce
             expect(collectionsStore.favourites).to.be.ok
-            expect(favourites.display_name).to.equal('Favourites test/project')
+            expect(favourites.display_name).to.equal('Favorites test/project')
             expect(favourites.links.project).to.equal('2')
             expect(favourites.links.subjects).to.eql([])
           })


### PR DESCRIPTION
Fix a test that broke when I changed the default name for new collections.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

