### PR TITLE
Use zooniverse markdown instead of grommet

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/DrawingTask/DrawingTask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/DrawingTask/DrawingTask.js
@@ -1,6 +1,7 @@
-import { Markdown, Text } from 'grommet'
-import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
+import { Markdownz } from '@zooniverse/react-components'
+import { Text } from 'grommet'
 import { observable } from 'mobx'
+import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
@@ -35,9 +36,9 @@ class DrawingTask extends React.Component {
     }
     return (
       <Text size='small' tag='legend'>
-        <Markdown>
+        <Markdownz>
           {task.instruction}
-        </Markdown>
+        </Markdownz>
       </Text>
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/MultipleChoiceTask/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/MultipleChoiceTask/MultipleChoiceTask.js
@@ -1,9 +1,11 @@
-import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
+import { Markdownz } from '@zooniverse/react-components'
+import { Text } from 'grommet'
 import { observable } from 'mobx'
+import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Markdown, Text } from 'grommet'
+
 import TaskInputField from '../TaskInputField'
 
 export const StyledFieldset = styled.fieldset`
@@ -48,7 +50,11 @@ class MultipleChoiceTask extends React.Component {
     }
     return (
       <StyledFieldset autoFocus={(annotation && annotation.value && annotation.value.length === 0)}>
-        <Text size='small' tag='legend'><Markdown>{task.question}</Markdown></Text>
+        <Text size='small' tag='legend'>
+          <Markdownz>
+            {task.question}
+          </Markdownz>
+        </Text>
         {task.answers.map((answer, index) => {
           const checked = (annotation && annotation.value && annotation.value.length > 0) ? annotation.value.includes(index) : false
           return (

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/SingleChoiceTask/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/SingleChoiceTask/SingleChoiceTask.js
@@ -1,10 +1,11 @@
-import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
+import { Markdownz } from '@zooniverse/react-components'
+import { Markdown, Text } from 'grommet'
 import { observable } from 'mobx'
-import React from 'react'
-
+import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
 import PropTypes from 'prop-types'
+import React from 'react'
 import styled from 'styled-components'
-import { Box, Markdown, Text } from 'grommet'
+
 import TaskInputField from '../TaskInputField'
 
 export const StyledBox = styled(Box)`
@@ -46,9 +47,9 @@ class SingleChoiceTask extends React.Component {
     return (
       <StyledBox as='fieldset' className={className}>
         <Text size='small' tag='legend'>
-          <Markdown>
+          <Markdownz>
             {task.question}
-          </Markdown>
+          </Markdownz>
         </Text>
 
         {task.answers.map((answer, index) => {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/SingleChoiceTask/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/SingleChoiceTask/SingleChoiceTask.js
@@ -1,5 +1,5 @@
 import { Markdownz } from '@zooniverse/react-components'
-import { Markdown, Text } from 'grommet'
+import { Box, Text } from 'grommet'
 import { observable } from 'mobx'
 import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
 import PropTypes from 'prop-types'


### PR DESCRIPTION
Package: lib-classifier

Closes #638.

Use the Zooniverse Markdown component instead of the one from Grommet.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

