### PR TITLE
Allow first answer to be checked in question tasks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/MultipleChoiceTask/MultipleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/MultipleChoiceTask/MultipleChoiceTask.spec.js
@@ -37,6 +37,29 @@ describe('MultipleChoiceTask', function () {
     })
   })
 
+  describe('with an annotation', function () {
+    let wrapper
+
+    before(function () {
+      const annotation = { task: task.taskKey, value: [0] }
+      const annotations = new Map([[task.taskKey, annotation]])
+      const addAnnotation = () => {}
+      wrapper = shallow(
+        <MultipleChoiceTask.wrappedComponent
+          annotations={annotations}
+          addAnnotation={addAnnotation}
+          task={task}
+        />
+      )
+    })
+
+    it('should check the selected answer', function () {
+      const answer = task.answers[0]
+      const input = wrapper.find({ label: answer.label })
+      expect(input.prop('checked')).to.be.true
+    })
+  })
+
   describe('onChange event handler', function () {
     let wrapper
     let addAnnotationSpy

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/SingleChoiceTask/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/SingleChoiceTask/SingleChoiceTask.js
@@ -43,7 +43,7 @@ class SingleChoiceTask extends React.Component {
       <StyledFieldset>
         <Text size='small' tag='legend'><Markdown>{task.question}</Markdown></Text>
         {task.answers.map((answer, index) => {
-          const checked = (annotation && annotation.value) ? index === annotation.value : false
+          const checked = (annotation && annotation.value + 1) ? index === annotation.value : false
           return (
             <TaskInputField
               autoFocus={checked}

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/SingleChoiceTask/SingleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/SingleChoiceTask/SingleChoiceTask.spec.js
@@ -35,6 +35,29 @@ describe('SingleChoiceTask', function () {
     })
   })
 
+  describe('with an annotation', function () {
+    let wrapper
+
+    before(function () {
+      const annotation = { task: task.taskKey, value: 0 }
+      const annotations = new Map([[task.taskKey, annotation]])
+      const addAnnotation = () => {}
+      wrapper = shallow(
+        <SingleChoiceTask.wrappedComponent
+          annotations={annotations}
+          addAnnotation={addAnnotation}
+          task={task}
+        />
+      )
+    })
+
+    it('should check the selected answer', function () {
+      const answer = task.answers[0]
+      const input = wrapper.find({ label: answer.label })
+      expect(input.prop('checked')).to.be.true
+    })
+  })
+
   describe('onChange event handler', function () {
     let wrapper
     let addAnnotationSpy


### PR DESCRIPTION
Package:
lib-classifier

Closes #548.

Describe your changes:
Adds tests for the case where the first answer has been selected in single and multiple answer tasks. Fixes single answer tasks when the first answer is selected.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

