### PR TITLE
Classifier - add "Done and Talk" button

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -1,5 +1,5 @@
 import asyncStates from '@zooniverse/async-states'
-import { Box } from 'grommet'
+import { Box, Paragraph } from 'grommet'
 import { inject, observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -28,12 +28,12 @@ export class Tasks extends React.Component {
   }
 
   [asyncStates.loading] () {
-    return (<div>Loading</div>)
+    return (<Paragraph>Loading</Paragraph>)
   }
 
   [asyncStates.error] () {
     console.error('There was an error loading the workflow steps and tasks.')
-    return (<div>Something went wrong</div>)
+    return (<Paragraph>Something went wrong</Paragraph>)
   }
 
   [asyncStates.success] () {
@@ -52,7 +52,7 @@ export class Tasks extends React.Component {
                 )
               }
 
-              return (<div>Task component could not be rendered.</div>)
+              return (<Paragraph>Task component could not be rendered.</Paragraph>)
             })}
             <TaskHelp />
             <TaskNavButtons />

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
@@ -17,12 +17,12 @@ describe('Tasks', function () {
 
   it('should render a loading UI when the workflow loading', function () {
     const wrapper = shallow(<Tasks.wrappedComponent loadingState={asyncStates.loading} />)
-    expect(wrapper.text()).to.equal('Loading')
+    expect(wrapper.contains('Loading')).to.be.true
   })
 
   it('should render an error message when there is a loading error', function () {
     const wrapper = shallow(<Tasks.wrappedComponent loadingState={asyncStates.error} />)
-    expect(wrapper.text()).to.equal('Something went wrong')
+    expect(wrapper.contains('Something went wrong')).to.be.true
   })
 
   it('should render null if the workflow is load but has no tasks', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
@@ -53,8 +53,6 @@ export default function TaskNavButtons (props) {
         goldStandardMode={goldStandardMode}
         onClick={props.onSubmit}
         disabled={props.waitingForAnswer}
-        projectSlug={props.projectSlug}
-        subjectId={props.subjectId}
       />
       <DoneButton
         completed={props.completed}

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { Box } from 'grommet'
 import NextButton from './components/NextButton'
 import DoneButton from './components/DoneButton'
+import DoneAndTalkButton from './components/DoneAndTalkButton'
 import BackButton from './components/BackButton'
 
 export default function TaskNavButtons (props) {
@@ -43,6 +44,15 @@ export default function TaskNavButtons (props) {
         <BackButton
           areAnnotationsNotPersisted={props.areAnnotationsNotPersisted}
           onClick={props.goToPreviousStep}
+        />}
+      {props.showDoneAndTalkLink &&
+        <DoneAndTalkButton
+          completed={props.completed}
+          demoMode={props.demoMode}
+          flex='grow'
+          goldStandardMode={props.classification ? props.classification.goldStandard : false}
+          onClick={props.completeClassification}
+          disabled={props.waitingForAnswer}
         />}
       <DoneButton
         completed={props.completed}

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
@@ -53,6 +53,8 @@ export default function TaskNavButtons (props) {
           goldStandardMode={props.classification ? props.classification.goldStandard : false}
           onClick={props.completeClassification}
           disabled={props.waitingForAnswer}
+          projectSlug={props.projectSlug}
+          subjectId={props.subjectId}
         />}
       <DoneButton
         completed={props.completed}
@@ -74,9 +76,12 @@ TaskNavButtons.defaultProps = {
   goToPreviousStep: () => {},
   onSubmit: () => {},
   nextSubject: () => {},
+  projectSlug: '',
   showBackButton: false,
   showNextButton: false,
   showDoneAndTalkLink: false,
+  subjectId: '',
+  completeClassification: () => {},
   waitingForAnswer: false
 }
 
@@ -88,8 +93,11 @@ TaskNavButtons.propTypes = {
   goToPreviousStep: PropTypes.func,
   nextSubject: PropTypes.func,
   onSubmit: PropTypes.func,
+  projectSlug: PropTypes.string,
   showBackButton: PropTypes.bool,
   showNextButton: PropTypes.bool,
   showDoneAndTalkLink: PropTypes.bool,
+  subjectId: PropTypes.string,
+  completeClassification: PropTypes.func,
   waitingForAnswer: PropTypes.bool
 }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
 import { Box } from 'grommet'
 import NextButton from './components/NextButton'
 import DoneButton from './components/DoneButton'
@@ -8,6 +7,8 @@ import DoneAndTalkButton from './components/DoneAndTalkButton'
 import BackButton from './components/BackButton'
 
 export default function TaskNavButtons (props) {
+  const goldStandardMode = props.classification ? props.classification.goldStandard : false
+
   if (props.showNextButton) {
     return (
       <Box pad='small' direction='row'>
@@ -45,22 +46,21 @@ export default function TaskNavButtons (props) {
           areAnnotationsNotPersisted={props.areAnnotationsNotPersisted}
           onClick={props.goToPreviousStep}
         />}
-      {props.showDoneAndTalkLink &&
-        <DoneAndTalkButton
-          completed={props.completed}
-          demoMode={props.demoMode}
-          flex='grow'
-          goldStandardMode={props.classification ? props.classification.goldStandard : false}
-          onClick={props.completeClassification}
-          disabled={props.waitingForAnswer}
-          projectSlug={props.projectSlug}
-          subjectId={props.subjectId}
-        />}
+      <DoneAndTalkButton
+        completed={props.completed}
+        demoMode={props.demoMode}
+        flex='grow'
+        goldStandardMode={goldStandardMode}
+        onClick={props.onSubmit}
+        disabled={props.waitingForAnswer}
+        projectSlug={props.projectSlug}
+        subjectId={props.subjectId}
+      />
       <DoneButton
         completed={props.completed}
         demoMode={props.demoMode}
         flex='grow'
-        goldStandardMode={props.classification ? props.classification.goldStandard : false}
+        goldStandardMode={goldStandardMode}
         onClick={props.onSubmit}
         disabled={props.waitingForAnswer}
       />
@@ -76,12 +76,9 @@ TaskNavButtons.defaultProps = {
   goToPreviousStep: () => {},
   onSubmit: () => {},
   nextSubject: () => {},
-  projectSlug: '',
   showBackButton: false,
   showNextButton: false,
   showDoneAndTalkLink: false,
-  subjectId: '',
-  completeClassification: () => {},
   waitingForAnswer: false
 }
 
@@ -93,11 +90,7 @@ TaskNavButtons.propTypes = {
   goToPreviousStep: PropTypes.func,
   nextSubject: PropTypes.func,
   onSubmit: PropTypes.func,
-  projectSlug: PropTypes.string,
   showBackButton: PropTypes.bool,
   showNextButton: PropTypes.bool,
-  showDoneAndTalkLink: PropTypes.bool,
-  subjectId: PropTypes.string,
-  completeClassification: PropTypes.func,
   waitingForAnswer: PropTypes.bool
 }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.spec.js
@@ -49,7 +49,7 @@ describe('TaskNavButtons', function () {
   describe('when props.completed is true and props.showNextButton is false', function () {
     let wrapper
     before(function () {
-      wrapper = mount(<TaskNavButtons completed classification={classification} />)
+      wrapper = shallow(<TaskNavButtons completed classification={classification} />)
     })
 
     it('should render a NextButton component if props.completed is true and props.showNextButton is false', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.spec.js
@@ -1,7 +1,11 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { expect } from 'chai'
-import TaskNavButtons, { ButtonsWrapper } from './TaskNavButtons'
+import TaskNavButtons from './TaskNavButtons'
+import NextButton from './components/NextButton'
+import DoneButton from './components/DoneButton'
+import BackButton from './components/BackButton'
+import DoneAndTalkButton from './components/DoneAndTalkButton'
 
 const classification = { gold_standard: false }
 
@@ -11,70 +15,74 @@ const project = { slug: 'zooniverse/my-project' }
 
 describe('TaskNavButtons', function () {
   it('should render without crashing', function () {
-    const wrapper = shallow(<TaskNavButtons classification={classification} project={project} subject={subject} />)
+    const wrapper = shallow(<TaskNavButtons classification={classification} />)
     expect(wrapper).to.be.ok
   })
 
   it('should not render a NextButton component if props.showNextButton is false and and props.completed is false', function () {
-    const wrapper = shallow(<TaskNavButtons classification={classification} project={project} subject={subject} />)
-    expect(wrapper.find('NextButton')).to.have.lengthOf(0)
+    const wrapper = shallow(<TaskNavButtons classification={classification} />)
+    expect(wrapper.find(NextButton)).to.have.lengthOf(0)
   })
 
   describe('when props.showNextButton is true', function () {
     let wrapper
     before(function () {
-      wrapper = shallow(<TaskNavButtons classification={classification} goToNextStep={() => {}} project={project} subject={subject} showNextButton />)
+      wrapper = shallow(<TaskNavButtons classification={classification} goToNextStep={() => {}} showNextButton />)
     })
 
     it('should render a NextButton component', function () {
       wrapper.setProps({ showNextButton: true })
-      expect(wrapper.find('NextButton')).to.have.lengthOf(1)
+      expect(wrapper.find(NextButton)).to.have.lengthOf(1)
     })
 
     it('should not render a BackButton if props.showBackButton is false', function () {
-      expect(wrapper.find('BackButton')).to.have.lengthOf(0)
+      expect(wrapper.find(BackButton)).to.have.lengthOf(0)
     })
 
     it('should render a BackButton if props.showBackButton is true', function () {
       wrapper.setProps({ showBackButton: true })
-      expect(wrapper.find('BackButton')).to.have.lengthOf(1)
+      expect(wrapper.find(BackButton)).to.have.lengthOf(1)
     })
 
     it('should disable the Next button when waiting for a required answer.', function () {
       wrapper.setProps({ waitingForAnswer: true })
-      expect(wrapper.find('NextButton').prop('disabled')).to.be.true
+      expect(wrapper.find(NextButton).prop('disabled')).to.be.true
     })
   })
 
   describe('when props.completed is true and props.showNextButton is false', function () {
     let wrapper
     before(function () {
-      wrapper = shallow(<TaskNavButtons completed classification={classification} project={project} subject={subject} />)
+      wrapper = mount(<TaskNavButtons completed classification={classification} />)
     })
 
     it('should render a NextButton component if props.completed is true and props.showNextButton is false', function () {
-      expect(wrapper.find('NextButton')).to.have.lengthOf(1)
+      expect(wrapper.find(NextButton)).to.have.lengthOf(1)
     })
   })
 
   describe('the default rendering', function () {
     let wrapper
     before(function () {
-      wrapper = shallow(<TaskNavButtons classification={classification} project={project} subject={subject} />)
+      wrapper = shallow(<TaskNavButtons classification={classification} />)
     })
 
     it('should render a DoneButton component', function () {
-      expect(wrapper.find('DoneButton')).to.have.lengthOf(1)
+      expect(wrapper.find(DoneButton)).to.have.lengthOf(1)
+    })
+
+    it('should render a DoneAndTalkButton component', function () {
+      expect(wrapper.find(DoneAndTalkButton)).to.have.lengthOf(1)
     })
 
     it('should render a BackButton if props.showBackButton is true', function () {
       wrapper.setProps({ showBackButton: true })
-      expect(wrapper.find('BackButton')).to.have.lengthOf(1)
+      expect(wrapper.find(BackButton)).to.have.lengthOf(1)
     })
 
     it('should disable the Done button when waiting for a required answer.', function () {
       wrapper.setProps({ waitingForAnswer: true })
-      expect(wrapper.find('DoneButton').prop('disabled')).to.be.true
+      expect(wrapper.find(DoneButton).prop('disabled')).to.be.true
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.spec.js
@@ -9,10 +9,6 @@ import DoneAndTalkButton from './components/DoneAndTalkButton'
 
 const classification = { gold_standard: false }
 
-const subject = { id: '1' }
-
-const project = { slug: 'zooniverse/my-project' }
-
 describe('TaskNavButtons', function () {
   it('should render without crashing', function () {
     const wrapper = shallow(<TaskNavButtons classification={classification} />)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.js
@@ -77,7 +77,7 @@ class TaskNavButtonsContainer extends React.Component {
     event.preventDefault()
     const { completeClassification } = this.props
     this.createDefaultAnnotationIfThereIsNone()
-    completeClassification()
+    return completeClassification()
   }
 
   render () {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.js
@@ -10,7 +10,6 @@ function storeMapper (stores) {
     getPreviousStepKey,
     isThereANextStep,
     isThereAPreviousStep,
-    shouldWeShowDoneAndTalkButton,
     selectStep
   } = stores.classifierStore.workflowSteps
   const {
@@ -19,12 +18,6 @@ function storeMapper (stores) {
     createDefaultAnnotation,
     removeAnnotation
   } = stores.classifierStore.classifications
-  const {
-    active: subject
-  } = stores.classifierStore.subjects
-  const {
-    active: project
-  } = stores.classifierStore.projects
   
   return {
     classification,
@@ -33,12 +26,9 @@ function storeMapper (stores) {
     getPreviousStepKey,
     isThereANextStep,
     isThereAPreviousStep,
-    project,
     removeAnnotation,
     selectStep,
-    shouldWeShowDoneAndTalkButton,
     step,
-    subject,
     tasks
   }
 }
@@ -91,11 +81,8 @@ class TaskNavButtonsContainer extends React.Component {
   }
 
   render () {
-    const { isThereANextStep, isThereAPreviousStep, shouldWeShowDoneAndTalkButton, completeClassification, project, subject } = this.props
-    
-    const projectSlug = project && project.slug
-    const subjectId = subject && subject.id
-    
+    const { isThereANextStep, isThereAPreviousStep } = this.props
+
     return (
       <TaskNavButtons
         goToNextStep={this.goToNextStep.bind(this)}
@@ -103,10 +90,6 @@ class TaskNavButtonsContainer extends React.Component {
         showBackButton={isThereAPreviousStep()}
         showNextButton={isThereANextStep()}
         onSubmit={this.onSubmit.bind(this)}
-        showDoneAndTalkLink={shouldWeShowDoneAndTalkButton()}
-        completeClassification={completeClassification}
-        projectSlug={projectSlug}
-        subjectId={subjectId}
       />
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.js
@@ -19,7 +19,13 @@ function storeMapper (stores) {
     createDefaultAnnotation,
     removeAnnotation
   } = stores.classifierStore.classifications
-
+  const {
+    active: subject
+  } = stores.classifierStore.subjects
+  const {
+    active: project
+  } = stores.classifierStore.projects
+  
   return {
     classification,
     completeClassification,
@@ -27,10 +33,12 @@ function storeMapper (stores) {
     getPreviousStepKey,
     isThereANextStep,
     isThereAPreviousStep,
+    project,
     removeAnnotation,
     selectStep,
     shouldWeShowDoneAndTalkButton,
     step,
+    subject,
     tasks
   }
 }
@@ -83,7 +91,11 @@ class TaskNavButtonsContainer extends React.Component {
   }
 
   render () {
-    const { isThereANextStep, isThereAPreviousStep, shouldWeShowDoneAndTalkButton, completeClassification } = this.props
+    const { isThereANextStep, isThereAPreviousStep, shouldWeShowDoneAndTalkButton, completeClassification, project, subject } = this.props
+    
+    const projectSlug = project && project.slug
+    const subjectId = subject && subject.id
+    
     return (
       <TaskNavButtons
         goToNextStep={this.goToNextStep.bind(this)}
@@ -93,6 +105,8 @@ class TaskNavButtonsContainer extends React.Component {
         onSubmit={this.onSubmit.bind(this)}
         showDoneAndTalkLink={shouldWeShowDoneAndTalkButton()}
         completeClassification={completeClassification}
+        projectSlug={projectSlug}
+        subjectId={subjectId}
       />
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.js
@@ -10,6 +10,7 @@ function storeMapper (stores) {
     getPreviousStepKey,
     isThereANextStep,
     isThereAPreviousStep,
+    shouldWeShowDoneAndTalkButton,
     selectStep
   } = stores.classifierStore.workflowSteps
   const {
@@ -28,6 +29,7 @@ function storeMapper (stores) {
     isThereAPreviousStep,
     removeAnnotation,
     selectStep,
+    shouldWeShowDoneAndTalkButton,
     step,
     tasks
   }
@@ -81,7 +83,7 @@ class TaskNavButtonsContainer extends React.Component {
   }
 
   render () {
-    const { isThereANextStep, isThereAPreviousStep } = this.props
+    const { isThereANextStep, isThereAPreviousStep, shouldWeShowDoneAndTalkButton, completeClassification } = this.props
     return (
       <TaskNavButtons
         goToNextStep={this.goToNextStep.bind(this)}
@@ -89,6 +91,8 @@ class TaskNavButtonsContainer extends React.Component {
         showBackButton={isThereAPreviousStep()}
         showNextButton={isThereANextStep()}
         onSubmit={this.onSubmit.bind(this)}
+        showDoneAndTalkLink={shouldWeShowDoneAndTalkButton()}
+        completeClassification={completeClassification}
       />
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.spec.js
@@ -34,6 +34,7 @@ describe('TaskNavButtonsContainer', function () {
         <TaskNavButtonsContainer.wrappedComponent
           isThereAPreviousStep={() => {}}
           isThereANextStep={() => {}}
+          shouldWeShowDoneAndTalkButton={() => {}}
           tasks={tasks}
         />
       )
@@ -63,6 +64,7 @@ describe('TaskNavButtonsContainer', function () {
         <TaskNavButtonsContainer.wrappedComponent
           isThereAPreviousStep={() => {}}
           isThereANextStep={() => {}}
+          shouldWeShowDoneAndTalkButton={() => {}}
           selectStep={selectStepSpy}
           tasks={tasks}
         />
@@ -104,6 +106,7 @@ describe('TaskNavButtonsContainer', function () {
         <TaskNavButtonsContainer.wrappedComponent
           isThereAPreviousStep={() => {}}
           isThereANextStep={() => {}}
+          shouldWeShowDoneAndTalkButton={() => {}}
           removeAnnotation={removeAnnotationSpy}
           selectStep={selectStepSpy}
           steps={steps}
@@ -153,6 +156,7 @@ describe('TaskNavButtonsContainer', function () {
           createDefaultAnnotation={createDefaultAnnotationSpy}
           isThereAPreviousStep={() => {}}
           isThereANextStep={() => {}}
+          shouldWeShowDoneAndTalkButton={() => {}}
           tasks={tasks}
         />
       )

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
@@ -25,7 +25,6 @@ export const StyledDoneAndTalkButton = styled(Button)`
     dark: `solid thin ${TALK_LINK_BLUE}`,
     light: `solid thin transparent`
   })};
-  border-radius: 0;
   color: white;
   cursor: pointer;
   flex: 3 0;
@@ -71,23 +70,6 @@ export const StyledDoneAndTalkButton = styled(Button)`
   }
   `
 
-export const StyledDisabledTalkPlaceholder = styled.span`
-  background: ${theme('mode', {
-    dark: zooTheme.dark.colors.background.default,
-    light: TALK_LINK_BLUE
-  })};
-  border: ${theme('mode', {
-    dark: `thin solid ${TALK_LINK_BLUE}`,
-    light: 'thin solid transparent'
-  })};
-  color: ${theme('mode', {
-    dark: zooTheme.dark.colors.font,
-    light: 'white'
-  })};
-  cursor: not-allowed;
-  opacity: 0.5;
-  `
-
 function openTalkLinkAndClick (event, props) {
   props.onClick(event)
   
@@ -106,23 +88,13 @@ function openTalkLinkAndClick (event, props) {
 }
 
 export function DoneAndTalkButton (props) {
-  if (props.disabled) {
-    return (
-      <ThemeProvider theme={{ mode: props.theme }}>
-        <StyledDisabledTalkPlaceholder>
-          <Text size='small'>{counterpart('DoneAndTalkButton.doneAndTalk')}</Text>
-        </StyledDisabledTalkPlaceholder>
-      </ThemeProvider>
-    )
-  }
-  
   if (!props.completed) {
     return (
       <ThemeProvider theme={{ mode: props.theme }}>
         <StyledDoneAndTalkButton
           disabled={props.disabled}
           label={<Text size='small'>{counterpart('DoneAndTalkButton.doneAndTalk')}</Text>}
-          onClick={(e)=>{ openTalkLinkAndClick(e, props) }}
+          onClick={(e) => { openTalkLinkAndClick(e, props) }}
           type='submit'
         />
       </ThemeProvider>
@@ -134,12 +106,10 @@ export function DoneAndTalkButton (props) {
 
 DoneAndTalkButton.defaultProps = {
   completed: false,
-  demoMode: false,  // Holdover from DoneButton pattern - unknown if needed
+  demoMode: false,  // TODO: add demo mode to classifier
   disabled: false,
-  goldStandardMode: false,  // Holdover from DoneButton pattern - unknown if needed
+  goldStandardMode: false,  // TODO: add gold standard mode to classifier
   onClick: () => {},
-  projectSlug: undefined,
-  subjectId: undefined,
   theme: 'light'
 }
 
@@ -149,8 +119,8 @@ DoneAndTalkButton.propTypes = {
   disabled: PropTypes.bool,
   goldStandardMode: PropTypes.bool,
   onClick: PropTypes.func,
-  projectSlug: PropTypes.string,
-  subjectId: PropTypes.string,
+  projectSlug: PropTypes.string.isRequired,
+  subjectId: PropTypes.string.isRequired,
   theme: PropTypes.string
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
@@ -58,11 +58,25 @@ export const StyledDoneAndTalkButton = styled(Button)`
   `
 
 export function DoneAndTalkButton (props) {
-  function openTalkLinkAndClick(event) {
-    if (window && props.talkUrl) {
-      window.location = props.talkUrl
-    }
+  const openTalkLinkAndClick = function (event) {
+    const isCmdClick = event.metaKey
+
     props.onClick(event)
+      .then(() => {
+        if (window && props.talkURL) {
+          const url = `${window.location.origin}${props.talkURL}`
+          if (isCmdClick) {
+            event.preventDefault()
+            const newTab = window.open()
+            newTab.opener = null
+            newTab.location = url
+            newTab.target = '_blank'
+            newTab.focus()
+          } else {
+            window.location.assign(url)
+          }
+        }
+      })
   }
 
   if (!props.completed) {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
@@ -88,6 +88,16 @@ export const StyledDisabledTalkPlaceholder = styled.span`
   opacity: 0.5;
   `
 
+function openTalkLinkAndClick (event, props) {
+  props.onClick(event)
+  
+  const talkUrl = 'https://google.com'
+  if (talkUrl) {
+    const newTab = window.open(talkUrl, '_blank', 'noopener')
+    //newTab.focus()
+  }
+}
+
 export function DoneAndTalkButton (props) {
   if (props.disabled) {
     return (
@@ -105,7 +115,7 @@ export function DoneAndTalkButton (props) {
         <StyledDoneAndTalkButton
           disabled={props.disabled}
           label={<Text size='small'>{counterpart('DoneAndTalkButton.doneAndTalk')}</Text>}
-          onClick={props.onClick}
+          onClick={(e)=>{ openTalkLinkAndClick(e, props) }}
           type='submit'
         />
       </ThemeProvider>

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
@@ -91,7 +91,10 @@ export const StyledDisabledTalkPlaceholder = styled.span`
 function openTalkLinkAndClick (event, props) {
   props.onClick(event)
   
-  const talkUrl = 'https://google.com'
+  const talkUrl =
+    props.projectSlug && props.subjectId &&
+    `/projects/${props.projectSlug}/talk/subjects/${props.subjectId}`
+  
   if (talkUrl) {
     // Bypasses issue with using window.open(talkUrl, '_blank', 'noopener')
     const newTab = window.open()
@@ -99,7 +102,6 @@ function openTalkLinkAndClick (event, props) {
     newTab.location = talkUrl
     newTab.target = '_blank'
     newTab.focus()
-    console.log(newTab)
   }
 }
 
@@ -132,10 +134,12 @@ export function DoneAndTalkButton (props) {
 
 DoneAndTalkButton.defaultProps = {
   completed: false,
-  demoMode: false,
+  demoMode: false,  // Holdover from DoneButton pattern - unknown if needed
   disabled: false,
-  goldStandardMode: false,
+  goldStandardMode: false,  // Holdover from DoneButton pattern - unknown if needed
   onClick: () => {},
+  projectSlug: undefined,
+  subjectId: undefined,
   theme: 'light'
 }
 
@@ -145,6 +149,8 @@ DoneAndTalkButton.propTypes = {
   disabled: PropTypes.bool,
   goldStandardMode: PropTypes.bool,
   onClick: PropTypes.func,
+  projectSlug: PropTypes.string,
+  subjectId: PropTypes.string,
   theme: PropTypes.string
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
@@ -30,12 +30,12 @@ export const StyledDoneAndTalkButton = styled(Button)`
   cursor: pointer;
   flex: 3 0;
   font-size: 0.9em;
+  margin-right: 1ch;
   padding: 0.9em;
   text-transform: capitalize;
-
+  
   > i {
     margin-left: 1ch;
-    margin-right: 1ch;
   }
 
   &:hover, &:focus {
@@ -93,8 +93,13 @@ function openTalkLinkAndClick (event, props) {
   
   const talkUrl = 'https://google.com'
   if (talkUrl) {
-    const newTab = window.open(talkUrl, '_blank', 'noopener')
-    //newTab.focus()
+    // Bypasses issue with using window.open(talkUrl, '_blank', 'noopener')
+    const newTab = window.open()
+    newTab.opener = null
+    newTab.location = talkUrl
+    newTab.target = '_blank'
+    newTab.focus()
+    console.log(newTab)
   }
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
@@ -57,31 +57,21 @@ export const StyledDoneAndTalkButton = styled(Button)`
   }
   `
 
-function openTalkLinkAndClick (event, props) {
-  props.onClick(event)
-  
-  const talkUrl =
-    props.projectSlug && props.subjectId &&
-    `/projects/${props.projectSlug}/talk/subjects/${props.subjectId}`
-  
-  if (talkUrl) {
-    // Bypasses issue with using window.open(talkUrl, '_blank', 'noopener')
-    const newTab = window.open()
-    newTab.opener = null
-    newTab.location = talkUrl
-    newTab.target = '_blank'
-    newTab.focus()
-  }
-}
-
 export function DoneAndTalkButton (props) {
+  function openTalkLinkAndClick(event) {
+    if (window && props.talkUrl) {
+      window.location = props.talkUrl
+    }
+    props.onClick(event)
+  }
+
   if (!props.completed) {
     return (
       <ThemeProvider theme={{ mode: props.theme }}>
         <StyledDoneAndTalkButton
           disabled={props.disabled}
           label={<Text size='small'>{counterpart('DoneAndTalkButton.doneAndTalk')}</Text>}
-          onClick={(e) => { openTalkLinkAndClick(e, props) }}
+          onClick={(e) => { openTalkLinkAndClick(e) }}
           type='submit'
         />
       </ThemeProvider>
@@ -106,8 +96,7 @@ DoneAndTalkButton.propTypes = {
   disabled: PropTypes.bool,
   goldStandardMode: PropTypes.bool,
   onClick: PropTypes.func,
-  projectSlug: PropTypes.string.isRequired,
-  subjectId: PropTypes.string.isRequired,
+  talkURL: PropTypes.string.isRequired,
   theme: PropTypes.string
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
@@ -10,15 +10,20 @@ import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
 
+// Taken from PFE on 2019.02.28; these colours aren't part of the current theme.
+const TALK_LINK_BLUE = '#43bbfd';
+const TALK_LINK_BLUE_HOVER = '#69c9fd';
+const TALK_LINK_BLUE_HOVER_DARK = '#104A79';
+
 // TODO move what makes sense into theme
 export const StyledDoneAndTalkButton = styled(Button)`
   background-color: ${theme('mode', {
     dark: zooTheme.global.colors.midDarkGrey,
-    light: zooTheme.light.colors.button.done
+    light: TALK_LINK_BLUE
   })};
   border: ${theme('mode', {
-    dark: `solid thin ${zooTheme.dark.colors.button.done.default}`,
-    light: `solid thin ${zooTheme.light.colors.button.done}`
+    dark: `solid thin ${TALK_LINK_BLUE}`,
+    light: `solid thin transparent`
   })};
   border-radius: 0;
   color: white;
@@ -30,41 +35,70 @@ export const StyledDoneAndTalkButton = styled(Button)`
 
   > i {
     margin-left: 1ch;
+    margin-right: 1ch;
   }
 
   &:hover, &:focus {
     background: ${theme('mode', {
-    dark: zooTheme.dark.colors.button.done.hover,
-    light: darken(0.15, zooTheme.light.colors.button.done)
-  })};
+      dark: TALK_LINK_BLUE_HOVER_DARK,
+      light: darken(0.25, TALK_LINK_BLUE_HOVER)
+    })};
     border: ${theme('mode', {
-    dark: `solid thin ${zooTheme.dark.colors.button.done.default}`,
-    light: `solid thin ${darken(0.15, zooTheme.light.colors.button.done)}`
-  })};
-    color: 'white';
+      dark: `solid thin ${TALK_LINK_BLUE}`,
+      light: `solid thin ${darken(0.15, zooTheme.light.colors.button.done)}`
+    })};
+    color: ${theme('mode', {
+      dark: zooTheme.dark.colors.font,
+      light: `white`
+    })};
   }
 
   &:disabled {
     background: ${theme('mode', {
-    dark: lighten(0.05, zooTheme.global.colors.midDarkGrey),
-    light: lighten(0.05, zooTheme.light.colors.button.done)
-  })};
+      dark: lighten(0.05, zooTheme.global.colors.midDarkGrey),
+      light: lighten(0.05, TALK_LINK_BLUE)
+    })};
     border: ${theme('mode', {
-    dark: `solid thin ${zooTheme.dark.colors.button.done.default}`,
-    light: `solid thin ${lighten(0.05, zooTheme.light.colors.button.done)}`
-  })};
+      dark: `solid thin ${TALK_LINK_BLUE}`,
+      light: `solid thin transparent`
+    })};
     color: ${theme('mode', {
-    dark: zooTheme.dark.colors.font,
-    light: '#EEF1F4'
-  })};
+      dark: zooTheme.dark.colors.font,
+      light: '#EEF1F4'
+    })};
     cursor: not-allowed;
     opacity: 0.5;
   }
   `
-// TODO add back gold standard and demo buttons using grommet Button icon prop
-// {props.demoMode && <i className="fa fa-trash fa-fw" />}
-// {props.goldStandardMode && <i className="fa fa-star fa-fw" />}
+
+export const StyledDisabledTalkPlaceholder = styled.span`
+  background: ${theme('mode', {
+    dark: zooTheme.dark.colors.background.default,
+    light: TALK_LINK_BLUE
+  })};
+  border: ${theme('mode', {
+    dark: `thin solid ${TALK_LINK_BLUE}`,
+    light: 'thin solid transparent'
+  })};
+  color: ${theme('mode', {
+    dark: zooTheme.dark.colors.font,
+    light: 'white'
+  })};
+  cursor: not-allowed;
+  opacity: 0.5;
+  `
+
 export function DoneAndTalkButton (props) {
+  if (props.disabled) {
+    return (
+      <ThemeProvider theme={{ mode: props.theme }}>
+        <StyledDisabledTalkPlaceholder>
+          <Text size='small'>{counterpart('DoneAndTalkButton.doneAndTalk')}</Text>
+        </StyledDisabledTalkPlaceholder>
+      </ThemeProvider>
+    )
+  }
+  
   if (!props.completed) {
     return (
       <ThemeProvider theme={{ mode: props.theme }}>

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
@@ -12,25 +12,24 @@ counterpart.registerTranslations('en', en)
 
 // Taken from PFE on 2019.02.28; these colours aren't part of the current theme.
 const TALK_LINK_BLUE = '#43bbfd';
-const TALK_LINK_BLUE_HOVER = '#69c9fd';
+const TALK_LINK_BLUE_HOVER = darken(0.18, TALK_LINK_BLUE);
 const TALK_LINK_BLUE_HOVER_DARK = '#104A79';
 
 // TODO move what makes sense into theme
 export const StyledDoneAndTalkButton = styled(Button)`
   background-color: ${theme('mode', {
-    dark: zooTheme.global.colors.midDarkGrey,
+    dark: zooTheme.global.colors['dark-1'],
     light: TALK_LINK_BLUE
   })};
   border: ${theme('mode', {
     dark: `solid thin ${TALK_LINK_BLUE}`,
-    light: `solid thin transparent`
+    light: `solid thin ${TALK_LINK_BLUE_HOVER}`
   })};
+  box-shadow: none;
   color: white;
-  cursor: pointer;
   flex: 3 0;
-  font-size: 0.9em;
   margin-right: 1ch;
-  padding: 0.9em;
+  padding: 0.5em;
   text-transform: capitalize;
   
   > i {
@@ -40,33 +39,21 @@ export const StyledDoneAndTalkButton = styled(Button)`
   &:hover, &:focus {
     background: ${theme('mode', {
       dark: TALK_LINK_BLUE_HOVER_DARK,
-      light: darken(0.25, TALK_LINK_BLUE_HOVER)
+      light: TALK_LINK_BLUE_HOVER
     })};
     border: ${theme('mode', {
       dark: `solid thin ${TALK_LINK_BLUE}`,
-      light: `solid thin ${darken(0.15, zooTheme.light.colors.button.done)}`
+      light: `solid thin ${TALK_LINK_BLUE_HOVER}`
     })};
+    box-shadow: none;
     color: ${theme('mode', {
-      dark: zooTheme.dark.colors.font,
+      dark: zooTheme.global.colors.text.dark,
       light: `white`
     })};
   }
 
   &:disabled {
-    background: ${theme('mode', {
-      dark: lighten(0.05, zooTheme.global.colors.midDarkGrey),
-      light: lighten(0.05, TALK_LINK_BLUE)
-    })};
-    border: ${theme('mode', {
-      dark: `solid thin ${TALK_LINK_BLUE}`,
-      light: `solid thin transparent`
-    })};
-    color: ${theme('mode', {
-      dark: zooTheme.dark.colors.font,
-      light: '#EEF1F4'
-    })};
     cursor: not-allowed;
-    opacity: 0.5;
   }
   `
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
@@ -1,0 +1,102 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button, Text } from 'grommet'
+import styled, { ThemeProvider } from 'styled-components'
+import theme from 'styled-theming'
+import { darken, lighten } from 'polished'
+import zooTheme from '@zooniverse/grommet-theme'
+import counterpart from 'counterpart'
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
+
+// TODO move what makes sense into theme
+export const StyledDoneAndTalkButton = styled(Button)`
+  background-color: ${theme('mode', {
+    dark: zooTheme.global.colors.midDarkGrey,
+    light: zooTheme.light.colors.button.done
+  })};
+  border: ${theme('mode', {
+    dark: `solid thin ${zooTheme.dark.colors.button.done.default}`,
+    light: `solid thin ${zooTheme.light.colors.button.done}`
+  })};
+  border-radius: 0;
+  color: white;
+  cursor: pointer;
+  flex: 3 0;
+  font-size: 0.9em;
+  padding: 0.9em;
+  text-transform: capitalize;
+
+  > i {
+    margin-left: 1ch;
+  }
+
+  &:hover, &:focus {
+    background: ${theme('mode', {
+    dark: zooTheme.dark.colors.button.done.hover,
+    light: darken(0.15, zooTheme.light.colors.button.done)
+  })};
+    border: ${theme('mode', {
+    dark: `solid thin ${zooTheme.dark.colors.button.done.default}`,
+    light: `solid thin ${darken(0.15, zooTheme.light.colors.button.done)}`
+  })};
+    color: 'white';
+  }
+
+  &:disabled {
+    background: ${theme('mode', {
+    dark: lighten(0.05, zooTheme.global.colors.midDarkGrey),
+    light: lighten(0.05, zooTheme.light.colors.button.done)
+  })};
+    border: ${theme('mode', {
+    dark: `solid thin ${zooTheme.dark.colors.button.done.default}`,
+    light: `solid thin ${lighten(0.05, zooTheme.light.colors.button.done)}`
+  })};
+    color: ${theme('mode', {
+    dark: zooTheme.dark.colors.font,
+    light: '#EEF1F4'
+  })};
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+  `
+// TODO add back gold standard and demo buttons using grommet Button icon prop
+// {props.demoMode && <i className="fa fa-trash fa-fw" />}
+// {props.goldStandardMode && <i className="fa fa-star fa-fw" />}
+export function DoneAndTalkButton (props) {
+  if (!props.completed) {
+    return (
+      <ThemeProvider theme={{ mode: props.theme }}>
+        <StyledDoneAndTalkButton
+          disabled={props.disabled}
+          label={<Text size='small'>{counterpart('DoneAndTalkButton.doneAndTalk')}</Text>}
+          onClick={props.onClick}
+          type='submit'
+        />
+      </ThemeProvider>
+    )
+  }
+
+  return null
+}
+
+DoneAndTalkButton.defaultProps = {
+  completed: false,
+  demoMode: false,
+  disabled: false,
+  goldStandardMode: false,
+  onClick: () => {},
+  theme: 'light'
+}
+
+DoneAndTalkButton.propTypes = {
+  completed: PropTypes.bool,
+  demoMode: PropTypes.bool,
+  disabled: PropTypes.bool,
+  goldStandardMode: PropTypes.bool,
+  onClick: PropTypes.func,
+  theme: PropTypes.string
+}
+
+export default DoneAndTalkButton

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.spec.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { expect } from 'chai'
+import sinon from 'sinon'
+import DoneAndTalkButton, { StyledDoneAndTalkButton } from './DoneAndTalkButton'
+
+describe('DoneAndTalkButton', function () {
+  it('should render without crashing', function () {
+    const wrapper = mount(<DoneAndTalkButton />)
+    expect(wrapper).to.be.ok
+  })
+  
+  describe('when props.completed is true', function () {
+    it('should render null', function () {
+      const wrapper = mount(<DoneAndTalkButton completed />)
+      expect(wrapper.html()).to.be.null
+    })
+  })
+
+  it('should call props.onClick for the onClick event', function () {
+    const onClickSpy = sinon.spy()
+    const wrapper = mount(<DoneAndTalkButton onClick={onClickSpy} />)
+    wrapper.find('button').simulate('click')
+    expect(onClickSpy.calledOnce).to.be.true
+  })
+
+  describe('when props.completed is false', function () {
+    it('should render a ThemeProvider', function () {
+      const wrapper = mount(<DoneAndTalkButton />)
+      expect(wrapper.find('ThemeProvider')).to.have.lengthOf(1)
+    })
+
+    it('should render a StyledDoneAndTalkButton', function () {
+      const wrapper = mount(<DoneAndTalkButton />)
+      expect(wrapper.find(StyledDoneAndTalkButton)).to.have.lengthOf(1)
+    })
+  })
+
+  xdescribe('props.goldStandardMode', function () {
+    it('should not render a star icon if props.goldStandardMode is false', function () {
+      const wrapper = mount(<DoneAndTalkButton />)
+      expect(wrapper.find('i.fa-star')).to.have.lengthOf(0)
+    })
+
+    it('should render a star icon if props.goldStandardMode is true', function () {
+      const wrapper = mount(<DoneAndTalkButton goldStandardMode />)
+      expect(wrapper.find('i.fa-star')).to.have.lengthOf(1)
+    })
+  })
+
+  xdescribe('props.demoMode', function () {
+    it('should not render a trash icon if props.demoMode is false', function () {
+      const wrapper = mount(<DoneAndTalkButton />)
+      expect(wrapper.find('i.fa-trash')).to.have.lengthOf(0)
+    })
+
+    it('should render a trash icon if props.demoMode is true', function () {
+      const wrapper = mount(<DoneAndTalkButton demoMode />)
+      expect(wrapper.find('i.fa-trash')).to.have.lengthOf(1)
+    })
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.spec.js
@@ -1,37 +1,42 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { shallow } from 'enzyme'
 import { expect } from 'chai'
 import sinon from 'sinon'
 import DoneAndTalkButton, { StyledDoneAndTalkButton } from './DoneAndTalkButton'
+import { ProjectFactory, SubjectFactory } from '../../../../../../../../../../../test/factories'
+
+const project = ProjectFactory.build()
+const subject = SubjectFactory.build()
+const talkURL = `/projects/${project.slug}/talk/subjects/${subject.id}`
 
 describe('DoneAndTalkButton', function () {
   it('should render without crashing', function () {
-    const wrapper = mount(<DoneAndTalkButton />)
+    const wrapper = shallow(<DoneAndTalkButton talkURL={talkURL} />)
     expect(wrapper).to.be.ok
-  })
-  
-  describe('when props.completed is true', function () {
-    it('should render null', function () {
-      const wrapper = mount(<DoneAndTalkButton completed />)
-      expect(wrapper.html()).to.be.null
-    })
   })
 
   it('should call props.onClick for the onClick event', function () {
     const onClickSpy = sinon.spy()
-    const wrapper = mount(<DoneAndTalkButton onClick={onClickSpy} />)
-    wrapper.find('button').simulate('click')
+    const wrapper = shallow(<DoneAndTalkButton onClick={onClickSpy} talkURL={talkURL} />)
+    wrapper.find('Styled(WithTheme(Button))').simulate('click')
     expect(onClickSpy.calledOnce).to.be.true
+  })
+  
+  describe('when props.completed is true', function () {
+    it('should render null', function () {
+      const wrapper = shallow(<DoneAndTalkButton completed talkURL={talkURL} />)
+      expect(wrapper.html()).to.be.null
+    })
   })
 
   describe('when props.completed is false', function () {
     it('should render a ThemeProvider', function () {
-      const wrapper = mount(<DoneAndTalkButton />)
+      const wrapper = shallow(<DoneAndTalkButton talkURL={talkURL} />)
       expect(wrapper.find('ThemeProvider')).to.have.lengthOf(1)
     })
 
     it('should render a StyledDoneAndTalkButton', function () {
-      const wrapper = mount(<DoneAndTalkButton />)
+      const wrapper = shallow(<DoneAndTalkButton talkURL={talkURL} />)
       expect(wrapper.find(StyledDoneAndTalkButton)).to.have.lengthOf(1)
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.spec.js
@@ -16,9 +16,9 @@ describe('DoneAndTalkButton', function () {
   })
 
   it('should call props.onClick for the onClick event', function () {
-    const onClickSpy = sinon.spy()
+    const onClickSpy = sinon.stub().callsFake(() => { return Promise.resolve() })
     const wrapper = shallow(<DoneAndTalkButton onClick={onClickSpy} talkURL={talkURL} />)
-    wrapper.find('Styled(WithTheme(Button))').simulate('click')
+    wrapper.find('Styled(WithTheme(Button))').simulate('click', { event: { metaKey: false }})
     expect(onClickSpy.calledOnce).to.be.true
   })
   

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.spec.js
@@ -35,28 +35,4 @@ describe('DoneAndTalkButton', function () {
       expect(wrapper.find(StyledDoneAndTalkButton)).to.have.lengthOf(1)
     })
   })
-
-  xdescribe('props.goldStandardMode', function () {
-    it('should not render a star icon if props.goldStandardMode is false', function () {
-      const wrapper = mount(<DoneAndTalkButton />)
-      expect(wrapper.find('i.fa-star')).to.have.lengthOf(0)
-    })
-
-    it('should render a star icon if props.goldStandardMode is true', function () {
-      const wrapper = mount(<DoneAndTalkButton goldStandardMode />)
-      expect(wrapper.find('i.fa-star')).to.have.lengthOf(1)
-    })
-  })
-
-  xdescribe('props.demoMode', function () {
-    it('should not render a trash icon if props.demoMode is false', function () {
-      const wrapper = mount(<DoneAndTalkButton />)
-      expect(wrapper.find('i.fa-trash')).to.have.lengthOf(0)
-    })
-
-    it('should render a trash icon if props.demoMode is true', function () {
-      const wrapper = mount(<DoneAndTalkButton demoMode />)
-      expect(wrapper.find('i.fa-trash')).to.have.lengthOf(1)
-    })
-  })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
@@ -24,10 +24,6 @@ function storeMapper(stores) {
 @inject(storeMapper)
 @observer
 class DoneAndTalkButtonContainer extends React.Component {
-  constructor () {
-    super()
-  }
-
   render () {
     const { 
       completed,
@@ -75,9 +71,13 @@ DoneAndTalkButtonContainer.wrappedComponent.propTypes = {
   disabled: PropTypes.bool,
   goldStandardMode: PropTypes.bool,
   onClick: () => {},
-  project: PropTypes.object.isRequired,
+  project: PropTypes.shape({
+    slug: PropTypes.string
+  }).isRequired,
   shouldWeShowDoneAndTalkButton: PropTypes.bool,
-  subject: PropTypes.object.isRequired
+  subject: PropTypes.shape({
+    id: PropTypes.string
+  }).isRequired
 }
 
 export default DoneAndTalkButtonContainer

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
@@ -62,7 +62,9 @@ DoneAndTalkButtonContainer.wrappedComponent.defaultProps = {
   disabled: false,
   goldStandardMode: false,
   onClick: () => {},
+  project: {},
   shouldWeShowDoneAndTalkButton: false,
+  subject: {}
 }
 
 DoneAndTalkButtonContainer.wrappedComponent.propTypes = {
@@ -73,11 +75,11 @@ DoneAndTalkButtonContainer.wrappedComponent.propTypes = {
   onClick: () => {},
   project: PropTypes.shape({
     slug: PropTypes.string
-  }).isRequired,
+  }),
   shouldWeShowDoneAndTalkButton: PropTypes.bool,
   subject: PropTypes.shape({
     id: PropTypes.string
-  }).isRequired
+  })
 }
 
 export default DoneAndTalkButtonContainer

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
@@ -39,6 +39,8 @@ class DoneAndTalkButtonContainer extends React.Component {
     const subjectId = subject && subject.id
 
     if (shouldWeShowDoneAndTalkButton && projectSlug && subjectId) {
+      const talkURL = `/projects/${projectSlug}/talk/subjects/${subjectId}`
+
       return (
         <DoneAndTalkButton
           completed={completed}
@@ -46,6 +48,7 @@ class DoneAndTalkButtonContainer extends React.Component {
           disabled={disabled}
           goldStandardMode={goldStandardMode}
           onClick={onClick}
+          talkURL={talkURL}
           projectSlug={projectSlug}
           subjectId={subjectId}
         />

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
@@ -49,8 +49,6 @@ class DoneAndTalkButtonContainer extends React.Component {
           goldStandardMode={goldStandardMode}
           onClick={onClick}
           talkURL={talkURL}
-          projectSlug={projectSlug}
-          subjectId={subjectId}
         />
       )
     }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
@@ -1,0 +1,83 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
+import DoneAndTalkButton from './DoneAndTalkButton';
+
+function storeMapper(stores) {
+  const {
+    shouldWeShowDoneAndTalkButton,
+  } = stores.classifierStore.workflowSteps
+  const {
+    active: subject
+  } = stores.classifierStore.subjects
+  const {
+    active: project
+  } = stores.classifierStore.projects
+
+  return {
+    project,
+    shouldWeShowDoneAndTalkButton,
+    subject
+  }
+}
+
+@inject(storeMapper)
+@observer
+class DoneAndTalkButtonContainer extends React.Component {
+  constructor () {
+    super()
+  }
+
+  render () {
+    const { 
+      completed,
+      demoMode,
+      disabled,
+      goldStandardMode,
+      onClick, 
+      project, 
+      shouldWeShowDoneAndTalkButton, 
+      subject 
+    } = this.props
+    const projectSlug = project && project.slug
+    const subjectId = subject && subject.id
+
+    if (shouldWeShowDoneAndTalkButton && projectSlug && subjectId) {
+      return (
+        <DoneAndTalkButton
+          completed={completed}
+          demoMode={demoMode}
+          disabled={disabled}
+          goldStandardMode={goldStandardMode}
+          onClick={onClick}
+          projectSlug={projectSlug}
+          subjectId={subjectId}
+        />
+      )
+    }
+
+    return null
+  }
+}
+
+DoneAndTalkButtonContainer.wrappedComponent.defaultProps = {
+  completed: false,
+  demoMode: false,
+  disabled: false,
+  goldStandardMode: false,
+  onClick: () => {},
+  shouldWeShowDoneAndTalkButton: false,
+}
+
+DoneAndTalkButtonContainer.wrappedComponent.propTypes = {
+  completed: PropTypes.bool,
+  demoMode: PropTypes.bool,
+  disabled: PropTypes.bool,
+  goldStandardMode: PropTypes.bool,
+  onClick: () => {},
+  project: PropTypes.object.isRequired,
+  shouldWeShowDoneAndTalkButton: PropTypes.bool,
+  subject: PropTypes.object.isRequired
+}
+
+export default DoneAndTalkButtonContainer

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.spec.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import { shallow, mount } from 'enzyme'
+import { expect } from 'chai'
+import sinon from 'sinon'
+import { ProjectFactory, SubjectFactory } from '../../../../../../../../../../../test/factories'
+import DoneAndTalkButtonContainer from './DoneAndTalkButtonContainer'
+import DoneAndTalkButton from './DoneAndTalkButton'
+
+const subject = SubjectFactory.build()
+
+const project = ProjectFactory.build()
+
+describe('DoneAndTalkButton', function () {
+  it('should render without crashing', function () {
+    const wrapper = shallow(<DoneAndTalkButtonContainer.wrappedComponent subject={subject} project={project} />)
+    expect(wrapper).to.be.ok
+  })
+
+  it('should render null if shouldWeShowDoneAndTalkButton is false', function () {
+    const wrapper = shallow(<DoneAndTalkButtonContainer.wrappedComponent subject={subject} project={project} />)
+    expect(wrapper.html()).to.be.null
+  })
+
+  it('should render null if there is no project slug', function () {
+    const wrapper = shallow(
+      <DoneAndTalkButtonContainer.wrappedComponent
+        shouldWeShowDoneAndTalkButton={true}
+        subject={subject}
+        project={{ id: '1'}}
+      />)
+    expect(wrapper.html()).to.be.null
+  })
+
+  it('should render null if there is no subject id', function () {
+    const wrapper = shallow(
+      <DoneAndTalkButtonContainer.wrappedComponent
+        shouldWeShowDoneAndTalkButton={true}
+        subject={{ metadata: { myId: 5 }}}
+        project={project}
+      />)
+    expect(wrapper.html()).to.be.null
+  })
+
+  it('should render DoneAndTalkButton component if shouldWeShowDoneAndTalkButton is true', function () {
+    const wrapper = shallow(
+      <DoneAndTalkButtonContainer.wrappedComponent
+        shouldWeShowDoneAndTalkButton={true}
+        subject={subject}
+        project={project} 
+      />
+    )
+    expect(wrapper.find(DoneAndTalkButton)).to.have.lengthOf(1)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './DoneAndTalkButton'

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/index.js
@@ -1,1 +1,1 @@
-export { default } from './DoneAndTalkButton'
+export { default } from './DoneAndTalkButtonContainer'

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/locales/en.json
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/locales/en.json
@@ -1,0 +1,5 @@
+{
+  "DoneAndTalkButton": {
+    "doneAndTalk": "done & talk"
+  }
+}

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneButton/DoneButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneButton/DoneButton.js
@@ -20,11 +20,10 @@ export const StyledDoneButton = styled(Button)`
     dark: `solid thin ${zooTheme.global.colors['dark-5']}`,
     light: `solid thin ${green}`
   })};
+  box-shadow: none;
   color: white;
-  cursor: pointer;
   flex: 3 0;
-  font-size: 0.9em;
-  padding: 0.9em;
+  padding: 0.5em;
   text-transform: capitalize;
 
   > i {
@@ -40,24 +39,12 @@ export const StyledDoneButton = styled(Button)`
     dark: `solid thin ${zooTheme.global.colors['dark-5']}`,
     light: `solid thin ${darken(0.15, green)}`
   })};
+  box-shadow: none;
     color: 'white';
   }
 
   &:disabled {
-    background: ${theme('mode', {
-    dark: lighten(0.05, zooTheme.global.colors['dark-1']),
-    light: lighten(0.05, green)
-  })};
-    border: ${theme('mode', {
-    dark: `solid thin ${zooTheme.global.colors['dark-5']}`,
-    light: `solid thin ${lighten(0.05, green)}`
-  })};
-    color: ${theme('mode', {
-    dark: zooTheme.global.colors.text.dark,
-    light: zooTheme.global.colors['light-1']
-  })};
     cursor: not-allowed;
-    opacity: 0.5;
   }
   `
 // TODO add back gold standard and demo buttons using grommet Button icon prop

--- a/packages/lib-classifier/src/store/Classification.js
+++ b/packages/lib-classifier/src/store/Classification.js
@@ -21,6 +21,7 @@ const ClassificationMetadata = types.model('ClassificationMetadata', {
     selection_state: types.maybe(types.string),
     user_has_finished_workflow: types.optional(types.boolean, false)
   }),
+  subject_flagged: types.optional(types.boolean, false),
   userAgent: types.optional(types.string, navigator.userAgent),
   userLanguage: types.string,
   utcOffset: types.optional(types.string, ((new Date()).getTimezoneOffset() * 60).toString()),

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -165,7 +165,7 @@ const ClassificationStore = types
       self.onComplete(classification.toJSON(), subject.toJSON())
 
       console.log('Completed classification', classificationToSubmit)
-      self.submitClassification(classificationToSubmit)
+      return self.submitClassification(classificationToSubmit)
     }
 
     function onClassificationSaved (savedClassification) {

--- a/packages/lib-classifier/src/store/Project.js
+++ b/packages/lib-classifier/src/store/Project.js
@@ -6,7 +6,7 @@ const Project = types
     configuration: types.frozen({}),
     display_name: types.string,
     experimental_tools: types.frozen([]),
-    links: types.frozen({})
+    slug: types.string
   })
 
 export default types.compose('ProjectResource', Resource, Project)

--- a/packages/lib-classifier/src/store/Project.js
+++ b/packages/lib-classifier/src/store/Project.js
@@ -6,6 +6,7 @@ const Project = types
     configuration: types.frozen({}),
     display_name: types.string,
     experimental_tools: types.frozen([]),
+    links: types.frozen({}),
     slug: types.string
   })
 

--- a/packages/lib-classifier/src/store/Project.spec.js
+++ b/packages/lib-classifier/src/store/Project.spec.js
@@ -12,7 +12,8 @@ const stub = {
     arrayLink: [
       'foobar'
     ]
-  }
+  },
+  slug: 'zooniverse/foobar'
 }
 
 describe('Model > Project', function () {
@@ -34,5 +35,9 @@ describe('Model > Project', function () {
 
   it('should have a `links` property', function () {
     expect(model.links).to.deep.equal(stub.links)
+  })
+  
+  it('should have a `slug` property', function () {
+    expect(model.slug).to.deep.equal(stub.slug)
   })
 })

--- a/packages/lib-classifier/src/store/Workflow.js
+++ b/packages/lib-classifier/src/store/Workflow.js
@@ -5,7 +5,9 @@ import Resource from './Resource'
 // Steps will be stored as an array of pairs to preserve order.
 const Workflow = types
   .model('Workflow', {
-    configuration: types.frozen({}),
+    configuration: types.frozen({
+      hide_classification_summaries: types.optional(types.boolean, false)
+    }),
     display_name: types.string,
     first_task: types.maybe(types.string),
     steps: types.union(types.frozen({}), types.array(types.array(

--- a/packages/lib-classifier/src/store/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.js
@@ -43,7 +43,19 @@ const WorkflowStepStore = types
     },
     
     get shouldWeShowDoneAndTalkButton () {
-      return true  // TEST
+      const isThereANextStep = self.isThereANextStep()
+      const workflow = getRoot(self).workflows.active
+      const classification = getRoot(self).classifications.active
+
+      if (workflow && classification) {
+        const disableTalk = classification.metadata.subject_flagged
+        return !isThereANextStep &&
+        workflow.configuration.hide_classification_summaries && // TODO: we actually want to reverse this logic
+        !disableTalk //&&
+        // !completed TODO: implement classification completed validations per task?
+      }
+
+      return false
     }
   }))
   .actions(self => {

--- a/packages/lib-classifier/src/store/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.js
@@ -42,7 +42,7 @@ const WorkflowStepStore = types
       return tasks.some(task => task.help)
     },
     
-    shouldWeShowDoneAndTalkButton () {
+    get shouldWeShowDoneAndTalkButton () {
       return true  // TEST
     }
   }))

--- a/packages/lib-classifier/src/store/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.js
@@ -40,6 +40,10 @@ const WorkflowStepStore = types
       const tasks = self.activeStepTasks
 
       return tasks.some(task => task.help)
+    },
+    
+    shouldWeShowDoneAndTalkButton () {
+      return true  // TEST
     }
   }))
   .actions(self => {

--- a/packages/lib-classifier/test/factories/ClassificationFactory.js
+++ b/packages/lib-classifier/test/factories/ClassificationFactory.js
@@ -1,0 +1,11 @@
+import { Factory } from 'rosie'
+
+export default new Factory()
+  .sequence('id', (id) => { return id.toString() })
+  .attr('display_name', ['id'], function (id) {
+    return `Workflow #${id}`
+  })
+  .attr('annotations', [])
+  .attr('completed', false)
+  .attr('links', {})
+  .attr('metadata', {})

--- a/packages/lib-classifier/test/factories/ProjectFactory.js
+++ b/packages/lib-classifier/test/factories/ProjectFactory.js
@@ -14,3 +14,4 @@ export default new Factory()
       workflows: [workflowId]
     }
   })
+  .attr('slug', 'zooniverse/example')

--- a/packages/lib-classifier/test/factories/index.js
+++ b/packages/lib-classifier/test/factories/index.js
@@ -9,3 +9,4 @@ export { default as SingleChoiceTaskFactory } from './tasks/SingleChoiceTaskFact
 export { default as TutorialFactory } from './TutorialFactory'
 export { default as UPPFactory } from './UPPFactory'
 export { default as UserFactory } from './UserFactory'
+export { default as ClassificationFactory } from './ClassificationFactory'


### PR DESCRIPTION
## PR Overview

package: `lib-classifier`
Closes #383 

This PR adds a **"Done & Talk"** button the the Classifier.
- The "Done & Talk" button appears at the final step of the Classification process.
- Clicking on the button **submits the Classification** AND **opens a new window/tab** to the Talk page, featuring the Subject that was just classified.
- ⚠️ currently, the "Done & Talk" button always appears, regardless of the workflow configuration and whether the Talk board has been set up. I'm considering whether I should use the [PFE implementation](https://github.com/zooniverse/Panoptes-Front-End/blob/96959d42d2a2228b35b99d1d7b2a2d5c7b2a62e4/app/classifier/task-nav.jsx#L94), but I'm still trying to wrap my head around the "check if Talk board has been disabled by looking at `classification.metadata.subject_flagged`"_ logic.
  ```
  // Panoptes-Front-End: app/classifier/task-nav.jsx
  const showDoneAndTalkLink = !nextTaskKey &&
    this.props.workflow.configuration.hide_classification_summaries &&
    this.props.project &&
     !disableTalk &&  // disableTalk = this.props.classification.metadata.subject_flagged
    !completed;
  ```
- ⚠️ when testing this feature, the new tab opens to an invalid path, e.g. `http://localhost:8080/projects/brooke/i-fancy-cats/talk/subjects/4212`, but that's because `lib-classifier` isn't hooked up to the (non-existent) `Talk` system yet.
  - To proper testing, manually change the host in the new tab from, e.g., `http://localhost:8080` to `http://master.pfe-preview.zooniverse.org`

Collateral updates:
- the `Project` resource now has the `slug` attribute.

### Implementation Notes

![screen shot 2019-03-01 at 15 42 17](https://user-images.githubusercontent.com/13952701/53649870-1b48be80-3c3b-11e9-8b96-84ec938b0206.png)
_Baseline: the "Talk" button on PFE, appears after the final Task in the Workflow_

![screen shot 2019-03-01 at 15 42 37](https://user-images.githubusercontent.com/13952701/53649887-27348080-3c3b-11e9-90e2-dee6750c60ee.png)
_New feature: the "Done & Talk" button on the monorepo's lib-classifier, appears during the final Task in the Workflow_

**Functionality:**
- the previous "Talk" button is a Link that navigated the _current browser window_ to the Talk page.
- the new "Done & Talk" button is a functional Button that performs the same "submit Classification" action as the "Done" button, plus opens a new window/tab to the Talk page.
- this functional change was made because the new monorepo Classifier **does not have a "Summary page"** that is shown when a Classification is submitted (i.e. after the final Task of the Workflow), and is instead shown _during_ the final Task of the Workflow.

**Design:**
- the previous Talk button in PFE uses a distinct blue colour ( `#43bbfd` ) that's separate from the known Theme colours. If somebody wants to correct me on this based on our current [theme palette](https://projects.invisionapp.com/dsm/zooniverse/primary-brand/folder/colors/5bbd0dbcd018e900118186e8), please let me know.

### Status

Ready for review. Special tag for @beckyrother to confirm that the "Done & Talk" UX is in order.