### PR TITLE
FieldGuide store

### DIFF
--- a/packages/lib-classifier/src/store/FieldGuide.js
+++ b/packages/lib-classifier/src/store/FieldGuide.js
@@ -3,11 +3,11 @@ import Resource from './Resource'
 
 const FieldGuide = types
   .model('FieldGuide', {
-    items: types.array(types.frozen({
+    items: types.array(types.maybe(types.frozen({
       content: types.optional(types.string, ''),
       icon: types.optional(types.string, ''),
       title: types.optional(types.string, '')
-    })),
+    }))),
     language: types.optional(types.string, 'en')
   })
 

--- a/packages/lib-classifier/src/store/FieldGuide.js
+++ b/packages/lib-classifier/src/store/FieldGuide.js
@@ -1,0 +1,14 @@
+import { types } from 'mobx-state-tree'
+import Resource from './Resource'
+
+const FieldGuide = types
+  .model('FieldGuide', {
+    items: types.array(types.frozen({
+      content: types.optional(types.string, ''),
+      icon: types.optional(types.string, ''),
+      title: types.optional(types.string, '')
+    })),
+    language: types.optional(types.string, 'en')
+  })
+
+export default types.compose('FieldGuideResource', Resource, FieldGuide)

--- a/packages/lib-classifier/src/store/FieldGuide.spec.js
+++ b/packages/lib-classifier/src/store/FieldGuide.spec.js
@@ -1,0 +1,7 @@
+import FieldGuide from './FieldGuide'
+
+describe('Model > FieldGuide', function () {
+  it('should exist', function () {
+    expect(FieldGuide).to.be.an('object')
+  })
+})

