### PR TITLE
Classifier - fix tests on Light Curve Viewer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBackgroundLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBackgroundLayer.spec.js
@@ -7,6 +7,10 @@ const attrStub = sinon.stub().returnsThis()
 const appendStub = sinon.stub(selectionFixture, 'append')
   .returns({ attr: attrStub })
 
+const chartStyle = {
+  background: '#005d69', // Zooniverse Dark Teal
+}
+
 describe('LightCurveViewer > d3 > addBackgroundLayer', function () {
   afterEach(function () {
     appendStub.resetHistory()
@@ -18,10 +22,10 @@ describe('LightCurveViewer > d3 > addBackgroundLayer', function () {
   })
 
   it('should append a rect with the correct attributes to the selection', function () {
-    addBackgroundLayer(selectionFixture)
+    addBackgroundLayer(selectionFixture, chartStyle)
     expect(appendStub.calledWith('rect')).to.be.true
     expect(attrStub.calledWith('width', '100%')).to.be.true
     expect(attrStub.calledWith('height', '100%')).to.be.true
-    expect(attrStub.calledWith('fill', '#f8f8f8')).to.be.true
+    expect(attrStub.calledWith('fill', chartStyle.background)).to.be.true
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBorderLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBorderLayer.spec.js
@@ -23,7 +23,7 @@ describe('LightCurveViewer > d3 > addBorderLayer', function () {
     expect(attrStub.calledWith('width', '100%')).to.be.true
     expect(attrStub.calledWith('height', '100%')).to.be.true
     expect(attrStub.calledWith('fill', 'none')).to.be.true
-    expect(attrStub.calledWith('stroke', '#333')).to.be.true
+    expect(attrStub.calledWith('stroke', '#444')).to.be.true
     expect(attrStub.calledWith('stroke-width', '2')).to.be.true
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setDataPointStyle.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setDataPointStyle.spec.js
@@ -5,6 +5,11 @@ import setDataPointStyle from './setDataPointStyle'
 const selectionFixture = { attr: Function.prototype }
 const attrStub = sinon.stub(selectionFixture, 'attr').returnsThis()
 
+const chartStyle = {
+  color: '#eff2f5', // Zooniverse Light Grey
+  dataPointSize: '1.5',
+}
+
 describe('LightCurveViewer > d3 > setDataPointStyle', function () {
   afterEach(function () {
     attrStub.resetHistory()
@@ -15,9 +20,9 @@ describe('LightCurveViewer > d3 > setDataPointStyle', function () {
   })
 
   it('should add the correct attributes to the selection', function () {
-    setDataPointStyle(selectionFixture)
-    expect(attrStub.calledWith('r', 1.25)).to.be.true
+    setDataPointStyle(selectionFixture, chartStyle)
+    expect(attrStub.calledWith('r', chartStyle.dataPointSize)).to.be.true
     expect(attrStub.calledWith('class', 'data-point')).to.be.true
-    expect(attrStub.calledWith('fill', '#488')).to.be.true
+    expect(attrStub.calledWith('fill', chartStyle.color)).to.be.true
   })
 })


### PR DESCRIPTION
## PR Overview

package: `lib-classifier`

This PR fixes tests in the LightCurveViewer's d3 sub-tasks' tests. This unfortunately wasn't caught in #400, which introduced configurable chart styles.

### Status
Ready for review