### PR TITLE
Remove page tests, and re-export page components

### DIFF
--- a/packages/app-project/pages/About.spec.js
+++ b/packages/app-project/pages/About.spec.js
@@ -1,9 +1,0 @@
-import { shallow } from 'enzyme'
-
-import About from './About'
-
-describe('Page > About', function () {
-  it('should render without crashing', function () {
-    shallow(<About />)
-  })
-})

--- a/packages/app-project/pages/Classify.js
+++ b/packages/app-project/pages/Classify.js
@@ -1,5 +1,1 @@
-import React from 'react'
-
-import ClassifyPage from '../src/screens/ClassifyPage'
-
-export default () => <ClassifyPage />
+export { default } from '../src/screens/ClassifyPage'

--- a/packages/app-project/pages/Classify.spec.js
+++ b/packages/app-project/pages/Classify.spec.js
@@ -1,9 +1,0 @@
-import { shallow } from 'enzyme'
-
-import Classify from './Classify'
-
-describe('Page > Classify', function () {
-  it('should render without crashing', function () {
-    shallow(<Classify />)
-  })
-})

--- a/packages/app-project/pages/Home.js
+++ b/packages/app-project/pages/Home.js
@@ -1,5 +1,1 @@
-import React from 'react'
-
-import ProjectHomePage from '../src/screens/ProjectHomePage'
-
-export default () => <ProjectHomePage />
+export { default } from '../src/screens/ProjectHomePage'

--- a/packages/app-project/pages/Home.spec.js
+++ b/packages/app-project/pages/Home.spec.js
@@ -1,9 +1,0 @@
-import { shallow } from 'enzyme'
-
-import Home from './Home'
-
-describe('Page > Home', function () {
-  it('should render without crashing', function () {
-    shallow(<Home />)
-  })
-})

--- a/packages/app-project/pages/Index.spec.js
+++ b/packages/app-project/pages/Index.spec.js
@@ -1,9 +1,0 @@
-import { shallow } from 'enzyme'
-
-import Index from './Index'
-
-describe('Page > Index', function () {
-  it('should render without crashing', function () {
-    shallow(<Index />)
-  })
-})


### PR DESCRIPTION
Package: app-project

Removes the test files from the `pages` directory, since Next.js has a non-configurable behaviour that builds _everything_ in that folder into the production bundles, and re-exports the page components from the src directory in the remaining pages files (which should be tested).