### PR TITLE
Remove .only from project header tests

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
@@ -10,7 +10,7 @@ let componentWrapper
 
 const PROJECT = projects.mocks.resources.projectOne
 
-describe.only('Component > ProjectHeaderContainer', function () {
+describe('Component > ProjectHeaderContainer', function () {
   before(function () {
     wrapper = shallow(<ProjectHeaderContainer.wrappedComponent project={PROJECT} />)
     componentWrapper = wrapper.find(ProjectHeader)


### PR DESCRIPTION
# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

