### PR TITLE
Start project header component

### DIFF
--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -76,7 +76,6 @@ export default class MyApp extends App {
           <Grommet theme={theme}>
             <Head />
             <ZooHeaderWrapper />
-            <Navigation />
             <ProjectHeader />
             <Component {...pageProps} />
             <ZooFooter />

--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -12,6 +12,7 @@ import urlParse from 'url-parse'
 import AuthModals from '../src/components/AuthModals'
 import Head from '../src/components/Head'
 import Navigation from '../src/components/Navigation'
+import ProjectHeader from '../src/components/ProjectHeader'
 import ZooHeaderWrapper from '../src/components/ZooHeaderWrapper'
 import initStore from '../stores'
 
@@ -76,6 +77,7 @@ export default class MyApp extends App {
             <Head />
             <ZooHeaderWrapper />
             <Navigation />
+            <ProjectHeader />
             <Component {...pageProps} />
             <ZooFooter />
             <AuthModals />

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
@@ -1,0 +1,21 @@
+import counterpart from 'counterpart'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
+
+export default function ProjectHeader () {
+  return (
+    <div>
+      component
+    </div>
+  )
+}
+
+ProjectHeader.propTypes = {
+}
+
+ProjectHeader.defaultProps = {
+}

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
@@ -9,7 +9,7 @@ import en from './locales/en'
 counterpart.registerTranslations('en', en)
 
 const StyledHeading = styled(Heading)`
-  text-shadow: 0 2px 4px 0 rgba(0,0,0,0.5);
+  text-shadow: 0 2px 4px rgba(0,0,0,0.5);
 `
 
 export default function ProjectHeader (props) {

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
@@ -1,21 +1,28 @@
 import counterpart from 'counterpart'
-import PropTypes from 'prop-types'
+import { Box, Heading } from 'grommet'
+import { string } from 'prop-types'
 import React from 'react'
+import styled from 'styled-components'
 
 import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
 
-export default function ProjectHeader () {
+const StyledHeading = styled(Heading)`
+  text-shadow: 0 2px 4px 0 rgba(0,0,0,0.5);
+`
+
+export default function ProjectHeader (props) {
+  const { title } = props
   return (
-    <div>
-      component
-    </div>
+    <Box pad='medium' background='teal'>
+      <StyledHeading color='white' margin='none' size='small'>
+        {title}
+      </StyledHeading>
+    </Box>
   )
 }
 
 ProjectHeader.propTypes = {
-}
-
-ProjectHeader.defaultProps = {
+  title: string.isRequired
 }

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.spec.js
@@ -1,0 +1,16 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import ProjectHeader from './ProjectHeader'
+
+let wrapper
+
+describe('Component > ProjectHeader', function () {
+  before(function () {
+    wrapper = shallow(<ProjectHeader />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok
+  })
+})

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.spec.js
@@ -1,16 +1,23 @@
-import { shallow } from 'enzyme'
+import { render } from 'enzyme'
 import React from 'react'
 
 import ProjectHeader from './ProjectHeader'
 
+const TITLE = 'Project title'
 let wrapper
 
 describe('Component > ProjectHeader', function () {
   before(function () {
-    wrapper = shallow(<ProjectHeader />)
+    wrapper = render(<ProjectHeader title={TITLE} />)
   })
 
   it('should render without crashing', function () {
     expect(wrapper).to.be.ok
+  })
+
+  it('should render the title prop as an h1', function () {
+    const heading = wrapper.find('h1')
+    expect(heading).to.be.ok
+    expect(heading.text()).to.equal(TITLE)
   })
 })

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
@@ -1,0 +1,23 @@
+import { inject, observer } from 'mobx-react'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+import ProjectHeader from './ProjectHeader'
+
+@inject('store')
+@observer
+class ProjectHeaderContainer extends Component {
+  render () {
+    return (
+      <ProjectHeader />
+    )
+  }
+}
+
+ProjectHeaderContainer.propTypes = {
+}
+
+ProjectHeaderContainer.defaultProps = {
+}
+
+export default ProjectHeaderContainer

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
@@ -1,23 +1,29 @@
 import { inject, observer } from 'mobx-react'
-import PropTypes from 'prop-types'
+import { shape, string } from 'prop-types'
 import React, { Component } from 'react'
 
 import ProjectHeader from './ProjectHeader'
 
-@inject('store')
+function storeMapper (stores) {
+  return {
+    project: stores.store.project
+  }
+}
+
+@inject(storeMapper)
 @observer
-class ProjectHeaderContainer extends Component {
+export default class ProjectHeaderContainer extends Component {
   render () {
     return (
-      <ProjectHeader />
+      <ProjectHeader
+        title={this.props.project.display_name}
+      />
     )
   }
 }
 
 ProjectHeaderContainer.propTypes = {
+  project: shape({
+    display_name: string
+  })
 }
-
-ProjectHeaderContainer.defaultProps = {
-}
-
-export default ProjectHeaderContainer

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
@@ -1,0 +1,23 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import ProjectHeaderContainer from './ProjectHeaderContainer'
+import ProjectHeader from './ProjectHeader'
+
+let wrapper
+let componentWrapper
+
+describe('Component > ProjectHeaderContainer', function () {
+  before(function () {
+    wrapper = shallow(<ProjectHeaderContainer.wrappedComponent />)
+    componentWrapper = wrapper.find(ProjectHeader)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok
+  })
+
+  it('should render the `ProjectHeader` component', function () {
+    expect(componentWrapper).to.have.lengthOf(1)
+  })
+})

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
@@ -1,5 +1,6 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+import { projects } from '@zooniverse/panoptes-js'
 
 import ProjectHeaderContainer from './ProjectHeaderContainer'
 import ProjectHeader from './ProjectHeader'
@@ -7,9 +8,11 @@ import ProjectHeader from './ProjectHeader'
 let wrapper
 let componentWrapper
 
-describe('Component > ProjectHeaderContainer', function () {
+const PROJECT = projects.mocks.resources.projectOne
+
+describe.only('Component > ProjectHeaderContainer', function () {
   before(function () {
-    wrapper = shallow(<ProjectHeaderContainer.wrappedComponent />)
+    wrapper = shallow(<ProjectHeaderContainer.wrappedComponent project={PROJECT} />)
     componentWrapper = wrapper.find(ProjectHeader)
   })
 
@@ -19,5 +22,9 @@ describe('Component > ProjectHeaderContainer', function () {
 
   it('should render the `ProjectHeader` component', function () {
     expect(componentWrapper).to.have.lengthOf(1)
+  })
+
+  it('should pass down the project title', function () {
+    expect(componentWrapper.prop('title')).to.equal(PROJECT.display_name)
   })
 })

--- a/packages/app-project/src/components/ProjectHeader/index.js
+++ b/packages/app-project/src/components/ProjectHeader/index.js
@@ -1,0 +1,1 @@
+export { default } from './ProjectHeaderContainer'

--- a/packages/app-project/src/components/ProjectHeader/locales/en.json
+++ b/packages/app-project/src/components/ProjectHeader/locales/en.json
@@ -1,0 +1,4 @@
+{
+  "ProjectHeader": {
+  }
+}

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -1,4 +1,4 @@
-import { Grid } from 'grommet'
+import { Box, Grid } from 'grommet'
 import dynamic from 'next/dynamic'
 import React from 'react'
 
@@ -15,11 +15,13 @@ const ClassifierWrapper = dynamic(() =>
 
 export default function ClassifyPage () {
   return (
-    <Grid gap='medium' margin='medium'>
-      <ClassifierWrapper />
-      <FinishedForTheDay />
-      <ProjectStatistics />
-      <ConnectWithProject />
-    </Grid>
+    <Box background='lighterGrey' pad={{ top: 'medium' }}>
+      <Grid gap='medium' margin='medium'>
+        <ClassifierWrapper />
+        <FinishedForTheDay />
+        <ProjectStatistics />
+        <ConnectWithProject />
+      </Grid>
+    </Box>
   )
 }


### PR DESCRIPTION
Package: app-project

Related to #44.

Adds the start of the project header component. In the interest of keeping velocity up, I'm trying to keep PRs small at the moment - this one simply adds in the component with the project title. Backgrounds, nav etc to come in subsequent PRs.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

