### PR TITLE
Wire up the favourite button

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
@@ -7,12 +7,13 @@ import asyncStates from '@zooniverse/async-states'
 import ErrorMessage from './components/ErrorMessage'
 
 function storeMapper (stores) {
-  const { project, recents, user } = stores.store
+  const { collections, project, recents, user } = stores.store
   const { mode } = stores.store.ui
   // We return a POJO here, as the `project` resource is also stored in a
   // `mobx-state-tree` store in the classifier and an MST node can't be in two
   // stores at the same time.
   return {
+    collections,
     mode,
     project: project.toJSON(),
     recents,
@@ -26,6 +27,7 @@ class ClassifierWrapperContainer extends Component {
   constructor () {
     super()
     this.onCompleteClassification = this.onCompleteClassification.bind(this)
+    this.onToggleFavourite = this.onToggleFavourite.bind(this)
     this.state = {
       error: null
     }
@@ -43,6 +45,15 @@ class ClassifierWrapperContainer extends Component {
       subjectId: subject.id,
       locations: subject.locations
     })
+  }
+
+  onToggleFavourite(subjectId, isFavourite) {
+    const { collections } = this.props
+    if (isFavourite) {
+      collections.addFavourites([subjectId])
+    } else {
+      collections.removeFavourites([subjectId])
+    }
   }
 
   render () {
@@ -72,6 +83,7 @@ class ClassifierWrapperContainer extends Component {
           key={key}
           mode={mode}
           onCompleteClassification={this.onCompleteClassification}
+          onToggleFavourite={this.onToggleFavourite}
           project={project}
         />
       )

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.spec.js
@@ -26,6 +26,7 @@ describe('Component > ClassifierWrapperContainer', function () {
 
   describe('with a project and user loaded', function () {
     let recents
+    let collections
 
     before(function () {
       const project = {
@@ -34,11 +35,16 @@ describe('Component > ClassifierWrapperContainer', function () {
       recents = {
         add: sinon.stub()
       }
+      collections = {
+        addFavourites: sinon.stub(),
+        removeFavourites: sinon.stub()
+      }
       const user = {
         loadingState: asyncStates.success
       }
       wrapper = shallow(
         <ClassifierWrapperContainer.wrappedComponent
+          collections={collections}
           project={project}
           recents={recents}
           user={user}
@@ -63,6 +69,18 @@ describe('Component > ClassifierWrapperContainer', function () {
       }
       wrapper.instance().onCompleteClassification({}, subject)
       expect(recents.add.withArgs(recent)).to.have.been.calledOnce()
+    })
+
+    describe('on toggle favourite', function () {
+      it('should add a subject to favourites', function () {
+        wrapper.instance().onToggleFavourite('3', true)
+        expect(collections.addFavourites.withArgs(['3'])).to.have.been.calledOnce()
+      })
+
+      it('should remove a subject from favourites', function () {
+        wrapper.instance().onToggleFavourite('3', false)
+        expect(collections.removeFavourites.withArgs(['3'])).to.have.been.calledOnce()
+      })
     })
   })
 })

--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -146,14 +146,11 @@ const Collections = types
           id,
           subjects: subjectIds
         }
-        const response = yield client.collections.removeSubjects(params)
-        const [ collection ] = response.body.collections
-        return collection
+        yield client.collections.removeSubjects(params)
       }),
 
       removeFavourites: flow(function * removeFavourites (subjectIds) {
-        const favourites = yield self.removeSubjects(self.favourites.id, subjectIds)
-        self.favourites = Collection.create(favourites)
+        yield self.removeSubjects(self.favourites.id, subjectIds)
       })
     }
   })

--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -120,12 +120,12 @@ const Collections = types
         }
       }),
 
