### PR TITLE
Remove self.fetchMedia from tutorial store

### DIFF
--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -142,7 +142,7 @@ const TutorialStore = types
         const response = yield tutorialsClient.get({ workflowId: workflow.id })
         const { tutorials } = response.body
         if (tutorials && tutorials.length > 0) {
-          const mediaRequests = tutorials.map(tutorial => fetchMedia(tutorial))
+          const mediaRequests = tutorials.map(fetchMedia)
           yield Promise.all(mediaRequests)
           self.setTutorials(tutorials)
           self.loadingState = asyncStates.success

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -224,7 +224,6 @@ const TutorialStore = types
 
     return {
       afterAttach,
-      fetchMedia: flow(fetchMedia),
       fetchTutorials: flow(fetchTutorials),
       resetActiveTutorial,
       resetSeen,

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -142,7 +142,8 @@ const TutorialStore = types
         const response = yield tutorialsClient.get({ workflowId: workflow.id })
         const { tutorials } = response.body
         if (tutorials && tutorials.length > 0) {
-          yield Promise.all(tutorials.map(tutorial => self.fetchMedia(tutorial)))
+          const mediaRequests = tutorials.map(tutorial => flow(fetchMedia)(tutorial))
+          yield Promise.all(mediaRequests)
           self.setTutorials(tutorials)
           self.loadingState = asyncStates.success
           if (upp.loadingState === asyncStates.success) {

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -110,7 +110,7 @@ const TutorialStore = types
       addDisposer(self, uppDisposer)
     }
 
-    function * fetchMedia (tutorial) {
+    const fetchMedia = flow(function * fetchMedia (tutorial) {
       const { tutorials } = getRoot(self).client
       if (tutorial) {
         self.loadingState = asyncStates.loading
@@ -124,7 +124,7 @@ const TutorialStore = types
           console.error(error)
         }
       }
-    }
+    })
 
     function setMediaResources (media) {
       media.forEach(medium => self.attachedMedia.put(medium))
@@ -142,7 +142,7 @@ const TutorialStore = types
         const response = yield tutorialsClient.get({ workflowId: workflow.id })
         const { tutorials } = response.body
         if (tutorials && tutorials.length > 0) {
-          const mediaRequests = tutorials.map(tutorial => flow(fetchMedia)(tutorial))
+          const mediaRequests = tutorials.map(tutorial => fetchMedia(tutorial))
           yield Promise.all(mediaRequests)
           self.setTutorials(tutorials)
           self.loadingState = asyncStates.success

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -110,13 +110,10 @@ describe('Model > TutorialStore', function () {
       tutorials: TutorialStore.create(),
       workflows: WorkflowStore.create()
     }, { authClient: authClientStubWithUser, client: clientStub() })
-    sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
     rootStore.workflows.setActive(workflow.id)
       .then(() => {
         const tutorialInStore = rootStore.tutorials.resources.get(tutorial.id)
         expect(tutorialInStore.toJSON()).to.deep.equal(tutorial)
-      }).then(() => {
-        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
   })
 
@@ -145,14 +142,11 @@ describe('Model > TutorialStore', function () {
         })
       })
 
-      const fetchMediaSpy = sinon.spy(rootStore.tutorials, 'fetchMedia')
       const setTutorialsSpy = sinon.spy(rootStore.tutorials, 'setTutorials')
       rootStore.workflows.setActive(workflow.id).then(() => {
-        expect(fetchMediaSpy).to.have.not.been.called
         expect(setTutorialsSpy).to.have.not.been.called
         expect(rootStore.tutorials.loadingState).to.equal(asyncStates.success)
       }).then(() => {
-        fetchMediaSpy.restore()
         setTutorialsSpy.restore()
       }).then(done, done)
     })
@@ -176,13 +170,11 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
-      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
 
       const setTutorialsSpy = sinon.spy(rootStore.tutorials, 'setTutorials')
       rootStore.workflows.setActive(workflow.id).then(() => {
         expect(setTutorialsSpy).to.have.been.calledOnceWith([tutorial])
       }).then(() => {
-        rootStore.tutorials.fetchMedia.restore()
         setTutorialsSpy.restore()
       }).then(done, done)
     })
