### PR TITLE
Set active tutorial depending on UPP state

### DIFF
--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -104,7 +104,7 @@ const TutorialStore = types
       const uppDisposer = autorun(() => {
         const upp = getRoot(self).userProjectPreferences
         if (upp.loadingState === asyncStates.success) {
-          self.shouldTutorialBeShown()
+          self.showTutorialInModal()
         }
       })
       addDisposer(self, uppDisposer)
@@ -145,7 +145,7 @@ const TutorialStore = types
           tutorials.forEach(tutorial => self.fetchMedia(tutorial))
           self.setTutorials(tutorials)
           if (upp.loadingState === asyncStates.success) {
-            self.shouldTutorialBeShown()
+            self.showTutorialInModal()
           }
         }
         self.loadingState = asyncStates.success
@@ -172,6 +172,7 @@ const TutorialStore = types
 
     function setActiveTutorial (id, stepIndex) {
       if (!id) return self.resetActiveTutorial()
+      console.log('calling setActiveTutorial')
       self.active = id
       self.setTutorialStep(stepIndex)
       self.setSeenTime()
@@ -209,12 +210,15 @@ const TutorialStore = types
     }
 
     function setModalVisibility (boolean) {
+      console.log('calling setModalVisibility')
       self.showModal = boolean
     }
 
-    function shouldTutorialBeShown() {
+    function showTutorialInModal() {
       const { tutorial } = self
+      console.log('tutorial', tutorial)
       if (tutorial && self.hasNotSeenTutorialBefore) {
+        console.log('has not seen before')
         self.setActiveTutorial(tutorial.id)
         self.setModalVisibility(true)
       }
@@ -232,7 +236,7 @@ const TutorialStore = types
       setTutorialStep,
       setTutorials,
       setModalVisibility,
-      shouldTutorialBeShown
+      showTutorialInModal
     }
   })
 

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -13,7 +13,7 @@ const TutorialStore = types
     attachedMedia: types.map(Medium),
     resources: types.map(Tutorial),
     tutorialSeenTime: types.maybe(types.string),
-    miniCourseSeenTime: types.maybe(types.string),
+    showModal: types.optional(types.boolean, false),
     type: types.optional(types.string, 'tutorials')
   })
 
@@ -40,24 +40,52 @@ const TutorialStore = types
       }
 
       return null
+    },
+
+    get miniCourse() {
+      if (tutorials) {
+        return tutorials.find((tutorial) => {
+          return tutorial.kind === 'mini-course'
+        })
+      }
+
+      return null
+    },
+
+    get hasNotSeenTutorialBefore() {
+      const upp = getRoot(self).userProjectPreferences.active
+      const { tutorial } = self
+      if (upp && tutorial) {
+        return !(upp.preferences.tutorials_completed_at && upp.preferences.tutorials_completed_at[tutorial.id])
+      }
+
+      return true
+    },
+
+    get tutorialLastSeen() {
+      const upp = getRoot(self).userProjectPreferences.active
+      const { tutorial } = self
+
+      if (upp && upp.preferences.tutorials_completed_at && tutorial) {
+        return upp.preferences.tutorials_completed_at[tutorial.id]
+      }
+
+      return null
+    },
+
+    isMiniCourseCompleted (lastStepSeen) {
+      const { miniCourse } = self
+
+      if (miniCourse) return lastStepSeen === miniCourse.steps.length - 1
+
+      return false
     }
-
-    // Stubbed out getter for returning the linked mini-course if there is one
-    // Uncomment this to use when minicourse UI is added
-    // get miniCourse() {
-    // if (tutorials) {
-    //   return tutorials.find((tutorial) => {
-    //     return tutorial.kind === 'mini-course'
-    //   })
-    // }
-
-    // return null
-    // }
   }))
 
   .actions(self => {
     function afterAttach () {
       createWorkflowObserver()
+      createUPPObserver()
     }
 
     function createWorkflowObserver () {
@@ -70,6 +98,16 @@ const TutorialStore = types
         }
       })
       addDisposer(self, workflowDisposer)
