### PR TITLE
Populate <head />

### DIFF
--- a/packages/app-project/components/Head/Head.js
+++ b/packages/app-project/components/Head/Head.js
@@ -1,40 +1,66 @@
+import counterpart from 'counterpart'
 import NextHead from 'next/head'
 import { string } from 'prop-types'
 import React from 'react'
 
-const defaultDescription = ''
-const defaultOGURL = ''
-const defaultOGImage = ''
+import en from './locales/en'
 
-function Head (props) {
+counterpart.registerTranslations('en', en)
+
+export default function Head (props) {
+  const {
+    description,
+    ogImage,
+    projectTwitterUsername,
+    siteName,
+    title,
+    url,
+    zooniverseTwitterUsername
+  } = props
+
   return (
     <NextHead>
       <meta charSet='UTF-8' />
-      <title>{props.title || ''}</title>
-      <meta name='description' content={props.description || defaultDescription} />
+
+      <title>
+        {title} | {siteName}
+      </title>
+
+      <meta name='description' content={description} />
       <meta name='viewport' content='width=device-width, initial-scale=1' />
+
       <link rel='icon' sizes='192x192' href='/static/touch-icon.png' />
       <link rel='apple-touch-icon' href='/static/touch-icon.png' />
       <link rel='mask-icon' href='/static/favicon-mask.svg' color='#49B882' />
       <link rel='icon' href='/static/favicon.ico' />
-      <meta property='og:url' content={props.url || defaultOGURL} />
-      <meta property='og:title' content={props.title || ''} />
-      <meta property='og:description' content={props.description || defaultDescription} />
-      <meta name='twitter:site' content={props.url || defaultOGURL} />
+
+      <meta property='og:url' content={url} />
+      <meta property='og:title' content={title} />
+      <meta property='og:description' content={description} />
+      <meta property='og:image' content={ogImage} />
+
+      {(projectTwitterUsername) && (
+        <meta name='twitter:creator' content={projectTwitterUsername} />
+      )}
+      <meta name='twitter:site' content={zooniverseTwitterUsername} />
       <meta name='twitter:card' content='summary_large_image' />
-      <meta name='twitter:image' content={props.ogImage || defaultOGImage} />
-      <meta property='og:image' content={props.ogImage || defaultOGImage} />
-      <meta property='og:image:width' content='1200' />
-      <meta property='og:image:height' content='630' />
+      <meta name='twitter:image' content={ogImage} />
     </NextHead>
   )
 }
 
 Head.propTypes = {
-  title: string,
   description: string,
+  ogImage: string,
+  projectTwitterUsername: string,
+  siteName: string,
+  title: string,
   url: string,
-  ogImage: string
 }
 
-export default Head
+Head.defaultProps = {
+  description: counterpart('Head.defaultDescription'),
+  siteName: counterpart('Head.siteName'),
+  title: counterpart('Head.defaultTitle'),
+  zooniverseTwitterUsername: '@the_zooniverse'
+}

--- a/packages/app-project/components/Head/Head.spec.js
+++ b/packages/app-project/components/Head/Head.spec.js
@@ -3,8 +3,59 @@ import React from 'react'
 
 import Head from './Head'
 
+let wrapper
+
 describe('Component > Head', function () {
+  before(function () {
+    wrapper = shallow(<Head />)
+  })
+
   it('should render without crashing', function () {
-    shallow(<Head />)
+    expect(wrapper).to.be.ok
+  })
+
+  it('should render a meta `og:url` tag', function () {
+    const tag = wrapper.find(`meta[property='og:url']`)
+    expect(tag).to.have.lengthOf(1)
+  })
+
+  it('should render a meta `og:title` tag', function () {
+    const tag = wrapper.find(`meta[property='og:title']`)
+    expect(tag).to.have.lengthOf(1)
+  })
+
+  it('should render a meta `og:description` tag', function () {
+    const tag = wrapper.find(`meta[property='og:description']`)
+    expect(tag).to.have.lengthOf(1)
+  })
+
+  it('should render a meta `og:image` tag', function () {
+    const tag = wrapper.find(`meta[property='og:image']`)
+    expect(tag).to.have.lengthOf(1)
+  })
+
+  it('should render a meta `twitter:creator` tag if available', function () {
+    let tag = wrapper.find(`meta[name='twitter:creator']`)
+    expect(tag).to.have.lengthOf(0)
+    wrapper.setProps({ projectTwitterUsername: 'foobar'})
+    tag = wrapper.find(`meta[name='twitter:creator']`)
+    expect(tag).to.have.lengthOf(1)
+    expect(tag.prop('content')).to.equal('foobar')
+  })
+
+  it('should render a meta `twitter:site` tag', function () {
+    const tag = wrapper.find(`meta[name='twitter:site']`)
+    expect(tag).to.have.lengthOf(1)
+  })
+
+  it('should render a meta `twitter:card` tag', function () {
+    const tag = wrapper.find(`meta[name='twitter:card']`)
+    expect(tag).to.have.lengthOf(1)
+    expect(tag.prop('content')).to.equal('summary_large_image')
+  })
+
+  it('should render a meta `twitter:image` tag', function () {
+    const tag = wrapper.find(`meta[name='twitter:image']`)
+    expect(tag).to.have.lengthOf(1)
   })
 })

--- a/packages/app-project/components/Head/HeadContainer.js
+++ b/packages/app-project/components/Head/HeadContainer.js
@@ -1,6 +1,7 @@
+import { get } from 'lodash'
 import { inject, observer } from 'mobx-react'
 import { withRouter } from 'next/router'
-import { shape, string } from 'prop-types'
+import { arrayOf, shape, string } from 'prop-types'
 import React, { Component } from 'react'
 import urlParse from 'url-parse'
 
@@ -21,8 +22,10 @@ export default class HeadContainer extends Component {
     return this.props.project.description || undefined
   }
 
-  getProjectBackgroundImage () {
-    return this.props.project.background.src || undefined
+  getProjectImage () {
+    return get(this.props.project, 'avatar.src') ||
+      get(this.props.project, 'background.src') ||
+      undefined
   }
 
   getProjectTitle () {
@@ -32,8 +35,8 @@ export default class HeadContainer extends Component {
 
   getProjectTwitterUsername () {
     const { urls } = this.props.project
-    const twitter = urls.find(url => url.site &&
-      url.site.includes('twitter.com'))
+    const twitter = urls.find(({ site }) => site &&
+      site.includes('twitter.com'))
     if (twitter && twitter.path) {
       return (twitter.path.startsWith('@'))
         ? twitter.path
@@ -54,7 +57,7 @@ export default class HeadContainer extends Component {
     return (
       <Head
         description={this.getProjectDescription()}
-        ogImage={this.getProjectBackgroundImage()}
+        ogImage={this.getProjectImage()}
         projectTwitterUsername={this.getProjectTwitterUsername()}
         title={this.getProjectTitle()}
         url={this.getProjectUrl()}
@@ -67,6 +70,10 @@ HeadContainer.propTypes = {
   project: shape({
     description: string,
     display_name: string,
+    urls: arrayOf(shape({
+      path: string.isRequired,
+      site: string.isRequired
+    })),
     slug: string,
   }),
 }

--- a/packages/app-project/components/Head/HeadContainer.js
+++ b/packages/app-project/components/Head/HeadContainer.js
@@ -1,0 +1,72 @@
+import { inject, observer } from 'mobx-react'
+import { withRouter } from 'next/router'
+import { shape, string } from 'prop-types'
+import React, { Component } from 'react'
+import urlParse from 'url-parse'
+
+import Head from './Head'
+
+function storeMapper (stores) {
+  const { project } = stores.store
+  return {
+    project
+  }
+}
+
+@withRouter
+@inject(storeMapper)
+@observer
+export default class HeadContainer extends Component {
+  getProjectDescription () {
+    return this.props.project.description || undefined
+  }
+
+  getProjectBackgroundImage () {
+    return this.props.project.background.src || undefined
+  }
+
+  getProjectTitle () {
+    const { display_name, slug } = this.props.project
+    return display_name || slug || undefined
+  }
+
+  getProjectTwitterUsername () {
+    const { urls } = this.props.project
+    const twitter = urls.find(url => url.site &&
+      url.site.includes('twitter.com'))
+    if (twitter && twitter.path) {
+      return (twitter.path.startsWith('@'))
+        ? twitter.path
+        : `@${twitter.path}`
+    } else {
+      return undefined
+    }
+  }
+
+  getProjectUrl () {
+    // TODO: Set this from an environment variable
+    const host = 'http://localhost:3000'
+    const { slug } = this.props.project
+    return `${host}/projects/${slug}`
+  }
+
+  render () {
+    return (
+      <Head
+        description={this.getProjectDescription()}
+        ogImage={this.getProjectBackgroundImage()}
+        projectTwitterUsername={this.getProjectTwitterUsername()}
+        title={this.getProjectTitle()}
+        url={this.getProjectUrl()}
+      />
+    )
+  }
+}
+
+HeadContainer.propTypes = {
+  project: shape({
+    description: string,
+    display_name: string,
+    slug: string,
+  }),
+}

--- a/packages/app-project/components/Head/HeadContainer.spec.js
+++ b/packages/app-project/components/Head/HeadContainer.spec.js
@@ -1,0 +1,67 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import { projects } from '@zooniverse/panoptes-js'
+
+import HeadContainer from './HeadContainer'
+import Head from './Head'
+
+const MOCK_PROJECT = {
+  ...projects.mocks.resources.projectOne,
+  background: projects.mocks.resources.projectBackground
+}
+
+let wrapper
+let componentWrapper
+
+describe('Component > HeadContainer', function () {
+  before(function () {
+    wrapper = shallow(<HeadContainer.wrappedComponent project={MOCK_PROJECT} />)
+    componentWrapper = wrapper.find(Head)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok
+  })
+
+  it('should render the `Head` component', function () {
+    expect(componentWrapper).to.have.lengthOf(1)
+  })
+
+  it('should pass a `description` prop to `Head` if available', function () {
+    expect(componentWrapper.prop('description')).to.equal(MOCK_PROJECT.description)
+  })
+
+  it('should pass a `ogImage` prop to `Head` if available', function () {
+    expect(componentWrapper.prop('ogImage')).to.equal(MOCK_PROJECT.background.src)
+  })
+
+  it('should pass a `projectTwitterUsername` prop to `Head` if available', function () {
+    expect(componentWrapper.prop('projectTwitterUsername')).to.be.undefined
+
+    const MOCK_PROJECT_WITH_TWITTER = {
+      ...MOCK_PROJECT,
+      urls: [
+        {
+          "url": "https://twitter.com/testproject",
+          "path": "testproject",
+          "site": "twitter.com/",
+        }
+      ]
+    }
+    const wrapperWithTwitter = shallow(<HeadContainer.wrappedComponent project={MOCK_PROJECT_WITH_TWITTER} />)
+    const componentWrapperWithTwitter = wrapperWithTwitter.find(Head)
+    expect(componentWrapperWithTwitter.prop('projectTwitterUsername')).to.equal('@testproject')
+  })
+
+  it('should pass a `siteName` prop to `Head`', function () {
+    expect(componentWrapper.prop('siteName')).to.be.ok
+  })
+
+  it('should pass a `title` prop to `Head`', function () {
+    expect(componentWrapper.prop('title')).to.equal(MOCK_PROJECT.display_name)
+  })
+
+  it('should pass a `url` prop to `Head`', function () {
+    expect(componentWrapper.prop('url')).to.be.ok
+  })
+})

--- a/packages/app-project/components/Head/HeadContainer.spec.js
+++ b/packages/app-project/components/Head/HeadContainer.spec.js
@@ -5,10 +5,7 @@ import { projects } from '@zooniverse/panoptes-js'
 import HeadContainer from './HeadContainer'
 import Head from './Head'
 
-const MOCK_PROJECT = {
-  ...projects.mocks.resources.projectOne,
-  background: projects.mocks.resources.projectBackground
-}
+const MOCK_PROJECT = createMockProject()
 
 let wrapper
 let componentWrapper
@@ -31,23 +28,31 @@ describe('Component > HeadContainer', function () {
     expect(componentWrapper.prop('description')).to.equal(MOCK_PROJECT.description)
   })
 
-  it('should pass a `ogImage` prop to `Head` if available', function () {
+  it('should pass the project avatar as `ogImage` to `Head` if available', function () {
+    const MOCK_PROJECT_WITH_AVATAR = createMockProject({
+      avatar: projects.mocks.resources.projectAvatar
+    })
+
+    const wrapperWithAvatar = shallow(<HeadContainer.wrappedComponent project={MOCK_PROJECT_WITH_AVATAR} />)
+    const componentWrapperWithAvatar = wrapperWithAvatar.find(Head)
+    expect(componentWrapperWithAvatar.prop('ogImage')).to.equal(MOCK_PROJECT_WITH_AVATAR.avatar.src)
+  })
+
+  it('should pass the project background as `ogImage` to `Head` if avatar is unavailable', function () {
     expect(componentWrapper.prop('ogImage')).to.equal(MOCK_PROJECT.background.src)
   })
 
   it('should pass a `projectTwitterUsername` prop to `Head` if available', function () {
     expect(componentWrapper.prop('projectTwitterUsername')).to.be.undefined
 
-    const MOCK_PROJECT_WITH_TWITTER = {
-      ...MOCK_PROJECT,
-      urls: [
-        {
-          "url": "https://twitter.com/testproject",
-          "path": "testproject",
-          "site": "twitter.com/",
-        }
-      ]
-    }
+    const MOCK_PROJECT_WITH_TWITTER = createMockProject({
+      urls: [{
+        "url": "https://twitter.com/testproject",
+        "path": "testproject",
+        "site": "twitter.com/",
+      }]
+    })
+
     const wrapperWithTwitter = shallow(<HeadContainer.wrappedComponent project={MOCK_PROJECT_WITH_TWITTER} />)
     const componentWrapperWithTwitter = wrapperWithTwitter.find(Head)
     expect(componentWrapperWithTwitter.prop('projectTwitterUsername')).to.equal('@testproject')
@@ -65,3 +70,12 @@ describe('Component > HeadContainer', function () {
     expect(componentWrapper.prop('url')).to.be.ok
   })
 })
+
+function createMockProject (additional = {}) {
+  return Object.assign(
+    {},
+    projects.mocks.resources.projectOne,
+    { background: projects.mocks.resources.projectBackground },
+    additional
+  )
+}

--- a/packages/app-project/components/Head/index.js
+++ b/packages/app-project/components/Head/index.js
@@ -1,1 +1,1 @@
-export { default } from './Head'
+export { default } from './HeadContainer'

--- a/packages/app-project/components/Head/locales/en.json
+++ b/packages/app-project/components/Head/locales/en.json
@@ -1,0 +1,7 @@
+{
+  "Head": {
+    "defaultDescription": "The Zooniverse is the world’s largest and most popular platform for people-powered research.",
+    "defaultTitle": "Projects",
+    "siteName": "Zooniverse - People-powered research"
+  }
+}

--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -24,7 +24,7 @@ const GlobalStyle = createGlobalStyle`
 export default class MyApp extends App {
   static async getInitialProps ({ Component, router, ctx: context }) {
     let pageProps = {
-      isServer: !!context.req
+      isServer: !!context.req,
     }
 
     if (Component.getInitialProps) {

--- a/packages/app-project/stores/Project.js
+++ b/packages/app-project/stores/Project.js
@@ -1,3 +1,4 @@
+import { get } from 'lodash'
 import asyncStates from '@zooniverse/async-states'
 import { flow, getRoot, types } from 'mobx-state-tree'
 
@@ -5,6 +6,7 @@ import numberString from './types/numberString'
 
 const Project = types
   .model('Project', {
+    avatar: types.frozen({}),
     background: types.frozen({}),
     classifications_count: types.optional(types.number, 0),
     classifiers_count: types.optional(types.number, 0),
@@ -42,7 +44,8 @@ const Project = types
           const project = response.body.projects[0]
           const linked = response.body.linked
 
-          self.background = linked.backgrounds[0] || {}
+          self.avatar = get(linked, 'avatars[0]', {})
+          self.background = get(linked, 'backgrounds[0]', {})
 
           const properties = [
             'classifications_count',


### PR DESCRIPTION
Package: app-project

Fills out title, description and other meta tags.

Closes #425 .

TODO:

- [ ] Pull in the origin from an environment variable in order to populate the URL correctly. (Created as #468, since I want to have a look into the correct way to do this.)
- [ ] Ultimately make this reusable and move to `@zooniverse/react-components`

