### PR TITLE
Add classifier_version to classification metadata

### DIFF
--- a/packages/lib-classifier/src/store/Classification.js
+++ b/packages/lib-classifier/src/store/Classification.js
@@ -3,6 +3,7 @@ import Resource from './Resource'
 import { SingleChoiceAnnotation, MultipleChoiceAnnotation, Graph2dRangeXAnnotation } from './annotations'
 
 const ClassificationMetadata = types.model('ClassificationMetadata', {
+  classifier_version: types.literal('2.0'),
   feedback: types.frozen({}),
   finishedAt: types.maybe(types.string),
   session: types.maybe(types.string),

--- a/packages/lib-classifier/src/store/Classification.spec.js
+++ b/packages/lib-classifier/src/store/Classification.spec.js
@@ -12,6 +12,7 @@ describe('Model > Classification', function () {
         workflow: '5678'
       },
       metadata: ClassificationMetadata.create({
+        classifier_version: "2.0",
         source: 'api',
         userLanguage: 'en',
         workflowVersion: '1.0'

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -68,6 +68,7 @@ const ClassificationStore = types
           workflow: workflow.id
         },
         metadata: ClassificationMetadata.create({
+          classifier_version: '2.0',
           source: subject.metadata.intervention ? 'sugar' : 'api',
           subjectSelectionState: {
             already_seen: subject.already_seen,


### PR DESCRIPTION
Package: lib-classifier

Closes #498

Describe your changes:
Adds `classifier_version` to the classification metadata. Services like caesar/aggregation may want to know this and act upon it if necessary.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

