### PR TITLE
Set default annotation on Done button submit

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskInputField/TaskInputField.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskInputField/TaskInputField.js
@@ -143,7 +143,7 @@ export function TaskInputField (props) {
       >
         <input
           autoFocus={autoFocus}
-          defaultChecked={checked}
+          checked={checked}
           name={name}
           onChange={onChange}
           type={type}

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
@@ -49,7 +49,7 @@ export default function TaskNavButtons (props) {
         demoMode={props.demoMode}
         flex='grow'
         goldStandardMode={props.classification ? props.classification.goldStandard : false}
-        onClick={props.completeClassification}
+        onClick={props.onSubmit}
         disabled={props.waitingForAnswer}
       />
     </Box>
@@ -62,11 +62,11 @@ TaskNavButtons.defaultProps = {
   completed: false,
   demoMode: false,
   goToPreviousStep: () => {},
+  onSubmit: () => {},
   nextSubject: () => {},
   showBackButton: false,
   showNextButton: false,
   showDoneAndTalkLink: false,
-  completeClassification: () => {},
   waitingForAnswer: false
 }
 
@@ -77,9 +77,9 @@ TaskNavButtons.propTypes = {
   demoMode: PropTypes.bool,
   goToPreviousStep: PropTypes.func,
   nextSubject: PropTypes.func,
+  onSubmit: PropTypes.func,
   showBackButton: PropTypes.bool,
   showNextButton: PropTypes.bool,
   showDoneAndTalkLink: PropTypes.bool,
-  completeClassification: PropTypes.func,
   waitingForAnswer: PropTypes.bool
 }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.spec.js
@@ -23,7 +23,7 @@ describe('TaskNavButtons', function () {
   describe('when props.showNextButton is true', function () {
     let wrapper
     before(function () {
-      wrapper = mount(<TaskNavButtons classification={classification} project={project} subject={subject} showNextButton />)
+      wrapper = mount(<TaskNavButtons classification={classification} goToNextStep={() => {}} project={project} subject={subject} showNextButton />)
     })
 
     it('should render a NextButton component', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.js
@@ -42,7 +42,6 @@ class TaskNavButtonsContainer extends React.Component {
       tasks.forEach((task) => {
         // User didn't submit annotation and task is not required
         // Create the default annotation before going to the next step
-        // console.log(classification.annotations, task.taskKey, classification.annotations.get(task.taskKey))
         if (classification.annotations && !(classification.annotations.get(task.taskKey))) {
           createDefaultAnnotation(task)
         }
@@ -74,15 +73,22 @@ class TaskNavButtonsContainer extends React.Component {
     selectStep()
   }
 
+ onSubmit (event) {
+    event.preventDefault()
+    const { completeClassification } = this.props
+    this.createDefaultAnnotationIfThereIsNone()
+    completeClassification()
+  }
+
   render () {
-    const { isThereANextStep, isThereAPreviousStep, completeClassification } = this.props
+    const { isThereANextStep, isThereAPreviousStep } = this.props
     return (
       <TaskNavButtons
         goToNextStep={this.goToNextStep.bind(this)}
         goToPreviousStep={this.goToPreviousStep.bind(this)}
         showBackButton={isThereAPreviousStep()}
         showNextButton={isThereANextStep()}
-        completeClassification={completeClassification}
+        onSubmit={this.onSubmit.bind(this)}
       />
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.spec.js
@@ -141,7 +141,7 @@ describe('TaskNavButtonsContainer', function () {
     })
   })
 
-  describe('#createDefaultAnnoationIfThereIsNone', function () {
+  describe('#createDefaultAnnotationIfThereIsNone', function () {
     let wrapper
     let createDefaultAnnotationSpy
 
@@ -183,6 +183,56 @@ describe('TaskNavButtonsContainer', function () {
       wrapper.setProps({ classification: { annotations } })
       wrapper.instance().createDefaultAnnotationIfThereIsNone()
       expect(createDefaultAnnotationSpy.notCalled).to.be.true
+    })
+  })
+
+  describe('#onSubmit', function () {
+    let wrapper
+    let completeClassificationSpy
+    let createDefaultAnnotationIfThereIsNoneSpy
+    let onSubmitSpy
+    const preventDefaultSpy = sinon.spy()
+
+    before(function () {
+      completeClassificationSpy = sinon.spy()
+      createDefaultAnnotationIfThereIsNoneSpy = sinon.spy(TaskNavButtonsContainer.wrappedComponent.prototype, 'createDefaultAnnotationIfThereIsNone')
+      onSubmitSpy = sinon.spy(TaskNavButtonsContainer.wrappedComponent.prototype, 'onSubmit')
+
+      wrapper = shallow(
+        <TaskNavButtonsContainer.wrappedComponent
+          completeClassification={completeClassificationSpy}
+          isThereAPreviousStep={() => { }}
+          isThereANextStep={() => { }}
+          tasks={tasks}
+        />
+      )
+    })
+
+    afterEach(function () {
+      completeClassificationSpy.resetHistory()
+      createDefaultAnnotationIfThereIsNoneSpy.resetHistory()
+      onSubmitSpy.resetHistory()
+      preventDefaultSpy.resetHistory()
+    })
+
+    after(function () {
+      createDefaultAnnotationIfThereIsNoneSpy.restore()
+      onSubmitSpy.restore()
+    })
+
+    it('should prevent the event default', function () {
+      wrapper.instance().onSubmit({ preventDefault: preventDefaultSpy })
+      expect(preventDefaultSpy).to.have.been.calledOnce
+    })
+
+    it('should call createDefaultAnnotationIfThereIsNone', function () {
+      wrapper.instance().onSubmit({ preventDefault: preventDefaultSpy })
+      expect(createDefaultAnnotationIfThereIsNoneSpy).to.have.been.calledOnce
+    })
+
+    it('should call completeClassification', function () {
+      wrapper.instance().onSubmit({ preventDefault: preventDefaultSpy })
+      expect(completeClassificationSpy).to.have.been.calledOnce
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/NextButton/NextButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/NextButton/NextButton.js
@@ -58,18 +58,6 @@ export const StyledNextButton = styled(Button)`
   }
 
   &:disabled {
-    ${'' /* background: ${theme('mode', {
-      dark: zooTheme.dark.colors.background.default,
-      light: zooTheme.global.colors.lightGold
-    })};
-    border: ${theme('mode', {
-      dark: `solid thin ${zooTheme.global.colors.gold}`,
-      light: `solid thin ${zooTheme.global.colors.gold}`
-    })};
-    color: ${theme('mode', {
-      dark: zooTheme.global.colors.gold,
-      light: 'black'
-    })}; */}
     cursor: not-allowed;
   }
   `

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -14,7 +14,6 @@ import {
   convertMapToArray,
   sessionUtils
 } from './utils'
-import { isServiceWorkerAvailable, isBackgroundSyncAvailable } from '../helpers/featureDetection'
 
 const ClassificationStore = types
   .model('ClassificationStore', {
@@ -128,8 +127,7 @@ const ClassificationStore = types
       if (classification && !isPersistAnnotationsSet) classification.annotations.delete(taskKey)
     }
 
-    function completeClassification (event) {
-      event.preventDefault()
+    function completeClassification () {
       const classification = self.active
       // TODO store intervention metadata if we have a user...
       self.updateClassificationMetadata({


### PR DESCRIPTION
Package: lib-classifier

Closes #513 and closes #514 .

Describe your changes:
- I created an onSubmit event handler for the done button which handles adding a default annotation before calling to complete the classification. 
- Switch the TaskInputField to use `checked` instead of `defaultChecked` which is why the task appeared to have an annotation for new subjects and classifications. The store was correctly resetting the classification and annotations, just the UI was not displaying the checked state correctly.
- Updates tests and fixes a missing prop warning for the NextButton tests.
- Removes some cruft

When testing in the app-project, I didn't see that MST warning anymore, so I think this was related to #514 and thus I'm saying it's resolved too. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

