### PR TITLE
UPP PUT request when tutorial is seen by logged in user

### DIFF
--- a/packages/app-project/stores/Recents.js
+++ b/packages/app-project/stores/Recents.js
@@ -42,7 +42,7 @@ const Recents = types
             project_id: project.id,
             sort: '-created_at'
           }
-          const response = yield client.panoptes.get(`/users/${user.id}/recents`, query, authorization)
+          const response = yield client.panoptes.get(`/users/${user.id}/recents`, query, { authorization })
           const { recents } = response.body
           self.recents = recents.map(recent => ({
             subjectId: recent.links.subject,

--- a/packages/app-project/stores/Recents.spec.js
+++ b/packages/app-project/stores/Recents.spec.js
@@ -63,13 +63,13 @@ describe('Stores > Recents', function () {
     })
 
     it('should request recent subjects from Panoptes', function () {
-      const token = 'Bearer '
+      const authorization = 'Bearer '
       const endpoint = '/users/123/recents'
       const query = {
         project_id: '2',
         sort: '-created_at'
       }
-      expect(rootStore.client.panoptes.get.withArgs(endpoint, query, token)).to.have.been.calledOnce()
+      expect(rootStore.client.panoptes.get.withArgs(endpoint, query, { authorization })).to.have.been.calledOnce()
     })
 
     it('should store existing recents', function () {

--- a/packages/app-project/stores/YourStats.js
+++ b/packages/app-project/stores/YourStats.js
@@ -49,7 +49,7 @@ const YourStats = types
             user_id: user.id
           }
           // TODO: this should really share the UPP that's being requested by the classifier.
-          const response = yield panoptes.get('/project_preferences', query, authorization)
+          const response = yield panoptes.get('/project_preferences', query, { authorization })
           const [ preferences ] = response.body.project_preferences
           self.totalCount = preferences ? preferences.activity_count : 0
         } catch (error) {

--- a/packages/app-project/stores/YourStats.spec.js
+++ b/packages/app-project/stores/YourStats.spec.js
@@ -58,13 +58,13 @@ describe('Stores > YourStats', function () {
     })
 
     it('should request user preferences', function () {
-      const token = 'Bearer '
+      const authorization = 'Bearer '
       const endpoint = '/project_preferences'
       const query = {
         project_id: '2',
         user_id: '123'
       }
-      expect(rootStore.client.panoptes.get.withArgs(endpoint, query, token)).to.have.been.calledOnce()
+      expect(rootStore.client.panoptes.get.withArgs(endpoint, query, { authorization })).to.have.been.calledOnce()
     })
 
     it('should store your activity count', function () {

--- a/packages/lib-async-states/src/async-states.js
+++ b/packages/lib-async-states/src/async-states.js
@@ -12,6 +12,12 @@ Object.defineProperty(asyncStates, 'loading', {
   enumerable: true
 })
 
+// remote put in progress
+Object.defineProperty(asyncStates, 'putting', {
+  value: 'putting',
+  enumerable: true
+})
+
 // remote post in progress
 Object.defineProperty(asyncStates, 'posting', {
   value: 'posting',

--- a/packages/lib-async-states/src/async-states.spec.js
+++ b/packages/lib-async-states/src/async-states.spec.js
@@ -6,6 +6,7 @@ describe('asyncStates', function () {
   const states = [
     'initialized',
     'loading',
+    'putting',
     'posting',
     'success',
     'error'

--- a/packages/lib-classifier/dev/components/App/App.js
+++ b/packages/lib-classifier/dev/components/App/App.js
@@ -32,10 +32,10 @@ class App extends React.Component {
       })
   }
 
-  getBearerToken () {
-    const token = oauth.checkBearerToken()
+  async getBearerToken () {
+    const token = await oauth.checkBearerToken()
     if (token) {
-      return `Bearer ${token}`
+      return `Bearer ${token.access_token}`
     }
 
     return ''
@@ -53,8 +53,8 @@ class App extends React.Component {
     }
 
     try {
-      const bearerToken = this.getBearerToken()
-      const response = await panoptes.get(`/projects/${id}`, {}, bearerToken)
+      const bearerToken = await this.getBearerToken()
+      const response = await panoptes.get(`/projects/${id}`, {}, { authorization: bearerToken })
       const project = response.body.projects[0]
       this.setState({ project })
     } catch (error) {

--- a/packages/lib-classifier/src/store/ResourceStore.js
+++ b/packages/lib-classifier/src/store/ResourceStore.js
@@ -21,6 +21,7 @@ const ResourceStore = types
       self.loadingState = asyncStates.loading
       try {
         const response = yield client.get(`/${type}/${id}`)
+        self.headers = response.headers
         const resource = response.body[type][0]
         self.loadingState = asyncStates.success
         return resource
@@ -31,9 +32,7 @@ const ResourceStore = types
     }),
 
     reset () {
-      if (self.headers) {
-        self.headers = undefined
-      }
+      self.headers = undefined
       self.active = undefined
       self.resources.clear()
     },

--- a/packages/lib-classifier/src/store/ResourceStore.js
+++ b/packages/lib-classifier/src/store/ResourceStore.js
@@ -6,6 +6,9 @@ import Resource from './Resource'
 const ResourceStore = types
   .model('ResourceStore', {
     active: types.maybe(types.reference(Resource)),
+    headers: types.maybe(types.frozen({
+      etag: types.string
+    })),
     resources: types.map(Resource),
     loadingState: types.optional(types.enumeration('loadingState', asyncStates.values), asyncStates.initialized),
     type: types.string
@@ -28,6 +31,9 @@ const ResourceStore = types
     }),
 
     reset () {
+      if (self.headers) {
+        self.headers = undefined
+      }
       self.active = undefined
       self.resources.clear()
     },

--- a/packages/lib-classifier/src/store/ResourceStore.js
+++ b/packages/lib-classifier/src/store/ResourceStore.js
@@ -7,7 +7,7 @@ const ResourceStore = types
   .model('ResourceStore', {
     active: types.maybe(types.reference(Resource)),
     headers: types.maybe(types.frozen({
-      etag: types.string
+      // etag: types.string // setting this is causing the store to be set with a MST type and thus defined. Maybe a bug?
     })),
     resources: types.map(Resource),
     loadingState: types.optional(types.enumeration('loadingState', asyncStates.values), asyncStates.initialized),

--- a/packages/lib-classifier/src/store/ResourceStore.spec.js
+++ b/packages/lib-classifier/src/store/ResourceStore.spec.js
@@ -72,7 +72,7 @@ describe('Model > ResourceStore', function () {
     resetStore.reset()
     expect(resetStore.resources.size).to.equal(0)
     expect(resetStore.active).to.be.undefined
-    // expect(resetStore.headers).to.be.undefined
+    expect(Object.keys(resourceStore.headers)).to.have.lengthOf(0)
   })
 
   it('should use an existing resources object when `setActive` is called', async function () {
@@ -87,12 +87,10 @@ describe('Model > ResourceStore', function () {
     expect(clientStub.panoptes.get.called).to.be.true
   })
 
-  // This test is failing due to a MST error, that might be a bug.
-  // We should try upgrading MST because we're a few minor versions behind...
-  // it('should set the headers object when a successful get request is made', async function () {
-  //   resourceStore.reset()
-  //   expect(resourceStore.headers).to.be.undefined
-  //   await resourceStore.setActive('789')
-  //   expect(resourceStore.headers).to.include({ etag: etagStub })
-  // })
+  it('should set the headers object when a successful get request is made', async function () {
+    resourceStore.reset()
+    expect(Object.keys(resourceStore.headers)).to.have.lengthOf(0)
+    await resourceStore.setActive('789')
+    expect(resourceStore.headers).to.include({ etag: etagStub })
+  })
 })

--- a/packages/lib-classifier/src/store/ResourceStore.spec.js
+++ b/packages/lib-classifier/src/store/ResourceStore.spec.js
@@ -28,12 +28,17 @@ const otherResourceStub = {
   id: '789'
 }
 
+const etagStub = 'W/"0b15c86677"'
+
 const clientStub = {
   panoptes: {
     get () {
       return Promise.resolve({
         body: {
           foobar: [otherResourceStub]
+        },
+        headers: {
+          etag: etagStub
         }
       })
     }
@@ -67,6 +72,7 @@ describe('Model > ResourceStore', function () {
     resetStore.reset()
     expect(resetStore.resources.size).to.equal(0)
     expect(resetStore.active).to.be.undefined
+    // expect(resetStore.headers).to.be.undefined
   })
 
   it('should use an existing resources object when `setActive` is called', async function () {
@@ -80,4 +86,13 @@ describe('Model > ResourceStore', function () {
     expect(resourceStore.active).to.deep.equal(otherResourceStub)
     expect(clientStub.panoptes.get.called).to.be.true
   })
+
+  // This test is failing due to a MST error, that might be a bug.
+  // We should try upgrading MST because we're a few minor versions behind...
+  // it('should set the headers object when a successful get request is made', async function () {
+  //   resourceStore.reset()
+  //   expect(resourceStore.headers).to.be.undefined
+  //   await resourceStore.setActive('789')
+  //   expect(resourceStore.headers).to.include({ etag: etagStub })
+  // })
 })

--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -74,7 +74,7 @@ const SubjectStore = types
       try {
         const { authClient } = getRoot(self)
         const authorization = yield getBearerToken(authClient)
-        const response = yield client.get(`/subjects/queued`, { workflow_id: workflowId }, authorization)
+        const response = yield client.get(`/subjects/queued`, { workflow_id: workflowId }, { authorization })
 
         response.body.subjects.forEach(subject => {
           self.resources.put(subject)

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -187,11 +187,10 @@ const TutorialStore = types
         if (tutorial.kind === 'tutorial' || tutorial.kind === null) {
           self.tutorialSeenTime = seen
           if (uppStore.active) {
+            console.log('calling upp update')
             const changes = {
-              preferences: {
-                tutorials_completed_at: {
-                  [tutorial.id]: seen
-                }
+              tutorials_completed_at: {
+                [tutorial.id]: seen
               }
             }
             uppStore.updateUPP(changes)

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -187,10 +187,11 @@ const TutorialStore = types
         if (tutorial.kind === 'tutorial' || tutorial.kind === null) {
           self.tutorialSeenTime = seen
           if (uppStore.active) {
-            console.log('calling upp update')
             const changes = {
-              tutorials_completed_at: {
-                [tutorial.id]: seen
+              preferences: {
+                tutorials_completed_at: {
+                  [tutorial.id]: seen
+                }
               }
             }
             uppStore.updateUPP(changes)

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -503,6 +503,7 @@ describe('Model > TutorialStore', function () {
       })
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
+      sinon.stub(rootStore.userProjectPreferences, 'updateUPP').callsFake(() => {})
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
@@ -514,6 +515,7 @@ describe('Model > TutorialStore', function () {
       }).then(() => {
         setActiveTutorialSpy.restore()
         setModalVisibilitySpy.restore()
+        rootStore.userProjectPreferences.updateUPP.restore()
       }).then(done, done)
     })
 
@@ -523,7 +525,8 @@ describe('Model > TutorialStore', function () {
       })
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
-
+      sinon.stub(rootStore.userProjectPreferences, 'updateUPP').callsFake(() => { })
+      
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
       rootStore.workflows.setActive(workflow.id)
@@ -535,6 +538,7 @@ describe('Model > TutorialStore', function () {
         }).then(() => {
           setActiveTutorialSpy.restore()
           setModalVisibilitySpy.restore()
+          rootStore.userProjectPreferences.updateUPP.restore()
         }).then(done, done)
     })
 

--- a/packages/lib-classifier/src/store/UserProjectPreferencesStore.js
+++ b/packages/lib-classifier/src/store/UserProjectPreferencesStore.js
@@ -9,9 +9,6 @@ import merge from 'lodash/merge'
 const UserProjectPreferencesStore = types
   .model('UserProjectPreferencesStore', {
     active: types.maybe(types.reference(UserProjectPreferences)),
-    headers: types.maybe(types.frozen({
-      etag: types.string
-    })),
     resources: types.optional(types.map(UserProjectPreferences), {}),
     type: types.optional(types.string, 'project_preferences')
   })

--- a/packages/lib-classifier/src/store/UserProjectPreferencesStore.spec.js
+++ b/packages/lib-classifier/src/store/UserProjectPreferencesStore.spec.js
@@ -160,7 +160,7 @@ describe('Model > UserProjectPreferencesStore', function () {
           expect(getSpy).to.have.been.calledWith(
             '/project_preferences',
             { project_id: project.id, user_id: user.id },
-            'Bearer 1234'
+            { authorization: 'Bearer 1234' }
           )
         }).then(done, done)
 
@@ -218,7 +218,7 @@ describe('Model > UserProjectPreferencesStore', function () {
               links: { project: project.id },
               preferences: {}
             } },
-            `Bearer ${token}`
+            { authorization: `Bearer ${token}` }
           )
         }).then(done, done)
     })

--- a/packages/lib-classifier/src/store/utils/ClassificationQueue.js
+++ b/packages/lib-classifier/src/store/utils/ClassificationQueue.js
@@ -63,7 +63,7 @@ class ClassificationQueue {
     return getBearerToken(this.authClient)
       .then((authorization) => {
         return Promise.all(pendingClassifications.map((classificationData) => {
-          return this.apiClient.post(this.endpoint, { classifications: classificationData }, authorization)
+          return this.apiClient.post(this.endpoint, { classifications: classificationData }, { authorization })
             .then((response) => {
               if (response.ok) {
                 const savedClassification = response.body.classifications[0]

--- a/packages/lib-classifier/test/stubPanoptesJs/stubPanoptesJs.js
+++ b/packages/lib-classifier/test/stubPanoptesJs/stubPanoptesJs.js
@@ -11,7 +11,8 @@ export default function stubPanoptesJs (factories) {
   return {
     panoptes: {
       get: (url) => createResponse(url, factories),
-      post: (url) => createResponse(url, factories)
+      post: (url) => createResponse(url, factories),
+      put: (url) => createResponse(url, factories)
     }
   }
 }

--- a/packages/lib-panoptes-js/src/panoptes.js
+++ b/packages/lib-panoptes-js/src/panoptes.js
@@ -16,7 +16,7 @@ function checkForAdminFlag () {
 }
 
 // TODO: Consider how to integrate a GraphQL option
-function get (endpoint, query, authorization = '', host) {
+function get (endpoint, query, headers = {}, host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
 
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
@@ -25,7 +25,7 @@ function get (endpoint, query, authorization = '', host) {
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/vnd.api+json; version=1')
 
-  if (authorization) request.set('Authorization', authorization)
+  if (headers && headers.authorization) request.set('Authorization', headers.authorization)
 
   if (query && Object.keys(query).length > 0) {
     if (typeof query !== 'object') return Promise.reject(new TypeError('Query must be an object'))
@@ -38,7 +38,7 @@ function get (endpoint, query, authorization = '', host) {
   return request.then(response => response)
 }
 
-function post (endpoint, data, authorization = '', host) {
+function post (endpoint, data, headers = {}, host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
 
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
@@ -48,16 +48,15 @@ function post (endpoint, data, authorization = '', host) {
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/vnd.api+json; version=1')
 
-  if (authorization) request.set('Authorization', authorization)
+  if (headers && headers.authorization) request.set('Authorization', headers.authorization)
 
   return request.query(defaultParams)
     .send(data)
     .then(response => response)
 }
 
-function put (endpoint, data, authorization = '', host) {
+function put (endpoint, data, headers = {}, host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
-
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
   if (!data) return handleMissingParameter('Request needs a defined data for update')
   const apiHost = host || config.host
@@ -66,14 +65,17 @@ function put (endpoint, data, authorization = '', host) {
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/vnd.api+json; version=1')
 
-  if (authorization) request.set('Authorization', authorization)
+  if (headers && headers.authorization) request.set('Authorization', headers.authorization)
+  if (headers && headers.etag) request.set('If-Match', headers.etag)
+  // This is a fallback method for matching if etag is missing...
+  if (headers && headers.lastModified) request.set('If-Unmodified-Since', headers.lastModified)
 
   return request.query(defaultParams)
     .send(data)
     .then(response => response)
 }
 
-function del (endpoint, authorization = '', host) {
+function del (endpoint, headers = {}, host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
 
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
@@ -83,7 +85,7 @@ function del (endpoint, authorization = '', host) {
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/vnd.api+json; version=1')
 
-  if (authorization) request.set('Authorization', authorization)
+  if (headers && headers.authorization) request.set('Authorization', headers.authorization)
 
   return request.query(defaultParams)
     .then(response => response)

--- a/packages/lib-panoptes-js/src/panoptes.js
+++ b/packages/lib-panoptes-js/src/panoptes.js
@@ -67,7 +67,6 @@ function put (endpoint, data, headers = {}, host) {
 
   if (headers && headers.authorization) request.set('Authorization', headers.authorization)
   if (headers && headers.etag) request.set('If-Match', headers.etag)
-  if (headers && headers.lastModified) request.set('If-Unmodified-Since', headers.lastModified)
 
   return request.query(defaultParams)
     .send(data)

--- a/packages/lib-panoptes-js/src/panoptes.js
+++ b/packages/lib-panoptes-js/src/panoptes.js
@@ -67,7 +67,6 @@ function put (endpoint, data, headers = {}, host) {
 
   if (headers && headers.authorization) request.set('Authorization', headers.authorization)
   if (headers && headers.etag) request.set('If-Match', headers.etag)
-  // This is a fallback method for matching if etag is missing...
   if (headers && headers.lastModified) request.set('If-Unmodified-Since', headers.lastModified)
 
   return request.query(defaultParams)

--- a/packages/lib-panoptes-js/src/panoptes.spec.js
+++ b/packages/lib-panoptes-js/src/panoptes.spec.js
@@ -114,12 +114,6 @@ describe('panoptes.js', function () {
       expect(response.req.headers['if-match']).to.equal(etag)
     })
 
-    it('should add If-Unmodified-Since header to the request', async function () {
-      const lastModified = 'Sun, 17 Mar 2019 23:40:50 GMT'
-      const response = await panoptes.put(endpoint, update, { lastModified })
-      expect(response.req.headers['if-unmodified-since']).to.equal(lastModified)
-    })
-
     it('should send any data params if defined', async function () {
       const response = await panoptes.put(endpoint, update)
       expect(response.body).to.deep.equal(expectedResponse)

--- a/packages/lib-panoptes-js/src/panoptes.spec.js
+++ b/packages/lib-panoptes-js/src/panoptes.spec.js
@@ -108,6 +108,18 @@ describe('panoptes.js', function () {
     testAdminParam('put', endpoint, update)
     testNoEndpoint('put')
 
+    it('should add If-Match header to the request', async function () {
+      const etag = 'W/"8d26cb6718e250b"'
+      const response = await panoptes.put(endpoint, update, { etag })
+      expect(response.req.headers['if-match']).to.equal(etag)
+    })
+
+    it('should add If-Unmodified-Since header to the request', async function () {
+      const lastModified = 'Sun, 17 Mar 2019 23:40:50 GMT'
+      const response = await panoptes.put(endpoint, update, { lastModified })
+      expect(response.req.headers['if-unmodified-since']).to.equal(lastModified)
+    })
+
     it('should send any data params if defined', async function () {
       const response = await panoptes.put(endpoint, update)
       expect(response.body).to.deep.equal(expectedResponse)
@@ -195,12 +207,13 @@ describe('panoptes.js', function () {
   function testAuthHeader (method, endpoint, update = null) {
     it('should add the `Authorization` header to the request if param is defined', async function () {
       const isDel = method === 'del'
+      const headers = { authorization: 'Bearer 12345' }
       const methodArgs = isDel
-        ? [endpoint, '12345']
-        : [endpoint, update, '12345']
+        ? [endpoint, headers]
+        : [endpoint, update, headers]
 
       const response = await panoptes[method].apply(this, methodArgs)
-      expect(response.req.headers['authorization']).to.equal('12345')
+      expect(response.req.headers['authorization']).to.equal('Bearer 12345')
     })
   }
 

--- a/packages/lib-panoptes-js/src/resources/collections/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/collections/commonRequests.js
@@ -11,7 +11,7 @@ function addSubjects (params) {
 
   if (typeof collectionId !== 'string') return raiseError('Collections add link: collections id must be a string.', 'typeError')
 
-  return panoptes.post(`${endpoint}/${collectionId}/links/subjects`, { subjects }, authorization)
+  return panoptes.post(`${endpoint}/${collectionId}/links/subjects`, { subjects }, { authorization })
 }
 
 function removeSubjects (params) {
@@ -23,7 +23,7 @@ function removeSubjects (params) {
 
   if (typeof collectionId !== 'string') return raiseError('Collections remove link: collections id must be a string.', 'typeError')
 
-  return panoptes.del(`${endpoint}/${collectionId}/links/subjects/${subjects.join(',')}`, authorization)
+  return panoptes.del(`${endpoint}/${collectionId}/links/subjects/${subjects.join(',')}`, { authorization })
 }
 
 module.exports = { addSubjects, removeSubjects }

--- a/packages/lib-panoptes-js/src/resources/collections/rest.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.js
@@ -14,7 +14,7 @@ function create (params) {
   }
   const collections = Object.assign({}, newCollectionData, { links })
 
-  return panoptes.post(endpoint, { collections }, authorization)
+  return panoptes.post(endpoint, { collections }, { authorization })
 }
 
 function get (params) {
@@ -22,10 +22,10 @@ function get (params) {
   const collectionId = (params && params.id) ? params.id : ''
   const authorization = (params && params.authorization) ? params.authorization : ''
 
-  if (!collectionId) return panoptes.get(endpoint, queryParams, authorization)
+  if (!collectionId) return panoptes.get(endpoint, queryParams, { authorization })
   if (collectionId && typeof collectionId !== 'string') return raiseError('Collections: Get request id must be a string.', 'typeError')
 
-  return panoptes.get(`${endpoint}/${collectionId}`, {}, authorization)
+  return panoptes.get(`${endpoint}/${collectionId}`, {}, { authorization })
 }
 
 function update (params) {
@@ -35,7 +35,7 @@ function update (params) {
   if (!collectionId) return raiseError('Collections: Update request id must be present.', 'typeError')
   if (!changes) return raiseError('Collection update: payload not supplied.', 'error')
 
-  return panoptes.put(`${endpoint}/${collectionId}`, { collections: changes }, authorization)
+  return panoptes.put(`${endpoint}/${collectionId}`, { collections: changes }, { authorization })
 }
 
 function del (params) {
@@ -45,7 +45,7 @@ function del (params) {
   if (!collectionId) return raiseError('Collections: Delete request id must be present.', 'typeError')
   if (collectionId && typeof collectionId !== 'string') return raiseError('Collections: Delete request id must be a string.', 'typeError')
 
-  return panoptes.del(`${endpoint}/${collectionId}`, authorization)
+  return panoptes.del(`${endpoint}/${collectionId}`, { authorization })
 }
 
 module.exports = { create, get, update, del }

--- a/packages/lib-panoptes-js/src/resources/projects/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/projects/commonRequests.js
@@ -12,7 +12,7 @@ function getBySlug (params) {
   }
 
   if (queryParams.slug) {
-    return panoptes.get(endpoint, queryParams, authorization)
+    return panoptes.get(endpoint, queryParams, { authorization })
   }
 
   return raiseError('Projects: Get by slug request missing required parameter: slug string.', 'error')
@@ -30,13 +30,13 @@ function getWithLinkedResources (params) {
   if (projectId && typeof projectId !== 'string') return raiseError('Projects: Get request id must be a string.', 'typeError')
   if (!queryParams.slug && !projectId) return raiseError('Projects: Get request must have either project id or slug.', 'typeError')
 
-  if (projectId) return panoptes.get(`${endpoint}/${projectId}`, queryParams, authorization)
+  if (projectId) return panoptes.get(`${endpoint}/${projectId}`, queryParams, { authorization })
 
   if (queryParams.slug && queryParams.slug.includes('projects')) {
     queryParams.slug = getProjectSlugFromURL(queryParams.slug)
   }
 
-  return panoptes.get(endpoint, queryParams, authorization)
+  return panoptes.get(endpoint, queryParams, { authorization })
 }
 
 module.exports = { getBySlug, getWithLinkedResources }

--- a/packages/lib-panoptes-js/src/resources/projects/rest.js
+++ b/packages/lib-panoptes-js/src/resources/projects/rest.js
@@ -10,7 +10,7 @@ function create (params) {
     private: true
   }, newProjectData)
 
-  return panoptes.post(endpoint, allProjectData, authorization)
+  return panoptes.post(endpoint, allProjectData, { authorization })
 }
 
 function get (params) {
@@ -18,10 +18,10 @@ function get (params) {
   const projectId = (params && params.id) ? params.id : ''
   const authorization = (params && params.authorization) ? params.authorization : ''
 
-  if (!projectId) return panoptes.get(endpoint, queryParams, authorization)
+  if (!projectId) return panoptes.get(endpoint, queryParams, { authorization })
   if (projectId && typeof projectId !== 'string') return raiseError('Projects: Get request id must be a string.', 'typeError')
 
-  return panoptes.get(`${endpoint}/${projectId}`, queryParams, authorization)
+  return panoptes.get(`${endpoint}/${projectId}`, queryParams, { authorization })
 }
 
 function update (params) {
@@ -29,7 +29,7 @@ function update (params) {
   const authorization = (params && params.authorization) ? params.authorization : ''
 
   if (id && typeof id !== 'string') return raiseError('Projects: Update request id must be a string.', 'typeError')
-  if (id && data) return panoptes.put(`${endpoint}/${id}`, data, authorization)
+  if (id && data) return panoptes.put(`${endpoint}/${id}`, data, { authorization })
   if (!id) return raiseError('Projects: Update request missing project id.', 'error')
   if (!data) return raiseError('Projects: Update request missing data to post.', 'error')
 
@@ -41,7 +41,7 @@ function del (params) {
   const authorization = (params && params.authorization) ? params.authorization : ''
 
   if (id && typeof id !== 'string') return raiseError('Projects: Delete request id must be a string.', 'typeError')
-  if (id) return panoptes.del(`${endpoint}/${id}`, authorization)
+  if (id) return panoptes.del(`${endpoint}/${id}`, { authorization })
   return raiseError('Projects: Delete request missing project id.', 'error')
 }
 

--- a/packages/lib-panoptes-js/src/resources/subjects/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/commonRequests.js
@@ -15,7 +15,7 @@ function getSubjectQueue (params) {
     queryParams.workflow_id = workflowId
     if (subjectSetId) queryParams.subject_set_id = subjectSetId
 
-    return panoptes.get(queuedEndpoint, queryParams, authorization)
+    return panoptes.get(queuedEndpoint, queryParams, { authorization })
   }
 
   return raiseError('Subjects: Get request must include a workflow id.', 'error')

--- a/packages/lib-panoptes-js/src/resources/subjects/rest.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/rest.js
@@ -14,7 +14,7 @@ function get (params) {
   if (isParamTypeInvalid(subjectId, 'string')) return raiseError('Subjects: Get request id must be a string.', 'typeError')
 
   if (subjectId) {
-    return panoptes.get(`${endpoint}/${subjectId}`, queryParams, authorization)
+    return panoptes.get(`${endpoint}/${subjectId}`, queryParams, { authorization })
   }
 
   if (console && !subjectId && process.env.NODE_ENV !== 'test') {

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.js
@@ -11,7 +11,7 @@ function getAttachedImages (params) {
     const queryParams = (params && params.query) ? params.query : {}
     const tutorialAttachedImagesEndpoint = `${endpoint}/${tutorialId}/attached_images`
 
-    return panoptes.get(tutorialAttachedImagesEndpoint, queryParams, authorization)
+    return panoptes.get(tutorialAttachedImagesEndpoint, queryParams, { authorization })
   }
 
   return raiseError('Tutorials: getAttachedImages request requires a tutorial id.', 'error')

--- a/packages/lib-panoptes-js/src/resources/tutorials/rest.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/rest.js
@@ -16,12 +16,12 @@ function get (params) {
   if (isParamTypeInvalid(workflowId, 'string')) return raiseError('Tutorials: Get request workflow id must be a string.', 'typeError')
 
   if (tutorialId) {
-    return panoptes.get(`${endpoint}/${tutorialId}`, queryParams, authorization)
+    return panoptes.get(`${endpoint}/${tutorialId}`, queryParams, { authorization })
   }
 
   if (workflowId) {
     queryParams.workflow_id = workflowId
-    return panoptes.get(endpoint, queryParams, authorization)
+    return panoptes.get(endpoint, queryParams, { authorization })
   }
 
   return raiseError('Tutorials: Get request must include a workflow id or a tutorial id.', 'error')


### PR DESCRIPTION
Package: lib-panoptes-js, lib-classifier, app-project, lib-async-states

Describe your changes:
This is branched off of the branch for #552. This is a fairly large refactor to allow setting many headers for the panoptes requests. This is because we need to set `If-Match` and `If-Unmodified-Since` headers for successful PUT requests (we didn't have one in the code until now). I missed this at first pass of writing the new panoptes.js client. So, the basic request functions now take a headers object rather than just the string for the authorization header. I've updated all of the places where I found a header being set to be an object now. 

The PUT request is almost working, but I'm still getting a 412 because I haven't figured out how `If-Unmodified-Since` is supposed to be set. I'm looking at the json-api-client:

https://github.com/zooniverse/json-api-client/blob/1a2433b28464ca37854774586d5133ebaf0be60e/src/resource.coffee#L204

And it's using a `Last-Modified` header, but I'm not sure where that is coming from. I don't see these in the responses from Panoptes. Any help would be appreciated.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

