### PR TITLE
Unregister workers

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -24,7 +24,7 @@ const client = {
 // We might want to move this check elsewhere once we add other service workers for other tasks
 // if (isBackgroundSyncAvailable()) registerWorkers()
 
-// TODO: The workbox background sync queue isn't working as expected 
+// TODO: The workbox background sync queue isn't working as expected
 // It doesn't work with superagent/XHR req for interception
 // We need to migrate to fetch API, otherwise the POST will occur twice
 // Once in our store, once in the worker

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -9,7 +9,7 @@ import {
   tutorials as tutorialsClient
 } from '@zooniverse/panoptes-js'
 
-import { registerWorkers } from '../../workers'
+import { registerWorkers, unregisterWorkers } from '../../workers'
 import RootStore from 'src/store'
 import Layout from './components/Layout'
 import { isBackgroundSyncAvailable } from '../../helpers/featureDetection'
@@ -22,7 +22,14 @@ const client = {
 
 // We don't register the queue service worker if background sync API is not available
 // We might want to move this check elsewhere once we add other service workers for other tasks
-if (isBackgroundSyncAvailable()) registerWorkers()
+// if (isBackgroundSyncAvailable()) registerWorkers()
+
+// TODO: The workbox background sync queue isn't working as expected 
+// It doesn't work with superagent/XHR req for interception
+// We need to migrate to fetch API, otherwise the POST will occur twice
+// Once in our store, once in the worker
+// So we'll unregister the worker for now.
+unregisterWorkers('./queue.js')
 
 export default class Classifier extends React.Component {
   constructor (props) {

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -158,28 +158,14 @@ const ClassificationStore = types
     }
 
     function * submitClassification (classification) {
-      console.log('Saving classification')
-      const root = getRoot(self)
-      const client = root.client.panoptes
       self.loadingState = asyncStates.posting
 
-      if (!isServiceWorkerAvailable() || !isBackgroundSyncAvailable()) {
-        // Use fallback queuing class
-        self.classificationQueue.add(classification)
-      } else {
-        try {
-          const response = yield client.post(`/${self.type}`, { classifications: classification })
-          if (response.ok) {
-            const savedClassification = response.body.classifications[0]
-            console.log(`Saved classification ${savedClassification.id}`)
-            // TODO: instead of callback here, let's add a Split store that uses an observer
-            self.onClassificationSaved(savedClassification)
-            self.loadingState = asyncStates.success
-          }
-        } catch (error) {
-          console.error(error)
-          self.loadingState = asyncStates.error
-        }
+      // Service worker isn't working right now, so let's use the fallback queue for all browsers
+      try {
+        yield self.classificationQueue.add(classification)
+      } catch (error) {
+        console.error(error)
+        self.loadingState = asyncStates.error
       }
     }
 

--- a/packages/lib-classifier/src/workers/index.js
+++ b/packages/lib-classifier/src/workers/index.js
@@ -1,3 +1,2 @@
 export { default as registerWorkers } from './registerWorkers'
 export { default as unregisterWorkers } from './unregisterWorkers'
-

--- a/packages/lib-classifier/src/workers/index.js
+++ b/packages/lib-classifier/src/workers/index.js
@@ -1,1 +1,3 @@
 export { default as registerWorkers } from './registerWorkers'
+export { default as unregisterWorkers } from './unregisterWorkers'
+

--- a/packages/lib-classifier/src/workers/registerWorkers.js
+++ b/packages/lib-classifier/src/workers/registerWorkers.js
@@ -18,3 +18,4 @@ export default function registerWorkers () {
     })
   }
 }
+

--- a/packages/lib-classifier/src/workers/registerWorkers.js
+++ b/packages/lib-classifier/src/workers/registerWorkers.js
@@ -18,4 +18,3 @@ export default function registerWorkers () {
     })
   }
 }
-

--- a/packages/lib-classifier/src/workers/unregisterWorkers.js
+++ b/packages/lib-classifier/src/workers/unregisterWorkers.js
@@ -1,0 +1,19 @@
+import { isServiceWorkerAvailable } from '../helpers/featureDetection'
+
+export default function unregisterWorkers(which) {
+  if (isServiceWorkerAvailable()) {
+    if (which) {
+      console.log()
+      navigator.serviceWorker.getRegistration(which).then((registration) => {
+        if (registration) {
+          registration.unregister()
+          console.log(`${registration.scope} found and now unregistered.`)
+        }
+      })
+    } else {
+      navigator.serviceWorker.getRegistrations().then((registration) => {
+        registration.unregister()
+      })
+    }
+  }
+}

--- a/packages/lib-classifier/src/workers/unregisterWorkers.js
+++ b/packages/lib-classifier/src/workers/unregisterWorkers.js
@@ -1,9 +1,8 @@
 import { isServiceWorkerAvailable } from '../helpers/featureDetection'
 
-export default function unregisterWorkers(which) {
+export default function unregisterWorkers (which) {
   if (isServiceWorkerAvailable()) {
     if (which) {
-      console.log()
       navigator.serviceWorker.getRegistration(which).then((registration) => {
         if (registration) {
           registration.unregister()


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
I discovered that the worker for the classification queue wasn't functioning as I believed it was. The issue is that I thought it was intercepting the POST request when there was a failure to put it into the queue, but with normal functioning, the POST request in the store and in the worker were going through, duplicating the classification. A few changes are needed:

1. If we're going to listen to the fetch event and intercept it, we need to be using fetch. Superagent is XHR. 
2. We then need to use a listener and call `event.respondWith` to interrupt the original POST request OR use a built in workbox tool for route listening on fetch that will call a callback upon failure (see: https://stackoverflow.com/questions/50129311/requests-through-service-worker-are-done-twice)
  - My experiment in trying this out, I broke the classification callbacks, so we still need to figure out how to get these to work together between the store and the worker.

This is a fair amount of work for something that only works in Chrome right now, so I'm unregistering the worker for now. 

To confirm the worker is unregistered: Go to Chrome dev tools, under the application tab, select Service Workers on the left hand side. Then you should see a worker, queue.js, with an 'uninstalled' state. Refresh and it should totally be gone then. 

Then when you make a classification, you should see only one POST that is handled by the queuing class. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