--- a/packages/lib-classifier/src/store/FieldGuideStore.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.js
@@ -44,7 +44,7 @@ const FieldGuideStore = types
     // TODO: this might need to paginate for field guides that have 20+ items
     const fetchMedia = flow(function * fetchMedia (fieldGuide) {
       const { type } = self
-      const { client } = getRoot(self)
+      const client = getRoot(self).client.panoptes
       if (fieldGuide) {
         self.loadingState = asyncStates.loading
         try {
@@ -68,7 +68,7 @@ const FieldGuideStore = types
     function * fetchFieldGuide () {
       const { type } = self
       const project = getRoot(self).projects.active
-      const { client } = getRoot(self)
+      const client = getRoot(self).client.panoptes
 
       self.loadingState = asyncStates.loading
       try {

--- a/packages/lib-classifier/src/store/FieldGuideStore.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.js
@@ -48,7 +48,7 @@ const FieldGuideStore = types
       if (fieldGuide) {
         self.loadingState = asyncStates.loading
         try {
-          const url = `${type}/${fieldGuide.id}/attached_images`
+          const url = `/${type}/${fieldGuide.id}/attached_images`
           const response = yield client.get(url)
           const { media } = response.body
           if (media && media.length > 0) self.setMediaResources(media)
@@ -72,7 +72,7 @@ const FieldGuideStore = types
 
       self.loadingState = asyncStates.loading
       try {
-        const response = yield client.get(`${type}`, { project_id: project.id })
+        const response = yield client.get(`/${type}`, { project_id: project.id })
         const fieldGuide = response.body[type][0]
         if (fieldGuide) {
           yield fetchMedia(fieldGuide)

--- a/packages/lib-classifier/src/store/FieldGuideStore.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.js
@@ -54,7 +54,7 @@ const FieldGuideStore = types
           if (media && media.length > 0) self.setMediaResources(media)
         } catch (error) {
           // We're not setting the store state to error because
-          // we do not want to prevent the tutorial from rendering
+          // we do not want to prevent the field guide from rendering
           console.error(error)
         }
       }

--- a/packages/lib-classifier/src/store/FieldGuideStore.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.js
@@ -1,0 +1,108 @@
+import { autorun } from 'mobx'
+import { addDisposer, getRoot, types, flow } from 'mobx-state-tree'
+import asyncStates from '@zooniverse/async-states'
+import ResourceStore from './ResourceStore'
+import FieldGuide from './FieldGuide'
+import Medium from './Medium'
+
+const FieldGuideStore = types
+  .model('FieldGuideStore', {
+    active: types.maybe(types.reference(FieldGuide)),
+    activeMedium: types.maybe(types.reference(Medium)),
+    activeItem: types.maybe(types.integer),
+    attachedMedia: types.map(Medium),
+    resources: types.map(FieldGuide),
+    showModal: types.optional(types.boolean, false),
+    type: types.optional(types.string, 'field_guides')
+  })
+
+  .actions(self => {
+    function afterAttach() {
+      createProjectObserver()
+    }
+
+    function createProjectObserver() {
+      const projectDisposer = autorun(() => {
+        const project = getRoot(self).projects.active
+        if (project) {
+          self.reset()
+          flow(self.fetchFieldGuide)()
+        }
+      })
+      addDisposer(self, projectDisposer)
+    }
+
+    function reset () {
+      self.active = undefined
+      self.resources.clear()
+      self.activeMedium = undefined
+      self.attachedMedia.clear()
+      self.activeItem = undefined
+      self.showModal = false
+    }
+
+    // TODO: this might need to paginate for field guides that have 20+ items
+    function * fetchMedia (fieldGuide) {
+      const { type } = self
+      const { panoptes } = getRoot(self).client
+      if (fieldGuide) {
+        self.loadingState = asyncStates.loading
+        try {
+          const url = `${type}/${fieldGuide.id}/attached_images`
+          const response = yield panoptes.get(url)
+          const { media } = response.body
+          if (media && media.length > 0) self.setMediaResources(media)
+        } catch (error) {
+          // We're not setting the store state to error because
+          // we do not want to prevent the tutorial from rendering
+          console.error(error)
+        }
+      }
+    }
+
+    function setMediaResources (media) {
+      media.forEach(medium => self.attachedMedia.put(medium))
+    }
+
+    // TODO: move req in panoptes.js
+    function * fetchFieldGuide () {
+      const { type } = self
+      const project = getRoot(self).projectss.active
+      const { panoptes } = getRoot(self).client
+
+      self.loadingState = asyncStates.loading
+      try {
+        const response = yield panoptes.get(`${type}`, { project_id: project.id })
+        const fieldGuide = response.body[type][0]
+        if (fieldGuide) {
+          yield flow(self.fetchMedia)(fieldGuide)
+          self.resources = fieldGuide
+          self.active = fieldGuide.id
+          self.loadingState = asyncStates.success
+        } else {
+          self.loadingState = asyncStates.success
+        }
+      } catch (error) {
+        console.error(error)
+        self.loadingState = asyncStates.error
+      }
+    }
+
+    function setModalVisibility (boolean) {
+      self.showModal = boolean
+    }
+
+    function setActiveItem (index) {
+      if (fieldGuide && fieldGuide.items[index]) self.activeItem = index
+    }
+
+    return {
+      afterAttach,
+      reset,
+      setActiveItem,
+      setMediaResources,
+      setModalVisibility
+    }
+  })
+
+export default types.compose('FieldGuideResourceStore', ResourceStore, FieldGuideStore)

--- a/packages/lib-classifier/src/store/FieldGuideStore.spec.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.spec.js
@@ -32,7 +32,7 @@ const fieldGuideWithoutIcon = FieldGuideFactory.build({
 
 const project = ProjectFactory.build()
 
-describe.only('Model > FieldGuideStore', function () {
+describe('Model > FieldGuideStore', function () {
   let rootStore
   function fetchFieldGuide () {
     sinon.stub(rootStore.fieldGuide, 'fetchFieldGuide')

--- a/packages/lib-classifier/src/store/FieldGuideStore.spec.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.spec.js
@@ -52,10 +52,10 @@ describe('Model > FieldGuideStore', function () {
     rootStore = RootStore.create({
       fieldGuide: FieldGuideStore.create(),
       projects: ProjectStore.create()
-    }, { client: { get: sinon.stub().callsFake(() => Promise.resolve(null) )} })
+    }, { client: { panoptes: { get: sinon.stub().callsFake(() => Promise.resolve(null) )}} })
 
     expect(rootStore.tutorials.loadingState).to.equal(asyncStates.initialized)
-    expect(rootStore.client.get).to.not.been.called
+    expect(rootStore.client.panoptes.get).to.not.been.called
   })
 
   it('should set the field guide if there is a project', function (done) {
@@ -64,10 +64,12 @@ describe('Model > FieldGuideStore', function () {
       projects: ProjectStore.create()
     }, { 
       client: { 
-        get: sinon.stub().callsFake((url) => {
-          if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] }})
-          if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] }})
-        })
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+            if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+          })
+        }
       }
     })
 
@@ -85,16 +87,18 @@ describe('Model > FieldGuideStore', function () {
         projects: ProjectStore.create()
       }, { 
         client: {
-          get: sinon.stub().callsFake((url) => {
-            if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-            if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-          })
+          panoptes: {
+            get: sinon.stub().callsFake((url) => {
+              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+              if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            })
+          }
         } 
       })
 
       fetchFieldGuide()
         .then(() => {
-          expect(rootStore.client.get.withArgs('field_guides', { project_id: project.id })).to.have.been.calledOnce          
+          expect(rootStore.client.panoptes.get.withArgs('field_guides', { project_id: project.id })).to.have.been.calledOnce          
         }).then(done, done)
     })
 
@@ -104,10 +108,12 @@ describe('Model > FieldGuideStore', function () {
         projects: ProjectStore.create()
       }, { 
         client: {
-          get: sinon.stub().callsFake((url) => {
-            if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [] } })
-            if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-          })
+          panoptes: {
+            get: sinon.stub().callsFake((url) => {
+              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [] } })
+              if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            })
+          }
         } 
       })
 
