### PR TITLE
Adjust paddings/margins in theme to match design

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
@@ -32,10 +32,16 @@ function FinishedForTheDay ({ imageSrc, projectName }) {
     <Grid columns={columns}>
       {imageSrc && <ProjectImage imageSrc={imageSrc} projectName={projectName} />}
       <ContentBox>
-        <Heading level='3' margin='none' color='#5C5C5C'>
+        <Heading
+          level='3'
+          margin={{ bottom: 'small', top: 'none' }}
+        >
           {counterpart('FinishedForTheDay.title')}
         </Heading>
-        <StyledParagraph margin={{ vertical: 'small' }} size='small'>
+        <StyledParagraph
+          margin={{ bottom: 'small', top: 'none' }}
+          size='small'
+        >
           {counterpart('FinishedForTheDay.text', { projectName })}
         </StyledParagraph>
         <StyledBox direction='row' wrap>

--- a/packages/app-project/src/shared/components/ContentBox/ContentBox.js
+++ b/packages/app-project/src/shared/components/ContentBox/ContentBox.js
@@ -24,7 +24,7 @@ function ContentBox ({ className, children, linkLabel, linkUrl, mode, title }) {
           as='header'
           direction='row'
           justify={title ? 'between' : 'end'}
-          margin={{ bottom: 'medium' }}
+          margin={{ bottom: 'small' }}
         >
 
           {title && (

--- a/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatistics.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatistics.js
@@ -43,7 +43,7 @@ function ProjectStatistics ({
       <MainGrid>
         <section>
           <Subtitle text={counterpart('ProjectStatistics.subtitle')} />
-          <StyledParagraph margin={{ top: 'none' }} size='small'>
+          <StyledParagraph margin={{ bottom: 'small', top: 'none' }} size='small'>
             {counterpart('ProjectStatistics.text')}
           </StyledParagraph>
           <CompletionBar />

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -27,7 +27,7 @@ class ImageToolbar extends Component {
           }}
           direction='column'
           fill
-          pad='xsmall'
+          pad='14px'
         >
           <AnnotateButton />
           <MoveButton />

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -27,7 +27,7 @@ class ImageToolbar extends Component {
           }}
           direction='column'
           fill
-          pad='small'
+          pad='xsmall'
         >
           <AnnotateButton />
           <MoveButton />

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -41,7 +41,7 @@ export class Tasks extends React.Component {
     if (tasks.length > 0) {
       return (
         <ThemeProvider theme={{ mode: this.props.theme }}>
-          <Box tag='form' pad={{ top: 'medium' }}>
+          <Box as='form' pad='medium'>
             {tasks.map((task) => {
               const TaskComponent = getTaskComponent(task.type)
               if (TaskComponent) {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/SingleChoiceTask/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/SingleChoiceTask/SingleChoiceTask.js
@@ -1,13 +1,16 @@
 import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
 import { observable } from 'mobx'
 import React from 'react'
+
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Markdown, Text } from 'grommet'
+import { Box, Markdown, Text } from 'grommet'
 import TaskInputField from '../TaskInputField'
 
-export const StyledFieldset = styled.fieldset`
+export const StyledBox = styled(Box)`
   border: none;
+  margin: 0;
+  padding: 0;
 `
 
 function storeMapper (stores) {
@@ -32,6 +35,7 @@ class SingleChoiceTask extends React.Component {
   render () {
     const {
       annotations,
+      className,
       task
     } = this.props
     let annotation
@@ -40,8 +44,13 @@ class SingleChoiceTask extends React.Component {
     }
 
     return (
-      <StyledFieldset>
-        <Text size='small' tag='legend'><Markdown>{task.question}</Markdown></Text>
+      <StyledBox as='fieldset' className={className}>
+        <Text size='small' tag='legend'>
+          <Markdown>
+            {task.question}
+          </Markdown>
+        </Text>
+
         {task.answers.map((answer, index) => {
           const checked = (annotation && annotation.value + 1) ? index === annotation.value : false
           return (
@@ -58,7 +67,7 @@ class SingleChoiceTask extends React.Component {
             />
           )
         })}
-      </StyledFieldset>
+      </StyledBox>
     )
   }
 }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskHelp/TaskHelp.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskHelp/TaskHelp.js
@@ -41,8 +41,8 @@ class TaskHelp extends React.Component {
       return (
         <>
           <StyledPlainButton
-            margin='small'
             onClick={() => this.setState({ showModal: true })}
+            margin={{ bottom: 'small' }}
             text={label}
           />
           <Modal

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
@@ -11,7 +11,7 @@ export default function TaskNavButtons (props) {
 
   if (props.showNextButton) {
     return (
-      <Box pad='small' direction='row'>
+      <Box direction='row'>
         {props.showBackButton &&
           <BackButton
             areAnnotationsNotPersisted={props.areAnnotationsNotPersisted}
@@ -29,7 +29,7 @@ export default function TaskNavButtons (props) {
   // Shown on summary enabled workflows.
   if (props.completed) {
     return (
-      <Box pad='small'>
+      <Box>
         <NextButton
           autoFocus={props.autoFocus}
           disabled={false}
@@ -40,7 +40,7 @@ export default function TaskNavButtons (props) {
   }
 
   return (
-    <Box direction='row' pad='small'>
+    <Box direction='row'>
       {props.showBackButton &&
         <BackButton
           areAnnotationsNotPersisted={props.areAnnotationsNotPersisted}

--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -107,6 +107,14 @@ Object.keys(statusColors).forEach((color) => {
 const theme = deepFreeze({
   global: {
     colors,
+    edgeSize: {
+      xxsmall: '5px',
+      xsmall: `10px`,
+      small: `20px`,
+      medium: `30px`,
+      large: `50px`,
+      xlarge: `90px`,
+    },
     font: {
       family: "'Karla', Arial, sans-serif",
       face: `

--- a/packages/lib-react-components/src/ZooFooter/ZooFooter.js
+++ b/packages/lib-react-components/src/ZooFooter/ZooFooter.js
@@ -74,7 +74,7 @@ export default function ZooFooter (props) {
       tag='footer'
     >
       <Box
-        pad={{ horizontal: 'large', bottom: 'xlarge' }}
+        pad={{ horizontal: 'large', bottom: 'medium' }}
         fill='horizontal'
       >
         <Box
@@ -113,6 +113,7 @@ export default function ZooFooter (props) {
             'count': 'fit',
             'size': 'small'
           }}
+          margin={{ bottom: 'large' }}
           tag='section'
         >
           <LinkList

--- a/packages/lib-react-components/src/ZooFooter/components/SocialAnchor/SocialAnchor.js
+++ b/packages/lib-react-components/src/ZooFooter/components/SocialAnchor/SocialAnchor.js
@@ -6,6 +6,8 @@ import styled from 'styled-components'
 import zooTheme from '@zooniverse/grommet-theme'
 
 const StyledAnchor = styled(Anchor)`
+  padding: 0;
+
   &:focus > svg,
   &:hover > svg {
     fill: ${zooTheme.global.colors['accent-2']} !important;
@@ -21,10 +23,10 @@ export default function SocialAnchor ({ className, hrefs, service }) {
 
   return (
       <StyledAnchor
-        className={className}
-        href={hrefs[service]}
         a11yTitle={service}
+        className={className}
         icon={icons[service]}
+        href={hrefs[service]}
       />
   )
 }

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.js
@@ -67,7 +67,7 @@ export default function ZooHeader (props) {
       <Box
         align='center'
         direction='row'
-        pad={{ horizontal: 'medium', vertical: 'small' }}
+        pad={{ horizontal: 'medium' }}
         responsive={false}
         tag='nav'
       >


### PR DESCRIPTION
Package: app-project, lib-grommet-theme, lib-classifier

Adds an `edgeSize` property to the grommet theme using the 10px multiples as per the designs, then adjust the spacing on the actual elements to match.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

