### PR TITLE
Add ProjectHeader nav links

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
@@ -5,6 +5,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 import Avatar from './components/Avatar'
+import Nav from './components/Nav'
 import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
@@ -21,13 +22,16 @@ function ProjectHeader (props) {
       background='brand'
       className={className}
       direction='row'
-      gap='medium'
+      justify='between'
       pad='medium'
     >
-      <Avatar />
-      <StyledHeading color='white' margin='none' size='small'>
-        {title}
-      </StyledHeading>
+      <Box align='center' direction='row' gap='medium'>
+        <Avatar />
+        <StyledHeading color='white' margin='none' size='small'>
+          {title}
+        </StyledHeading>
+      </Box>
+      <Nav />
     </Box>
   )
 }

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.js
@@ -16,7 +16,8 @@ function Nav (props) {
     <Box as='nav' direction='row' gap='medium'>
       <NavLink
         href={`${baseUrl}/about`}
-        text={counterpart('Nav.about')} />
+        text={counterpart('Nav.about')}
+      />
       <NavLink
         href={`${baseUrl}/classify`}
         text={counterpart('Nav.classify')}
@@ -47,3 +48,4 @@ Nav.propTypes = {
 }
 
 export default withRouter(Nav)
+export { Nav }

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.js
@@ -1,0 +1,49 @@
+import counterpart from 'counterpart'
+import { shape, string } from 'prop-types'
+import React from 'react'
+import { Box } from 'grommet'
+import { withRouter } from 'next/router'
+
+import en from './locales/en'
+import NavLink from './components/NavLink'
+
+counterpart.registerTranslations('en', en)
+
+function Nav (props) {
+  const { owner, project } = props.router.query
+  const baseUrl = `/projects/${owner}/${project}`
+  return (
+    <Box as='nav' direction='row' gap='medium'>
+      <NavLink
+        href={`${baseUrl}/about`}
+        text={counterpart('Nav.about')} />
+      <NavLink
+        href={`${baseUrl}/classify`}
+        text={counterpart('Nav.classify')}
+      />
+      <NavLink
+        href={`${baseUrl}/talk`}
+        text={counterpart('Nav.talk')}
+      />
+      <NavLink
+        href={`${baseUrl}/collections`}
+        text={counterpart('Nav.collect')}
+      />
+      <NavLink
+        href={`${baseUrl}/recents`}
+        text={counterpart('Nav.recents')}
+      />
+    </Box>
+  )
+}
+
+Nav.propTypes = {
+  router: shape({
+    query: shape({
+      owner: string,
+      project: string,
+    }),
+  }),
+}
+
+export default withRouter(Nav)

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.js
@@ -1,5 +1,5 @@
 import counterpart from 'counterpart'
-import { shape, string } from 'prop-types'
+import { bool, shape, string } from 'prop-types'
 import React from 'react'
 import { Box } from 'grommet'
 import { withRouter } from 'next/router'
@@ -10,7 +10,8 @@ import NavLink from './components/NavLink'
 counterpart.registerTranslations('en', en)
 
 function Nav (props) {
-  const { owner, project } = props.router.query
+  const { isLoggedIn, router } = props
+  const { owner, project } = router.query
   const baseUrl = `/projects/${owner}/${project}`
   return (
     <Box as='nav' direction='row' gap='medium'>
@@ -30,15 +31,16 @@ function Nav (props) {
         href={`${baseUrl}/collections`}
         text={counterpart('Nav.collect')}
       />
-      <NavLink
+      {isLoggedIn && (<NavLink
         href={`${baseUrl}/recents`}
         text={counterpart('Nav.recents')}
-      />
+      />)}
     </Box>
   )
 }
 
 Nav.propTypes = {
+  isLoggedIn: bool,
   router: shape({
     query: shape({
       owner: string,

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.spec.js
@@ -22,7 +22,7 @@ const LINKS = [
   { text: 'Recents', href: `${BASE_URL}/recents` }
 ]
 
-describe.only('Component > Nav', function () {
+describe('Component > Nav', function () {
   before(function () {
     wrapper = shallow(<Nav router={ROUTER} isLoggedIn={true} />)
   })

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.spec.js
@@ -1,0 +1,16 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import Nav from './Nav'
+
+let wrapper
+
+describe('Component > Nav', function () {
+  before(function () {
+    wrapper = shallow(<Nav />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+})

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.spec.js
@@ -22,9 +22,9 @@ const LINKS = [
   { text: 'Recents', href: `${BASE_URL}/recents` }
 ]
 
-describe('Component > Nav', function () {
+describe.only('Component > Nav', function () {
   before(function () {
-    wrapper = shallow(<Nav router={ROUTER} />)
+    wrapper = shallow(<Nav router={ROUTER} isLoggedIn={true} />)
   })
 
   it('should render without crashing', function () {
@@ -35,9 +35,16 @@ describe('Component > Nav', function () {
     LINKS.map(link => {
       it(`should show a \`${link.text}\` link`, function () {
         const innerWrapper = wrapper.dive().shallow()
-        expect(innerWrapper.find({ text: link.text })).to.have.lengthOf(1)
-        expect(innerWrapper.find({ href: link.href })).to.have.lengthOf(1)
+        expect(innerWrapper.find({ ...link })).to.have.lengthOf(1)
       })
+    })
+
+    it('should hide the `Recents` link if not logged in', function () {
+      let innerWrapper = wrapper.dive().shallow()
+      expect(innerWrapper.find({ ...LINKS[4] })).to.have.lengthOf(1)
+      wrapper.setProps({ isLoggedIn: false })
+      innerWrapper = wrapper.dive().shallow()
+      expect(innerWrapper.find({ ...LINKS[4] })).to.have.lengthOf(0)
     })
   })
 })

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.spec.js
@@ -1,16 +1,43 @@
 import { shallow } from 'enzyme'
 import React from 'react'
 
-import Nav from './Nav'
+import { Nav } from './Nav'
 
 let wrapper
 
+const OWNER = 'foo'
+const PROJECT = 'bar'
+const ROUTER = {
+  query: {
+    owner: OWNER,
+    project: PROJECT
+  }
+}
+const BASE_URL = `/projects/${OWNER}/${PROJECT}`
+const LINKS = [
+  { text: 'About', href: `${BASE_URL}/about` },
+  { text: 'Classify', href: `${BASE_URL}/classify` },
+  { text: 'Talk', href: `${BASE_URL}/talk` },
+  { text: 'Collect', href: `${BASE_URL}/collections` },
+  { text: 'Recents', href: `${BASE_URL}/recents` }
+]
+
 describe('Component > Nav', function () {
   before(function () {
-    wrapper = shallow(<Nav />)
+    wrapper = shallow(<Nav router={ROUTER} />)
   })
 
   it('should render without crashing', function () {
     expect(wrapper).to.be.ok()
+  })
+
+  describe('Links', function () {
+    LINKS.map(link => {
+      it(`should show a \`${link.text}\` link`, function () {
+        const innerWrapper = wrapper.dive().shallow()
+        expect(innerWrapper.find({ text: link.text })).to.have.lengthOf(1)
+        expect(innerWrapper.find({ href: link.href })).to.have.lengthOf(1)
+      })
+    })
   })
 })

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/NavContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/NavContainer.js
@@ -1,0 +1,31 @@
+import { inject, observer } from 'mobx-react'
+import { bool } from 'prop-types'
+import React, { Component } from 'react'
+
+import Nav from './Nav'
+
+function storeMapper (stores) {
+  return {
+    isLoggedIn: stores.store.user.isLoggedIn
+  }
+}
+
+@inject(storeMapper)
+@observer
+class NavContainer extends Component {
+  render () {
+    return (
+      <Nav isLoggedIn={this.props.isLoggedIn} />
+    )
+  }
+}
+
+NavContainer.propTypes = {
+  isLoggedIn: bool
+}
+
+NavContainer.defaultProps = {
+  isLoggedIn: false
+}
+
+export default NavContainer

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/NavContainer.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/NavContainer.spec.js
@@ -1,0 +1,23 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import NavContainer from './NavContainer'
+import Nav from './Nav'
+
+let wrapper
+let componentWrapper
+
+describe('Component > NavContainer', function () {
+  before(function () {
+    wrapper = shallow(<NavContainer.wrappedComponent />)
+    componentWrapper = wrapper.find(Nav)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render the `Nav` component', function () {
+    expect(componentWrapper).to.have.lengthOf(1)
+  })
+})

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/components/NavLink/NavLink.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/components/NavLink/NavLink.js
@@ -42,3 +42,4 @@ NavLink.propTypes = {
 }
 
 export default withRouter(NavLink)
+export { NavLink }

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/components/NavLink/NavLink.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/components/NavLink/NavLink.js
@@ -1,0 +1,44 @@
+import { SpacedText } from '@zooniverse/react-components'
+import { Anchor } from 'grommet'
+import { shape, string } from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+import { withRouter } from 'next/router'
+
+const StyledSpacedText = styled(SpacedText)`
+  text-shadow: 0 2px 2px rgba(0,0,0,0.22);
+`
+
+const StyledAnchor = styled(Anchor)`
+  border-bottom: 3px solid transparent;
+  &:hover,
+  &:focus {
+    text-decoration: none;
+    border-color: white;
+  }
+  ${props => props.isActive && `
+    border-color: white;
+  `}
+`
+
+function NavLink (props) {
+  const { href, router, text } = props
+  const isActive = router.asPath.includes(href)
+  return (
+    <StyledAnchor href={href} isActive={isActive}>
+      <StyledSpacedText color='white' weight='bold'>
+        {text}
+      </StyledSpacedText>
+    </StyledAnchor>
+  )
+}
+
+NavLink.propTypes = {
+  href: string.isRequired,
+  router: shape({
+    asPath: string,
+  }),
+  text: string.isRequired,
+}
+
+export default withRouter(NavLink)

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/components/NavLink/NavLink.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/components/NavLink/NavLink.spec.js
@@ -13,9 +13,9 @@ const ROUTER = {
 }
 const BASE_URL = `/projects/${OWNER}/${PROJECT}`
 
-describe.only('Component > NavLink', function () {
+describe('Component > NavLink', function () {
   before(function () {
-    wrapper = shallow(<NavLink router={ROUTER} href={HREF} text={TEXT} />)
+    wrapper = shallow(<NavLink href={HREF} router={ROUTER} text={TEXT} />)
   })
 
   it('should render without crashing', function () {

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/components/NavLink/NavLink.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/components/NavLink/NavLink.spec.js
@@ -1,16 +1,32 @@
 import { shallow } from 'enzyme'
 import React from 'react'
 
-import NavLink from './NavLink'
+import { NavLink } from './NavLink'
 
 let wrapper
+const TEXT = 'Foobar'
+const OWNER = 'foo'
+const PROJECT = 'bar'
+const HREF = `http://www.foobar.com/projects/${OWNER}/${PROJECT}`
+const ROUTER = {
+  asPath: `/projects/${OWNER}/${PROJECT}`
+}
+const BASE_URL = `/projects/${OWNER}/${PROJECT}`
 
-describe('Component > NavLink', function () {
+describe.only('Component > NavLink', function () {
   before(function () {
-    wrapper = shallow(<NavLink />)
+    wrapper = shallow(<NavLink router={ROUTER} href={HREF} text={TEXT} />)
   })
 
   it('should render without crashing', function () {
     expect(wrapper).to.be.ok()
+  })
+
+  it('should have the correct text', function () {
+    expect(wrapper.text()).to.equal(TEXT)
+  })
+
+  it('should have the correct `href`', function () {
+    expect(wrapper.prop('href')).to.equal(HREF)
   })
 })

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/components/NavLink/NavLink.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/components/NavLink/NavLink.spec.js
@@ -1,0 +1,16 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import NavLink from './NavLink'
+
+let wrapper
+
+describe('Component > NavLink', function () {
+  before(function () {
+    wrapper = shallow(<NavLink />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+})

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/components/NavLink/index.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/components/NavLink/index.js
@@ -1,0 +1,1 @@
+export { default } from './NavLink'

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/index.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/index.js
@@ -1,0 +1,1 @@
+export { default } from './Nav'

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/index.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/index.js
@@ -1,1 +1,1 @@
-export { default } from './Nav'
+export { default } from './NavContainer'

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/locales/en.json
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/locales/en.json
@@ -1,0 +1,9 @@
+{
+  "Nav": {
+    "about": "About",
+    "classify": "Classify",
+    "talk": "Talk",
+    "collect": "Collect",
+    "recents": "Recents"
+  }
+}


### PR DESCRIPTION
Package: app-project

Adds the standard nav links to the project header.

cc #44 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

