### PR TITLE
Field guide style fixes

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideContainer.js
@@ -36,7 +36,7 @@ class FieldGuideContainer extends React.Component {
         <Modal
           active={showModal}
           closeFn={this.onClose.bind(this)}
-          pad='small'
+          pad={{ horizontal: '30px', vertical: 'small' }}
           title={counterpart('FieldGuide.title')}
         >
           <FieldGuide />

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.js
@@ -28,6 +28,23 @@ const FieldGuideItemHeader = styled(Box)`
   }
 `
 
+const FieldGuideItemContent = styled(Box)`
+  > h1, h2, h3, h4, h5, h6 {
+    font-size: 14px;
+    letter-spacing: 1.5px;
+    line-height: 17px;
+    margin: 5px 0;
+  }
+
+  > p {
+    margin: 5px 0;
+
+    &:last-of-type {
+      margin: 5px 0 20px;
+    }
+  }
+`
+
 function storeMapper(stores) {
   const { setActiveItemIndex, attachedMedia: icons } = stores.classifierStore.fieldGuide
   return {
@@ -45,7 +62,7 @@ class FieldGuideItem extends React.Component {
 
     return (
       <Box className={className}>
-        <FieldGuideItemHeader align='center' direction='row' margin={{ bottom: 'small' }}>
+        <FieldGuideItemHeader align='center' direction='row' flex={{ grow: 1, shrink: 0 }} margin={{ bottom: 'small' }}>
           <StyledButton
             a11yTitle={counterpart("FieldGuideItem.ariaTitle")}
             icon={<FormPrevious color='light-5' />}
@@ -57,12 +74,12 @@ class FieldGuideItem extends React.Component {
             {`### ${item.title}`}
           </Markdownz>
         </FieldGuideItemHeader>
-        <Box direction='column'>
-          <FieldGuideItemIcon icon={icon} height='140' viewBox='0 0 200 100' />
+        <FieldGuideItemContent direction='column'>
+          <FieldGuideItemIcon icon={icon} height='140' margin={{ bottom: '35px' }} viewBox='0 0 200 100' />
           <Markdownz>
             {item.content}
           </Markdownz>
-        </Box>
+        </FieldGuideItemContent>
       </Box>
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.js
@@ -38,10 +38,6 @@ const FieldGuideItemContent = styled(Box)`
 
   > p {
     margin: 5px 0;
-
-    &:last-of-type {
-      margin: 5px 0 20px;
-    }
   }
 `
 

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItemIcon/FieldGuideItemIcon.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItemIcon/FieldGuideItemIcon.js
@@ -3,15 +3,24 @@ import React from 'react'
 import { Media } from '@zooniverse/react-components'
 import PropTypes from 'prop-types'
 
-export default function FieldGuideItemIcon({ alt, className, height, icon, viewBox, width }) {
+export default function FieldGuideItemIcon(props) {
+  const { alt, className, height, icon, viewBox, width } = props
   if (icon && Object.keys(icon).length > 0) {
     return (
-      <Media alt={alt} className={className} fit='contain' height={height} src={icon.src} width={width} />
+      <Media
+        alt={alt}
+        className={className}
+        fit='contain'
+        height={height}
+        src={icon.src}
+        width={width}
+        {...props}
+      />
     )
   }
 
   return (
-    <svg className={className} viewBox={viewBox}>
+    <svg className={className} viewBox={viewBox} {...props}>
       <rect fill={zooTheme.global.colors['accent-2']} height={height} width={width} />
     </svg>
   )

--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -349,27 +349,27 @@ const theme = deepFreeze({
     small: {
       size: '12px',
       height: '18px',
-      maxWidth: '288px'
+      maxWidth: '100%'
     },
     medium: {
       size: '14px',
       height: '22px',
-      maxWidth: '336px'
+      maxWidth: '100%'
     },
     large: {
       size: '18px',
       height: '26px',
-      maxWidth: '432px'
+      maxWidth: '100%'
     },
     xlarge: {
       size: '22px',
       height: '30px',
-      maxWidth: '528px'
+      maxWidth: '100%'
     },
     xxlarge: {
       size: '26px',
       height: '34px',
-      maxWidth: '624px'
+      maxWidth: '100%'
     },
     extend: props => `margin: ${props.margin || '1em 0 1em 0'}`
   },
@@ -377,32 +377,32 @@ const theme = deepFreeze({
     xsmall: {
       size: "12px",
       height: "18px",
-      maxWidth: "288px"
+      maxWidth: "100%"
     },
     small: {
       size: "14px",
       height: "20px",
-      maxWidth: "336px"
+      maxWidth: "100%"
     },
     medium: {
       size: "18px",
       height: "24px",
-      maxWidth: "432px"
+      maxWidth: "100%"
     },
     large: {
       size: "22px",
       height: "28px",
-      maxWidth: "528px"
+      maxWidth: "100%"
     },
     xlarge: {
       size: "26px",
       height: "32px",
-      maxWidth: "624px"
+      maxWidth: "100%"
     },
     xxlarge: {
       size: "34px",
       height: "40px",
-      maxWidth: "816px"
+      maxWidth: "100%"
     }
   },
   radioButton: {

--- a/packages/lib-react-components/src/Media/components/Audio/Audio.js
+++ b/packages/lib-react-components/src/Media/components/Audio/Audio.js
@@ -2,9 +2,10 @@ import React from 'react'
 import { Anchor, Box } from 'grommet'
 import { propTypes, defaultProps } from '../../helpers/mediaPropTypes'
 
-export default function Audio({ alt, controls, flex, src }) {
+export default function Audio(props) {
+  const { alt, controls, flex, src } = props
   return (
-    <Box flex={flex}>
+    <Box flex={flex} {...props}>
       <audio aria-label={alt} controls={controls} preload='metadata'>
         <source src={src} />
         <Anchor href={src} label={alt} />

--- a/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.js
+++ b/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.js
@@ -20,7 +20,7 @@ const StyledImage = styled(Image)`
 
 export function Placeholder(props) {
   return (
-    <Box background={zooTheme.global.colors.brand} flex={props.flex} justify='center' align='center'>
+    <Box background={zooTheme.global.colors.brand} flex={props.flex} justify='center' align='center' {...props}>
       {props.children}
     </Box>
   )
@@ -57,8 +57,8 @@ export default class ThumbnailImage extends React.Component {
         {(returnedSrc, loading) => (
           <>
             {loading ?
-              <Placeholder height={height} flex={flex} width={width}>{placeholder}</Placeholder> :
-              <StyledBox animation={loading ? undefined : "fadeIn"} flex={flex} maxWidth={width} maxHeight={height}>
+              <Placeholder height={height} flex={flex} width={width} {...this.props}>{placeholder}</Placeholder> :
+              <StyledBox animation={loading ? undefined : "fadeIn"} flex={flex} maxWidth={width} maxHeight={height} {...this.props}>
                 <StyledImage
                   alt={alt}
                   fit={fit}

--- a/packages/lib-react-components/src/Media/components/Video/Video.js
+++ b/packages/lib-react-components/src/Media/components/Video/Video.js
@@ -2,10 +2,11 @@ import React from 'react'
 import { Anchor, Box, Video as GrommetVideo } from 'grommet'
 import { propTypes, defaultProps } from '../../helpers/mediaPropTypes'
 
-export default function Video({ alt, controls, flex, fit, src }) {
+export default function Video(props) {
+  const { alt, controls, flex, fit, src } = props
   const controlsOption = (controls) ? 'below' : false
   return (
-    <Box flex={flex}>
+    <Box flex={flex} {...props}>
       <GrommetVideo a11yTitle={alt} controls={controlsOption} fit={fit} preload='metadata' src={src}>
         <Anchor href={src} label={alt} />
       </GrommetVideo>

--- a/packages/lib-react-components/src/Modal/WithLayer.js
+++ b/packages/lib-react-components/src/Modal/WithLayer.js
@@ -1,6 +1,13 @@
 import { Layer } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
+import styled from 'styled-components'
+
+// All modals should have box-shadow, but we do not set this as the standard for Layer in the theme
+// Because layer can be used without modality
+const StyledLayer = styled(Layer)`
+  box-shadow: 0px 10px 20px #000030;
+`
 
 function WithLayer (WrappedComponent) {
   function HOC ({ active, className, closeFn, modal, ...props }) {
@@ -9,14 +16,14 @@ function WithLayer (WrappedComponent) {
     }
 
     return (
-      <Layer
+      <StyledLayer
         className={className}
         modal={modal}
         onClickOutside={closeFn}
         onEsc={closeFn}
       >
         <WrappedComponent {...props} closeFn={closeFn} />
-      </Layer>
+      </StyledLayer>
     )
   }
 


### PR DESCRIPTION
Package: lib-classifier, lib-react-components, lib-grommet-theme

For #666

Describe your changes:
Fixes:

- heading and paragraph styling in selected item content
- item heading no longer being cutoff when overflow happens
- adds box-shadow to the react-components Modal
- set paragraph default in theme to take a max-width of 100% and more specific styles can be defined in components

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

