### PR TITLE
use the correct dockerhub repo

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
         - name: fe-project-staging
-          image: zooniverse/fe-project:__IMAGE_TAG__
+          image: zooniverse/front-end-monorepo:__IMAGE_TAG__
           ports:
             - containerPort: 3000


### PR DESCRIPTION
use the one we push to in jenkinsfile

```
kubectl get pods
front-end-staging-f5b475878-kdqpj          0/1       ErrImagePull   0          4s

kubectl describe pod front-end-staging-f5b475878-kdqpj
... pulling image "zooniverse/fe-project:0646cd983059a46e5e11eaf1cfb2359b15f01b4a"
... Failed to pull image "zooniverse/fe-project:0646cd983059a46e5e11eaf1cfb2359b15f01b4a": rpc error: code = Unknown desc = Error response from daemon: manifest for zooniverse/fe-project:0646cd983059a46e5e11eaf1cfb2359b15f01b4a not found
... Error: ErrImagePull
... Back-off pulling image "zooniverse/fe-project:0646cd983059a46e5e11eaf1cfb2359b15f01b4a"
```

Package:

Closes # .

Describe your changes:


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