+    }
+
+    function createUPPObserver() {
+      const uppDisposer = autorun(() => {
+        const upp = getRoot(self).userProjectPreferences
+        if (upp.loadingState === asyncStates.success) {
+          self.shouldTutorialBeShown()
+        }
+      })
+      addDisposer(self, uppDisposer)
     }
 
     function * fetchMedia (tutorial) {
@@ -97,6 +135,8 @@ const TutorialStore = types
     function * fetchTutorials () {
       const workflow = getRoot(self).workflows.active
       const tutorialsClient = getRoot(self).client.tutorials
+      const upp = getRoot(self).userProjectPreferences
+
       self.loadingState = asyncStates.loading
       try {
         const response = yield tutorialsClient.get({ workflowId: workflow.id })
@@ -104,6 +144,9 @@ const TutorialStore = types
         if (tutorials && tutorials.length > 0) {
           tutorials.forEach(tutorial => self.fetchMedia(tutorial))
           self.setTutorials(tutorials)
+          if (upp.loadingState === asyncStates.success) {
+            self.shouldTutorialBeShown()
+          }
         }
         self.loadingState = asyncStates.success
       } catch (error) {
@@ -129,22 +172,28 @@ const TutorialStore = types
 
     function setActiveTutorial (id, stepIndex) {
       if (!id) return self.resetActiveTutorial()
-
       self.active = id
       self.setTutorialStep(stepIndex)
       self.setSeenTime()
     }
 
     function setSeenTime () {
+      const uppStore = getRoot(self).userProjectPreferences
       const tutorial = self.active
       const seen = new Date().toISOString()
       if (tutorial) {
         if (tutorial.kind === 'tutorial' || tutorial.kind === null) {
           self.tutorialSeenTime = seen
-        }
-
-        if (tutorial.kind === 'mini-course') {
-          self.miniCourseSeenTime = seen
+          if (uppStore.active) {
+            const changes = {
+              preferences: {
+                tutorials_completed_at: {
+                  [tutorial.id]: seen
+                }
+              }
+            }
+            uppStore.updateUPP(changes)
+          }
         }
       }
     }
@@ -155,14 +204,19 @@ const TutorialStore = types
       self.activeMedium = undefined
     }
 
-    function resetSeen (type) {
-      if (type === 'tutorial') {
-        self.tutorialSeenTime = undefined
-      } else if (type === 'mini-course') {
-        self.miniCourseSeenTime = undefined
-      } else {
-        self.tutorialSeenTime = undefined
-        self.miniCourseSeenTime = undefined
+    function resetSeen () {
+      self.tutorialSeenTime = undefined
+    }
+
+    function setModalVisibility (boolean) {
+      self.showModal = boolean
+    }
+
+    function shouldTutorialBeShown() {
+      const { tutorial } = self
+      if (tutorial && self.hasNotSeenTutorialBefore) {
+        self.setActiveTutorial(tutorial.id)
+        self.setModalVisibility(true)
       }
     }
 
@@ -176,7 +230,9 @@ const TutorialStore = types
       setMediaResources,
       setSeenTime,
       setTutorialStep,
-      setTutorials
+      setTutorials,
+      setModalVisibility,
+      shouldTutorialBeShown
     }
   })
 

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -172,7 +172,6 @@ const TutorialStore = types
 
     function setActiveTutorial (id, stepIndex) {
       if (!id) return self.resetActiveTutorial()
-      console.log('calling setActiveTutorial')
       self.active = id
       self.setTutorialStep(stepIndex)
       self.setSeenTime()
@@ -210,15 +209,12 @@ const TutorialStore = types
     }
 
     function setModalVisibility (boolean) {
-      console.log('calling setModalVisibility')
       self.showModal = boolean
     }
 
     function showTutorialInModal() {
       const { tutorial } = self
-      console.log('tutorial', tutorial)
       if (tutorial && self.hasNotSeenTutorialBefore) {
-        console.log('has not seen before')
         self.setActiveTutorial(tutorial.id)
         self.setModalVisibility(true)
       }

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -2,22 +2,28 @@ import sinon from 'sinon'
 import asyncStates from '@zooniverse/async-states'
 
 import RootStore from './RootStore'
+import ProjectStore from './ProjectStore'
 import TutorialStore from './TutorialStore'
 import WorkflowStore from './WorkflowStore'
 import {
+  ProjectFactory,
   TutorialFactory,
   TutorialMediumFactory,
-  WorkflowFactory
+  WorkflowFactory,
+  UPPFactory,
+  UserFactory
 } from '../../test/factories'
 import stubPanoptesJs from '../../test/stubPanoptesJs'
 
 let rootStore
+const seenMock = new Date().toISOString()
+const token = '1235'
 
-const workflow = WorkflowFactory.build()
-
-const panoptesClient = stubPanoptesJs({ workflows: workflow })
-
+const user = UserFactory.build()
+const project = ProjectFactory.build()
+const workflow = WorkflowFactory.build({ id: project.configuration.default_workflow })
 const medium = TutorialMediumFactory.build()
+
 const tutorial = TutorialFactory.build({ steps: [
   { content: '# Hello', media: medium.id },
   { content: '# Step 2' }
@@ -42,6 +48,17 @@ const tutorialMiniCourseKind = TutorialFactory.build(
     kind: 'mini-course'
   }
 )
+
+const upp = UPPFactory.build()
+const uppWithTutorialTimeStamp = UPPFactory.build({ 
+  preferences: {
+    tutorials_completed_at: {
+      [tutorial.id]: seenMock 
+    }
+  }
+})
+
+const panoptesClient = stubPanoptesJs({ project_preferences: upp, workflows: workflow })
 
 const clientStub = (tutorialResource = tutorial) => {
   return Object.assign({}, panoptesClient, {
@@ -74,7 +91,7 @@ const authClientStubWithUser = {
   checkBearerToken: sinon.stub().callsFake(() => Promise.resolve(token))
 }
 
-describe('Model > TutorialStore', function () {
+describe.only('Model > TutorialStore', function () {
   it('should exist', function () {
     expect(TutorialStore).to.be.an('object')
   })
@@ -373,46 +390,18 @@ describe('Model > TutorialStore', function () {
   })
 
   describe('Actions > resetSeen', function () {
-    it('should reset only the tutorial seen time if the resource is a tutorial', function () {
+    it('should reset the tutorial seen time when a new workflow loads', function (done) {
       const seen = new Date().toISOString()
       rootStore = RootStore.create({
-        tutorials: TutorialStore.create({ tutorialSeenTime: seen, miniCourseSeenTime: seen }),
+        tutorials: TutorialStore.create({ tutorialSeenTime: seen }),
         workflows: WorkflowStore.create()
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
 
-      rootStore.tutorials.resetSeen('tutorial')
-      expect(rootStore.tutorials.tutorialSeenTime).to.be.undefined
-      expect(rootStore.tutorials.miniCourseSeenTime).to.equal(seen)
-    })
-
-    it('should reset only the mini-course seen time if the resource is a mini-course', function () {
-      const seen = new Date().toISOString()
-      rootStore = RootStore.create({
-        tutorials: TutorialStore.create({ tutorialSeenTime: seen, miniCourseSeenTime: seen }),
-        workflows: WorkflowStore.create()
-      }, {
-        authClient: authClientStubWithoutUser, client: clientStub()
-      })
-
-      rootStore.tutorials.resetSeen('mini-course')
-      expect(rootStore.tutorials.tutorialSeenTime).to.equal(seen)
-      expect(rootStore.tutorials.miniCourseSeenTime).to.be.undefined
-    })
-
-    it('should reset both seen times if there is no defined kind', function () {
-      const seen = new Date().toISOString()
-      rootStore = RootStore.create({
-        tutorials: TutorialStore.create({ tutorialSeenTime: seen, miniCourseSeenTime: seen }),
-        workflows: WorkflowStore.create()
-      }, {
-        authClient: authClientStubWithoutUser, client: clientStub()
-      })
-
-      rootStore.tutorials.resetSeen()
-      expect(rootStore.tutorials.tutorialSeenTime).to.be.undefined
-      expect(rootStore.tutorials.miniCourseSeenTime).to.be.undefined
+      rootStore.workflows.setActive(workflow.id).then(() => {
+        expect(rootStore.tutorials.tutorialSeenTime).to.be.undefined
+      }).then(done, done)
     })
   })
 
@@ -427,7 +416,6 @@ describe('Model > TutorialStore', function () {
 
       rootStore.tutorials.setSeenTime()
       expect(rootStore.tutorials.tutorialSeenTime).to.be.undefined
-      expect(rootStore.tutorials.miniCourseSeenTime).to.be.undefined
     })
 
     it('should set the seen time for the tutorial kind of tutorial resource', function (done) {
@@ -459,19 +447,64 @@ describe('Model > TutorialStore', function () {
         expect(rootStore.tutorials.tutorialSeenTime).to.be.a('string')
       }).then(done, done)
     })
+  })
 
-    it('should set the seen time for the mini-course kind of tutorial resource', function (done) {
+  describe('Actions > setModalVisibility', function () {
+    it('should set the modal visibility', function () {
       rootStore = RootStore.create({
         tutorials: TutorialStore.create(),
         workflows: WorkflowStore.create()
       }, {
-        authClient: authClientStubWithoutUser, client: clientStub(tutorialMiniCourseKind)
+        authClient: authClientStubWithoutUser, client: clientStub()
       })
 
-      rootStore.workflows.setActive(workflow.id).then(() => {
-        rootStore.tutorials.setActiveTutorial(tutorialMiniCourseKind.id)
-      }).then(() => {
-        expect(rootStore.tutorials.miniCourseSeenTime).to.be.a('string')
+      rootStore.tutorials.setModalVisibility(true)
+      expect(rootStore.tutorials.showModal).to.be.true
+      rootStore.tutorials.setModalVisibility(false)
+      expect(rootStore.tutorials.showModal).to.be.false
+    })
+  })
+
+  describe('Actions > shouldTutorialBeShown', function (done) {
+    it('should show the tutorial for logged out users', function () {
+      rootStore = RootStore.create({
+        projects: ProjectStore.create(),
+        tutorials: TutorialStore.create(),
+        workflows: WorkflowStore.create()
+      }, {
+        authClient: authClientStubWithoutUser, client: clientStub()
+      })
+
+      rootStore.projects.setResource(project)
+      rootStore.projects.setActive(project.id).then(() => {
+        expect(rootStore.tutorials.active).to.deep.equal(tutorial)
+        expect(rootStore.tutorials.showModal).to.be.true
+      }).then(done, done)
+    })
+
+    it('should show the tutorial for logged in users without a seen timestamp for the loaded tutorial', function () {
+      rootStore = RootStore.create({}, {
+        authClient: authClientStubWithUser, client: clientStub()
+      })
+
+      rootStore.projects.setResource(project)
+      rootStore.projects.setActive(project.id)
+      Promise.resolve(rootStore.userProjectPreferences.setUPP(upp)).then(() => {
+        expect(rootStore.tutorials.active).to.deep.equal(tutorial)
+        expect(rootStore.tutorials.showModal).to.be.true
+      }).then(done, done)
+    })
+
+    it.only('should not show the tutorial for logged in users with a seen timestamp for the loaded tutorial', function () {
+      rootStore = RootStore.create({}, {
+        authClient: authClientStubWithUser, client: clientStub()
+      })
+
+      rootStore.projects.setResource(project)
+      rootStore.projects.setActive(project.id)
+      Promise.resolve(rootStore.userProjectPreferences.setUPP(uppWithTutorialTimeStamp)).then(() => {
+        expect(rootStore.tutorials.active).to.be.undefined
+        expect(rootStore.tutorials.showModal).to.be.false
       }).then(done, done)
     })
   })

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -465,8 +465,8 @@ describe.only('Model > TutorialStore', function () {
     })
   })
 
-  describe('Actions > shouldTutorialBeShown', function (done) {
-    it('should show the tutorial for logged out users', function () {
+  describe.only('Actions > showTutorialInModal', function () {
+    it('should show the tutorial for logged out users', function (done) {
       rootStore = RootStore.create({
         projects: ProjectStore.create(),
         tutorials: TutorialStore.create(),
@@ -474,37 +474,60 @@ describe.only('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
+      const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
+      const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id).then(() => {
-        expect(rootStore.tutorials.active).to.deep.equal(tutorial)
-        expect(rootStore.tutorials.showModal).to.be.true
+        expect(setActiveTutorialSpy).to.have.been.calledOnceWith(tutorial.id)
+        expect(setModalVisibilitySpy).to.have.been.calledOnce
+        // expect(rootStore.tutorials.active).to.deep.equal(tutorial)
+        // expect(rootStore.tutorials.showModal).to.be.true
+      }).then(() => {
+        setActiveTutorialSpy.restore()
+        setModalVisibilitySpy.restore()
       }).then(done, done)
     })
 
-    it('should show the tutorial for logged in users without a seen timestamp for the loaded tutorial', function () {
+    it.only('should show the tutorial for logged in users without a seen timestamp for the loaded tutorial', function (done) {
       rootStore = RootStore.create({}, {
         authClient: authClientStubWithUser, client: clientStub()
       })
+      const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
+      const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
-      Promise.resolve(rootStore.userProjectPreferences.setUPP(upp)).then(() => {
-        expect(rootStore.tutorials.active).to.deep.equal(tutorial)
-        expect(rootStore.tutorials.showModal).to.be.true
-      }).then(done, done)
+      rootStore.userProjectPreferences.setUPP(upp)
+      Promise.resolve()
+        .then(() => {
+          expect(setActiveTutorialSpy).to.have.been.calledOnceWith(tutorial.id)
+          expect(setModalVisibilitySpy).to.have.been.calledOnce
+          // expect(rootStore.tutorials.active).to.deep.equal(tutorial)
+          // expect(rootStore.tutorials.showModal).to.be.true
+        }).then(() => {
+          setActiveTutorialSpy.restore()
+          setModalVisibilitySpy.restore()
+        }).then(done, done)
     })
 
-    it.only('should not show the tutorial for logged in users with a seen timestamp for the loaded tutorial', function () {
+    it('should not show the tutorial for logged in users with a seen timestamp for the loaded tutorial', function (done) {
       rootStore = RootStore.create({}, {
         authClient: authClientStubWithUser, client: clientStub()
       })
+      const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
+      const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
       Promise.resolve(rootStore.userProjectPreferences.setUPP(uppWithTutorialTimeStamp)).then(() => {
-        expect(rootStore.tutorials.active).to.be.undefined
-        expect(rootStore.tutorials.showModal).to.be.false
+        expect(setActiveTutorialSpy).to.not.have.been.called
+        expect(setModalVisibilitySpy).to.not.have.been.called
+        // expect(rootStore.tutorials.active).to.be.undefined
+        // expect(rootStore.tutorials.showModal).to.be.false
+      }).then(() => {
+        setActiveTutorialSpy.restore()
+        setModalVisibilitySpy.restore()
       }).then(done, done)
     })
   })

--- a/packages/lib-classifier/src/store/UserProjectPreferencesStore.js
+++ b/packages/lib-classifier/src/store/UserProjectPreferencesStore.js
@@ -58,6 +58,7 @@ const UserProjectPreferencesStore = types
           self.fetchUPP(bearerToken, user)
         } else {
           self.reset()
+          self.loadingState = asyncStates.success
         }
       } catch (error) {
         console.error(error)
@@ -88,6 +89,10 @@ const UserProjectPreferencesStore = types
       }
     }
 
+    function updateUPP (changes) {
+      console.log('TODO: UPP PUT request', changes)
+    }
+
     function setUPP (userProjectPreferences) {
       self.setResource(userProjectPreferences)
       self.setActive(userProjectPreferences.id)
@@ -98,7 +103,8 @@ const UserProjectPreferencesStore = types
       checkForUser: flow(checkForUser),
       createUPP: flow(createUPP),
       fetchUPP: flow(fetchUPP),
-      setUPP
+      setUPP,
+      updateUPP
     }
   })
 

--- a/packages/lib-classifier/src/store/UserProjectPreferencesStore.spec.js
+++ b/packages/lib-classifier/src/store/UserProjectPreferencesStore.spec.js
@@ -159,7 +159,7 @@ describe('Model > UserProjectPreferencesStore', function () {
         .then(() => {
           expect(getSpy).to.have.been.calledWith(
             '/project_preferences',
-            { project_id: '1', user_id: '1' },
+            { project_id: project.id, user_id: user.id },
             'Bearer 1234'
           )
         }).then(done, done)

--- a/packages/lib-classifier/src/store/UserProjectPreferencesStore.spec.js
+++ b/packages/lib-classifier/src/store/UserProjectPreferencesStore.spec.js
@@ -78,7 +78,7 @@ describe('Model > UserProjectPreferencesStore', function () {
         }).then(done, done)
     })
 
-    it('should reset to an initialized state if there is no user', function (done) {
+    it('should set to a successful state if there is no user', function (done) {
       rootStore = RootStore.create({
         projects: ProjectStore.create(),
         userProjectPreferences: UserProjectPreferencesStore.create()
@@ -86,7 +86,8 @@ describe('Model > UserProjectPreferencesStore', function () {
 
       rootStore.projects.setActive(project.id)
         .then(() => {
-          expect(rootStore.userProjectPreferences.loadingState).to.equal(asyncStates.initialized)
+          expect(rootStore.userProjectPreferences.loadingState).to.equal(asyncStates.success)
+          expect(rootStore.userProjectPreferences.active).to.be.undefined
         }).then(done, done)
     })
 


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
Sets up an observer in the TutorialStore and updates seen date time depending on the UPP state. Still WIP due to tests. I removed the seen time for mini-courses because I refreshed myself on how these work and they are only shown to logged in users, so we do not need to track the seen time for the session in addition to the UPP. 

The store is getting a bit unwieldy, so I think the common actions between tutorials and minicourses should be pulled out into a general store, then a store for tutorial kind and minicourse kind could be composed as a follow up, post TESS launch. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

