### PR TITLE
Fix delayed image loading test

### DIFF
--- a/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.spec.js
+++ b/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.spec.js
@@ -42,15 +42,16 @@ describe('Image', function () {
     expect(wrapper.find(Image)).to.have.lengthOf(0)
   })
 
-  xit('should delay loading the image the given time in props.delay', function () {
+  it('should delay loading the image the given time in props.delay', function (done) {
     const delay = 1000
     const wrapper = mount(<ThumbnailImage delay={delay} src={image} />)
     const progressiveImageInstance = wrapper.find(ProgressiveImage).instance()
     progressiveImageInstance.onLoad()
-    wrapper.update()
-    setTimeout(() => {
+    setTimeout(function () {
+      wrapper.update()
       expect(wrapper.find(Placeholder)).to.have.lengthOf(0)
       expect(wrapper.find(Image)).to.have.lengthOf(1)
+      done()
     }, delay + 1)
   })
 


### PR DESCRIPTION
Re-render after the timeout.
Use done() to delay evaluating the test.

Closes #491.

This should be merged into #487 before that merges.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

