### PR TITLE
Get hostname from request headers for meta tags

### DIFF
--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -25,6 +25,7 @@ const GlobalStyle = createGlobalStyle`
 export default class MyApp extends App {
   static async getInitialProps ({ Component, router, ctx: context }) {
     let pageProps = {
+      host: generateHostUrl(context),
       isServer: !!context.req
     }
 
@@ -76,7 +77,7 @@ export default class MyApp extends App {
         <GlobalStyle />
         <Provider store={this.store}>
           <Grommet theme={mergedThemes}>
-            <Head />
+            <Head host={pageProps.host} />
             <ZooHeaderWrapper />
             <ProjectHeader />
             <Component {...pageProps} />
@@ -98,4 +99,10 @@ function getSlugFromUrl (relativeUrl) {
   return (fragments[2] && fragments[3])
     ? `${fragments[2]}/${fragments[3]}`
     : undefined
+}
+
+function generateHostUrl (context) {
+  const { connection, headers } = context.req
+  const protocol = connection.encrypted ? 'https' : 'http'
+  return `${protocol}://${context.req.headers.host}`
 }

--- a/packages/app-project/src/components/Head/HeadContainer.js
+++ b/packages/app-project/src/components/Head/HeadContainer.js
@@ -46,9 +46,7 @@ class HeadContainer extends Component {
   }
 
   getProjectUrl () {
-    // TODO: Set this from an environment variable
-    const host = 'http://localhost:3000'
-    const { slug } = this.props.project
+    const { host, project: { slug } } = this.props
     return `${host}/projects/${slug}`
   }
 
@@ -66,6 +64,7 @@ class HeadContainer extends Component {
 }
 
 HeadContainer.propTypes = {
+  host: string,
   project: shape({
     avatar: shape({
       src: string


### PR DESCRIPTION
Package:

app-project

Generates the url to use for the meta tags from the request headers.

fix #569 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

