### PR TITLE
Focus accessibility for tutorial navigation

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
@@ -46,7 +46,7 @@ class SlideTutorial extends React.Component {
               height={200}
               src={medium.src}
             />}
-          <StyledMarkdownWrapper autoFocus isThereMedia={isThereMedia} overflow='auto'>
+          <StyledMarkdownWrapper aria-live='polite' autoFocus isThereMedia={isThereMedia} overflow='auto'>
             {/* TODO: translation */}
             <Markdownz>{step.content}</Markdownz>
           </StyledMarkdownWrapper>

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/StepNavigation/StepNavigation.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/StepNavigation/StepNavigation.js
@@ -2,24 +2,29 @@ import counterpart from 'counterpart'
 import React from 'react'
 import PropTypes from 'prop-types'
 import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
-import { Button, Box, RadioButton } from 'grommet'
+import { Button, Box, RadioButtonGroup } from 'grommet'
 import styled from 'styled-components'
 import { FormNext, FormPrevious } from 'grommet-icons'
+import zooTheme from '@zooniverse/grommet-theme'
 import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
 
-const HiddenRadioLabel = styled.span`
-  display: flex;
-  flex-direction: row;
-  position: relative;
-  ${RadioButton} span {
-    height: 0;
-    overflow: hidden;
-    position: absolute;
-    width: 0;
-  }
-`
+// const HiddenRadioLabel = styled.span`
+//   display: flex;
+//   flex-direction: row;
+//   position: relative;
+//   ${StyledRadioButton} span {
+//     height: 0;
+//     overflow: hidden;
+//     position: absolute;
+//     width: 0;
+//   }
+// `
+
+// const StyledRadioButton = styled(RadioButton)`
+//   outline: ${(props) => (props.focused) ? zooTheme.global.colors['accent-2'] : 'none'}
+// `
 
 function storeMapper (stores) {
   const { active: tutorial, activeStep, setTutorialStep } = stores.classifierStore.tutorials
@@ -33,11 +38,45 @@ function storeMapper (stores) {
 @inject(storeMapper)
 @observer
 class StepNavigation extends React.Component {
+  constructor() {
+    super()
+    this.state = {
+      focused: -1
+    }
+  }
+
+  onFocus (e) {
+    const keyPressed = e.keyCode ? e.keyCode : e.which
+    console.log('onfocus', keyPressed, e, e.target)
+    if (keyPressed === 9) { // tab is pressed
+      this.setState({ focused: e.target.value })
+    }
+  }
+
+  removeFocus () {
+    this.setState({ focused: -1 })
+  }
+
+  onChange (event) {
+    const { setTutorialStep } = this.props
+    const indexValue = event.target.value.split('-')[1]
+    setTutorialStep(Number(indexValue))
+  }
+
   render () {
     const { activeStep, setTutorialStep, steps } = this.props
     if (steps && steps.length > 1) {
       const nextStep = activeStep + 1
       const prevStep = activeStep - 1
+      const options = steps.map((step, index) => {
+        const name = counterpart('StepNavigation.go', { index: index + 1 })
+        return {
+          id: `step-${index}`,
+          name,
+          // We can't just use index because Grommet is using indexes internally as keys and this will error with a duplicate key
+          value: `step-${index}` 
+        }
+      })
       return (
         <Box direction='row' justify='center' tag='nav'>
           <Button
@@ -48,22 +87,13 @@ class StepNavigation extends React.Component {
             onClick={() => setTutorialStep(prevStep)}
             plain
           />
-          {steps.map((step, index) => {
-            const active = index === activeStep
-            const key = `step-${index}`
-            return (
-              <HiddenRadioLabel key={key}>
-                <RadioButton
-                  checked={active}
-                  id={key}
-                  label={counterpart('StepNavigation.go', { index: index + 1 })}
-                  name='step-selectors'
-                  onChange={() => setTutorialStep(index)}
-                  value={index}
-                />
-              </HiddenRadioLabel>
-            )
-          })}
+          <RadioButtonGroup
+            direction='row'
+            name='step-selectors'
+            onChange={this.onChange.bind(this)}
+            options={options}
+            value={`step-${activeStep}`}
+          />
           <Button
             a11yTitle={counterpart('StepNavigation.next')}
             data-index={nextStep}
@@ -93,3 +123,26 @@ StepNavigation.wrappedComponent.propTypes = {
 }
 
 export default StepNavigation
+
+
+// {
+//   steps.map((step, index) => {
+//     const active = index === activeStep
+//     const key = `step-${index}`
+//     const focused = index === this.state.focused
+//     console.log(this.state.focused)
+//     return (
+//       <HiddenRadioLabel key={key}>
+//         <StyledRadioButton
+//           autoFocus={index === 0}
+//           checked={active}
+//           focused={focused}
+//           id={key}
+//           label={counterpart('StepNavigation.go', { index: index + 1 })}
+//           name='step-selectors'
+//           onChange={() => setTutorialStep(index)}
+//           value={index}
+//         />
+//       </HiddenRadioLabel>
+//     )
+    // })}

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/StepNavigation/StepNavigation.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/StepNavigation/StepNavigation.js
@@ -5,26 +5,20 @@ import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
 import { Button, Box, RadioButtonGroup } from 'grommet'
 import styled from 'styled-components'
 import { FormNext, FormPrevious } from 'grommet-icons'
-import zooTheme from '@zooniverse/grommet-theme'
 import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
 
-// const HiddenRadioLabel = styled.span`
-//   display: flex;
-//   flex-direction: row;
-//   position: relative;
-//   ${StyledRadioButton} span {
-//     height: 0;
-//     overflow: hidden;
-//     position: absolute;
-//     width: 0;
-//   }
-// `
+const StyledRadioButtonGroup = styled(RadioButtonGroup)`
+  position: relative;
 
-// const StyledRadioButton = styled(RadioButton)`
-//   outline: ${(props) => (props.focused) ? zooTheme.global.colors['accent-2'] : 'none'}
-// `
+  > label > span {
+    height: 0;
+    overflow: hidden;
+    position: absolute;
+    width: 0;
+  }
+`
 
 function storeMapper (stores) {
   const { active: tutorial, activeStep, setTutorialStep } = stores.classifierStore.tutorials
@@ -38,25 +32,6 @@ function storeMapper (stores) {
 @inject(storeMapper)
 @observer
 class StepNavigation extends React.Component {
-  constructor() {
-    super()
-    this.state = {
-      focused: -1
-    }
-  }
-
-  onFocus (e) {
-    const keyPressed = e.keyCode ? e.keyCode : e.which
-    console.log('onfocus', keyPressed, e, e.target)
-    if (keyPressed === 9) { // tab is pressed
-      this.setState({ focused: e.target.value })
-    }
-  }
-
-  removeFocus () {
-    this.setState({ focused: -1 })
-  }
-
   onChange (event) {
     const { setTutorialStep } = this.props
     const indexValue = event.target.value.split('-')[1]
@@ -64,21 +39,23 @@ class StepNavigation extends React.Component {
   }
 
   render () {
-    const { activeStep, setTutorialStep, steps } = this.props
+    const { activeStep, className, setTutorialStep, steps } = this.props
     if (steps && steps.length > 1) {
       const nextStep = activeStep + 1
       const prevStep = activeStep - 1
       const options = steps.map((step, index) => {
-        const name = counterpart('StepNavigation.go', { index: index + 1 })
+        const label = counterpart('StepNavigation.go', { index: index + 1 })
+        // We can't just use index for the value
+        // because Grommet is using indexes internally as keys and this will error with a duplicate key
+        const value = `step-${index}`
         return {
-          id: `step-${index}`,
-          name,
-          // We can't just use index because Grommet is using indexes internally as keys and this will error with a duplicate key
-          value: `step-${index}` 
+          id: value,
+          label,
+          value
         }
       })
       return (
-        <Box direction='row' justify='center' tag='nav'>
+        <Box as='nav' className={className} direction='row' justify='center'>
           <Button
             a11yTitle={counterpart('StepNavigation.previous')}
             data-index={prevStep}
@@ -87,7 +64,7 @@ class StepNavigation extends React.Component {
             onClick={() => setTutorialStep(prevStep)}
             plain
           />
-          <RadioButtonGroup
+          <StyledRadioButtonGroup
             direction='row'
             name='step-selectors'
             onChange={this.onChange.bind(this)}
@@ -112,37 +89,16 @@ class StepNavigation extends React.Component {
 
 StepNavigation.wrappedComponent.defaultProps = {
   activeStep: 0,
+  className: '',
   setTutorialStep: () => {},
   steps: []
 }
 
 StepNavigation.wrappedComponent.propTypes = {
   activeStep: PropTypes.number,
+  className: PropTypes.string,
   setTutorialStep: PropTypes.func,
   steps: PropTypes.array
 }
 
 export default StepNavigation
-
-
-// {
-//   steps.map((step, index) => {
-//     const active = index === activeStep
-//     const key = `step-${index}`
-//     const focused = index === this.state.focused
-//     console.log(this.state.focused)
-//     return (
-//       <HiddenRadioLabel key={key}>
-//         <StyledRadioButton
-//           autoFocus={index === 0}
-//           checked={active}
-//           focused={focused}
-//           id={key}
-//           label={counterpart('StepNavigation.go', { index: index + 1 })}
-//           name='step-selectors'
-//           onChange={() => setTutorialStep(index)}
-//           value={index}
-//         />
-//       </HiddenRadioLabel>
-//     )
-    // })}

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/StepNavigation/StepNavigation.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/StepNavigation/StepNavigation.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import sinon from 'sinon'
-import { Button, RadioButton } from 'grommet'
+import { Button } from 'grommet'
 import { FormNext, FormPrevious } from 'grommet-icons'
 import StepNavigation from './StepNavigation'
 
@@ -36,17 +36,23 @@ describe('StepNavigation', function () {
     expect(wrapper.find({ icon: <FormNext /> })).to.have.lengthOf(1)
   })
 
-  it('should render a radio button for each step', function () {
+  it('should render a radio button group', function () {
     const wrapper = shallow(<StepNavigation.wrappedComponent steps={steps} />)
-    const buttons = wrapper.find(RadioButton)
 
-    expect(buttons).to.have.lengthOf(steps.length)
+    expect(wrapper.find('Styled(RadioButtonGroup)')).to.have.lengthOf(1)
   })
 
-  it('should render a radio button with the checked attribute as true if active', function () {
+  it('should use the steps to set the options on RadioButtonGroup', function () {
     const wrapper = shallow(<StepNavigation.wrappedComponent steps={steps} />)
-    const activeButton = wrapper.find(RadioButton).find({ checked: true })
-    expect(activeButton).to.have.lengthOf(1)
+    const options = wrapper.find('Styled(RadioButtonGroup)').props().options
+    expect(Object.keys(options)).to.have.lengthOf(steps.length)
+  })
+
+  it('should set the active value of the RadioButtonGroup', function () {
+    const activeStep = 1
+    const wrapper = shallow(<StepNavigation.wrappedComponent activeStep={activeStep} steps={steps} />)
+    const activeValue = wrapper.find('Styled(RadioButtonGroup)').props().value
+    expect(activeValue).to.equal(`step-${activeStep}`)
   })
 
   it('should disable the previous step button when props.activeStep is 0', function () {
@@ -59,6 +65,22 @@ describe('StepNavigation', function () {
     const wrapper = shallow(<StepNavigation.wrappedComponent activeStep={1} steps={steps} />)
     expect(wrapper.find({ icon: <FormPrevious /> }).props().disabled).to.be.false
     expect(wrapper.find({ icon: <FormNext /> }).props().disabled).to.be.true
+  })
+
+  describe('#onChange', function () {
+    let setTutorialStepSpy
+    let wrapper
+    const step = 1
+
+    before(function () {
+      setTutorialStepSpy = sinon.spy()
+      wrapper = shallow(<StepNavigation.wrappedComponent setTutorialStep={setTutorialStepSpy} steps={steps} />)
+    })
+
+    it('should call setTutorialStep with the value index as a number', function () {
+      wrapper.instance().onChange({ target: { value: `step-${step}` }})
+      expect(setTutorialStepSpy).to.be.calledOnceWith(step)
+    })
   })
 
   describe('props.setTutorialStep', function () {
@@ -85,35 +107,12 @@ describe('StepNavigation', function () {
       })
     })
 
-    it('should call props.setTutorialStep on change for each radio button', function () {
-      const buttons = wrapper.find(RadioButton)
-
-      buttons.forEach(button => {
-        button.simulate('change')
-        expect(setTutorialStepSpy).to.have.been.calledOnce
-        setTutorialStepSpy.resetHistory()
-      })
-    })
-
     it('should call setTutorialStep when the previous step button is clicked with props.activeStep - 1', function () {
       wrapper.setProps({ activeStep: 1 })
       const prevButton = wrapper.find({ icon: <FormPrevious /> })
       prevButton.simulate('click')
       expect(setTutorialStepSpy).to.have.been.calledOnce
       expect(setTutorialStepSpy).to.have.been.calledWith(prevButton.props()['data-index'])
-    })
-
-    it('should call setTutorialStep when a specific step button is clicked with the correct index', function () {
-      wrapper.setProps({ activeStep: 0 })
-      const buttons = wrapper.find(RadioButton)
-
-      buttons.forEach(button => {
-        const buttonIndex = button.props().value
-        button.simulate('change')
-        expect(setTutorialStepSpy).to.have.been.calledOnce
-        expect(setTutorialStepSpy).to.have.been.calledWith(buttonIndex)
-        setTutorialStepSpy.resetHistory()
-      })
     })
 
     it('should call setTutorialStep when the next step button is clicked with props.activeStep + 1', function () {


### PR DESCRIPTION
Package: lib-classifier

Closes #607.

Describe your changes:
I gave it another go to try using Grommet's `RadioButtonGroup` which does have accessible focus, and this seems to be working. @eatyourgreens if this is better, then let me know and I'll update tests accordingly. Is there anything else needed for accessibility here?

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

