### PR TITLE
Hookup view more stats link

### DIFF
--- a/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatistics.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatistics.js
@@ -29,6 +29,7 @@ function ProjectStatistics ({
   classifications,
   completedSubjects,
   projectName,
+  projectSlug,
   subjects,
   volunteers
 }) {
@@ -36,7 +37,7 @@ function ProjectStatistics ({
     <ContentBox
       className={className}
       linkLabel={counterpart('ProjectStatistics.viewMoreStats')}
-      linkUrl='#'
+      linkUrl={`/projects/${projectSlug}/stats`}
       title={counterpart('ProjectStatistics.title', { projectName })}
     >
       <MainGrid>

--- a/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatisticsContainer.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatisticsContainer.js
@@ -10,6 +10,7 @@ function storeMapper (stores) {
     classifications: project.classifications_count,
     completedSubjects: project.retired_subjects_count,
     projectName: project.display_name,
+    projectSlug: project.slug,
     subjects: project.subjects_count,
     volunteers: project.classifiers_count
   }
@@ -24,6 +25,7 @@ class ProjectStatisticsContainer extends Component {
       classifications,
       completedSubjects,
       projectName,
+      projectSlug,
       subjects,
       volunteers
     } = this.props
@@ -34,6 +36,7 @@ class ProjectStatisticsContainer extends Component {
         classifications={classifications}
         completedSubjects={completedSubjects}
         projectName={projectName}
+        projectSlug={projectSlug}
         subjects={subjects}
         volunteers={volunteers}
       />

--- a/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatisticsContainer.spec.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatisticsContainer.spec.js
@@ -9,6 +9,7 @@ let projectStatisticsWrapper
 
 const CLASSIFICATIONS = 1
 const COMPLETEDSUBJECTS = 2
+const SLUG = 'foo/bar'
 const SUBJECTS = 3
 const VOLUNTEERS = 4
 
@@ -17,6 +18,7 @@ describe('Component > CompletionBarContainer', function () {
     wrapper = shallow(<ProjectStatisticsContainer.wrappedComponent
       classifications={CLASSIFICATIONS}
       completedSubjects={COMPLETEDSUBJECTS}
+      projectSlug={SLUG}
       subjects={SUBJECTS}
       volunteers={VOLUNTEERS}
     />)
@@ -37,6 +39,10 @@ describe('Component > CompletionBarContainer', function () {
 
   it('should pass through a `completedSubjects` prop', function () {
     expect(projectStatisticsWrapper.prop('completedSubjects')).to.equal(COMPLETEDSUBJECTS)
+  })
+
+  it('should pass through a `projectSlug` prop', function () {
+    expect(projectStatisticsWrapper.prop('projectSlug')).to.equal(SLUG)
   })
 
   it('should pass through a `subjects` prop', function () {


### PR DESCRIPTION
Package:

app-project

Hooks up the `View more stats` link in the corner of the stats widget.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

