### PR TITLE
Prevent ZooHeader page links from growing too wide

### DIFF
--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.js
@@ -65,7 +65,6 @@ export default function ZooHeader (props) {
       <Box
         align='center'
         direction='row'
-        flex='grow'
         pad={{ horizontal: 'medium', vertical: 'small' }}
         responsive={false}
         tag='nav'


### PR DESCRIPTION
Package: lib-react-components

The `Box` containing the main project links expands the width of the container, which it doesn't need to do; removing `flex='grow'` stops this.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

