### PR TITLE
Track seen date for tutorial during session

### DIFF
--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -13,10 +13,8 @@ const TutorialStore = types
     activeStep: types.maybe(types.integer),
     attachedMedia: types.map(Medium),
     resources: types.map(Tutorial),
-    seen: types.model('TutorialSeen', {
-      tutorial: types.maybe(types.Date),
-      miniCourse: types.maybe(types.Date)
-    }),
+    tutorialSeenTime: types.maybe(types.string),
+    miniCourseSeenTime: types.maybe(types.string),
     type: types.optional(types.string, 'tutorials')
   })
 
@@ -140,8 +138,16 @@ const TutorialStore = types
 
     function setSeenTime () {
       const tutorial = self.active
-      const tutorialKind = _.camelCase(tutorial.kind)
-      self.seen[tutorialKind] = new Date().toISOString()
+      const seen = new Date().toISOString()
+      if (tutorial) {
+        if (tutorial.kind === 'tutorial' || tutorial.kind === null) {
+          self.tutorialSeenTime = seen
+        }
+
+        if (tutorial.kind === 'mini-course') {
+          self.miniCourseSeenTime = seen
+        }
+      }
     }
 
     function resetActiveTutorial () {
@@ -151,10 +157,13 @@ const TutorialStore = types
     }
 
     function resetSeen (type) {
-      if (type) {
-        self.seen[type] = undefined
+      if (type === 'tutorial') {
+        self.tutorialSeenTime = undefined
+      } else if (type === 'mini-course') {
+        self.miniCourseSeenTime = undefined
       } else {
-        self.seen = { tutorial: undefined, miniCourse: undefined }
+        self.tutorialSeenTime = undefined
+        self.miniCourseSeenTime = undefined
       }
     }
 

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -1,7 +1,6 @@
 import { autorun } from 'mobx'
 import { addDisposer, getRoot, types, flow } from 'mobx-state-tree'
 import asyncStates from '@zooniverse/async-states'
-import _ from 'lodash'
 import ResourceStore from './ResourceStore'
 import Tutorial from './Tutorial'
 import Medium from './Medium'

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -75,11 +75,6 @@ const authClientStubWithUser = {
 }
 
 describe('Model > TutorialStore', function () {
-  // afterEach(function () {
-  //   clientStub.tutorials.get.resetHistory()
-  //   clientStub.tutorials.getAttachedImages.resetHistory()
-  // })
-
   it('should exist', function () {
     expect(TutorialStore).to.be.an('object')
   })
@@ -229,7 +224,7 @@ describe('Model > TutorialStore', function () {
   })
 
   describe('Actions > setActiveTutorial', function () {
-    it('should call resetActiveTutorial if the id parameter is not defined', function () {
+    it('should reset the active tutorial if the id parameter is not defined', function () {
       rootStore = RootStore.create({
         tutorials: TutorialStore.create(),
         workflows: WorkflowStore.create()
@@ -261,7 +256,7 @@ describe('Model > TutorialStore', function () {
       }).then(done, done)
     })
 
-    it('should call setTutorialStep if the id parameter is defined', function (done) {
+    it('should set the tutorial step if the id parameter is defined', function (done) {
       rootStore = RootStore.create({
         tutorials: TutorialStore.create(),
         workflows: WorkflowStore.create()
@@ -274,12 +269,13 @@ describe('Model > TutorialStore', function () {
         rootStore.tutorials.setActiveTutorial(tutorial.id, 1)
       }).then(() => {
         expect(setTutorialStepSpy).to.have.been.calledOnceWith(1)
+        expect(rootStore.tutorials.activeStep).to.equal(1)
       }).then(() => {
         setTutorialStepSpy.restore()
       }).then(done, done)
     })
 
-    it('should call setSeenTime if the id parameter is defined', function (done) {
+    it('should set the seen time if the id parameter is defined', function (done) {
       rootStore = RootStore.create({
         tutorials: TutorialStore.create(),
         workflows: WorkflowStore.create()
@@ -292,6 +288,7 @@ describe('Model > TutorialStore', function () {
         rootStore.tutorials.setActiveTutorial(tutorial.id)
       }).then(() => {
         expect(setSeenTimeSpy).to.have.been.calledOnce
+        expect(rootStore.tutorials.tutorialSeenTime).to.be.a('string')
       }).then(() => {
         setSeenTimeSpy.restore()
       }).then(done, done)
@@ -376,7 +373,7 @@ describe('Model > TutorialStore', function () {
   })
 
   describe('Actions > resetSeen', function () {
-    it('should reset only the tutorial seen time if tutorial is the kind', function () {
+    it('should reset only the tutorial seen time if the resource is a tutorial', function () {
       const seen = new Date().toISOString()
       rootStore = RootStore.create({
         tutorials: TutorialStore.create({ tutorialSeenTime: seen, miniCourseSeenTime: seen }),
@@ -390,7 +387,7 @@ describe('Model > TutorialStore', function () {
       expect(rootStore.tutorials.miniCourseSeenTime).to.equal(seen)
     })
 
-    it('should reset only the tutorial seen time if mini-course is the kind', function () {
+    it('should reset only the mini-course seen time if the resource is a mini-course', function () {
       const seen = new Date().toISOString()
       rootStore = RootStore.create({
         tutorials: TutorialStore.create({ tutorialSeenTime: seen, miniCourseSeenTime: seen }),
@@ -463,7 +460,7 @@ describe('Model > TutorialStore', function () {
       }).then(done, done)
     })
 
-    it('should set the seen time for the null kind of tutorial resource', function (done) {
+    it('should set the seen time for the mini-course kind of tutorial resource', function (done) {
       rootStore = RootStore.create({
         tutorials: TutorialStore.create(),
         workflows: WorkflowStore.create()


### PR DESCRIPTION
Package: lib-classifier

Toward #113

Describe your changes:
This adds the seen timestamp to the `TutorialStore` when the tutorial is made active. This is in preparation for determining whether or not the tutorial should be seen on first visit. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

