### PR TITLE
Recent classifications for project

### DIFF
--- a/packages/app-project/stores/Recents.js
+++ b/packages/app-project/stores/Recents.js
@@ -1,0 +1,69 @@
+import { autorun } from 'mobx'
+import { addDisposer, flow, getRoot, types } from 'mobx-state-tree'
+import auth from 'panoptes-client/lib/auth'
+import asyncStates from '@zooniverse/async-states'
+
+export const Recent = types
+  .model('Recent', {
+    subjectId: types.string,
+    locations: types.frozen({})
+  })
+
+const Recents = types
+  .model('Recents', {
+    error: types.maybeNull(types.frozen({})),
+    recents: types.optional(types.array(Recent), []),
+    loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.initialized),
+  })
+
+  .actions(self => {
+
+    function createProjectObserver () {
+      const projectDisposer = autorun(() => {
+        const { project, user } = getRoot(self)
+        if (project.id && user.id) {
+          self.fetch()
+        }
+      })
+      addDisposer(self, projectDisposer)
+    }
+
+    return {
+      afterAttach () {
+        createProjectObserver()
+      },
+
+      fetch: flow( function * fetch () {
+        const { client, project, user } = getRoot(self)
+        self.loadingState = asyncStates.loading
+        try {
+          const token = yield auth.checkBearerToken()
+          const authorization = `Bearer ${token}`
+          const query = {
+            project_id: project.id,
+            sort: '-created_at'
+          }
+          const response = yield client.panoptes.get(`/users/${user.id}/recents`, query, authorization)
+          const { recents } = response.body
+          self.recents = recents.map(recent => ({
+            subjectId: recent.links.subject,
+            locations: recent.locations
+          }))
+          self.loadingState = asyncStates.success
+          self.recents.map(recent => console.log(recent.subjectId, recent.locations))
+        }
+        catch(error) {
+          console.log(error)
+          self.error = error
+          self.loadingState = asyncStates.error
+        }
+      }),
+
+      add ({ subjectId, locations }) {
+        self.recents.unshift(Recent.create({ subjectId, locations }))
+      }
+    }
+  })
+
+export default Recents
+  

--- a/packages/app-project/stores/Recents.js
+++ b/packages/app-project/stores/Recents.js
@@ -12,7 +12,7 @@ export const Recent = types
 const Recents = types
   .model('Recents', {
     error: types.maybeNull(types.frozen({})),
-    recents: types.optional(types.array(Recent), []),
+    recents: types.array(Recent),
     loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.initialized)
   })
 

--- a/packages/app-project/stores/Recents.js
+++ b/packages/app-project/stores/Recents.js
@@ -51,7 +51,7 @@ const Recents = types
           self.loadingState = asyncStates.success
           self.recents.map(recent => console.log(recent.subjectId, recent.locations))
         } catch (error) {
-          console.log(error)
+          console.log(error.message)
           self.error = error
           self.loadingState = asyncStates.error
         }