@@ -385,14 +377,11 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
-      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
       rootStore.workflows.setActive(workflow.id).then(() => {
         rootStore.tutorials.setActiveTutorial(tutorial.id)
         rootStore.tutorials.setMediaResources([medium])
       }).then(() => {
         expect(rootStore.tutorials.activeMedium).to.deep.equal(medium)
-      }).then(() => {
-        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
     })
   })
@@ -433,13 +422,10 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
-      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
       rootStore.workflows.setActive(workflow.id).then(() => {
         rootStore.tutorials.setActiveTutorial(tutorial.id)
       }).then(() => {
         expect(rootStore.tutorials.tutorialSeenTime).to.be.a('string')
-      }).then(() => {
-        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
     })
 
@@ -450,13 +436,10 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub(tutorialNullKind)
       })
-      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
       rootStore.workflows.setActive(workflow.id).then(() => {
         rootStore.tutorials.setActiveTutorial(tutorialNullKind.id)
       }).then(() => {
         expect(rootStore.tutorials.tutorialSeenTime).to.be.a('string')
-      }).then(() => {
-        rootStore.tutorials.fetchMedia.restore()
       }).then(done, done)
     })
   })
@@ -516,7 +499,6 @@ describe('Model > TutorialStore', function () {
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
       sinon.stub(rootStore.userProjectPreferences, 'updateUPP').callsFake(() => {})
-      sinon.stub(rootStore.tutorials, 'fetchMedia').callsFake(() => Promise.resolve())
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
@@ -526,7 +508,6 @@ describe('Model > TutorialStore', function () {
         expect(rootStore.tutorials.active).to.deep.equal(tutorial)
         expect(rootStore.tutorials.showModal).to.be.true
       }).then(() => {
-        rootStore.tutorials.fetchMedia.restore()
         setActiveTutorialSpy.restore()
         setModalVisibilitySpy.restore()
         rootStore.userProjectPreferences.updateUPP.restore()
@@ -540,7 +521,6 @@ describe('Model > TutorialStore', function () {
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
       sinon.stub(rootStore.userProjectPreferences, 'updateUPP').callsFake(() => { })
-      sinon.stub(rootStore.tutorials, 'fetchMedia')
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
@@ -551,7 +531,6 @@ describe('Model > TutorialStore', function () {
           expect(rootStore.tutorials.active).to.deep.equal(tutorial)
           expect(rootStore.tutorials.showModal).to.be.true
         }).then(() => {
-          rootStore.tutorials.fetchMedia.restore()
           setActiveTutorialSpy.restore()
           setModalVisibilitySpy.restore()
           rootStore.userProjectPreferences.updateUPP.restore()
@@ -564,7 +543,6 @@ describe('Model > TutorialStore', function () {
       })
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
-      sinon.stub(rootStore.tutorials, 'fetchMedia')
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
@@ -574,7 +552,6 @@ describe('Model > TutorialStore', function () {
         expect(rootStore.tutorials.active).to.be.undefined
         expect(rootStore.tutorials.showModal).to.be.false
       }).then(() => {
-        rootStore.tutorials.fetchMedia.restore()
         setActiveTutorialSpy.restore()
         setModalVisibilitySpy.restore()
       }).then(done, done)

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -519,68 +519,72 @@ describe('Model > TutorialStore', function () {
       clientStubWithUPP = Object.assign({}, tutorialsClient, panoptesClientWithUPP)
       clientStubWithUPPTimestamp = Object.assign({}, tutorialsClient, panoptesClientWithUPPTimestamp)
     })
-
-    it('should show the tutorial for logged out users', function (done) {
-      rootStore = RootStore.create({
-        projects: ProjectStore.create(),
-        tutorials: TutorialStore.create(),
-        workflows: WorkflowStore.create()
-      }, {
-        authClient: authClientStubWithoutUser, client: clientStub()
-      })
-      const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
-      const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
-      sinon.stub(rootStore.userProjectPreferences, 'updateUPP').callsFake(() => {})
-      sinon.stub(rootStore.tutorials, 'fetchTutorials')
-
-      rootStore.projects.setResource(project)
-      rootStore.projects.setActive(project.id)
-      rootStore.workflows.setActive(workflow.id)
-        .then(() => {
-          rootStore.tutorials.fetchTutorials.restore()
-          return rootStore.tutorials.fetchTutorials()
+    
+    describe('for logged-out users', function () {
+      it('should show the tutorial', function (done) {
+        rootStore = RootStore.create({
+          projects: ProjectStore.create(),
+          tutorials: TutorialStore.create(),
+          workflows: WorkflowStore.create()
+        }, {
+          authClient: authClientStubWithoutUser, client: clientStub()
         })
-        .then(() => {
-          expect(setActiveTutorialSpy).to.have.been.calledOnceWith(tutorial.id)
-          expect(setModalVisibilitySpy).to.have.been.calledOnce
-          expect(rootStore.tutorials.active).to.deep.equal(tutorial)
-          expect(rootStore.tutorials.showModal).to.be.true
-        }).then(() => {
-          setActiveTutorialSpy.restore()
-          setModalVisibilitySpy.restore()
-          rootStore.userProjectPreferences.updateUPP.restore()
-        }).then(done, done)
+        const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
+        const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
+        sinon.stub(rootStore.userProjectPreferences, 'updateUPP').callsFake(() => {})
+        sinon.stub(rootStore.tutorials, 'fetchTutorials')
+
+        rootStore.projects.setResource(project)
+        rootStore.projects.setActive(project.id)
+        rootStore.workflows.setActive(workflow.id)
+          .then(() => {
+            rootStore.tutorials.fetchTutorials.restore()
+            return rootStore.tutorials.fetchTutorials()
+          })
+          .then(() => {
+            expect(setActiveTutorialSpy).to.have.been.calledOnceWith(tutorial.id)
+            expect(setModalVisibilitySpy).to.have.been.calledOnce
+            expect(rootStore.tutorials.active).to.deep.equal(tutorial)
+            expect(rootStore.tutorials.showModal).to.be.true
+          }).then(() => {
+            setActiveTutorialSpy.restore()
+            setModalVisibilitySpy.restore()
+            rootStore.userProjectPreferences.updateUPP.restore()
+          }).then(done, done)
+      })
     })
 
-    it('should show the tutorial for logged in users without a seen timestamp for the loaded tutorial', function (done) {
-      rootStore = RootStore.create({}, {
-        authClient: authClientStubWithUser, client: clientStubWithUPP
-      })
-      const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
-      const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
-      sinon.stub(rootStore.userProjectPreferences, 'updateUPP').callsFake(() => { })
-      sinon.stub(rootStore.tutorials, 'fetchTutorials')
-
-      rootStore.projects.setResource(project)
-      rootStore.projects.setActive(project.id)
-      rootStore.workflows.setActive(workflow.id)
-        .then(() => {
-          rootStore.tutorials.fetchTutorials.restore()
-          return rootStore.tutorials.fetchTutorials()
+    describe('for logged-in users', function () {
+      it('should show the tutorial if it has not been seen', function (done) {
+        rootStore = RootStore.create({}, {
+          authClient: authClientStubWithUser, client: clientStubWithUPP
         })
-        .then(() => {
-          expect(setActiveTutorialSpy).to.have.been.calledOnceWith(tutorial.id)
-          expect(setModalVisibilitySpy).to.have.been.calledOnce
-          expect(rootStore.tutorials.active).to.deep.equal(tutorial)
-          expect(rootStore.tutorials.showModal).to.be.true
-        }).then(() => {
-          setActiveTutorialSpy.restore()
-          setModalVisibilitySpy.restore()
-          rootStore.userProjectPreferences.updateUPP.restore()
-        }).then(done, done)
+        const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
+        const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
+        sinon.stub(rootStore.userProjectPreferences, 'updateUPP').callsFake(() => { })
+        sinon.stub(rootStore.tutorials, 'fetchTutorials')
+
+        rootStore.projects.setResource(project)
+        rootStore.projects.setActive(project.id)
+        rootStore.workflows.setActive(workflow.id)
+          .then(() => {
+            rootStore.tutorials.fetchTutorials.restore()
+            return rootStore.tutorials.fetchTutorials()
+          })
+          .then(() => {
+            expect(setActiveTutorialSpy).to.have.been.calledOnceWith(tutorial.id)
+            expect(setModalVisibilitySpy).to.have.been.calledOnce
+            expect(rootStore.tutorials.active).to.deep.equal(tutorial)
+            expect(rootStore.tutorials.showModal).to.be.true
+          }).then(() => {
+            setActiveTutorialSpy.restore()
+            setModalVisibilitySpy.restore()
+            rootStore.userProjectPreferences.updateUPP.restore()
+          }).then(done, done)
+      })
     })
 
-    it('should not show the tutorial for logged in users with a seen timestamp for the loaded tutorial', function (done) {
+    it('should not show the tutorial if it has been seen', function (done) {
       rootStore = RootStore.create({}, {
         authClient: authClientStubWithUser, client: clientStubWithUPPTimestamp
       })

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -92,6 +92,15 @@ const authClientStubWithUser = {
 }
 
 describe('Model > TutorialStore', function () {
+  function fetchTutorials () {
+    sinon.stub(rootStore.tutorials, 'fetchTutorials')
+    return rootStore.workflows.setActive(workflow.id)
+      .then(() => {
+        rootStore.tutorials.fetchTutorials.restore()
+        return rootStore.tutorials.fetchTutorials()
+      })
+  }
+
   it('should exist', function () {
     expect(TutorialStore).to.be.an('object')
   })
@@ -110,12 +119,8 @@ describe('Model > TutorialStore', function () {
       tutorials: TutorialStore.create(),
       workflows: WorkflowStore.create()
     }, { authClient: authClientStubWithUser, client: clientStub() })
-    sinon.stub(rootStore.tutorials, 'fetchTutorials')
-    rootStore.workflows.setActive(workflow.id)
-      .then(() => {
-        rootStore.tutorials.fetchTutorials.restore()
-        return rootStore.tutorials.fetchTutorials()
-      })
+
+    fetchTutorials()
       .then(() => {
         const tutorialInStore = rootStore.tutorials.resources.get(tutorial.id)
         expect(tutorialInStore.toJSON()).to.deep.equal(tutorial)
@@ -129,13 +134,8 @@ describe('Model > TutorialStore', function () {
         tutorials: TutorialStore.create(),
         workflows: WorkflowStore.create()
       }, { authClient: authClientStubWithoutUser, client })
-      sinon.stub(rootStore.tutorials, 'fetchTutorials')
 
-      rootStore.workflows.setActive(workflow.id)
-        .then(() => {
-          rootStore.tutorials.fetchTutorials.restore()
-          return rootStore.tutorials.fetchTutorials()
-        })
+      fetchTutorials()
         .then(() => {
           expect(client.tutorials.get).to.have.been.calledWith({ workflowId: workflow.id })
         }).then(done, done)
@@ -154,12 +154,8 @@ describe('Model > TutorialStore', function () {
       })
 
       const setTutorialsSpy = sinon.spy(rootStore.tutorials, 'setTutorials')
-      sinon.stub(rootStore.tutorials, 'fetchTutorials')
-      rootStore.workflows.setActive(workflow.id)
-        .then(() => {
-          rootStore.tutorials.fetchTutorials.restore()
-          return rootStore.tutorials.fetchTutorials()
-        })
+
+      fetchTutorials()
         .then(() => {
           expect(setTutorialsSpy).to.have.not.been.called
           expect(rootStore.tutorials.loadingState).to.equal(asyncStates.success)
@@ -196,12 +192,8 @@ describe('Model > TutorialStore', function () {
       })
 
       const setTutorialsSpy = sinon.spy(rootStore.tutorials, 'setTutorials')
-      sinon.stub(rootStore.tutorials, 'fetchTutorials')
-      rootStore.workflows.setActive(workflow.id)
-        .then(() => {
-          rootStore.tutorials.fetchTutorials.restore()
-          return rootStore.tutorials.fetchTutorials()
-        })
+
+      fetchTutorials()
         .then(() => {
           expect(setTutorialsSpy).to.have.been.calledOnceWith([tutorial])
         }).then(() => {
@@ -221,13 +213,8 @@ describe('Model > TutorialStore', function () {
           }
         })
       })
-      sinon.stub(rootStore.tutorials, 'fetchTutorials')
 
-      rootStore.workflows.setActive(workflow.id)
-        .then(() => {
-          rootStore.tutorials.fetchTutorials.restore()
-          return rootStore.tutorials.fetchTutorials()
-        })
+      fetchTutorials()
         .then(() => {
           expect(rootStore.tutorials.loadingState).to.equal(asyncStates.error)
         }).then(done, done)
@@ -249,12 +236,8 @@ describe('Model > TutorialStore', function () {
       })
 
       const setMediaResourcesSpy = sinon.spy(rootStore.tutorials, 'setMediaResources')
-      sinon.stub(rootStore.tutorials, 'fetchTutorials')
-      rootStore.workflows.setActive(workflow.id)
-        .then(() => {
-          rootStore.tutorials.fetchTutorials.restore()
-          return rootStore.tutorials.fetchTutorials()
-        })
+
+      fetchTutorials()
         .then(() => {
           expect(setMediaResourcesSpy).to.have.not.been.called
         }).then(() => {
@@ -271,12 +254,8 @@ describe('Model > TutorialStore', function () {
       })
 
       const setMediaResourcesSpy = sinon.spy(rootStore.tutorials, 'setMediaResources')
-      sinon.stub(rootStore.tutorials, 'fetchTutorials')
-      rootStore.workflows.setActive(workflow.id)
-        .then(() => {
-          rootStore.tutorials.fetchTutorials.restore()
-          return rootStore.tutorials.fetchTutorials()
-        })
+
+      fetchTutorials()
         .then(() => {
           expect(setMediaResourcesSpy).to.have.been.calledOnceWith([medium])
         }).then(() => {
@@ -425,12 +404,8 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
-      sinon.stub(rootStore.tutorials, 'fetchTutorials')
-      rootStore.workflows.setActive(workflow.id)
-        .then(() => {
-          rootStore.tutorials.fetchTutorials.restore()
-          return rootStore.tutorials.fetchTutorials()
-        })
+
+      fetchTutorials()
         .then(() => {
           rootStore.tutorials.setActiveTutorial(tutorial.id)
           rootStore.tutorials.setMediaResources([medium])
@@ -449,13 +424,8 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
-      sinon.stub(rootStore.tutorials, 'fetchTutorials')
 
-      rootStore.workflows.setActive(workflow.id)
-        .then(() => {
-          rootStore.tutorials.fetchTutorials.restore()
-          return rootStore.tutorials.fetchTutorials()
-        })
+      fetchTutorials()
         .then(() => {
           expect(rootStore.tutorials.tutorialSeenTime).to.be.undefined
         }).then(done, done)
@@ -482,12 +452,8 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
-      sinon.stub(rootStore.tutorials, 'fetchTutorials')
-      rootStore.workflows.setActive(workflow.id)
-        .then(() => {
-          rootStore.tutorials.fetchTutorials.restore()
-          return rootStore.tutorials.fetchTutorials()
-        })
+
+      fetchTutorials()
         .then(() => {
           rootStore.tutorials.setActiveTutorial(tutorial.id)
         }).then(() => {
@@ -502,12 +468,8 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub(tutorialNullKind)
       })
-      sinon.stub(rootStore.tutorials, 'fetchTutorials')
-      rootStore.workflows.setActive(workflow.id)
-        .then(() => {
-          rootStore.tutorials.fetchTutorials.restore()
-          return rootStore.tutorials.fetchTutorials()
-        })
+
+      fetchTutorials()
         .then(() => {
           rootStore.tutorials.setActiveTutorial(tutorialNullKind.id)
         }).then(() => {
@@ -572,15 +534,11 @@ describe('Model > TutorialStore', function () {
         const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
         const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
         sinon.stub(rootStore.userProjectPreferences, 'updateUPP').callsFake(() => {})
-        sinon.stub(rootStore.tutorials, 'fetchTutorials')
 
         rootStore.projects.setResource(project)
         rootStore.projects.setActive(project.id)
-        rootStore.workflows.setActive(workflow.id)
-          .then(() => {
-            rootStore.tutorials.fetchTutorials.restore()
-            return rootStore.tutorials.fetchTutorials()
-          })
+
+        fetchTutorials()
           .then(() => {
             expect(setActiveTutorialSpy).to.have.been.calledOnceWith(tutorial.id)
             expect(setModalVisibilitySpy).to.have.been.calledOnce
@@ -602,15 +560,11 @@ describe('Model > TutorialStore', function () {
         const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
         const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
         sinon.stub(rootStore.userProjectPreferences, 'updateUPP').callsFake(() => { })
-        sinon.stub(rootStore.tutorials, 'fetchTutorials')
 
         rootStore.projects.setResource(project)
         rootStore.projects.setActive(project.id)
-        rootStore.workflows.setActive(workflow.id)
-          .then(() => {
-            rootStore.tutorials.fetchTutorials.restore()
-            return rootStore.tutorials.fetchTutorials()
-          })
+
+        fetchTutorials()
           .then(() => {
             expect(setActiveTutorialSpy).to.have.been.calledOnceWith(tutorial.id)
             expect(setModalVisibilitySpy).to.have.been.calledOnce
@@ -630,15 +584,11 @@ describe('Model > TutorialStore', function () {
       })
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
-      sinon.stub(rootStore.tutorials, 'fetchTutorials')
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
-      rootStore.workflows.setActive(workflow.id)
-        .then(() => {
-          rootStore.tutorials.fetchTutorials.restore()
-          return rootStore.tutorials.fetchTutorials()
-        })
+
+      fetchTutorials()
         .then(() => {
           expect(setActiveTutorialSpy).to.not.have.been.called
           expect(setModalVisibilitySpy).to.not.have.been.called

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -110,8 +110,12 @@ describe('Model > TutorialStore', function () {
       tutorials: TutorialStore.create(),
       workflows: WorkflowStore.create()
     }, { authClient: authClientStubWithUser, client: clientStub() })
+    sinon.stub(rootStore.tutorials, 'fetchTutorials')
     rootStore.workflows.setActive(workflow.id)
-      .then(rootStore.tutorials.fetchTutorials)
+      .then(() => {
+        rootStore.tutorials.fetchTutorials.restore()
+        return rootStore.tutorials.fetchTutorials()
+      })
       .then(() => {
         const tutorialInStore = rootStore.tutorials.resources.get(tutorial.id)
         expect(tutorialInStore.toJSON()).to.deep.equal(tutorial)
@@ -125,9 +129,13 @@ describe('Model > TutorialStore', function () {
         tutorials: TutorialStore.create(),
         workflows: WorkflowStore.create()
       }, { authClient: authClientStubWithoutUser, client })
+      sinon.stub(rootStore.tutorials, 'fetchTutorials')
 
       rootStore.workflows.setActive(workflow.id)
-        .then(rootStore.tutorials.fetchTutorials)
+        .then(() => {
+          rootStore.tutorials.fetchTutorials.restore()
+          return rootStore.tutorials.fetchTutorials()
+        })
         .then(() => {
           expect(client.tutorials.get).to.have.been.calledWith({ workflowId: workflow.id })
         }).then(done, done)
@@ -146,8 +154,12 @@ describe('Model > TutorialStore', function () {
       })
 
       const setTutorialsSpy = sinon.spy(rootStore.tutorials, 'setTutorials')
+      sinon.stub(rootStore.tutorials, 'fetchTutorials')
       rootStore.workflows.setActive(workflow.id)
-        .then(rootStore.tutorials.fetchTutorials)
+        .then(() => {
+          rootStore.tutorials.fetchTutorials.restore()
+          return rootStore.tutorials.fetchTutorials()
+        })
         .then(() => {
           expect(setTutorialsSpy).to.have.not.been.called
           expect(rootStore.tutorials.loadingState).to.equal(asyncStates.success)
@@ -162,10 +174,14 @@ describe('Model > TutorialStore', function () {
         tutorials: TutorialStore.create(),
         workflows: WorkflowStore.create()
       }, { authClient: authClientStubWithoutUser, client })
+      sinon.stub(rootStore.tutorials, 'fetchTutorials')
 
       rootStore.workflows.setActive(workflow.id)
         .then(() => client.tutorials.getAttachedImages.resetHistory())
-        .then(rootStore.tutorials.fetchTutorials)
+        .then(() => {
+          rootStore.tutorials.fetchTutorials.restore()
+          return rootStore.tutorials.fetchTutorials()
+        })
         .then(() => {
           expect(client.tutorials.getAttachedImages).to.have.been.calledOnceWith({ id: tutorial.id })
         }).then(done, done)
@@ -205,9 +221,13 @@ describe('Model > TutorialStore', function () {
           }
         })
       })
+      sinon.stub(rootStore.tutorials, 'fetchTutorials')
 
       rootStore.workflows.setActive(workflow.id)
-        .then(rootStore.tutorials.fetchTutorials)
+        .then(() => {
+          rootStore.tutorials.fetchTutorials.restore()
+          return rootStore.tutorials.fetchTutorials()
+        })
         .then(() => {
           expect(rootStore.tutorials.loadingState).to.equal(asyncStates.error)
         }).then(done, done)
@@ -229,8 +249,12 @@ describe('Model > TutorialStore', function () {
       })
 
       const setMediaResourcesSpy = sinon.spy(rootStore.tutorials, 'setMediaResources')
+      sinon.stub(rootStore.tutorials, 'fetchTutorials')
       rootStore.workflows.setActive(workflow.id)
-        .then(rootStore.tutorials.fetchTutorials)
+        .then(() => {
+          rootStore.tutorials.fetchTutorials.restore()
+          return rootStore.tutorials.fetchTutorials()
+        })
         .then(() => {
           expect(setMediaResourcesSpy).to.have.not.been.called
         }).then(() => {
@@ -401,8 +425,12 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
+      sinon.stub(rootStore.tutorials, 'fetchTutorials')
       rootStore.workflows.setActive(workflow.id)
-        .then(rootStore.tutorials.fetchTutorials)
+        .then(() => {
+          rootStore.tutorials.fetchTutorials.restore()
+          return rootStore.tutorials.fetchTutorials()
+        })
         .then(() => {
           rootStore.tutorials.setActiveTutorial(tutorial.id)
           rootStore.tutorials.setMediaResources([medium])
@@ -421,9 +449,13 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
+      sinon.stub(rootStore.tutorials, 'fetchTutorials')
 
       rootStore.workflows.setActive(workflow.id)
-        .then(rootStore.tutorials.fetchTutorials)
+        .then(() => {
+          rootStore.tutorials.fetchTutorials.restore()
+          return rootStore.tutorials.fetchTutorials()
+        })
         .then(() => {
           expect(rootStore.tutorials.tutorialSeenTime).to.be.undefined
         }).then(done, done)
@@ -450,8 +482,12 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub()
       })
+      sinon.stub(rootStore.tutorials, 'fetchTutorials')
       rootStore.workflows.setActive(workflow.id)
-        .then(rootStore.tutorials.fetchTutorials)
+        .then(() => {
+          rootStore.tutorials.fetchTutorials.restore()
+          return rootStore.tutorials.fetchTutorials()
+        })
         .then(() => {
           rootStore.tutorials.setActiveTutorial(tutorial.id)
         }).then(() => {
@@ -466,8 +502,12 @@ describe('Model > TutorialStore', function () {
       }, {
         authClient: authClientStubWithoutUser, client: clientStub(tutorialNullKind)
       })
+      sinon.stub(rootStore.tutorials, 'fetchTutorials')
       rootStore.workflows.setActive(workflow.id)
-        .then(rootStore.tutorials.fetchTutorials)
+        .then(() => {
+          rootStore.tutorials.fetchTutorials.restore()
+          return rootStore.tutorials.fetchTutorials()
+        })
         .then(() => {
           rootStore.tutorials.setActiveTutorial(tutorialNullKind.id)
         }).then(() => {
@@ -590,11 +630,15 @@ describe('Model > TutorialStore', function () {
       })
       const setActiveTutorialSpy = sinon.spy(rootStore.tutorials, 'setActiveTutorial')
       const setModalVisibilitySpy = sinon.spy(rootStore.tutorials, 'setModalVisibility')
+      sinon.stub(rootStore.tutorials, 'fetchTutorials')
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
       rootStore.workflows.setActive(workflow.id)
-        .then(rootStore.tutorials.fetchTutorials)
+        .then(() => {
+          rootStore.tutorials.fetchTutorials.restore()
+          return rootStore.tutorials.fetchTutorials()
+        })
         .then(() => {
           expect(setActiveTutorialSpy).to.not.have.been.called
           expect(setModalVisibilitySpy).to.not.have.been.called


### PR DESCRIPTION
Package:
lib-classifier

Removes `self.fetchMedia` from the tutorial store, since it isn't used outside the store. Can anyone see why doing this breaks the tests?


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

