### PR TITLE
Use correct background color

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -15,14 +15,14 @@ const ClassifierWrapper = dynamic(() =>
 }
 )
 
-function ClassifyPage ({ mode }) {
+function ClassifyPage (props) {
   const collectionsModal = React.createRef()
   function addToCollection (subjectId) {
     collectionsModal.current.wrappedInstance.open(subjectId)
   }
   return (
     <Box
-      background={mode === 'light' ? 'lighterGrey' : 'midDarkGrey'}
+      background={props.mode === 'light' ? 'light-1' : 'dark-1'}
       pad={{ top: 'medium' }}
     >
       <CollectionsModal


### PR DESCRIPTION
Package: app-project

Set the correct background colour for the classify page

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