-      addSubjects: flow(function * addSubjects (collectionId, subjectIds) {
+      addSubjects: flow(function * addSubjects (id, subjectIds) {
         const token = yield auth.checkBearerToken()
         const authorization = `Bearer ${token}`
         const params = {
           authorization,
-          collectionId,
+          id,
           subjects: subjectIds
         }
         const response = yield client.collections.addSubjects(params)
@@ -138,12 +138,12 @@ const Collections = types
         self.favourites = Collection.create(favourites)
       }),
 
-      removeSubjects: flow(function * removeSubjects(collectionId, subjectIds) {
+      removeSubjects: flow(function * removeSubjects(id, subjectIds) {
         const token = yield auth.checkBearerToken()
         const authorization = `Bearer ${token}`
         const params = {
           authorization,
-          collectionId,
+          id,
           subjects: subjectIds
         }
         const response = yield client.collections.removeSubjects(params)

--- a/packages/app-project/stores/Collections.spec.js
+++ b/packages/app-project/stores/Collections.spec.js
@@ -268,7 +268,7 @@ describe('stores > Collections', function () {
           const favourites = getSnapshot(collectionsStore.favourites)
           const params = {
             authorization: 'Bearer ',
-            collectionId: favourites.id,
+            id: favourites.id,
             subjects: ['1', '2']
           }
           expect(rootStore.client.collections.addSubjects).to.have.been.calledOnceWith(params)
@@ -316,7 +316,7 @@ describe('stores > Collections', function () {
           const favourites = getSnapshot(collectionsStore.favourites)
           const params = {
             authorization: 'Bearer ',
-            collectionId: favourites.id,
+            id: favourites.id,
             subjects: ['1', '2']
           }
           expect(rootStore.client.collections.removeSubjects).to.have.been.calledOnceWith(params)

--- a/packages/app-project/stores/Collections.spec.js
+++ b/packages/app-project/stores/Collections.spec.js
@@ -320,7 +320,6 @@ describe('stores > Collections', function () {
             subjects: ['1', '2']
           }
           expect(rootStore.client.collections.removeSubjects).to.have.been.calledOnceWith(params)
-          expect(favourites.links.subjects).to.eql([])
         })
         .then(done, done)
     })

--- a/packages/lib-classifier/dev/components/App/App.js
+++ b/packages/lib-classifier/dev/components/App/App.js
@@ -91,6 +91,7 @@ class App extends React.Component {
           <Classifier
             authClient={oauth}
             onCompleteClassification={(classification, subject) => console.log('onComplete', classification, subject)}
+            onToggleFavourite={(subjectId, isFave) => console.log(subjectId, isFave)}
             project={this.state.project}
           />
         </Box>

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -44,9 +44,10 @@ export default class Classifier extends React.Component {
   }
 
   componentDidMount () {
-    const { onCompleteClassification, project } = this.props
+    const { onCompleteClassification, onToggleFavourite, project } = this.props
     this.setProject(project)
     this.classifierStore.classifications.setOnComplete(onCompleteClassification)
+    this.classifierStore.setOnToggleFavourite(onToggleFavourite)
   }
 
   componentDidUpdate (prevProps) {
@@ -81,6 +82,7 @@ export default class Classifier extends React.Component {
 Classifier.defaultProps = {
   mode: 'light',
   onCompleteClassification: () => true,
+  onToggleFavourite: () => true,
   theme: zooTheme
 }
 
@@ -88,6 +90,7 @@ Classifier.propTypes = {
   authClient: PropTypes.object.isRequired,
   mode: PropTypes.string,
   onCompleteClassification: PropTypes.func,
+  onToggleFavourite: PropTypes.func,
   project: PropTypes.shape({
     id: PropTypes.string.isRequired
   }).isRequired,

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
@@ -9,10 +9,8 @@ import CollectionsButton from './components/CollectionsButton'
 
 function storeMapper(stores) {
   const { active: subject, isThereMetadata } = stores.classifierStore.subjects
-  const { onToggleFavourite } = stores.classifierStore
   return {
     isThereMetadata,
-    onToggleFavourite,
     subject
   }
 }
@@ -36,9 +34,8 @@ export default class MetaTools extends React.Component {
   }
 
   toggleFavourites () {
-    const { onToggleFavourite, subject } = this.props
+    const { subject } = this.props
     subject.toggleFavorite()
-    onToggleFavourite(subject.id, subject.favorite)
   }
 
   render () {

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
@@ -27,7 +27,6 @@ export default class MetaTools extends React.Component {
     this.toggleMetadataModal = this.toggleMetadataModal.bind(this)
 
     this.state = {
-      isFavourite: false,
       showMetadataModal: false
     }
   }
@@ -38,11 +37,8 @@ export default class MetaTools extends React.Component {
 
   toggleFavourites () {
     const { onToggleFavourite, subject } = this.props
-    this.setState((prevState) => {
-      const isFavourite = !prevState.isFavourite
-      onToggleFavourite(subject.id, isFavourite)
-      return { isFavourite }
-    })
+    subject.toggleFavorite()
+    onToggleFavourite(subject.id, subject.favorite)
   }
 
   render () {
@@ -60,7 +56,7 @@ export default class MetaTools extends React.Component {
             metadata={subject.metadata}
           />}
         <FavouritesButton
-          checked={this.state.isFavourite}
+          checked={subject && subject.favorite}
           onClick={this.toggleFavourites}
         />
         <CollectionsButton />

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
@@ -9,8 +9,10 @@ import CollectionsButton from './components/CollectionsButton'
 
 function storeMapper(stores) {
   const { active: subject, isThereMetadata } = stores.classifierStore.subjects
+  const { onToggleFavourite } = stores.classifierStore
   return {
     isThereMetadata,
+    onToggleFavourite,
     subject
   }
 }
@@ -35,7 +37,12 @@ export default class MetaTools extends React.Component {
   }
 
   toggleFavourites () {
-    this.setState(prevState => ({ isFavourite: !prevState.isFavourite }))
+    const { onToggleFavourite, subject } = this.props
+    this.setState((prevState) => {
+      const isFavourite = !prevState.isFavourite
+      onToggleFavourite(subject.id, isFavourite)
+      return { isFavourite }
+    })
   }
 
   render () {

--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -23,6 +23,21 @@ const RootStore = types
     userProjectPreferences: types.optional(UserProjectPreferencesStore, UserProjectPreferencesStore.create())
   })
 
+  .volatile(self => {
+    return {
+      onToggleFavourite: () => true
+    }
+  })
+
+  .actions(self => {
+    function setOnToggleFavourite (callback) {
+      self.onToggleFavourite = callback
+    }
+    return {
+      setOnToggleFavourite
+    }
+  })
+
   .views(self => ({
     get authClient () {
       return getEnv(self).authClient

--- a/packages/lib-classifier/src/store/RootStore.spec.js
+++ b/packages/lib-classifier/src/store/RootStore.spec.js
@@ -1,3 +1,4 @@
+import sinon from 'sinon'
 import RootStore from './RootStore'
 
 let model
@@ -31,5 +32,11 @@ describe('Model > RootStore', function () {
 
   it('should expose the client when passed in', function () {
     expect(model.client).to.equal(client)
+  })
+
+  it('should have an onToggleFavourite callback', function () {
+    const onToggleFavourite = sinon.stub()
+    model.setOnToggleFavourite(onToggleFavourite)
+    expect(model.onToggleFavourite).to.equal(onToggleFavourite)
   })
 })

--- a/packages/lib-classifier/src/store/Subject.js
+++ b/packages/lib-classifier/src/store/Subject.js
@@ -17,7 +17,9 @@ const Subject = types
 
   .actions(self => {
     function toggleFavorite () {
+      const rootStore = getRoot(self)
       self.favorite = !self.favorite
+      rootStore.onToggleFavourite(self.id, self.favorite)
     }
 
     return {

--- a/packages/lib-classifier/src/store/Subject.js
+++ b/packages/lib-classifier/src/store/Subject.js
@@ -15,6 +15,16 @@ const Subject = types
     user_has_finished_workflow: types.optional(types.boolean, false)
   })
 
+  .actions(self => {
+    function toggleFavorite () {
+      self.favorite = !self.favorite
+    }
+
+    return {
+      toggleFavorite
+    }
+  })
+
   .views(self => ({
     get viewer () {
       const counts = createLocationCounts(self)

--- a/packages/lib-classifier/src/store/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject.spec.js
@@ -1,3 +1,4 @@
+import sinon from 'sinon'
 import Subject from './Subject'
 import { SubjectFactory } from '../../test/factories'
 
@@ -8,6 +9,7 @@ describe('Model > Subject', function () {
 
   before(function () {
     subject = Subject.create(stub)
+    subject.onToggleFavourite = sinon.stub()
   })
 
   it('should exist', function () {
@@ -26,6 +28,10 @@ describe('Model > Subject', function () {
 
     it('should toggle subject.favorite', function () {
       expect(subject.favorite).to.be.true
+    })
+
+    it('should call the onToggleFavourite callback', function () {
+      expect(subject.onToggleFavourite).to.have.been.calledOnceWith(subject.id, subject.favorite)
     })
   })
 })

--- a/packages/lib-classifier/src/store/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject.spec.js
@@ -18,4 +18,14 @@ describe('Model > Subject', function () {
   it('should have a `locations` property', function () {
     expect(subject.locations).to.deep.equal(stub.locations)
   })
+
+  describe('toggleFavorite', function () {
+    before(function () {
+      subject.toggleFavorite()
+    })
+
+    it('should toggle subject.favorite', function () {
+      expect(subject.favorite).to.be.true
+    })
+  })
 })


### PR DESCRIPTION
Package:
lib-classifier
app-project

Closes #397.

Adds an `onToggleFavourite` callback prop to the classifier. Wires up the favourites button so that clicking it adds/removes the current subject from your favourites collection for the project.

Still needs some work to maybe disable the button, or prompt to sign in, if there's no logged-in user.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

