### PR TITLE
Subject metadata modal fixes

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { Box } from 'grommet'
 import { inject, observer } from 'mobx-react'
 import MetadataButton from './components/MetadataButton'
-import MetadataModal from './components/MetadataModal'
+import { MetadataModal } from './components/MetadataModal'
 import FavouritesButton from './components/FavouritesButton'
 import CollectionsButton from './components/CollectionsButton'
 
@@ -46,12 +46,10 @@ export default class MetaTools extends React.Component {
 
   render () {
     const { className, isThereMetadata, subject } = this.props
-    // Grommet's Button determines disabled state by whether or not onClick is defined
-    const onClick = (isThereMetadata) ? this.toggleMetadataModal : undefined
     return (
       <Box className={className} direction="row">
         {isThereMetadata &&
-          <MetadataButton onClick={onClick} />}
+          <MetadataButton onClick={this.toggleMetadataModal} />}
         {isThereMetadata &&
           <MetadataModal
             active={this.state.showMetadataModal}

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/MetadataModal/MetadataModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/MetadataModal/MetadataModal.js
@@ -75,11 +75,13 @@ export default function MetadataModal (props) {
       closeFn={closeFn}
       title={counterpart('MetadataModal.title')}
     >
-      <StyledDataTable
-        columns={columns}
-        data={data}
-        sortable
-      />
+      <Box height='medium' overflow='auto'>
+        <StyledDataTable
+          columns={columns}
+          data={data}
+          sortable
+        />
+      </Box>
     </Modal>
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/MetadataModal/MetadataModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/MetadataModal/MetadataModal.js
@@ -1,33 +1,30 @@
 import { Markdownz, Modal, SpacedText } from '@zooniverse/react-components'
 import counterpart from 'counterpart'
-import { Box, DataTable } from 'grommet'
+import { Box, DataTable, Text } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
-
+import filterByLabel, { filters } from './filterByLabel'
 import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
 
 const StyledDataTable = styled(DataTable)`
   height: auto;
+
+  th > div {
+    padding: 0 20px;
+  }
+
+  td >  div {
+    padding: 0 20px;
+  }
 `
 
-const DatumWrapper = styled(Box)`
+const DatumWrapper = styled(Text)`
   overflow-wrap: break-word;
   word-break: break-word;
 `
-
-export function filterByLabel (label, filters) {
-  if (label) {
-    const firstCharacter = label.trim().charAt(0)
-    if (!filters.includes(firstCharacter) && !label.slice(0, 2) !== '//') {
-      return label
-    }
-  }
-
-  return ''
-}
 
 export function formatValue (value) {
   if (value) {
@@ -81,7 +78,6 @@ export default function MetadataModal (props) {
       <StyledDataTable
         columns={columns}
         data={data}
-        size='medium'
         sortable
       />
     </Modal>
@@ -91,8 +87,8 @@ export default function MetadataModal (props) {
 MetadataModal.defaultProps = {
   active: false,
   closeFn: () => { },
-  filters: ['#', '!'],
-  prefixes: ['#', '!']
+  filters,
+  prefixes: filters
 }
 
 MetadataModal.propTypes = {

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/MetadataModal/filterByLabel.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/MetadataModal/filterByLabel.js
@@ -1,0 +1,16 @@
+export default function filterByLabel (label, filters = []) {
+  if (label) {
+    const firstCharacter = label.trim().charAt(0)
+    // Does anyone use // to hide metadata?
+    // see https://github.com/zooniverse/Panoptes-Front-End/pull/1082#issuecomment-121662275
+    if (!filters.includes(firstCharacter) && label.slice(0, 2) !== '//') {
+      return label
+    }
+
+    return ''
+  }
+
+  return ''
+}
+
+export const filters = ['#', '!']

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/MetadataModal/filterByLabel.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/MetadataModal/filterByLabel.spec.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai'
+import filterByLabel, { filters } from './filterByLabel'
+
+describe('filterByLabel', function () {
+  it('should return an empty string if label is not defined', function () {
+    const result = filterByLabel()
+    expect(result).to.be.a.string
+    expect(result).to.have.lengthOf(0)
+  })
+
+  it('should return the label if filters are not defined', function () {
+    const label = 'foo'
+    const result = filterByLabel(label)
+    expect(result).to.equal(label)
+  })
+
+  it('should return an empty string if the first character of the label does match a defined filter', function () {
+    const result = filterByLabel('#foo', filters)
+    expect(result).to.be.a.string
+    expect(result).to.have.lengthOf(0)
+  })
+
+  it('should return an empty string if the label starts with //', function () {
+    const result = filterByLabel('//foo', filters)
+    expect(result).to.be.a.string
+    expect(result).to.have.lengthOf(0)
+  })
+
+  it('should return the label if the first character of the label does not match a defined filter', function () {
+    const label = '@foo'
+    const result = filterByLabel(label, filters)
+    expect(result).to.equal(label)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/MetadataModal/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/MetadataModal/index.js
@@ -1,1 +1,4 @@
-export { default } from './MetadataModal'
+import { filters } from './filterByLabel'
+export { default as MetadataModal } from './MetadataModal'
+export { default as filterByLabel } from './filterByLabel'
+export { filters }

--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -2,7 +2,7 @@ import asyncStates from '@zooniverse/async-states'
 import { autorun } from 'mobx'
 import { addDisposer, flow, getRoot, onPatch, types } from 'mobx-state-tree'
 import { getBearerToken } from './utils'
-
+import { filterByLabel, filters } from '../components/Classifier/components/MetaTools/components/MetadataModal'
 import ResourceStore from './ResourceStore'
 import Subject from './Subject'
 
@@ -16,7 +16,9 @@ const SubjectStore = types
   .views(self => ({
     get isThereMetadata () {
       if (self.active) {
-        return Object.keys(self.active.metadata).length > 0
+        const filteredMetadata = Object.keys(self.active.metadata)
+          .filter((label) => filterByLabel(label, filters))
+        return filteredMetadata.length > 0
       }
 
       return false

--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -78,15 +78,17 @@ const SubjectStore = types
         const authorization = yield getBearerToken(authClient)
         const response = yield client.get(`/subjects/queued`, { workflow_id: workflowId }, { authorization })
 
-        response.body.subjects.forEach(subject => {
-          self.resources.put(subject)
-        })
+        if (response.body.subjects && response.body.subjects.length > 0) {
+          response.body.subjects.forEach(subject => {
+            self.resources.put(subject)
+          })
+
+          if (!self.active) {
+            self.advance()
+          }
+        }
 
         self.loadingState = asyncStates.success
-
-        if (!self.active) {
-          self.advance()
-        }
       } catch (error) {
         console.error(error)
         self.loadingState = asyncStates.error

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -1,55 +1,23 @@
 import sinon from 'sinon'
-import { getEnv, types } from 'mobx-state-tree'
+import ProjectStore from './ProjectStore'
+import RootStore from './RootStore'
 import SubjectStore from './SubjectStore'
+import WorkflowStore from './WorkflowStore'
+import { ProjectFactory, WorkflowFactory } from '../../test/factories'
+import { Factory } from 'rosie'
 
 let rootStore
-let subjectStore
 
-const WorkflowStoreStub = types
-  .model('WorkflowStoreStub', {
-    active: types.maybe(types.string)
-  })
-
-const RootStub = types
-  .model('RootStore', {
-    subjects: SubjectStore,
-    workflows: WorkflowStoreStub
-  })
-  .views(self => ({
-    get client () {
-      return getEnv(self).client
-    }
-  }))
-
-function * subjectGen () {
-  let index = 0
-  while (index < index + 1) {
-    index++
-    const id = index.toString()
-    yield {
-      id,
-      subject: {
-        id,
-        locations: [{ 'image/jpg': `http://foobar.com/image${id}.jpg` }]
-      }
-    }
-  }
-}
-
-const subGen = subjectGen()
-
-const subjectsStub = {
-  active: null,
-  queue: [],
-  resources: {}
-}
+const project = ProjectFactory.build()
+const workflow = WorkflowFactory.build({ id: project.configuration.default_workflow })
+const subjects = Factory.buildList('subject', 10)
 
 const clientStub = {
   panoptes: {
     get () {
       return Promise.resolve({
         body: {
-          subjects: [subGen.next().value.subject]
+          subjects
         }
       })
     }
@@ -58,25 +26,64 @@ const clientStub = {
 sinon.spy(clientStub.panoptes, 'get')
 
 describe('Model > SubjectStore', function () {
-  before(function () {
-    for (let index = 0; index < 6; index++) {
-      const obj = subGen.next().value
-      subjectsStub.resources[obj.id] = obj.subject
-      subjectsStub.queue.push(obj.id)
-    }
-    subjectsStub.active = '1'
+  describe('Actions > advance', function () {
+    before(function () {
+      rootStore = RootStore.create(
+        { projects: ProjectStore.create(), subjects: SubjectStore.create(), workflows: WorkflowStore.create() },
+        { client: clientStub }
+      )
+    })
 
-    subjectStore = SubjectStore.create(subjectsStub)
-    rootStore = RootStub.create(
-      { subjects: subjectStore, workflows: WorkflowStoreStub.create() },
-      { client: clientStub }
-    )
+    it('should make the next subject in the queue active when calling `advance()`', function (done) {
+      rootStore.projects.setResource(project)
+      rootStore.workflows.setResource(workflow)
+      rootStore.workflows.setActive(workflow.id)
+      rootStore.subjects.populateQueue().then(() => {
+        expect(rootStore.subjects.active.id).to.equal(rootStore.subjects.resources.values().next().value.id)
+        rootStore.subjects.advance()
+        expect(rootStore.subjects.active.id).to.equal(rootStore.subjects.resources.values().next().value.id)
+        expect(rootStore.subjects.resources.get('1')).to.be.undefined
+      }).then(done, done)
+    })
   })
 
-  it('should make the next subject in the queue active when calling `advance()`', function () {
-    subjectStore.active.id.should.equal(subjectsStub.resources['1'].id)
-    subjectStore.advance()
-    subjectStore.active.id.should.equal(subjectsStub.resources['2'].id)
-    expect(subjectStore.resources.get('1')).to.equal(undefined)
+  describe('Views > isThereMetadata', function (done) {
+    it('should return false when there is not an active queue subject', function () {
+      rootStore = RootStore.create(
+        { projects: ProjectStore.create(), subjects: SubjectStore.create(), workflows: WorkflowStore.create() },
+        { client: {
+            panoptes: {
+              get: () => {
+                return Promise.resolve({
+                  body: { subjects: [] }
+                })
+              }
+            }
+          }
+        }
+      )
+
+      rootStore.projects.setResource(project)
+      rootStore.workflows.setResource(workflow)
+      rootStore.workflows.setActive(workflow.id)
+      rootStore.subjects.populateQueue().then(() => {
+        expect(rootStore.subjects.isThereMetadata).to.be.false
+      }).then(done, done)
+    })
+
+    it('should false if the active subject does not have metadata', function (done) {
+      rootStore = RootStore.create(
+        { projects: ProjectStore.create(), subjects: SubjectStore.create(), workflows: WorkflowStore.create() },
+        { client: clientStub }
+      )
+
+      rootStore.projects.setResource(project)
+      rootStore.workflows.setResource(workflow)
+      rootStore.workflows.setActive(workflow.id)
+      rootStore.subjects.populateQueue().then(() => {
+        expect(Object.keys(rootStore.subjects.active.toJSON().metadata)).to.have.lengthOf(0)
+        expect(rootStore.subjects.isThereMetadata).to.be.false
+      }).then(done, done)
+    })
   })
 })

--- a/packages/lib-classifier/test/factories/SubjectFactory.js
+++ b/packages/lib-classifier/test/factories/SubjectFactory.js
@@ -1,7 +1,10 @@
 import { Factory } from 'rosie'
 
-export default new Factory()
+const subject = Factory.define('subject')
   .sequence('id', (id) => { return id.toString() })
+  .attr('already_seen', false)
+  .attr('favorite', false)
+  .attr('finished_workflow', false)
   .attr('locations', () => {
     return [1, 2].map((int) => {
       const randomString = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5)
@@ -9,3 +12,8 @@ export default new Factory()
     })
   })
   .attr('metadata', {})
+  .attr('retired', false)
+  .attr('selection_state', '')
+  .attr('user_has_finished_workflow', false)
+
+export default subject


### PR DESCRIPTION
Package: lib-classifier

Closes #649 

Describe your changes:
I removed the `size` prop from the DataTable and the table is now accessible. This seems to be a Grommet bug, opened issue at https://github.com/grommet/grommet/issues/3006

To still have the table overflow, I wrapped it with a Box and set the height and overflow. 

I reduced the size of the rows. I'm not 100% what the size should be since the InDesign prototype is not inspectable: https://projects.invisionapp.com/d/#/console/12923997/270495352/preview so I tried to eyeball it. @beckyrother what should the size of the rows be here?

I extracted out the function that filters what is displayed to be usable by the store. Project 272 has subjects that only have hidden metadata, so the button should be hidden. (This is actually a bug in current PFE now btw). The store view function isn't tested.

Also, the original implementation of the filters supports `//` as a filter, but I do not know of any project that uses this? I think we should drop support for it. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

