### PR TITLE
deploy the correct image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ timeout(20) {
       echo 'Publishing Monorepo Docker image...'
       if (BRANCH_NAME == 'master') {
         def dockerRepoName = 'zooniverse/front-end-monorepo'
-        def dockerImageName = "${dockerRepoName}:${scmVars.GIT_COMMIT}"
+        def dockerImageName = "${dockerRepoName}:${BRANCH_NAME}"
         def newImage = docker.build(dockerImageName)
         newImage.push()
         newImage.push('latest')
@@ -27,13 +27,15 @@ timeout(20) {
         if (appFolders.size() > 0) {
           for (appDir in appFolders) {
             dir (appDir) {
+              // get the app's project name - ideally this shell code moves to a package.json script in each app
               def dockerRepoName = sh(returnStdout: true, script: 'grep name package.json | cut -c 13- | rev | cut -c 3- | rev').trim()
-              def dockerImageName = "${dockerRepoName}:${BRANCH_NAME}"
+              def dockerImageName = "${dockerRepoName}:${scmVars.GIT_COMMIT}"
 
               echo "Building image for ${dockerImageName}..."
               def newImage = docker.build(dockerImageName, '--quiet .')
 
               echo "Pushing ${dockerImageName} to Docker Hub..."
+              newImage.push()
               newImage.push('latest')
             }
           }

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
         - name: fe-project-staging
-          image: zooniverse/front-end-monorepo:__IMAGE_TAG__
+          image: zooniverse/fe-project:__IMAGE_TAG__
           ports:
             - containerPort: 3000


### PR DESCRIPTION
Package: fe-project

1. deploy the fe-project app image to kubernetes
2. switch the image labelling for the base vs app images
3. App images deploy via k8 so they need to have a unique image tag (Git commit)
4. Switch the deployment template to deploy the fe-project app.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

