### PR TITLE
Add Subject flags (metadata) to Classifications

### DIFF
--- a/packages/lib-classifier/src/store/Classification.js
+++ b/packages/lib-classifier/src/store/Classification.js
@@ -14,8 +14,8 @@ const ClassificationMetadata = types.model('ClassificationMetadata', {
     naturalWidth: types.integer
   })),
   subjectSelectionState: types.frozen({
-    alreadySeen: types.optional(types.boolean, false),
-    finishedWorkflow: types.optional(types.boolean, false),
+    already_seen: types.optional(types.boolean, false),
+    finished_workflow: types.optional(types.boolean, false),
     retired: types.optional(types.boolean, false),
     selection_state: types.maybe(types.string),
     user_has_finished_workflow: types.optional(types.boolean, false),

--- a/packages/lib-classifier/src/store/Classification.js
+++ b/packages/lib-classifier/src/store/Classification.js
@@ -13,6 +13,13 @@ const ClassificationMetadata = types.model('ClassificationMetadata', {
     naturalHeight: types.integer,
     naturalWidth: types.integer
   })),
+  subjectSelectionState: types.frozen({
+    alreadySeen: types.optional(types.boolean, false),
+    finishedWorkflow: types.optional(types.boolean, false),
+    retired: types.optional(types.boolean, false),
+    selection_state: types.maybe(types.string),
+    user_has_finished_workflow: types.optional(types.boolean, false),
+  }),
   userAgent: types.optional(types.string, navigator.userAgent),
   userLanguage: types.string,
   utcOffset: types.optional(types.string, ((new Date()).getTimezoneOffset() * 60).toString()),

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -54,6 +54,8 @@ const ClassificationStore = types
       const tempID = cuid()
       const projectID = getRoot(self).projects.active.id
       const workflow = getRoot(self).workflows.active
+      
+      console.log('+++ subject: ', subject)
 
       const newClassification = Classification.create({
         id: tempID, // Generate an id just for serialization in MST. Should be dropped before POST...
@@ -65,11 +67,11 @@ const ClassificationStore = types
         metadata: ClassificationMetadata.create({
           source: subject.metadata.intervention ? 'sugar' : 'api',
           subjectSelectionState: {
-            alreadySeen: subject.alreadySeen,
-            finishedWorkflow: subject.finishedWorkflow,
+            already_seen: subject.already_seen,
+            finished_workflow: subject.finished_workflow,
             retired: subject.retired,
-            selection_state: subject.selectionState,
-            user_has_finished_workflow: subject.userHasFinishedWorkflow,
+            selection_state: subject.selection_state,
+            user_has_finished_workflow: subject.user_has_finished_workflow,
           },
           userLanguage: counterpart.getLocale(),
           workflowVersion: workflow.version

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -64,6 +64,13 @@ const ClassificationStore = types
         },
         metadata: ClassificationMetadata.create({
           source: subject.metadata.intervention ? 'sugar' : 'api',
+          subjectSelectionState: {
+            alreadySeen: subject.alreadySeen,
+            finishedWorkflow: subject.finishedWorkflow,
+            retired: subject.retired,
+            selection_state: subject.selectionState,
+            user_has_finished_workflow: subject.userHasFinishedWorkflow,
+          },
           userLanguage: counterpart.getLocale(),
           workflowVersion: workflow.version
         })

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -54,8 +54,6 @@ const ClassificationStore = types
       const tempID = cuid()
       const projectID = getRoot(self).projects.active.id
       const workflow = getRoot(self).workflows.active
-      
-      console.log('+++ subject: ', subject)
 
       const newClassification = Classification.create({
         id: tempID, // Generate an id just for serialization in MST. Should be dropped before POST...

--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -1,13 +1,5 @@
-import Classification from './Classification'
 import ClassificationStore from './ClassificationStore'
-import Project from './Project'
-import ProjectStore from './ProjectStore'
 import Subject from './Subject'
-import SubjectStore from './SubjectStore'
-import UserProjectPreferences from './UserProjectPreferences'
-import UserProjectPreferencesStore from './UserProjectPreferencesStore'
-import Workflow from './Workflow'
-import WorkflowStore from './WorkflowStore'
 
 import { types } from 'mobx-state-tree'
 

--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -1,8 +1,63 @@
+import Classification from './Classification'
 import ClassificationStore from './ClassificationStore'
+import Project from './Project'
+import ProjectStore from './ProjectStore'
+import Subject from './Subject'
+import SubjectStore from './SubjectStore'
+import UserProjectPreferences from './UserProjectPreferences'
+import UserProjectPreferencesStore from './UserProjectPreferencesStore'
+import Workflow from './Workflow'
+import WorkflowStore from './WorkflowStore'
 
-describe('Model > ClassificationStore', function () {
+import { types } from 'mobx-state-tree'
+
+let rootStore
+
+const RootStub = types
+  .model('RootStore', {
+    classifications: ClassificationStore,
+    projects: types.frozen(),
+    subjects: types.frozen(),
+    workflows: types.frozen() 
+  })
+
+describe.only('Model > ClassificationStore', function () {
+  let subject
+  before(function () {
+    subject = Subject.create({
+      already_seen: true,
+      favorite: true,
+      finished_workflow: true,
+      id: '3333',
+      locations: [
+        { 'image/jpeg': 'https://panoptes-uploads.zooniverse.org/335/0/44a48dd2-23b3-4bb5-9aa4-0e803ac4fe6d.jpeg' }
+      ],
+      metadata: {},
+      retired: false,
+      selection_state: 'normal',
+      user_has_finished_workflow: true
+    })
+    
+    rootStore = RootStub.create({
+      classifications: ClassificationStore.create({
+        active: undefined,
+        resources: {},
+        type: 'classifications'
+      }),
+      projects: { active: { id: '1111' } },
+      subjects: { active: undefined },
+      workflows: { active: { id: '2222', version: 'v0.2' } }
+    })
+  })
+  
   it('should exist', function () {
     expect(ClassificationStore).to.exist
     expect(ClassificationStore).to.be.an('object')
+  })
+  
+  it('should create an empty Classification that matches a Subject', function () {
+    rootStore.classifications.createClassification(subject)
+    
+    console.log('+++ C\n', rootStore.classifications.resources.get(0))
   })
 })

--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -22,7 +22,7 @@ const subjectStub = {
     { 'image/jpeg': 'https://panoptes-uploads.zooniverse.org/335/0/44a48dd2-23b3-4bb5-9aa4-0e803ac4fe6d.jpeg' }
   ],
   metadata: {},
-  retired: false,
+  retired: true,
   selection_state: 'normal',
   user_has_finished_workflow: true
 }

--- a/packages/lib-classifier/src/store/Subject.js
+++ b/packages/lib-classifier/src/store/Subject.js
@@ -5,8 +5,13 @@ import subjectViewers from '../helpers/subjectViewers'
 
 const Subject = types
   .model('Subject', {
+    already_seen: types.optional(types.boolean, false),
+    finished_workflow: types.optional(types.boolean, false),
     locations: types.frozen(),
-    metadata: types.frozen()
+    metadata: types.frozen(),
+    retired: types.optional(types.boolean, false),
+    selection_state: types.maybe(types.string),
+    user_has_finished_workflow: types.optional(types.boolean, false)
   })
 
   .views(self => ({

--- a/packages/lib-classifier/src/store/Subject.js
+++ b/packages/lib-classifier/src/store/Subject.js
@@ -6,6 +6,7 @@ import subjectViewers from '../helpers/subjectViewers'
 const Subject = types
   .model('Subject', {
     already_seen: types.optional(types.boolean, false),
+    favorite: types.optional(types.boolean, false),
     finished_workflow: types.optional(types.boolean, false),
     locations: types.frozen(),
     metadata: types.frozen(),


### PR DESCRIPTION
## PR Overview

package: `lib-classifier`
Closes #364

This PR adds a number of Subject-related information to the submitted Classification's metadata. Basically, it's a copy of this PR from PFE - https://github.com/zooniverse/Panoptes-Front-End/pull/5197 - and the goal of this PR is to get the Classifier closer to par with the PFE Classifier.

### Status
~~WIP.~~
- ~~I've already updated the Classifications store to accept `metadata.subjectSelectionState` (note: will be translated to `metadata.subject_selection_state`)~~
- ~~but it turns out I need to update the _Subject store_ too, because the data model missing ol' stuff like `subject.alreadySeen` (aka `subject.already_seen`) and etc. I _think,_ anyway. brb while I check.~~

Ready for review. See https://github.com/zooniverse/front-end-monorepo/pull/476#issuecomment-465284353 for dev thoughts.