@@ -128,23 +134,25 @@ describe('Model > FieldGuideStore', function () {
         projects: ProjectStore.create()
       }, {
           client: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-              if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-            })
+            panoptes: {
+              get: sinon.stub().callsFake((url) => {
+                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+                if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+              })
+            }
           }
         })
       sinon.stub(rootStore.fieldGuide, 'fetchFieldGuide')
 
       rootStore.projects.setResource(project)
       rootStore.projects.setActive(project.id)
-        .then(() => rootStore.client.get.resetHistory())
+        .then(() => rootStore.client.panoptes.get.resetHistory())
         .then(() => {
           rootStore.fieldGuide.fetchFieldGuide.restore()
           return rootStore.fieldGuide.fetchFieldGuide()
         })
         .then(() => {
-          expect(rootStore.client.get.withArgs(`field_guides/${fieldGuide.id}/attached_images`)).to.have.been.calledOnce
+          expect(rootStore.client.panoptes.get.withArgs(`field_guides/${fieldGuide.id}/attached_images`)).to.have.been.calledOnce
         }).then(done, done)
     })
 
@@ -154,10 +162,12 @@ describe('Model > FieldGuideStore', function () {
         projects: ProjectStore.create()
       }, {
           client: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-              if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-            })
+            panoptes: {
+              get: sinon.stub().callsFake((url) => {
+                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+                if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+              })
+            }
           }
         })
 
@@ -180,9 +190,11 @@ describe('Model > FieldGuideStore', function () {
         projects: ProjectStore.create()
       }, {
         client: {
-          get: sinon.stub().callsFake(() => {
+          panoptes: {
+            get: sinon.stub().callsFake(() => {
               return Promise.reject('testing error state')
-          })
+            })
+          }
         }
       })
 
@@ -200,10 +212,12 @@ describe('Model > FieldGuideStore', function () {
         projects: ProjectStore.create()
       }, {
           client: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-              if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-            })
+            panoptes: {
+              get: sinon.stub().callsFake((url) => {
+                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+                if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+              })
+            }
           }
         })
 
@@ -223,10 +237,12 @@ describe('Model > FieldGuideStore', function () {
         projects: ProjectStore.create()
       }, {
         client: {
-          get: sinon.stub().callsFake((url) => {
-            if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-            if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
-          })
+          panoptes: {
+            get: sinon.stub().callsFake((url) => {
+              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+              if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+            })
+          }
         }
       })
 
@@ -248,10 +264,12 @@ describe('Model > FieldGuideStore', function () {
         projects: ProjectStore.create()
       }, {
           client: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-              if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
-            })
+            panoptes: {
+              get: sinon.stub().callsFake((url) => {
+                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+                if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+              })
+            }
           }
         })
 
@@ -269,10 +287,12 @@ describe('Model > FieldGuideStore', function () {
         projects: ProjectStore.create()
       }, {
           client: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [] } })
-              if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-            })
+            panoptes: {
+              get: sinon.stub().callsFake((url) => {
+                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [] } })
+                if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+              })
+            }
           }
         })
 
@@ -289,10 +309,12 @@ describe('Model > FieldGuideStore', function () {
         projects: ProjectStore.create()
       }, {
           client: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-              if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
-            })
+            panoptes: {
+              get: sinon.stub().callsFake((url) => {
+                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+                if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+              })
+            }
           }
         })
 
@@ -309,10 +331,12 @@ describe('Model > FieldGuideStore', function () {
         projects: ProjectStore.create()
       }, {
           client: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-              if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
-            })
+            panoptes: {
+              get: sinon.stub().callsFake((url) => {
+                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+                if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+              })
+            }
           }
         })
 
@@ -329,10 +353,12 @@ describe('Model > FieldGuideStore', function () {
         projects: ProjectStore.create()
       }, {
           client: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-              if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
-            })
+            panoptes: {
+              get: sinon.stub().callsFake((url) => {
+                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+                if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+              })
+            }
           }
         })
 
@@ -350,10 +376,12 @@ describe('Model > FieldGuideStore', function () {
         projects: ProjectStore.create()
       }, {
           client: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithoutIcon] } })
