### PR TITLE
Add project header background image

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
@@ -5,10 +5,15 @@ import React from 'react'
 import styled from 'styled-components'
 
 import Avatar from './components/Avatar'
+import Background from './components/Background'
 import Nav from './components/Nav'
 import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
+
+const StyledBox = styled(Box)`
+  position: relative;
+`
 
 const StyledHeading = styled(Heading)`
   text-shadow: 0 2px 4px rgba(0,0,0,0.5);
@@ -17,22 +22,25 @@ const StyledHeading = styled(Heading)`
 function ProjectHeader (props) {
   const { className, title } = props
   return (
-    <Box
-      align='center'
-      background='brand'
-      className={className}
-      direction='row'
-      justify='between'
-      pad='medium'
-    >
-      <Box align='center' direction='row' gap='medium'>
-        <Avatar />
-        <StyledHeading color='white' margin='none' size='small'>
-          {title}
-        </StyledHeading>
+    <StyledBox>
+      <Background />
+      <Box
+        align='center'
+        className={className}
+        direction='row'
+        justify='between'
+        pad='medium'
+      >
+        <Box align='center' direction='row' gap='medium'>
+          <Avatar />
+          <StyledHeading color='white' margin='none' size='small'>
+            {title}
+          </StyledHeading>
+        </Box>
+        <Nav />
       </Box>
-      <Nav />
-    </Box>
+    </StyledBox>
+
   )
 }
 

--- a/packages/app-project/src/components/ProjectHeader/components/Background/Background.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Background/Background.js
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types'
-import { string } from 'react'
+import { string } from 'prop-types'
+import React from 'react'
 import { Box } from 'grommet'
 import styled from 'styled-components'
 

--- a/packages/app-project/src/components/ProjectHeader/components/Background/Background.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Background/Background.js
@@ -3,32 +3,32 @@ import React from 'react'
 import { Box } from 'grommet'
 import styled from 'styled-components'
 
-const StyledBox = styled(Box)`
-  height: 100%;
-  overflow: hidden;
+const BackgroundBox = styled(Box)`
   position: absolute;
-  width: 100%;
   z-index: -1;
 `
 
-const StyledImg = styled.img`
-  filter: blur(4px);
-  object-fit: cover;
-  opacity: 0.5;
+const BackgroundImage = styled.div`
+  background-blend-mode: multiply;
+  background-color: rgba(0,93,105,0.3);
+  background-image: url("${props => props.src}");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  filter: blur(5px) brightness(50%);
+  height: 100%;
+  transform: scale(1.15);
 `
 
 function Background ({ backgroundSrc }) {
   return (
-    <StyledBox
-      align='center'
-      background={backgroundSrc ? 'black' : 'brand'}
+    <BackgroundBox
+      background='brand'
       height='100%'
-      justify='center'
+      width='100%'
     >
-      {backgroundSrc && (
-        <StyledImg aria-hidden='true' src={backgroundSrc} />
-      )}
-    </StyledBox>
+      {backgroundSrc && <BackgroundImage src={backgroundSrc} />}
+    </BackgroundBox>
   )
 }
 

