### PR TITLE
Add to collection

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -3,6 +3,7 @@ import dynamic from 'next/dynamic'
 import { string } from 'prop-types'
 import React from 'react'
 
+import CollectionsModal from './components/CollectionsModal'
 import ProjectStatistics from '../../shared/components/ProjectStatistics'
 import ConnectWithProject from '../../shared/components/ConnectWithProject'
 
@@ -20,6 +21,9 @@ function ClassifyPage ({ mode }) {
       background={mode === 'light' ? 'lighterGrey' : 'midDarkGrey'}
       pad={{ top: 'medium' }}
     >
+      <CollectionsModal
+        subjectId='123'
+      />
       <Grid gap='medium' margin='medium'>
         <ClassifierWrapper />
         <FinishedForTheDay />

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -16,16 +16,22 @@ const ClassifierWrapper = dynamic(() =>
 )
 
 function ClassifyPage ({ mode }) {
+  const collectionsModal = React.createRef()
+  function addToCollection (subjectId) {
+    collectionsModal.current.wrappedInstance.open(subjectId)
+  }
   return (
     <Box
       background={mode === 'light' ? 'lighterGrey' : 'midDarkGrey'}
       pad={{ top: 'medium' }}
     >
       <CollectionsModal
-        subjectId='123'
+        ref={collectionsModal}
       />
       <Grid gap='medium' margin='medium'>
-        <ClassifierWrapper />
+        <ClassifierWrapper
+          onAddToCollection={addToCollection}
+        />
         <FinishedForTheDay />
         <ProjectStatistics />
         <ConnectWithProject />

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
@@ -4,6 +4,7 @@ import React from 'react'
 import ClassifyPage from './ClassifyPage'
 import FinishedForTheDay from './components/FinishedForTheDay'
 import ProjectStatistics from '../../shared/components/ProjectStatistics'
+import CollectionsModal from './components/CollectionsModal'
 
 let wrapper
 
@@ -22,5 +23,9 @@ describe('Component > ClassifyPage', function () {
 
   it('should render the `ProjectStatistics` component', function () {
     expect(wrapper.find(ProjectStatistics)).to.have.lengthOf(1)
+  })
+
+  it('should render the `CollectionsModal` component', function () {
+    expect(wrapper.find(CollectionsModal)).to.have.lengthOf(1)
   })
 })

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -3,7 +3,6 @@ import { string } from 'prop-types'
 import React, { Component } from 'react'
 
 import ClassifyPage from './ClassifyPage'
-import CollectionsModal from './components/CollectionsModal'
 
 function storeMapper (stores) {
   const { mode } = stores.store.ui
@@ -16,14 +15,7 @@ function storeMapper (stores) {
 @observer
 class ClassifyPageContainer extends Component {
   render () {
-    return (
-      <React.Fragment>
-        <ClassifyPage {...this.props} />
-        <CollectionsModal
-          subjectId='123'
-        />
-      </React.Fragment>
-    )
+    return <ClassifyPage {...this.props} />
   }
 }
 

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -3,6 +3,7 @@ import { string } from 'prop-types'
 import React, { Component } from 'react'
 
 import ClassifyPage from './ClassifyPage'
+import CollectionsModal from './components/CollectionsModal'
 
 function storeMapper (stores) {
   const { mode } = stores.store.ui
@@ -16,7 +17,12 @@ function storeMapper (stores) {
 class ClassifyPageContainer extends Component {
   render () {
     return (
-      <ClassifyPage {...this.props} />
+      <React.Fragment>
+        <ClassifyPage {...this.props} />
+        <CollectionsModal
+          subjectId='123'
+        />
+      </React.Fragment>
     )
   }
 }

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
@@ -1,7 +1,7 @@
 import Classifier from '@zooniverse/classifier'
 import { inject, observer } from 'mobx-react'
 import auth from 'panoptes-client/lib/auth'
-import { shape } from 'prop-types'
+import { func, shape } from 'prop-types'
 import React, { Component } from 'react'
 import asyncStates from '@zooniverse/async-states'
 import ErrorMessage from './components/ErrorMessage'
@@ -57,7 +57,7 @@ class ClassifierWrapperContainer extends Component {
   }
 
   render () {
-    const { authClient, mode, project, user } = this.props
+    const { onAddToCollection, authClient, mode, project, user } = this.props
     const somethingWentWrong = this.state.error || project.loadingState === asyncStates.error
 
     if (somethingWentWrong) {
@@ -82,6 +82,7 @@ class ClassifierWrapperContainer extends Component {
           authClient={authClient}
           key={key}
           mode={mode}
+          onAddToCollection={onAddToCollection}
           onCompleteClassification={this.onCompleteClassification}
           onToggleFavourite={this.onToggleFavourite}
           project={project}
@@ -96,11 +97,13 @@ class ClassifierWrapperContainer extends Component {
 }
 
 ClassifierWrapperContainer.propTypes = {
+  onAddToCollection: func,
   authClient: shape({}),
   project: shape({})
 }
 
 ClassifierWrapperContainer.defaultProps = {
+  onAddToCollection: () => true,
   authClient: auth
 }
 

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
@@ -47,7 +47,7 @@ class ClassifierWrapperContainer extends Component {
     })
   }
 
-  onToggleFavourite(subjectId, isFavourite) {
+  onToggleFavourite (subjectId, isFavourite) {
     const { collections } = this.props
     if (isFavourite) {
       collections.addFavourites([subjectId])

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModal.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModal.js
@@ -1,7 +1,10 @@
 import counterpart from 'counterpart'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { Grid, Grommet } from 'grommet'
+import zooTheme from '@zooniverse/grommet-theme'
 import { Modal } from '@zooniverse/react-components'
+import styled from 'styled-components'
 
 import en from './locales/en'
 
@@ -9,6 +12,7 @@ counterpart.registerTranslations('en', en)
 
 function CollectionsModal ({
   active,
+  children,
   closeFn
 }) {
   return (
@@ -16,7 +20,13 @@ function CollectionsModal ({
       active={active}
       closeFn={closeFn}
       title={counterpart('CollectionsModal.title')}
-    />
+    >
+      <Grommet>
+        <Grid columns={['2fr', '1fr']} gap='small' rows={['1fr']}>
+          {children}
+        </Grid>
+      </Grommet>
+    </Modal>
   )
 }
 

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModal.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModal.js
@@ -1,7 +1,7 @@
 import counterpart from 'counterpart'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Grid, Grommet } from 'grommet'
+import { Grid } from 'grommet'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Modal } from '@zooniverse/react-components'
 import styled from 'styled-components'
@@ -21,11 +21,9 @@ function CollectionsModal ({
       closeFn={closeFn}
       title={counterpart('CollectionsModal.title')}
     >
-      <Grommet>
-        <Grid columns={['2fr', '1fr']} gap='small' rows={['1fr']}>
-          {children}
-        </Grid>
-      </Grommet>
+      <Grid columns={['2fr', '1fr']} gap='small' rows={['1fr']}>
+        {children}
+      </Grid>
     </Modal>
   )
 }

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModal.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModal.js
@@ -1,0 +1,32 @@
+import counterpart from 'counterpart'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { Modal } from '@zooniverse/react-components'
+
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
+
+function CollectionsModal ({
+  active,
+  closeFn
+}) {
+  return (
+    <Modal
+      active={active}
+      closeFn={closeFn}
+      title={counterpart('CollectionsModal.title')}
+    />
+  )
+}
+
+CollectionsModal.propTypes = {
+  active: PropTypes.bool,
+  closeFn: PropTypes.func.isRequired
+}
+
+CollectionsModal.defaultProps = {
+  active: false
+}
+
+export default CollectionsModal

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModal.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModal.js
@@ -1,7 +1,6 @@
 import counterpart from 'counterpart'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Grid } from 'grommet'
 import { Modal } from '@zooniverse/react-components'
 
 import en from './locales/en'
@@ -19,9 +18,7 @@ function CollectionsModal ({
       closeFn={closeFn}
       title={counterpart('CollectionsModal.title')}
     >
-      <Grid columns={['2fr', '1fr']} gap='small' rows={['1fr']}>
-        {children}
-      </Grid>
+      {children}
     </Modal>
   )
 }

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModal.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModal.js
@@ -2,9 +2,7 @@ import counterpart from 'counterpart'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Grid } from 'grommet'
-import zooTheme from '@zooniverse/grommet-theme'
 import { Modal } from '@zooniverse/react-components'
-import styled from 'styled-components'
 
 import en from './locales/en'
 

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModal.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModal.spec.js
@@ -1,0 +1,28 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import CollectionsModal from './CollectionsModal'
+
+let wrapper
+
+describe('Component > CollectionsModal', function () {
+  before(function () {
+    wrapper = shallow(<CollectionsModal />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should contain a text input to search collections by name', function () {
+
+  })
+
+  it('should contain a text input to create new collections by name', function () {
+
+  })
+
+  it('should contain a checkbox to create new private collections', function () {
+
+  })
+})

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModal.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModal.spec.js
@@ -13,16 +13,4 @@ describe('Component > CollectionsModal', function () {
   it('should render without crashing', function () {
     expect(wrapper).to.be.ok()
   })
-
-  it('should contain a text input to search collections by name', function () {
-
-  })
-
-  it('should contain a text input to create new collections by name', function () {
-
-  })
-
-  it('should contain a checkbox to create new private collections', function () {
-
-  })
 })

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
@@ -22,9 +22,15 @@ class CollectionsModalContainer extends Component {
   constructor () {
     super()
     this.addToCollection = this.addToCollection.bind(this)
+    this.createCollection = this.createCollection.bind(this)
     this.onSelect = this.onSelect.bind(this)
+    this.updateCollection = this.updateCollection.bind(this)
     this.state = {
       active: false,
+      newCollection: {
+        display_name: '',
+        private: false
+      },
       selectedCollectionId: null
     }
   }
@@ -38,14 +44,26 @@ class CollectionsModalContainer extends Component {
     this.props.addSubjects(selectedCollectionId, [])
   }
 
+  createCollection () {
+    const { newCollection } = this.state
+    this.props.createCollection(newCollection, [])
+  }
+
   onSelect (event) {
     const selectedCollectionId = event.value.id
     this.setState({ selectedCollectionId })
   }
 
+  updateCollection (collectionDetails) {
+    this.setState((prevState) => {
+      const newCollection = Object.assign({}, prevState.newCollection, collectionDetails)
+      return { newCollection }
+    })
+  }
+
   render () {
-    const { collections, createCollection, searchCollections } = this.props
-    const { active, selectedCollectionId } = this.state
+    const { collections, searchCollections } = this.props
+    const { active, newCollection, selectedCollectionId } = this.state
 
     return (
       <CollectionsModal
@@ -61,7 +79,10 @@ class CollectionsModalContainer extends Component {
           selected={selectedCollectionId}
         />
         <CreateCollection
-          onSubmit={createCollection}
+          disabled={!newCollection.display_name}
+          collection={newCollection}
+          onChange={this.updateCollection}
+          onSubmit={this.createCollection}
         />
       </CollectionsModal>
     )

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
@@ -3,11 +3,16 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
 import CollectionsModal from './CollectionsModal'
+import SelectCollection from './components/SelectCollection'
+import CreateCollection from './components/CreateCollection'
 
 function storeMapper (stores) {
-  const { collections } = stores.store
+  const { addSubjects, collections, createCollection, searchCollections } = stores.store.collections
   return {
-    collections
+    addSubjects,
+    collections,
+    createCollection,
+    searchCollections
   }
 }
 
@@ -16,8 +21,11 @@ function storeMapper (stores) {
 class CollectionsModalContainer extends Component {
   constructor () {
     super()
+    this.addToCollection = this.addToCollection.bind(this)
+    this.onSelect = this.onSelect.bind(this)
     this.state = {
-      active: false
+      active: false,
+      selectedCollectionId: null
     }
   }
 
@@ -25,14 +33,37 @@ class CollectionsModalContainer extends Component {
     this.setState({ active: true })
   }
 
+  addToCollection () {
+    const { selectedCollectionId } = this.state
+    this.props.addSubjects(selectedCollectionId, [])
+  }
+
+  onSelect (event) {
+    const selectedCollectionId = event.value.id
+    this.setState({ selectedCollectionId })
+  }
+
   render () {
-    const { active } = this.state
+    const { collections, createCollection, searchCollections } = this.props
+    const { active, selectedCollectionId } = this.state
 
     return (
       <CollectionsModal
         active={active}
         closeFn={() => this.setState({ active: false })}
-      />
+      >
+        <SelectCollection
+          collections={collections}
+          disabled={!selectedCollectionId}
+          onSelect={this.onSelect}
+          onSearch={searchCollections}
+          onSubmit={this.addToCollection}
+          selected={selectedCollectionId}
+        />
+        <CreateCollection
+          onSubmit={createCollection}
+        />
+      </CollectionsModal>
     )
   }
 }

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
@@ -40,13 +40,15 @@ class CollectionsModalContainer extends Component {
     this.setState({ active: true })
   }
 
-  addToCollection () {
+  addToCollection (event) {
+    event.preventDefault()
     const { selectedCollectionId } = this.state
     this.props.addSubjects(selectedCollectionId, [])
     this.close()
   }
 
-  createCollection () {
+  createCollection (event) {
+    event.preventDefault()
     const { newCollection } = this.state
     this.props.createCollection(newCollection, [])
     this.close()

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
@@ -22,6 +22,7 @@ class CollectionsModalContainer extends Component {
   constructor () {
     super()
     this.addToCollection = this.addToCollection.bind(this)
+    this.close = this.close.bind(this)
     this.createCollection = this.createCollection.bind(this)
     this.onSelect = this.onSelect.bind(this)
     this.updateCollection = this.updateCollection.bind(this)
@@ -42,11 +43,17 @@ class CollectionsModalContainer extends Component {
   addToCollection () {
     const { selectedCollectionId } = this.state
     this.props.addSubjects(selectedCollectionId, [])
+    this.close()
   }
 
   createCollection () {
     const { newCollection } = this.state
     this.props.createCollection(newCollection, [])
+    this.close()
+  }
+
+  close () {
+    this.setState({ active: false })
   }
 
   onSelect (event) {
@@ -68,7 +75,7 @@ class CollectionsModalContainer extends Component {
     return (
       <CollectionsModal
         active={active}
-        closeFn={() => this.setState({ active: false })}
+        closeFn={this.close}
       >
         <SelectCollection
           collections={collections}

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
@@ -1,0 +1,47 @@
+import { inject, observer } from 'mobx-react'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+import CollectionsModal from './CollectionsModal'
+
+function storeMapper (stores) {
+  const { collections } = stores.store
+  return {
+    collections
+  }
+}
+
+@inject(storeMapper)
+@observer
+class CollectionsModalContainer extends Component {
+  constructor () {
+    super()
+    this.state = {
+      active: false
+    }
+  }
+
+  componentDidMount () {
+    this.setState({ active: true })
+  }
+
+  render () {
+    const { active } = this.state
+
+    return (
+      <CollectionsModal
+        active={active}
+        closeFn={() => this.setState({ active: false })}
+      />
+    )
+  }
+}
+
+CollectionsModalContainer.propTypes = {
+  subjectId: PropTypes.string.isRequired
+}
+
+CollectionsModalContainer.defaultProps = {
+}
+
+export default CollectionsModalContainer

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
@@ -32,30 +32,37 @@ class CollectionsModalContainer extends Component {
         display_name: '',
         private: false
       },
-      selectedCollectionId: null
+      selectedCollectionId: null,
+      subjectId: null
     }
-  }
-
-  componentDidMount () {
-    this.setState({ active: true })
   }
 
   addToCollection (event) {
     event.preventDefault()
-    const { selectedCollectionId } = this.state
-    this.props.addSubjects(selectedCollectionId, [])
+    const { selectedCollectionId, subjectId } = this.state
+    this.props.addSubjects(selectedCollectionId, [ subjectId ])
     this.close()
   }
 
   createCollection (event) {
     event.preventDefault()
-    const { newCollection } = this.state
-    this.props.createCollection(newCollection, [])
+    const { newCollection, subjectId } = this.state
+    this.props.createCollection(newCollection, [ subjectId ])
     this.close()
   }
 
+  open (subjectId) {
+    this.setState({
+      active: true,
+      subjectId
+    })
+  }
   close () {
-    this.setState({ active: false })
+    const subjectId = null
+    this.setState({
+      active: false,
+      subjectId
+    })
   }
 
   onSelect (event) {

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
@@ -32,15 +32,15 @@ class CollectionsModalContainer extends Component {
         display_name: '',
         private: false
       },
-      selectedCollectionId: null,
+      selectedCollection: undefined,
       subjectId: null
     }
   }
 
   addToCollection (event) {
     event.preventDefault()
-    const { selectedCollectionId, subjectId } = this.state
-    this.props.addSubjects(selectedCollectionId, [ subjectId ])
+    const { selectedCollection, subjectId } = this.state
+    this.props.addSubjects(selectedCollection.id, [ subjectId ])
     this.close()
   }
 
@@ -57,6 +57,7 @@ class CollectionsModalContainer extends Component {
       subjectId
     })
   }
+
   close () {
     const subjectId = null
     this.setState({
@@ -66,8 +67,8 @@ class CollectionsModalContainer extends Component {
   }
 
   onSelect (event) {
-    const selectedCollectionId = event.value.id
-    this.setState({ selectedCollectionId })
+    const selectedCollection = event.value
+    this.setState({ selectedCollection })
   }
 
   updateCollection (collectionDetails) {
@@ -79,7 +80,7 @@ class CollectionsModalContainer extends Component {
 
   render () {
     const { collections, searchCollections } = this.props
-    const { active, newCollection, selectedCollectionId } = this.state
+    const { active, newCollection, selectedCollection } = this.state
 
     return (
       <CollectionsModal
@@ -88,11 +89,11 @@ class CollectionsModalContainer extends Component {
       >
         <SelectCollection
           collections={collections}
-          disabled={!selectedCollectionId}
+          disabled={!selectedCollection}
           onSelect={this.onSelect}
           onSearch={searchCollections}
           onSubmit={this.addToCollection}
-          selected={selectedCollectionId}
+          selected={selectedCollection}
         />
         <CreateCollection
           disabled={!newCollection.display_name}

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.spec.js
@@ -1,0 +1,45 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import CollectionsModalContainer from './CollectionsModalContainer'
+import CollectionsModal from './CollectionsModal'
+
+let wrapper
+let componentWrapper
+
+describe('Component > CollectionsModalContainer', function () {
+  before(function () {
+    wrapper = shallow(<CollectionsModalContainer.wrappedComponent />)
+    componentWrapper = wrapper.find(CollectionsModal)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render the `CollectionsModal` component', function () {
+    expect(componentWrapper).to.have.lengthOf(1)
+  })
+
+  describe('with a partial collection name', function () {
+    it('should fetch a list of collections filtered by name', function () {
+
+    })
+  })
+
+  describe('with a selected collection and subjects', function () {
+    it('should add those subjects to the selected collection', function () {
+
+    })
+  })
+
+  describe('with a new collection name', function () {
+    it('should create a new collection with that name', function () {
+
+    })
+
+    it('should create a new collection with the supplied subjects', function () {
+
+    })
+  })
+})

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.spec.js
@@ -78,7 +78,10 @@ describe('Component > CollectionsModalContainer', function () {
 
       describe('on submit', function () {
         before(function () {
-          select.simulate('submit')
+          const fakeEvent = {
+            preventDefault: sinon.stub()
+          }
+          select.simulate('submit', fakeEvent)
         })
 
         it('should add subjects to the selected collection', function () {
@@ -133,7 +136,10 @@ describe('Component > CollectionsModalContainer', function () {
 
       describe('on submit', function () {
         before(function () {
-          create.simulate('submit')
+          const fakeEvent = {
+            preventDefault: sinon.stub()
+          }
+          create.simulate('submit', fakeEvent)
         })
 
         it('should create a new collection with that name', function () {

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.spec.js
@@ -76,9 +76,18 @@ describe('Component > CollectionsModalContainer', function () {
         expect(select.prop('disabled')).to.be.false()
       })
 
-      it('should add subjects to the selected collection', function () {
-        select.simulate('submit')
-        expect(addSubjects).to.have.been.calledOnceWith('1', [])
+      describe('on submit', function () {
+        before(function () {
+          select.simulate('submit')
+        })
+
+        it('should add subjects to the selected collection', function () {
+          expect(addSubjects).to.have.been.calledOnceWith('1', [])
+        })
+
+        it('should close the modal', function () {
+          expect(wrapper.state().active).to.be.false()
+        })
       })
     })
   })
@@ -116,15 +125,24 @@ describe('Component > CollectionsModalContainer', function () {
       before(function () {
         create.simulate('change', query)
         create = wrapper.find(CreateCollection)
-        create.simulate('submit')
       })
 
       it('should not be disabled', function () {
         expect(create.prop('disabled')).to.be.false()
       })
 
-      it('should create a new collection with that name', function () {
-        expect(createCollection).to.have.been.calledOnceWith(query, [])
+      describe('on submit', function () {
+        before(function () {
+          create.simulate('submit')
+        })
+
+        it('should create a new collection with that name', function () {
+          expect(createCollection).to.have.been.calledOnceWith(query, [])
+        })
+
+        it('should close the modal', function () {
+          expect(wrapper.state().active).to.be.false()
+        })
       })
     })
   })

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.spec.js
@@ -14,6 +14,7 @@ describe('Component > CollectionsModalContainer', function () {
   let addSubjects = sinon.stub()
   let createCollection = sinon.stub()
   let searchCollections = sinon.stub()
+  const subjectId = '123'
 
   before(function () {
     wrapper = shallow(
@@ -38,7 +39,12 @@ describe('Component > CollectionsModalContainer', function () {
     let select
 
     before(function () {
+      wrapper.instance().open(subjectId)
       select = wrapper.find(SelectCollection)
+    })
+
+    after(function () {
+      wrapper.instance().close()
     })
 
     it('should exist', function () {
@@ -85,7 +91,7 @@ describe('Component > CollectionsModalContainer', function () {
         })
 
         it('should add subjects to the selected collection', function () {
-          expect(addSubjects).to.have.been.calledOnceWith('1', [])
+          expect(addSubjects).to.have.been.calledOnceWith('1', [ subjectId ])
         })
 
         it('should close the modal', function () {
@@ -99,7 +105,12 @@ describe('Component > CollectionsModalContainer', function () {
     let create
 
     before(function () {
+      wrapper.instance().open(subjectId)
       create = wrapper.find(CreateCollection)
+    })
+
+    after(function () {
+      wrapper.instance().close()
     })
 
     it('should exist', function () {
@@ -143,7 +154,7 @@ describe('Component > CollectionsModalContainer', function () {
         })
 
         it('should create a new collection with that name', function () {
-          expect(createCollection).to.have.been.calledOnceWith(query, [])
+          expect(createCollection).to.have.been.calledOnceWith(query, [ subjectId ])
         })
 
         it('should close the modal', function () {

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.spec.js
@@ -12,12 +12,14 @@ let componentWrapper
 
 describe('Component > CollectionsModalContainer', function () {
   let addSubjects = sinon.stub()
+  let createCollection = sinon.stub()
   let searchCollections = sinon.stub()
 
   before(function () {
     wrapper = shallow(
       <CollectionsModalContainer.wrappedComponent
         addSubjects={addSubjects}
+        createCollection={createCollection}
         searchCollections={searchCollections}
       />
     )
@@ -81,18 +83,49 @@ describe('Component > CollectionsModalContainer', function () {
     })
   })
 
-  it('should contain a form to create a new collection', function () {
-    const create = wrapper.find(CreateCollection)
-    expect(create).to.have.lengthOf(1)
-  })
+  describe('create a collection form', function () {
+    let create
 
-  describe('with a new collection name', function () {
-    it('should create a new collection with that name', function () {
-
+    before(function () {
+      create = wrapper.find(CreateCollection)
     })
 
-    it('should create a new collection with the supplied subjects', function () {
+    it('should exist', function () {
+      expect(create).to.have.lengthOf(1)
+    })
 
+    it('should be disabled by default', function () {
+      expect(create.prop('disabled')).to.be.true()
+    })
+
+    describe('on change', function () {
+      const query = { private: false, display_name: 'Hello' }
+
+      before(function () {
+        create.simulate('change', query)
+      })
+
+      it('should update collection details', function () {
+        expect(wrapper.state().newCollection).to.eql(query)
+      })
+    })
+
+    describe('with a collection name', function () {
+      const query = { private: false, display_name: 'Hello' }
+
+      before(function () {
+        create.simulate('change', query)
+        create = wrapper.find(CreateCollection)
+        create.simulate('submit')
+      })
+
+      it('should not be disabled', function () {
+        expect(create.prop('disabled')).to.be.false()
+      })
+
+      it('should create a new collection with that name', function () {
+        expect(createCollection).to.have.been.calledOnceWith(query, [])
+      })
     })
   })
 })

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.spec.js
@@ -1,15 +1,26 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
 
 import CollectionsModalContainer from './CollectionsModalContainer'
 import CollectionsModal from './CollectionsModal'
+import SelectCollection from './components/SelectCollection'
+import CreateCollection from './components/CreateCollection'
 
 let wrapper
 let componentWrapper
 
 describe('Component > CollectionsModalContainer', function () {
+  let addSubjects = sinon.stub()
+  let searchCollections = sinon.stub()
+
   before(function () {
-    wrapper = shallow(<CollectionsModalContainer.wrappedComponent />)
+    wrapper = shallow(
+      <CollectionsModalContainer.wrappedComponent
+        addSubjects={addSubjects}
+        searchCollections={searchCollections}
+      />
+    )
     componentWrapper = wrapper.find(CollectionsModal)
   })
 
@@ -21,16 +32,58 @@ describe('Component > CollectionsModalContainer', function () {
     expect(componentWrapper).to.have.lengthOf(1)
   })
 
-  describe('with a partial collection name', function () {
-    it('should fetch a list of collections filtered by name', function () {
+  describe('select a collection form', function () {
+    let select
 
+    before(function () {
+      select = wrapper.find(SelectCollection)
+    })
+
+    it('should exist', function () {
+      expect(select).to.have.lengthOf(1)
+    })
+
+    it('should be disabled by default', function () {
+      expect(select.prop('disabled')).to.be.true()
+    })
+
+    describe('with a partial collection name', function () {
+      const query = { favorite: false, search: 'Hello' }
+
+      before(function () {
+        select.simulate('search', query)
+      })
+
+      it('should fetch a list of collections filtered by name', function () {
+        expect(searchCollections).to.have.been.calledOnceWith(query)
+      })
+    })
+
+    describe('with a selected collection', function () {
+      let collection = { id: '1', display_name: 'Test One' }
+
+      before(function () {
+        const fakeEvent = {
+          value: collection
+        }
+        select.simulate('select', fakeEvent)
+        select = wrapper.find(SelectCollection)
+      })
+
+      it('should not be disabled', function () {
+        expect(select.prop('disabled')).to.be.false()
+      })
+
+      it('should add subjects to the selected collection', function () {
+        select.simulate('submit')
+        expect(addSubjects).to.have.been.calledOnceWith('1', [])
+      })
     })
   })
 
-  describe('with a selected collection and subjects', function () {
-    it('should add those subjects to the selected collection', function () {
-
-    })
+  it('should contain a form to create a new collection', function () {
+    const create = wrapper.find(CreateCollection)
+    expect(create).to.have.lengthOf(1)
   })
 
   describe('with a new collection name', function () {

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.js
@@ -1,7 +1,8 @@
 import counterpart from 'counterpart'
-import { Box, Button, CheckBox, FormField, TextInput } from 'grommet'
+import { Box, Button, CheckBox, FormField, Grid, TextInput } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
+import styled from 'styled-components'
 
 import en from './locales/en'
 
@@ -25,7 +26,11 @@ function CreateCollection ({
     })
   }
   return (
-    <form
+    <Grid
+      as='form'
+      columns={['2fr', '1fr']}
+      gap='small'
+      rows={['1fr']}
       method='post'
       action=''
       onSubmit={onSubmit}
@@ -58,7 +63,7 @@ function CreateCollection ({
         onChange={updateCollection}
         ref={checkbox}
       />
-    </form>
+    </Grid>
   )
 }
 

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.js
@@ -25,7 +25,11 @@ function CreateCollection ({
     })
   }
   return (
-    <React.Fragment>
+    <form
+      method='post'
+      action=''
+      onSubmit={onSubmit}
+    >
       <FormField
         htmlFor='collectionName'
         label={counterpart('CreateCollection.label')}
@@ -45,7 +49,7 @@ function CreateCollection ({
         <Button
           disabled={disabled}
           label={counterpart('CreateCollection.createButton')}
-          onClick={onSubmit}
+          type='submit'
         />
       </Box>
       <CheckBox
@@ -54,7 +58,7 @@ function CreateCollection ({
         onChange={updateCollection}
         ref={checkbox}
       />
-    </React.Fragment>
+    </form>
   )
 }
 

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.js
@@ -1,0 +1,56 @@
+import counterpart from 'counterpart'
+import { Box, Button, CheckBox, FormField, TextInput } from 'grommet'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
+
+function CreateCollection ({
+  disabled
+}) {
+  const checkbox = React.createRef()
+  let isPrivate = false
+  function onTogglePrivate () {
+    isPrivate = !isPrivate
+    checkbox.current.checked = isPrivate
+    console.log(checkbox.current, checkbox.current.checked)
+  }
+  return (
+    <React.Fragment>
+      <FormField
+        htmlFor='collectionName'
+        label={counterpart('CreateCollection.label')}
+      >
+        <TextInput
+          id='collectionName'
+        />
+      </FormField>
+      <Box
+        align='center'
+        margin={{ top: 'medium' }}
+        pad={{ top: 'small' }}
+      >
+        <Button
+          disabled={disabled}
+          label={counterpart('CreateCollection.createButton')}
+        />
+      </Box>
+      <CheckBox
+        checked={isPrivate}
+        label='Private collection'
+        onChange={onTogglePrivate}
+        ref={checkbox}
+      />
+    </React.Fragment>
+  )
+}
+
+CreateCollection.propTypes = {
+}
+
+CreateCollection.defaultProps = {
+}
+
+export default CreateCollection

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.js
@@ -8,14 +8,21 @@ import en from './locales/en'
 counterpart.registerTranslations('en', en)
 
 function CreateCollection ({
-  disabled
+  collection,
+  disabled,
+  onChange,
+  onSubmit
 }) {
   const checkbox = React.createRef()
-  let isPrivate = false
-  function onTogglePrivate () {
-    isPrivate = !isPrivate
-    checkbox.current.checked = isPrivate
-    console.log(checkbox.current, checkbox.current.checked)
+  const textInput = React.createRef()
+  const { display_name, private: isPrivate } = collection
+  function updateCollection () {
+    const display_name = textInput.current.value
+    const isPrivate = checkbox.current.checked
+    onChange({
+      display_name,
+      private: isPrivate
+    })
   }
   return (
     <React.Fragment>
@@ -25,6 +32,9 @@ function CreateCollection ({
       >
         <TextInput
           id='collectionName'
+          onChange={updateCollection}
+          ref={textInput}
+          value={display_name}
         />
       </FormField>
       <Box
@@ -35,12 +45,13 @@ function CreateCollection ({
         <Button
           disabled={disabled}
           label={counterpart('CreateCollection.createButton')}
+          onClick={onSubmit}
         />
       </Box>
       <CheckBox
         checked={isPrivate}
-        label='Private collection'
-        onChange={onTogglePrivate}
+        label={counterpart('CreateCollection.private')}
+        onChange={updateCollection}
         ref={checkbox}
       />
     </React.Fragment>
@@ -48,9 +59,23 @@ function CreateCollection ({
 }
 
 CreateCollection.propTypes = {
+  collection: PropTypes.shape({
+    display_name: PropTypes.string,
+    private: PropTypes.bool
+  }),
+  disabled: PropTypes.bool,
+  onChange: PropTypes.func,
+  onSubmit: PropTypes.func
 }
 
 CreateCollection.defaultProps = {
+  collection: {
+    display_name: '',
+    private: false
+  },
+  disabled: false,
+  onChange: () => true,
+  onSubmit: () => true
 }
 
 export default CreateCollection

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.spec.js
@@ -1,0 +1,32 @@
+import { shallow } from 'enzyme'
+import { Button, CheckBox, TextInput } from 'grommet'
+import React from 'react'
+
+import CreateCollection from './CreateCollection'
+
+let wrapper
+
+describe('Component > CreateCollection', function () {
+  before(function () {
+    wrapper = shallow(<CreateCollection />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should contain a text input to create new collections by name', function () {
+    const textInput = wrapper.find(TextInput)
+    expect(textInput).to.have.lengthOf(1)
+  })
+
+  it('should contain a checkbox to create new private collections', function () {
+    const checkbox = wrapper.find(CheckBox)
+    expect(checkbox).to.have.lengthOf(1)
+  })
+
+  it('should contain a button', function () {
+    const button = wrapper.find(Button)
+    expect(button).to.have.lengthOf(1)
+  })
+})

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.spec.js
@@ -1,32 +1,97 @@
-import { shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import { Button, CheckBox, TextInput } from 'grommet'
 import React from 'react'
+import sinon from 'sinon'
 
 import CreateCollection from './CreateCollection'
 
-let wrapper
-
 describe('Component > CreateCollection', function () {
+  let wrapper
+  const collection = { display_name: 'Test One', private: true }
+  const onChange = sinon.stub()
+  const onSubmit = sinon.stub()
+
   before(function () {
-    wrapper = shallow(<CreateCollection />)
+    // use mount because we're t4esting a component that uses refs
+    wrapper = mount(
+      <CreateCollection
+        collection={collection}
+        onChange={onChange}
+        onSubmit={onSubmit}
+      />
+    )
+  })
+
+  afterEach(function () {
+    onChange.resetHistory()
   })
 
   it('should render without crashing', function () {
     expect(wrapper).to.be.ok()
   })
 
-  it('should contain a text input to create new collections by name', function () {
-    const textInput = wrapper.find(TextInput)
-    expect(textInput).to.have.lengthOf(1)
+  describe('collection name input', function () {
+    let textInput
+
+    before(function () {
+      textInput = wrapper.find(TextInput)
+    })
+
+    it('should exist', function () {
+      expect(textInput).to.have.lengthOf(1)
+    })
+
+    it('should display the collection name', function () {
+      expect(textInput.prop('value')).to.equal(collection.display_name)
+    })
+
+    it('should call the onChange callback', function () {
+      textInput.props().onChange()
+      expect(onChange).to.have.been.calledOnceWith({ display_name: 'Test One', private: true })
+    })
   })
 
-  it('should contain a checkbox to create new private collections', function () {
-    const checkbox = wrapper.find(CheckBox)
-    expect(checkbox).to.have.lengthOf(1)
+  describe('private checkbox', function () {
+    let checkbox
+
+    before(function () {
+      checkbox = wrapper.find(CheckBox)
+    })
+
+    it('should exist', function () {
+      expect(checkbox).to.have.lengthOf(1)
+    })
+
+    it('should show the collection private status', function () {
+      expect(checkbox.prop('checked')).to.equal(collection.private)
+    })
+
+    it('should call the onChange callback', function () {
+      checkbox.props().onChange()
+      expect(onChange).to.have.been.calledOnceWith({ display_name: 'Test One', private: true })
+    })
   })
 
-  it('should contain a button', function () {
-    const button = wrapper.find(Button)
-    expect(button).to.have.lengthOf(1)
+  describe('Add button', function () {
+    let button
+
+    before(function () {
+      button = wrapper.find(Button)
+    })
+
+    it('should exist', function () {
+      expect(button).to.have.lengthOf(1)
+    })
+
+    it('should call the onSubmit callback', function () {
+      button.simulate('click')
+      expect(onSubmit).to.have.been.calledOnce()
+    })
+
+    it('can be disabled', function () {
+      wrapper.setProps({ disabled: true })
+      button = wrapper.find(Button)
+      expect(button.prop('disabled')).to.be.true()
+    })
   })
 })

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.spec.js
@@ -30,6 +30,11 @@ describe('Component > CreateCollection', function () {
     expect(wrapper).to.be.ok()
   })
 
+  it('should call the onSubmit callback on submit', function () {
+    wrapper.find('form').simulate('submit')
+    expect(onSubmit).to.have.been.calledOnce()
+  })
+
   describe('collection name input', function () {
     let textInput
 
@@ -83,9 +88,8 @@ describe('Component > CreateCollection', function () {
       expect(button).to.have.lengthOf(1)
     })
 
-    it('should call the onSubmit callback', function () {
-      button.simulate('click')
-      expect(onSubmit).to.have.been.calledOnce()
+    it('should submit the form', function () {
+      expect(button.props().type).to.equal('submit')
     })
 
     it('can be disabled', function () {

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/index.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/index.js
@@ -1,0 +1,1 @@
+export { default } from './CreateCollection'

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/locales/en.json
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/locales/en.json
@@ -1,6 +1,7 @@
 {
   "CreateCollection": {
     "label": "Create a new collection",
-    "createButton": "Create and add"
+    "createButton": "Create and add",
+    "private": "Private collection"
   }
 }

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/locales/en.json
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/locales/en.json
@@ -1,0 +1,6 @@
+{
+  "CreateCollection": {
+    "label": "Create a new collection",
+    "createButton": "Create and add"
+  }
+}

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.js
@@ -1,0 +1,55 @@
+import counterpart from 'counterpart'
+import { Box, Button, FormField, Select } from 'grommet'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
+
+function SelectCollection ({
+  collections,
+  disabled,
+  onSelect,
+  onSearch,
+  onSubmit
+}) {
+  return (
+    <React.Fragment>
+      <FormField
+        htmlFor='collectionsSearch'
+        label={counterpart('SelectCollection.label')}
+      >
+        <Select
+          id='collectionsSearch'
+          labelKey='display_name'
+          onChange={onSelect}
+          onSearch={searchText => onSearch({ favorite: false, search: searchText })}
+          options={collections}
+          valueKey='id'
+        />
+      </FormField>
+      <Box
+        align='center'
+        margin={{ top: 'medium' }}
+        pad={{ top: 'small' }}
+      >
+        <Button
+          disabled={disabled}
+          label={counterpart('SelectCollection.addButton')}
+          onClick={onSubmit}
+        />
+      </Box>
+    </React.Fragment>
+  )
+}
+
+SelectCollection.propTypes = {
+  disabled: PropTypes.bool
+}
+
+SelectCollection.defaultProps = {
+  disabled: false
+}
+
+export default SelectCollection

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.js
@@ -12,7 +12,8 @@ function SelectCollection ({
   disabled,
   onSelect,
   onSearch,
-  onSubmit
+  onSubmit,
+  selected
 }) {
   return (
     <form
@@ -36,6 +37,7 @@ function SelectCollection ({
           })}
           options={collections}
           valueKey='id'
+          value={selected}
         />
       </FormField>
       <Box
@@ -54,11 +56,13 @@ function SelectCollection ({
 }
 
 SelectCollection.propTypes = {
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  selected: PropTypes.shape({})
 }
 
 SelectCollection.defaultProps = {
-  disabled: false
+  disabled: false,
+  selected: {}
 }
 
 export default SelectCollection

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.js
@@ -15,7 +15,11 @@ function SelectCollection ({
   onSubmit
 }) {
   return (
-    <React.Fragment>
+    <form
+      method='post'
+      action=''
+      onSubmit={onSubmit}
+    >
       <FormField
         htmlFor='collectionsSearch'
         label={counterpart('SelectCollection.label')}
@@ -23,8 +27,13 @@ function SelectCollection ({
         <Select
           id='collectionsSearch'
           labelKey='display_name'
+          name='display_name'
           onChange={onSelect}
-          onSearch={searchText => onSearch({ favorite: false, search: searchText })}
+          onSearch={searchText => onSearch({
+            favorite: false,
+            current_user_roles: 'owner,collaborator,contributor',
+            search: searchText
+          })}
           options={collections}
           valueKey='id'
         />
@@ -37,10 +46,10 @@ function SelectCollection ({
         <Button
           disabled={disabled}
           label={counterpart('SelectCollection.addButton')}
-          onClick={onSubmit}
+          type='submit'
         />
       </Box>
-    </React.Fragment>
+    </form>
   )
 }
 

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.js
@@ -1,7 +1,8 @@
 import counterpart from 'counterpart'
-import { Box, Button, FormField, Select } from 'grommet'
+import { Box, Button, FormField, Grid, Select } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
+import styled from 'styled-components'
 
 import en from './locales/en'
 
@@ -16,7 +17,11 @@ function SelectCollection ({
   selected
 }) {
   return (
-    <form
+    <Grid
+      as='form'
+      columns={['2fr', '1fr']}
+      gap='small'
+      rows={['1fr']}
       method='post'
       action=''
       onSubmit={onSubmit}
@@ -51,7 +56,7 @@ function SelectCollection ({
           type='submit'
         />
       </Box>
-    </form>
+    </Grid>
   )
 }
 

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.spec.js
@@ -45,6 +45,10 @@ describe('Component > SelectCollection', function () {
       expect(select).to.have.lengthOf(1)
     })
 
+    it('should be empty by default', function () {
+      expect(select.prop('value')).to.eql({})
+    })
+
     it('should list collections', function () {
       expect(select.prop('options')).to.equal(collections)
     })
@@ -57,6 +61,12 @@ describe('Component > SelectCollection', function () {
         current_user_roles: 'owner,collaborator,contributor',
         search: searchText
       })
+    })
+    it('should display the selected collection', function () {
+      const collection = {id: '1', display_name: 'Selected collection'}
+      wrapper.setProps({selected: collection})
+      select = wrapper.find(Select)
+      expect(select.prop('value')).to.eql(collection)
     })
   })
 

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.spec.js
@@ -29,6 +29,11 @@ describe('Component > SelectCollection', function () {
     expect(wrapper).to.be.ok()
   })
 
+  it('should call the onSubmit callback on submit', function () {
+    wrapper.find('form').simulate('submit')
+    expect(onSubmit).to.have.been.calledOnce()
+  })
+
   describe('collections search input', function () {
     let select
 
@@ -47,7 +52,11 @@ describe('Component > SelectCollection', function () {
     it('should call the onSearch callback', function () {
       const searchText = 'Hello'
       select.simulate('search', searchText)
-      expect(onSearch).to.have.been.calledOnceWith({ favorite: false, search: searchText })
+      expect(onSearch).to.have.been.calledOnceWith({
+        favorite: false,
+        current_user_roles: 'owner,collaborator,contributor',
+        search: searchText
+      })
     })
   })
 
@@ -62,9 +71,8 @@ describe('Component > SelectCollection', function () {
       expect(button).to.have.lengthOf(1)
     })
 
-    it('should call the onSubmit callback', function () {
-      button.simulate('click')
-      expect(onSubmit).to.have.been.calledOnce()
+    it('should submit the form', function () {
+      expect(button.props().type).to.equal('submit')
     })
 
     it('can be disabled', function () {

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.spec.js
@@ -30,7 +30,7 @@ describe('Component > SelectCollection', function () {
   })
 
   it('should call the onSubmit callback on submit', function () {
-    wrapper.find('form').simulate('submit')
+    wrapper.find('Grid').simulate('submit')
     expect(onSubmit).to.have.been.calledOnce()
   })
 

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.spec.js
@@ -1,0 +1,76 @@
+import { shallow } from 'enzyme'
+import { Button, Select } from 'grommet'
+import React from 'react'
+import sinon from 'sinon'
+
+import SelectCollection from './SelectCollection'
+
+let wrapper
+
+describe('Component > SelectCollection', function () {
+  const collections = [
+    { id: '1', display_name: 'Test One' },
+    { id: '2', display_name: 'Test Two' }
+  ]
+  const onSearch = sinon.stub()
+  const onSubmit = sinon.stub()
+
+  before(function () {
+    wrapper = shallow(
+      <SelectCollection
+        collections={collections}
+        onSearch={onSearch}
+        onSubmit={onSubmit}
+      />
+    )
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  describe('collections search input', function () {
+    let select
+
+    before(function () {
+      select = wrapper.find(Select)
+    })
+
+    it('should exist', function () {
+      expect(select).to.have.lengthOf(1)
+    })
+
+    it('should list collections', function () {
+      expect(select.prop('options')).to.equal(collections)
+    })
+
+    it('should call the onSearch callback', function () {
+      const searchText = 'Hello'
+      select.simulate('search', searchText)
+      expect(onSearch).to.have.been.calledOnceWith({ favorite: false, search: searchText })
+    })
+  })
+
+  describe('Add button', function () {
+    let button
+
+    before(function () {
+      button = wrapper.find(Button)
+    })
+
+    it('should contain a button', function () {
+      expect(button).to.have.lengthOf(1)
+    })
+
+    it('should call the onSubmit callback', function () {
+      button.simulate('click')
+      expect(onSubmit).to.have.been.calledOnce()
+    })
+
+    it('can be disabled', function () {
+      wrapper.setProps({ disabled: true })
+      button = wrapper.find(Button)
+      expect(button.prop('disabled')).to.be.true()
+    })
+  })
+})

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/index.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/index.js
@@ -1,0 +1,1 @@
+export { default } from './SelectCollection'

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/locales/en.json
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/locales/en.json
@@ -1,0 +1,6 @@
+{
+  "SelectCollection": {
+    "label": "Add to an existing collection",
+    "addButton": "Add"
+  }
+}

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/index.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './CollectionsModalContainer'

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/locales/en.json
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/locales/en.json
@@ -1,0 +1,5 @@
+{
+  "CollectionsModal": {
+    "title": "Add to collection"
+  }
+}

--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -103,9 +103,7 @@ const Collections = types
       }),
 
       searchCollections: flow(function * searchCollections (query) {
-        console.log(query)
         self.collections = yield fetchCollections(query)
-        console.log(self.collections.length)
       }),
 
       fetchFavourites: flow(function * fetchFavourites () {

--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -29,7 +29,10 @@ const Collections = types
         const user = getRoot(self).user
         if (project.id && user.id) {
           self.fetchFavourites()
-          self.searchCollections({ favorite: false })
+          self.searchCollections({
+            favorite: false,
+            current_user_roles: 'owner,collaborator,contributor'
+          })
         }
       })
       addDisposer(self, projectDisposer)

--- a/packages/app-project/stores/Collections.js
+++ b/packages/app-project/stores/Collections.js
@@ -29,6 +29,7 @@ const Collections = types
         const user = getRoot(self).user
         if (project.id && user.id) {
           self.fetchFavourites()
+          self.searchCollections({ favorite: false })
         }
       })
       addDisposer(self, projectDisposer)
@@ -99,7 +100,9 @@ const Collections = types
       }),
 
       searchCollections: flow(function * searchCollections (query) {
+        console.log(query)
         self.collections = yield fetchCollections(query)
+        console.log(self.collections.length)
       }),
 
       fetchFavourites: flow(function * fetchFavourites () {
@@ -136,7 +139,7 @@ const Collections = types
         self.favourites = Collection.create(favourites)
       }),
 
-      removeSubjects: flow(function * removeSubjects(id, subjectIds) {
+      removeSubjects: flow(function * removeSubjects (id, subjectIds) {
         const token = yield auth.checkBearerToken()
         const authorization = `Bearer ${token}`
         const params = {

--- a/packages/lib-classifier/dev/components/App/App.js
+++ b/packages/lib-classifier/dev/components/App/App.js
@@ -94,6 +94,7 @@ class App extends React.Component {
           <Box as='section'>
             <Classifier
               authClient={oauth}
+              onAddToCollection={(subjectId) => console.log(subjectId)}
               onCompleteClassification={(classification, subject) => console.log('onComplete', classification, subject)}
               project={this.state.project}
             />

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -44,8 +44,9 @@ export default class Classifier extends React.Component {
   }
 
   componentDidMount () {
-    const { onCompleteClassification, onToggleFavourite, project } = this.props
+    const { onAddToCollection, onCompleteClassification, onToggleFavourite, project } = this.props
     this.setProject(project)
+    this.classifierStore.setOnAddToCollection(onAddToCollection)
     this.classifierStore.classifications.setOnComplete(onCompleteClassification)
     this.classifierStore.setOnToggleFavourite(onToggleFavourite)
   }
@@ -79,6 +80,7 @@ export default class Classifier extends React.Component {
 
 Classifier.defaultProps = {
   mode: 'light',
+  onAddToCollection: () => true,
   onCompleteClassification: () => true,
   onToggleFavourite: () => true,
   theme: zooTheme
@@ -87,6 +89,7 @@ Classifier.defaultProps = {
 Classifier.propTypes = {
   authClient: PropTypes.object.isRequired,
   mode: PropTypes.string,
+  onAddToCollection: PropTypes.func,
   onCompleteClassification: PropTypes.func,
   onToggleFavourite: PropTypes.func,
   project: PropTypes.shape({

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
@@ -21,12 +21,18 @@ export default class MetaTools extends React.Component {
   constructor () {
     super()
 
+    this.addToCollection = this.addToCollection.bind(this)
     this.toggleFavourites = this.toggleFavourites.bind(this)
     this.toggleMetadataModal = this.toggleMetadataModal.bind(this)
 
     this.state = {
       showMetadataModal: false
     }
+  }
+
+  addToCollection () {
+    const { subject } = this.props
+    subject.addToCollection()
   }
 
   toggleMetadataModal () {
@@ -56,7 +62,9 @@ export default class MetaTools extends React.Component {
           checked={subject && subject.favorite}
           onClick={this.toggleFavourites}
         />
-        <CollectionsButton />
+        <CollectionsButton
+          onClick={this.addToCollection}
+        />
       </Box>
     )
   }

--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -25,15 +25,22 @@ const RootStore = types
 
   .volatile(self => {
     return {
+      onAddToCollection: () => true,
       onToggleFavourite: () => true
     }
   })
 
   .actions(self => {
+    function setOnAddToCollection (callback) {
+      self.onAddToCollection = callback
+    }
+
     function setOnToggleFavourite (callback) {
       self.onToggleFavourite = callback
     }
+
     return {
+      setOnAddToCollection,
       setOnToggleFavourite
     }
   })

--- a/packages/lib-classifier/src/store/RootStore.spec.js
+++ b/packages/lib-classifier/src/store/RootStore.spec.js
@@ -39,4 +39,10 @@ describe('Model > RootStore', function () {
     model.setOnToggleFavourite(onToggleFavourite)
     expect(model.onToggleFavourite).to.equal(onToggleFavourite)
   })
+
+  it('should have an onAddToCollection callback', function () {
+    const addToCollection = sinon.stub()
+    model.setOnAddToCollection(addToCollection)
+    expect(model.onAddToCollection).to.equal(addToCollection)
+  })
 })

--- a/packages/lib-classifier/src/store/Subject.js
+++ b/packages/lib-classifier/src/store/Subject.js
@@ -16,6 +16,11 @@ const Subject = types
   })
 
   .actions(self => {
+    function addToCollection () {
+      const rootStore = getRoot(self)
+      rootStore.onAddToCollection(self.id)
+    }
+
     function toggleFavorite () {
       const rootStore = getRoot(self)
       self.favorite = !self.favorite
@@ -23,6 +28,7 @@ const Subject = types
     }
 
     return {
+      addToCollection,
       toggleFavorite
     }
   })

--- a/packages/lib-classifier/src/store/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject.spec.js
@@ -10,6 +10,7 @@ describe('Model > Subject', function () {
   before(function () {
     subject = Subject.create(stub)
     subject.onToggleFavourite = sinon.stub()
+    subject.onAddToCollection = sinon.stub()
   })
 
   it('should exist', function () {
@@ -32,6 +33,16 @@ describe('Model > Subject', function () {
 
     it('should call the onToggleFavourite callback', function () {
       expect(subject.onToggleFavourite).to.have.been.calledOnceWith(subject.id, subject.favorite)
+    })
+  })
+
+  describe('addToCollection', function () {
+    before(function () {
+      subject.addToCollection()
+    })
+
+    it('should call the onAddToCollection callback', function () {
+      expect(subject.onAddToCollection).to.have.been.calledOnceWith(subject.id)
     })
   })
 })


### PR DESCRIPTION
Package:
app-project

Closes #398.

Adds an 'Add to collection' modal box to the Classify page, which can then be triggered from the Classifier or from the Recent Subjects components.

It should be passed a subject ID, and allow you to add that subject to an existing collection or a new collection.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

