### PR TITLE
Wait for the media fetch

### DIFF
--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -540,8 +540,7 @@ describe('Model > TutorialStore', function () {
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
       sinon.stub(rootStore.userProjectPreferences, 'updateUPP').callsFake(() => { })
-      
-      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
+      sinon.stub(rootStore.tutorials, 'fetchMedia')
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
@@ -565,7 +564,7 @@ describe('Model > TutorialStore', function () {
       })
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
-      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
+      sinon.stub(rootStore.tutorials, 'fetchMedia')
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -110,10 +110,13 @@ describe('Model > TutorialStore', function () {
       tutorials: TutorialStore.create(),
       workflows: WorkflowStore.create()
     }, { authClient: authClientStubWithUser, client: clientStub() })
+    sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
     rootStore.workflows.setActive(workflow.id)
       .then(() => {
         const tutorialInStore = rootStore.tutorials.resources.get(tutorial.id)
         expect(tutorialInStore.toJSON()).to.deep.equal(tutorial)
+      }).then(() => {
+        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
   })
 
@@ -173,11 +176,13 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
+      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
 
       const setTutorialsSpy = sinon.spy(rootStore.tutorials, 'setTutorials')
       rootStore.workflows.setActive(workflow.id).then(() => {
         expect(setTutorialsSpy).to.have.been.calledOnceWith([tutorial])
       }).then(() => {
+        rootStore.tutorials.fetchMedia.restore()
         setTutorialsSpy.restore()
       }).then(done, done)
     })
@@ -380,11 +385,14 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
-
+      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
       rootStore.workflows.setActive(workflow.id).then(() => {
         rootStore.tutorials.setActiveTutorial(tutorial.id)
+        rootStore.tutorials.setMediaResources([medium])
       }).then(() => {
         expect(rootStore.tutorials.activeMedium).to.deep.equal(medium)
+      }).then(() => {
+        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
     })
   })
@@ -425,11 +433,13 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
-
+      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
       rootStore.workflows.setActive(workflow.id).then(() => {
         rootStore.tutorials.setActiveTutorial(tutorial.id)
       }).then(() => {
         expect(rootStore.tutorials.tutorialSeenTime).to.be.a('string')
+      }).then(() => {
+        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
     })
 
@@ -440,11 +450,13 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub(tutorialNullKind)
       })
-
+      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
       rootStore.workflows.setActive(workflow.id).then(() => {
         rootStore.tutorials.setActiveTutorial(tutorialNullKind.id)
       }).then(() => {
         expect(rootStore.tutorials.tutorialSeenTime).to.be.a('string')
+      }).then(() => {
+        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
     })
   })
@@ -504,6 +516,7 @@ describe('Model > TutorialStore', function () {
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
       sinon.stub(rootStore.userProjectPreferences, 'updateUPP').callsFake(() => {})
+      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
@@ -513,6 +526,7 @@ describe('Model > TutorialStore', function () {
         expect(rootStore.tutorials.active).to.deep.equal(tutorial)
         expect(rootStore.tutorials.showModal).to.be.true
       }).then(() => {
+        rootStore.tutorials.fetchMedia.restore()
         setActiveTutorialSpy.restore()
         setModalVisibilitySpy.restore()
         rootStore.userProjectPreferences.updateUPP.restore()
@@ -527,6 +541,8 @@ describe('Model > TutorialStore', function () {
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
       sinon.stub(rootStore.userProjectPreferences, 'updateUPP').callsFake(() => { })
       
+      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
+
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
       rootStore.workflows.setActive(workflow.id)
@@ -536,6 +552,7 @@ describe('Model > TutorialStore', function () {
           expect(rootStore.tutorials.active).to.deep.equal(tutorial)
           expect(rootStore.tutorials.showModal).to.be.true
         }).then(() => {
+          rootStore.tutorials.fetchMedia.restore()
           setActiveTutorialSpy.restore()
           setModalVisibilitySpy.restore()
           rootStore.userProjectPreferences.updateUPP.restore()
@@ -548,6 +565,7 @@ describe('Model > TutorialStore', function () {
       })
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
+      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
@@ -557,6 +575,7 @@ describe('Model > TutorialStore', function () {
         expect(rootStore.tutorials.active).to.be.undefined
         expect(rootStore.tutorials.showModal).to.be.false
       }).then(() => {
+        rootStore.tutorials.fetchMedia.restore()
         setActiveTutorialSpy.restore()
         setModalVisibilitySpy.restore()
       }).then(done, done)


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
Branched off of #552. This fixes an issue where sometimes the reference to the media would not resolve because the request for it hadn't finished before the tutorial modal opened up. We now wait for the request for the media to finish before setting the tutorial and calling to show the modal. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