-              if (url === `field_guides/${fieldGuideWithoutIcon.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-            })
+            panoptes: {
+              get: sinon.stub().callsFake((url) => {
+                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithoutIcon] } })
+                if (url === `field_guides/${fieldGuideWithoutIcon.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+              })
+            }
           }
         })
 
@@ -372,10 +400,12 @@ describe('Model > FieldGuideStore', function () {
         projects: ProjectStore.create()
       }, {
           client: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-              if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
-            })
+            panoptes: {
+              get: sinon.stub().callsFake((url) => {
+                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+                if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+              })
+            }
           }
         })
 

--- a/packages/lib-classifier/src/store/FieldGuideStore.spec.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.spec.js
@@ -1,0 +1,38 @@
+import sinon from 'sinon'
+import asyncStates from '@zooniverse/async-states'
+
+import RootStore from './RootStore'
+import ProjectStore from './ProjectStore'
+import FieldGuideStore from './FieldGuideStore'
+
+import {
+  ProjectFactory,
+  FieldGuideFactory,
+  FieldGuideMediumFactory
+} from '../../test/factories'
+import stubPanoptesJs from '../../test/stubPanoptesJs'
+
+const fieldGuide = FieldGuideFactory.build()
+const medium = FieldGuideMediumFactory.build()
+const project = ProjectFactory.build()
+
+describe('Model > FieldGuideStore', function () {
+  let clientStub
+  let rootStore
+  it('should exist', function () {
+    expect(FieldGuideStore).to.be.an('object')
+  })
+
+  it('should remain in an initialized state if there is no project', function () {
+    clientStub = stubPanoptesJs({
+      field_guides: undefined,
+      projects: undefined
+    })
+    rootStore = RootStore.create({
+      fieldGuide: FieldGuideStore.create(),
+      projects: ProjectStore.create()
+    }, { client: clientStub })
+
+    expect(rootStore.tutorials.loadingState).to.equal(asyncStates.initialized)
+  })
+})

--- a/packages/lib-classifier/src/store/FieldGuideStore.spec.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.spec.js
@@ -66,8 +66,8 @@ describe('Model > FieldGuideStore', function () {
       client: { 
         panoptes: {
           get: sinon.stub().callsFake((url) => {
-            if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-            if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+            if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
           })
         }
       }
@@ -89,8 +89,8 @@ describe('Model > FieldGuideStore', function () {
         client: {
           panoptes: {
             get: sinon.stub().callsFake((url) => {
-              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-              if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+              if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
             })
           }
         } 
@@ -98,7 +98,7 @@ describe('Model > FieldGuideStore', function () {
 
       fetchFieldGuide()
         .then(() => {
-          expect(rootStore.client.panoptes.get.withArgs('field_guides', { project_id: project.id })).to.have.been.calledOnce          
+          expect(rootStore.client.panoptes.get.withArgs('/field_guides', { project_id: project.id })).to.have.been.calledOnce          
         }).then(done, done)
     })
 
@@ -110,8 +110,8 @@ describe('Model > FieldGuideStore', function () {
         client: {
           panoptes: {
             get: sinon.stub().callsFake((url) => {
-              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [] } })
-              if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [] } })
+              if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
             })
           }
         } 
@@ -136,8 +136,8 @@ describe('Model > FieldGuideStore', function () {
           client: {
             panoptes: {
               get: sinon.stub().callsFake((url) => {
-                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-                if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+                if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+                if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
               })
             }
           }
@@ -152,7 +152,7 @@ describe('Model > FieldGuideStore', function () {
           return rootStore.fieldGuide.fetchFieldGuide()
         })
         .then(() => {
-          expect(rootStore.client.panoptes.get.withArgs(`field_guides/${fieldGuide.id}/attached_images`)).to.have.been.calledOnce
+          expect(rootStore.client.panoptes.get.withArgs(`/field_guides/${fieldGuide.id}/attached_images`)).to.have.been.calledOnce
         }).then(done, done)
     })
 
