### PR TITLE
Fix warning about `Avatar` missing a prop

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/components/Avatar/AvatarContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Avatar/AvatarContainer.js
@@ -16,21 +16,16 @@ function storeMapper (stores) {
 @observer
 class AvatarContainer extends Component {
   render () {
-    const { avatarSrc, child: Child, projectTitle } = this.props
+    const { avatarSrc, projectTitle } = this.props
     return (
-      <Child projectTitle={projectTitle} src={avatarSrc} />
+      <Avatar projectTitle={projectTitle} src={avatarSrc} />
     )
   }
 }
 
 AvatarContainer.propTypes = {
   avatarSrc: string,
-  child: node,
   projectTitle: string
-}
-
-AvatarContainer.defaultProps = {
-  child: Avatar
 }
 
 export default AvatarContainer

--- a/packages/app-project/src/components/ProjectHeader/components/Avatar/AvatarContainer.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Avatar/AvatarContainer.spec.js
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme'
 import React from 'react'
 
 import AvatarContainer from './AvatarContainer'
+import Avatar from './Avatar'
 
 let wrapper
 const avatarSrc = 'https://example.com/image.jpg'
@@ -20,12 +21,12 @@ describe('Component > AvatarContainer', function () {
     expect(wrapper).to.be.ok()
   })
 
-  it('should render the `child` component prop', function () {
-    expect(wrapper.find(StubComponent)).to.have.lengthOf(1)
+  it('should render the `Avatar` component', function () {
+    expect(wrapper.find(Avatar)).to.have.lengthOf(1)
   })
 
-  it('should pass the required props to the child component', function () {
-    const child = wrapper.find(StubComponent)
+  it('should pass the required props to the Avatar component', function () {
+    const child = wrapper.find(Avatar)
     expect(child.prop('src')).to.equal(avatarSrc)
     expect(child.prop('projectTitle')).to.equal(projectTitle)
   })


### PR DESCRIPTION
This was an experiment in using DI via default props, but it practice it just threw up warnings.

Package: app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

