### PR TITLE
Remove logging of event stream subscription

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -24,8 +24,8 @@ class InteractionLayerContainer extends Component {
   componentDidMount () {
     // TODO: We're simply logging the event stream here for now, but this will
     // be passed to the active drawing tool for parsing
-    const stream = this.props.drawing.eventStream
-    stream.subscribe(z => console.log(z))
+    // const stream = this.props.drawing.eventStream
+    // stream.subscribe(z => console.log(z))
   }
 
   addToStream (event, type) {


### PR DESCRIPTION
Package: lib-classifier

I've removed logging of the event stream, as it was cluttering the console. I have left the code in, however, as a reminder of how to start interacting with it when we start building out the tools for the SingleImageViewer

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

