### PR TITLE
Search and create collections

### DIFF
--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -40,7 +40,7 @@ const Collections = types
         self.loadingState = asyncStates.loading
         const token = yield auth.checkBearerToken()
         const authorization = `Bearer ${token}`
-        const response = yield client.get({ authorization, query })
+        const response = yield client.collections.get({ authorization, query })
         const { collections } = response.body
         self.loadingState = asyncStates.success
         return collections
@@ -65,7 +65,7 @@ const Collections = types
           private: false
         }
         const data = Object.assign({}, defaults, options)
-        const response = yield client.create({ authorization, data, project: project.id, subjects: subjectIds })
+        const response = yield client.collections.create({ authorization, data, project: project.id, subjects: subjectIds })
         self.loadingState = asyncStates.success
         const [ collection ] = response.body.collections
         return collection
@@ -80,7 +80,7 @@ const Collections = types
 
     return {
       afterAttach () {
-        client = getRoot(self).client.collections
+        client = getRoot(self).client
         createProjectObserver()
       },
 
@@ -128,7 +128,7 @@ const Collections = types
           collectionId,
           subjects: subjectIds
         }
-        const response = yield client.addSubjects(params)
+        const response = yield client.collections.addSubjects(params)
         const [ collection ] = response.body.collections
         return collection
       }),
@@ -146,7 +146,7 @@ const Collections = types
           collectionId,
           subjects: subjectIds
         }
-        const response = yield client.removeSubjects(params)
+        const response = yield client.collections.removeSubjects(params)
         const [ collection ] = response.body.collections
         return collection
       }),

--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -40,7 +40,7 @@ const Collections = types
         createProjectObserver()
       },
 
