### PR TITLE
Add avatar to project header

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
@@ -4,6 +4,7 @@ import { string } from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 
+import Avatar from './components/Avatar'
 import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
@@ -15,7 +16,15 @@ const StyledHeading = styled(Heading)`
 function ProjectHeader (props) {
   const { className, title } = props
   return (
-    <Box className={className} pad='medium' background='brand'>
+    <Box
+      align='center'
+      background='brand'
+      className={className}
+      direction='row'
+      gap='medium'
+      pad='medium'
+    >
+      <Avatar />
       <StyledHeading color='white' margin='none' size='small'>
         {title}
       </StyledHeading>

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.spec.js
@@ -1,4 +1,4 @@
-import { render } from 'enzyme'
+import { shallow } from 'enzyme'
 import React from 'react'
 
 import ProjectHeader from './ProjectHeader'
@@ -8,7 +8,7 @@ let wrapper
 
 describe('Component > ProjectHeader', function () {
   before(function () {
-    wrapper = render(<ProjectHeader title={TITLE} />)
+    wrapper = shallow(<ProjectHeader title={TITLE} />)
   })
 
   it('should render without crashing', function () {
@@ -16,8 +16,7 @@ describe('Component > ProjectHeader', function () {
   })
 
   it('should render the title prop as an h1', function () {
-    const heading = wrapper.find('h1')
-    expect(heading).to.be.ok()
+    const heading = wrapper.find('ProjectHeader__StyledHeading').render()
     expect(heading.text()).to.equal(TITLE)
   })
 })

--- a/packages/app-project/src/components/ProjectHeader/components/Avatar/Avatar.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Avatar/Avatar.js
@@ -1,0 +1,41 @@
+import counterpart from 'counterpart'
+import { bool, string } from 'prop-types'
+import React, { Component } from 'react'
+import styled from 'styled-components'
+
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
+
+const StyledAvatar = styled.img`
+  border-radius: 100%;
+  box-shadow: 5px 10px 20px rgba(0, 0, 0, 0.22);
+  width: ${props => props.isNarrow ? '40px' : '80px'};
+  object-fit: cover;
+  overflow: hidden;
+  width: ${props => props.isNarrow ? '40px' : '80px'};
+`
+
+function Avatar (props) {
+  if (!props.src) {
+    return null
+  }
+
+  const { projectTitle, ...rest } = props
+  const alt = counterpart('Avatar.alt', { project: projectTitle })
+
+  return (
+    <StyledAvatar alt={alt} {...rest} />
+  )
+}
+
+Avatar.propTypes = {
+  isNarrow: bool,
+  src: string,
+}
+
+Avatar.defaultProps = {
+  isNarrow: false
+}
+
+export default Avatar

--- a/packages/app-project/src/components/ProjectHeader/components/Avatar/Avatar.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Avatar/Avatar.spec.js
@@ -1,0 +1,16 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import Avatar from './Avatar'
+
+let wrapper
+
+describe('Component > Avatar', function () {
+  before(function () {
+    wrapper = shallow(<Avatar />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+})

--- a/packages/app-project/src/components/ProjectHeader/components/Avatar/Avatar.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Avatar/Avatar.spec.js
@@ -3,14 +3,21 @@ import React from 'react'
 
 import Avatar from './Avatar'
 
+const src = 'https://example.com/image.jpg'
+const projectTitle = 'Example project'
+
 let wrapper
 
 describe('Component > Avatar', function () {
   before(function () {
-    wrapper = shallow(<Avatar />)
+    wrapper = shallow(<Avatar projectTitle={projectTitle} src={src} />)
   })
 
   it('should render without crashing', function () {
     expect(wrapper).to.be.ok()
+  })
+
+  it('should have some `alt` text', function () {
+    expect(wrapper.prop('alt')).to.equal(`Project avatar for ${projectTitle}`)
   })
 })

--- a/packages/app-project/src/components/ProjectHeader/components/Avatar/AvatarContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Avatar/AvatarContainer.js
@@ -1,12 +1,11 @@
 import { inject, observer } from 'mobx-react'
-import { string } from 'prop-types'
+import { node, string } from 'prop-types'
 import React, { Component } from 'react'
 
 import Avatar from './Avatar'
 
 function storeMapper (stores) {
   const { project } = stores.store
-  console.info(project)
   return {
     avatarSrc: project.avatar.src,
     projectTitle: project.display_name
@@ -17,16 +16,21 @@ function storeMapper (stores) {
 @observer
 class AvatarContainer extends Component {
   render () {
-    const { avatarSrc, projectTitle } = this.props
+    const { avatarSrc, child: Child, projectTitle } = this.props
     return (
-      <Avatar projectTitle={projectTitle} src={avatarSrc} />
+      <Child projectTitle={projectTitle} src={avatarSrc} />
     )
   }
 }
 
 AvatarContainer.propTypes = {
   avatarSrc: string,
+  child: node,
   projectTitle: string,
+}
+
+AvatarContainer.defaultProps = {
+  child: Avatar
 }
 
 export default AvatarContainer

--- a/packages/app-project/src/components/ProjectHeader/components/Avatar/AvatarContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Avatar/AvatarContainer.js
@@ -1,0 +1,32 @@
+import { inject, observer } from 'mobx-react'
+import { string } from 'prop-types'
+import React, { Component } from 'react'
+
+import Avatar from './Avatar'
+
+function storeMapper (stores) {
+  const { project } = stores.store
+  console.info(project)
+  return {
+    avatarSrc: project.avatar.src,
+    projectTitle: project.display_name
+  }
+}
+
+@inject(storeMapper)
+@observer
+class AvatarContainer extends Component {
+  render () {
+    const { avatarSrc, projectTitle } = this.props
+    return (
+      <Avatar projectTitle={projectTitle} src={avatarSrc} />
+    )
+  }
+}
+
+AvatarContainer.propTypes = {
+  avatarSrc: string,
+  projectTitle: string,
+}
+
+export default AvatarContainer

--- a/packages/app-project/src/components/ProjectHeader/components/Avatar/AvatarContainer.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Avatar/AvatarContainer.spec.js
@@ -4,10 +4,16 @@ import React from 'react'
 import AvatarContainer from './AvatarContainer'
 
 let wrapper
+const avatarSrc = 'https://example.com/image.jpg'
+const projectTitle = 'Example project'
 
 describe('Component > AvatarContainer', function () {
   before(function () {
-    wrapper = shallow(<AvatarContainer.wrappedComponent child={StubComponent} />)
+    wrapper = shallow(<AvatarContainer.wrappedComponent
+      avatarSrc={avatarSrc}
+      child={StubComponent}
+      projectTitle={projectTitle}
+    />)
   })
 
   it('should render without crashing', function () {
@@ -16,6 +22,12 @@ describe('Component > AvatarContainer', function () {
 
   it('should render the `child` component prop', function () {
     expect(wrapper.find(StubComponent)).to.have.lengthOf(1)
+  })
+
+  it('should pass the required props to the child component', function () {
+    const child = wrapper.find(StubComponent)
+    expect(child.prop('src')).to.equal(avatarSrc)
+    expect(child.prop('projectTitle')).to.equal(projectTitle)
   })
 })
 

--- a/packages/app-project/src/components/ProjectHeader/components/Avatar/AvatarContainer.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Avatar/AvatarContainer.spec.js
@@ -1,0 +1,23 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import AvatarContainer from './AvatarContainer'
+import Avatar from './Avatar'
+
+let wrapper
+let componentWrapper
+
+describe('Component > AvatarContainer', function () {
+  before(function () {
+    wrapper = shallow(<AvatarContainer.wrappedComponent />)
+    componentWrapper = wrapper.find(Avatar)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render the `Avatar` component', function () {
+    expect(componentWrapper).to.have.lengthOf(1)
+  })
+})

--- a/packages/app-project/src/components/ProjectHeader/components/Avatar/AvatarContainer.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Avatar/AvatarContainer.spec.js
@@ -2,22 +2,23 @@ import { shallow } from 'enzyme'
 import React from 'react'
 
 import AvatarContainer from './AvatarContainer'
-import Avatar from './Avatar'
 
 let wrapper
-let componentWrapper
 
 describe('Component > AvatarContainer', function () {
   before(function () {
-    wrapper = shallow(<AvatarContainer.wrappedComponent />)
-    componentWrapper = wrapper.find(Avatar)
+    wrapper = shallow(<AvatarContainer.wrappedComponent child={StubComponent} />)
   })
 
   it('should render without crashing', function () {
     expect(wrapper).to.be.ok()
   })
 
-  it('should render the `Avatar` component', function () {
-    expect(componentWrapper).to.have.lengthOf(1)
+  it('should render the `child` component prop', function () {
+    expect(wrapper.find(StubComponent)).to.have.lengthOf(1)
   })
 })
+
+function StubComponent (props) {
+  return <div {...props}>stub</div>
+}

--- a/packages/app-project/src/components/ProjectHeader/components/Avatar/README.md
+++ b/packages/app-project/src/components/ProjectHeader/components/Avatar/README.md
@@ -1,0 +1,3 @@
+# Avatar
+
+Produces a circular avatar image from the project's saved avatar resource.

--- a/packages/app-project/src/components/ProjectHeader/components/Avatar/index.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Avatar/index.js
@@ -1,0 +1,1 @@
+export { default } from './AvatarContainer'

--- a/packages/app-project/src/components/ProjectHeader/components/Avatar/locales/en.json
+++ b/packages/app-project/src/components/ProjectHeader/components/Avatar/locales/en.json
@@ -1,0 +1,5 @@
+{
+  "Avatar": {
+    "alt": "Project avatar for %(project)s"
+  }
+}


### PR DESCRIPTION
Package: app-project

cc #44

Adds a circular avatar icon into the project header.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

