### PR TITLE
Defer Done & Talk until feedback closes

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
@@ -11,9 +11,9 @@ import en from './locales/en'
 counterpart.registerTranslations('en', en)
 
 // Taken from PFE on 2019.02.28; these colours aren't part of the current theme.
-const TALK_LINK_BLUE = '#43bbfd';
-const TALK_LINK_BLUE_HOVER = darken(0.18, TALK_LINK_BLUE);
-const TALK_LINK_BLUE_HOVER_DARK = '#104A79';
+const TALK_LINK_BLUE = '#43bbfd'
+const TALK_LINK_BLUE_HOVER = darken(0.18, TALK_LINK_BLUE)
+const TALK_LINK_BLUE_HOVER_DARK = '#104A79'
 
 // TODO move what makes sense into theme
 export const StyledDoneAndTalkButton = styled(Button)`
@@ -38,18 +38,18 @@ export const StyledDoneAndTalkButton = styled(Button)`
 
   &:hover, &:focus {
     background: ${theme('mode', {
-      dark: TALK_LINK_BLUE_HOVER_DARK,
-      light: TALK_LINK_BLUE_HOVER
-    })};
+    dark: TALK_LINK_BLUE_HOVER_DARK,
+    light: TALK_LINK_BLUE_HOVER
+  })};
     border: ${theme('mode', {
-      dark: `solid thin ${TALK_LINK_BLUE}`,
-      light: `solid thin ${TALK_LINK_BLUE_HOVER}`
-    })};
+    dark: `solid thin ${TALK_LINK_BLUE}`,
+    light: `solid thin ${TALK_LINK_BLUE_HOVER}`
+  })};
     box-shadow: none;
     color: ${theme('mode', {
-      dark: zooTheme.global.colors.text.dark,
-      light: `white`
-    })};
+    dark: zooTheme.global.colors.text.dark,
+    light: `white`
+  })};
   }
 
   &:disabled {
@@ -58,34 +58,13 @@ export const StyledDoneAndTalkButton = styled(Button)`
   `
 
 export function DoneAndTalkButton (props) {
-  const openTalkLinkAndClick = function (event) {
-    const isCmdClick = event.metaKey
-
-    props.onClick(event)
-      .then(() => {
-        if (window && props.talkURL) {
-          const url = `${window.location.origin}${props.talkURL}`
-          if (isCmdClick) {
-            event.preventDefault()
-            const newTab = window.open()
-            newTab.opener = null
-            newTab.location = url
-            newTab.target = '_blank'
-            newTab.focus()
-          } else {
-            window.location.assign(url)
-          }
-        }
-      })
-  }
-
   if (!props.completed) {
     return (
       <ThemeProvider theme={{ mode: props.theme }}>
         <StyledDoneAndTalkButton
           disabled={props.disabled}
           label={<Text size='small'>{counterpart('DoneAndTalkButton.doneAndTalk')}</Text>}
-          onClick={(e) => { openTalkLinkAndClick(e) }}
+          onClick={props.onClick}
           type='submit'
         />
       </ThemeProvider>
@@ -97,9 +76,9 @@ export function DoneAndTalkButton (props) {
 
 DoneAndTalkButton.defaultProps = {
   completed: false,
-  demoMode: false,  // TODO: add demo mode to classifier
+  demoMode: false, // TODO: add demo mode to classifier
   disabled: false,
-  goldStandardMode: false,  // TODO: add gold standard mode to classifier
+  goldStandardMode: false, // TODO: add gold standard mode to classifier
   onClick: () => {},
   theme: 'light'
 }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.spec.js
@@ -18,10 +18,10 @@ describe('DoneAndTalkButton', function () {
   it('should call props.onClick for the onClick event', function () {
     const onClickSpy = sinon.stub().callsFake(() => { return Promise.resolve() })
     const wrapper = shallow(<DoneAndTalkButton onClick={onClickSpy} talkURL={talkURL} />)
-    wrapper.find('Styled(WithTheme(Button))').simulate('click', { event: { metaKey: false }})
+    wrapper.find('Styled(WithTheme(Button))').simulate('click', { event: { metaKey: false } })
     expect(onClickSpy.calledOnce).to.be.true
   })
-  
+
   describe('when props.completed is true', function () {
     it('should render null', function () {
       const wrapper = shallow(<DoneAndTalkButton completed talkURL={talkURL} />)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
@@ -14,11 +14,13 @@ function storeMapper (stores) {
     active: project
   } = stores.classifierStore.projects
   const {
+    onHide,
     setOnHide
   } = stores.classifierStore.feedback
 
   return {
     project,
+    onHide,
     setOnHide,
     shouldWeShowDoneAndTalkButton,
     subject
@@ -35,6 +37,7 @@ class DoneAndTalkButtonContainer extends React.Component {
       disabled,
       goldStandardMode,
       onClick,
+      onHide,
       project,
       setOnHide,
       shouldWeShowDoneAndTalkButton,
@@ -54,12 +57,14 @@ class DoneAndTalkButtonContainer extends React.Component {
             if (window && talkURL) {
               const url = `${window.location.origin}${talkURL}`
               if (isCmdClick) {
-                event.preventDefault()
-                const newTab = window.open()
-                newTab.opener = null
-                newTab.location = url
-                newTab.target = '_blank'
-                newTab.focus()
+                setOnHide(() => {
+                  onHide()
+                  const newTab = window.open()
+                  newTab.opener = null
+                  newTab.location = url
+                  newTab.target = '_blank'
+                  newTab.focus()
+                })
               } else {
                 setOnHide(() => window.location.assign(url))
               }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
-import DoneAndTalkButton from './DoneAndTalkButton';
+import DoneAndTalkButton from './DoneAndTalkButton'
 
-function storeMapper(stores) {
+function storeMapper (stores) {
   const {
-    shouldWeShowDoneAndTalkButton,
+    shouldWeShowDoneAndTalkButton
   } = stores.classifierStore.workflowSteps
   const {
     active: subject
@@ -13,9 +13,13 @@ function storeMapper(stores) {
   const {
     active: project
   } = stores.classifierStore.projects
+  const {
+    setOnHide
+  } = stores.classifierStore.feedback
 
   return {
     project,
+    setOnHide,
     shouldWeShowDoneAndTalkButton,
     subject
   }
@@ -25,15 +29,16 @@ function storeMapper(stores) {
 @observer
 class DoneAndTalkButtonContainer extends React.Component {
   render () {
-    const { 
+    const {
       completed,
       demoMode,
       disabled,
       goldStandardMode,
-      onClick, 
-      project, 
-      shouldWeShowDoneAndTalkButton, 
-      subject 
+      onClick,
+      project,
+      setOnHide,
+      shouldWeShowDoneAndTalkButton,
+      subject
     } = this.props
     const projectSlug = project && project.slug
     const subjectId = subject && subject.id
@@ -41,13 +46,34 @@ class DoneAndTalkButtonContainer extends React.Component {
     if (shouldWeShowDoneAndTalkButton && projectSlug && subjectId) {
       const talkURL = `/projects/${projectSlug}/talk/subjects/${subjectId}`
 
+      function openTalkLinkAndClick (event) {
+        const isCmdClick = event.metaKey
+
+        onClick(event)
+          .then(() => {
+            if (window && talkURL) {
+              const url = `${window.location.origin}${talkURL}`
+              if (isCmdClick) {
+                event.preventDefault()
+                const newTab = window.open()
+                newTab.opener = null
+                newTab.location = url
+                newTab.target = '_blank'
+                newTab.focus()
+              } else {
+                setOnHide(() => window.location.assign(url))
+              }
+            }
+          })
+      }
+
       return (
         <DoneAndTalkButton
           completed={completed}
           demoMode={demoMode}
           disabled={disabled}
           goldStandardMode={goldStandardMode}
-          onClick={onClick}
+          onClick={openTalkLinkAndClick}
           talkURL={talkURL}
         />
       )

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.spec.js
@@ -51,4 +51,55 @@ describe('DoneAndTalkButton', function () {
     )
     expect(wrapper.find(DoneAndTalkButton)).to.have.lengthOf(1)
   })
+  describe('on click', function () {
+    let onClick
+    let setOnHide
+    let onHide = () => null
+    let originalLocation
+
+    before(function () {
+      originalLocation = window.location
+      Object.defineProperty(window, 'location', {
+        value: {
+          origin: 'https://example.org',
+          assign: sinon.stub().callsFake(url => console.log(url))
+        },
+        writable: true
+      })
+      onClick = sinon.stub().callsFake(() => Promise.resolve(null))
+      setOnHide = sinon.stub().callsFake(callback => onHide = callback)
+      const wrapper = shallow(
+        <DoneAndTalkButtonContainer.wrappedComponent
+          onClick={onClick}
+          setOnHide={setOnHide}
+          shouldWeShowDoneAndTalkButton
+          subject={subject}
+          project={project}
+        />
+      )
+      const fakeEvent = {}
+      wrapper.simulate('click', fakeEvent)
+    })
+
+    after(function () {
+      window.location = originalLocation
+      Object.defineProperty(window, 'location', {
+        writable: false
+      })
+    })
+
+    it('should call the onClick handler', function () {
+      expect(onClick).to.have.been.calledOnce
+    })
+
+    it('should set an onHide callback', function () {
+      expect(setOnHide).to.have.been.calledOnce
+    })
+
+    it('should defer opening a Talk URL', function () {
+      onHide()
+      const url = 'https://example.org/projects/zooniverse/example/talk/subjects/2'
+      expect(window.location.assign).to.have.been.calledOnceWith(url)
+    })
+  })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.spec.js
@@ -24,9 +24,9 @@ describe('DoneAndTalkButton', function () {
   it('should render null if there is no project slug', function () {
     const wrapper = shallow(
       <DoneAndTalkButtonContainer.wrappedComponent
-        shouldWeShowDoneAndTalkButton={true}
+        shouldWeShowDoneAndTalkButton
         subject={subject}
-        project={{ id: '1'}}
+        project={{ id: '1' }}
       />)
     expect(wrapper.html()).to.be.null
   })
@@ -34,8 +34,8 @@ describe('DoneAndTalkButton', function () {
   it('should render null if there is no subject id', function () {
     const wrapper = shallow(
       <DoneAndTalkButtonContainer.wrappedComponent
-        shouldWeShowDoneAndTalkButton={true}
-        subject={{ metadata: { myId: 5 }}}
+        shouldWeShowDoneAndTalkButton
+        subject={{ metadata: { myId: 5 } }}
         project={project}
       />)
     expect(wrapper.html()).to.be.null
@@ -44,9 +44,9 @@ describe('DoneAndTalkButton', function () {
   it('should render DoneAndTalkButton component if shouldWeShowDoneAndTalkButton is true', function () {
     const wrapper = shallow(
       <DoneAndTalkButtonContainer.wrappedComponent
-        shouldWeShowDoneAndTalkButton={true}
+        shouldWeShowDoneAndTalkButton
         subject={subject}
-        project={project} 
+        project={project}
       />
     )
     expect(wrapper.find(DoneAndTalkButton)).to.have.lengthOf(1)

--- a/packages/lib-classifier/src/store/FeedbackStore.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.js
@@ -57,8 +57,6 @@ const FeedbackStore = types
       const shouldShowFeedback = self.isActive && self.messages.length && !self.showModal
       if (shouldShowFeedback) {
         abort()
-        const onHide = getRoot(self).subjects.advance
-        self.setOnHide(onHide)
         self.showFeedback()
       } else {
         next(call)
@@ -123,6 +121,8 @@ const FeedbackStore = types
       self.isActive = false
       self.rules.clear()
       self.showModal = false
+      const onHide = getRoot(self).subjects.advance
+      self.setOnHide(onHide)
     }
 
     return {

--- a/packages/lib-classifier/src/store/FeedbackStore.spec.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.spec.js
@@ -102,6 +102,9 @@ describe('Model > FeedbackStore', function () {
 
   describe('reset', function () {
     beforeEach(function () {
+      feedback.subjects = {
+        advance: sinon.stub()
+      }
       feedback.reset()
     })
 
@@ -115,6 +118,10 @@ describe('Model > FeedbackStore', function () {
 
     it('should reset showModal state', function () {
       expect(feedback.showModal).to.be.false
+    })
+
+    it('should set the onHide callback', function () {
+      expect(feedback.onHide).to.equal(feedback.subjects.advance)
     })
   })
 
@@ -180,9 +187,6 @@ describe('Model > FeedbackStore', function () {
     describe('when feedback is active', function () {
       beforeEach(function () {
         feedback = FeedbackStore.create(feedbackStub)
-        feedback.subjects = {
-          advance: sinon.stub()
-        }
         feedback.onSubjectAdvance(call, next, abort)
       })
 
@@ -192,10 +196,6 @@ describe('Model > FeedbackStore', function () {
 
       it('should show feedback', function () {
         expect(feedback.showModal).to.be.true
-      })
-
-      it('should set the onHide callback', function () {
-        expect(feedback.onHide).to.equal(feedback.subjects.advance)
       })
     })
   })


### PR DESCRIPTION
Update the Done & Talk onClick handler to set the url redirect as the onHide callback for feedback.

ToDo:
- [x] set the default onHide callback for feedback to `subjects.advance`.
- [x] remove `setOnHide` from `onSubjectsAdvance` in the feedback model.

Package:
lib-classifier

Closes #598.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

