### PR TITLE
Add deployed commit id

### DIFF
--- a/packages/app-project/next.config.js
+++ b/packages/app-project/next.config.js
@@ -1,3 +1,4 @@
+const { execSync } = require('child_process')
 const path = require('path')
 const { setAliases } = require('require-control')
 
@@ -15,6 +16,7 @@ module.exports = {
   useFileSystemPublicRoutes: false,
 
   env: {
+    COMMIT_ID: execSync('git rev-parse HEAD').toString('utf8').trim(),
     PANOPTES_ENV: process.env.PANOPTES_ENV || 'staging'
   },
 

--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -54,6 +54,7 @@ export default class MyApp extends App {
   }
 
   componentDidMount () {
+    console.info(`Deployed commit is ${process.env.COMMIT_ID}`)
     this.store.user.checkCurrent()
   }
 

--- a/packages/app-project/src/components/Head/Head.js
+++ b/packages/app-project/src/components/Head/Head.js
@@ -45,6 +45,8 @@ function Head (props) {
       <meta name='twitter:site' content={zooniverseTwitterUsername} />
       <meta name='twitter:card' content='summary_large_image' />
       <meta name='twitter:image' content={ogImage} />
+
+      <meta name='zooniverse:deployed_commit' content={process.env.COMMIT_ID} />
     </NextHead>
   )
 }


### PR DESCRIPTION
Package: app-project

Closes #574.

Gets the current HEAD commit id, logs it to the console and injects it into the rendered HTML. It turns out it's not at all straightforward to create HTML comments in JSX, so a custom `meta` tag seemed like a good compromise

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

