### PR TITLE
Render modal title as an h2

### DIFF
--- a/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
+++ b/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
@@ -9,7 +9,7 @@ import CloseIcon from '../CloseIcon'
 
 counterpart.registerTranslations('en', en)
 
-const Heading = styled.h5`
+const Heading = styled.h2`
   color: white;
   font-size: 1rem;
   font-weight: bold;

--- a/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.spec.js
+++ b/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.spec.js
@@ -3,15 +3,22 @@ import React from 'react'
 
 import ModalHeading from './ModalHeading'
 
+let wrapper
 const title = 'Modal Heading'
 
 describe('Modal > ModalHeading', function () {
+  before(function () {
+    wrapper = shallow(<ModalHeading closeFn={() => {}} title={title} />)
+  })
   it('should render without crashing', function () {
-    shallow(<ModalHeading closeFn={() => {}} title={title} />)
+    expect(wrapper).to.be.ok
   })
 
   it('should render the title prop', function () {
-    const wrapper = render(<ModalHeading closeFn={() => {}} title={title} />)
-    expect(wrapper.text()).to.equal(title)
+    expect(wrapper.render().text()).to.equal(title)
+  })
+
+  it('should render the title as an h2', function () {
+    expect(wrapper.render().children().eq(0).is('h2')).to.be.true
   })
 })


### PR DESCRIPTION
Package: lib-react-components

Closes #654.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

