### PR TITLE
Update _document to match latest next example for styled components

### DIFF
--- a/packages/app-project/pages/_document.js
+++ b/packages/app-project/pages/_document.js
@@ -1,26 +1,25 @@
-import Document, { Head, Main, NextScript } from 'next/document'
+import Document from 'next/document'
 import React from 'react'
 import { ServerStyleSheet } from 'styled-components'
 
 export default class MyDocument extends Document {
-  static getInitialProps ({ renderPage }) {
+  static async getInitialProps (ctx) {
     const sheet = new ServerStyleSheet()
-    const page = renderPage(App => props => sheet.collectStyles(<App {...props} />))
-    const styleTags = sheet.getStyleElement()
-    return { ...page, styleTags }
-  }
+    const originalRenderPage = ctx.renderPage
 
-  render () {
-    return (
-      <html>
-        <Head>
-          {this.props.styleTags}
-        </Head>
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </html>
-    )
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: App => props => sheet.collectStyles(<App {...props} />)
+        })
+
+      const initialProps = await Document.getInitialProps(ctx)
+      return {
+        ...initialProps,
+        styles: <>{initialProps.styles}{sheet.getStyleElement()}</>
+      }
+    } finally {
+      sheet.seal()
+    }
   }
 }


### PR DESCRIPTION
Package: app-project

Update `_document.js` to match [latest next example for styled components](https://github.com/zeit/next.js/blob/canary/examples/with-styled-components/pages/_document.js)

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

