### PR TITLE
use the new graphql stats host

### DIFF
--- a/packages/app-project/stores/YourStats.js
+++ b/packages/app-project/stores/YourStats.js
@@ -5,7 +5,7 @@ import { GraphQLClient } from 'graphql-request'
 import asyncStates from '@zooniverse/async-states'
 import { panoptes } from '@zooniverse/panoptes-js'
 
-export const statsClient = new GraphQLClient('https://stats.zooniverse.org/graphql')
+export const statsClient = new GraphQLClient('https://graphql-stats.zooniverse.org/graphql')
 
 const YourStats = types
   .model('YourStats', {


### PR DESCRIPTION
Use the newly minted stats host in kubernetes cluster, this will fix the long timeout errors that were happening in the swarm cluster.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

