### PR TITLE
Test tutorial media errors

### DIFF
--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -122,7 +122,6 @@ const TutorialStore = types
           // We're not setting the store state to error because
           // we do not want to prevent the tutorial from rendering
           console.error(error)
-          self.setMediaResources([])
         }
       }
     })

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -122,6 +122,7 @@ const TutorialStore = types
           // We're not setting the store state to error because
           // we do not want to prevent the tutorial from rendering
           console.error(error)
+          self.setMediaResources([])
         }
       }
     })

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -91,8 +91,7 @@ const authClientStubWithUser = {
   checkBearerToken: sinon.stub().callsFake(() => Promise.resolve(token))
 }
 
-
-describe.only('Model > TutorialStore', function () {
+describe('Model > TutorialStore', function () {
   function fetchTutorials () {
     sinon.stub(rootStore.tutorials, 'fetchTutorials')
     return rootStore.workflows.setActive(workflow.id)


### PR DESCRIPTION
Package:
lib-classifier

This builds off #606 because I made changes to the tutorial tests there. It mocks the tutorial client to reject with an error on `tutorials.getAttachedImages()`, and expects the tutorial not to be shown in that case.

It also tests the case where media requests resolve after tutorial requests, to make sure that we aren't showing the tutorial before it's ready.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

