### PR TITLE
Add onCompleteClassification callback to the classifier

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
@@ -37,7 +37,7 @@ class ClassifierWrapperContainer extends Component {
     }
   }
 
-  onCompleteClassification(classification, subject) {
+  onCompleteClassification (classification, subject) {
     const { recents } = this.props
     recents.add({
       subjectId: subject.id,

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
@@ -7,7 +7,7 @@ import asyncStates from '@zooniverse/async-states'
 import ErrorMessage from './components/ErrorMessage'
 
 function storeMapper (stores) {
-  const { project, user } = stores.store
+  const { project, recents, user } = stores.store
   const { mode } = stores.store.ui
   // We return a POJO here, as the `project` resource is also stored in a
   // `mobx-state-tree` store in the classifier and an MST node can't be in two
@@ -15,6 +15,7 @@ function storeMapper (stores) {
   return {
     mode,
     project: project.toJSON(),
+    recents,
     user
   }
 }
@@ -24,6 +25,7 @@ function storeMapper (stores) {
 class ClassifierWrapperContainer extends Component {
   constructor () {
     super()
+    this.onCompleteClassification = this.onCompleteClassification.bind(this)
     this.state = {
       error: null
     }
@@ -33,6 +35,14 @@ class ClassifierWrapperContainer extends Component {
     return {
       error
     }
+  }
+
+  onCompleteClassification(classification, subject) {
+    const { recents } = this.props
+    recents.add({
+      subjectId: subject.id,
+      locations: subject.locations
+    })
   }
 
   render () {
@@ -61,6 +71,7 @@ class ClassifierWrapperContainer extends Component {
           authClient={authClient}
           key={key}
           mode={mode}
+          onCompleteClassification={this.onCompleteClassification}
           project={project}
         />
       )

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.spec.js
@@ -1,0 +1,67 @@
+import { shallow } from 'enzyme'
+import sinon from 'sinon'
+import React from 'react'
+import asyncStates from '@zooniverse/async-states'
+import Classifier from '@zooniverse/classifier'
+
+import ClassifierWrapperContainer from './ClassifierWrapperContainer'
+
+describe('Component > ClassifierWrapperContainer', function () {
+  let wrapper
+
+  before(function () {
+    const project = {}
+    const user = {}
+    wrapper = shallow(
+      <ClassifierWrapperContainer.wrappedComponent
+        project={project}
+        user={user}
+      />
+    )
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  describe('with a project and user loaded', function () {
+    let recents
+    before(function () {
+      const project = {
+        loadingState: asyncStates.success
+      }
+      recents = {
+        add: sinon.stub()
+      }
+      const user = {
+        loadingState: asyncStates.success
+      }
+      wrapper = shallow(
+        <ClassifierWrapperContainer.wrappedComponent
+          project={project}
+          recents={recents}
+          user={user}
+        />
+      )
+    })
+
+    it('should render the classifier', function () {
+      expect(wrapper.find(Classifier)).to.have.lengthOf(1)
+    })
+
+    it('should add to recents on classification complete', function () {
+      const subject = {
+        id: '1',
+        locations: [
+          { 'image/jpeg': 'thing.jpg' }
+        ]
+      }
+      const recent = {
+        subjectId: subject.id,
+        locations: subject.locations
+      }
+      wrapper.instance().onCompleteClassification({}, subject)
+      expect(recents.add.withArgs(recent)).to.have.been.calledOnce()
+    })
+  })
+})

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.spec.js
@@ -26,6 +26,7 @@ describe('Component > ClassifierWrapperContainer', function () {
 
   describe('with a project and user loaded', function () {
     let recents
+
     before(function () {
       const project = {
         loadingState: asyncStates.success

--- a/packages/app-project/test/create-global-document.js
+++ b/packages/app-project/test/create-global-document.js
@@ -2,7 +2,7 @@
 // `mount` method in enzyme.
 import { JSDOM } from 'jsdom'
 
-const jsdom = new JSDOM('<!doctype html><html><body></body></html>')
+const jsdom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://localhost' })
 const { window } = jsdom
 
 function copyProps (src, target) {

--- a/packages/lib-classifier/dev/components/App/App.js
+++ b/packages/lib-classifier/dev/components/App/App.js
@@ -90,6 +90,7 @@ class App extends React.Component {
         <Box tag='section'>
           <Classifier
             authClient={oauth}
+            onCompleteClassification={(classification, subject) => console.log('onComplete', classification, subject)}
             project={this.state.project}
           />
         </Box>

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -44,8 +44,9 @@ export default class Classifier extends React.Component {
   }
 
   componentDidMount () {
-    const { project } = this.props
+    const { onCompleteClassification, project } = this.props
     this.setProject(project)
+    this.classifierStore.classifications.setOnComplete(onCompleteClassification)
   }
 
   componentDidUpdate (prevProps) {
@@ -79,12 +80,14 @@ export default class Classifier extends React.Component {
 
 Classifier.defaultProps = {
   mode: 'light',
+  onCompleteClassification: () => true,
   theme: zooTheme
 }
 
 Classifier.propTypes = {
   authClient: PropTypes.object.isRequired,
   mode: PropTypes.string,
+  onCompleteClassification: PropTypes.func,
   project: PropTypes.shape({
     id: PropTypes.string.isRequired
   }).isRequired,

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -34,6 +34,11 @@ const ClassificationStore = types
       return new ClassificationQueue(client, self.onClassificationSaved)
     }
   }))
+  .volatile(self => {
+    return {
+      onComplete: () => null
+    }
+  })
   .actions(self => {
     function afterAttach () {
       createSubjectObserver()
@@ -149,6 +154,9 @@ const ClassificationStore = types
       })
       classificationToSubmit.metadata = convertedMetadata
 
+      const subject = getRoot(self).subjects.active
+      self.onComplete(classification.toJSON(), subject.toJSON())
+
       console.log('Completed classification', classificationToSubmit)
       self.submitClassification(classificationToSubmit)
     }
@@ -169,6 +177,10 @@ const ClassificationStore = types
       }
     }
 
+    function setOnComplete(onComplete) {
+      self.onComplete = onComplete
+    }
+
     return {
       addAnnotation,
       afterAttach,
@@ -177,6 +189,7 @@ const ClassificationStore = types
       createDefaultAnnotation,
       onClassificationSaved,
       removeAnnotation,
+      setOnComplete,
       submitClassification: flow(submitClassification),
       updateClassificationMetadata
     }


### PR DESCRIPTION
Packages:
lib-classifier
app-project

- Adds an onCompleteClassification prop to the classifier, which is called with the classification and subject when a classification completes. 
- Updates the classify page to add a new recent subject on classification complete.
- Adds tests.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

