### PR TITLE
Move aria label to icon

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/components/ApprovedIcon/ApprovedIcon.js
+++ b/packages/app-project/src/components/ProjectHeader/components/ApprovedIcon/ApprovedIcon.js
@@ -19,14 +19,12 @@ const StyledSVG = styled.svg`
 
 function ApprovedIcon ({ approved }) {
   if (approved) {
-    const title = counterpart('ApprovedIcon.title')
     return (
-      <StyledBox
-        aria-label={title}
-        background='white'
-        title={title}
-      >
-        <FormCheckmark color='brand' />
+      <StyledBox background='white'>
+        <FormCheckmark
+          aria-label={counterpart('ApprovedIcon.title')}
+          color='brand'
+        />
       </StyledBox>
     )
   }

--- a/packages/app-project/src/components/ProjectHeader/components/ApprovedIcon/ApprovedIcon.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/ApprovedIcon/ApprovedIcon.spec.js
@@ -30,8 +30,7 @@ describe('Component > ApprovedIcon', function () {
     })
 
     it('should have a text equivalent for screen readers', function () {
-      expect(wrapper.prop('title')).to.equal('Zooniverse Approved')
-      expect(wrapper.prop('aria-label')).to.equal('Zooniverse Approved')
+      expect(wrapper.find('FormCheckmark').prop('aria-label')).to.equal('Zooniverse Approved')
     })
   })
 })


### PR DESCRIPTION
Package: app-project

Closes #625.

Moves the `aria-label` for the Zooniverse Approved icon to the icon svg, and removes the `title` attribute.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