-      createCollection: flow(function * createCollection (options) {
+      createCollection: flow(function * createCollection (options, subjectIds=[]) {
         const { project } = getRoot(self)
         self.loadingState = asyncStates.loading
         const token = yield auth.checkBearerToken()
@@ -51,8 +51,7 @@ const Collections = types
           private: false
         }
         const data = Object.assign({}, defaults, options)
-        const subjects = []
-        const response = yield client.create({ authorization, data, project: project.id, subjects })
+        const response = yield client.create({ authorization, data, project: project.id, subjects: subjectIds })
         const [ collection ] = response.body.collections
         self.loadingState = asyncStates.success
         if (options.favorite) {
@@ -62,14 +61,14 @@ const Collections = types
         }
       }),
 
-      createFavourites: flow(function * createFavourites () {
+      createFavourites: flow(function * createFavourites (subjectIds=[]) {
         const { project } = getRoot(self)
         const options = {
           display_name: `Favorites ${project.slug}`,
           favorite: true,
           private: true
         }
-        return self.createCollection(options)
+        return self.createCollection(options, subjectIds)
       }),
 
       fetchCollections: flow(function * fetchCollections (query) {

--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -15,7 +15,7 @@ export const Collection = types
 const Collections = types
   .model('Collections', {
     error: types.maybeNull(types.frozen({})),
-    collections: types.optional(types.array(Collection), []),
+    collections: types.array(Collection),
     favourites: types.maybeNull(Collection),
     loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.initialized)
   })

--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -102,29 +102,39 @@ const Collections = types
         }
       }),
 
-      addFavourites: flow(function * addFavourites (subjectIds) {
+      addSubjects: flow(function * addSubjects (collectionId, subjectIds) {
         const token = yield auth.checkBearerToken()
         const authorization = `Bearer ${token}`
         const params = {
           authorization,
-          collectionId: self.favourites.id,
+          collectionId,
           subjects: subjectIds
         }
         const response = yield client.addSubjects(params)
-        const [ favourites ] = response.body.collections
+        const [ collection ] = response.body.collections
+        return collection
+      }),
+
+      addFavourites: flow(function * addFavourites (subjectIds) {
+        const favourites = yield self.addSubjects(self.favourites.id, subjectIds)
         self.favourites = Collection.create(favourites)
       }),
 
-      removeFavourites: flow(function * removeFavourites (subjectIds) {
+      removeSubjects: flow(function * removeSubjects(collectionId, subjectIds) {
         const token = yield auth.checkBearerToken()
         const authorization = `Bearer ${token}`
         const params = {
           authorization,
-          collectionId: self.favourites.id,
+          collectionId,
           subjects: subjectIds
         }
         const response = yield client.removeSubjects(params)
-        const [ favourites ] = response.body.collections
+        const [ collection ] = response.body.collections
+        return collection
+      }),
+
+      removeFavourites: flow(function * removeFavourites (subjectIds) {
+        const favourites = yield self.removeSubjects(self.favourites.id, subjectIds)
         self.favourites = Collection.create(favourites)
       })
     }

--- a/packages/app-project/stores/Collections.spec.js
+++ b/packages/app-project/stores/Collections.spec.js
@@ -49,7 +49,8 @@ describe('stores > Collections', function () {
         collectionsStore.fetchFavourites()
           .then(function () {
             expect(collectionsStore.loadingState).to.equal(asyncStates.success)
-            expect(collectionsStore.favourites).to.be.ok()
+            expect(collectionsStore.favourites.id).to.equal('1')
+            expect(collectionsStore.favourites.display_name).to.equal('test collection')
           })
           .then(done, done)
 

--- a/packages/app-project/stores/Collections.spec.js
+++ b/packages/app-project/stores/Collections.spec.js
@@ -11,7 +11,6 @@ import placeholderEnv from './helpers/placeholderEnv'
 describe('stores > Collections', function () {
   let rootStore = Store.create({}, placeholderEnv)
   let collectionsStore = rootStore.collections
-  let clientStub
 
   it('should exist', function () {
     expect(rootStore.collections).to.be.ok()
@@ -33,15 +32,15 @@ describe('stores > Collections', function () {
           login: 'test.user'
         }
         const snapshot = { project, user }
-        clientStub = {
-          collections: {
-            get: function () {
-              return Promise.resolve({ body: collections.mocks.responses.get.collection })
-            }
-          }
-        }
-        rootStore = initStore(true, snapshot, clientStub)
+        rootStore = initStore(true, snapshot)
+        sinon.stub(rootStore.client.collections, 'get').callsFake(function () {
+          return Promise.resolve({ body: collections.mocks.responses.get.collection })
+        })
         collectionsStore = rootStore.collections
+      })
+
+      after(function () {
+        rootStore.client.collections.get.restore()
       })
 
       it('should fetch a collection', function (done) {
@@ -71,25 +70,25 @@ describe('stores > Collections', function () {
           login: 'test.user'
         }
         const snapshot = { project, user }
-        clientStub = {
-          collections: {
-            create: sinon.stub().callsFake(function (payload) {
-              const [ favourites ] = collections.mocks.responses.get.collection.collections
-              const links = {
-                project: payload.project,
-                subjects: payload.subjects
-              }
-              const newCollection = Object.assign({}, favourites, payload.data, { links })
-              const body = Object.assign({}, collections.mocks.responses.get.collection, { collections: [newCollection] })
-              return Promise.resolve({ body })
-            }),
-            get: function () {
-              return Promise.resolve({ body: { collections: [] } })
-            }
+        rootStore = initStore(true, snapshot)
+        sinon.stub(rootStore.client.collections, 'create').callsFake(function (payload) {
+          const [ favourites ] = collections.mocks.responses.get.collection.collections
+          const links = {
+            project: payload.project,
+            subjects: payload.subjects
           }
-        }
-        rootStore = initStore(true, snapshot, clientStub)
+          const newCollection = Object.assign({}, favourites, payload.data, { links })
+          const body = Object.assign({}, collections.mocks.responses.get.collection, { collections: [newCollection] })
+          return Promise.resolve({ body })
+        })
+        sinon.stub(rootStore.client.collections, 'get').callsFake(function () {
+          return Promise.resolve({ body: { collections: [] } })
+        })
         collectionsStore = rootStore.collections
+      })
+      after(function () {
+        rootStore.client.collections.create.restore()
+        rootStore.client.collections.get.restore()
       })
 
       it('should create a new collection', function (done) {
@@ -99,8 +98,7 @@ describe('stores > Collections', function () {
           .then(function () {
             const favourites = getSnapshot(collectionsStore.favourites)
             expect(collectionsStore.loadingState).to.equal(asyncStates.success)
-            expect(clientStub.collections.create).to.have.been.calledOnce()
-            expect(collectionsStore.favourites).to.be.ok()
+            expect(rootStore.client.collections.create).to.have.been.calledOnce()
             expect(favourites.display_name).to.equal('Favorites test/project')
             expect(favourites.links.project).to.equal('2')
             expect(favourites.links.subjects).to.eql([])
@@ -130,20 +128,20 @@ describe('stores > Collections', function () {
       }
       const favourites = Object.assign({}, collections.mocks.resources.collection, { links })
       const snapshot = { project, user, collections: { favourites } }
-      clientStub = {
-        collections: {
-          addSubjects: sinon.stub().callsFake(function (params) {
-            const links = {
-              project: '1',
-              subjects: ['1', '2']
-            }
-            const newFavourites = Object.assign({}, favourites, { links })
-            return Promise.resolve({ body: { collections: [ newFavourites ] } })
-          })
+      rootStore = initStore(true, snapshot)
+      sinon.stub(rootStore.client.collections, 'addSubjects').callsFake(function (params) {
+        const links = {
+          project: '1',
+          subjects: ['1', '2']
         }
-      }
-      rootStore = initStore(true, snapshot, clientStub)
+        const newFavourites = Object.assign({}, favourites, { links })
+        return Promise.resolve({ body: { collections: [ newFavourites ] } })
+      })
       collectionsStore = rootStore.collections
+    })
+
+    after(function () {
+      rootStore.client.collections.addSubjects.restore()
     })
 
     it('should add subjects to the favourites collection', function (done) {
@@ -155,7 +153,7 @@ describe('stores > Collections', function () {
             collectionId: favourites.id,
             subjects: ['1', '2']
           }
-          expect(clientStub.collections.addSubjects).to.have.been.calledOnceWith(params)
+          expect(rootStore.client.collections.addSubjects).to.have.been.calledOnceWith(params)
           expect(favourites.links.subjects).to.eql(['1', '2'])
         })
         .then(done, done)
@@ -178,20 +176,20 @@ describe('stores > Collections', function () {
       }
       const favourites = Object.assign({}, collections.mocks.resources.collection, { links })
       const snapshot = { project, user, collections: { favourites } }
-      clientStub = {
-        collections: {
-          removeSubjects: sinon.stub().callsFake(function (params) {
-            const links = {
-              project: '1',
-              subjects: []
-            }
-            const newFavourites = Object.assign({}, favourites, { links })
-            return Promise.resolve({ body: { collections: [ newFavourites ] } })
-          })
+      rootStore = initStore(true, snapshot)
+      sinon.stub(rootStore.client.collections, 'removeSubjects').callsFake(function (params) {
+        const links = {
+          project: '1',
+          subjects: []
         }
-      }
-      rootStore = initStore(true, snapshot, clientStub)
+        const newFavourites = Object.assign({}, favourites, { links })
+        return Promise.resolve({ body: { collections: [ newFavourites ] } })
+      })
       collectionsStore = rootStore.collections
+    })
+
+    after(function () {
+      rootStore.client.collections.removeSubjects.restore()
     })
 
     it('should remove subjects from the favourites collection', function (done) {
@@ -203,7 +201,7 @@ describe('stores > Collections', function () {
             collectionId: favourites.id,
             subjects: ['1', '2']
           }
-          expect(clientStub.collections.removeSubjects).to.have.been.calledOnceWith(params)
+          expect(rootStore.client.collections.removeSubjects).to.have.been.calledOnceWith(params)
           expect(favourites.links.subjects).to.eql([])
         })
         .then(done, done)


### PR DESCRIPTION
Package:
app-project

Towards: #398

Update the collections store to allow for searching and creating collections, and adding new subjects to them.

My thinking, at the moment, for the 'add to collections' popup is:
 - searching collections calls `searchCollections(query)` and displays the results from the stored `collections` array.
- selecting a search result calls `addSubjects(collectionId, subjectIds)`.
- creating a new collection calls `createCollection(options, subjectIds)`, creating a new collection and adding the subject to it in one go.

Todo:
- [x] add tests simulating all the UI actions for the collections popup.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

