### PR TITLE
Ensure only required props are passed to <Box />

### DIFF
--- a/packages/lib-react-components/src/ZooHeader/ZooHeaderContainer.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeaderContainer.js
@@ -5,9 +5,9 @@ import { withResizeDetector } from 'react-resize-detector'
 import ZooHeader from './ZooHeader'
 
 function ZooHeaderContainer (props) {
-  const { className, width, breakpoint } = props
+  const { breakpoint, className, height, width, ...rest } = props
   const isNarrow = width <= breakpoint
-  return <ZooHeader className={className} isNarrow={isNarrow} {...props} />
+  return <ZooHeader className={className} isNarrow={isNarrow} {...rest} />
 }
 
 ZooHeaderContainer.defaultProps = {


### PR DESCRIPTION
Package:

react-components

Fixes a warning caused by Grommet's Box component inadvertently being passed a `height` and `width` prop from `react-resize-observer`

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

