### PR TITLE
Remove .only from UPP tests

### DIFF
--- a/packages/lib-classifier/src/store/UserProjectPreferencesStore.spec.js
+++ b/packages/lib-classifier/src/store/UserProjectPreferencesStore.spec.js
@@ -39,7 +39,7 @@ const authClientStubWithUser = {
   checkBearerToken: sinon.stub().callsFake(() => Promise.resolve(token))
 }
 
-describe.only('Model > UserProjectPreferencesStore', function () {
+describe('Model > UserProjectPreferencesStore', function () {
   it('should exist', function () {
     expect(UserProjectPreferencesStore).to.be.an('object')
   })


### PR DESCRIPTION
Package:
lib-classifier


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