--- a/packages/app-project/src/components/ProjectHeader/components/Background/Background.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Background/Background.js
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 const StyledBox = styled(Box)`
   height: 100%;
+  overflow: hidden;
   position: absolute;
   width: 100%;
   z-index: -1;

--- a/packages/app-project/src/components/ProjectHeader/components/Background/Background.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Background/Background.js
@@ -1,0 +1,38 @@
+import PropTypes from 'prop-types'
+import { string } from 'react'
+import { Box } from 'grommet'
+import styled from 'styled-components'
+
+const StyledBox = styled(Box)`
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  z-index: -1;
+`
+
+const StyledImg = styled.img`
+  filter: blur(4px);
+  object-fit: cover;
+  opacity: 0.5;
+`
+
+function Background ({ backgroundSrc }) {
+  return (
+    <StyledBox
+      align='center'
+      background={backgroundSrc ? 'black' : 'brand'}
+      height='100%'
+      justify='center'
+    >
+      {backgroundSrc && (
+        <StyledImg aria-hidden='true' src={backgroundSrc} />
+      )}
+    </StyledBox>
+  )
+}
+
+Background.propTypes = {
+  backgroundSrc: string
+}
+
+export default Background

--- a/packages/app-project/src/components/ProjectHeader/components/Background/Background.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Background/Background.spec.js
@@ -17,7 +17,7 @@ describe('Component > Background', function () {
 
   it('should render an image if the `backgroundSrc` prop has been passed', function () {
     const wrapperWithImage = render(<Background backgroundSrc={BACKGROUND_SRC} />)
-    const imageWrapper = wrapperWithImage.find('img')
+    const imageWrapper = wrapperWithImage.find('div')
     expect(imageWrapper).to.have.lengthOf(1)
     expect(imageWrapper.prop('src')).to.equal(BACKGROUND_SRC)
   })

--- a/packages/app-project/src/components/ProjectHeader/components/Background/Background.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Background/Background.spec.js
@@ -1,0 +1,24 @@
+import { shallow, render } from 'enzyme'
+import React from 'react'
+
+import Background from './Background'
+
+let wrapper
+const BACKGROUND_SRC = 'http://www.foobar.com/image.jpg'
+
+describe('Component > Background', function () {
+  before(function () {
+    wrapper = shallow(<Background />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render an image if the `backgroundSrc` prop has been passed', function () {
+    const wrapperWithImage = render(<Background backgroundSrc={BACKGROUND_SRC} />)
+    const imageWrapper = wrapperWithImage.find('img')
+    expect(imageWrapper).to.have.lengthOf(1)
+    expect(imageWrapper.prop('src')).to.equal(BACKGROUND_SRC)
+  })
+})

--- a/packages/app-project/src/components/ProjectHeader/components/Background/BackgroundContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Background/BackgroundContainer.js
@@ -1,0 +1,27 @@
+import { inject, observer } from 'mobx-react'
+import { string } from 'prop-types'
+import React, { Component } from 'react'
+
+import Background from './Background'
+
+function storeMapper (stores) {
+  return {
+    backgroundSrc: stores.store.project.background.src
+  }
+}
+
+@inject(storeMapper)
+@observer
+class BackgroundContainer extends Component {
+  render () {
+    return (
+      <Background backgroundSrc={this.props.backgroundSrc} />
+    )
+  }
+}
+
+BackgroundContainer.propTypes = {
+  backgroundSrc: string,
+}
+
+export default BackgroundContainer

--- a/packages/app-project/src/components/ProjectHeader/components/Background/BackgroundContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Background/BackgroundContainer.js
@@ -15,7 +15,7 @@ function storeMapper (stores) {
 class BackgroundContainer extends Component {
   render () {
     return (
-      <Background backgroundSrc={this.props.backgroundSrc} />
+      <Background aria-hidden={true} backgroundSrc={this.props.backgroundSrc} />
     )
   }
 }

--- a/packages/app-project/src/components/ProjectHeader/components/Background/BackgroundContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Background/BackgroundContainer.js
@@ -15,7 +15,10 @@ function storeMapper (stores) {
 class BackgroundContainer extends Component {
   render () {
     return (
-      <Background aria-hidden={true} backgroundSrc={this.props.backgroundSrc} />
+      <Background
+        aria-hidden={true}
+        backgroundSrc={this.props.backgroundSrc}
+      />
     )
   }
 }

--- a/packages/app-project/src/components/ProjectHeader/components/Background/BackgroundContainer.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Background/BackgroundContainer.spec.js
@@ -1,0 +1,28 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import BackgroundContainer from './BackgroundContainer'
+import Background from './Background'
+
+let wrapper
+let componentWrapper
+const BACKGROUND_SRC = 'http://www.foobar.com/image.jpg'
+
+describe('Component > BackgroundContainer', function () {
+  before(function () {
+    wrapper = shallow(<BackgroundContainer.wrappedComponent backgroundSrc={BACKGROUND_SRC} />)
+    componentWrapper = wrapper.find(Background)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render the `Background` component', function () {
+    expect(componentWrapper).to.have.lengthOf(1)
+  })
+
+  it('should pass through the `backgroundSrc` prop', function () {
+    expect(componentWrapper.prop('backgroundSrc')).to.equal(BACKGROUND_SRC)
+  })
+})

--- a/packages/app-project/src/components/ProjectHeader/components/Background/index.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Background/index.js
@@ -1,0 +1,1 @@
+export { default } from './BackgroundContainer'


### PR DESCRIPTION
Package:

app-project

Closes #556.

Adds the project background image to the header component.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

