### PR TITLE
Init add of feedback brushes to feedback modal

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
@@ -43,6 +43,7 @@ class FeedbackModal extends React.Component {
             <Box
               height='medium'
               overflow='auto'
+              width='medium'
             >
               {!hideSubjectViewer && <SubjectViewer />}
               <ul>

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
@@ -33,9 +33,10 @@ class FeedbackModal extends React.Component {
   render () {
     const label = counterpart('FeedbackModal.label')
     const { applicableRules, hideFeedback, hideSubjectViewer, messages, showModal } = this.props
+    const showViewer = !hideSubjectViewer && applicableRules && applicableRules.length > 0
     let FeedbackViewer = null
-    if (!hideSubjectViewer && applicableRules && applicableRules.length > 0) {
-      FeedbackViewer = getFeedbackViewer(applicableRules)
+    if (showViewer) {
+      FeedbackViewer = getFeedbackViewer(applicableRules)      
     }
 
     if (showModal) {
@@ -51,7 +52,7 @@ class FeedbackModal extends React.Component {
               overflow='auto'
               width='medium'
             >
-              {!hideSubjectViewer && <FeedbackViewer />}
+              {showViewer && <FeedbackViewer />}
               <ul>
                 {messages.map(message =>
                   <li key={Math.random()}>

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
@@ -6,18 +6,20 @@ import { Modal } from '@zooniverse/react-components'
 import counterpart from 'counterpart'
 import en from './locales/en'
 
-import SubjectViewer from '../SubjectViewer'
+import getFeedbackViewer from './helpers/getFeedbackViewer'
 
 counterpart.registerTranslations('en', en)
 
 function storeMapper (stores) {
   const {
+    applicableRules,
     hideFeedback,
     hideSubjectViewer,
     messages,
     showModal
   } = stores.classifierStore.feedback
   return {
+    applicableRules,
     hideFeedback,
     hideSubjectViewer,
     messages,
@@ -30,7 +32,8 @@ function storeMapper (stores) {
 class FeedbackModal extends React.Component {
   render () {
     const label = counterpart('FeedbackModal.label')
-    const { hideFeedback, hideSubjectViewer, messages, showModal } = this.props
+    const { applicableRules, hideFeedback, hideSubjectViewer, messages, showModal } = this.props
+    const FeedbackViewer = getFeedbackViewer(applicableRules)
 
     if (showModal) {
       return (
@@ -45,7 +48,7 @@ class FeedbackModal extends React.Component {
               overflow='auto'
               width='medium'
             >
-              {!hideSubjectViewer && <SubjectViewer />}
+              {!hideSubjectViewer && <FeedbackViewer />}
               <ul>
                 {messages.map(message =>
                   <li key={Math.random()}>
@@ -71,7 +74,13 @@ class FeedbackModal extends React.Component {
 }
 
 FeedbackModal.wrappedComponent.propTypes = {
+  applicableRules: PropTypes.arrayOf(
+    PropTypes.shape({
+      strategy: PropTypes.string
+    })
+  ),
   hideFeedback: PropTypes.func,
+  hideSubjectViewer: PropTypes.bool,
   messages: PropTypes.arrayOf(PropTypes.string),
   showModal: PropTypes.bool
 }

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
@@ -33,7 +33,10 @@ class FeedbackModal extends React.Component {
   render () {
     const label = counterpart('FeedbackModal.label')
     const { applicableRules, hideFeedback, hideSubjectViewer, messages, showModal } = this.props
-    const FeedbackViewer = getFeedbackViewer(applicableRules)
+    let FeedbackViewer = null
+    if (!hideSubjectViewer && applicableRules && applicableRules.length > 0) {
+      FeedbackViewer = getFeedbackViewer(applicableRules)
+    }
 
     if (showModal) {
       return (

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/components/Graph2dRangeFeedback.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/components/Graph2dRangeFeedback.js
@@ -33,6 +33,7 @@ class Graph2dRangeFeedback extends Component {
   }
 
   drawFeedbackBrushes (d3annotationsLayer, repositionBrush) {
+    console.log('d3annotationsLayer = ', d3annotationsLayer)
     const annotationBrushes = []
     this.props.annotations.forEach(annotation => {
       const { task, value } = toJS(annotation)

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/components/Graph2dRangeFeedback.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/components/Graph2dRangeFeedback.js
@@ -33,7 +33,6 @@ class Graph2dRangeFeedback extends Component {
   }
 
   drawFeedbackBrushes (d3annotationsLayer, repositionBrush) {
-    console.log('d3annotationsLayer = ', d3annotationsLayer)
     const annotationBrushes = []
     this.props.annotations.forEach(annotation => {
       const { task, value } = toJS(annotation)

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/components/Graph2dRangeFeedback.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/components/Graph2dRangeFeedback.js
@@ -1,0 +1,116 @@
+import * as d3 from 'd3'
+import { toJS } from 'mobx'
+import { inject, observer } from 'mobx-react'
+import React, { Component } from 'react'
+
+import LightCurveViewer from '../../SubjectViewer/components/LightCurveViewer'
+
+function storeMapper (stores) {
+  const annotations = stores.classifierStore.classifications.currentAnnotations
+  const { 
+    applicableRules,
+    showModal: feedback
+  } = stores.classifierStore.feedback
+  const {
+    active: subject
+  } = stores.classifierStore.subjects
+
+  return {
+    annotations,
+    applicableRules,
+    feedback,
+    subject
+  }
+}
+
+@inject(storeMapper)
+@observer
+class Graph2dRangeFeedback extends Component {
+  constructor () {
+    super()
+
+    this.drawFeedbackBrushes = this.drawFeedbackBrushes.bind(this)
+  }
+
+  drawFeedbackBrushes (d3annotationsLayer, repositionBrush) {
+    const annotationBrushes = []
+    this.props.annotations.forEach(annotation => {
+      const { task, value } = toJS(annotation)
+      value.forEach((marking, i) => {
+        const markingBrush = {
+          id: i,
+          brush: d3.brushX(),
+          maxX: (marking.x + (marking.width / 2)),
+          minX: (marking.x - (marking.width / 2))
+        }
+        annotationBrushes.push(markingBrush)
+      })
+    })
+
+    const ruleBrushes = []
+    this.props.applicableRules.forEach(rule => {
+      const ruleBrush = {
+        id: rule.id,
+        brush: d3.brushX(),
+        maxX: (parseInt(rule.x, 10) + (parseInt(rule.width, 10) / 2) + parseInt(rule.tolerance, 10)),
+        minX: (parseInt(rule.x, 10) - (parseInt(rule.width, 10) / 2) - parseInt(rule.tolerance, 10)),
+        success: rule.success
+      }
+      ruleBrushes.push(ruleBrush)
+    })
+
+    const feedbackBrushes = annotationBrushes.concat(ruleBrushes)
+
+    // Join the D3 brush objects with our internal annotationBrushes array
+    const brushSelection = d3annotationsLayer
+      .selectAll('.brush')
+      .data(feedbackBrushes, (d) => d.id)
+
+    // Set up new brushes
+    brushSelection.enter()
+      .insert('g', '.brush')
+      .attr('class', 'brush')
+      .attr('id', (brush) => (`brush-${brush.id}`))
+      .each(function applyBrushLogic (feedbackBrush) { // Don't use ()=>{}
+        feedbackBrush.brush(d3.select(this)) // Apply the brush logic to the <g.brush> element (i.e. 'this')
+      })
+
+    // Modify brush fill color...
+    brushSelection
+      .each(function fill (feedbackBrush) { // Don't use ()=>{}
+        d3.select(this)
+          .attr('class', 'brush')
+          .selectAll('.selection')
+          .style('fill', () => {
+            if (feedbackBrush.success === true) {
+              return 'green'
+            } else if (feedbackBrush.success === false) {
+              return 'red'
+            } else {
+              return 'white'
+            }
+          })
+      })
+
+    // Reposition/re-draw brushes
+    feedbackBrushes.forEach((feedbackBrush) => {
+      const d3brush = d3annotationsLayer.select(`#brush-${feedbackBrush.id}`)
+
+      repositionBrush(feedbackBrush, d3brush)
+    })
+  }
+
+  render () {
+    const { feedback, subject } = this.props
+    return (
+      <LightCurveViewer 
+        drawFeedbackBrushes={this.drawFeedbackBrushes}
+        feedback={feedback}
+        subject={subject}
+        subjectId={subject.id}
+      />
+    )
+  }
+}
+
+export default Graph2dRangeFeedback

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/components/Graph2dRangeFeedback.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/components/Graph2dRangeFeedback.spec.js
@@ -1,0 +1,17 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import Graph2dRangeFeedback from './Graph2dRangeFeedback'
+import LightCurveViewer from '../../SubjectViewer/components/LightCurveViewer'
+
+describe('Component > Graph2dRangeFeedback', function () {
+  it('should render without crashing', function () {
+    const wrapper = shallow(<Graph2dRangeFeedback.wrappedComponent subject={{ id: '1' }} />)
+    expect(wrapper).to.be.ok
+  })
+
+  it('should render the LightCurveViewer', function () {
+    const wrapper = shallow(<Graph2dRangeFeedback.wrappedComponent subject={{ id: '1' }} />)
+    expect(wrapper.find(LightCurveViewer)).to.have.lengthOf(1)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/components/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/components/index.js
@@ -1,0 +1,1 @@
+export { default } from './Graph2dRangeFeedback'

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/getFeedbackViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/getFeedbackViewer.js
@@ -15,7 +15,7 @@ function getFeedbackViewer (applicableRules) {
   })
 
   if (uniqStrategies.length > 1) {
-    return <p>More than one feedback strategy is not currently supported</p>
+    return null
   }
 
   return viewers[[uniqStrategies]] || null

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/getFeedbackViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/getFeedbackViewer.js
@@ -1,0 +1,24 @@
+import Graph2dRangeFeedback from '../components/Graph2dRangeFeedback'
+
+const viewers = {
+  graph2drange: Graph2dRangeFeedback
+}
+
+function getFeedbackViewer (applicableRules) {
+  if (applicableRules.length === 0) {
+    return null
+  }
+
+  const strategies = applicableRules.map(rule => rule.strategy)
+  const uniqStrategies = strategies.filter((strat, index) => {
+    return strategies.indexOf(strat) >= index
+  })
+
+  if (uniqStrategies.length > 1) {
+    return <p>More than one feedback strategy is not currently supported</p>
+  }
+
+  return viewers[[uniqStrategies]] || null
+}
+
+export default getFeedbackViewer

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/getFeedbackViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/getFeedbackViewer.spec.js
@@ -19,12 +19,12 @@ describe('Helpers > getFeedbackViewer', function () {
   })
 
   it('should return null if no rules', function () {
-    expect(getFeedbackViewer([])).to.equal(null)
+    expect(getFeedbackViewer([])).to.be.null
   })
 
   it('should return null if multiple strategies', function () {
     const multipleStratRules = rules
     multipleStratRules[0].strategy = 'column'
-    expect(getFeedbackViewer(multipleStratRules)).to.equal(null)
+    expect(getFeedbackViewer(multipleStratRules)).to.be.null
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/getFeedbackViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/getFeedbackViewer.spec.js
@@ -1,0 +1,30 @@
+import getFeedbackViewer from './getFeedbackViewer'
+
+import Graph2dRangeFeedback from '../components/Graph2dRangeFeedback'
+
+const rules = [
+  {
+    id: 'testRule1-1',
+    strategy: 'graph2drange'
+  },
+  {
+    id: 'testRule1-2',
+    strategy: 'graph2drange'
+  }
+]
+
+describe('Helpers > getFeedbackViewer', function () {
+  it('should return the `Graph2dRangeFeedback` component if passed `graph2drange` strategy rules', function () {
+    expect(getFeedbackViewer(rules)).to.equal(Graph2dRangeFeedback)
+  })
+
+  it('should return null if no rules', function () {
+    expect(getFeedbackViewer([])).to.equal(null)
+  })
+
+  it('should return null if multiple strategies', function () {
+    const multipleStratRules = rules
+    multipleStratRules[0].strategy = 'column'
+    expect(getFeedbackViewer(multipleStratRules)).to.equal(null)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/index.js
@@ -1,0 +1,1 @@
+export { default } from './getFeedbackViewer'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
@@ -98,6 +98,8 @@ class LightCurveViewerContainer extends Component {
       <LightCurveViewer
         dataExtent={this.state.dataExtent}
         dataPoints={this.state.dataPoints}
+        drawFeedbackBrushes={this.props.drawFeedbackBrushes}
+        feedback={this.props.feedback}
       />
     )
   }

--- a/packages/lib-classifier/src/store/FeedbackStore.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.js
@@ -17,11 +17,7 @@ const FeedbackStore = types
   .views(self => ({
     get applicableRules () {
       return flatten(Array.from(self.rules.values()))
-        .map(rule => {
-          if ((rule.success && rule.successEnabled) || (!rule.success && rule.failureEnabled)) {
-            return rule
-          }
-        }).filter(Boolean)
+        .filter(rule => (rule.success && rule.successEnabled) || (!rule.success && rule.failureEnabled))
     },
     get hideSubjectViewer () {
       return flatten(Array.from(self.rules.values()))

--- a/packages/lib-classifier/src/store/FeedbackStore.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.js
@@ -15,6 +15,14 @@ const FeedbackStore = types
     onHide: () => true
   }))
   .views(self => ({
+    get applicableRules () {
+      return flatten(Array.from(self.rules.values()))
+        .map(rule => {
+          if ((rule.success && rule.successEnabled) || (!rule.success && rule.failureEnabled)) {
+            return rule
+          }
+        }).filter(Boolean)
+    },
     get hideSubjectViewer () {
       return flatten(Array.from(self.rules.values()))
         .some(rule => rule.hideSubjectViewer)

--- a/packages/lib-classifier/src/store/FeedbackStore.spec.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.spec.js
@@ -20,20 +20,32 @@ describe('Model > FeedbackStore', function () {
     feedbackStub = {
       isActive: true,
       rules: {
-        T0: [{
-          id: 'testRule',
-          hideSubjectViewer: true,
-          answer: '0',
-          strategy: 'testStrategy',
-          success: true,
-          successEnabled: true,
-          successMessage: 'Yay!',
-          failureEnabled: true,
-          failureMessage: 'No!'
-        }],
+        T0: [
+          {
+            id: 'testRule1-1',
+            hideSubjectViewer: false,
+            answer: '0',
+            strategy: 'testStrategy',
+            success: true,
+            successEnabled: true,
+            successMessage: 'Yay! 1-1',
+            failureEnabled: true,
+            failureMessage: 'No!'
+          },
+          {
+            id: 'testRule1-2',
+            hideSubjectViewer: false,
+            answer: '1',
+            strategy: 'testStrategy',
+            success: false,
+            successEnabled: true,
+            successMessage: 'Yay! 1-2',
+            failureEnabled: false
+          }
+        ],
         T1: [{
-          id: 'testRule',
-          hideSubjectViewer: false,
+          id: 'testRule2-1',
+          hideSubjectViewer: true,
           answer: '0',
           strategy: 'testStrategy',
           success: false,
@@ -90,12 +102,12 @@ describe('Model > FeedbackStore', function () {
 
   describe('update', function () {
     beforeEach(function () {
-      const annotation = { task: 'T0', value: 0 }
+      const annotation = { task: 'T1', value: 0 }
       feedback.update(annotation)
     })
 
     it('should reduce the rule and value', function () {
-      const [ rule ] = feedback.rules.get('T0')
+      const [ rule ] = feedback.rules.get('T1')
       expect(strategies.testStrategy.reducer).to.have.been.calledOnceWith(rule, 0)
     })
   })
@@ -147,9 +159,11 @@ describe('Model > FeedbackStore', function () {
     })
   })
 
-  describe('messages', function () {
-    it('should return an array of feedback messages', function () {
-      expect(feedback.messages).to.eql(['Yay!', 'Nope!'])
+  describe('applicableRules', function () {
+    it('should return an array of applicable rules', function () {
+      expect(feedback.applicableRules.length).to.equal(2)
+      expect(feedback.applicableRules.some(rule => rule.id === 'testRule1-1')).to.equal(true)
+      expect(feedback.applicableRules.some(rule => rule.id === 'testRule2-1')).to.equal(true)
     })
   })
 
@@ -159,9 +173,15 @@ describe('Model > FeedbackStore', function () {
     })
 
     it('should return false if no rule hides subject viewer', function () {
-      const [ rule ] = feedback.rules.get('T0')
+      const [ rule ] = feedback.rules.get('T1')
       rule.hideSubjectViewer = false
       expect(feedback.hideSubjectViewer).to.equal(false)
+    })
+  })
+
+  describe('messages', function () {
+    it('should return an array of feedback messages', function () {
+      expect(feedback.messages).to.eql(['Yay! 1-1', 'Nope!'])
     })
   })
 


### PR DESCRIPTION
Package: lib-classifier

Towards #205.

Describe your changes:
- adds feedback related brushes to `LightCurverViewer`

**Refactor in progress:**
- extract feedback specific code from `LightCurveViewer`
- move feedback specific brush code elsewhere
- add to LCV something like `renderAlternativeBrushes` that takes custom brush render code prop

^ should be done soon, but don't want to hold this up for beta testing

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

