### PR TITLE
Ensure toolbar buttons have an aria-label

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -20,7 +20,10 @@ class ImageToolbar extends Component {
     return (
       <Box as='aside' {...props}>
         <Box
-          background={mode === 'light' ? 'white' : 'dark-3'}
+          background={{
+            dark: 'dark-3',
+            light: 'white'
+          }}
           border={{
             color: mode === 'light' ? 'light-3' : 'dark-3',
             side: 'all'

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButton.js
@@ -12,7 +12,7 @@ function AnnotateButton ({ active, onClick }) {
   return (
     <Button
       active={active}
-      aria-label={counterpart('AnnotateButton.ariaLabel')}
+      a11yTitle={counterpart('AnnotateButton.ariaLabel')}
       onClick={onClick}
       svgAdjustments={{ x: '1', y: '4' }}
     >

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButton.spec.js
@@ -8,10 +8,10 @@ describe('Component > AnnotateButton', function () {
     shallow(<AnnotateButton />)
   })
 
-  it('should have an ARIA label', function () {
+  it('should have an `a11yTitle` prop', function () {
     const wrapper = shallow(<AnnotateButton />)
     const button = wrapper.dive().dive() // Grommet button is wrapped with a couple of HOCs
-    expect(button.prop('aria-label')).to.equal('Annotate')
+    expect(button.prop('a11yTitle')).to.equal('Annotate')
   })
 
   it('should call the onClick prop function on click', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
@@ -55,6 +55,7 @@ class Button extends React.Component {
   render () {
     const {
       active,
+      a11yTitle,
       children,
       disabled,
       focused,
@@ -84,7 +85,11 @@ class Button extends React.Component {
       React.cloneElement(child, { ...this.getSize(size) }))
 
     return (
-      <StyledButton {...eventHandlers} disabled={disabled}>
+      <StyledButton
+        aria-label={a11yTitle}
+        disabled={disabled}
+        {...eventHandlers}
+      >
         <svg viewBox='0 0 100 100'>
           <Background
             active={active}

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.spec.js
@@ -67,4 +67,14 @@ describe('Component > Button', function () {
     wrapper.find('button').simulate('mouseout')
     expect(spy.called).to.be.true
   })
+
+  it.only('should add an `aria-label` from the `a11yTitle` prop', function () {
+    const A11Y_TITLE = 'Foobar'
+    const wrapper = mount(
+      <Button
+        a11yTitle={A11Y_TITLE}
+      />
+    )
+    expect(wrapper.find('button').prop('aria-label')).to.equal(A11Y_TITLE)
+  })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.spec.js
@@ -68,7 +68,7 @@ describe('Component > Button', function () {
     expect(spy.called).to.be.true
   })
 
-  it.only('should add an `aria-label` from the `a11yTitle` prop', function () {
+  it('should add an `aria-label` from the `a11yTitle` prop', function () {
     const A11Y_TITLE = 'Foobar'
     const wrapper = mount(
       <Button

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/FullscreenButton/FullscreenButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/FullscreenButton/FullscreenButton.js
@@ -16,9 +16,9 @@ function FullscreenButton ({ active, disabled, onClick }) {
 
   return (
     <Button
+      a11yTitle={label}
       active={active}
       disabled={disabled}
-      aria-label={label}
       onClick={onClick}
     >
       {icon}

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/FullscreenButton/FullscreenButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/FullscreenButton/FullscreenButton.spec.js
@@ -9,10 +9,10 @@ describe('Component > FullscreenButton', function () {
     shallow(<FullscreenButton />)
   })
 
-  it('should have an ARIA label', function () {
+  it('should have an `a11yTitle` label', function () {
     const wrapper = shallow(<FullscreenButton />)
     const button = wrapper.dive().dive()
-    expect(button.prop('aria-label')).to.equal('View subject in full screen mode')
+    expect(button.prop('a11yTitle')).to.equal('View subject in full screen mode')
   })
 
   it('should call the onClick prop function on click', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/MoveButton/MoveButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/MoveButton/MoveButton.js
@@ -11,8 +11,8 @@ counterpart.registerTranslations('en', en)
 function MoveButton ({ active, onClick }) {
   return (
     <Button
+      a11yTitle={counterpart('MoveButton.ariaLabel')}
       active={active}
-      aria-label={counterpart('MoveButton.ariaLabel')}
       onClick={onClick}
     >
       {moveIcon}

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/MoveButton/MoveButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/MoveButton/MoveButton.spec.js
@@ -8,10 +8,10 @@ describe('Component > MoveButton', function () {
     shallow(<MoveButton />)
   })
 
-  it('should have an ARIA label', function () {
+  it('should have an `a11yTitle` label', function () {
     const wrapper = shallow(<MoveButton />)
     const button = wrapper.dive().dive()
-    expect(button.prop('aria-label')).to.equal('Move subject')
+    expect(button.prop('a11yTitle')).to.equal('Move subject')
   })
 
   it('should call the onClick prop function on click', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButton.js
@@ -11,7 +11,7 @@ counterpart.registerTranslations('en', en)
 function ResetButton ({ disabled, onClick }) {
   return (
     <Button
-      aria-label={counterpart('ResetButton.ariaLabel')}
+      a11yTitle={counterpart('ResetButton.ariaLabel')}
       disabled={disabled}
       onClick={onClick}
     >

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButton.spec.js
@@ -8,10 +8,10 @@ describe('Component > ResetButton', function () {
     shallow(<ResetButton />)
   })
 
-  it('should have an ARIA label', function () {
+  it('should have an `a11yTitle` label', function () {
     const wrapper = shallow(<ResetButton />)
     const button = wrapper.dive().dive()
-    expect(button.prop('aria-label')).to.equal('Reset subject view')
+    expect(button.prop('a11yTitle')).to.equal('Reset subject view')
   })
 
   it('should call the onClick prop function on click', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButton.js
@@ -11,7 +11,7 @@ counterpart.registerTranslations('en', en)
 function RotateButton ({ disabled, onClick }) {
   return (
     <Button
-      aria-label={counterpart('RotateButton.ariaLabel')}
+      a11yTitle={counterpart('RotateButton.ariaLabel')}
       disabled={disabled}
       onClick={onClick}
       svgAdjustments={{ y: '2' }}

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButton.spec.js
@@ -8,10 +8,10 @@ describe('Component > RotateButton', function () {
     shallow(<RotateButton />)
   })
 
-  it('should have an ARIA label', function () {
+  it('should have an `a11yTitle` prop', function () {
     const wrapper = shallow(<RotateButton />)
     const button = wrapper.dive().dive()
-    expect(button.prop('aria-label')).to.equal('Rotate subject')
+    expect(button.prop('a11yTitle')).to.equal('Rotate subject')
   })
 
   it('should call the onClick prop function on click', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.js
@@ -11,7 +11,7 @@ counterpart.registerTranslations('en', en)
 function ZoomInButton ({ onClick }) {
   return (
     <Button
-      aria-label={counterpart('ZoomInButton.ariaLabel')}
+      a11yTitle={counterpart('ZoomInButton.ariaLabel')}
       onClick={onClick}
     >
       {zoomInIcon}

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.spec.js
@@ -8,10 +8,10 @@ describe('Component > ZoomInButton', function () {
     shallow(<ZoomInButton />)
   })
 
-  it('should have an ARIA label', function () {
+  it('should have an `a11yTitle` label', function () {
     const wrapper = shallow(<ZoomInButton />)
     const button = wrapper.dive().dive()
-    expect(button.prop('aria-label')).to.equal('Zoom in on subject')
+    expect(button.prop('a11yTitle')).to.equal('Zoom in on subject')
   })
 
   it('should call the onClick prop function on click', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.js
@@ -11,7 +11,7 @@ counterpart.registerTranslations('en', en)
 function ZoomOutButton ({ onClick }) {
   return (
     <Button
-      aria-label={counterpart('ZoomOutButton.ariaLabel')}
+      a11yTitle={counterpart('ZoomOutButton.ariaLabel')}
       onClick={onClick}
     >
       {zoomOutIcon}

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.spec.js
@@ -8,10 +8,10 @@ describe('Component > ZoomOutButton', function () {
     shallow(<ZoomOutButton />)
   })
 
-  it('should have an ARIA label', function () {
+  it('should have an `a11yTitle` label', function () {
     const wrapper = shallow(<ZoomOutButton />)
     const button = wrapper.dive().dive()
-    expect(button.prop('aria-label')).to.equal('Zoom out from subject')
+    expect(button.prop('a11yTitle')).to.equal('Zoom out from subject')
   })
 
   it('should call the onClick prop function on click', function () {


### PR DESCRIPTION
Package: lib-classifier

Adds in the missing `aria-label`s to the classifier toolbar

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

