### PR TITLE
Bump to node 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:10
 
 RUN mkdir -p /usr/src
 WORKDIR /usr/src/

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:ci": "nyc lerna run --parallel test:ci"
   },
   "engines": {
-    "node": "8"
+    "node": "10"
   },
   "nyc": {
     "exclude": [

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -13,9 +13,9 @@
     "dev": "npm run _check && npm run _serve",
     "lint": "npm run _check && standard --fix | snazzy; exit 0",
     "start": "npm run _check && NODE_ENV=production npm run _serve",
+    "storybook": "start-storybook -p 9001 -c .storybook",
     "test": "npm run _test && exit 0",
-    "test:ci": "npm run _test -- --reporter=min",
-    "storybook": "start-storybook -p 9001 -c .storybook"
+    "test:ci": "npm run _test -- --reporter=min"
   },
   "dependencies": {
     "@babel/plugin-proposal-decorators": "~7.1.6",
@@ -65,7 +65,7 @@
     "standard": "~12.0.1"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "standard": {
     "env": [

--- a/packages/lib-async-states/package.json
+++ b/packages/lib-async-states/package.json
@@ -30,6 +30,9 @@
     "snazzy": "~8.0.0",
     "standard": "~12.0.1"
   },
+  "engines": {
+    "node": ">=0.12.18"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -100,6 +100,9 @@
       "expect",
       "it"
     ],
-    "parser": "babel-eslint"
+    "parser": "babel-eslint",
+    "engines": {
+      "node": ">=10"
+    }
   }
 }

--- a/packages/lib-grommet-theme/package.json
+++ b/packages/lib-grommet-theme/package.json
@@ -26,6 +26,9 @@
     "babel-preset-minify": "~0.5.0",
     "standard": "~12.0.1"
   },
+  "engines": {
+    "node": ">=10"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/lib-panoptes-js/package.json
+++ b/packages/lib-panoptes-js/package.json
@@ -30,7 +30,7 @@
     "standard": "~11.0.1"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "standard": {
     "env": {

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -87,7 +87,7 @@
     "webpack-cli": "~3.1.2"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=10",
     "npm": ">=5"
   },
   "publishConfig": {


### PR DESCRIPTION
Package: all

Following on from https://github.com/zooniverse/front-end-monorepo/pull/584#discussion_r267945685, this bumps the required node version to 10.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

