### PR TITLE
Make project title a link when not on the project home page

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
@@ -1,5 +1,5 @@
 import counterpart from 'counterpart'
-import { Box, Heading } from 'grommet'
+import { Anchor, Box, Heading } from 'grommet'
 import { string } from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
@@ -20,8 +20,24 @@ const StyledHeading = styled(Heading)`
   text-shadow: 0 2px 4px rgba(0,0,0,0.5);
 `
 
+const StyledAnchor = styled(Anchor)`
+  border-bottom: 3px solid transparent;
+  &:focus,
+  &:hover {
+    text-decoration: none;
+    border-color: white;
+  }
+`
+
 function ProjectHeader (props) {
-  const { className, title } = props
+  const { className, href, title } = props
+
+  const Title = () => (
+    <StyledHeading color='white' margin='none' size='small'>
+      {title}
+    </StyledHeading>
+  )
+
   return (
     <StyledBox>
       <Background />
@@ -34,9 +50,10 @@ function ProjectHeader (props) {
       >
         <Box align='center' direction='row' gap='medium'>
           <Avatar />
-          <StyledHeading color='white' margin='none' size='small'>
-            {title}
-          </StyledHeading>
+          {href
+            ? <StyledAnchor href={href}><Title /></StyledAnchor>
+            : <Title />
+          }
           <ApprovedIcon />
         </Box>
         <Nav />
@@ -47,6 +64,8 @@ function ProjectHeader (props) {
 }
 
 ProjectHeader.propTypes = {
+  className: string,
+  href: string,
   title: string.isRequired
 }
 

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
@@ -39,11 +39,10 @@ function ProjectHeader (props) {
   )
 
   return (
-    <StyledBox>
+    <StyledBox className={className}>
       <Background />
       <Box
         align='center'
-        className={className}
         direction='row'
         justify='between'
         pad='medium'

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.spec.js
@@ -3,6 +3,7 @@ import React from 'react'
 
 import ProjectHeader from './ProjectHeader'
 
+const HREF = '/foo'
 const TITLE = 'Project title'
 let wrapper
 
@@ -16,7 +17,15 @@ describe('Component > ProjectHeader', function () {
   })
 
   it('should render the title prop as an h1', function () {
-    const heading = wrapper.find('ProjectHeader__StyledHeading').render()
-    expect(heading.text()).to.equal(TITLE)
+    const title = wrapper.find('Title').render()
+    expect(title.is('h1')).to.be.ok()
+    expect(title.text()).to.equal(TITLE)
+  })
+
+  it('should wrap the heading in an anchor if it has an `href` prop', function () {
+    const wrapperWithHref = shallow(<ProjectHeader href={HREF} title={TITLE} />)
+    const linkWrapper = wrapperWithHref.find('ProjectHeader__StyledAnchor')
+    expect(linkWrapper).to.have.lengthOf(1)
+    expect(linkWrapper.prop('href')).to.equal(HREF)
   })
 })

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
@@ -1,6 +1,7 @@
 import { inject, observer } from 'mobx-react'
-import { shape, string } from 'prop-types'
+import { array, shape, string } from 'prop-types'
 import React, { Component } from 'react'
+import { withRouter } from 'next/router'
 
 import ProjectHeader from './ProjectHeader'
 
@@ -11,12 +12,22 @@ function storeMapper (stores) {
 }
 
 @inject(storeMapper)
+@withRouter
 @observer
 class ProjectHeaderContainer extends Component {
+  getHref () {
+    const { query } = this.props.router
+    if (query.subroute) {
+      return `/projects/${query.owner}/${query.project}`
+    }
+    return ''
+  }
+
   render () {
     return (
       <ProjectHeader
         className={this.props.className}
+        href={this.getHref()}
         title={this.props.project.display_name}
       />
     )
@@ -26,6 +37,13 @@ class ProjectHeaderContainer extends Component {
 ProjectHeaderContainer.propTypes = {
   project: shape({
     display_name: string
+  }),
+  router: shape({
+    query: shape({
+      subroute: array,
+      project: string,
+      owner: string,
+    })
   })
 }
 

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
@@ -9,11 +9,23 @@ let wrapper
 let componentWrapper
 
 const PROJECT = projects.mocks.resources.projectOne
+const OWNER = 'foo'
+const PROJECT_SLUG = 'bar'
+const ROUTER = {
+  query: {
+    owner: OWNER,
+    project: PROJECT_SLUG,
+    subroute: ['baz']
+  }
+}
 
 describe('Component > ProjectHeaderContainer', function () {
   before(function () {
-    wrapper = shallow(<ProjectHeaderContainer.wrappedComponent project={PROJECT} />)
-    componentWrapper = wrapper.find(ProjectHeader)
+    wrapper = shallow(<ProjectHeaderContainer.wrappedComponent
+      project={PROJECT}
+      router={ROUTER}
+    />)
+    componentWrapper = wrapper.dive().find(ProjectHeader)
   })
 
   it('should render without crashing', function () {
@@ -26,5 +38,20 @@ describe('Component > ProjectHeaderContainer', function () {
 
   it('should pass down the project title', function () {
     expect(componentWrapper.prop('title')).to.equal(PROJECT.display_name)
+  })
+
+  it('should pass down the project homepage href if on another page', function () {
+    expect(componentWrapper.prop('href')).to.equal(`/projects/${OWNER}/${PROJECT_SLUG}`)
+  })
+
+  it(`shouldn't pass down an href if on the home page`, function () {
+    const HOME_ROUTER = Object.assign({}, ROUTER)
+    delete HOME_ROUTER.query.subroute
+    const onHomePageWrapper = shallow(<ProjectHeaderContainer.wrappedComponent
+      project={PROJECT}
+      router={HOME_ROUTER}
+    />)
+    const onHomePageComponentWrapper = onHomePageWrapper.dive().find(ProjectHeader)
+    expect(onHomePageComponentWrapper.prop('href')).to.equal('')
   })
 })

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
@@ -10,11 +10,11 @@ let componentWrapper
 
 const PROJECT = projects.mocks.resources.projectOne
 const OWNER = 'foo'
-const PROJECT_SLUG = 'bar'
+const PROJECT_DISPLAY_NAME = 'bar'
 const ROUTER = {
   query: {
     owner: OWNER,
-    project: PROJECT_SLUG,
+    project: PROJECT_DISPLAY_NAME,
     subroute: ['baz']
   }
 }
@@ -41,7 +41,7 @@ describe('Component > ProjectHeaderContainer', function () {
   })
 
   it('should pass down the project homepage href if on another page', function () {
-    expect(componentWrapper.prop('href')).to.equal(`/projects/${OWNER}/${PROJECT_SLUG}`)
+    expect(componentWrapper.prop('href')).to.equal(`/projects/${OWNER}/${PROJECT_DISPLAY_NAME}`)
   })
 
   it(`shouldn't pass down an href if on the home page`, function () {


### PR DESCRIPTION
Package: app-project

Closes #567.

Makes the project title a link back to the project home when on another page. Copies PFE, in that only the title and not the avatar work as a link.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

