### PR TITLE
Remove self.fetchMedia from tutorial store

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -14,6 +14,7 @@ import {
 import { registerWorkers, unregisterWorkers } from '../../workers'
 import RootStore from 'src/store'
 import Layout from './components/Layout'
+import ModalTutorial from './components/ModalTutorial'
 import { isBackgroundSyncAvailable } from '../../helpers/featureDetection'
 
 const client = {
@@ -70,9 +71,14 @@ export default class Classifier extends React.Component {
   render () {
     return (
       <Provider classifierStore={this.classifierStore}>
-        <ThemeProvider theme={{ mode: this.props.mode }}>
-          <Layout />
-        </ThemeProvider>
+        <Grommet theme={this.props.theme}>
+          <ThemeProvider theme={{ mode: this.props.mode }}>
+            <>
+              <Layout />
+              <ModalTutorial />
+            </>
+          </ThemeProvider>
+        </Grommet>
       </Provider>
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -1,4 +1,3 @@
-import { Grommet } from 'grommet'
 import makeInspectable from 'mobx-devtools-mst'
 import { Provider } from 'mobx-react'
 import PropTypes from 'prop-types'
@@ -71,14 +70,12 @@ export default class Classifier extends React.Component {
   render () {
     return (
       <Provider classifierStore={this.classifierStore}>
-        <Grommet theme={this.props.theme}>
-          <ThemeProvider theme={{ mode: this.props.mode }}>
-            <>
-              <Layout />
-              <ModalTutorial />
-            </>
-          </ThemeProvider>
-        </Grommet>
+        <ThemeProvider theme={{ mode: this.props.mode }}>
+          <>
+            <Layout />
+            <ModalTutorial />
+          </>
+        </ThemeProvider>
       </Provider>
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.js
@@ -1,0 +1,49 @@
+import counterpart from 'counterpart'
+import React from 'react'
+import PropTypes from 'prop-types'
+import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
+import { Modal } from '@zooniverse/react-components'
+import asyncStates from '@zooniverse/async-states'
+import SlideTutorial from '../SlideTutorial'
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
+
+function storeMapper(stores) {
+  const { active: tutorial, loadingState, setModalVisibility, showModal } = stores.classifierStore.tutorials
+  return {
+    loadingState,
+    setModalVisibility,
+    showModal,
+    tutorial
+  }
+}
+
+@inject(storeMapper)
+@observer
+class ModalTutorial extends React.Component {
+  render() {
+    const { loadingState, showModal, setModalVisibility, tutorial } = this.props
+    if (loadingState === asyncStates.success && tutorial) {
+      return (
+        <Modal active={showModal} closeFn={() => { setModalVisibility(false) }} title={counterpart('ModalTutorial.title')}>
+          <SlideTutorial />
+        </Modal>
+      )
+    }
+
+    return null
+  }
+}
+
+ModalTutorial.wrappedComponent.defaultProps = {
+  showModal: false
+}
+
+ModalTutorial.wrappedComponent.propTypes = {
+  showModal: PropTypes.bool,
+  setModalVisibility: PropTypes.func.isRequired,
+  tutorial: PropTypes.object.isRequired
+}
+
+export default ModalTutorial

--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.js
@@ -26,8 +26,13 @@ class ModalTutorial extends React.Component {
     const { loadingState, showModal, setModalVisibility, tutorial } = this.props
     if (loadingState === asyncStates.success && tutorial) {
       return (
-        <Modal active={showModal} closeFn={() => { setModalVisibility(false) }} title={counterpart('ModalTutorial.title')}>
-          <SlideTutorial />
+        <Modal
+          {...this.props}
+          active={showModal}
+          closeFn={() => { setModalVisibility(false) }}
+          title={counterpart('ModalTutorial.title')}
+        >
+          <SlideTutorial pad="none" width="330px" />
         </Modal>
       )
     }
@@ -37,13 +42,16 @@ class ModalTutorial extends React.Component {
 }
 
 ModalTutorial.wrappedComponent.defaultProps = {
-  showModal: false
+  loadingState: asyncStates.initialized,
+  showModal: false,
+  tutorial: {}
 }
 
 ModalTutorial.wrappedComponent.propTypes = {
+  loadingState: PropTypes.string,
   showModal: PropTypes.bool,
   setModalVisibility: PropTypes.func.isRequired,
-  tutorial: PropTypes.object.isRequired
+  tutorial: PropTypes.object
 }
 
 export default ModalTutorial

--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.spec.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ModalTutorial from './ModalTutorial'
+import { Modal } from '@zooniverse/react-components'
+import asyncStates from '@zooniverse/async-states'
+import { TutorialFactory } from '../../../../../test/factories'
+import SlideTutorial from '../SlideTutorial'
+
+const tutorial = TutorialFactory.build()
+
+describe('ModalTutorial', function () {
+  it('should render without crashing', function () {
+    const wrapper = shallow(<ModalTutorial.wrappedComponent setModalVisibility={() => {}} />)
+    expect(wrapper).to.be.ok
+  })
+
+  it('should render null if a tutorial has not been successfully loaded', function () {
+    const wrapper = shallow(<ModalTutorial.wrappedComponent setModalVisibility={() => { }} />)
+    expect(wrapper.html()).to.be.null
+  })
+
+  it('should render a Modal when a tutorial is successfully loaded', function () {
+    const wrapper = shallow(
+      <ModalTutorial.wrappedComponent
+        loadingState={asyncStates.success}
+        setModalVisibility={() => { }} 
+        tutorial={tutorial}
+      />
+    )
+    
+    expect(wrapper.find(Modal)).to.have.lengthOf(1)
+  })
+
+  it('should render a SlideTutorial as the child of the Modal', function () {
+    const wrapper = shallow(
+      <ModalTutorial.wrappedComponent
+        loadingState={asyncStates.success}
+        setModalVisibility={() => { }}
+        tutorial={tutorial}
+      />
+    )
+
+    expect(wrapper.find(SlideTutorial)).to.have.lengthOf(1)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/index.js
@@ -1,0 +1,1 @@
+export { default } from './ModalTutorial'

--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/locales/en.json
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/locales/en.json
@@ -1,0 +1,5 @@
+{
+  "ModalTutorial": {
+    "title": "Tutorial"
+  }
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
@@ -37,7 +37,7 @@ class SlideTutorial extends React.Component {
         <Box
           height='100%'
           justify='between'
-          pad='medium'
+          {...this.props}
         >
           {isThereMedia &&
             <Media
@@ -59,7 +59,7 @@ class SlideTutorial extends React.Component {
       <Box
         height='100%'
         justify='between'
-        pad='medium'
+        {...this.props}
       >
         <Paragraph>{counterpart('SlideTutorial.error')}</Paragraph>
       </Box>
@@ -68,7 +68,8 @@ class SlideTutorial extends React.Component {
 }
 
 SlideTutorial.wrappedComponent.defaultProps = {
-  activeStep: 0
+  activeStep: 0,
+  pad: "medium"
 }
 
 SlideTutorial.wrappedComponent.propTypes = {

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -142,7 +142,7 @@ const TutorialStore = types
         const response = yield tutorialsClient.get({ workflowId: workflow.id })
         const { tutorials } = response.body
         if (tutorials && tutorials.length > 0) {
-          yield Promise.all(tutorials.map(tutorial => self.fetchMedia(tutorial)))
+          tutorials.forEach(tutorial => flow(fetchMedia)(tutorial))
           self.setTutorials(tutorials)
           self.loadingState = asyncStates.success
           if (upp.loadingState === asyncStates.success) {

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -172,6 +172,7 @@ const TutorialStore = types
 
     function setActiveTutorial (id, stepIndex) {
       if (!id) return self.resetActiveTutorial()
+      console.log('calling setActiveTutorial')
       self.active = id
       self.setTutorialStep(stepIndex)
       self.setSeenTime()
@@ -209,12 +210,15 @@ const TutorialStore = types
     }
 
     function setModalVisibility (boolean) {
+      console.log('calling setModalVisibility')
       self.showModal = boolean
     }
 
     function showTutorialInModal() {
       const { tutorial } = self
+      console.log('tutorial', tutorial)
       if (tutorial && self.hasNotSeenTutorialBefore) {
+        console.log('has not seen before')
         self.setActiveTutorial(tutorial.id)
         self.setModalVisibility(true)
       }

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -224,7 +224,6 @@ const TutorialStore = types
 
     return {
       afterAttach,
-      fetchMedia: flow(fetchMedia),
       fetchTutorials: flow(fetchTutorials),
       resetActiveTutorial,
       resetSeen,

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -148,6 +148,8 @@ const TutorialStore = types
         if (tutorials && tutorials.length > 0) {
           tutorials.forEach(tutorial => self.fetchMedia(tutorial))
           self.setTutorials(tutorials)
+        } else {
+          self.loadingState = asyncStates.success
         }
       } catch (error) {
         console.error(error)

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -111,6 +111,7 @@ const TutorialStore = types
     }
 
     function * fetchMedia (tutorial) {
+      const upp = getRoot(self).userProjectPreferences
       const { tutorials } = getRoot(self).client
       if (tutorial) {
         self.loadingState = asyncStates.loading
@@ -118,6 +119,10 @@ const TutorialStore = types
           const response = yield tutorials.getAttachedImages({ id: tutorial.id })
           const { media } = response.body
           if (media && media.length > 0) self.setMediaResources(media)
+          self.loadingState = asyncStates.success
+          if (upp.loadingState === asyncStates.success) {
+            self.showTutorialInModal()
+          }
         } catch (error) {
           // We're not setting the store state to error because
           // we do not want to prevent the tutorial from rendering
@@ -135,7 +140,6 @@ const TutorialStore = types
     function * fetchTutorials () {
       const workflow = getRoot(self).workflows.active
       const tutorialsClient = getRoot(self).client.tutorials
-      const upp = getRoot(self).userProjectPreferences
 
       self.loadingState = asyncStates.loading
       try {
@@ -144,11 +148,7 @@ const TutorialStore = types
         if (tutorials && tutorials.length > 0) {
           tutorials.forEach(tutorial => self.fetchMedia(tutorial))
           self.setTutorials(tutorials)
-          if (upp.loadingState === asyncStates.success) {
-            self.showTutorialInModal()
-          }
         }
-        self.loadingState = asyncStates.success
       } catch (error) {
         console.error(error)
         self.loadingState = asyncStates.error

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -142,7 +142,8 @@ const TutorialStore = types
         const response = yield tutorialsClient.get({ workflowId: workflow.id })
         const { tutorials } = response.body
         if (tutorials && tutorials.length > 0) {
-          tutorials.forEach(tutorial => flow(fetchMedia)(tutorial))
+          const mediaRequests = tutorials.map(tutorial => flow(fetchMedia)(tutorial))
+          yield Promise.all(mediaRequests)
           self.setTutorials(tutorials)
           self.loadingState = asyncStates.success
           if (upp.loadingState === asyncStates.success) {

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -172,7 +172,6 @@ const TutorialStore = types
 
     function setActiveTutorial (id, stepIndex) {
       if (!id) return self.resetActiveTutorial()
-      console.log('calling setActiveTutorial')
       self.active = id
       self.setTutorialStep(stepIndex)
       self.setSeenTime()
@@ -210,15 +209,12 @@ const TutorialStore = types
     }
 
     function setModalVisibility (boolean) {
-      console.log('calling setModalVisibility')
       self.showModal = boolean
     }
 
     function showTutorialInModal() {
       const { tutorial } = self
-      console.log('tutorial', tutorial)
       if (tutorial && self.hasNotSeenTutorialBefore) {
-        console.log('has not seen before')
         self.setActiveTutorial(tutorial.id)
         self.setModalVisibility(true)
       }

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -91,7 +91,7 @@ const authClientStubWithUser = {
   checkBearerToken: sinon.stub().callsFake(() => Promise.resolve(token))
 }
 
-describe.only('Model > TutorialStore', function () {
+describe('Model > TutorialStore', function () {
   it('should exist', function () {
     expect(TutorialStore).to.be.an('object')
   })

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -110,10 +110,13 @@ describe('Model > TutorialStore', function () {
       tutorials: TutorialStore.create(),
       workflows: WorkflowStore.create()
     }, { authClient: authClientStubWithUser, client: clientStub() })
+    sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
     rootStore.workflows.setActive(workflow.id)
       .then(() => {
         const tutorialInStore = rootStore.tutorials.resources.get(tutorial.id)
         expect(tutorialInStore.toJSON()).to.deep.equal(tutorial)
+      }).then(() => {
+        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
   })
 
@@ -173,11 +176,13 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
+      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
 
       const setTutorialsSpy = sinon.spy(rootStore.tutorials, 'setTutorials')
       rootStore.workflows.setActive(workflow.id).then(() => {
         expect(setTutorialsSpy).to.have.been.calledOnceWith([tutorial])
       }).then(() => {
+        rootStore.tutorials.fetchMedia.restore()
         setTutorialsSpy.restore()
       }).then(done, done)
     })
@@ -380,11 +385,14 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
-
+      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
       rootStore.workflows.setActive(workflow.id).then(() => {
         rootStore.tutorials.setActiveTutorial(tutorial.id)
+        rootStore.tutorials.setMediaResources([medium])
       }).then(() => {
         expect(rootStore.tutorials.activeMedium).to.deep.equal(medium)
+      }).then(() => {
+        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
     })
   })
@@ -425,11 +433,13 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
-
+      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
       rootStore.workflows.setActive(workflow.id).then(() => {
         rootStore.tutorials.setActiveTutorial(tutorial.id)
       }).then(() => {
         expect(rootStore.tutorials.tutorialSeenTime).to.be.a('string')
+      }).then(() => {
+        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
     })
 
@@ -440,11 +450,13 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub(tutorialNullKind)
       })
-
+      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
       rootStore.workflows.setActive(workflow.id).then(() => {
         rootStore.tutorials.setActiveTutorial(tutorialNullKind.id)
       }).then(() => {
         expect(rootStore.tutorials.tutorialSeenTime).to.be.a('string')
+      }).then(() => {
+        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
     })
   })
@@ -503,6 +515,7 @@ describe('Model > TutorialStore', function () {
       })
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
+      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
@@ -512,6 +525,7 @@ describe('Model > TutorialStore', function () {
         expect(rootStore.tutorials.active).to.deep.equal(tutorial)
         expect(rootStore.tutorials.showModal).to.be.true
       }).then(() => {
+        rootStore.tutorials.fetchMedia.restore()
         setActiveTutorialSpy.restore()
         setModalVisibilitySpy.restore()
       }).then(done, done)
@@ -523,6 +537,7 @@ describe('Model > TutorialStore', function () {
       })
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
+      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
@@ -533,6 +548,7 @@ describe('Model > TutorialStore', function () {
           expect(rootStore.tutorials.active).to.deep.equal(tutorial)
           expect(rootStore.tutorials.showModal).to.be.true
         }).then(() => {
+          rootStore.tutorials.fetchMedia.restore()
           setActiveTutorialSpy.restore()
           setModalVisibilitySpy.restore()
         }).then(done, done)
@@ -544,6 +560,7 @@ describe('Model > TutorialStore', function () {
       })
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
+      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
@@ -553,6 +570,7 @@ describe('Model > TutorialStore', function () {
         expect(rootStore.tutorials.active).to.be.undefined
         expect(rootStore.tutorials.showModal).to.be.false
       }).then(() => {
+        rootStore.tutorials.fetchMedia.restore()
         setActiveTutorialSpy.restore()
         setModalVisibilitySpy.restore()
       }).then(done, done)

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -110,13 +110,10 @@ describe('Model > TutorialStore', function () {
       tutorials: TutorialStore.create(),
       workflows: WorkflowStore.create()
     }, { authClient: authClientStubWithUser, client: clientStub() })
-    sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
     rootStore.workflows.setActive(workflow.id)
       .then(() => {
         const tutorialInStore = rootStore.tutorials.resources.get(tutorial.id)
         expect(tutorialInStore.toJSON()).to.deep.equal(tutorial)
-      }).then(() => {
-        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
   })
 
@@ -145,14 +142,11 @@ describe('Model > TutorialStore', function () {
         })
       })
 
-      const fetchMediaSpy = sinon.spy(rootStore.tutorials, 'fetchMedia')
       const setTutorialsSpy = sinon.spy(rootStore.tutorials, 'setTutorials')
       rootStore.workflows.setActive(workflow.id).then(() => {
-        expect(fetchMediaSpy).to.have.not.been.called
         expect(setTutorialsSpy).to.have.not.been.called
         expect(rootStore.tutorials.loadingState).to.equal(asyncStates.success)
       }).then(() => {
-        fetchMediaSpy.restore()
         setTutorialsSpy.restore()
       }).then(done, done)
     })
@@ -176,13 +170,11 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
-      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
 
       const setTutorialsSpy = sinon.spy(rootStore.tutorials, 'setTutorials')
       rootStore.workflows.setActive(workflow.id).then(() => {
         expect(setTutorialsSpy).to.have.been.calledOnceWith([tutorial])
       }).then(() => {
-        rootStore.tutorials.fetchMedia.restore()
         setTutorialsSpy.restore()
       }).then(done, done)
     })
@@ -385,14 +377,11 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
-      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
       rootStore.workflows.setActive(workflow.id).then(() => {
         rootStore.tutorials.setActiveTutorial(tutorial.id)
         rootStore.tutorials.setMediaResources([medium])
       }).then(() => {
         expect(rootStore.tutorials.activeMedium).to.deep.equal(medium)
-      }).then(() => {
-        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
     })
   })
@@ -433,13 +422,10 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
-      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
       rootStore.workflows.setActive(workflow.id).then(() => {
         rootStore.tutorials.setActiveTutorial(tutorial.id)
       }).then(() => {
         expect(rootStore.tutorials.tutorialSeenTime).to.be.a('string')
-      }).then(() => {
-        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
     })
 
@@ -450,13 +436,10 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub(tutorialNullKind)
       })
-      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
       rootStore.workflows.setActive(workflow.id).then(() => {
         rootStore.tutorials.setActiveTutorial(tutorialNullKind.id)
       }).then(() => {
         expect(rootStore.tutorials.tutorialSeenTime).to.be.a('string')
-      }).then(() => {
-        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
     })
   })
@@ -515,7 +498,6 @@ describe('Model > TutorialStore', function () {
       })
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
-      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
@@ -525,7 +507,6 @@ describe('Model > TutorialStore', function () {
         expect(rootStore.tutorials.active).to.deep.equal(tutorial)
         expect(rootStore.tutorials.showModal).to.be.true
       }).then(() => {
-        rootStore.tutorials.fetchMedia.restore()
         setActiveTutorialSpy.restore()
         setModalVisibilitySpy.restore()
       }).then(done, done)
@@ -537,7 +518,6 @@ describe('Model > TutorialStore', function () {
       })
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
-      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
@@ -548,7 +528,6 @@ describe('Model > TutorialStore', function () {
           expect(rootStore.tutorials.active).to.deep.equal(tutorial)
           expect(rootStore.tutorials.showModal).to.be.true
         }).then(() => {
-          rootStore.tutorials.fetchMedia.restore()
           setActiveTutorialSpy.restore()
           setModalVisibilitySpy.restore()
         }).then(done, done)
@@ -560,7 +539,6 @@ describe('Model > TutorialStore', function () {
       })
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
-      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
@@ -570,7 +548,6 @@ describe('Model > TutorialStore', function () {
         expect(rootStore.tutorials.active).to.be.undefined
         expect(rootStore.tutorials.showModal).to.be.false
       }).then(() => {
-        rootStore.tutorials.fetchMedia.restore()
         setActiveTutorialSpy.restore()
         setModalVisibilitySpy.restore()
       }).then(done, done)

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -91,7 +91,7 @@ const authClientStubWithUser = {
   checkBearerToken: sinon.stub().callsFake(() => Promise.resolve(token))
 }
 
-describe('Model > TutorialStore', function () {
+describe.only('Model > TutorialStore', function () {
   it('should exist', function () {
     expect(TutorialStore).to.be.an('object')
   })

--- a/packages/lib-react-components/src/Modal/Modal.js
+++ b/packages/lib-react-components/src/Modal/Modal.js
@@ -18,6 +18,7 @@ function Modal ({ children, className, closeFn, colorTheme, theme, title }) {
 
 Modal.propTypes = {
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
   closeFn: PropTypes.func,
   colorTheme: PropTypes.oneOf(['light', 'dark']),
   title: PropTypes.string.isRequired,
@@ -26,6 +27,7 @@ Modal.propTypes = {
 
 Modal.defaultProps = {
   colorTheme: 'light',
+  className: '',
   closeFn: () => {}
 }
 

--- a/packages/lib-react-components/src/Modal/Modal.js
+++ b/packages/lib-react-components/src/Modal/Modal.js
@@ -5,11 +5,11 @@ import WithLayer from './WithLayer'
 import ModalBody from './components/ModalBody'
 import ModalHeading from './components/ModalHeading'
 
-function Modal ({ children, closeFn, colorTheme, theme, title }) {
+function Modal ({ children, className, closeFn, colorTheme, theme, title }) {
   return (
     <React.Fragment>
-      <ModalHeading closeFn={closeFn} title={title} />
-      <ModalBody colorTheme={colorTheme}>
+      <ModalHeading className={className} closeFn={closeFn} title={title} />
+      <ModalBody className={className} colorTheme={colorTheme}>
         {children}
       </ModalBody>
     </React.Fragment>

--- a/packages/lib-react-components/src/Modal/WithLayer.js
+++ b/packages/lib-react-components/src/Modal/WithLayer.js
@@ -22,12 +22,14 @@ function WithLayer (WrappedComponent) {
 
   HOC.propTypes = {
     active: PropTypes.bool,
+    className: PropTypes.string,
     closeFn: PropTypes.func,
     modal: PropTypes.bool
   }
 
   HOC.defaultProps = {
     active: false,
+    className: '',
     modal: true
   }
 

--- a/packages/lib-react-components/src/Modal/WithLayer.js
+++ b/packages/lib-react-components/src/Modal/WithLayer.js
@@ -1,24 +1,22 @@
-import { Grommet, Layer } from 'grommet'
+import { Layer } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
-import zooTheme from '@zooniverse/grommet-theme'
 
-function WithLayer (WrappedComponent, theme = zooTheme) {
-  function HOC ({ active, closeFn, modal, ...props }) {
+function WithLayer (WrappedComponent) {
+  function HOC ({ active, className, closeFn, modal, ...props }) {
     if (!active) {
       return null
     }
 
     return (
-      <Grommet theme={theme}>
-        <Layer
-          modal={modal}
-          onClickOutside={closeFn}
-          onEsc={closeFn}
-        >
-          <WrappedComponent {...props} closeFn={closeFn} />
-        </Layer>
-      </Grommet>
+      <Layer
+        className={className}
+        modal={modal}
+        onClickOutside={closeFn}
+        onEsc={closeFn}
+      >
+        <WrappedComponent {...props} closeFn={closeFn} />
+      </Layer>
     )
   }
 

--- a/packages/lib-react-components/src/Modal/components/ModalBody/ModalBody.js
+++ b/packages/lib-react-components/src/Modal/components/ModalBody/ModalBody.js
@@ -4,12 +4,14 @@ import React from 'react'
 
 function ModalBody ({
   children,
+  className,
   colorTheme
 }) {
   const background = (colorTheme === 'light') ? 'white' : 'dark-5'
   return (
     <Box
       background={background}
+      className={className}
       pad='medium'
     >
       {children}

--- a/packages/lib-react-components/src/Modal/components/ModalBody/ModalBody.js
+++ b/packages/lib-react-components/src/Modal/components/ModalBody/ModalBody.js
@@ -20,11 +20,13 @@ function ModalBody ({
 }
 
 ModalBody.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.node.isRequired,
   colorTheme: PropTypes.oneOf(['light', 'dark'])
 }
 
 ModalBody.defaultProps = {
+  className: '',
   colorTheme: 'light'
 }
 

--- a/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
+++ b/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
@@ -58,8 +58,13 @@ function ModalHeading ({ className, closeFn, title }) {
 }
 
 ModalHeading.propTypes = {
+  className: PropTypes.string,
   closeFn: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired
+}
+
+ModalHeading.defaultProps = {
+  className: ''
 }
 
 export default ModalHeading

--- a/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
+++ b/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
@@ -33,11 +33,12 @@ const StyledButton = styled(Button)`
   }
 `
 
-function ModalHeading ({ closeFn, title }) {
+function ModalHeading ({ className, closeFn, title }) {
   return (
     <Box
       align='center'
-      background='teal'
+      background='brand'
+      className={className}
       direction='row'
       gap='large'
       justify='between'


### PR DESCRIPTION
Package:
lib-classifier

Remove the public `fetchMedia` action. It was only being exported so that it could be stubbed in tests.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

