### PR TITLE
Set env by query during initial server side load

### DIFF
--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -38,7 +38,7 @@ export default class MyApp extends App {
       if (owner && project) {
         const projectSlug = `${owner}/${project}`
         const store = initStore(pageProps.isServer)
-        await store.project.fetch(projectSlug)
+        await store.project.fetch(projectSlug, { env: context.query.env })
         pageProps.initialState = getSnapshot(store)
       }
     }

--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -38,7 +38,8 @@ export default class MyApp extends App {
       if (owner && project) {
         const projectSlug = `${owner}/${project}`
         const store = initStore(pageProps.isServer)
-        await store.project.fetch(projectSlug, { env: context.query.env })
+        const query = (context.query.env) ? { env: context.query.env } : {}
+        await store.project.fetch(projectSlug, query)
         pageProps.initialState = getSnapshot(store)
       }
     }

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperContainer.js
@@ -34,6 +34,7 @@ class ClassifierWrapperContainer extends Component {
   }
 
   static getDerivedStateFromError (error) {
+    console.error('error', error)
     return {
       error
     }
@@ -62,8 +63,9 @@ class ClassifierWrapperContainer extends Component {
 
     if (somethingWentWrong) {
       const { error } = this.state || project
+      const errorToMessage = error || new Error('Something went wrong')
       return (
-        <ErrorMessage error={error} />
+        <ErrorMessage error={errorToMessage} />
       )
     }
 

--- a/packages/app-project/stores/Project.js
+++ b/packages/app-project/stores/Project.js
@@ -46,33 +46,31 @@ const Project = types
           const query = { ...params, slug }
           const response = yield client.getWithLinkedResources({ query })
           const project = response.body.projects[0]
-          if (project) {
-            const linked = response.body.linked
-
-            self.avatar = get(linked, 'avatars[0]', {})
-            self.background = get(linked, 'backgrounds[0]', {})
-
-            const properties = [
-              'classifications_count',
-              'classifiers_count',
-              'completeness',
-              'configuration',
-              'description',
-              'display_name',
-              'experimental_tools',
-              'id',
-              'launch_approved',
-              'links',
-              'retired_subjects_count',
-              'slug',
-              'subjects_count',
-              'urls'
-            ]
-            properties.forEach(property => { self[property] = project[property] })
-            self.loadingState = asyncStates.success
-          }
-
           if (!project) throw new Error(`${slug} could not be found`)
+
+          const linked = response.body.linked
+
+          self.avatar = get(linked, 'avatars[0]', {})
+          self.background = get(linked, 'backgrounds[0]', {})
+
+          const properties = [
+            'classifications_count',
+            'classifiers_count',
+            'completeness',
+            'configuration',
+            'description',
+            'display_name',
+            'experimental_tools',
+            'id',
+            'launch_approved',
+            'links',
+            'retired_subjects_count',
+            'slug',
+            'subjects_count',
+            'urls'
+          ]
+          properties.forEach(property => { self[property] = project[property] })
+          self.loadingState = asyncStates.success
         } catch (error) {
           console.error('Error loading project:', error)
           self.error = error

--- a/packages/lib-panoptes-js/src/config.js
+++ b/packages/lib-panoptes-js/src/config.js
@@ -54,4 +54,4 @@ const baseConfig = {
 
 const config = baseConfig[env]
 
-module.exports = { config, env, locationMatch }
+module.exports = { baseConfig, config, env, locationMatch }

--- a/packages/lib-panoptes-js/src/panoptes.js
+++ b/packages/lib-panoptes-js/src/panoptes.js
@@ -18,7 +18,7 @@ function checkForAdminFlag () {
 function determineHost (query, host) {
   if (host) return host
   if (query && query.env) {
-    return query.env
+    return baseConfig[query.env].host
   }
 
   return config.host
@@ -29,7 +29,6 @@ function get (endpoint, query = {}, headers = {}, host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
   const apiHost = determineHost(query, host)
-
   const request = superagent.get(`${apiHost}${endpoint}`)
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/vnd.api+json; version=1')

--- a/packages/lib-panoptes-js/src/panoptes.js
+++ b/packages/lib-panoptes-js/src/panoptes.js
@@ -1,7 +1,7 @@
 /* global localStorage */
 
 const superagent = require('superagent')
-const { config } = require('./config')
+const { baseConfig, config } = require('./config')
 
 function handleMissingParameter (message) {
   return Promise.reject(new Error(message))
@@ -15,12 +15,21 @@ function checkForAdminFlag () {
   return undefined
 }
 
-// TODO: Consider how to integrate a GraphQL option
-function get (endpoint, query, headers = {}, host) {
-  const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
+function determineHost (query, host) {
+  if (host) return host
+  if (query && query.env) {
+    return query.env
+  }
 
+  return config.host
+}
+
+// TODO: Consider how to integrate a GraphQL option
+function get (endpoint, query = {}, headers = {}, host) {
+  const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
-  const apiHost = host || config.host
+  const apiHost = determineHost(query, host)
+
   const request = superagent.get(`${apiHost}${endpoint}`)
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/vnd.api+json; version=1')
@@ -29,6 +38,7 @@ function get (endpoint, query, headers = {}, host) {
 
   if (query && Object.keys(query).length > 0) {
     if (typeof query !== 'object') return Promise.reject(new TypeError('Query must be an object'))
+    if (query && query.env) delete query.env
     const fullQuery = Object.assign({}, query, defaultParams)
     request.query(fullQuery)
   } else {
@@ -38,6 +48,7 @@ function get (endpoint, query, headers = {}, host) {
   return request.then(response => response)
 }
 
+// TODO support env query
 function post (endpoint, data, headers = {}, host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
 
@@ -55,6 +66,8 @@ function post (endpoint, data, headers = {}, host) {
     .then(response => response)
 }
 
+
+// TODO: support env query
 function put (endpoint, data, headers = {}, host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
@@ -73,11 +86,11 @@ function put (endpoint, data, headers = {}, host) {
     .then(response => response)
 }
 
-function del (endpoint, headers = {}, host) {
+function del (endpoint, query = {}, headers = {}, host) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
 
   if (!endpoint) return handleMissingParameter('Request needs a defined resource endpoint')
-  const apiHost = host || config.host
+  const apiHost = determineHost(query, host)
 
   const request = superagent.delete(`${apiHost}${endpoint}`)
     .set('Content-Type', 'application/json')

--- a/packages/lib-panoptes-js/src/panoptes.spec.js
+++ b/packages/lib-panoptes-js/src/panoptes.spec.js
@@ -4,7 +4,7 @@ const nock = require('nock')
 const { config } = require('./config')
 const panoptes = require('./panoptes')
 
-describe('panoptes.js', function () {
+describe.only('panoptes.js', function () {
   let scope
 
   describe('get', function () {
@@ -161,11 +161,7 @@ describe('panoptes.js', function () {
       const isDel = method === 'del'
       // Nock calls it 'delete', panoptes-js calls it 'del'
       const nockMethod = isDel ? 'delete' : method
-      // There is one less argument for `del`, so to set the correct order we
-      // `apply` an array of arguments
-      const methodArgs = isDel
-        ? [endpoint, null, mockAPIHost]
-        : [endpoint, update, null, mockAPIHost]
+      const methodArgs = [endpoint, update, null, mockAPIHost]
 
       const mockAPIHostScope = nock(mockAPIHost)
         [nockMethod](uri => uri.includes(endpoint))
@@ -200,11 +196,8 @@ describe('panoptes.js', function () {
 
   function testAuthHeader (method, endpoint, update = null) {
     it('should add the `Authorization` header to the request if param is defined', async function () {
-      const isDel = method === 'del'
       const headers = { authorization: 'Bearer 12345' }
-      const methodArgs = isDel
-        ? [endpoint, headers]
-        : [endpoint, update, headers]
+      const methodArgs = [endpoint, update, headers]
 
       const response = await panoptes[method].apply(this, methodArgs)
       expect(response.req.headers['authorization']).to.equal('Bearer 12345')

--- a/packages/lib-panoptes-js/src/panoptes.spec.js
+++ b/packages/lib-panoptes-js/src/panoptes.spec.js
@@ -4,7 +4,7 @@ const nock = require('nock')
 const { config } = require('./config')
 const panoptes = require('./panoptes')
 
-describe.only('panoptes.js', function () {
+describe('panoptes.js', function () {
   let scope
 
   describe('get', function () {

--- a/packages/lib-panoptes-js/src/resources/projects/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/projects/commonRequests.js
@@ -29,7 +29,6 @@ function getWithLinkedResources (params) {
   if (queryParams.slug && typeof queryParams.slug !== 'string') return raiseError('Projects: Get request slug must be a string.', 'typeError')
   if (projectId && typeof projectId !== 'string') return raiseError('Projects: Get request id must be a string.', 'typeError')
   if (!queryParams.slug && !projectId) return raiseError('Projects: Get request must have either project id or slug.', 'typeError')
-
   if (projectId) return panoptes.get(`${endpoint}/${projectId}`, queryParams, { authorization })
 
   if (queryParams.slug && queryParams.slug.includes('projects')) {

--- a/packages/lib-panoptes-js/src/resources/projects/rest.js
+++ b/packages/lib-panoptes-js/src/resources/projects/rest.js
@@ -41,7 +41,7 @@ function del (params) {
   const authorization = (params && params.authorization) ? params.authorization : ''
 
   if (id && typeof id !== 'string') return raiseError('Projects: Delete request id must be a string.', 'typeError')
-  if (id) return panoptes.del(`${endpoint}/${id}`, { authorization })
+  if (id) return panoptes.del(`${endpoint}/${id}`, null, { authorization })
   return raiseError('Projects: Delete request missing project id.', 'error')
 }
 


### PR DESCRIPTION
Package: app-project, lib-panoptes-js

Describe your changes:
This another attempt at setting the correct env by using url query param during the initial server side load in the app. I've decided to pass the env along as a query param, so it's still panoptes.js's responsibility to set the host based on the env for the requests, but it just adds another route to set it.

This makes loading a staging project in production work:
- Locally run `npm run build && npm start` to start the app in production mode
- Load up a staging project like: `http://localhost:3000/projects/nora-dot-test/planet-finders-beta/classify?env=staging`

Or:
- locally run `npm run dev` to start the app in staging mode 
- Load up a production project like: `http://localhost:3000/projects/zookeeper/galaxy-zoo/classify?env=production`

Either should work now. 

I updated the error handling in the app-project too because we were eating the server side errors. At the very least we'll now get a server side console log, it won't attempt to set the state when there's no project in the response, and it'll show a generic error message in the UI when there's no project. I couldn't figure out how to pass along the project not found error from the server to the client, but that's a separate issue.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