@@ -164,8 +164,8 @@ describe('Model > FieldGuideStore', function () {
           client: {
             panoptes: {
               get: sinon.stub().callsFake((url) => {
-                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-                if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+                if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+                if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
               })
             }
           }
@@ -214,8 +214,8 @@ describe('Model > FieldGuideStore', function () {
           client: {
             panoptes: {
               get: sinon.stub().callsFake((url) => {
-                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-                if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+                if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+                if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
               })
             }
           }
@@ -239,8 +239,8 @@ describe('Model > FieldGuideStore', function () {
         client: {
           panoptes: {
             get: sinon.stub().callsFake((url) => {
-              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-              if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+              if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
             })
           }
         }
@@ -266,8 +266,8 @@ describe('Model > FieldGuideStore', function () {
           client: {
             panoptes: {
               get: sinon.stub().callsFake((url) => {
-                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-                if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+                if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+                if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
               })
             }
           }
@@ -289,8 +289,8 @@ describe('Model > FieldGuideStore', function () {
           client: {
             panoptes: {
               get: sinon.stub().callsFake((url) => {
-                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [] } })
-                if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+                if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [] } })
+                if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
               })
             }
           }
@@ -311,8 +311,8 @@ describe('Model > FieldGuideStore', function () {
           client: {
             panoptes: {
               get: sinon.stub().callsFake((url) => {
-                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-                if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+                if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+                if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
               })
             }
           }
@@ -333,8 +333,8 @@ describe('Model > FieldGuideStore', function () {
           client: {
             panoptes: {
               get: sinon.stub().callsFake((url) => {
-                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-                if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+                if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+                if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
               })
             }
           }
@@ -355,8 +355,8 @@ describe('Model > FieldGuideStore', function () {
           client: {
             panoptes: {
               get: sinon.stub().callsFake((url) => {
-                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-                if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+                if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+                if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
               })
             }
           }
@@ -378,8 +378,8 @@ describe('Model > FieldGuideStore', function () {
           client: {
             panoptes: {
               get: sinon.stub().callsFake((url) => {
-                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithoutIcon] } })
-                if (url === `field_guides/${fieldGuideWithoutIcon.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+                if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithoutIcon] } })
+                if (url === `/field_guides/${fieldGuideWithoutIcon.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
               })
             }
           }
@@ -402,8 +402,8 @@ describe('Model > FieldGuideStore', function () {
           client: {
             panoptes: {
               get: sinon.stub().callsFake((url) => {
-                if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-                if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+                if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+                if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
               })
             }
           }

--- a/packages/lib-classifier/src/store/FieldGuideStore.spec.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.spec.js
@@ -10,29 +10,396 @@ import {
   FieldGuideFactory,
   FieldGuideMediumFactory
 } from '../../test/factories'
-import stubPanoptesJs from '../../test/stubPanoptesJs'
 
-const fieldGuide = FieldGuideFactory.build()
 const medium = FieldGuideMediumFactory.build()
+const fieldGuide = FieldGuideFactory.build()
+const fieldGuideWithItems = FieldGuideFactory.build({ items: [
+  { 
+    content: 'All about cats',
+    icon: medium.id,
+    title: 'Cats'
+  }
+]})
+
+const fieldGuideWithoutIcon = FieldGuideFactory.build({
+  items: [
+    {
+      content: 'All about cats',
+      title: 'Cats'
+    }
+  ]
+})
+
 const project = ProjectFactory.build()
 
-describe('Model > FieldGuideStore', function () {
-  let clientStub
+describe.only('Model > FieldGuideStore', function () {
   let rootStore
+  function fetchFieldGuide () {
+    sinon.stub(rootStore.fieldGuide, 'fetchFieldGuide')
+    rootStore.projects.setResource(project)
+    return rootStore.projects.setActive(project.id)
+      .then(() => {
+        rootStore.fieldGuide.fetchFieldGuide.restore()
+        return rootStore.fieldGuide.fetchFieldGuide()
+      })
+  }
+
   it('should exist', function () {
     expect(FieldGuideStore).to.be.an('object')
   })
 
   it('should remain in an initialized state if there is no project', function () {
-    clientStub = stubPanoptesJs({
-      field_guides: undefined,
-      projects: undefined
-    })
     rootStore = RootStore.create({
       fieldGuide: FieldGuideStore.create(),
       projects: ProjectStore.create()
-    }, { client: clientStub })
+    }, { client: { get: sinon.stub().callsFake(() => Promise.resolve(null) )} })
 
     expect(rootStore.tutorials.loadingState).to.equal(asyncStates.initialized)
+    expect(rootStore.client.get).to.not.been.called
+  })
+
+  it('should set the field guide if there is a project', function (done) {
+    rootStore = RootStore.create({
+      fieldGuide: FieldGuideStore.create(),
+      projects: ProjectStore.create()
+    }, { 
+      client: { 
+        get: sinon.stub().callsFake((url) => {
+          if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] }})
+          if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] }})
+        })
+      }
+    })
+
+    fetchFieldGuide()
+      .then(() => {
+        const fieldGuideInStore = rootStore.fieldGuide.active
+        expect(fieldGuideInStore.toJSON()).to.deep.equal(fieldGuide)
+      }).then(done, done)
+  })
+
+  describe('Actions > fetchFieldGuide', function () {
+    it('should request for a field guide linked to the active project', function (done) {
+      rootStore = RootStore.create({
+        fieldGuide: FieldGuideStore.create(),
+        projects: ProjectStore.create()
+      }, { 
+        client: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+            if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+          })
+        } 
+      })
+
+      fetchFieldGuide()
+        .then(() => {
+          expect(rootStore.client.get.withArgs('field_guides', { project_id: project.id })).to.have.been.calledOnce          
+        }).then(done, done)
+    })
+
+    it('should not request for media or set the resources if there are not a field guide in the response', function (done) {
+      rootStore = RootStore.create({
+        fieldGuide: FieldGuideStore.create(),
+        projects: ProjectStore.create()
+      }, { 
+        client: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [] } })
+            if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+          })
+        } 
+      })
+
+      const setResourceSpy = sinon.spy(rootStore.fieldGuide, 'setResource')
+
+      fetchFieldGuide()
+        .then(() => {
+          expect(setResourceSpy).to.have.not.been.called
+          expect(rootStore.fieldGuide.loadingState).to.equal(asyncStates.success)
+        }).then(() => {
+          setResourceSpy.restore()
+        }).then(done, done)
+    })
+
+    it('should request for the media if there is a field guide', function (done) {
+      rootStore = RootStore.create({
+        fieldGuide: FieldGuideStore.create(),
+        projects: ProjectStore.create()
+      }, {
+          client: {
+            get: sinon.stub().callsFake((url) => {
+              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+              if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            })
+          }
+        })
+      sinon.stub(rootStore.fieldGuide, 'fetchFieldGuide')
+
+      rootStore.projects.setResource(project)
+      rootStore.projects.setActive(project.id)
+        .then(() => rootStore.client.get.resetHistory())
+        .then(() => {
+          rootStore.fieldGuide.fetchFieldGuide.restore()
+          return rootStore.fieldGuide.fetchFieldGuide()
+        })
+        .then(() => {
+          expect(rootStore.client.get.withArgs(`field_guides/${fieldGuide.id}/attached_images`)).to.have.been.calledOnce
+        }).then(done, done)
+    })
+
+    it('should call setResource and setActive if there is a field guide', function (done) {
+      rootStore = RootStore.create({
+        fieldGuide: FieldGuideStore.create(),
+        projects: ProjectStore.create()
+      }, {
+          client: {
+            get: sinon.stub().callsFake((url) => {
+              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+              if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            })
+          }
+        })
+
+      const setResourceSpy = sinon.spy(rootStore.fieldGuide, 'setResource')
+      const setActiveSpy = sinon.spy(rootStore.fieldGuide, 'setActive')
+
+      fetchFieldGuide()
+        .then(() => {
+          expect(setResourceSpy).to.have.been.calledOnceWith(fieldGuide)
+          expect(setActiveSpy).to.have.been.calledOnceWith(fieldGuide.id)
+        }).then(() => {
+          setResourceSpy.restore()
+          setActiveSpy.restore()
+        }).then(done, done)
+    })
+
+    it('should set the loadingState to error if the request errors', function (done) {
+      rootStore = RootStore.create({
+        fieldGuide: FieldGuideStore.create(),
+        projects: ProjectStore.create()
+      }, {
+        client: {
+          get: sinon.stub().callsFake(() => {
+              return Promise.reject('testing error state')
+          })
+        }
+      })
+
+      fetchFieldGuide()
+        .then(() => {
+          expect(rootStore.fieldGuide.loadingState).to.equal(asyncStates.error)
+        }).then(done, done)
+    })
+  })
+
+  describe('Actions > fetchMedia', function () {
+    it('should not call setMediaResources if there is no media in the response', function (done) {
+      rootStore = RootStore.create({
+        fieldGuide: FieldGuideStore.create(),
+        projects: ProjectStore.create()
+      }, {
+          client: {
+            get: sinon.stub().callsFake((url) => {
+              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+              if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            })
+          }
+        })
+
+      const setMediaResourcesSpy = sinon.spy(rootStore.fieldGuide, 'setMediaResources')
+
+      fetchFieldGuide()
+        .then(() => {
+          expect(setMediaResourcesSpy).to.have.not.been.called
+        }).then(() => {
+          setMediaResourcesSpy.restore()
+        }).then(done, done)
+    })
+
+    it('should call setMediaResources if there is media in the response', function (done) {
+      rootStore = RootStore.create({
+        fieldGuide: FieldGuideStore.create(),
+        projects: ProjectStore.create()
+      }, {
+        client: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+            if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+          })
+        }
+      })
+
+      const setMediaResourcesSpy = sinon.spy(rootStore.fieldGuide, 'setMediaResources')
+
+      fetchFieldGuide()
+        .then(() => {
+          expect(setMediaResourcesSpy).to.have.been.calledOnceWith([medium])
+        }).then(() => {
+          setMediaResourcesSpy.restore()
+        }).then(done, done)
+    })
+  })
+
+  describe('Actions > setModalVisibility', function () {
+    it('should set the modal visibility', function () {
+      rootStore = RootStore.create({
+        fieldGuide: FieldGuideStore.create(),
+        projects: ProjectStore.create()
+      }, {
+          client: {
+            get: sinon.stub().callsFake((url) => {
+              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+              if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+            })
+          }
+        })
+
+      rootStore.fieldGuide.setModalVisibility(true)
+      expect(rootStore.fieldGuide.showModal).to.be.true
+      rootStore.fieldGuide.setModalVisibility(false)
+      expect(rootStore.fieldGuide.showModal).to.be.false
+    })
+  })
+
+  describe('Actions > setActiveItem', function () {
+    it('should not set the active item if there is no field guide', function (done) {
+      rootStore = RootStore.create({
+        fieldGuide: FieldGuideStore.create(),
+        projects: ProjectStore.create()
+      }, {
+          client: {
+            get: sinon.stub().callsFake((url) => {
+              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [] } })
+              if (url === `field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            })
+          }
+        })
+
+      fetchFieldGuide().then(() => {
+        rootStore.fieldGuide.setActiveItem(0)
+        expect(rootStore.fieldGuide.activeItem).to.be.undefined
+        expect(rootStore.fieldGuide.activeMedium).to.be.undefined
+      }).then(done, done)
+    })
+
+    it('should not set the active item if not called with an item index', function (done) {
+      rootStore = RootStore.create({
+        fieldGuide: FieldGuideStore.create(),
+        projects: ProjectStore.create()
+      }, {
+          client: {
+            get: sinon.stub().callsFake((url) => {
+              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+              if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+            })
+          }
+        })
+
+      fetchFieldGuide().then(() => {
+        rootStore.fieldGuide.setActiveItem()
+        expect(rootStore.fieldGuide.activeItem).to.be.undefined
+        expect(rootStore.fieldGuide.activeMedium).to.be.undefined
+      }).then(done, done)
+    })
+
+    it('should not set the active item if the item does not exist', function (done) {
+      rootStore = RootStore.create({
+        fieldGuide: FieldGuideStore.create(),
+        projects: ProjectStore.create()
+      }, {
+          client: {
+            get: sinon.stub().callsFake((url) => {
+              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+              if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+            })
+          }
+        })
+
+      fetchFieldGuide().then(() => {
+        rootStore.fieldGuide.setActiveItem(1)
+        expect(rootStore.fieldGuide.activeItem).to.be.undefined
+        expect(rootStore.fieldGuide.activeMedium).to.be.undefined
+      }).then(done, done)
+    })
+
+    it('should set the active item', function (done) {
+      rootStore = RootStore.create({
+        fieldGuide: FieldGuideStore.create(),
+        projects: ProjectStore.create()
+      }, {
+          client: {
+            get: sinon.stub().callsFake((url) => {
+              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+              if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+            })
+          }
+        })
+
+      fetchFieldGuide()
+        .then(() => {
+          rootStore.fieldGuide.setActiveItem(0)
+          expect(rootStore.fieldGuide.activeItem).to.equal(0)
+          expect(rootStore.fieldGuide.activeMedium.toJSON()).to.deep.equal(medium)
+        }).then(done, done)
+    })
+
+    it('should not set the active medium if the item does not have an icon', function (done) {
+      rootStore = RootStore.create({
+        fieldGuide: FieldGuideStore.create(),
+        projects: ProjectStore.create()
+      }, {
+          client: {
+            get: sinon.stub().callsFake((url) => {
+              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithoutIcon] } })
+              if (url === `field_guides/${fieldGuideWithoutIcon.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            })
+          }
+        })
+
+      fetchFieldGuide().then(() => {
+        rootStore.fieldGuide.setActiveItem(0)
+        expect(rootStore.fieldGuide.activeItem).to.equal(0)
+        expect(rootStore.fieldGuide.activeMedium).to.be.undefined
+      }).then(done, done)
+    })
+  })
+
+  describe('Actions > reset', function () {
+    it('should reset the store', function (done) {
+      rootStore = RootStore.create({
+        fieldGuide: FieldGuideStore.create(),
+        projects: ProjectStore.create()
+      }, {
+          client: {
+            get: sinon.stub().callsFake((url) => {
+              if (url === 'field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+              if (url === `field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+            })
+          }
+        })
+
+      fetchFieldGuide()
+        .then(() => {
+          rootStore.fieldGuide.setActiveItem(0)
+          rootStore.fieldGuide.setModalVisibility(true)
+        })
+        .then(() => {
+          expect(rootStore.fieldGuide.active).to.exist
+          expect(rootStore.fieldGuide.resources).to.exist
+          expect(rootStore.fieldGuide.attachedMedia).to.exist
+          expect(rootStore.fieldGuide.activeMedium).to.exist
+          expect(rootStore.fieldGuide.activeItem).to.equal(0)
+          expect(rootStore.fieldGuide.showModal).to.be.true
+          return rootStore.fieldGuide.reset()
+        }).then(() => {
+          expect(rootStore.fieldGuide.active).to.be.undefined
+          expect(rootStore.fieldGuide.resources.size).to.equal(0)
+          expect(rootStore.fieldGuide.attachedMedia.size).to.equal(0)
+          expect(rootStore.fieldGuide.activeMedium).to.be.undefined
+          expect(rootStore.fieldGuide.activeItem).to.be.undefined
+          expect(rootStore.fieldGuide.showModal).to.be.false
+        }).then(done, done)
+    })
   })
 })

--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -4,6 +4,7 @@ import ClassificationStore from './ClassificationStore'
 import DataVisAnnotatingStore from './DataVisAnnotatingStore'
 import DrawingStore from './DrawingStore'
 import FeedbackStore from './FeedbackStore'
+import FieldGuideStore from './FieldGuideStore'
 import ProjectStore from './ProjectStore'
 import SubjectStore from './SubjectStore'
 import SubjectViewerStore from './SubjectViewerStore'
@@ -18,6 +19,7 @@ const RootStore = types
     dataVisAnnotating: types.optional(DataVisAnnotatingStore, DataVisAnnotatingStore.create()),
     drawing: types.optional(DrawingStore, DrawingStore.create()),
     feedback: types.optional(FeedbackStore, FeedbackStore.create()),
+    fieldGuide: types.optional(FieldGuideStore, FieldGuideStore.create()),
     projects: types.optional(ProjectStore, ProjectStore.create()),
     subjects: types.optional(SubjectStore, SubjectStore.create()),
     subjectViewer: types.optional(SubjectViewerStore, SubjectViewerStore.create()),

--- a/packages/lib-classifier/test/factories/FieldGuideFactory.js
+++ b/packages/lib-classifier/test/factories/FieldGuideFactory.js
@@ -1,0 +1,6 @@
+import { Factory } from 'rosie'
+
+export default new Factory()
+  .sequence('id', (id) => { return id.toString() })
+  .attr('items', [])
+  .attr('language', 'en')

--- a/packages/lib-classifier/test/factories/MediumFactory.js
+++ b/packages/lib-classifier/test/factories/MediumFactory.js
@@ -18,3 +18,21 @@ export const TutorialMediumFactory = new Factory()
   .attr('media_type', 'tutorial_attached_image')
   .attr('metadata', {})
   .attr('src', 'https://panoptes-uploads.zooniverse.org/staging/tutorial_attached_image/1ab2bd93-b422-4d10-a700-fa34d4e7e716.gif')
+
+export const FieldGuideMediumFactory = new Factory()
+  .extend(medium)
+  .attr('content_type', 'image/png')
+  .attr('external_link', false)
+  .attr('href', ['id'], function (id) {
+    return `/field_guides/25/attached_images/${id}`
+  })
+  .attr('links', {
+    linked: {
+      href: '/field_guides/25',
+      id: '20',
+      type: 'field_guides'
+    }
+  })
+  .attr('media_type', 'field_guide_attached_image')
+  .attr('metadata', {})
+  .attr('src', 'https://panoptes-uploads.zooniverse.org/staging/field_guide_attached_image/a04dc00f-ef28-4e52-9490-368ba9029aca.png')

--- a/packages/lib-classifier/test/factories/index.js
+++ b/packages/lib-classifier/test/factories/index.js
@@ -1,5 +1,5 @@
-import { TutorialMediumFactory } from './MediumFactory'
-export { TutorialMediumFactory }
+import { FieldGuideMediumFactory, TutorialMediumFactory } from './MediumFactory'
+export { FieldGuideMediumFactory, TutorialMediumFactory }
 
 export { default as ProjectFactory } from './ProjectFactory'
 export { default as SubjectFactory } from './SubjectFactory'
@@ -10,3 +10,4 @@ export { default as TutorialFactory } from './TutorialFactory'
 export { default as UPPFactory } from './UPPFactory'
 export { default as UserFactory } from './UserFactory'
 export { default as ClassificationFactory } from './ClassificationFactory'
+export { default as FieldGuideFactory } from './FieldGuideFactory'


### PR DESCRIPTION
Package: lib-classifier

For #391

Describe your changes:
This is adding the store and tests for the field guide in the classifier. UI will be added in a separate PR

~WIP because we're working on improving the tests for the tutorial still and the field guide is fairly similar, so we should learn from that first.~

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

