### PR TITLE
Fix warning about required prop in CollectionsModalContainer

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.js
@@ -1,5 +1,5 @@
 import { inject, observer } from 'mobx-react'
-import PropTypes from 'prop-types'
+import { array, func } from 'prop-types'
 import React, { Component } from 'react'
 
 import CollectionsModal from './CollectionsModal'
@@ -107,10 +107,13 @@ class CollectionsModalContainer extends Component {
 }
 
 CollectionsModalContainer.propTypes = {
-  subjectId: PropTypes.string.isRequired
+  collections: array.isRequired,
+  searchCollections: func.isRequired
 }
 
 CollectionsModalContainer.defaultProps = {
+  collections: [],
+  searchCollections: Function.prototype
 }
 
 export default CollectionsModalContainer


### PR DESCRIPTION
Package: app-project

Fixes the console warning about a missing required prop, and adds propTypes for the props that are still being used. 

Note that I've used `isRequired` _and_ provided a default prop; I think the store hasn't finished instantiating itself by the time this component is mounted, so this avoids further warnings. We've avoided doing this in the past, but I think this will need to be done throughout the app, as these props are strictly speaking required by the component for it to work.