### PR TITLE
Fix some of the colours on the classifier page

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -10,14 +10,14 @@ import FinishedForTheDay from './components/FinishedForTheDay'
 
 const ClassifierWrapper = dynamic(() =>
   import('./components/ClassifierWrapper'), {
-    ssr: false
-  }
+  ssr: false
+}
 )
 
 function ClassifyPage ({ mode }) {
   return (
     <Box
-      background={ mode === 'light' ? 'lighterGrey' : 'midDarkGrey' }
+      background={mode === 'light' ? 'lighterGrey' : 'midDarkGrey'}
       pad={{ top: 'medium' }}
     >
       <Grid gap='medium' margin='medium'>

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -1,5 +1,6 @@
 import { Box, Grid } from 'grommet'
 import dynamic from 'next/dynamic'
+import { string } from 'prop-types'
 import React from 'react'
 
 import ProjectStatistics from '../../shared/components/ProjectStatistics'
@@ -9,13 +10,16 @@ import FinishedForTheDay from './components/FinishedForTheDay'
 
 const ClassifierWrapper = dynamic(() =>
   import('./components/ClassifierWrapper'), {
-  ssr: false
-}
+    ssr: false
+  }
 )
 
-export default function ClassifyPage () {
+function ClassifyPage ({ mode }) {
   return (
-    <Box background='lighterGrey' pad={{ top: 'medium' }}>
+    <Box
+      background={ mode === 'light' ? 'lighterGrey' : 'midDarkGrey' }
+      pad={{ top: 'medium' }}
+    >
       <Grid gap='medium' margin='medium'>
         <ClassifierWrapper />
         <FinishedForTheDay />
@@ -25,3 +29,9 @@ export default function ClassifyPage () {
     </Box>
   )
 }
+
+ClassifyPage.propTypes = {
+  mode: string
+}
+
+export default ClassifyPage

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -1,0 +1,30 @@
+import { inject, observer } from 'mobx-react'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+import ClassifyPage from './ClassifyPage'
+
+function storeMapper (stores) {
+  const { mode } = stores.store.ui
+  return {
+    mode
+  }
+}
+
+@inject(storeMapper)
+@observer
+class ClassifyPageContainer extends Component {
+  render () {
+    return (
+      <ClassifyPage {...this.props} />
+    )
+  }
+}
+
+ClassifyPageContainer.propTypes = {
+}
+
+ClassifyPageContainer.defaultProps = {
+}
+
+export default ClassifyPageContainer

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -1,5 +1,5 @@
 import { inject, observer } from 'mobx-react'
-import PropTypes from 'prop-types'
+import { string } from 'prop-types'
 import React, { Component } from 'react'
 
 import ClassifyPage from './ClassifyPage'
@@ -22,9 +22,11 @@ class ClassifyPageContainer extends Component {
 }
 
 ClassifyPageContainer.propTypes = {
+  mode: string
 }
 
 ClassifyPageContainer.defaultProps = {
+  mode: 'light'
 }
 
 export default ClassifyPageContainer

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.spec.js
@@ -1,0 +1,23 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import ClassifyPageContainer from './ClassifyPageContainer'
+import ClassifyPage from './ClassifyPage'
+
+let wrapper
+let componentWrapper
+
+describe('Component > ClassifyPageContainer', function () {
+  before(function () {
+    wrapper = shallow(<ClassifyPageContainer.wrappedComponent />)
+    componentWrapper = wrapper.find(ClassifyPage)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok
+  })
+
+  it('should render the `ClassifyPage` component', function () {
+    expect(componentWrapper).to.have.lengthOf(1)
+  })
+})

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.spec.js
@@ -14,7 +14,7 @@ describe('Component > ClassifyPageContainer', function () {
   })
 
   it('should render without crashing', function () {
-    expect(wrapper).to.be.ok
+    expect(wrapper).to.be.ok()
   })
 
   it('should render the `ClassifyPage` component', function () {

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
@@ -8,10 +8,12 @@ import ErrorMessage from './components/ErrorMessage'
 
 function storeMapper (stores) {
   const { project, user } = stores.store
+  const { mode } = stores.store.ui
   // We return a POJO here, as the `project` resource is also stored in a
   // `mobx-state-tree` store in the classifier and an MST node can't be in two
   // stores at the same time.
   return {
+    mode,
     project: project.toJSON(),
     user
   }
@@ -34,7 +36,7 @@ class ClassifierWrapperContainer extends Component {
   }
 
   render () {
-    const { authClient, project, user } = this.props
+    const { authClient, mode, project, user } = this.props
     const somethingWentWrong = this.state.error || project.loadingState === asyncStates.error
 
     if (somethingWentWrong) {
@@ -56,8 +58,9 @@ class ClassifierWrapperContainer extends Component {
       const key = user.id || 'no-user'
       return (
         <Classifier
-          key={key}
           authClient={authClient}
+          key={key}
+          mode={mode}
           project={project}
         />
       )

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
@@ -1,4 +1,4 @@
-import { shallow, render } from 'enzyme'
+import { shallow } from 'enzyme'
 import React from 'react'
 
 import FinishedForTheDay from './FinishedForTheDay'
@@ -11,7 +11,7 @@ let wrapper
 
 describe('Component > FinishedForTheDay', function () {
   before(function () {
-    wrapper = render(<FinishedForTheDay projectName={projectName} />)
+    wrapper = shallow(<FinishedForTheDay projectName={projectName} />)
   })
 
   it('should render without crashing', function () {
@@ -19,11 +19,11 @@ describe('Component > FinishedForTheDay', function () {
   })
 
   it('should contain a title', function () {
-    expect(wrapper.find('h3')).to.have.lengthOf(1)
+    expect(wrapper.find('Heading')).to.have.lengthOf(1)
   })
 
   it('should contain some text', function () {
-    const para = wrapper.find('p')
+    const para = wrapper.find('FinishedForTheDay__StyledParagraph')
     expect(para).to.have.lengthOf(1)
     expect(para.text().length).to.be.ok()
   })

--- a/packages/app-project/src/screens/ClassifyPage/index.js
+++ b/packages/app-project/src/screens/ClassifyPage/index.js
@@ -1,1 +1,1 @@
-export { default } from './ClassifyPage'
+export { default } from './ClassifyPageContainer'

--- a/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/ProjectLink.js
+++ b/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/ProjectLink.js
@@ -16,7 +16,7 @@ const StyledAnchor = styled(Anchor)`
   text-transform: uppercase;
 `
 
-function ProjectLink ({ urlObject }) {
+function ProjectLink ({ mode, urlObject }) {
   const { IconComponent, label, type, url } = formatUrlObject(urlObject)
   return (
     <Box direction='row' margin={{ bottom: 'small' }}>
@@ -26,13 +26,20 @@ function ProjectLink ({ urlObject }) {
       <Box>
         <SpacedText>
           <Link href={url} passHref>
-            <StyledAnchor color='#005D69' size='small'>
+            <StyledAnchor
+              color={ mode === 'light' ? '#005D69' : 'lightTeal' }
+              size='small'
+            >
               {label}
             </StyledAnchor>
           </Link>
         </SpacedText>
         <Box area='type'>
-          <Text color='#5c5c5c' size='small' weight='bold'>
+          <Text
+            color={ mode === 'light' ? '#5c5c5c' : 'midGrey' }
+            size='small'
+            weight='bold'
+          >
             {type}
           </Text>
         </Box>
@@ -42,6 +49,7 @@ function ProjectLink ({ urlObject }) {
 }
 
 ProjectLink.propTypes = {
+  mode: string,
   urlObject: shape({
     label: string,
     path: string,

--- a/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/ProjectLink.js
+++ b/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/ProjectLink.js
@@ -27,7 +27,7 @@ function ProjectLink ({ mode, urlObject }) {
         <SpacedText>
           <Link href={url} passHref>
             <StyledAnchor
-              color={ mode === 'light' ? '#005D69' : 'lightTeal' }
+              color={mode === 'light' ? '#005D69' : 'lightTeal'}
               size='small'
             >
               {label}
@@ -36,7 +36,7 @@ function ProjectLink ({ mode, urlObject }) {
         </SpacedText>
         <Box area='type'>
           <Text
-            color={ mode === 'light' ? '#5c5c5c' : 'midGrey' }
+            color={mode === 'light' ? '#5c5c5c' : 'midGrey'}
             size='small'
             weight='bold'
           >

--- a/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/ProjectLinkContainer.js
+++ b/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/ProjectLinkContainer.js
@@ -1,0 +1,28 @@
+import { inject, observer } from 'mobx-react'
+import { string } from 'prop-types'
+import React, { Component } from 'react'
+
+import ProjectLink from './ProjectLink'
+
+function storeMapper (stores) {
+  const { mode } = stores.store.ui
+  return {
+    mode
+  }
+}
+
+@inject(storeMapper)
+@observer
+class ProjectLinkContainer extends Component {
+  render () {
+    return (
+      <ProjectLink {...this.props} />
+    )
+  }
+}
+
+ProjectLinkContainer.propTypes = {
+  mode: string
+}
+
+export default ProjectLinkContainer

--- a/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/ProjectLinkContainer.spec.js
+++ b/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/ProjectLinkContainer.spec.js
@@ -1,0 +1,23 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import ProjectLinkContainer from './ProjectLinkContainer'
+import ProjectLink from './ProjectLink'
+
+let wrapper
+let componentWrapper
+
+describe('Component > ProjectLinkContainer', function () {
+  before(function () {
+    wrapper = shallow(<ProjectLinkContainer.wrappedComponent />)
+    componentWrapper = wrapper.find(ProjectLink)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok
+  })
+
+  it('should render the `ProjectLink` component', function () {
+    expect(componentWrapper).to.have.lengthOf(1)
+  })
+})

--- a/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/ProjectLinkContainer.spec.js
+++ b/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/ProjectLinkContainer.spec.js
@@ -14,7 +14,7 @@ describe('Component > ProjectLinkContainer', function () {
   })
 
   it('should render without crashing', function () {
-    expect(wrapper).to.be.ok
+    expect(wrapper).to.be.ok()
   })
 
   it('should render the `ProjectLink` component', function () {

--- a/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/index.js
+++ b/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/index.js
@@ -1,1 +1,1 @@
-export { default } from './ProjectLink'
+export { default } from './ProjectLinkContainer'

--- a/packages/app-project/src/shared/components/ContentBox/ContentBox.js
+++ b/packages/app-project/src/shared/components/ContentBox/ContentBox.js
@@ -8,13 +8,13 @@ function ContentBox ({ children, linkLabel, linkUrl, mode, title }) {
   const showHeader = title || (linkLabel && linkUrl)
   return (
     <Box
-      background={ mode === 'light' ? 'white' : '#333' }
+      background={mode === 'light' ? 'white' : '#333'}
       border={{
         color: mode === 'light' ? 'lightGrey' : '#333',
         side: 'all',
         size: 'thin'
       }}
-      elevation={ mode === 'light' ? 'none' : 'large' }
+      elevation={mode === 'light' ? 'none' : 'large'}
       pad='medium'
     >
       {showHeader && (
@@ -29,7 +29,7 @@ function ContentBox ({ children, linkLabel, linkUrl, mode, title }) {
           {title && (
             <Heading level='4' margin='none'>
               <SpacedText
-                color={ mode === 'light' ? 'black' : 'lighterGrey' }
+                color={mode === 'light' ? 'black' : 'lighterGrey'}
                 weight='bold'
               >
                 {title}
@@ -60,7 +60,7 @@ ContentBox.propTypes = {
   linkLabel: string,
   linkUrl: string,
   title: string,
-  mode: string,
+  mode: string
 }
 
 export default ContentBox

--- a/packages/app-project/src/shared/components/ContentBox/ContentBox.js
+++ b/packages/app-project/src/shared/components/ContentBox/ContentBox.js
@@ -7,7 +7,15 @@ import Link from 'next/link'
 function ContentBox ({ children, linkLabel, linkUrl, title }) {
   const showHeader = title || (linkLabel && linkUrl)
   return (
-    <Box background='white' border='all' pad='medium'>
+    <Box
+      background='white'
+      border={{
+        color: 'lightGrey',
+        side: 'all',
+        size: 'thin'
+      }}
+      pad='medium'
+    >
       {showHeader && (
         <Box
           align='center'

--- a/packages/app-project/src/shared/components/ContentBox/ContentBox.js
+++ b/packages/app-project/src/shared/components/ContentBox/ContentBox.js
@@ -1,19 +1,20 @@
+import { SpacedText } from '@zooniverse/react-components'
 import { Anchor, Box, Heading } from 'grommet'
+import Link from 'next/link'
 import { node, string } from 'prop-types'
 import React from 'react'
-import { SpacedText } from '@zooniverse/react-components'
-import Link from 'next/link'
 
-function ContentBox ({ children, linkLabel, linkUrl, title }) {
+function ContentBox ({ children, linkLabel, linkUrl, mode, title }) {
   const showHeader = title || (linkLabel && linkUrl)
   return (
     <Box
-      background='white'
+      background={ mode === 'light' ? 'white' : '#333' }
       border={{
-        color: 'lightGrey',
+        color: mode === 'light' ? 'lightGrey' : '#333',
         side: 'all',
         size: 'thin'
       }}
+      elevation={ mode === 'light' ? 'none' : 'large' }
       pad='medium'
     >
       {showHeader && (
@@ -24,13 +25,18 @@ function ContentBox ({ children, linkLabel, linkUrl, title }) {
           justify={title ? 'between' : 'end'}
           margin={{ bottom: 'medium' }}
         >
+
           {title && (
             <Heading level='4' margin='none'>
-              <SpacedText color='black' weight='bold'>
+              <SpacedText
+                color={ mode === 'light' ? 'black' : 'lighterGrey' }
+                weight='bold'
+              >
                 {title}
               </SpacedText>
             </Heading>
           )}
+
           {(linkLabel && linkUrl) && (
             <Link href={linkUrl} passHref>
               <Anchor>
@@ -40,8 +46,10 @@ function ContentBox ({ children, linkLabel, linkUrl, title }) {
               </Anchor>
             </Link>
           )}
+
         </Box>
       )}
+
       {children}
     </Box>
   )
@@ -49,7 +57,10 @@ function ContentBox ({ children, linkLabel, linkUrl, title }) {
 
 ContentBox.propTypes = {
   children: node,
-  title: string
+  linkLabel: string,
+  linkUrl: string,
+  title: string,
+  mode: string,
 }
 
 export default ContentBox

--- a/packages/app-project/src/shared/components/ContentBox/ContentBoxContainer.js
+++ b/packages/app-project/src/shared/components/ContentBox/ContentBoxContainer.js
@@ -26,4 +26,8 @@ ContentBoxContainer.propTypes = {
   mode: string
 }
 
+ContentBoxContainer.defaultProps = {
+  mode: 'light'
+}
+
 export default ContentBoxContainer

--- a/packages/app-project/src/shared/components/ContentBox/ContentBoxContainer.js
+++ b/packages/app-project/src/shared/components/ContentBox/ContentBoxContainer.js
@@ -1,0 +1,29 @@
+import { inject, observer } from 'mobx-react'
+import { string } from 'prop-types'
+import React, { Component } from 'react'
+
+import ContentBox from './ContentBox'
+
+function storeMapper (stores) {
+  const { mode } = stores.store.ui
+  return {
+    mode
+  }
+}
+
+@inject(storeMapper)
+@observer
+class ContentBoxContainer extends Component {
+  render () {
+    const { mode, ...props } = this.props
+    return (
+      <ContentBox mode={mode} {...props} />
+    )
+  }
+}
+
+ContentBoxContainer.propTypes = {
+  mode: string
+}
+
+export default ContentBoxContainer

--- a/packages/app-project/src/shared/components/ContentBox/ContentBoxContainer.spec.js
+++ b/packages/app-project/src/shared/components/ContentBox/ContentBoxContainer.spec.js
@@ -14,7 +14,7 @@ describe('Component > ContentBoxContainer', function () {
   })
 
   it('should render without crashing', function () {
-    expect(wrapper).to.be.ok
+    expect(wrapper).to.be.ok()
   })
 
   it('should render the `ContentBox` component', function () {

--- a/packages/app-project/src/shared/components/ContentBox/ContentBoxContainer.spec.js
+++ b/packages/app-project/src/shared/components/ContentBox/ContentBoxContainer.spec.js
@@ -1,0 +1,23 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import ContentBoxContainer from './ContentBoxContainer'
+import ContentBox from './ContentBox'
+
+let wrapper
+let componentWrapper
+
+describe('Component > ContentBoxContainer', function () {
+  before(function () {
+    wrapper = shallow(<ContentBoxContainer.wrappedComponent />)
+    componentWrapper = wrapper.find(ContentBox)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok
+  })
+
+  it('should render the `ContentBox` component', function () {
+    expect(componentWrapper).to.have.lengthOf(1)
+  })
+})

--- a/packages/app-project/src/shared/components/ContentBox/index.js
+++ b/packages/app-project/src/shared/components/ContentBox/index.js
@@ -1,1 +1,1 @@
-export { default } from './ContentBox'
+export { default } from './ContentBoxContainer'

--- a/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/Subtitle.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/Subtitle.js
@@ -5,7 +5,7 @@ import React from 'react'
 function Subtitle ({ mode, text, ...props }) {
   return (
     <Text
-      color={ mode === 'light' ? 'black' : 'lightGrey' }
+      color={mode === 'light' ? 'black' : 'lightGrey'}
       {...props}
     >
       {text}
@@ -19,7 +19,7 @@ Subtitle.propTypes = {
   size: string,
   tag: string,
   text: string.isRequired,
-  weight: string,
+  weight: string
 }
 
 Subtitle.defaultProps = {

--- a/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/Subtitle.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/Subtitle.js
@@ -1,21 +1,28 @@
 import { Text } from 'grommet'
-import { string } from 'prop-types'
+import { object, oneOfType, string } from 'prop-types'
 import React from 'react'
 
-function Subtitle ({ text, ...props }) {
+function Subtitle ({ mode, text, ...props }) {
   return (
-    <Text {...props}>
+    <Text
+      color={ mode === 'light' ? 'black' : 'lightGrey' }
+      {...props}
+    >
       {text}
     </Text>
   )
 }
 
 Subtitle.propTypes = {
-  text: string.isRequired
+  margin: oneOfType([object, string]),
+  mode: string,
+  size: string,
+  tag: string,
+  text: string.isRequired,
+  weight: string,
 }
 
 Subtitle.defaultProps = {
-  color: 'black',
   margin: 'none',
   size: 'small',
   tag: 'h5',

--- a/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/SubtitleContainer.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/SubtitleContainer.js
@@ -1,0 +1,28 @@
+import { inject, observer } from 'mobx-react'
+import { string } from 'prop-types'
+import React, { Component } from 'react'
+
+import Subtitle from './Subtitle'
+
+function storeMapper (stores) {
+  const { mode } = stores.store.ui
+  return {
+    mode
+  }
+}
+
+@inject(storeMapper)
+@observer
+class SubtitleContainer extends Component {
+  render () {
+    return (
+      <Subtitle {...this.props} />
+    )
+  }
+}
+
+SubtitleContainer.propTypes = {
+  mode: string
+}
+
+export default SubtitleContainer

--- a/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/SubtitleContainer.spec.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/SubtitleContainer.spec.js
@@ -14,7 +14,7 @@ describe('Component > SubtitleContainer', function () {
   })
 
   it('should render without crashing', function () {
-    expect(wrapper).to.be.ok
+    expect(wrapper).to.be.ok()
   })
 
   it('should render the `Subtitle` component', function () {

--- a/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/SubtitleContainer.spec.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/SubtitleContainer.spec.js
@@ -1,0 +1,23 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import SubtitleContainer from './SubtitleContainer'
+import Subtitle from './Subtitle'
+
+let wrapper
+let componentWrapper
+
+describe('Component > SubtitleContainer', function () {
+  before(function () {
+    wrapper = shallow(<SubtitleContainer.wrappedComponent />)
+    componentWrapper = wrapper.find(Subtitle)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok
+  })
+
+  it('should render the `Subtitle` component', function () {
+    expect(componentWrapper).to.have.lengthOf(1)
+  })
+})

--- a/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/index.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/index.js
@@ -1,1 +1,1 @@
-export { default } from './Subtitle'
+export { default } from './SubtitleContainer'

--- a/packages/app-project/stores/Store.js
+++ b/packages/app-project/stores/Store.js
@@ -13,7 +13,7 @@ const Store = types
     project: types.optional(Project, {}),
     recents: types.optional(Recents, {}),
     ui: types.optional(UI, {}),
-    user: types.optional(User, {})
+    user: types.optional(User, {}),
     yourStats: types.optional(YourStats, {})
   })
 

--- a/packages/app-project/stores/Store.js
+++ b/packages/app-project/stores/Store.js
@@ -3,6 +3,7 @@ import { getEnv, types } from 'mobx-state-tree'
 import Collections from './Collections'
 import Project from './Project'
 import Recents from './Recents'
+import UI from './UI'
 import User from './User'
 
 const Store = types
@@ -10,6 +11,7 @@ const Store = types
     collections: types.optional(Collections, {}),
     project: types.optional(Project, {}),
     recents: types.optional(Recents, {}),
+    ui: types.optional(UI, {}),
     user: types.optional(User, {})
   })
 

--- a/packages/app-project/stores/UI.js
+++ b/packages/app-project/stores/UI.js
@@ -1,5 +1,13 @@
 import { types } from 'mobx-state-tree'
 
+/*
+  TODO: The mode setting should be picked up from the client. PFE does it via a setting in `localStorage`, but this can only be picked up by the client bundle. So you'd get a flicker of light theme until the client bundle is loaded and picks up the correct theme setting and switches.
+
+  A better way to do it would be via a cookie, since it'll get passed on the
+  initial request and the dark theme can be rendered server-side. We could use
+  https://github.com/matthewmueller/next-cookies for this.
+*/
+
 const UI = types
   .model('UI', {
     mode: types.optional(types.enumeration('mode', ['light', 'dark']), 'light')

--- a/packages/app-project/stores/UI.js
+++ b/packages/app-project/stores/UI.js
@@ -1,4 +1,4 @@
-import { flow, types } from 'mobx-state-tree'
+import { types } from 'mobx-state-tree'
 
 const UI = types
   .model('UI', {

--- a/packages/app-project/stores/UI.js
+++ b/packages/app-project/stores/UI.js
@@ -1,0 +1,26 @@
+import { flow, types } from 'mobx-state-tree'
+
+const UI = types
+  .model('UI', {
+    mode: types.optional(types.enumeration('mode', ['light', 'dark']), 'light')
+  })
+
+  .actions(self => ({
+    setDarkMode () {
+      self.mode = 'dark'
+    },
+
+    setLightMode () {
+      self.mode = 'light'
+    },
+
+    toggleMode () {
+      if (self.mode === 'light') {
+        self.setDarkMode()
+      } else {
+        self.setLightMode()
+      }
+    }
+  }))
+
+export default UI

--- a/packages/app-project/stores/UI.spec.js
+++ b/packages/app-project/stores/UI.spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai'
 
 import UI from './UI'
 
-
 describe('Stores > UI', function () {
   let store
 

--- a/packages/app-project/stores/UI.spec.js
+++ b/packages/app-project/stores/UI.spec.js
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import UI from './UI'
 
 
-describe.only('Stores > UI', function () {
+describe('Stores > UI', function () {
   let store
 
   beforeEach(function () {

--- a/packages/app-project/stores/UI.spec.js
+++ b/packages/app-project/stores/UI.spec.js
@@ -1,0 +1,46 @@
+import { expect } from 'chai'
+
+import UI from './UI'
+
+
+describe.only('Stores > UI', function () {
+  let store
+
+  beforeEach(function () {
+    store = UI.create()
+  })
+
+  it('should export an object', function () {
+    expect(UI).to.be.an('object')
+  })
+
+  it('should contain a mode property', function () {
+    expect(store.mode).to.be.ok()
+  })
+
+  it('should default to the light mode', function () {
+    expect(store.mode).to.equal('light')
+  })
+
+  it('should have a `setDarkMode` action', function () {
+    expect(store.mode).to.equal('light')
+    store.setDarkMode()
+    expect(store.mode).to.equal('dark')
+  })
+
+  it('should have a `setLightMode` action', function () {
+    expect(store.mode).to.equal('light')
+    store.setDarkMode()
+    expect(store.mode).to.equal('dark')
+    store.setLightMode()
+    expect(store.mode).to.equal('light')
+  })
+
+  it('should have a `toggleMode` action', function () {
+    expect(store.mode).to.equal('light')
+    store.toggleMode()
+    expect(store.mode).to.equal('dark')
+    store.toggleMode()
+    expect(store.mode).to.equal('light')
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -1,8 +1,10 @@
+import { Grommet } from 'grommet'
 import makeInspectable from 'mobx-devtools-mst'
 import { Provider } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { ThemeProvider } from 'styled-components'
+import zooTheme from '@zooniverse/grommet-theme'
 import {
   panoptes as panoptesClient,
   projects as projectsClient,
@@ -58,16 +60,19 @@ export default class Classifier extends React.Component {
   render () {
     return (
       <Provider classifierStore={this.classifierStore}>
-        <ThemeProvider theme={{ mode: this.props.mode }}>
-          <Layout />
-        </ThemeProvider>
+        <Grommet theme={this.props.theme}>
+          <ThemeProvider theme={{ mode: this.props.mode }}>
+            <Layout />
+          </ThemeProvider>
+        </Grommet>
       </Provider>
     )
   }
 }
 
 Classifier.defaultProps = {
-  mode: 'light'
+  mode: 'light',
+  theme: zooTheme
 }
 
 Classifier.propTypes = {
@@ -75,5 +80,6 @@ Classifier.propTypes = {
   mode: PropTypes.string,
   project: PropTypes.shape({
     id: PropTypes.string.isRequired
-  }).isRequired
+  }).isRequired,
+  theme: PropTypes.object,
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -1,5 +1,6 @@
-import React from 'react'
 import { Box } from 'grommet'
+import React from 'react'
+
 import AnnotateButton from './components/AnnotateButton'
 import FieldGuideButton from './components/FieldGuideButton'
 import FullscreenButton from './components/FullscreenButton'
@@ -9,18 +10,17 @@ import RotateButton from './components/RotateButton'
 import ZoomInButton from './components/ZoomInButton'
 import ZoomOutButton from './components/ZoomOutButton'
 
-const toolbarStyles = {
-  border: {
-    color: 'lightGrey',
-    side: 'all'
-  },
-  pad: 'small'
-}
-
-function ImageToolbar (props) {
+export default function ImageToolbar (props) {
   return (
     <aside {...props}>
-      <Box {...toolbarStyles}>
+      <Box
+        background='white'
+        border={{
+          color: 'lightGrey',
+          side: 'all'
+        }}
+        pad='small'
+      >
         <AnnotateButton />
         <MoveButton />
         <ZoomInButton />
@@ -33,5 +33,3 @@ function ImageToolbar (props) {
     </aside>
   )
 }
-
-export default ImageToolbar

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -1,5 +1,7 @@
 import { Box } from 'grommet'
-import React from 'react'
+import { shape, string } from 'prop-types'
+import React, { Component } from 'react'
+import { withTheme } from 'styled-components'
 
 import AnnotateButton from './components/AnnotateButton'
 import FieldGuideButton from './components/FieldGuideButton'
@@ -10,26 +12,40 @@ import RotateButton from './components/RotateButton'
 import ZoomInButton from './components/ZoomInButton'
 import ZoomOutButton from './components/ZoomOutButton'
 
-export default function ImageToolbar (props) {
-  return (
-    <aside {...props}>
-      <Box
-        background='white'
-        border={{
-          color: 'lightGrey',
-          side: 'all'
-        }}
-        pad='small'
-      >
-        <AnnotateButton />
-        <MoveButton />
-        <ZoomInButton />
-        <ZoomOutButton />
-        <RotateButton />
-        <FullscreenButton />
-        <ResetButton />
-      </Box>
-      <FieldGuideButton />
-    </aside>
-  )
+@withTheme
+class ImageToolbar extends Component {
+  render () {
+    const { theme: { mode }, ...props } = this.props
+    // const mode = theme.mode
+    return (
+      <aside {...props}>
+        <Box
+          background={ mode === 'light' ? 'white' : '#333' }
+          border={{
+            color: mode === 'light' ? 'lightGrey' : '#333',
+            side: 'all'
+          }}
+          pad='small'
+          >
+          <AnnotateButton />
+          <MoveButton />
+          <ZoomInButton />
+          <ZoomOutButton />
+          <RotateButton />
+          <FullscreenButton />
+          <ResetButton />
+        </Box>
+        <FieldGuideButton />
+      </aside>
+    )
+  }
 }
+
+
+ImageToolbar.propTypes = {
+  theme: shape({
+    mode: string
+  })
+}
+
+export default ImageToolbar

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+import theme from 'styled-theming'
 import { withFocusProps, withHoverProps } from '@klarna/higher-order-components'
 
 const StyledButton = styled.button`
@@ -10,13 +11,31 @@ const StyledButton = styled.button`
   padding: 0;
 `
 
+const backgroundStyles = theme('mode', {
+  light: css`
+    fill: ${props => (props.hoveredOrFocused || props.active) ? '#00979D' : 'transparent'};
+  `,
+  dark: css`
+    fill: ${props => (props.hoveredOrFocused || props.active) ? '#00979D' : '#2d2d2d'};
+  `,
+})
+
 const Background = styled.circle`
-  fill: ${props => (props.hoveredOrFocused || props.active) ? '#00979D' : 'transparent'};
+  ${backgroundStyles}
   opacity: ${props => props.hoveredOrFocused ? '0.5' : '1'};
 `
 
+const iconSVGStyles = theme('mode', {
+  light: css`
+    fill: ${props => (props.hoveredOrFocused || props.active) ? 'white' : 'black'};
+  `,
+  dark: css`
+    fill: white;
+  `,
+})
+
 const IconSVG = styled.svg`
-  fill: ${props => (props.hoveredOrFocused || props.active) ? 'white' : 'black'};
+  ${iconSVGStyles}
 `
 
 @withHoverProps({ hovered: true })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { inject, observer } from 'mobx-react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { SpacedText } from '@zooniverse/react-components'
-
+import { Box } from 'grommet'
 import { Tab, Tabs } from './components/Tabs'
 import Tasks from './components/Tasks'
 import SlideTutorial from '../SlideTutorial'
@@ -41,19 +41,24 @@ class TaskArea extends React.Component {
     }
     return (
       <Tabs
-        onActive={this.onTabClick.bind(this)}
+        background='white'
         border={border}
         className={this.props.className}
         margin='none'
+        onActive={this.onTabClick.bind(this)}
       >
         <Tab title={<SpacedText size='medium' weight='bold'>{counterpart('TaskArea.task')}</SpacedText>}>
-          <Tasks />
+          <Box background='white'>
+            <Tasks />
+          </Box>
         </Tab>
         <Tab
           disabled={disableTutorialTab}
           title={<SpacedText size='medium' weight='bold'>{counterpart('TaskArea.tutorial')}</SpacedText>}
         >
-          <SlideTutorial />
+          <Box background='white'>
+            <SlideTutorial />
+          </Box>
         </Tab>
       </Tabs>
     )

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
@@ -1,10 +1,12 @@
-import counterpart from 'counterpart'
-import React from 'react'
-import PropTypes from 'prop-types'
-import { inject, observer } from 'mobx-react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { SpacedText } from '@zooniverse/react-components'
+import counterpart from 'counterpart'
 import { Box } from 'grommet'
+import { inject, observer } from 'mobx-react'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { withTheme } from 'styled-components'
+
 import { Tab, Tabs } from './components/Tabs'
 import Tasks from './components/Tasks'
 import SlideTutorial from '../SlideTutorial'
@@ -23,6 +25,7 @@ function storeMapper (stores) {
   }
 }
 
+@withTheme
 @inject(storeMapper)
 @observer
 class TaskArea extends React.Component {
@@ -33,22 +36,30 @@ class TaskArea extends React.Component {
   }
 
   render () {
-    const { colorTheme, disableTutorialTab } = this.props
+    const { theme: { mode }, disableTutorialTab } = this.props
+
     const border = {
       side: 'all',
-      color: (colorTheme === 'light') ? zooTheme.light.colors.tabs.border : zooTheme.dark.colors.tabs.border,
+      color: zooTheme[mode].colors.tabs.border,
       size: 'xsmall'
     }
+
     return (
       <Tabs
-        background='white'
+        background={ mode === 'light' ? 'white' : '#2d2d2d' }
         border={border}
         className={this.props.className}
         margin='none'
         onActive={this.onTabClick.bind(this)}
       >
-        <Tab title={<SpacedText size='medium' weight='bold'>{counterpart('TaskArea.task')}</SpacedText>}>
-          <Box background='white'>
+        <Tab
+          title={(
+            <SpacedText size='medium' weight='bold'>
+              {counterpart('TaskArea.task')}
+            </SpacedText>
+          )}
+        >
+          <Box background={ mode === 'light' ? 'white' : '#2d2d2d' }>
             <Tasks />
           </Box>
         </Tab>
@@ -56,7 +67,7 @@ class TaskArea extends React.Component {
           disabled={disableTutorialTab}
           title={<SpacedText size='medium' weight='bold'>{counterpart('TaskArea.tutorial')}</SpacedText>}
         >
-          <Box background='white'>
+          <Box background={ mode === 'light' ? 'white' : '#2d2d2d' }>
             <SlideTutorial />
           </Box>
         </Tab>

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
@@ -25,8 +25,8 @@ function storeMapper (stores) {
   }
 }
 
-@withTheme
 @inject(storeMapper)
+@withTheme
 @observer
 class TaskArea extends React.Component {
   onTabClick (activeIndex) {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
@@ -3,7 +3,7 @@ import { SpacedText } from '@zooniverse/react-components'
 import counterpart from 'counterpart'
 import { Box } from 'grommet'
 import { inject, observer } from 'mobx-react'
-import PropTypes from 'prop-types'
+import { bool, func, object, oneOf, shape } from 'prop-types'
 import React from 'react'
 import { withTheme } from 'styled-components'
 
@@ -46,7 +46,7 @@ class TaskArea extends React.Component {
 
     return (
       <Tabs
-        background={ mode === 'light' ? 'white' : '#2d2d2d' }
+        background={mode === 'light' ? 'white' : '#2d2d2d'}
         border={border}
         className={this.props.className}
         margin='none'
@@ -65,7 +65,11 @@ class TaskArea extends React.Component {
         </Tab>
         <Tab
           disabled={disableTutorialTab}
-          title={<SpacedText size='medium' weight='bold'>{counterpart('TaskArea.tutorial')}</SpacedText>}
+          title={(
+            <SpacedText size='medium' weight='bold'>
+              {counterpart('TaskArea.tutorial')}
+            </SpacedText>
+          )}
         >
           <Box background={ mode === 'light' ? 'white' : '#2d2d2d' }>
             <SlideTutorial />
@@ -77,16 +81,21 @@ class TaskArea extends React.Component {
 }
 
 TaskArea.wrappedComponent.propTypes = {
-  colorTheme: PropTypes.oneOf(['light', 'dark']),
-  disableTutorialTab: PropTypes.bool,
-  setActiveTutorial: PropTypes.func,
-  tutorial: PropTypes.object
+  disableTutorialTab: bool,
+  setActiveTutorial: func,
+  theme: shape({
+    mode: oneOf(['light', 'dark']),
+  }),
+  tutorial: object
 }
 
 TaskArea.wrappedComponent.defaultProps = {
   colorTheme: 'light',
   disableTutorialTab: true,
   setActiveTutorial: () => {},
+  theme: {
+    mode: 'light'
+  },
   tutorial: null
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
@@ -25,9 +25,6 @@ function storeMapper (stores) {
   }
 }
 
-@inject(storeMapper)
-@withTheme
-@observer
 class TaskArea extends React.Component {
   onTabClick (activeIndex) {
     const { setActiveTutorial, tutorial } = this.props
@@ -80,7 +77,7 @@ class TaskArea extends React.Component {
   }
 }
 
-TaskArea.wrappedComponent.propTypes = {
+TaskArea.propTypes = {
   disableTutorialTab: bool,
   setActiveTutorial: func,
   theme: shape({
@@ -89,7 +86,7 @@ TaskArea.wrappedComponent.propTypes = {
   tutorial: object
 }
 
-TaskArea.wrappedComponent.defaultProps = {
+TaskArea.defaultProps = {
   colorTheme: 'light',
   disableTutorialTab: true,
   setActiveTutorial: () => {},
@@ -99,4 +96,13 @@ TaskArea.wrappedComponent.defaultProps = {
   tutorial: null
 }
 
-export default TaskArea
+/*
+  Enzyme doesn't support the context API properly yet, so using @withTheme as
+  recommended currently doesn't work. So instead, we're exporting the unwrapped
+  component for testing, and using the HOC function syntax to export the wrapped
+  component.
+
+  https://github.com/styled-components/jest-styled-components/issues/191#issuecomment-465020345
+*/
+export default inject(storeMapper)(withTheme(observer(TaskArea)))
+export { TaskArea }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.spec.js
@@ -2,30 +2,30 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { expect } from 'chai'
 import sinon from 'sinon'
-import TaskArea from './TaskArea'
+import { TaskArea } from './TaskArea'
 import { Tab, Tabs } from './components/Tabs'
 import Tasks from './components/Tasks'
 import SlideTutorial from '../SlideTutorial'
 
 describe('TaskArea', function () {
   it('should render without crashing', function () {
-    const wrapper = shallow(<TaskArea.wrappedComponent />)
+    const wrapper = shallow(<TaskArea />)
     expect(wrapper).to.be.ok
   })
 
   it('should render a Tabs wrapper component and two Tab components', function () {
-    const wrapper = shallow(<TaskArea.wrappedComponent />)
+    const wrapper = shallow(<TaskArea />)
     expect(wrapper.find(Tabs)).to.have.lengthOf(1)
     expect(wrapper.find(Tab)).to.have.lengthOf(2)
   })
 
   it('should render Tasks', function () {
-    const wrapper = shallow(<TaskArea.wrappedComponent />)
+    const wrapper = shallow(<TaskArea />)
     expect(wrapper.find(Tasks)).to.have.lengthOf(1)
   })
 
   it('should render SlideTutorial', function () {
-    const wrapper = shallow(<TaskArea.wrappedComponent />)
+    const wrapper = shallow(<TaskArea />)
     expect(wrapper.find(SlideTutorial)).to.have.lengthOf(1)
   })
 
@@ -35,7 +35,7 @@ describe('TaskArea', function () {
     let wrapper
     before(function () {
       setActiveTutorialSpy = sinon.spy()
-      wrapper = shallow(<TaskArea.wrappedComponent setActiveTutorial={setActiveTutorialSpy} tutorial={tutorial} />)
+      wrapper = shallow(<TaskArea setActiveTutorial={setActiveTutorialSpy} tutorial={tutorial} />)
     })
     afterEach(function () {
       setActiveTutorialSpy.resetHistory()

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tabs/Tabs.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tabs/Tabs.js
@@ -2,7 +2,7 @@ import { Tabs } from 'grommet'
 import styled from 'styled-components'
 
 const StyledTabs = styled(Tabs)`
-  height: 100%;
+  height: auto;
   max-height: 570px;
 
   > div[role="tabpanel"] {


### PR DESCRIPTION
Package: app-project, lib-classifier

There are some missing/incorrect colours for various elements, this PR fixes some of those to match the designs.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

