### PR TITLE
Disabling minification for now for easier debugging

### DIFF
--- a/packages/lib-classifier/webpack.dist.js
+++ b/packages/lib-classifier/webpack.dist.js
@@ -18,6 +18,9 @@ module.exports = {
     /^(@zooniverse\/panoptes-js\/.*)$/i,
     /^(@zooniverse\/react-components\/.*)$/i
   ],
+  optimization: {
+    minimize: false // disabled for now to make debugging easier
+  },
   mode: 'production',
   module: {
     rules: [

--- a/packages/lib-react-components/webpack.dist.js
+++ b/packages/lib-react-components/webpack.dist.js
@@ -13,6 +13,9 @@ module.exports = {
       }
     ]
   },
+  optimization: {
+    minimize: false // disabled for now to make debugging easier
+  },
   output: {
     path: path.resolve('dist'),
     filename: 'main.js',


### PR DESCRIPTION
Package: lib-classifier, lib-react-components

Describe your changes:
Disables minification for easier debugging for now.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