--- a/packages/app-project/stores/Recents.js
+++ b/packages/app-project/stores/Recents.js
@@ -13,11 +13,10 @@ const Recents = types
   .model('Recents', {
     error: types.maybeNull(types.frozen({})),
     recents: types.optional(types.array(Recent), []),
-    loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.initialized),
+    loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.initialized)
   })
 
   .actions(self => {
-
     function createProjectObserver () {
       const projectDisposer = autorun(() => {
         const { project, user } = getRoot(self)
@@ -33,7 +32,7 @@ const Recents = types
         createProjectObserver()
       },
 
-      fetch: flow( function * fetch () {
+      fetch: flow(function * fetch () {
         const { client, project, user } = getRoot(self)
         self.loadingState = asyncStates.loading
         try {
@@ -51,8 +50,7 @@ const Recents = types
           }))
           self.loadingState = asyncStates.success
           self.recents.map(recent => console.log(recent.subjectId, recent.locations))
-        }
-        catch(error) {
+        } catch (error) {
           console.log(error)
           self.error = error
           self.loadingState = asyncStates.error
@@ -66,4 +64,3 @@ const Recents = types
   })
 
 export default Recents
-  

--- a/packages/app-project/stores/Recents.spec.js
+++ b/packages/app-project/stores/Recents.spec.js
@@ -1,0 +1,139 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+import { getSnapshot } from 'mobx-state-tree'
+import asyncStates from '@zooniverse/async-states'
+import { panoptes } from '@zooniverse/panoptes-js'
+
+import Project from './Project'
+import Store from './Store'
+import initStore from './initStore'
+import placeholderEnv from './helpers/placeholderEnv'
+
+describe('Stores > Recents', function () {
+  let rootStore
+  const project = {
+    id: '2',
+    display_name: 'Hello',
+    slug: 'test/project'
+  }
+
+  before(function () {
+    const mockResponse = {
+      body: {
+        recents: [
+          {
+            locations: [
+              { 'image/jpeg': 'subject.jpeg'}
+            ],
+            links: {
+              subject: '345'
+            }
+          }
+        ]
+      }
+    }
+    rootStore = initStore(true, { project })
+    sinon.stub(rootStore.client.panoptes, 'get').callsFake(() => Promise.resolve(mockResponse))
+  })
+
+  after(function () {
+    rootStore.client.panoptes.get.restore()
+  })
+
+  it('should exist', function () {
+    expect(rootStore.recents).to.be.ok
+  })
+
+  describe('with a project and user', function () {
+    before(function () {
+      const user = {
+        id: '123',
+        login: 'test.user'
+      }
+      sinon.stub(rootStore.collections, 'fetchFavourites')
+      rootStore.user.set(user)
+    })
+
+    after(function () {
+      rootStore.client.panoptes.get.resetHistory()
+      rootStore.collections.fetchFavourites.restore()
+    })
+
+    it('should request recent subjects from Panoptes', function () {
+      const token = 'Bearer '
+      const endpoint = '/users/123/recents'
+      const query = {
+        project_id: '2',
+        sort: '-created_at'
+      }
+      expect(rootStore.client.panoptes.get).to.have.been.calledOnceWith(endpoint, query, token)
+    })
+
+    it('should store existing recents', function () {
+      expect(rootStore.recents.recents).to.have.lengthOf(1)
+      const recents = getSnapshot(rootStore.recents.recents)
+      expect(recents[0].subjectId).to.equal('345')
+      expect(recents[0].locations).to.eql([
+        { 'image/jpeg': 'subject.jpeg'}
+      ])
+    })
+
+    describe('adding a subject', function () {
+      const mockRecent = {
+        subjectId: '123',
+        locations: [
+          { 'image/jpeg': 'test.jpeg'}
+        ]
+      }
+
+      before(function () {
+        rootStore.recents.add(mockRecent)
+      })
+
+      it('should add a new subject to the store', function () {
+        expect(rootStore.recents.recents).to.have.lengthOf(2)
+        const recents = getSnapshot(rootStore.recents.recents)
+        expect(recents[0].subjectId).to.equal('123')
+        expect(recents[0].locations).to.eql([
+          { 'image/jpeg': 'test.jpeg'}
+        ])
+      })
+    })
+  })
+
+  describe('with a project and anonymous user', function () {
+    before(function () {
+      rootStore = initStore(true, { project })
+    })
+
+    it('should not request recent subjects from Panoptes', function () {
+      expect(rootStore.client.panoptes.get).to.have.not.been.called
+    })
+
+    it('should initialise recents with an empty array', function () {
+      expect(rootStore.recents.recents).to.have.lengthOf(0)
+    })
+
+    describe('adding a subject', function () {
+      const mockRecent = {
+        subjectId: '123',
+        locations: [
+          { 'image/jpeg': 'test.jpeg'}
+        ]
+      }
+
+      before(function () {
+        rootStore.recents.add(mockRecent)
+      })
+
+      it('should add a new subject to the store', function () {
+        expect(rootStore.recents.recents).to.have.lengthOf(1)
+        const recents = getSnapshot(rootStore.recents.recents)
+        expect(recents[0].subjectId).to.equal('123')
+        expect(recents[0].locations).to.eql([
+          { 'image/jpeg': 'test.jpeg'}
+        ])
+      })
+    })
+  })
+})

--- a/packages/app-project/stores/Recents.spec.js
+++ b/packages/app-project/stores/Recents.spec.js
@@ -1,13 +1,8 @@
 import { expect } from 'chai'
 import sinon from 'sinon'
 import { getSnapshot } from 'mobx-state-tree'
-import asyncStates from '@zooniverse/async-states'
-import { panoptes } from '@zooniverse/panoptes-js'
 
-import Project from './Project'
-import Store from './Store'
 import initStore from './initStore'
-import placeholderEnv from './helpers/placeholderEnv'
 
 describe('Stores > Recents', function () {
   let rootStore
@@ -23,7 +18,7 @@ describe('Stores > Recents', function () {
         recents: [
           {
             locations: [
-              { 'image/jpeg': 'subject.jpeg'}
+              { 'image/jpeg': 'subject.jpeg' }
             ],
             links: {
               subject: '345'
@@ -74,7 +69,7 @@ describe('Stores > Recents', function () {
       const recents = getSnapshot(rootStore.recents.recents)
       expect(recents[0].subjectId).to.equal('345')
       expect(recents[0].locations).to.eql([
-        { 'image/jpeg': 'subject.jpeg'}
+        { 'image/jpeg': 'subject.jpeg' }
       ])
     })
 
@@ -82,7 +77,7 @@ describe('Stores > Recents', function () {
       const mockRecent = {
         subjectId: '123',
         locations: [
-          { 'image/jpeg': 'test.jpeg'}
+          { 'image/jpeg': 'test.jpeg' }
         ]
       }
 
@@ -95,7 +90,7 @@ describe('Stores > Recents', function () {
         const recents = getSnapshot(rootStore.recents.recents)
         expect(recents[0].subjectId).to.equal('123')
         expect(recents[0].locations).to.eql([
-          { 'image/jpeg': 'test.jpeg'}
+          { 'image/jpeg': 'test.jpeg' }
         ])
       })
     })
@@ -118,7 +113,7 @@ describe('Stores > Recents', function () {
       const mockRecent = {
         subjectId: '123',
         locations: [
-          { 'image/jpeg': 'test.jpeg'}
+          { 'image/jpeg': 'test.jpeg' }
         ]
       }
 
@@ -131,7 +126,7 @@ describe('Stores > Recents', function () {
         const recents = getSnapshot(rootStore.recents.recents)
         expect(recents[0].subjectId).to.equal('123')
         expect(recents[0].locations).to.eql([
-          { 'image/jpeg': 'test.jpeg'}
+          { 'image/jpeg': 'test.jpeg' }
         ])
       })
     })

--- a/packages/app-project/stores/Recents.spec.js
+++ b/packages/app-project/stores/Recents.spec.js
@@ -7,6 +7,7 @@ import initStore from './initStore'
 
 describe('Stores > Recents', function () {
   let rootStore
+  let recentsStore
   const project = {
     id: '2',
     display_name: 'Hello',
@@ -29,6 +30,7 @@ describe('Stores > Recents', function () {
       }
     }
     rootStore = initStore(true, { project })
+    recentsStore = rootStore.recents
     sinon.stub(rootStore.client.panoptes, 'get').callsFake(() => Promise.resolve(mockResponse))
   })
 
@@ -37,7 +39,7 @@ describe('Stores > Recents', function () {
   })
 
   it('should exist', function () {
-    expect(rootStore.recents).to.be.ok
+    expect(recentsStore).to.be.ok
   })
 
   describe('with a project and user', function () {
@@ -66,8 +68,8 @@ describe('Stores > Recents', function () {
     })
 
     it('should store existing recents', function () {
-      expect(rootStore.recents.recents).to.have.lengthOf(1)
-      const recents = getSnapshot(rootStore.recents.recents)
+      expect(recentsStore.recents).to.have.lengthOf(1)
+      const recents = getSnapshot(recentsStore.recents)
       expect(recents[0].subjectId).to.equal('345')
       expect(recents[0].locations).to.eql([
         { 'image/jpeg': 'subject.jpeg' }
@@ -83,12 +85,12 @@ describe('Stores > Recents', function () {
       }
 
       before(function () {
-        rootStore.recents.add(mockRecent)
+        recentsStore.add(mockRecent)
       })
 
       it('should add a new subject to the store', function () {
-        expect(rootStore.recents.recents).to.have.lengthOf(2)
-        const recents = getSnapshot(rootStore.recents.recents)
+        expect(recentsStore.recents).to.have.lengthOf(2)
+        const recents = getSnapshot(recentsStore.recents)
         expect(recents[0].subjectId).to.equal('123')
         expect(recents[0].locations).to.eql([
           { 'image/jpeg': 'test.jpeg' }
@@ -100,6 +102,7 @@ describe('Stores > Recents', function () {
   describe('with a project and anonymous user', function () {
     before(function () {
       rootStore = initStore(true, { project })
+      recentsStore = rootStore.recents
     })
 
     it('should not request recent subjects from Panoptes', function () {
@@ -107,7 +110,7 @@ describe('Stores > Recents', function () {
     })
 
     it('should initialise recents with an empty array', function () {
-      expect(rootStore.recents.recents).to.have.lengthOf(0)
+      expect(recentsStore.recents).to.have.lengthOf(0)
     })
 
     describe('adding a subject', function () {
@@ -119,12 +122,12 @@ describe('Stores > Recents', function () {
       }
 
       before(function () {
-        rootStore.recents.add(mockRecent)
+        recentsStore.add(mockRecent)
       })
 
       it('should add a new subject to the store', function () {
-        expect(rootStore.recents.recents).to.have.lengthOf(1)
-        const recents = getSnapshot(rootStore.recents.recents)
+        expect(recentsStore.recents).to.have.lengthOf(1)
+        const recents = getSnapshot(recentsStore.recents)
         expect(recents[0].subjectId).to.equal('123')
         expect(recents[0].locations).to.eql([
           { 'image/jpeg': 'test.jpeg' }
@@ -143,6 +146,7 @@ describe('Stores > Recents', function () {
 
     before(function () {
       rootStore = initStore(true, { project })
+      recentsStore = rootStore.recents
       const user = {
         id: '123',
         login: 'test.user'
@@ -150,7 +154,7 @@ describe('Stores > Recents', function () {
       sinon.stub(auth, 'checkBearerToken').callsFake(() => Promise.reject(new Error('Auth is not available')))
       sinon.stub(rootStore.collections, 'fetchFavourites')
       rootStore.user.set(user)
-      rootStore.recents.add(mockRecent)
+      recentsStore.add(mockRecent)
     })
 
     after(function () {
@@ -159,8 +163,8 @@ describe('Stores > Recents', function () {
     })
 
     it('should record subjects classified this session', function () {
-      expect(rootStore.recents.recents).to.have.lengthOf(1)
-      const recents = getSnapshot(rootStore.recents.recents)
+      expect(recentsStore.recents).to.have.lengthOf(1)
+      const recents = getSnapshot(recentsStore.recents)
       expect(recents[0].subjectId).to.equal('123')
       expect(recents[0].locations).to.eql([
         { 'image/jpeg': 'test.jpeg' }
@@ -178,6 +182,7 @@ describe('Stores > Recents', function () {
 
     before(function () {
       rootStore = initStore(true, { project })
+      recentsStore = rootStore.recents
       const user = {
         id: '123',
         login: 'test.user'
@@ -185,7 +190,7 @@ describe('Stores > Recents', function () {
       rootStore.client.panoptes.get.callsFake(() => Promise.reject(new Error('Panoptes is not available')))
       sinon.stub(rootStore.collections, 'fetchFavourites')
       rootStore.user.set(user)
-      rootStore.recents.add(mockRecent)
+      recentsStore.add(mockRecent)
     })
 
     after(function () {
@@ -193,8 +198,8 @@ describe('Stores > Recents', function () {
     })
 
     it('should record subjects classified this session', function () {
-      expect(rootStore.recents.recents).to.have.lengthOf(1)
-      const recents = getSnapshot(rootStore.recents.recents)
+      expect(recentsStore.recents).to.have.lengthOf(1)
+      const recents = getSnapshot(recentsStore.recents)
       expect(recents[0].subjectId).to.equal('123')
       expect(recents[0].locations).to.eql([
         { 'image/jpeg': 'test.jpeg' }

--- a/packages/app-project/stores/Store.js
+++ b/packages/app-project/stores/Store.js
@@ -2,12 +2,14 @@ import { getEnv, types } from 'mobx-state-tree'
 
 import Collections from './Collections'
 import Project from './Project'
+import Recents from './Recents'
 import User from './User'
 
 const Store = types
   .model('Store', {
     collections: types.optional(Collections, {}),
     project: types.optional(Project, {}),
+    recents: types.optional(Recents, {}),
     user: types.optional(User, {})
   })
 


### PR DESCRIPTION
Package:
app-project

Towards #37.

Store recent subjects for user and project
Add a Recents store. Request recents on initial user login.
Test that the store initialises, fetches recents on user change and adds new subjects properly for both authenticated and anonymous users.
Actions:
- `recents.fetch()` fetches existing recents for authenticated users.
- `recents.add({ subjectId, locations })` adds a recent subject to the beginning of the recents queue.

Todo:
- [x] Tests.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

