### PR TITLE
Install an accessibility linter

### DIFF
--- a/packages/app-project/package-lock.json
+++ b/packages/app-project/package-lock.json
@@ -15,7 +15,7 @@
 		"@babel/core": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.2.tgz",
-			"integrity": "sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==",
+			"integrity": "sha1-+NKpzraDKIcymntg+dA1eRQAuk4=",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/generator": "^7.1.2",
@@ -70,7 +70,7 @@
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
-			"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+			"integrity": "sha1-a2lijf5Ah3mODE7Zjj1Kay+9L18=",
 			"requires": {
 				"@babel/helper-explode-assignable-expression": "^7.1.0",
 				"@babel/types": "^7.0.0"
@@ -79,7 +79,7 @@
 		"@babel/helper-builder-react-jsx": {
 			"version": "7.3.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
-			"integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
+			"integrity": "sha1-oayVpdKz6Irl5UhGv0Yu64GzGKQ=",
 			"requires": {
 				"@babel/types": "^7.3.0",
 				"esutils": "^2.0.0"
@@ -88,7 +88,7 @@
 		"@babel/helper-call-delegate": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
-			"integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+			"integrity": "sha1-apV/EF83dV6GRTQ9MDiiLhRJzEo=",
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.0.0",
 				"@babel/traverse": "^7.1.0",
@@ -112,7 +112,7 @@
 		"@babel/helper-define-map": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
-			"integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+			"integrity": "sha1-O3TK7DKbPIDBFikIh8DdmuRowgw=",
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/types": "^7.0.0",
@@ -122,7 +122,7 @@
 		"@babel/helper-explode-assignable-expression": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
-			"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+			"integrity": "sha1-U3+hP28WdN90WwwA7I/k6ZaByPY=",
 			"requires": {
 				"@babel/traverse": "^7.1.0",
 				"@babel/types": "^7.0.0"
@@ -149,7 +149,7 @@
 		"@babel/helper-hoist-variables": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
-			"integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+			"integrity": "sha1-Rq3ExedYZFrnpF3rkrqwkYwju4g=",
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -173,7 +173,7 @@
 		"@babel/helper-module-transforms": {
 			"version": "7.2.2",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz",
-			"integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
+			"integrity": "sha1-qy+OjSMUCfg3DIg9IMM1GQKEuWM=",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-simple-access": "^7.1.0",
@@ -186,7 +186,7 @@
 				"@babel/template": {
 					"version": "7.2.2",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
-					"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+					"integrity": "sha1-AFs/3w7ZbogEEzA3ng2ppwjrKQc=",
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"@babel/parser": "^7.2.2",
@@ -211,7 +211,7 @@
 		"@babel/helper-regex": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
-			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+			"integrity": "sha1-LBcYkjtX+bvmRwX/5WQKxk2b2yc=",
 			"requires": {
 				"lodash": "^4.17.10"
 			}
@@ -219,7 +219,7 @@
 		"@babel/helper-remap-async-to-generator": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
-			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+			"integrity": "sha1-Nh2AghtvONp1vT8HheziCojF/n8=",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"@babel/helper-wrap-function": "^7.1.0",
@@ -242,7 +242,7 @@
 		"@babel/helper-simple-access": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
-			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+			"integrity": "sha1-Ze65VMjCRb6qToWdphiPOdceWFw=",
 			"requires": {
 				"@babel/template": "^7.1.0",
 				"@babel/types": "^7.0.0"
@@ -259,7 +259,7 @@
 		"@babel/helper-wrap-function": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
-			"integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+			"integrity": "sha1-xOABJEV2nigVtVKW6tQ6lYVJ9vo=",
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/template": "^7.1.0",
@@ -270,7 +270,7 @@
 		"@babel/helpers": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz",
-			"integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
+			"integrity": "sha1-lJ7snqS0XTIQ/rfcHCLbZkyeRLk=",
 			"requires": {
 				"@babel/template": "^7.1.2",
 				"@babel/traverse": "^7.1.5",
@@ -295,7 +295,7 @@
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
-			"integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+			"integrity": "sha1-somzBmadzkrSCwJSiJoVdoydQX4=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-remap-async-to-generator": "^7.1.0",
@@ -305,7 +305,7 @@
 		"@babel/plugin-proposal-class-properties": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
-			"integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
+			"integrity": "sha1-mvAYVrEkHbYOyIONhGkaoL0ejfQ=",
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-member-expression-to-functions": "^7.0.0",
@@ -329,7 +329,7 @@
 		"@babel/plugin-proposal-json-strings": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
-			"integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
+			"integrity": "sha1-Vo7MRGxhSK5rJn8CVREwiR4p8xc=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-json-strings": "^7.2.0"
@@ -338,7 +338,7 @@
 		"@babel/plugin-proposal-object-rest-spread": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
-			"integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
+			"integrity": "sha1-mhe1R/ZNBna2yc7NTt90qCq4Xn4=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-object-rest-spread": "^7.0.0"
@@ -347,7 +347,7 @@
 		"@babel/plugin-proposal-optional-catch-binding": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
-			"integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+			"integrity": "sha1-E12B7baKCB5V5W7EhUHs6AZcOPU=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
@@ -365,7 +365,7 @@
 		"@babel/plugin-proposal-unicode-property-regex": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz",
-			"integrity": "sha512-LvRVYb7kikuOtIoUeWTkOxQEV1kYvL5B6U3iWEGCzPNRus1MzJweFqORTj+0jkxozkTSYNJozPOddxmqdqsRpw==",
+			"integrity": "sha1-q+coH+Rsld3BQ6ZeU1hkd5IDlSA=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0",
@@ -375,7 +375,7 @@
 		"@babel/plugin-syntax-async-generators": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
-			"integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+			"integrity": "sha1-aeHw2zTG9aDPfiszI78VmnbIy38=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -383,7 +383,7 @@
 		"@babel/plugin-syntax-class-properties": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.2.0.tgz",
-			"integrity": "sha512-UxYaGXYQ7rrKJS/PxIKRkv3exi05oH7rokBAsmCSsCxz1sVPZ7Fu6FzKoGgUvmY+0YgSkYHgUoCh5R5bCNBQlw==",
+			"integrity": "sha1-I7O3ubzavXNnKpFJ9yjNO+YhSBI=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -399,7 +399,7 @@
 		"@babel/plugin-syntax-dynamic-import": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
-			"integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
+			"integrity": "sha1-bft9i2w74UzpUpYvZY87frVMM+4=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -407,7 +407,7 @@
 		"@babel/plugin-syntax-flow": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz",
-			"integrity": "sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==",
+			"integrity": "sha1-p2XwYfgDvEjyQMJvh0f6+Xwmv3w=",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -416,7 +416,7 @@
 		"@babel/plugin-syntax-json-strings": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
-			"integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+			"integrity": "sha1-cr0T9v/h0lk4Ep0qGGsR/WKVFHA=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -424,7 +424,7 @@
 		"@babel/plugin-syntax-jsx": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
-			"integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
+			"integrity": "sha1-C4WjtLx830zEuL8jYzW5B8oi58c=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -432,7 +432,7 @@
 		"@babel/plugin-syntax-object-rest-spread": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
-			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+			"integrity": "sha1-O3o+czUQxX6CC5FCpleayLDfrS4=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -440,7 +440,7 @@
 		"@babel/plugin-syntax-optional-catch-binding": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
-			"integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+			"integrity": "sha1-qUAT1u2okI3+akd+f57ahWVuz1w=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -456,7 +456,7 @@
 		"@babel/plugin-syntax-typescript": {
 			"version": "7.3.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
-			"integrity": "sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==",
+			"integrity": "sha1-p8w/ZhGan36+LeU4PM4ZNHPWWZE=",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -465,7 +465,7 @@
 		"@babel/plugin-transform-arrow-functions": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
-			"integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+			"integrity": "sha1-mur75Nb/xlY7+Pg3IJFijwB3lVA=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -483,7 +483,7 @@
 		"@babel/plugin-transform-block-scoped-functions": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
-			"integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+			"integrity": "sha1-XTzBHo1d3XUqpkyRSNDbbLef0ZA=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -515,7 +515,7 @@
 		"@babel/plugin-transform-computed-properties": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
-			"integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+			"integrity": "sha1-g6ffamWIZbHI9kHVEMbzryICFto=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -523,7 +523,7 @@
 		"@babel/plugin-transform-destructuring": {
 			"version": "7.3.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.3.2.tgz",
-			"integrity": "sha512-Lrj/u53Ufqxl/sGxyjsJ2XNtNuEjDyjpqdhMNh5aZ+XFOdThL46KBj27Uem4ggoezSYBxKWAil6Hu8HtwqesYw==",
+			"integrity": "sha1-8vVSC+BVuhw4xBwOCU2KRh3Xjy0=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -531,7 +531,7 @@
 		"@babel/plugin-transform-dotall-regex": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz",
-			"integrity": "sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==",
+			"integrity": "sha1-8Kq7k9EgqKxh6SXqC6RAgS2+Dkk=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0",
@@ -541,7 +541,7 @@
 		"@babel/plugin-transform-duplicate-keys": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
-			"integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+			"integrity": "sha1-2VLEkw8xKk2//xjwspFOYMNVMLM=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -549,7 +549,7 @@
 		"@babel/plugin-transform-exponentiation-operator": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
-			"integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+			"integrity": "sha1-pjhoKJ5bQAf3BU1GSRr1FDV2YAg=",
 			"requires": {
 				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -568,7 +568,7 @@
 		"@babel/plugin-transform-for-of": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.2.0.tgz",
-			"integrity": "sha512-Kz7Mt0SsV2tQk6jG5bBv5phVbkd0gd27SgYD4hH1aLMJRchM0dzHaXvrWhVZ+WxAlDoAKZ7Uy3jVTW2mKXQ1WQ==",
+			"integrity": "sha1-q3RovvqA92S7A9PLXu+MyZjhytk=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -576,7 +576,7 @@
 		"@babel/plugin-transform-function-name": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz",
-			"integrity": "sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==",
+			"integrity": "sha1-95MDYoKf+ZoxdMOfCvzAJO9Zcxo=",
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -585,7 +585,7 @@
 		"@babel/plugin-transform-literals": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
-			"integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+			"integrity": "sha1-aQNT6B+SZ9rU/Yz9d+r6hqulPqE=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -593,7 +593,7 @@
 		"@babel/plugin-transform-modules-amd": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
-			"integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+			"integrity": "sha1-gqm85FuVRB9heiQBHcidEtp/TuY=",
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -602,7 +602,7 @@
 		"@babel/plugin-transform-modules-commonjs": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
-			"integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
+			"integrity": "sha1-Cp2GRRy7+ym9FRhjBol8Z/b5oFw=",
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -621,7 +621,7 @@
 		"@babel/plugin-transform-modules-umd": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
-			"integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+			"integrity": "sha1-dnjOdRafCHe46yI1U4wHQmjdAa4=",
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -630,7 +630,7 @@
 		"@babel/plugin-transform-named-capturing-groups-regex": {
 			"version": "7.3.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.3.0.tgz",
-			"integrity": "sha512-NxIoNVhk9ZxS+9lSoAQ/LM0V2UEvARLttEHUrRDGKFaAxOYQcrkN/nLRE+BbbicCAvZPl7wMP0X60HsHE5DtQw==",
+			"integrity": "sha1-FAtSmFstbvDLCS7zspUCuZD5zVA=",
 			"dev": true,
 			"requires": {
 				"regexp-tree": "^0.1.0"
@@ -639,7 +639,7 @@
 		"@babel/plugin-transform-new-target": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
-			"integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
+			"integrity": "sha1-ro+9iVF/p4ktIOZWTmQeh3DDqko=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -647,7 +647,7 @@
 		"@babel/plugin-transform-object-super": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
-			"integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+			"integrity": "sha1-s11MEPVrq11lAEfa0PHY6IFLZZg=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-replace-supers": "^7.1.0"
@@ -656,7 +656,7 @@
 		"@babel/plugin-transform-parameters": {
 			"version": "7.3.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.3.3.tgz",
-			"integrity": "sha512-IrIP25VvXWu/VlBWTpsjGptpomtIkYrN/3aDp4UKm7xK6UxZY88kcJ1UwETbzHAlwN21MnNfwlar0u8y3KpiXw==",
+			"integrity": "sha1-Ooc+BxFOGlvuF9BIFWYsgxfxDjA=",
 			"requires": {
 				"@babel/helper-call-delegate": "^7.1.0",
 				"@babel/helper-get-function-arity": "^7.0.0",
@@ -666,7 +666,7 @@
 		"@babel/plugin-transform-react-constant-elements": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.2.0.tgz",
-			"integrity": "sha512-YYQFg6giRFMsZPKUM9v+VcHOdfSQdz9jHCx3akAi3UYgyjndmdYGSXylQ/V+HswQt4fL8IklchD9HTsaOCrWQQ==",
+			"integrity": "sha1-7WAtwti/8vDLGlzikmPb3sQHefc=",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
@@ -676,7 +676,7 @@
 		"@babel/plugin-transform-react-display-name": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
-			"integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
+			"integrity": "sha1-6/rth4NM6NxCeWCaTwwyTBVuPrA=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -684,7 +684,7 @@
 		"@babel/plugin-transform-react-jsx": {
 			"version": "7.3.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
-			"integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
+			"integrity": "sha1-8sq5kCZjHHZ+J0WlNoszHP6PUpA=",
 			"requires": {
 				"@babel/helper-builder-react-jsx": "^7.3.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -694,7 +694,7 @@
 		"@babel/plugin-transform-react-jsx-self": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
-			"integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
+			"integrity": "sha1-Rh4hrZR48QMd1eJ2EI0CfxtSQLo=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-jsx": "^7.2.0"
@@ -703,7 +703,7 @@
 		"@babel/plugin-transform-react-jsx-source": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
-			"integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
+			"integrity": "sha1-IMjGDwFA9d081jQY1FKAHPP3GA8=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-jsx": "^7.2.0"
@@ -720,7 +720,7 @@
 		"@babel/plugin-transform-runtime": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.1.0.tgz",
-			"integrity": "sha512-WFLMgzu5DLQEah0lKTJzYb14vd6UiES7PTnXcvrPZ1VrwFeJ+mTbvr65fFAsXYMt2bIoOoC0jk76zY1S7HZjUg==",
+			"integrity": "sha1-n3aSDUJVG7V34txZTfIptfdiS2M=",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -731,7 +731,7 @@
 				"resolve": {
 					"version": "1.10.0",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-					"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+					"integrity": "sha1-O9qur0XMB/N1ZW39LlTtCBCxAbo=",
 					"requires": {
 						"path-parse": "^1.0.6"
 					}
@@ -741,7 +741,7 @@
 		"@babel/plugin-transform-shorthand-properties": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
-			"integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+			"integrity": "sha1-YzOu4vjW7n4oYVRXKYk0o7RhmPA=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -749,7 +749,7 @@
 		"@babel/plugin-transform-spread": {
 			"version": "7.2.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
-			"integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+			"integrity": "sha1-MQOpq+IvdCttQG7NPNSbd0kZtAY=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -757,7 +757,7 @@
 		"@babel/plugin-transform-sticky-regex": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
-			"integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+			"integrity": "sha1-oeRUtZlVYKnB4NU338FQYf0mh+E=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0"
@@ -766,7 +766,7 @@
 		"@babel/plugin-transform-template-literals": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
-			"integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
+			"integrity": "sha1-2H7QG46qx6kkc/YIyXwIneK6Hls=",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -775,7 +775,7 @@
 		"@babel/plugin-transform-typeof-symbol": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
-			"integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+			"integrity": "sha1-EX0rzsL79ktLWdH5gZiUaC0p8rI=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -783,7 +783,7 @@
 		"@babel/plugin-transform-typescript": {
 			"version": "7.3.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.3.2.tgz",
-			"integrity": "sha512-Pvco0x0ZSCnexJnshMfaibQ5hnK8aUHSvjCQhC1JR8eeg+iBwt0AtCO7gWxJ358zZevuf9wPSO5rv+WJcbHPXQ==",
+			"integrity": "sha1-WacicWPlVziELwQ9nlvXwEBEfZY=",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -793,7 +793,7 @@
 		"@babel/plugin-transform-unicode-regex": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz",
-			"integrity": "sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==",
+			"integrity": "sha1-TrjbFvly+Ku1BiwWG4sRVUat4Is=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0",
@@ -803,7 +803,7 @@
 		"@babel/preset-env": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.0.tgz",
-			"integrity": "sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==",
+			"integrity": "sha1-5n6lsEQc/qsdb0HptceXmIAOjRE=",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -851,7 +851,7 @@
 		"@babel/preset-flow": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.0.0.tgz",
-			"integrity": "sha512-bJOHrYOPqJZCkPVbG1Lot2r5OSsB+iUOaxiHdlOeB1yPWS6evswVHwvkDLZ54WTaTRIk89ds0iHmGZSnxlPejQ==",
+			"integrity": "sha1-r9dkg12VNexj2MfUyvHAZFcmPaI=",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -861,7 +861,7 @@
 		"@babel/preset-react": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
-			"integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
+			"integrity": "sha1-6GtLPZlDPHs+npF0fiZTlYvGs8A=",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-transform-react-display-name": "^7.0.0",
@@ -873,7 +873,7 @@
 		"@babel/preset-typescript": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.1.0.tgz",
-			"integrity": "sha512-LYveByuF9AOM8WrsNne5+N79k1YxjNB6gmpCQsnuSBAcV8QUeB+ZUxQzL7Rz7HksPbahymKkq2qBR+o36ggFZA==",
+			"integrity": "sha1-Sa1uIIT/C/tfH3+ztedsQ01ELH8=",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -931,7 +931,7 @@
 		"@babel/runtime-corejs2": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.1.2.tgz",
-			"integrity": "sha512-drxaPByExlcRDKW4ZLubUO4ZkI8/8ax9k9wve1aEthdLKFzjB7XRkOQ0xoTIWGxqdDnWDElkjYq77bt7yrcYJQ==",
+			"integrity": "sha1-hpWBGj/YCR9U8nS5MgM05ejGIgA=",
 			"requires": {
 				"core-js": "^2.5.7",
 				"regenerator-runtime": "^0.12.0"
@@ -947,7 +947,7 @@
 		"@babel/template": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
-			"integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+			"integrity": "sha1-CQSEpXT+9aLS13JqZ07O2lxbVkQ=",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/parser": "^7.1.2",
@@ -993,7 +993,7 @@
 		"@emotion/cache": {
 			"version": "0.8.8",
 			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-0.8.8.tgz",
-			"integrity": "sha512-yaQQjNAVkKclMX6D8jTU3rhQKjCnXU1KS+Ok0lgZcarGHI2yydU/kKHyF3PZnQhbTpIFBK5W4+HmLCtCie7ESw==",
+			"integrity": "sha1-LDvRql/biPHMIyUXaj8yAXOecmw=",
 			"dev": true,
 			"requires": {
 				"@emotion/sheet": "^0.8.1",
@@ -1004,7 +1004,7 @@
 		"@emotion/core": {
 			"version": "0.13.1",
 			"resolved": "https://registry.npmjs.org/@emotion/core/-/core-0.13.1.tgz",
-			"integrity": "sha512-5qzKP6bTe2Ah7Wvh1sgtzgy6ycdpxwgMAjQ/K/VxvqBxveG9PCpq+Z0GdVg7Houb1AwYjTfNtXstjSk4sqi/7g==",
+			"integrity": "sha1-T6SYPhjb8In6FlhEhsgDPKUAE+o=",
 			"dev": true,
 			"requires": {
 				"@emotion/cache": "^0.8.8",
@@ -1017,7 +1017,7 @@
 		"@emotion/css": {
 			"version": "0.9.8",
 			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-0.9.8.tgz",
-			"integrity": "sha512-Stov3+9+KWZAte/ED9Hts3r4DVBADd5erDrhrywokM31ctQsRPD3qk8W4d1ca48ry57g/nc0qUHNis/xd1SoFg==",
+			"integrity": "sha1-Q/1FxXZlbU7ZzDuLQnxmou1q8wo=",
 			"dev": true,
 			"requires": {
 				"@emotion/serialize": "^0.9.1",
@@ -1027,7 +1027,7 @@
 		"@emotion/hash": {
 			"version": "0.6.6",
 			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
-			"integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ==",
+			"integrity": "sha1-YiZsXw6saUH+zjAqutafLufiXkQ=",
 			"dev": true
 		},
 		"@emotion/is-prop-valid": {
@@ -1046,7 +1046,7 @@
 		"@emotion/provider": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/@emotion/provider/-/provider-0.11.2.tgz",
-			"integrity": "sha512-y/BRd6cJ9tyxsy4EK8WheD2X1/RfmudMYILpa8sgI3dKCjVWeEZuQM17wXRVEyhrisaRaIp1qT4h0eWUaaqNLg==",
+			"integrity": "sha1-cJnx31ZBlp7k1v9c8VYSlZFAMKo=",
 			"dev": true,
 			"requires": {
 				"@emotion/cache": "^0.8.8",
@@ -1056,7 +1056,7 @@
 		"@emotion/serialize": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.9.1.tgz",
-			"integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
+			"integrity": "sha1-pJSYKmkgcw26YwPrAYIgorYpwUU=",
 			"dev": true,
 			"requires": {
 				"@emotion/hash": "^0.6.6",
@@ -1074,7 +1074,7 @@
 				"@emotion/unitless": {
 					"version": "0.6.7",
 					"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
-					"integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg==",
+					"integrity": "sha1-U+nxiS9yWxlNXmoWhKezlN9ZI5c=",
 					"dev": true
 				}
 			}
@@ -1082,13 +1082,13 @@
 		"@emotion/sheet": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.8.1.tgz",
-			"integrity": "sha512-p82hFBHbNkPLZ410HOeaRJZMrN1uh9rI7JAaRXIp62PP5evspPXyi3xYtxZc1+sCSlwjnQPuOIa6N88iJNtPXw==",
+			"integrity": "sha1-bu1obJJ6HDn1BF7EXs+jbeiWgZ0=",
 			"dev": true
 		},
 		"@emotion/styled": {
 			"version": "0.10.6",
 			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-0.10.6.tgz",
-			"integrity": "sha512-DFNW8jlMjy1aYCj/PKsvBoJVZAQXzjmSCwtKXLs31qZzNPaUEPbTYSIKnMUtIiAOYsu0pUTGXM+l0a+MYNm4lA==",
+			"integrity": "sha1-H2rx09S/n96wWk0iAEbOEa0hp8o=",
 			"dev": true,
 			"requires": {
 				"@emotion/styled-base": "^0.10.6"
@@ -1097,7 +1097,7 @@
 		"@emotion/styled-base": {
 			"version": "0.10.6",
 			"resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-0.10.6.tgz",
-			"integrity": "sha512-7RfdJm2oEXiy3isFRY63mHRmWWjScFXFoZTFkCJPaL8NhX+H724WwIoQOt3WA1Jd+bb97xkJg31JbYYsSqnEaQ==",
+			"integrity": "sha1-yVYxtrTxnal+e0TuTj7hkxr94mQ=",
 			"dev": true,
 			"requires": {
 				"@emotion/is-prop-valid": "^0.6.8",
@@ -1125,7 +1125,7 @@
 		"@emotion/stylis": {
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
-			"integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ==",
+			"integrity": "sha1-UPYyJecS2Z4rKznBnHD/8CN5PKU=",
 			"dev": true
 		},
 		"@emotion/unitless": {
@@ -1136,19 +1136,19 @@
 		"@emotion/utils": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
-			"integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==",
+			"integrity": "sha1-V2/3+xIwGFthmnXSWMvJjwhnqNw=",
 			"dev": true
 		},
 		"@emotion/weak-memoize": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.1.3.tgz",
-			"integrity": "sha512-QsYGKdhhuDFNq7bjm2r44y0mp5xW3uO3csuTPDWZc0OIiMQv+AIY5Cqwd4mJiC5N8estVl7qlvOx1hbtOuUWbw==",
+			"integrity": "sha1-twDZc4X6ka/+1gxx39UcZ+na12I=",
 			"dev": true
 		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+			"integrity": "sha1-UkryQNGjYFJ7cwR17PoTRKpUDd4=",
 			"dev": true,
 			"requires": {
 				"call-me-maybe": "^1.0.1",
@@ -1158,7 +1158,7 @@
 		"@nodelib/fs.stat": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
-			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+			"integrity": "sha1-K1o6s/kYzKSKjHVMCBaOPwPrphs=",
 			"dev": true
 		},
 		"@sinonjs/commons": {
@@ -1345,7 +1345,7 @@
 				"@babel/plugin-transform-modules-commonjs": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
-					"integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
+					"integrity": "sha1-xPGTP1mR1RRenPrR39hI6hcn9AQ=",
 					"dev": true,
 					"requires": {
 						"@babel/helper-module-transforms": "^7.1.0",
@@ -1413,7 +1413,7 @@
 				"json5": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+					"integrity": "sha1-56DGLEgoXGKNIKELhcibuAfDKFA=",
 					"dev": true,
 					"requires": {
 						"minimist": "^1.2.0"
@@ -1428,13 +1428,13 @@
 				"node-fetch": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-					"integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+					"integrity": "sha1-Gh2UC7+5FqHT4CGfA36J5x+MX6U=",
 					"dev": true
 				},
 				"resolve": {
 					"version": "1.10.0",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-					"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+					"integrity": "sha1-O9qur0XMB/N1ZW39LlTtCBCxAbo=",
 					"dev": true,
 					"requires": {
 						"path-parse": "^1.0.6"
@@ -1451,7 +1451,7 @@
 		"@storybook/mantra-core": {
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/@storybook/mantra-core/-/mantra-core-1.7.2.tgz",
-			"integrity": "sha512-GD4OYJ8GsayVhIg306sfgcKDk9j8YfuSKIAWvdB/g7IDlw0pDgueONALVEEE2XWJtCwcsUyDtCYzXFgCBWLEjA==",
+			"integrity": "sha1-4Qx/rKKXaelxMeDgMI73z7ZVtww=",
 			"dev": true,
 			"requires": {
 				"@storybook/react-komposer": "^2.0.1",
@@ -1483,7 +1483,7 @@
 		"@storybook/podda": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/@storybook/podda/-/podda-1.2.3.tgz",
-			"integrity": "sha512-g7dsdsn50AhlGZ8iIDKdF8bi7Am++iFOq+QN+hNKz3FvgLuf8Dz+mpC/BFl90eE9bEYxXqXKeMf87399Ec5Qhw==",
+			"integrity": "sha1-U8Sho/jHu9V1Xf9cNFdv0a+dOLo=",
 			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.11.6",
@@ -1529,7 +1529,7 @@
 		"@storybook/react-komposer": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@storybook/react-komposer/-/react-komposer-2.0.5.tgz",
-			"integrity": "sha512-zX5UITgAh37tmD0MWnUFR29S5YM8URMHc/9iwczX/P1f3tM4nPn8VAzxG/UWQecg1xZVphmqkZoux+SDrtTZOQ==",
+			"integrity": "sha1-DCMWPyiy4b0q7rRCH+04K7US3g4=",
 			"dev": true,
 			"requires": {
 				"@storybook/react-stubber": "^1.0.0",
@@ -1550,7 +1550,7 @@
 		"@storybook/react-simple-di": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@storybook/react-simple-di/-/react-simple-di-1.3.0.tgz",
-			"integrity": "sha512-RH6gPQaYMs/VzQX2dgbZU8DQMKFXVOv1ruohHjjNPys4q+YdqMFMDe5jOP1AUE3j9g01x0eW7bVjRawSpl++Ew==",
+			"integrity": "sha1-ExFtiaL0KJhxan+MQJW0dBVSY3E=",
 			"dev": true,
 			"requires": {
 				"babel-runtime": "6.x.x",
@@ -1570,7 +1570,7 @@
 		"@storybook/react-stubber": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@storybook/react-stubber/-/react-stubber-1.0.1.tgz",
-			"integrity": "sha512-k+CHH+vA8bQfCmzBTtJsPkITFgD+C/w19KuByZ9WeEvNUFtnDaCqfP+Vp3/OR+3IAfAXYYOWolqPLxNPcEqEjw==",
+			"integrity": "sha1-jDEsJli57q/ORw4cOeQZPwtb+bE=",
 			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.5.0"
@@ -1645,55 +1645,55 @@
 		"@svgr/babel-plugin-add-jsx-attribute": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.0.0.tgz",
-			"integrity": "sha512-PDvHV2WhSGCSExp+eIMEKxYd1Q0SBvXLb4gAOXbdh0dswHFFgXWzxGjCmx5aln4qGrhkuN81khzYzR/44DYaMA==",
+			"integrity": "sha1-Ws8jnNJ0exo27H5wjeBdkUy5uUg=",
 			"dev": true
 		},
 		"@svgr/babel-plugin-remove-jsx-attribute": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-4.0.3.tgz",
-			"integrity": "sha512-fpG7AzzJxz1tc8ITYS1jCAt1cq4ydK2R+sx//BMTJgvOjfk91M5GiqFolP8aYTzLcum92IGNAVFS3zEcucOQEA==",
+			"integrity": "sha1-MlZLXE12G1HjRJK2pIlBlsD3WAM=",
 			"dev": true
 		},
 		"@svgr/babel-plugin-remove-jsx-empty-expression": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-4.0.0.tgz",
-			"integrity": "sha512-nBGVl6LzXTdk1c6w3rMWcjq3mYGz+syWc5b3CdqAiEeY/nswYDoW/cnGUKKC8ofD6/LaG+G/IUnfv3jKoHz43A==",
+			"integrity": "sha1-C1kzjABnHPgTfrgjvYSj76xoZQI=",
 			"dev": true
 		},
 		"@svgr/babel-plugin-replace-jsx-attribute-value": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-4.0.0.tgz",
-			"integrity": "sha512-ejQqpTfORy6TT5w1x/2IQkscgfbtNFjitcFDu63GRz7qfhVTYhMdiJvJ1+Aw9hmv9bO4tXThGQDr1IF5lIvgew==",
+			"integrity": "sha1-kXhWQ1QMIwDz2J5RWzevm1zk5pU=",
 			"dev": true
 		},
 		"@svgr/babel-plugin-svg-dynamic-title": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-4.0.0.tgz",
-			"integrity": "sha512-OE6GT9WRKWqd0Dk6NJ5TYXTF5OxAyn74+c/D+gTLbCXnK2A0luEXuwMbe5zR5Px4A/jow2OeEBboTENl4vtuQg==",
+			"integrity": "sha1-641QuAugom+bJ8cmjiqAPZDxvJ4=",
 			"dev": true
 		},
 		"@svgr/babel-plugin-svg-em-dimensions": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-4.0.0.tgz",
-			"integrity": "sha512-QeDRGHXfjYEBTXxV0TsjWmepsL9Up5BOOlMFD557x2JrSiVGUn2myNxHIrHiVW0+nnWnaDcrkjg/jUvbJ5nKCg==",
+			"integrity": "sha1-DeOXLEb/GWC+12VkYDejp/nh2j0=",
 			"dev": true
 		},
 		"@svgr/babel-plugin-transform-react-native-svg": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-4.0.0.tgz",
-			"integrity": "sha512-c6eE6ovs14k6dmHKoy26h7iRFhjWNnwYVrDWIPfouVm/gcLIeMw/ME4i91O5LEfaDHs6kTRCcVpbAVbNULZOtw==",
+			"integrity": "sha1-Xo7MKphwrgX7HlU7H+nGtYU6HGY=",
 			"dev": true
 		},
 		"@svgr/babel-plugin-transform-svg-component": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-4.1.0.tgz",
-			"integrity": "sha512-uulxdx2p3nrM2BkrtADQHK8IhEzCxdUILfC/ddvFC8tlFWuKiA3ych8C6q0ulyQHq34/3hzz+3rmUbhWF9redg==",
+			"integrity": "sha1-JXFZ4oohrCCYix6qX1nUck83/ao=",
 			"dev": true
 		},
 		"@svgr/babel-preset": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-4.1.0.tgz",
-			"integrity": "sha512-Nat5aJ3VO3LE8KfMyIbd3sGWnaWPiFCeWIdEV+lalga0To/tpmzsnPDdnrR9fNYhvSSLJbwhU/lrLYt9wXY0ZQ==",
+			"integrity": "sha1-9vqK2QBkuF3Xo1ZqcLcAbnieg4U=",
 			"dev": true,
 			"requires": {
 				"@svgr/babel-plugin-add-jsx-attribute": "^4.0.0",
@@ -1709,7 +1709,7 @@
 		"@svgr/core": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-4.1.0.tgz",
-			"integrity": "sha512-ahv3lvOKuUAcs0KbQ4Jr5fT5pGHhye4ew8jZVS4lw8IQdWrbG/o3rkpgxCPREBk7PShmEoGQpteeXVwp2yExuQ==",
+			"integrity": "sha1-T4rST7SrJceHwSpru1EcZDBVj4M=",
 			"dev": true,
 			"requires": {
 				"@svgr/plugin-jsx": "^4.1.0",
@@ -1720,7 +1720,7 @@
 		"@svgr/hast-util-to-babel-ast": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-4.1.0.tgz",
-			"integrity": "sha512-tdkEZHmigYYiVhIEzycAMKN5aUSpddUnjr6v7bPwaNTFuSyqGUrpCg1JlIGi7PUaaJVHbn6whGQMGUpKOwT5nw==",
+			"integrity": "sha1-oesPRwWXaYlvdZ9HmVtjb85dn6Q=",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.1.6"
@@ -1729,7 +1729,7 @@
 		"@svgr/plugin-jsx": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-4.1.0.tgz",
-			"integrity": "sha512-xwu+9TGziuN7cu7p+vhCw2EJIfv8iDNMzn2dR0C7fBYc8q+SRtYTcg4Uyn8ZWh6DM+IZOlVrS02VEMT0FQzXSA==",
+			"integrity": "sha1-QEXpzAWJN0psGCoSF8gOZzS1y+w=",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.6",
@@ -1765,7 +1765,7 @@
 				"@babel/template": {
 					"version": "7.2.2",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
-					"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+					"integrity": "sha1-AFs/3w7ZbogEEzA3ng2ppwjrKQc=",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
@@ -1776,7 +1776,7 @@
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -1785,7 +1785,7 @@
 				"json5": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+					"integrity": "sha1-56DGLEgoXGKNIKELhcibuAfDKFA=",
 					"dev": true,
 					"requires": {
 						"minimist": "^1.2.0"
@@ -1808,7 +1808,7 @@
 		"@svgr/plugin-svgo": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-4.0.3.tgz",
-			"integrity": "sha512-MgL1CrlxvNe+1tQjPUc2bIJtsdJOIE5arbHlPgW+XVWGjMZTUcyNNP8R7/IjM2Iyrc98UJY+WYiiWHrinnY9ZQ==",
+			"integrity": "sha1-oH6gpzbCb6OlRA/o4iLi6Id2TKs=",
 			"dev": true,
 			"requires": {
 				"cosmiconfig": "^5.0.7",
@@ -1819,7 +1819,7 @@
 		"@svgr/webpack": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-4.1.0.tgz",
-			"integrity": "sha512-d09ehQWqLMywP/PT/5JvXwPskPK9QCXUjiSkAHehreB381qExXf5JFCBWhfEyNonRbkIneCeYM99w+Ud48YIQQ==",
+			"integrity": "sha1-IMiPMvcxx7HUcRBFsrmTiH1zHCg=",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.6",
@@ -1867,7 +1867,7 @@
 				"@babel/plugin-transform-modules-commonjs": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
-					"integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
+					"integrity": "sha1-xPGTP1mR1RRenPrR39hI6hcn9AQ=",
 					"dev": true,
 					"requires": {
 						"@babel/helper-module-transforms": "^7.1.0",
@@ -1929,7 +1929,7 @@
 				"@babel/template": {
 					"version": "7.2.2",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
-					"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+					"integrity": "sha1-AFs/3w7ZbogEEzA3ng2ppwjrKQc=",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
@@ -1940,7 +1940,7 @@
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -1949,7 +1949,7 @@
 				"json5": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+					"integrity": "sha1-56DGLEgoXGKNIKELhcibuAfDKFA=",
 					"dev": true,
 					"requires": {
 						"minimist": "^1.2.0"
@@ -1984,13 +1984,13 @@
 		"@types/unist": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+			"integrity": "sha1-nAiGeYdvN061mD8VDUeHqm+zLX4=",
 			"dev": true
 		},
 		"@types/vfile": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
-			"integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+			"integrity": "sha1-GcGM0jLfEc5vpq2AJZvIbDZrCbk=",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -2001,7 +2001,7 @@
 		"@types/vfile-message": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
-			"integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
+			"integrity": "sha1-4emJXMazbEYtQkTmTm0Lbq9lNVo=",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -2031,7 +2031,7 @@
 		"@webassemblyjs/helper-buffer": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz",
-			"integrity": "sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w=="
+			"integrity": "sha1-MSLUjcxslFbtmC3r4WyPNxAd85s="
 		},
 		"@webassemblyjs/helper-code-frame": {
 			"version": "1.7.11",
@@ -2059,7 +2059,7 @@
 		"@webassemblyjs/helper-wasm-section": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz",
-			"integrity": "sha512-8ZRY5iZbZdtNFE5UFunB8mmBEAbSI3guwbrsCl4fWdfRiAcvqQpeqd5KHhSWLL5wuxo53zcaGZDBU64qgn4I4Q==",
+			"integrity": "sha1-nJrEHs+fvP/8lvbSZ14t4zgR5oo=",
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-buffer": "1.7.11",
@@ -2070,7 +2070,7 @@
 		"@webassemblyjs/ieee754": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz",
-			"integrity": "sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==",
+			"integrity": "sha1-yVg562N1ejGICq7HtlEtQZGsZAs=",
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
@@ -2078,7 +2078,7 @@
 		"@webassemblyjs/leb128": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.11.tgz",
-			"integrity": "sha512-vuGmgZjjp3zjcerQg+JA+tGOncOnJLWVkt8Aze5eWQLwTQGNgVLcyOTqgSCxWTR4J42ijHbBxnuRaL1Rv7XMdw==",
+			"integrity": "sha1-1yZ6HunEWU/T9+NymIGOxlaH22M=",
 			"requires": {
 				"@xtuc/long": "4.2.1"
 			}
@@ -2086,12 +2086,12 @@
 		"@webassemblyjs/utf8": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.11.tgz",
-			"integrity": "sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA=="
+			"integrity": "sha1-Btchjqn9yUpnk6qSIIFg2z0m7oI="
 		},
 		"@webassemblyjs/wasm-edit": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz",
-			"integrity": "sha512-FUd97guNGsCZQgeTPKdgxJhBXkUbMTY6hFPf2Y4OedXd48H97J+sOY2Ltaq6WGVpIH8o/TGOVNiVz/SbpEMJGg==",
+			"integrity": "sha1-jHTKR01PlR0B266b1wgU7iKoIAU=",
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-buffer": "1.7.11",
@@ -2106,7 +2106,7 @@
 		"@webassemblyjs/wasm-gen": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz",
-			"integrity": "sha512-U/KDYp7fgAZX5KPfq4NOupK/BmhDc5Kjy2GIqstMhvvdJRcER/kUsMThpWeRP8BMn4LXaKhSTggIJPOeYHwISA==",
+			"integrity": "sha1-m7upQvIjdWhqb7dZr816ycRdoag=",
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
@@ -2118,7 +2118,7 @@
 		"@webassemblyjs/wasm-opt": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz",
-			"integrity": "sha512-XynkOwQyiRidh0GLua7SkeHvAPXQV/RxsUeERILmAInZegApOUAIJfRuPYe2F7RcjOC9tW3Cb9juPvAC/sCqvg==",
+			"integrity": "sha1-szHo5874+OLwB9QsOjagWAp9bKc=",
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-buffer": "1.7.11",
@@ -2129,7 +2129,7 @@
 		"@webassemblyjs/wasm-parser": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz",
-			"integrity": "sha512-6lmXRTrrZjYD8Ng8xRyvyXQJYUQKYSXhJqXOBLw24rdiXsHAOlvw5PhesjdcaMadU/pyPQOJ5dHreMjBxwnQKg==",
+			"integrity": "sha1-bj0g+mo1GfawhO+Tka1YIR77Cho=",
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-api-error": "1.7.11",
@@ -2165,7 +2165,7 @@
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+			"integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A="
 		},
 		"@xtuc/long": {
 			"version": "4.2.1",
@@ -2196,7 +2196,7 @@
 		"acorn-dynamic-import": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-			"integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
+			"integrity": "sha1-SCIQFAWCo2uDw+NC4c/ryqkkCUg="
 		},
 		"acorn-globals": {
 			"version": "4.3.0",
@@ -2223,13 +2223,13 @@
 		"address": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
-			"integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==",
+			"integrity": "sha1-tfUGMfjWzsi9IMljljr7VeBsvOk=",
 			"dev": true
 		},
 		"airbnb-js-shims": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-2.1.1.tgz",
-			"integrity": "sha512-h8UtyB/TCdOwWoEPQJGHgsWwSnTqPrRZbhyZYjAwY9/AbjdjfkKy9L/T3fIFS6MKX8YrpWFRm6xqFSgU+2DRGw==",
+			"integrity": "sha1-pQlhFIDbfm2dti/irPrrRztoQqw=",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.0.3",
@@ -2263,7 +2263,7 @@
 		"ajv-errors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+			"integrity": "sha1-81mGrOuRr63sQQL72FAUlQzvpk0="
 		},
 		"ajv-keywords": {
 			"version": "3.4.0",
@@ -2273,7 +2273,7 @@
 		"ansi-align": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-			"integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+			"integrity": "sha1-tTazcc9ofKrvI2wY0+If43l0Z8s=",
 			"dev": true,
 			"requires": {
 				"string-width": "^3.0.0"
@@ -2350,7 +2350,7 @@
 		"anymatch": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
 			"requires": {
 				"micromatch": "^3.1.4",
 				"normalize-path": "^2.1.1"
@@ -2375,12 +2375,12 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+			"integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
 		},
 		"are-we-there-yet": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+			"integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
 			"dev": true,
 			"requires": {
 				"delegates": "^1.0.0",
@@ -2390,7 +2390,7 @@
 		"arg": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-3.0.0.tgz",
-			"integrity": "sha512-C5Scb477yHhNck9AFzW5RwAzS2Eqn0HR+Fv0pmcZBXBT8g/g7OOuZTr0upVSSUGWZQH+XWdAKIw2OfC86EuggQ=="
+			"integrity": "sha1-OGwgA1376xPigMqKHmhoqheULe8="
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -2407,6 +2407,16 @@
 					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 					"dev": true
 				}
+			}
+		},
+		"aria-query": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+			"integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+			"dev": true,
+			"requires": {
+				"ast-types-flow": "0.0.7",
+				"commander": "^2.11.0"
 			}
 		},
 		"arr-diff": {
@@ -2431,7 +2441,7 @@
 		},
 		"array-equal": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
 			"dev": true
 		},
@@ -2504,7 +2514,7 @@
 		"array.prototype.flatmap": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.1.tgz",
-			"integrity": "sha512-i18e2APdsiezkcqDyZor78Pbfjfds3S94dG6dgIV2ZASJaUf1N0dz2tGdrmwrmlZuNUgxH+wz6Z0zYVH2c5xzQ==",
+			"integrity": "sha1-MQPNSCbvkAGcmwpIObJTX6b69Ok=",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
@@ -2534,7 +2544,7 @@
 		"asn1.js": {
 			"version": "4.10.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+			"integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
 			"requires": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
@@ -2584,13 +2594,19 @@
 		"ast-types": {
 			"version": "0.11.7",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.7.tgz",
-			"integrity": "sha512-2mP3TwtkY/aTv5X3ZsMpNAbOnyoC/aMJwJSoaELPkHId0nSQgFcnU4dRW3isxiz7+zBexk0ym3WNVjMiQBnJSw==",
+			"integrity": "sha1-8xi/ROM522oyC+AAne1k7BRx9Gw=",
+			"dev": true
+		},
+		"ast-types-flow": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
 			"dev": true
 		},
 		"async": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-			"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+			"integrity": "sha1-GDMOp+bjE4h/XS8qkEusb+TdU4E=",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.11"
@@ -2610,7 +2626,7 @@
 		"async-sema": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/async-sema/-/async-sema-2.1.4.tgz",
-			"integrity": "sha512-NKdMgXT9RfmkscybzytzK/6uGF4cL8Mt3PSeO9QHXYKs3oFWkUwIepnAkzLWkqttOdDDFoED3c8kriS8RzP+ow==",
+			"integrity": "sha1-P1qgkdCnYzVARe6Jml0X/7aSUa8=",
 			"requires": {
 				"double-ended-queue": "2.1.0-0"
 			}
@@ -2628,7 +2644,7 @@
 		"autodll-webpack-plugin": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/autodll-webpack-plugin/-/autodll-webpack-plugin-0.4.2.tgz",
-			"integrity": "sha512-JLrV3ErBNKVkmhi0celM6PJkgYEtztFnXwsNBApjinpVHtIP3g/m2ZZSOvsAe7FoByfJzDhpOXBKFbH3k2UNjw==",
+			"integrity": "sha1-NumPuvMMI10dXQdjMEZKyAkBQVw=",
 			"requires": {
 				"bluebird": "^3.5.0",
 				"del": "^3.0.0",
@@ -2680,6 +2696,15 @@
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
 			"dev": true
 		},
+		"axobject-query": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+			"integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
+			"dev": true,
+			"requires": {
+				"ast-types-flow": "0.0.7"
+			}
+		},
 		"babel-code-frame": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -2722,7 +2747,7 @@
 		"babel-core": {
 			"version": "7.0.0-bridge.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-			"integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
+			"integrity": "sha1-laSS3dkPm06aSh2hTrM1uHtjTs4="
 		},
 		"babel-eslint": {
 			"version": "10.0.1",
@@ -2780,7 +2805,7 @@
 		"babel-helper-evaluate-path": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
-			"integrity": "sha512-mUh0UhS607bGh5wUMAQfOpt2JX2ThXMtppHRdRU1kL7ZLRWIXxoV2UIV1r2cAeeNeU1M5SB5/RSUgUxrK8yOkA==",
+			"integrity": "sha1-pi+pxOZP9+pc6pNTF07wI6kApnw=",
 			"dev": true
 		},
 		"babel-helper-flip-expressions": {
@@ -2816,7 +2841,7 @@
 		"babel-helper-to-multiple-sequence-expressions": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
-			"integrity": "sha512-m2CvfDW4+1qfDdsrtf4dwOslQC3yhbgyBFptncp4wvtdrDHqueW7slsYv4gArie056phvQFhT2nRcGS4bnm6mA==",
+			"integrity": "sha1-o/kk41YYgtQvz0iQeqmPeXmkWI0=",
 			"dev": true
 		},
 		"babel-helpers": {
@@ -2831,7 +2856,7 @@
 		"babel-loader": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.2.tgz",
-			"integrity": "sha512-Law0PGtRV1JL8Y9Wpzc0d6EE0GD7LzXWCfaeWwboUMcBWNG6gvaWTK1/+BK7a4X5EmeJiGEuDDFxUsOa8RSWCw==",
+			"integrity": "sha1-IHm47BYoKEqSkkHaPZD1s94qWuU=",
 			"requires": {
 				"find-cache-dir": "^1.0.0",
 				"loader-utils": "^1.0.2",
@@ -2870,7 +2895,7 @@
 		"babel-plugin-macros": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.0.tgz",
-			"integrity": "sha512-BWw0lD0kVZAXRD3Od1kMrdmfudqzDzYv2qrN3l2ISR1HVp1EgLKfbOrYV9xmY5k3qx3RIu5uPAUZZZHpo0o5Iw==",
+			"integrity": "sha1-AfTTtQ7VZ6Z7gKMLnaBm6U9Al7Y=",
 			"dev": true,
 			"requires": {
 				"cosmiconfig": "^5.0.5",
@@ -2880,7 +2905,7 @@
 				"resolve": {
 					"version": "1.10.0",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-					"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+					"integrity": "sha1-O9qur0XMB/N1ZW39LlTtCBCxAbo=",
 					"dev": true,
 					"requires": {
 						"path-parse": "^1.0.6"
@@ -2891,13 +2916,13 @@
 		"babel-plugin-minify-builtins": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz",
-			"integrity": "sha512-wpqbN7Ov5hsNwGdzuzvFcjgRlzbIeVv1gMIlICbPj0xkexnfoIDe7q+AZHMkQmAE/F9R5jkrB6TLfTegImlXag==",
+			"integrity": "sha1-MeuC7RoNDv3DExL5O25HQc6Cw2s=",
 			"dev": true
 		},
 		"babel-plugin-minify-constant-folding": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz",
-			"integrity": "sha512-Vj97CTn/lE9hR1D+jKUeHfNy+m1baNiJ1wJvoGyOBUx7F7kJqDZxr9nCHjO/Ad+irbR3HzR6jABpSSA29QsrXQ==",
+			"integrity": "sha1-+EvI2/alYeXjUP+VriFrCtVRW24=",
 			"dev": true,
 			"requires": {
 				"babel-helper-evaluate-path": "^0.5.0"
@@ -2906,7 +2931,7 @@
 		"babel-plugin-minify-dead-code-elimination": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.0.tgz",
-			"integrity": "sha512-XQteBGXlgEoAKc/BhO6oafUdT4LBa7ARi55mxoyhLHNuA+RlzRmeMAfc31pb/UqU01wBzRc36YqHQzopnkd/6Q==",
+			"integrity": "sha1-0j71RFI4rQbord9cHPauyDW82oc=",
 			"dev": true,
 			"requires": {
 				"babel-helper-evaluate-path": "^0.5.0",
@@ -2942,7 +2967,7 @@
 		"babel-plugin-minify-mangle-names": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz",
-			"integrity": "sha512-3jdNv6hCAw6fsX1p2wBGPfWuK69sfOjfd3zjUXkbq8McbohWy23tpXfy5RnToYWggvqzuMOwlId1PhyHOfgnGw==",
+			"integrity": "sha1-vN21B8kdLJnhOL1rF6GcPCceP9M=",
 			"dev": true,
 			"requires": {
 				"babel-helper-mark-eval-scopes": "^0.4.3"
@@ -2957,13 +2982,13 @@
 		"babel-plugin-minify-replace": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz",
-			"integrity": "sha512-aXZiaqWDNUbyNNNpWs/8NyST+oU7QTpK7J9zFEFSA0eOmtUNMU3fczlTTTlnCxHmq/jYNFEmkkSG3DDBtW3Y4Q==",
+			"integrity": "sha1-0+LJlGyQlsBw78lnYc4ojsXD9xw=",
 			"dev": true
 		},
 		"babel-plugin-minify-simplify": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.0.tgz",
-			"integrity": "sha512-TM01J/YcKZ8XIQd1Z3nF2AdWHoDsarjtZ5fWPDksYZNsoOjQ2UO2EWm824Ym6sp127m44gPlLFiO5KFxU8pA5Q==",
+			"integrity": "sha1-HwkAGK+5DYtU09An/YpJJ/JD2m8=",
 			"dev": true,
 			"requires": {
 				"babel-helper-flip-expressions": "^0.4.3",
@@ -2983,13 +3008,13 @@
 		"babel-plugin-named-asset-import": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.2.3.tgz",
-			"integrity": "sha512-9mx2Z9M4EGbutvXxoLV7aUBCY6ps3sqLFl094FeA2tFQzQffIh0XSsmwwQRxiSfpg3rnb5x/o46qRLxS/OzFTg==",
+			"integrity": "sha1-tA7VCoSOe7Cip+NNmQ0fnUb+mzg=",
 			"dev": true
 		},
 		"babel-plugin-react-docgen": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-2.0.2.tgz",
-			"integrity": "sha512-fFendfUUU2KqqE1ki2NyQoZm4uHPoEWPUgBZiPBiowcPZos+4q+chdQh0nlwY5hxs08AMHSH4Pp98RQL0VFS/g==",
+			"integrity": "sha1-MwfidBTDcDZXEFdrf628r4mE2GI=",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.10",
@@ -3015,7 +3040,7 @@
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
 			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -3065,7 +3090,7 @@
 		"babel-plugin-transform-react-remove-prop-types": {
 			"version": "0.4.15",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.15.tgz",
-			"integrity": "sha512-bFxxYdkZBwTjTgtZEPTLqu9g8Ajz8x8uEP/O1iVuaZIz2RuxJ2gtx0EXDJRonC++KGsgsW/4Hqvk4KViEtE2nw=="
+			"integrity": "sha1-e6gw53J2oOeIzVjqUntfcDluEqc="
 		},
 		"babel-plugin-transform-regexp-constructors": {
 			"version": "0.4.3",
@@ -3088,7 +3113,7 @@
 		"babel-plugin-transform-remove-undefined": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz",
-			"integrity": "sha512-+M7fJYFaEE/M9CXa0/IRkDbiV3wRELzA1kKQFCJ4ifhrzLKn/9VCCgj9OFmYWwBd8IB48YdgPkHYtbYq+4vtHQ==",
+			"integrity": "sha1-gCCLMSJXZsYwyX+i0oiVIFbqIt0=",
 			"dev": true,
 			"requires": {
 				"babel-helper-evaluate-path": "^0.5.0"
@@ -3118,7 +3143,7 @@
 		"babel-preset-minify": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.5.0.tgz",
-			"integrity": "sha512-xj1s9Mon+RFubH569vrGCayA9Fm2GMsCgDRm1Jb8SgctOB7KFcrVc2o8K3YHUyMz+SWP8aea75BoS8YfsXXuiA==",
+			"integrity": "sha1-4lu401kAh68CtlCWcVmnfBm/uWs=",
 			"dev": true,
 			"requires": {
 				"babel-plugin-minify-builtins": "^0.5.0",
@@ -3149,7 +3174,7 @@
 		"babel-preset-react-app": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-6.1.0.tgz",
-			"integrity": "sha512-8PJ4N+acfYsjhDK4gMWkqJMVRMjDKb93D+nz7lWlNe73Jcv38FNu37i5K/dVQnFDdRYHbe1SjII+Y0mCgink9A==",
+			"integrity": "sha1-R3rn+FV+uZzibReVMBJ5E7czMQ0=",
 			"dev": true,
 			"requires": {
 				"@babel/core": "7.1.0",
@@ -3176,7 +3201,7 @@
 				"@babel/core": {
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.0.tgz",
-					"integrity": "sha512-9EWmD0cQAbcXSc+31RIoYgEHx3KQ2CCSMDBhnXrShWvo45TMw+3/55KVxlhkG53kw9tl87DqINgHDgFVhZJV/Q==",
+					"integrity": "sha1-CJWPE3EXn2LfaWbYphQAPRH66wQ=",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
@@ -3198,7 +3223,7 @@
 				"@babel/plugin-proposal-decorators": {
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.1.2.tgz",
-					"integrity": "sha512-YooynBO6PmBgHvAd0fl5e5Tq/a0pEC6RqF62ouafme8FzdIVH41Mz/u1dn8fFVm4jzEJ+g/MsOxouwybJPuP8Q==",
+					"integrity": "sha1-eYKb11/O1lgexserGTDo1zjokuc=",
 					"dev": true,
 					"requires": {
 						"@babel/helper-plugin-utils": "^7.0.0",
@@ -3210,7 +3235,7 @@
 				"@babel/plugin-transform-classes": {
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
-					"integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
+					"integrity": "sha1-qz+KVkNhgAy8irHKbyEQgDhDIkk=",
 					"dev": true,
 					"requires": {
 						"@babel/helper-annotate-as-pure": "^7.0.0",
@@ -3226,7 +3251,7 @@
 				"@babel/plugin-transform-destructuring": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0.tgz",
-					"integrity": "sha512-Fr2GtF8YJSXGTyFPakPFB4ODaEKGU04bPsAllAIabwoXdFrPxL0LVXQX5dQWoxOjjgozarJcC9eWGsj0fD6Zsg==",
+					"integrity": "sha1-aOkR4ZNd2i8Gtsy78YT/sCTp1Do=",
 					"dev": true,
 					"requires": {
 						"@babel/helper-plugin-utils": "^7.0.0"
@@ -3235,7 +3260,7 @@
 				"@babel/plugin-transform-flow-strip-types": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0.tgz",
-					"integrity": "sha512-WhXUNb4It5a19RsgKKbQPrjmy4yWOY1KynpEbNw7bnd1QTcrT/EIl3MJvnGgpgvrKyKbqX7nUNOJfkpLOnoDKA==",
+					"integrity": "sha1-xAztNMJ4OYXZDZ+ax3oT5vs5agE=",
 					"dev": true,
 					"requires": {
 						"@babel/helper-plugin-utils": "^7.0.0",
@@ -3245,7 +3270,7 @@
 				"@babel/plugin-transform-react-constant-elements": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.0.0.tgz",
-					"integrity": "sha512-z8yrW4KCVcqPYr0r9dHXe7fu3daLzn0r6TQEFoGbXahdrzEwT1d1ux+/EnFcqIHv9uPilUlnRnPIUf7GMO0ehg==",
+					"integrity": "sha1-q0E+M+nEanZvUyYBS8v54rNO96Q=",
 					"dev": true,
 					"requires": {
 						"@babel/helper-annotate-as-pure": "^7.0.0",
@@ -3255,7 +3280,7 @@
 				"@babel/plugin-transform-react-display-name": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0.tgz",
-					"integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
+					"integrity": "sha1-k3WebAI3guUsLaO3Xspg1PEFM+4=",
 					"dev": true,
 					"requires": {
 						"@babel/helper-plugin-utils": "^7.0.0"
@@ -3264,7 +3289,7 @@
 				"@babel/runtime": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-					"integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+					"integrity": "sha1-ret4/t/IVaoFvAQWQPP2+Y6FQkw=",
 					"dev": true,
 					"requires": {
 						"regenerator-runtime": "^0.12.0"
@@ -3273,7 +3298,7 @@
 				"babel-loader": {
 					"version": "8.0.4",
 					"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.4.tgz",
-					"integrity": "sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==",
+					"integrity": "sha1-e78gy+RWBini5BU0FHaS0/7L3OY=",
 					"dev": true,
 					"requires": {
 						"find-cache-dir": "^1.0.0",
@@ -3285,7 +3310,7 @@
 				"babel-plugin-macros": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.2.tgz",
-					"integrity": "sha512-NBVpEWN4OQ/bHnu1fyDaAaTPAjnhXCEPqr1RwqxrU7b6tZ2hypp+zX4hlNfmVGfClD5c3Sl6Hfj5TJNF5VG5aA==",
+					"integrity": "sha1-IbGi6C4hMEA8X/eFy6ZUjptkSyg=",
 					"dev": true,
 					"requires": {
 						"cosmiconfig": "^5.0.5",
@@ -3295,7 +3320,7 @@
 						"resolve": {
 							"version": "1.10.0",
 							"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-							"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+							"integrity": "sha1-O9qur0XMB/N1ZW39LlTtCBCxAbo=",
 							"dev": true,
 							"requires": {
 								"path-parse": "^1.0.6"
@@ -3306,7 +3331,7 @@
 				"babel-plugin-transform-react-remove-prop-types": {
 					"version": "0.4.18",
 					"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.18.tgz",
-					"integrity": "sha512-azed2nHo8vmOy7EY26KH+om5oOcWRs0r1U8wOmhwta+SBMMnmJ4H6yaBZRCcHBtMeWp9AVhvBTL/lpR1kEx+Xw==",
+					"integrity": "sha1-hf951mBHs0KIxvfMmGuIVKs4T4w=",
 					"dev": true
 				},
 				"find-cache-dir": {
@@ -3418,7 +3443,7 @@
 				"regenerator-runtime": {
 					"version": "0.11.1",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+					"integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
 				}
 			}
 		},
@@ -3496,7 +3521,7 @@
 		"bail": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
-			"integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==",
+			"integrity": "sha1-Y8+53brIKbAqMSjNUyJL545sIaM=",
 			"dev": true
 		},
 		"balanced-match": {
@@ -3557,7 +3582,7 @@
 		"base64-js": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+			"integrity": "sha1-yrHmEY8FEJXli1KBrqjBzSK/wOM="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -3571,22 +3596,22 @@
 		"big.js": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+			"integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4="
 		},
 		"binary-extensions": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
-			"integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw=="
+			"integrity": "sha1-lSPgATBqMkRLkHQj8d4hZCIvarE="
 		},
 		"bluebird": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-			"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+			"integrity": "sha1-fQHG+WFsmlGrD4xUmnnf5uwz76c="
 		},
 		"bn.js": {
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+			"integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8="
 		},
 		"body-parser": {
 			"version": "1.18.3",
@@ -3609,7 +3634,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -3618,7 +3643,7 @@
 				"iconv-lite": {
 					"version": "0.4.23",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+					"integrity": "sha1-KXhx9jvlB63Pv8pxXQzQ7thOmmM=",
 					"dev": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
@@ -3659,7 +3684,7 @@
 		"boxen": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/boxen/-/boxen-2.1.0.tgz",
-			"integrity": "sha512-luq3RQOt2U5sUX+fiu+qnT+wWnHDcATLpEe63jvge6GUZO99AKbVRfp97d2jgLvq1iQa0ORzaAm4lGVG52ZSlw==",
+			"integrity": "sha1-jVdhVuM/wmo01r6GNf0WsddF8LI=",
 			"dev": true,
 			"requires": {
 				"ansi-align": "^3.0.0",
@@ -3774,7 +3799,7 @@
 		"browserify-cipher": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+			"integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
 			"requires": {
 				"browserify-aes": "^1.0.4",
 				"browserify-des": "^1.0.0",
@@ -3784,7 +3809,7 @@
 		"browserify-des": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+			"integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"des.js": "^1.0.0",
@@ -3818,7 +3843,7 @@
 		"browserify-zlib": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+			"integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
 			"requires": {
 				"pako": "~1.0.5"
 			}
@@ -3867,7 +3892,7 @@
 		"cacache": {
 			"version": "11.3.2",
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
-			"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+			"integrity": "sha1-LYHjCOPSWMo4Eltna5iyrJzmm/o=",
 			"requires": {
 				"bluebird": "^3.5.3",
 				"chownr": "^1.1.1",
@@ -3888,7 +3913,7 @@
 				"glob": {
 					"version": "7.1.3",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -3975,7 +4000,7 @@
 		"case-sensitive-paths-webpack-plugin": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.2.tgz",
-			"integrity": "sha512-oEZgAFfEvKtjSRCu6VgYkuGxwrWXMnQzyBmlLPP7r6PWQVtHxP5Z5N6XsuJvtoVax78am/r7lr46bwo3IVEBOg=="
+			"integrity": "sha1-yJm1IXV2NokiRXHa13h0LhM/AZI="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -3986,7 +4011,7 @@
 		"ccount": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
-			"integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==",
+			"integrity": "sha1-8c7EPzMuLqWlaf1G+fW95OYQKv8=",
 			"dev": true
 		},
 		"chai": {
@@ -4076,7 +4101,7 @@
 				"parse5": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-					"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+					"integrity": "sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=",
 					"dev": true,
 					"requires": {
 						"@types/node": "*"
@@ -4126,7 +4151,7 @@
 		"chokidar": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.2.tgz",
-			"integrity": "sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==",
+			"integrity": "sha1-nCPqQLAWOEOeBROGTTYq6sxa0Fg=",
 			"requires": {
 				"anymatch": "^2.0.0",
 				"async-each": "^1.0.1",
@@ -4145,12 +4170,12 @@
 		"chownr": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+			"integrity": "sha1-VHJri4//TfBTxCGH6AH7RBLfFJQ="
 		},
 		"chrome-trace-event": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
-			"integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+			"integrity": "sha1-Rakb0sIMlBHwljtarrmhuV4JzEg=",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -4158,7 +4183,7 @@
 		"cipher-base": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -4194,13 +4219,13 @@
 		"classnames": {
 			"version": "2.2.6",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+			"integrity": "sha1-Q5Nb/90pHzJtrQogUwmzjQD2UM4=",
 			"dev": true
 		},
 		"clean-css": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
-			"integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+			"integrity": "sha1-LUEe92uFabbQyEBo2r6FsKpeXBc=",
 			"dev": true,
 			"requires": {
 				"source-map": "~0.6.0"
@@ -4224,7 +4249,7 @@
 		"cli-table3": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-			"integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+			"integrity": "sha1-AlI3LZTfxA29jfBgBfSPMfZW8gI=",
 			"dev": true,
 			"requires": {
 				"colors": "^1.1.2",
@@ -4304,7 +4329,7 @@
 		"coa": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
-			"integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
+			"integrity": "sha1-Q/bCEVG07yv1cYfbDXPeIp4+fsM=",
 			"dev": true,
 			"requires": {
 				"@types/q": "^1.5.1",
@@ -4358,7 +4383,7 @@
 		"comma-separated-tokens": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.5.tgz",
-			"integrity": "sha512-Cg90/fcK93n0ecgYTAz1jaA3zvnQ0ExlmKY1rdbyHqAx6BHxwoJc+J7HDu0iuQ7ixEs1qaa+WyQ6oeuBpYP1iA==",
+			"integrity": "sha1-sTeTEx2eotJDHPW1B93sJY8M4Ns=",
 			"dev": true,
 			"requires": {
 				"trim": "0.0.1"
@@ -4372,7 +4397,7 @@
 		"common-tags": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+			"integrity": "sha1-jjFT5ULUo56bEFVENK+q+YlWqTc=",
 			"dev": true
 		},
 		"commondir": {
@@ -4435,13 +4460,13 @@
 		"content-type": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
 			"dev": true
 		},
 		"convert-source-map": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -4466,7 +4491,7 @@
 		"copy-concurrently": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
 			"requires": {
 				"aproba": "^1.1.1",
 				"fs-write-stream-atomic": "^1.0.8",
@@ -4494,7 +4519,7 @@
 		"cosmiconfig": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
-			"integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
+			"integrity": "sha1-bFw16X83+YUGHN9lPxFHhCMRhc8=",
 			"dev": true,
 			"requires": {
 				"import-fresh": "^2.0.0",
@@ -4531,7 +4556,7 @@
 		"create-ecdh": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+			"integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.0.0"
@@ -4565,7 +4590,7 @@
 		"create-react-class": {
 			"version": "15.6.3",
 			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-			"integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+			"integrity": "sha1-LXMjf7P5cK5uvgEanmb0bbyoADY=",
 			"dev": true,
 			"requires": {
 				"fbjs": "^0.8.9",
@@ -4611,7 +4636,7 @@
 		"crypto-browserify": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+			"integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
 			"requires": {
 				"browserify-cipher": "^1.0.0",
 				"browserify-sign": "^4.0.0",
@@ -4629,7 +4654,7 @@
 		"css": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+			"integrity": "sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=",
 			"requires": {
 				"inherits": "^2.0.3",
 				"source-map": "^0.6.1",
@@ -4645,7 +4670,7 @@
 		"css-loader": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.1.tgz",
-			"integrity": "sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==",
+			"integrity": "sha1-aIW7UjOzXsR7AGBX2gHMZAtref4=",
 			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
@@ -4665,7 +4690,7 @@
 				"postcss": {
 					"version": "6.0.23",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+					"integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
@@ -4677,7 +4702,7 @@
 		},
 		"css-select": {
 			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
 			"dev": true,
 			"requires": {
@@ -4690,13 +4715,13 @@
 		"css-select-base-adapter": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
-			"integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
+			"integrity": "sha1-Oy/0lyzDYquIVhUHqVQIoUMhNdc=",
 			"dev": true
 		},
 		"css-selector-tokenizer": {
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
-			"integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
+			"integrity": "sha1-oXcnGovKUBkXL0+JH8bu2cv2jV0=",
 			"dev": true,
 			"requires": {
 				"cssesc": "^0.1.0",
@@ -4751,7 +4776,7 @@
 		"css-tree": {
 			"version": "1.0.0-alpha.28",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
-			"integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
+			"integrity": "sha1-joloGQ2IbJR3vI1h6W9hrz9/+n8=",
 			"dev": true,
 			"requires": {
 				"mdn-data": "~1.1.0",
@@ -4787,7 +4812,7 @@
 		"csso": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
-			"integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+			"integrity": "sha1-e564vmFiiXPBsmHhadLwJACOdYs=",
 			"dev": true,
 			"requires": {
 				"css-tree": "1.0.0-alpha.29"
@@ -4796,7 +4821,7 @@
 				"css-tree": {
 					"version": "1.0.0-alpha.29",
 					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
-					"integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+					"integrity": "sha1-P6nU7zFCy9HDAedmTB81K9gvWjk=",
 					"dev": true,
 					"requires": {
 						"mdn-data": "~1.1.0",
@@ -5095,6 +5120,12 @@
 				"d3-transition": "1"
 			}
 		},
+		"damerau-levenshtein": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
+			"integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
+			"dev": true
+		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -5283,7 +5314,7 @@
 		"detect-port": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
-			"integrity": "sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==",
+			"integrity": "sha1-2cQOmsyt1N9crGp4Ku/QFNVz0fE=",
 			"dev": true,
 			"requires": {
 				"address": "^1.0.1",
@@ -5293,7 +5324,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -5326,7 +5357,7 @@
 		"dir-glob": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-			"integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+			"integrity": "sha1-+gnwaUFTyJGLGLoN6vrpR2n8UMQ=",
 			"dev": true,
 			"requires": {
 				"path-type": "^3.0.0"
@@ -5335,7 +5366,7 @@
 				"path-type": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
 					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
@@ -5367,7 +5398,7 @@
 		"dom-converter": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
-			"integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
+			"integrity": "sha1-ZyGp2u4uKTaClVtq/kFncWJ7t2g=",
 			"dev": true,
 			"requires": {
 				"utila": "~0.4"
@@ -5376,7 +5407,7 @@
 		"dom-helpers": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-			"integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+			"integrity": "sha1-6bNpcA+Vn2Ls3lprq95LzNkWmvg=",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.1.2"
@@ -5401,7 +5432,7 @@
 		"domain-browser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
+			"integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto="
 		},
 		"domelementtype": {
 			"version": "1.3.1",
@@ -5440,13 +5471,13 @@
 		"dotenv": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
-			"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
+			"integrity": "sha1-lBwEEFNdlCyL7PKNPzV9vZ1HYGQ=",
 			"dev": true
 		},
 		"dotenv-defaults": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-1.0.2.tgz",
-			"integrity": "sha512-iXFvHtXl/hZPiFj++1hBg4lbKwGM+t/GlvELDnRtOFdjXyWP7mubkVr+eZGWG62kdsbulXAef6v/j6kiWc/xGA==",
+			"integrity": "sha1-RBz18GdlP8pLvc6d07gD9vhMWF0=",
 			"dev": true,
 			"requires": {
 				"dotenv": "^6.2.0"
@@ -5461,7 +5492,7 @@
 		"dotenv-webpack": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.7.0.tgz",
-			"integrity": "sha512-wwNtOBW/6gLQSkb8p43y0Wts970A3xtNiG/mpwj9MLUhtPCQG6i+/DSXXoNN7fbPCU/vQ7JjwGmgOeGZSSZnsw==",
+			"integrity": "sha1-Q4TYxX7m9AXClieMFKn5FnhW06E=",
 			"dev": true,
 			"requires": {
 				"dotenv-defaults": "^1.0.2"
@@ -5481,7 +5512,7 @@
 		"duplexify": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+			"integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
 			"requires": {
 				"end-of-stream": "^1.0.0",
 				"inherits": "^2.0.1",
@@ -5507,7 +5538,7 @@
 		"ejs": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
+			"integrity": "sha1-SY7A1JVlWrxvI81hho2SZGQHGqA=",
 			"dev": true
 		},
 		"electron-to-chromium": {
@@ -5518,7 +5549,7 @@
 		"elliptic": {
 			"version": "6.4.1",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+			"integrity": "sha1-wtC3d2kRuGcixjLDwGxg8vgZk5o=",
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -5537,7 +5568,7 @@
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
 			"dev": true
 		},
 		"emojis-list": {
@@ -5561,7 +5592,7 @@
 		"end-of-stream": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -5569,7 +5600,7 @@
 		"enhanced-resolve": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-			"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
+			"integrity": "sha1-Qcfgv9/nSsH/4eV61qXGyfN0Kn8=",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"memory-fs": "^0.4.0",
@@ -5585,7 +5616,7 @@
 		"enzyme": {
 			"version": "3.9.0",
 			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.9.0.tgz",
-			"integrity": "sha512-JqxI2BRFHbmiP7/UFqvsjxTirWoM1HfeaJrmVSZ9a1EADKkZgdPcAuISPMpoUiHlac9J4dYt81MC5BBIrbJGMg==",
+			"integrity": "sha1-K0kfBsqWbrVrZRAGjHiUp+C+OQk=",
 			"dev": true,
 			"requires": {
 				"array.prototype.flat": "^1.2.1",
@@ -5614,7 +5645,7 @@
 		"enzyme-adapter-react-16": {
 			"version": "1.11.2",
 			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.11.2.tgz",
-			"integrity": "sha512-2ruTTCPRb0lPuw/vKTXGVZVBZqh83MNDnakMhzxhpJcIbneEwNy2Cv0KvL97pl57/GOazJHflWNLjwWhex5AAA==",
+			"integrity": "sha1-jv6vsn6WhzpUkv3vP0I2kxguudQ=",
 			"dev": true,
 			"requires": {
 				"enzyme-adapter-utils": "^1.10.1",
@@ -5629,7 +5660,7 @@
 		"enzyme-adapter-utils": {
 			"version": "1.10.1",
 			"resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.10.1.tgz",
-			"integrity": "sha512-oasinhhLoBuZsIkTe8mx0HiudtfErUtG0Ooe1FOplu/t4c9rOmyG5gtrBASK6u4whHIRWvv0cbZMElzNTR21SA==",
+			"integrity": "sha1-WCZO+hmnvv2/lk+3mBoQilRSrJY=",
 			"dev": true,
 			"requires": {
 				"function.prototype.name": "^1.1.0",
@@ -5642,7 +5673,7 @@
 				"object.fromentries": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
-					"integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+					"integrity": "sha1-SaVD2SFR+Cd7OslgDx6TCxidMKs=",
 					"dev": true,
 					"requires": {
 						"define-properties": "^1.1.2",
@@ -5656,7 +5687,7 @@
 		"errno": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+			"integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
 			"requires": {
 				"prr": "~1.0.1"
 			}
@@ -5695,7 +5726,7 @@
 		"es5-shim": {
 			"version": "4.5.12",
 			"resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.12.tgz",
-			"integrity": "sha512-MjoCAHE6P2Dirme70Cxd9i2Ng8rhXiaVSsxDWdSwimfLERJL/ypR2ed2rTYkeeYrMk8gq281dzKLiGcdrmc8qg==",
+			"integrity": "sha1-UIwT3aHIfdPfG1DmnnuWuCFJtkk=",
 			"dev": true
 		},
 		"es6-shim": {
@@ -6016,6 +6047,22 @@
 				}
 			}
 		},
+		"eslint-plugin-jsx-a11y": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
+			"integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
+			"dev": true,
+			"requires": {
+				"aria-query": "^3.0.0",
+				"array-includes": "^3.0.3",
+				"ast-types-flow": "^0.0.7",
+				"axobject-query": "^2.0.2",
+				"damerau-levenshtein": "^1.0.4",
+				"emoji-regex": "^7.0.2",
+				"has": "^1.0.3",
+				"jsx-ast-utils": "^2.0.1"
+			}
+		},
 		"eslint-plugin-node": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
@@ -6150,13 +6197,13 @@
 		"eventemitter3": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-			"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+			"integrity": "sha1-CQtNbNvWRe0Qv3UNS1QHlC17oWM=",
 			"dev": true
 		},
 		"events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
+			"integrity": "sha1-mgoN+vYok9krh1uPJpjKQRSXPog="
 		},
 		"eventsource": {
 			"version": "0.1.6",
@@ -6170,7 +6217,7 @@
 		"evp_bytestokey": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
 			"requires": {
 				"md5.js": "^1.3.4",
 				"safe-buffer": "^5.1.1"
@@ -6261,7 +6308,7 @@
 		"express": {
 			"version": "4.16.4",
 			"resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-			"integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+			"integrity": "sha1-/d72GSYQniTFFeqX/S8b2/Yt8S4=",
 			"dev": true,
 			"requires": {
 				"accepts": "~1.3.5",
@@ -6299,7 +6346,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -6326,7 +6373,7 @@
 				"send": {
 					"version": "0.16.2",
 					"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-					"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+					"integrity": "sha1-bsyh4PjBVtFBWXVZhI32RzCmu8E=",
 					"dev": true,
 					"requires": {
 						"debug": "2.6.9",
@@ -6347,7 +6394,7 @@
 				"statuses": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+					"integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic=",
 					"dev": true
 				}
 			}
@@ -6460,7 +6507,7 @@
 		"fast-glob": {
 			"version": "2.2.6",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
-			"integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
+			"integrity": "sha1-pdW2l+yN7aRo2Fp0A1KQoCWpUpU=",
 			"dev": true,
 			"requires": {
 				"@mrmlnc/readdir-enhanced": "^2.2.1",
@@ -6485,7 +6532,7 @@
 		"fastparse": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
-			"integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+			"integrity": "sha1-kXKMWllC7O2FMSg8eUQe5BIsNak=",
 			"dev": true
 		},
 		"faye-websocket": {
@@ -6514,7 +6561,7 @@
 		"figgy-pudding": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
+			"integrity": "sha1-hiRwESkBxyeg5JWoB0S9W6odZ5A="
 		},
 		"figures": {
 			"version": "2.0.0",
@@ -6538,7 +6585,7 @@
 		"file-loader": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-2.0.0.tgz",
-			"integrity": "sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==",
+			"integrity": "sha1-OXScgvAguehZAdz/mOgATmQBz94=",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^1.0.2",
@@ -6574,7 +6621,7 @@
 		"filesize": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+			"integrity": "sha1-CQuz7gG2+AGoqL6Z0xcQs0Irsxc=",
 			"dev": true
 		},
 		"fill-range": {
@@ -6601,7 +6648,7 @@
 		"finalhandler": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"integrity": "sha1-7r9O2EAHnIP0JJA4ydcDAIMBsQU=",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
@@ -6616,7 +6663,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -6631,7 +6678,7 @@
 				"statuses": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+					"integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic=",
 					"dev": true
 				}
 			}
@@ -6744,7 +6791,7 @@
 		"flush-write-stream": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
-			"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+			"integrity": "sha1-jdfYc6G6vCB9lOrQwuDkQnbr8ug=",
 			"requires": {
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.3.6"
@@ -6816,7 +6863,7 @@
 		"fs-extra": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+			"integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -6854,7 +6901,7 @@
 		"fsevents": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-			"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+			"integrity": "sha1-SFG2ZKN4PlIAOzxm6w7uEHSTOqQ=",
 			"optional": true,
 			"requires": {
 				"nan": "^2.9.2",
@@ -7507,7 +7554,7 @@
 		"grommet": {
 			"version": "2.5.5",
 			"resolved": "https://registry.npmjs.org/grommet/-/grommet-2.5.5.tgz",
-			"integrity": "sha512-OxHuYaMGDVYQk7cuoqDSGs5BU33MqTGD5SzVnsKF9W344fequywrLZWGMiBxvgL7Z6ZY8LHjdlWisAlrbsbWPw==",
+			"integrity": "sha1-CNT8BUQBbnl9A+N0R/+3D+We8XQ=",
 			"requires": {
 				"css": "^2.2.3",
 				"grommet-icons": "^4.2.0",
@@ -7524,7 +7571,7 @@
 		"grommet-icons": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/grommet-icons/-/grommet-icons-4.2.0.tgz",
-			"integrity": "sha512-HMPLQa2pgnCZFImUXwfq+79VizL6oyP2/AAfAzQDw57x/6qgWouoqoRrrt+2zodTjTxtKXxliBY1w/o5uC+DpA==",
+			"integrity": "sha1-e899Szf2lFFq3ghOJTbHKyJManY=",
 			"requires": {
 				"grommet-styles": "^0.2.0"
 			}
@@ -7543,7 +7590,7 @@
 		"gzip-size": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
-			"integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
+			"integrity": "sha1-pV7NmSIvTEj9jAHGJc47NJ0KDoA=",
 			"dev": true,
 			"requires": {
 				"duplexer": "^0.1.1",
@@ -7639,7 +7686,7 @@
 		"hash.js": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -7648,7 +7695,7 @@
 		"hast-util-from-parse5": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.0.tgz",
-			"integrity": "sha512-A7ev5OseS/J15214cvDdcI62uwovJO2PB60Xhnq7kaxvvQRFDEccuqbkrFXU03GPBGopdPqlpQBRqIcDS/Fjbg==",
+			"integrity": "sha1-pQWgV2bg+W44m/sLHdgJ7u/O9Hs=",
 			"dev": true,
 			"requires": {
 				"ccount": "^1.0.3",
@@ -7661,13 +7708,13 @@
 		"hast-util-parse-selector": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.1.tgz",
-			"integrity": "sha512-Xyh0v+nHmQvrOqop2Jqd8gOdyQtE8sIP9IQf7mlVDqp924W4w/8Liuguk2L2qei9hARnQSG2m+wAOCxM7npJVw==",
+			"integrity": "sha1-TduuGuEsEk4+uRtYHSVWRBdm8Ks=",
 			"dev": true
 		},
 		"hastscript": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.0.0.tgz",
-			"integrity": "sha512-xJtuJ8D42Xtq5yJrnDg/KAIxl2cXBXKoiIJwmWX9XMf8113qHTGl/Bf7jEsxmENJ4w6q4Tfl8s/Y6mEZo8x8qw==",
+			"integrity": "sha1-/uEDgsG8S6PxvjEVIdNowEfSxDo=",
 			"dev": true,
 			"requires": {
 				"comma-separated-tokens": "^1.0.0",
@@ -7695,7 +7742,7 @@
 		"hoist-non-react-statics": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-			"integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+			"integrity": "sha1-sJF48BIhhPuVrPUl2q7LTY9FlYs=",
 			"requires": {
 				"react-is": "^16.7.0"
 			}
@@ -7725,7 +7772,7 @@
 		"html-element-map": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.0.tgz",
-			"integrity": "sha512-/SP6aOiM5Ai9zALvCxDubIeez0LvG3qP7R9GcRDnJEP/HBmv0A8A9K0o8+HFudcFt46+i921ANjzKsjPjb7Enw==",
+			"integrity": "sha1-GaQZQCJRU+zf6tdPhQkVT/HNwYs=",
 			"dev": true,
 			"requires": {
 				"array-filter": "^1.0.0"
@@ -7756,7 +7803,7 @@
 		"html-minifier": {
 			"version": "3.5.21",
 			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
-			"integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
+			"integrity": "sha1-0AQOBUcw41TbAIRjWTGUAVIS0gw=",
 			"dev": true,
 			"requires": {
 				"camel-case": "3.0.x",
@@ -7779,7 +7826,7 @@
 		"html-webpack-plugin": {
 			"version": "4.0.0-beta.5",
 			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.5.tgz",
-			"integrity": "sha512-y5l4lGxOW3pz3xBTFdfB9rnnrWRPVxlAhX6nrBYIcW+2k2zC3mSp/3DxlWVCMBfnO6UAnoF8OcFn0IMy6kaKAQ==",
+			"integrity": "sha1-LFMIPBFRv+wgR5sfiq8AOed7VRM=",
 			"dev": true,
 			"requires": {
 				"html-minifier": "^3.5.20",
@@ -7838,7 +7885,7 @@
 		"http-parser-js": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
-			"integrity": "sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==",
+			"integrity": "sha1-1l7b7ehDSdDcMDIIFaFdOcw8u9g=",
 			"dev": true
 		},
 		"http-signature": {
@@ -7888,7 +7935,7 @@
 				"postcss": {
 					"version": "6.0.23",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+					"integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
@@ -7901,7 +7948,7 @@
 		"ieee754": {
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+			"integrity": "sha1-UL8k5bnIu5ivSWTJQc2wkY2ntgs="
 		},
 		"iferr": {
 			"version": "0.1.5",
@@ -7917,7 +7964,7 @@
 		"immer": {
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/immer/-/immer-1.7.2.tgz",
-			"integrity": "sha512-4Urocwu9+XLDJw4Tc6ZCg7APVjjLInCFvO4TwGsAYV5zT6YYSor14dsZR0+0tHlDIN92cFUOq+i7fC00G5vTxA==",
+			"integrity": "sha1-pR6XI8ULJ+Ey9lZvrL7ByF/GlUc=",
 			"dev": true
 		},
 		"immutable": {
@@ -8075,13 +8122,13 @@
 		"interpret": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+			"integrity": "sha1-1QYaYiS+WOgIOYX1AU2EQ1lXYpY=",
 			"dev": true
 		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -8264,7 +8311,7 @@
 		"is-path-in-cwd": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+			"integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
 			"requires": {
 				"is-path-inside": "^1.0.0"
 			}
@@ -8314,7 +8361,7 @@
 		"is-root": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-root/-/is-root-2.0.0.tgz",
-			"integrity": "sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg==",
+			"integrity": "sha1-g40egjGBROWm93gZ2QIHZFrMcBk=",
 			"dev": true
 		},
 		"is-stream": {
@@ -8403,7 +8450,7 @@
 		"js-levenshtein": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-			"integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
+			"integrity": "sha1-xs7ljrNVA3LfjeuF+tXOZs4B1Z0="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -8582,7 +8629,7 @@
 		"launch-editor": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.2.1.tgz",
-			"integrity": "sha512-On+V7K2uZK6wK7x691ycSUbLD/FyKKelArkbaAMSSJU8JmqmhwN2+mnJDNINuJWSrh2L0kDk+ZQtbC/gOWUwLw==",
+			"integrity": "sha1-hxtaPuOdZoD8wm03kwtu7aidsMo=",
 			"requires": {
 				"chalk": "^2.3.0",
 				"shell-quote": "^1.6.1"
@@ -8597,7 +8644,7 @@
 		"lazy-universal-dotenv": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/lazy-universal-dotenv/-/lazy-universal-dotenv-2.0.0.tgz",
-			"integrity": "sha512-1Wi0zgZMfRLaRAK21g3odYuU+HE1d85Loe2tb44YhcNwIzhmD49mTPR9aKckpB9Q9Q9mA+hUMLI2xlkcCAe3yw==",
+			"integrity": "sha1-4BWtn3e+nvgRlW1T6pUZscCrAhQ=",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.0.0",
@@ -8627,7 +8674,7 @@
 		},
 		"load-json-file": {
 			"version": "2.0.0",
-			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -8638,7 +8685,7 @@
 			"dependencies": {
 				"pify": {
 					"version": "2.3.0",
-					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
@@ -8646,7 +8693,7 @@
 		"loader-runner": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
-			"integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
+			"integrity": "sha1-7UcGa/5TTX6ExMe5mYwqdWB9k1c="
 		},
 		"loader-utils": {
 			"version": "1.1.0",
@@ -8796,7 +8843,7 @@
 		"md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1",
@@ -8806,7 +8853,7 @@
 		"mdn-data": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-			"integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+			"integrity": "sha1-ULXU/8RXUnZXPE7tuHgIEqhBnwE=",
 			"dev": true
 		},
 		"media-typer": {
@@ -8832,7 +8879,7 @@
 		"merge-deep": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
-			"integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
+			"integrity": "sha1-85+hAKTxvTT/KffSv0UI+7jYOtI=",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
@@ -8860,7 +8907,7 @@
 		"merge2": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-			"integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
+			"integrity": "sha1-fumdvWm7ZIFoklPwGEiKG5ArDtU=",
 			"dev": true
 		},
 		"methods": {
@@ -8891,7 +8938,7 @@
 		"miller-rabin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+			"integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
 			"requires": {
 				"bn.js": "^4.0.0",
 				"brorand": "^1.0.1"
@@ -8933,7 +8980,7 @@
 		"mini-css-extract-plugin": {
 			"version": "0.4.5",
 			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.5.tgz",
-			"integrity": "sha512-dqBanNfktnp2hwL2YguV9Jh91PFX7gu7nRLs4TGsbAfAG6WOtlynFRYzwDwmmeSb5uIwHo9nx1ta0f7vAZVp2w==",
+			"integrity": "sha1-yZ6eeNVPP6d1YzruWTOuqk6AcZo=",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^1.1.0",
@@ -8944,7 +8991,7 @@
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+			"integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc="
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
@@ -8967,7 +9014,7 @@
 		"mississippi": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-			"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+			"integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
 			"requires": {
 				"concat-stream": "^1.5.0",
 				"duplexify": "^3.4.2",
@@ -9131,7 +9178,7 @@
 		"moo": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+			"integrity": "sha1-P4R6JvMc9iWpVqh/KxD7wBO/0Q4=",
 			"dev": true
 		},
 		"mout": {
@@ -9172,7 +9219,7 @@
 		"nanoid": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.2.1.tgz",
-			"integrity": "sha512-S1QSG+TQtsqr2/ujHZcNT0OxygffUaUT755qTc/SPKfQ0VJBlOO6qb1425UYoHXPvCZ3pWgMVCuy1t7+AoCxnQ=="
+			"integrity": "sha1-kiv2wQ4197IImTdo2tZDV3yQet8="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -9201,7 +9248,7 @@
 		"nearley": {
 			"version": "2.16.0",
 			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
-			"integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+			"integrity": "sha1-d8KX0EGUHSaCkOyEtznQ7il+g6c=",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -9220,7 +9267,7 @@
 		"neo-async": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA=="
+			"integrity": "sha1-udFeTXHGdikIZUtRg+04t1M0CDU="
 		},
 		"next": {
 			"version": "8.0.3",
@@ -9288,7 +9335,7 @@
 				"@babel/runtime": {
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
-					"integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
+					"integrity": "sha1-gciZNfRkdwb8VFQRRea07P70uOM=",
 					"requires": {
 						"regenerator-runtime": "^0.12.0"
 					}
@@ -9296,7 +9343,7 @@
 				"hoist-non-react-statics": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.2.0.tgz",
-					"integrity": "sha512-3IascCRfaEkbmHjJnUxWSspIUE1okLPjGTMVXW8zraUo1t3yg1BadKAxAGILHwgoBzmMnzrgeeaDGBvpuPz6dA==",
+					"integrity": "sha1-0hufxytQ/cOMXYj24sUvLC2+XuI=",
 					"requires": {
 						"react-is": "^16.3.2"
 					}
@@ -9334,7 +9381,7 @@
 				"find-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
 					"requires": {
 						"locate-path": "^3.0.0"
 					}
@@ -9342,7 +9389,7 @@
 				"locate-path": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
@@ -9359,7 +9406,7 @@
 				"p-locate": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
 					"requires": {
 						"p-limit": "^2.0.0"
 					}
@@ -9367,7 +9414,7 @@
 				"p-try": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+					"integrity": "sha1-hQgLuHxkaI+keZb+j3376CEXYLE="
 				},
 				"prop-types": {
 					"version": "15.6.2",
@@ -9425,7 +9472,7 @@
 		"no-case": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+			"integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
 			"dev": true,
 			"requires": {
 				"lower-case": "^1.1.1"
@@ -9448,7 +9495,7 @@
 		"node-libs-browser": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
-			"integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
+			"integrity": "sha1-xy9g2dRt4IqUDe27JfP/ovm7qnc=",
 			"requires": {
 				"assert": "^1.1.1",
 				"browserify-zlib": "^0.2.0",
@@ -9492,7 +9539,7 @@
 		"node-version": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/node-version/-/node-version-1.2.0.tgz",
-			"integrity": "sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ==",
+			"integrity": "sha1-NP3j/6jhFJvTI5g0ed2mIOG1Bg0=",
 			"dev": true
 		},
 		"normalize-package-data": {
@@ -9519,7 +9566,7 @@
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+			"integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
 		},
 		"normalize-range": {
 			"version": "0.1.2",
@@ -9544,7 +9591,7 @@
 		"npmlog": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
 			"dev": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
@@ -9621,7 +9668,7 @@
 		"object-inspect": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+			"integrity": "sha1-xwtsv3LydKq0w0wMgvUWe/gs8Vs=",
 			"dev": true
 		},
 		"object-is": {
@@ -9669,7 +9716,7 @@
 		"object.fromentries": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-1.0.0.tgz",
-			"integrity": "sha512-F7XUm84lg0uNXNzrRAC5q8KJe0yYaxgLU9hTSqWYM6Rfnh0YjP24EG3xq7ncj2Wu1AdfueNHKCOlamIonG4UHQ==",
+			"integrity": "sha1-6Q7CdEXsbjf0i+mvkHfZqovvDUA=",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
@@ -9735,7 +9782,7 @@
 		"opn": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
-			"integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+			"integrity": "sha1-y1Reeqt4VivrEao7+rxwQuF2EDU=",
 			"dev": true,
 			"requires": {
 				"is-wsl": "^1.1.0"
@@ -9775,7 +9822,7 @@
 		"original": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-			"integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+			"integrity": "sha1-5EKmHP/hxf0gpl8yYcJmY7MD8l8=",
 			"dev": true,
 			"requires": {
 				"url-parse": "^1.4.3"
@@ -9830,7 +9877,7 @@
 		"p-map": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+			"integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s="
 		},
 		"p-try": {
 			"version": "1.0.0",
@@ -9874,7 +9921,7 @@
 		"parse-asn1": {
 			"version": "5.1.4",
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
-			"integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+			"integrity": "sha1-N/Zij4I/vesic7TVQENKIvPvH8w=",
 			"requires": {
 				"asn1.js": "^4.0.0",
 				"browserify-aes": "^1.0.0",
@@ -9956,7 +10003,7 @@
 			"dependencies": {
 				"http-errors": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
+					"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
 					"integrity": "sha1-bAJC3qaz33r9oVPHEImzHG6Cqr8=",
 					"requires": {
 						"inherits": "2.0.1",
@@ -9991,7 +10038,7 @@
 		"path-to-regexp": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.1.0.tgz",
-			"integrity": "sha512-dZY7QPCPp5r9cnNuQ955mOv4ZFVDXY/yvqeV7Y1W2PJA3PEFcuow9xKFfJxbBj1pIjOAP+M2B4/7xubmykLrXw=="
+			"integrity": "sha1-fjD59bE0vWoo/8Lj7x5HB1rFJZs="
 		},
 		"path-type": {
 			"version": "2.0.0",
@@ -10003,7 +10050,7 @@
 			"dependencies": {
 				"pify": {
 					"version": "2.3.0",
-					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
@@ -10017,7 +10064,7 @@
 		"pbkdf2": {
 			"version": "3.0.17",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+			"integrity": "sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=",
 			"requires": {
 				"create-hash": "^1.1.2",
 				"create-hmac": "^1.1.4",
@@ -10154,7 +10201,7 @@
 		"postcss": {
 			"version": "7.0.14",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-			"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+			"integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
@@ -10165,7 +10212,7 @@
 				"supports-color": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -10176,7 +10223,7 @@
 		"postcss-flexbugs-fixes": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.1.0.tgz",
-			"integrity": "sha512-jr1LHxQvStNNAHlgco6PzY308zvLklh7SJVYuWUwyUQncofaAlD2l+P/gxKHOdqWKe7xJSkVLFF/2Tp+JqMSZA==",
+			"integrity": "sha1-4JSp3xeD4iALexn4ddytOzr/iyA=",
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.0"
@@ -10185,7 +10232,7 @@
 		"postcss-load-config": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
-			"integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
+			"integrity": "sha1-8TEt2/WRLNdHF3CDxe96GdYu5IQ=",
 			"dev": true,
 			"requires": {
 				"cosmiconfig": "^4.0.0",
@@ -10195,7 +10242,7 @@
 				"cosmiconfig": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
-					"integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+					"integrity": "sha1-dgORVJWAu9LfHlYrwXexPCkJctw=",
 					"dev": true,
 					"requires": {
 						"is-directory": "^0.3.1",
@@ -10219,7 +10266,7 @@
 		"postcss-loader": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
-			"integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
+			"integrity": "sha1-a5eUPkfHLYRfqeA/Jzdz1OjdbC0=",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^1.1.0",
@@ -10231,7 +10278,7 @@
 		"postcss-modules-extract-imports": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
-			"integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
+			"integrity": "sha1-3IfjQUjsfqtfeR981YSYMzdbdBo=",
 			"dev": true,
 			"requires": {
 				"postcss": "^6.0.1"
@@ -10240,7 +10287,7 @@
 				"postcss": {
 					"version": "6.0.23",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+					"integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
@@ -10263,7 +10310,7 @@
 				"postcss": {
 					"version": "6.0.23",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+					"integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
@@ -10286,7 +10333,7 @@
 				"postcss": {
 					"version": "6.0.23",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+					"integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
@@ -10309,7 +10356,7 @@
 				"postcss": {
 					"version": "6.0.23",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+					"integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
@@ -10349,7 +10396,7 @@
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+			"integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8="
 		},
 		"process": {
 			"version": "0.11.10",
@@ -10388,7 +10435,7 @@
 		"promise.prototype.finally": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz",
-			"integrity": "sha512-7p/K2f6dI+dM8yjRQEGrTQs5hTQixUAdOGpMEA3+pVxpX5oHKRSKAXyLw9Q9HUWDTdwtoo39dSHGQtN90HcEwQ==",
+			"integrity": "sha1-ZvFhsWQ2NuUOfPIB3BuEqFfzhk4=",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
@@ -10409,7 +10456,7 @@
 		"prop-types-exact": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
-			"integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
+			"integrity": "sha1-gl1r5GCUZjhII345JamMbpROmGk=",
 			"requires": {
 				"has": "^1.0.3",
 				"object.assign": "^4.1.0",
@@ -10419,7 +10466,7 @@
 		"property-information": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/property-information/-/property-information-5.0.1.tgz",
-			"integrity": "sha512-nAtBDVeSwFM3Ot/YxT7s4NqZmqXI7lLzf46BThvotEtYf2uk2yH0ACYuWQkJ7gxKs49PPtKVY0UlDGkyN9aJlw==",
+			"integrity": "sha1-w7CfT1dQsWNMCyQgWtv3jxi9+U8=",
 			"dev": true,
 			"requires": {
 				"xtend": "^4.0.1"
@@ -10428,7 +10475,7 @@
 		"proxy-addr": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+			"integrity": "sha1-7PxzO/Iv+Mb0B/onUye5q2fki5M=",
 			"dev": true,
 			"requires": {
 				"forwarded": "~0.1.2",
@@ -10454,7 +10501,7 @@
 		"public-encrypt": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+			"integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
 			"requires": {
 				"bn.js": "^4.1.0",
 				"browserify-rsa": "^4.0.0",
@@ -10467,7 +10514,7 @@
 		"pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -10476,7 +10523,7 @@
 		"pumpify": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+			"integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
 			"requires": {
 				"duplexify": "^3.6.0",
 				"inherits": "^2.0.3",
@@ -10486,7 +10533,7 @@
 				"pump": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+					"integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -10528,7 +10575,7 @@
 		"raf": {
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+			"integrity": "sha1-B0LpmkplUvRF1z4+4DKK8P8e3jk=",
 			"dev": true,
 			"requires": {
 				"performance-now": "^2.1.0"
@@ -10549,7 +10596,7 @@
 		"randexp": {
 			"version": "0.4.6",
 			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+			"integrity": "sha1-6YatXl4x2uE93W97MBmqfIf2DKM=",
 			"dev": true,
 			"requires": {
 				"discontinuous-range": "1.0.0",
@@ -10559,7 +10606,7 @@
 		"randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -10567,7 +10614,7 @@
 		"randomfill": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+			"integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
 			"requires": {
 				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
@@ -10581,7 +10628,7 @@
 		"raw-body": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-			"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+			"integrity": "sha1-GzJOzmtXBuFThVvBFIxlu39uoMM=",
 			"dev": true,
 			"requires": {
 				"bytes": "3.0.0",
@@ -10593,7 +10640,7 @@
 				"iconv-lite": {
 					"version": "0.4.23",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+					"integrity": "sha1-KXhx9jvlB63Pv8pxXQzQ7thOmmM=",
 					"dev": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
@@ -10610,7 +10657,7 @@
 		"react": {
 			"version": "16.8.4",
 			"resolved": "https://registry.npmjs.org/react/-/react-16.8.4.tgz",
-			"integrity": "sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==",
+			"integrity": "sha1-/fe9muU/A6nEzRo3FDLCBr4cR2g=",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -10626,7 +10673,7 @@
 		"react-dev-utils": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-6.1.1.tgz",
-			"integrity": "sha512-ThbJ86coVd6wV/QiTo8klDTvdAJ1WsFCGQN07+UkN+QN9CtCSsl/+YuDJToKGeG8X4j9HMGXNKbk2QhPAZr43w==",
+			"integrity": "sha1-oH4+iSPEYJ2fJ+WvUgfjyiBySJU=",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0",
@@ -10664,7 +10711,7 @@
 				"browserslist": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.1.tgz",
-					"integrity": "sha512-VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==",
+					"integrity": "sha1-Mo60/xIVsS32WJ6auC+K2qT8jNY=",
 					"dev": true,
 					"requires": {
 						"caniuse-lite": "^1.0.30000884",
@@ -10686,7 +10733,7 @@
 				"cross-spawn": {
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
 					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
@@ -10699,7 +10746,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -10708,7 +10755,7 @@
 				"detect-port-alt": {
 					"version": "1.1.6",
 					"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
-					"integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
+					"integrity": "sha1-JHB96r6TLUo89iEwICfCsmZWgnU=",
 					"dev": true,
 					"requires": {
 						"address": "^1.0.1",
@@ -10718,7 +10765,7 @@
 				"find-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
 					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
@@ -10727,7 +10774,7 @@
 				"globby": {
 					"version": "8.0.1",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+					"integrity": "sha1-ta1IuKqAs1uBT8EoHsyFHx0rW1A=",
 					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
@@ -10742,7 +10789,7 @@
 				"inquirer": {
 					"version": "6.2.0",
 					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-					"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+					"integrity": "sha1-Ua3Nd29mE2ncHolIWcJWCiJKvdg=",
 					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
@@ -10769,7 +10816,7 @@
 				"locate-path": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
 					"dev": true,
 					"requires": {
 						"p-locate": "^3.0.0",
@@ -10794,7 +10841,7 @@
 				"p-locate": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
 					"dev": true,
 					"requires": {
 						"p-limit": "^2.0.0"
@@ -10803,7 +10850,7 @@
 				"p-try": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+					"integrity": "sha1-hQgLuHxkaI+keZb+j3376CEXYLE=",
 					"dev": true
 				},
 				"react-error-overlay": {
@@ -10836,7 +10883,7 @@
 		"react-docgen": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-3.0.0.tgz",
-			"integrity": "sha512-2UseoLWabFNXuk1Foz4VDPSIAkxz+1Hmmq4qijzUmYHDq0ZSloKDLXtGLpQRcAi/M76hRpPtH1rV4BI5jNAOnQ==",
+			"integrity": "sha1-ecbhsYcEgMPCvBplvt4Fd6EcOM0=",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.3",
@@ -10851,7 +10898,7 @@
 				"recast": {
 					"version": "0.16.2",
 					"resolved": "https://registry.npmjs.org/recast/-/recast-0.16.2.tgz",
-					"integrity": "sha512-O/7qXi51DPjRVdbrpNzoBQH5dnAPQNbfoOFyRiUwreTMJfIHYOEBzwuH+c0+/BTSJ3CQyKs6ILSWXhESH6Op3A==",
+					"integrity": "sha1-N5brrV/knthUc7R5zW31VK1yXcI=",
 					"dev": true,
 					"requires": {
 						"ast-types": "0.11.7",
@@ -10865,7 +10912,7 @@
 		"react-dom": {
 			"version": "16.8.4",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.4.tgz",
-			"integrity": "sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==",
+			"integrity": "sha1-EGGo4BorOwyBYAN0QcO/AKDjvEg=",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -10876,12 +10923,12 @@
 		"react-error-overlay": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.0.tgz",
-			"integrity": "sha512-FlsPxavEyMuR6TjVbSSywovXSEyOg6ZDj5+Z8nbsRl9EkOzAhEIcS+GLoQDC5fz/t9suhUXWmUrOBrgeUvrMxw=="
+			"integrity": "sha1-0ZhAioW0Bwk3qYZn9QDIMvhr1dQ="
 		},
 		"react-fuzzy": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/react-fuzzy/-/react-fuzzy-0.5.2.tgz",
-			"integrity": "sha512-qIZZxaCheb/HhcBi5fABbiCFg85+K5r1TCps1D4uaL0LAMMD/1zm/x1/kNR130Tx7nnY9V7mbFyY0DquPYeLAw==",
+			"integrity": "sha1-/BO/bwt4Xl/v6QhyTv6+xJNerv4=",
 			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.23.0",
@@ -10893,7 +10940,7 @@
 		"react-inspector": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.3.1.tgz",
-			"integrity": "sha512-tUUK7t3KWgZEIUktOYko5Ic/oYwvjEvQUFAGC1UeMeDaQ5za2yZFtItJa2RTwBJB//NxPr000WQK6sEbqC6y0Q==",
+			"integrity": "sha1-8Ot/UgZptUW0Qa+dOOxtcG5fZJw=",
 			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
@@ -10914,7 +10961,7 @@
 		"react-modal": {
 			"version": "3.8.1",
 			"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.8.1.tgz",
-			"integrity": "sha512-aLKeZM9pgXpIKVwopRHMuvqKWiBajkqisDA8UzocdCF6S4fyKVfLWmZR5G1Q0ODBxxxxf2XIwiCP8G/11GJAuw==",
+			"integrity": "sha1-cwD5Sm+SouF5lN4L5sy2FzRGTJ4=",
 			"dev": true,
 			"requires": {
 				"exenv": "^1.2.0",
@@ -10926,7 +10973,7 @@
 		"react-split-pane": {
 			"version": "0.1.85",
 			"resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.85.tgz",
-			"integrity": "sha512-3GhaYs6+eVNrewgN4eQKJoNMQ4pcegNMTMhR5bO/NFO91K6/98qdD1sCuWPpsefCjzxNTjkvVYWQC0bMaC45mA==",
+			"integrity": "sha1-ZIGZRqmbYX/6LSD29FoAVrbuT6o=",
 			"dev": true,
 			"requires": {
 				"prop-types": "^15.5.10",
@@ -10939,7 +10986,7 @@
 		"react-style-proptype": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.2.2.tgz",
-			"integrity": "sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==",
+			"integrity": "sha1-2OmY5iznnsNbCHJSuQ8Z8cM5aKA=",
 			"dev": true,
 			"requires": {
 				"prop-types": "^15.5.4"
@@ -10948,7 +10995,7 @@
 		"react-test-renderer": {
 			"version": "16.8.4",
 			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.4.tgz",
-			"integrity": "sha512-jQ9Tf/ilIGSr55Cz23AZ/7H3ABEdo9oy2zF9nDHZyhLHDSLKuoILxw2ifpBfuuwQvj4LCoqdru9iZf7gwFH28A==",
+			"integrity": "sha1-q+5MLDv5Z6iJKns393NwxVcNUyk=",
 			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1",
@@ -10960,7 +11007,7 @@
 		"react-textarea-autosize": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-7.1.0.tgz",
-			"integrity": "sha512-c2FlR/fP0qbxmlrW96SdrbgP/v0XZMTupqB90zybvmDVDutytUgPl7beU35klwcTeMepUIQEpQUn3P3bdshGPg==",
+			"integrity": "sha1-MTLLd+ZdlEF1WNN8C/5BWlr9NEU=",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.1.2",
@@ -10982,7 +11029,7 @@
 		"react-treebeard": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/react-treebeard/-/react-treebeard-3.1.0.tgz",
-			"integrity": "sha512-u4OEzwZk1Xcxp2s55Ny/Ofp8fHRwlabKOAeGbzQ7XUE9YXFbPj8ajl0FInbXEP4Ys9+E1vHCtgqJ6VBsgbCPVg==",
+			"integrity": "sha1-44C551+QDlOARCgKw2XSkJJYNkI=",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.0.0",
@@ -11016,7 +11063,7 @@
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
 				"core-util-is": "~1.0.0",
@@ -11031,7 +11078,7 @@
 		"readdirp": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+			"integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"micromatch": "^3.1.10",
@@ -11041,7 +11088,7 @@
 		"recast": {
 			"version": "0.14.7",
 			"resolved": "https://registry.npmjs.org/recast/-/recast-0.14.7.tgz",
-			"integrity": "sha512-/nwm9pkrcWagN40JeJhkPaRxiHXBRkXyRh/hgU088Z/v+qCy+zIHHY6bC6o7NaKAxPqtE6nD8zBH1LfU0/Wx6A==",
+			"integrity": "sha1-TxSXwrWCbUKmbo48nYDFEpg/9h0=",
 			"dev": true,
 			"requires": {
 				"ast-types": "0.11.3",
@@ -11053,7 +11100,7 @@
 				"ast-types": {
 					"version": "0.11.3",
 					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
-					"integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA==",
+					"integrity": "sha1-wgdX/nLucSeOoP89h+XCyjDZ7fg=",
 					"dev": true
 				}
 			}
@@ -11070,7 +11117,7 @@
 		"recompose": {
 			"version": "0.30.0",
 			"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-			"integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
+			"integrity": "sha1-gnc2QbOSfox9JKDYfWWu66GKq9A=",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
 				"change-emitter": "^0.1.2",
@@ -11083,7 +11130,7 @@
 				"hoist-non-react-statics": {
 					"version": "2.5.5",
 					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-					"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+					"integrity": "sha1-xZA89AnA39kI84jmGdhrnBF0y0c="
 				}
 			}
 		},
@@ -11141,7 +11188,7 @@
 		"recursive-readdir": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
-			"integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+			"integrity": "sha1-mUb7MnThYo3m42svZxSVO0hFCU8=",
 			"dev": true,
 			"requires": {
 				"minimatch": "3.0.4"
@@ -11150,7 +11197,7 @@
 		"redux": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
-			"integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+			"integrity": "sha1-Q2yubMQPvkcnaJ18j65EgI8b/vU=",
 			"dev": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
@@ -11165,7 +11212,7 @@
 		"regenerate": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+			"integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE="
 		},
 		"regenerate-unicode-properties": {
 			"version": "8.0.2",
@@ -11200,13 +11247,13 @@
 		"regexp-tree": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.5.tgz",
-			"integrity": "sha512-nUmxvfJyAODw+0B13hj8CFVAxhe7fDEAgJgaotBu3nnR+IgGgZq59YedJP5VYTlkEfqjuK6TuRpnymKdatLZfQ==",
+			"integrity": "sha1-fNcfyhcZjQS0F279eXE/KZgAk5c=",
 			"dev": true
 		},
 		"regexp.prototype.flags": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-			"integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+			"integrity": "sha1-azByTjBqJ4M+6xcbZqyIkLo35Bw=",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2"
@@ -11234,12 +11281,12 @@
 		"regjsgen": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA=="
+			"integrity": "sha1-p2NNwI+JIJwgSa3aNSVxH7lyZd0="
 		},
 		"regjsparser": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-			"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+			"integrity": "sha1-8eaui32iuulsmTmbhozWyTOiupw=",
 			"requires": {
 				"jsesc": "~0.5.0"
 			},
@@ -11254,7 +11301,7 @@
 		"rehype-parse": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.0.tgz",
-			"integrity": "sha512-V2OjMD0xcSt39G4uRdMTqDXXm6HwkUbLMDayYKA/d037j8/OtVSQ+tqKwYWOuyBeoCs/3clXRe30VUjeMDTBSA==",
+			"integrity": "sha1-9oFVXyWYFlvuLHeLOfkHPRexa8o=",
 			"dev": true,
 			"requires": {
 				"hast-util-from-parse5": "^5.0.0",
@@ -11276,7 +11323,7 @@
 		"render-fragment": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/render-fragment/-/render-fragment-0.1.1.tgz",
-			"integrity": "sha512-+DnAcalJYR8GE5VRuQGGu78Q0GDe8EXnkuk4DF8gbAhIeS6LRt4j+aaggLLj4PtQVfXNC61McXvXI58WqmRleQ==",
+			"integrity": "sha1-sjHyWbfu4zPTQlau4O8xab577zA=",
 			"dev": true
 		},
 		"renderkid": {
@@ -11446,7 +11493,7 @@
 		"require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
 			"dev": true
 		},
 		"require-uncached": {
@@ -11556,7 +11603,7 @@
 		"ripemd160": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
@@ -11630,7 +11677,7 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
 			"dev": true
 		},
 		"saxes": {
@@ -11645,7 +11692,7 @@
 		"scheduler": {
 			"version": "0.13.4",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.4.tgz",
-			"integrity": "sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==",
+			"integrity": "sha1-j+8F56NYDHbANk0t9eVQ5MkUApg=",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -11654,7 +11701,7 @@
 		"schema-utils": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-			"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+			"integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
 			"requires": {
 				"ajv": "^6.1.0",
 				"ajv-errors": "^1.0.0",
@@ -11669,7 +11716,7 @@
 		"send": {
 			"version": "0.16.1",
 			"resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-			"integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+			"integrity": "sha1-pw4coh0TgsEdDZ9iMd6ygQgNerM=",
 			"requires": {
 				"debug": "2.6.9",
 				"depd": "~1.1.1",
@@ -11689,7 +11736,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -11722,7 +11769,7 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+					"integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
 					"dev": true
 				}
 			}
@@ -11730,7 +11777,7 @@
 		"serve-static": {
 			"version": "1.13.2",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"integrity": "sha1-CV6Ecv1bRiN9tQzkhqQ/S4bGzsE=",
 			"dev": true,
 			"requires": {
 				"encodeurl": "~1.0.2",
@@ -11742,7 +11789,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -11757,7 +11804,7 @@
 				"send": {
 					"version": "0.16.2",
 					"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-					"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+					"integrity": "sha1-bsyh4PjBVtFBWXVZhI32RzCmu8E=",
 					"dev": true,
 					"requires": {
 						"debug": "2.6.9",
@@ -11778,7 +11825,7 @@
 				"statuses": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+					"integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic=",
 					"dev": true
 				}
 			}
@@ -11818,7 +11865,7 @@
 		"setprototypeof": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+			"integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -11861,7 +11908,7 @@
 		"shallowequal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+			"integrity": "sha1-GI1SHelbkIdAT9TctosT3wrk5/g=",
 			"dev": true
 		},
 		"shebang-command": {
@@ -11891,7 +11938,7 @@
 		"shelljs": {
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-			"integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+			"integrity": "sha1-p/MxlSDr8J7oEnWyNorbKGZZsJc=",
 			"dev": true,
 			"requires": {
 				"glob": "^7.0.0",
@@ -12129,7 +12176,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -12146,7 +12193,7 @@
 		"source-list-map": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
+			"integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ="
 		},
 		"source-map": {
 			"version": "0.6.1",
@@ -12182,7 +12229,7 @@
 		"space-separated-tokens": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.2.tgz",
-			"integrity": "sha512-G3jprCEw+xFEs0ORweLmblJ3XLymGGr6hxZYTYZjIlvDti9vOBUjRQa1Rzjt012aRrocKstHwdNi+F7HguPsEA==",
+			"integrity": "sha1-6Vq50ZroQeIAgIzZa8e9Ctu7NBI=",
 			"dev": true,
 			"requires": {
 				"trim": "0.0.1"
@@ -12191,7 +12238,7 @@
 		"spawn-promise": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/spawn-promise/-/spawn-promise-0.1.8.tgz",
-			"integrity": "sha512-pTkEOFxvYLq9SaI1d8bwepj0yD9Yyz65+4e979YZLv/L3oYPxZpDTabcm6e+KIZniGK9mQ+LGrwB5s1v2z67nQ==",
+			"integrity": "sha1-pb6piBTEj1LL4Ccg5/4tb8O1EZo=",
 			"dev": true,
 			"requires": {
 				"co": "^4.6.0"
@@ -12258,7 +12305,7 @@
 		"ssri": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+			"integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
 			"requires": {
 				"figgy-pudding": "^3.5.1"
 			}
@@ -12266,7 +12313,7 @@
 		"stable": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+			"integrity": "sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88=",
 			"dev": true
 		},
 		"standard": {
@@ -12315,6 +12362,56 @@
 				"concat-stream": "^1.5.0"
 			}
 		},
+		"standardx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/standardx/-/standardx-3.0.1.tgz",
+			"integrity": "sha512-HU4c9V/F6TAKAokrnClUIzuETYyVpO3iYs77stT29YRJu8HR0CQ7ypM2sgW1Qmn3+VPB6/eSy4aPMt8NYPtl3A==",
+			"dev": true,
+			"requires": {
+				"standard": "^12.0.1",
+				"standard-engine": "^10.0.0"
+			},
+			"dependencies": {
+				"deglob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/deglob/-/deglob-3.1.0.tgz",
+					"integrity": "sha512-al10l5QAYaM/PeuXkAr1Y9AQz0LCtWsnJG23pIgh44hDxHFOj36l6qvhfjnIWBYwZOqM1fXUFV9tkjL7JPdGvw==",
+					"dev": true,
+					"requires": {
+						"find-root": "^1.0.0",
+						"glob": "^7.0.5",
+						"ignore": "^5.0.0",
+						"pkg-config": "^1.1.0",
+						"run-parallel": "^1.1.2",
+						"uniq": "^1.0.1"
+					}
+				},
+				"ignore": {
+					"version": "5.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.6.tgz",
+					"integrity": "sha512-/+hp3kUf/Csa32ktIaj0OlRqQxrgs30n62M90UBpNd9k+ENEch5S+hmbW3DtcJGz3sYFTh4F3A6fQ0q7KWsp4w==",
+					"dev": true
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"standard-engine": {
+					"version": "10.0.0",
+					"resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-10.0.0.tgz",
+					"integrity": "sha512-91BjmzIRZbFmyOY73R6vaDd/7nw5qDWsfpJW5/N+BCXFgmvreyfrRg7oBSu4ihL0gFGXfnwCImJm6j+sZDQQyw==",
+					"dev": true,
+					"requires": {
+						"deglob": "^3.0.0",
+						"get-stdin": "^6.0.0",
+						"minimist": "^1.1.0",
+						"pkg-conf": "^2.0.0"
+					}
+				}
+			}
+		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -12348,7 +12445,7 @@
 		"stream-browserify": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
-			"integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+			"integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
 			"requires": {
 				"inherits": "~2.0.1",
 				"readable-stream": "^2.0.2"
@@ -12357,7 +12454,7 @@
 		"stream-each": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
-			"integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+			"integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"stream-shift": "^1.0.0"
@@ -12366,7 +12463,7 @@
 		"stream-http": {
 			"version": "2.8.3",
 			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-			"integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+			"integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
 			"requires": {
 				"builtin-status-codes": "^3.0.0",
 				"inherits": "^2.0.1",
@@ -12399,7 +12496,7 @@
 		"string.prototype.matchall": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-3.0.1.tgz",
-			"integrity": "sha512-NSiU0ILQr9PQ1SZmM1X327U5LsM+KfDTassJfqN1al1+0iNpKzmQ4BfXOJwRnTEqv8nKJ67mFpqRoPaGWwvy5A==",
+			"integrity": "sha1-Wp4LZLy+szaqSBSCAjfCAGmFZG0=",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
@@ -12444,7 +12541,7 @@
 		},
 		"string_decoder": {
 			"version": "1.1.1",
-			"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
 				"safe-buffer": "~5.1.0"
@@ -12452,7 +12549,7 @@
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
-			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
 				"ansi-regex": "^2.0.0"
@@ -12478,7 +12575,7 @@
 		"style-loader": {
 			"version": "0.23.1",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
-			"integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
+			"integrity": "sha1-y5FUYG8+dxq2xKtjcCahBJF02SU=",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^1.1.0",
@@ -12506,7 +12603,7 @@
 		"styled-jsx": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-3.2.1.tgz",
-			"integrity": "sha512-gM/WOrWYRpWReivzQqetEGohUc/TJSvUoZ5T/UJxJZIsVIPlRQLnp7R8Oue4q49sI08EBRQjQl2oBL3sfdrw2g==",
+			"integrity": "sha1-RSBR/lDfXpx8fz3SD6RsMGCsZbA=",
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-types": "6.26.0",
@@ -12521,12 +12618,12 @@
 				"big.js": {
 					"version": "5.2.2",
 					"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-					"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+					"integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg="
 				},
 				"json5": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
 					"requires": {
 						"minimist": "^1.2.0"
 					}
@@ -12534,7 +12631,7 @@
 				"loader-utils": {
 					"version": "1.2.3",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-					"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+					"integrity": "sha1-H/XcaRHJ8KBiUxpMBLYJQGEIwsc=",
 					"requires": {
 						"big.js": "^5.2.2",
 						"emojis-list": "^2.0.0",
@@ -12549,7 +12646,7 @@
 				"source-map": {
 					"version": "0.7.3",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+					"integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M="
 				}
 			}
 		},
@@ -12606,7 +12703,7 @@
 				"file-loader": {
 					"version": "1.1.11",
 					"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
-					"integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
+					"integrity": "sha1-b+iGRJsPKpNuQ8q6rAzb+zaVBvg=",
 					"dev": true,
 					"requires": {
 						"loader-utils": "^1.0.2",
@@ -12616,7 +12713,7 @@
 				"schema-utils": {
 					"version": "0.4.7",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-					"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+					"integrity": "sha1-unT1l9K+LqiAExdG7hfQoJPGgYc=",
 					"dev": true,
 					"requires": {
 						"ajv": "^6.1.0",
@@ -12650,7 +12747,7 @@
 				"css-select": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
-					"integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
+					"integrity": "sha1-q0OGzsnh9miFVWSxfDcztDsqXt4=",
 					"dev": true,
 					"requires": {
 						"boolbase": "^1.0.0",
@@ -12662,7 +12759,7 @@
 				"domutils": {
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-					"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+					"integrity": "sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=",
 					"dev": true,
 					"requires": {
 						"dom-serializer": "0",
@@ -12685,7 +12782,7 @@
 		"symbol.prototype.description": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/symbol.prototype.description/-/symbol.prototype.description-1.0.0.tgz",
-			"integrity": "sha512-I9mrbZ5M96s7QeJDv95toF1svkUjeBybe8ydhY7foPaBmr0SPJMFupArmMkDrOKTTj0sJVr+nvQNxWLziQ7nDQ==",
+			"integrity": "sha1-bjVWYOseRMqK1Tpo/bcu8THKSxI=",
 			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.0"
@@ -12741,7 +12838,7 @@
 		"tapable": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
-			"integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA=="
+			"integrity": "sha1-TSl5I8WnKkI2DeKrUtrfquwAAY4="
 		},
 		"term-size": {
 			"version": "1.2.0",
@@ -12755,7 +12852,7 @@
 		"terser": {
 			"version": "3.16.1",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-3.16.1.tgz",
-			"integrity": "sha512-JDJjgleBROeek2iBcSNzOHLKsB/MdDf+E/BOAJ0Tk9r7p9/fVobfv7LMJ/g/k3v9SXdmjZnIlFd5nfn/Rt0Xow==",
+			"integrity": "sha1-Ww3U+h/9CwtDwkk7LDZP0XkWBJM=",
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1",
@@ -12799,7 +12896,7 @@
 		"through2": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
 			"requires": {
 				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
@@ -12808,7 +12905,7 @@
 		"timers-browserify": {
 			"version": "2.0.10",
 			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+			"integrity": "sha1-HSjj0qrfHVpZlsTp+VYBzQU0gK4=",
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
@@ -12919,18 +13016,18 @@
 		"trough": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
-			"integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
+			"integrity": "sha1-4pvRYUxkWNRIafwoslWreFfvfCQ=",
 			"dev": true
 		},
 		"tslib": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+			"integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY="
 		},
 		"tty-aware-progress": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/tty-aware-progress/-/tty-aware-progress-1.0.3.tgz",
-			"integrity": "sha512-+UpHmP813cD/edyM72cFAJaVwYa6arzNMoiQ4etylmL3NUpluuiUZYYwFR15oIZB05J7IPFV/HHhDbCGycLl3Q==",
+			"integrity": "sha1-k/vobK8NecNfbhBOCPOlbFBp09Y=",
 			"requires": {
 				"progress": "2.0.3"
 			}
@@ -12973,7 +13070,7 @@
 		"type-is": {
 			"version": "1.6.16",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"integrity": "sha1-+JzjQVQcZysl7nrjxz3uOyvlAZQ=",
 			"dev": true,
 			"requires": {
 				"media-typer": "0.3.0",
@@ -12993,7 +13090,7 @@
 		"uglify-js": {
 			"version": "3.4.9",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+			"integrity": "sha1-rwLxgMEgfXZDLkc+0koo9KeCuuM=",
 			"dev": true,
 			"requires": {
 				"commander": "~2.17.1",
@@ -13016,12 +13113,12 @@
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+			"integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg="
 		},
 		"unicode-match-property-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+			"integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
 			"requires": {
 				"unicode-canonical-property-names-ecmascript": "^1.0.4",
 				"unicode-property-aliases-ecmascript": "^1.0.4"
@@ -13040,7 +13137,7 @@
 		"unified": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
-			"integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+			"integrity": "sha1-UDLxwe4zZL0J2hLif91KdVPHvhM=",
 			"dev": true,
 			"requires": {
 				"@types/unist": "^2.0.0",
@@ -13094,7 +13191,7 @@
 		"unique-filename": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+			"integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
 			"requires": {
 				"unique-slug": "^2.0.0"
 			}
@@ -13102,7 +13199,7 @@
 		"unique-slug": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
-			"integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+			"integrity": "sha1-Xp7cbRzo+yZNsYpQfvm9hURFHKY=",
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
@@ -13110,7 +13207,7 @@
 		"unist-util-stringify-position": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
+			"integrity": "sha1-Pzf881EnncvKdICrWIm7ioMu4cY=",
 			"dev": true
 		},
 		"unistore": {
@@ -13121,7 +13218,7 @@
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
 			"dev": true
 		},
 		"unpipe": {
@@ -13222,7 +13319,7 @@
 		"url-loader": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.2.tgz",
-			"integrity": "sha512-dXHkKmw8FhPqu8asTc1puBfe3TehOCo2+RmOOev5suNCIYBcT626kxiWg1NBVkwc4rO8BGa7gP70W7VXuqHrjg==",
+			"integrity": "sha1-uXHRkbg69pPF4/6kBkvp4fLX+Ng=",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^1.1.0",
@@ -13233,7 +13330,7 @@
 				"mime": {
 					"version": "2.4.0",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-					"integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+					"integrity": "sha1-4FH9iBNYWF8yed8zP+aU2gvP/dY=",
 					"dev": true
 				}
 			}
@@ -13255,7 +13352,7 @@
 		"util": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
-			"integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+			"integrity": "sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=",
 			"requires": {
 				"inherits": "2.0.3"
 			}
@@ -13268,7 +13365,7 @@
 		"util.promisify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
 			"requires": {
 				"define-properties": "^1.1.2",
 				"object.getownpropertydescriptors": "^2.0.3"
@@ -13314,13 +13411,13 @@
 		"velocity-animate": {
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/velocity-animate/-/velocity-animate-1.5.2.tgz",
-			"integrity": "sha512-m6EXlCAMetKztO1ppBhGU1/1MR3IiEevO6ESq6rcrSQ3Q77xYSW13jkfXW88o4xMrkXJhy/U7j4wFR/twMB0Eg==",
+			"integrity": "sha1-WjUddfyiqSdW9cOGdUi4c/bDIQU=",
 			"dev": true
 		},
 		"velocity-react": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/velocity-react/-/velocity-react-1.4.1.tgz",
-			"integrity": "sha512-ZyXBm+9C/6kNUNyc+aeNKEhtTu/Mn+OfpsNBGuTxU8S2DUcis/KQL0rTN6jWL+7ygdOrun18qhheNZTA7YERmg==",
+			"integrity": "sha1-HQtBhZzfJSHAiotX9E6T7S1Utfw=",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.5",
@@ -13343,7 +13440,7 @@
 		"vfile": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
-			"integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+			"integrity": "sha1-RzMdKr4ygkJPSku2rNIKRMQSGAM=",
 			"dev": true,
 			"requires": {
 				"is-buffer": "^2.0.0",
@@ -13355,7 +13452,7 @@
 				"is-buffer": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-					"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+					"integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU=",
 					"dev": true
 				}
 			}
@@ -13363,7 +13460,7 @@
 		"vfile-message": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+			"integrity": "sha1-WDOuB4od+i2W6WR4hs0ymTqzE+E=",
 			"dev": true,
 			"requires": {
 				"unist-util-stringify-position": "^1.1.1"
@@ -13409,7 +13506,7 @@
 		"watchpack": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+			"integrity": "sha1-S8EsLr6KonenHx0/FNaFx7RGzQA=",
 			"requires": {
 				"chokidar": "^2.0.2",
 				"graceful-fs": "^4.1.2",
@@ -13419,7 +13516,7 @@
 		"web-namespaces": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.2.tgz",
-			"integrity": "sha512-II+n2ms4mPxK+RnIxRPOw3zwF2jRscdJIUE9BfkKHm4FYEg9+biIoTMnaZF5MpemE3T+VhMLrhbyD4ilkPCSbg==",
+			"integrity": "sha1-yNwmerY5UFJ2uuGeEp29aucrIrQ=",
 			"dev": true
 		},
 		"webidl-conversions": {
@@ -13431,7 +13528,7 @@
 		"webpack": {
 			"version": "4.29.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.0.tgz",
-			"integrity": "sha512-pxdGG0keDBtamE1mNvT5zyBdx+7wkh6mh7uzMOo/uRQ/fhsdj5FXkh/j5mapzs060forql1oXqXN9HJGju+y7w==",
+			"integrity": "sha1-8s/vg/euQEuoif9dQ+/Shcom51A=",
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-module-context": "1.7.11",
@@ -13462,7 +13559,7 @@
 				"schema-utils": {
 					"version": "0.4.7",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-					"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+					"integrity": "sha1-unT1l9K+LqiAExdG7hfQoJPGgYc=",
 					"requires": {
 						"ajv": "^6.1.0",
 						"ajv-keywords": "^3.1.0"
@@ -13473,7 +13570,7 @@
 		"webpack-dev-middleware": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.4.0.tgz",
-			"integrity": "sha512-Q9Iyc0X9dP9bAsYskAVJ/hmIZZQwf/3Sy4xCAZgL5cUkjZmUZLt4l5HpbST/Pdgjn3u6pE7u5OdGd1apgzRujA==",
+			"integrity": "sha1-ETL+zJAm/ZDw7O2sXL/3XR+0WJA=",
 			"requires": {
 				"memory-fs": "~0.4.1",
 				"mime": "^2.3.1",
@@ -13484,14 +13581,14 @@
 				"mime": {
 					"version": "2.4.0",
 					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-					"integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
+					"integrity": "sha1-4FH9iBNYWF8yed8zP+aU2gvP/dY="
 				}
 			}
 		},
 		"webpack-hot-middleware": {
 			"version": "2.24.3",
 			"resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.24.3.tgz",
-			"integrity": "sha512-pPlmcdoR2Fn6UhYjAhp1g/IJy1Yc9hD+T6O9mjRcWV2pFbBjIFoJXhP0CoD0xPOhWJuWXuZXGBga9ybbOdzXpg==",
+			"integrity": "sha1-W7diWaj8DZdGOrUXZAupHTOC1KY=",
 			"requires": {
 				"ansi-html": "0.0.7",
 				"html-entities": "^1.2.0",
@@ -13502,7 +13599,7 @@
 		"webpack-log": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
-			"integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+			"integrity": "sha1-W3ko4GN1k/EZ0y9iJ8HgrDHhtH8=",
 			"requires": {
 				"ansi-colors": "^3.0.0",
 				"uuid": "^3.3.2"
@@ -13511,7 +13608,7 @@
 		"webpack-merge": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.1.tgz",
-			"integrity": "sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==",
+			"integrity": "sha1-XpI8+ALqKs5P1a8dMkc2imM0ibQ=",
 			"requires": {
 				"lodash": "^4.17.5"
 			}
@@ -13519,7 +13616,7 @@
 		"webpack-sources": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
-			"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+			"integrity": "sha1-KijcufH0X+lg2PFJMlK17mUw+oU=",
 			"requires": {
 				"source-list-map": "^2.0.0",
 				"source-map": "~0.6.1"
@@ -13538,7 +13635,7 @@
 		"websocket-extensions": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+			"integrity": "sha1-XS/yKXcAPsaHpLhwc9+7rBRszyk=",
 			"dev": true
 		},
 		"whatwg-encoding": {
@@ -13583,7 +13680,7 @@
 		"wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
 			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
@@ -13592,7 +13689,7 @@
 		"widest-line": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-			"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+			"integrity": "sha1-dDh2RzDsfvQ4HOTfgvuYpTFCo/w=",
 			"dev": true,
 			"requires": {
 				"string-width": "^2.1.1"
@@ -13639,7 +13736,7 @@
 		"worker-farm": {
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
-			"integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
+			"integrity": "sha1-MrMS5dw9XUXXnvRKzCWHSRzXKa4=",
 			"requires": {
 				"errno": "^0.1.4",
 				"xtend": "^4.0.1"
@@ -13694,7 +13791,7 @@
 		"y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+			"integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms="
 		},
 		"yallist": {
 			"version": "3.0.3",

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -11,7 +11,7 @@
     "_test": "npm run _check && BABEL_ENV=test mocha",
     "build": "npm run _check && PANOPTES_ENV=production next build",
     "dev": "npm run _check && npm run _serve",
-    "lint": "npm run _check && standard --fix | snazzy; exit 0",
+    "lint": "npm run _check && standardx --fix | snazzy; exit 0",
     "start": "npm run _check && NODE_ENV=production npm run _serve",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "test": "npm run _test && exit 0",
@@ -57,23 +57,32 @@
     "dirty-chai": "^2.0.1",
     "enzyme": "~3.9.0",
     "enzyme-adapter-react-16": "~1.11.2",
+    "eslint-plugin-jsx-a11y": "^6.2.1",
     "jsdom": "~13.0.0",
     "mocha": "~5.2.0",
     "sinon": "~7.2.3",
     "sinon-chai": "~3.3.0",
     "snazzy": "~8.0.0",
-    "standard": "~12.0.1"
+    "standardx": "^3.0.1"
   },
   "engines": {
     "node": ">=10"
   },
-  "standard": {
+  "eslintConfig": {
+    "extends": [
+      "plugin:jsx-a11y/recommended"
+    ]
+  },
+  "standardx": {
     "env": [
       "mocha"
     ],
     "globals": [
       "expect"
     ],
-    "parser": "babel-eslint"
+    "parser": "babel-eslint",
+    "plugins": [
+      "jsx-a11y"
+    ]
   }
 }

--- a/packages/lib-classifier/package-lock.json
+++ b/packages/lib-classifier/package-lock.json
@@ -1238,7 +1238,7 @@
     "acorn-jsx": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "integrity": "sha1-MqBk/ZJUKSFqCbFBECv90YX65A4=",
       "dev": true
     },
     "acorn-walk": {
@@ -1334,7 +1334,7 @@
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -1346,6 +1346,16 @@
           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
           "dev": true
         }
+      }
+    },
+    "aria-query": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
       }
     },
     "arr-diff": {
@@ -1368,7 +1378,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -1424,7 +1434,7 @@
     "array.prototype.flat": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
-      "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
+      "integrity": "sha1-gS248CytJNP6tl3WfqvjuJA0lKQ=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -1475,7 +1485,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -1502,9 +1512,15 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+      "dev": true
+    },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
@@ -1551,6 +1567,15 @@
       "requires": {
         "follow-redirects": "^1.2.3",
         "is-buffer": "^1.1.5"
+      }
+    },
+    "axobject-query": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+      "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7"
       }
     },
     "babel-code-frame": {
@@ -1726,7 +1751,7 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
@@ -2004,7 +2029,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -2041,7 +2066,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -2086,7 +2111,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -2192,7 +2217,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -2360,7 +2385,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "class-utils": {
@@ -2692,7 +2717,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -2705,7 +2730,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -2739,7 +2764,7 @@
     "css": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "integrity": "sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -2751,7 +2776,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -3081,6 +3106,12 @@
         "d3-transition": "1"
       }
     },
+    "damerau-levenshtein": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
+      "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
+      "dev": true
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -3122,7 +3153,7 @@
     },
     "debug-log": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
@@ -3357,7 +3388,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -3400,7 +3431,7 @@
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -3449,7 +3480,7 @@
     "domhandler": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
       "dev": true,
       "requires": {
         "domelementtype": "1"
@@ -3514,6 +3545,12 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -3564,7 +3601,7 @@
     "enzyme": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.9.0.tgz",
-      "integrity": "sha512-JqxI2BRFHbmiP7/UFqvsjxTirWoM1HfeaJrmVSZ9a1EADKkZgdPcAuISPMpoUiHlac9J4dYt81MC5BBIrbJGMg==",
+      "integrity": "sha1-K0kfBsqWbrVrZRAGjHiUp+C+OQk=",
       "dev": true,
       "requires": {
         "array.prototype.flat": "^1.2.1",
@@ -3593,7 +3630,7 @@
     "enzyme-adapter-react-16": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.11.2.tgz",
-      "integrity": "sha512-2ruTTCPRb0lPuw/vKTXGVZVBZqh83MNDnakMhzxhpJcIbneEwNy2Cv0KvL97pl57/GOazJHflWNLjwWhex5AAA==",
+      "integrity": "sha1-jv6vsn6WhzpUkv3vP0I2kxguudQ=",
       "dev": true,
       "requires": {
         "enzyme-adapter-utils": "^1.10.1",
@@ -3608,7 +3645,7 @@
     "enzyme-adapter-utils": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.10.1.tgz",
-      "integrity": "sha512-oasinhhLoBuZsIkTe8mx0HiudtfErUtG0Ooe1FOplu/t4c9rOmyG5gtrBASK6u4whHIRWvv0cbZMElzNTR21SA==",
+      "integrity": "sha1-WCZO+hmnvv2/lk+3mBoQilRSrJY=",
       "dev": true,
       "requires": {
         "function.prototype.name": "^1.1.0",
@@ -3663,7 +3700,7 @@
     },
     "es6-promise": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
       "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
     },
     "escape-html": {
@@ -3807,7 +3844,7 @@
     "eslint-import-resolver-node": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
       "dev": true,
       "requires": {
         "debug": "^2.6.9",
@@ -3913,6 +3950,22 @@
         }
       }
     },
+    "eslint-plugin-jsx-a11y": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
+      "integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
+      "dev": true,
+      "requires": {
+        "aria-query": "^3.0.0",
+        "array-includes": "^3.0.3",
+        "ast-types-flow": "^0.0.7",
+        "axobject-query": "^2.0.2",
+        "damerau-levenshtein": "^1.0.4",
+        "emoji-regex": "^7.0.2",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.0.1"
+      }
+    },
     "eslint-plugin-node": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
@@ -3994,7 +4047,7 @@
     "esquery": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
@@ -4255,7 +4308,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -4435,7 +4488,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -4506,7 +4559,7 @@
     "flat-cache": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "integrity": "sha1-LC73dSXMKSkAff/6HdMUqpyd7m8=",
       "dev": true,
       "requires": {
         "circular-json": "^0.3.1",
@@ -4648,8 +4701,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4670,14 +4722,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4692,20 +4742,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4822,8 +4869,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4835,7 +4881,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4850,7 +4895,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4858,14 +4902,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4884,7 +4926,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4965,8 +5006,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4978,7 +5018,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5064,8 +5103,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5101,7 +5139,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5121,7 +5158,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5165,14 +5201,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5185,7 +5219,7 @@
     "function.prototype.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
-      "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+      "integrity": "sha1-i9djzAr4YKhZzF1JOE10uTLNIyc=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -5307,7 +5341,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
@@ -5320,7 +5354,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -5334,7 +5368,7 @@
     "grommet": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.5.5.tgz",
-      "integrity": "sha512-OxHuYaMGDVYQk7cuoqDSGs5BU33MqTGD5SzVnsKF9W344fequywrLZWGMiBxvgL7Z6ZY8LHjdlWisAlrbsbWPw==",
+      "integrity": "sha1-CNT8BUQBbnl9A+N0R/+3D+We8XQ=",
       "dev": true,
       "requires": {
         "css": "^2.2.3",
@@ -5352,7 +5386,7 @@
     "grommet-icons": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/grommet-icons/-/grommet-icons-4.2.0.tgz",
-      "integrity": "sha512-HMPLQa2pgnCZFImUXwfq+79VizL6oyP2/AAfAzQDw57x/6qgWouoqoRrrt+2zodTjTxtKXxliBY1w/o5uC+DpA==",
+      "integrity": "sha1-e899Szf2lFFq3ghOJTbHKyJManY=",
       "dev": true,
       "requires": {
         "grommet-styles": "^0.2.0"
@@ -5361,7 +5395,7 @@
     "grommet-styles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/grommet-styles/-/grommet-styles-0.2.0.tgz",
-      "integrity": "sha512-0OMSYuGeyifYKpg4Gv2HzL8rUdd0ddnJ5LbCBKgDuloC71XIwr9g/Fxa6rs737MbPV7OZ4pEm4wvrjH4epzf1A==",
+      "integrity": "sha1-surCt+J0fLUjQ00hcozlI0+M5PQ=",
       "dev": true
     },
     "growl": {
@@ -5497,7 +5531,7 @@
     },
     "hoek": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
       "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "hoist-non-react-statics": {
@@ -5527,7 +5561,7 @@
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
       "dev": true
     },
     "hpack.js": {
@@ -5633,7 +5667,7 @@
     "htmlparser2": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
       "dev": true,
       "requires": {
         "domelementtype": "^1.3.1",
@@ -5665,7 +5699,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -5694,7 +5728,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
       "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
       "dev": true,
       "requires": {
@@ -5855,7 +5889,7 @@
     },
     "inquirer": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
       "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
       "dev": true,
       "requires": {
@@ -6107,7 +6141,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-path-cwd": {
@@ -6166,7 +6200,7 @@
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
       "dev": true
     },
     "is-stream": {
@@ -6290,7 +6324,7 @@
         "esprima": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
           "dev": true
         }
       }
@@ -6702,7 +6736,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -6908,7 +6942,7 @@
     "mobile-detect": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/mobile-detect/-/mobile-detect-1.4.3.tgz",
-      "integrity": "sha512-UaahPNLllQsstHOEHAmVnTHCMQrAS9eL5Qgdi50QrYz6UgGk+Xziz2udz2GN6NYcyODcPLnasC7a7s6R2DjiaQ==",
+      "integrity": "sha1-5Dajg59YB91NPNTggffTpR/9ot0=",
       "dev": true
     },
     "mobx": {
@@ -7026,7 +7060,7 @@
     "moo": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+      "integrity": "sha1-P4R6JvMc9iWpVqh/KxD7wBO/0Q4=",
       "dev": true
     },
     "mout": {
@@ -7117,7 +7151,7 @@
     "nearley": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
-      "integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+      "integrity": "sha1-d8KX0EGUHSaCkOyEtznQ7il+g6c=",
       "dev": true,
       "requires": {
         "commander": "^2.19.0",
@@ -7344,7 +7378,7 @@
     "object-inspect": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "integrity": "sha1-xwtsv3LydKq0w0wMgvUWe/gs8Vs=",
       "dev": true
     },
     "object-is": {
@@ -7371,7 +7405,7 @@
     "object.assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -7383,7 +7417,7 @@
     "object.entries": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "integrity": "sha1-ICT8bWuiRq7ji9sP/Vz7zzcbdRk=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -7395,7 +7429,7 @@
     "object.fromentries": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
-      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+      "integrity": "sha1-SaVD2SFR+Cd7OslgDx6TCxidMKs=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -7426,7 +7460,7 @@
     "object.values": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "integrity": "sha1-v2gQ712j5TJXkOqqK+IT6oRiTak=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -7687,7 +7721,7 @@
     "parse5": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "integrity": "sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -8185,7 +8219,7 @@
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "integrity": "sha1-B0LpmkplUvRF1z4+4DKK8P8e3jk=",
       "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
@@ -8200,7 +8234,7 @@
     "randexp": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "integrity": "sha1-6YatXl4x2uE93W97MBmqfIf2DKM=",
       "dev": true,
       "requires": {
         "discontinuous-range": "1.0.0",
@@ -8275,7 +8309,7 @@
     "react-desc": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/react-desc/-/react-desc-4.1.2.tgz",
-      "integrity": "sha512-JAVe89uaLr0HZ0IKodnpTPNgNyJ/SPDQnl3VJPVwI+SpebmHvJiBNZEOwX201QmSbsVGqRY8ql/VFPlAx85WzA==",
+      "integrity": "sha1-g/xO3may1Frk72PBhCFHTVWXKWY=",
       "dev": true
     },
     "react-dom": {
@@ -8385,7 +8419,7 @@
     "recompose": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
+      "integrity": "sha1-gnc2QbOSfox9JKDYfWWu66GKq9A=",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
@@ -8480,7 +8514,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -8981,7 +9015,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -9304,13 +9338,13 @@
     "spdx-exceptions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -9459,6 +9493,50 @@
       "dev": true,
       "requires": {
         "concat-stream": "^1.5.0"
+      }
+    },
+    "standardx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/standardx/-/standardx-3.0.1.tgz",
+      "integrity": "sha512-HU4c9V/F6TAKAokrnClUIzuETYyVpO3iYs77stT29YRJu8HR0CQ7ypM2sgW1Qmn3+VPB6/eSy4aPMt8NYPtl3A==",
+      "dev": true,
+      "requires": {
+        "standard": "^12.0.1",
+        "standard-engine": "^10.0.0"
+      },
+      "dependencies": {
+        "deglob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/deglob/-/deglob-3.1.0.tgz",
+          "integrity": "sha512-al10l5QAYaM/PeuXkAr1Y9AQz0LCtWsnJG23pIgh44hDxHFOj36l6qvhfjnIWBYwZOqM1fXUFV9tkjL7JPdGvw==",
+          "dev": true,
+          "requires": {
+            "find-root": "^1.0.0",
+            "glob": "^7.0.5",
+            "ignore": "^5.0.0",
+            "pkg-config": "^1.1.0",
+            "run-parallel": "^1.1.2",
+            "uniq": "^1.0.1"
+          }
+        },
+        "ignore": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.6.tgz",
+          "integrity": "sha512-/+hp3kUf/Csa32ktIaj0OlRqQxrgs30n62M90UBpNd9k+ENEch5S+hmbW3DtcJGz3sYFTh4F3A6fQ0q7KWsp4w==",
+          "dev": true
+        },
+        "standard-engine": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-10.0.0.tgz",
+          "integrity": "sha512-91BjmzIRZbFmyOY73R6vaDd/7nw5qDWsfpJW5/N+BCXFgmvreyfrRg7oBSu4ihL0gFGXfnwCImJm6j+sZDQQyw==",
+          "dev": true,
+          "requires": {
+            "deglob": "^3.0.0",
+            "get-stdin": "^6.0.0",
+            "minimist": "^1.1.0",
+            "pkg-conf": "^2.0.0"
+          }
+        }
       }
     },
     "static-extend": {
@@ -9622,7 +9700,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -9720,7 +9798,7 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ=",
       "dev": true
     },
     "symbol-tree": {
@@ -9731,7 +9809,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
@@ -9922,7 +10000,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
@@ -9983,7 +10061,7 @@
     },
     "topo": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
         "hoek": "4.x.x"
@@ -10377,7 +10455,7 @@
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
@@ -10945,7 +11023,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -10,7 +10,7 @@
     "_test": "npm run _check && NODE_PATH=. NODE_ENV=test mocha",
     "build": "npm run _check && webpack --config webpack.dist.js",
     "dev": "npm run _check && webpack-dev-server --config webpack.dev.js",
-    "lint": "npm run _check && standard --fix | snazzy; exit 0",
+    "lint": "npm run _check && standardx --fix | snazzy; exit 0",
     "start": "npm run _check && PANOPTES_ENV=production npm run dev",
     "test": "npm run _test && exit 0",
     "test:ci": "npm run _test -- --reporter=min"
@@ -64,6 +64,7 @@
     "check-dependencies": "~1.1.0",
     "enzyme": "~3.9.0",
     "enzyme-adapter-react-16": "~1.11.2",
+    "eslint-plugin-jsx-a11y": "^6.2.1",
     "grommet": "~2.5.5",
     "grommet-icons": "~4.2.0",
     "html-webpack-plugin": "~3.2.0",
@@ -83,7 +84,7 @@
     "sinon": "~7.1.1",
     "sinon-chai": "~3.3.0",
     "snazzy": "~8.0.0",
-    "standard": "~12.0.1",
+    "standardx": "^3.0.1",
     "styled-components": "~4.1.2",
     "styled-theming": "~2.2.0",
     "superagent": "~3.8.3",
@@ -91,7 +92,12 @@
     "webpack-cli": "~3.1.2",
     "webpack-dev-server": "~3.1.14"
   },
-  "standard": {
+  "eslintConfig": {
+    "extends": [
+      "plugin:jsx-a11y/recommended"
+    ]
+  },
+  "standardx": {
     "env": {
       "mocha": true
     },

--- a/packages/lib-react-components/package-lock.json
+++ b/packages/lib-react-components/package-lock.json
@@ -2230,6 +2230,16 @@
         }
       }
     },
+    "aria-query": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2413,6 +2423,12 @@
       "integrity": "sha512-nHiuV14upVGl7MWwFUYbzJ6YlfwWS084CU9EA8HajfYQjMSli5TQi3UTRygGF58LFWVkXxS1rbgRhROEqlQkXg==",
       "dev": true
     },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+      "dev": true
+    },
     "async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
@@ -2470,6 +2486,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
+    },
+    "axobject-query": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+      "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -3409,7 +3434,7 @@
         "domhandler": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+          "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
           "dev": true,
           "requires": {
             "domelementtype": "1"
@@ -3418,7 +3443,7 @@
         "htmlparser2": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-          "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+          "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
           "dev": true,
           "requires": {
             "domelementtype": "^1.3.1",
@@ -3432,7 +3457,7 @@
         "readable-stream": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "integrity": "sha1-3hfyKYZMEgqfVpRXVuTzLEBFJF0=",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -4118,6 +4143,12 @@
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
     },
+    "damerau-levenshtein": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
+      "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
+      "dev": true
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -4586,7 +4617,7 @@
     "enzyme": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.9.0.tgz",
-      "integrity": "sha512-JqxI2BRFHbmiP7/UFqvsjxTirWoM1HfeaJrmVSZ9a1EADKkZgdPcAuISPMpoUiHlac9J4dYt81MC5BBIrbJGMg==",
+      "integrity": "sha1-K0kfBsqWbrVrZRAGjHiUp+C+OQk=",
       "dev": true,
       "requires": {
         "array.prototype.flat": "^1.2.1",
@@ -4615,7 +4646,7 @@
     "enzyme-adapter-react-16": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.11.2.tgz",
-      "integrity": "sha512-2ruTTCPRb0lPuw/vKTXGVZVBZqh83MNDnakMhzxhpJcIbneEwNy2Cv0KvL97pl57/GOazJHflWNLjwWhex5AAA==",
+      "integrity": "sha1-jv6vsn6WhzpUkv3vP0I2kxguudQ=",
       "dev": true,
       "requires": {
         "enzyme-adapter-utils": "^1.10.1",
@@ -4630,7 +4661,7 @@
         "object.values": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-          "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+          "integrity": "sha1-v2gQ712j5TJXkOqqK+IT6oRiTak=",
           "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
@@ -4642,7 +4673,7 @@
         "prop-types": {
           "version": "15.7.2",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
           "dev": true,
           "requires": {
             "loose-envify": "^1.4.0",
@@ -4653,7 +4684,7 @@
         "react-is": {
           "version": "16.8.4",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
-          "integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==",
+          "integrity": "sha1-kPM2pow6KaCWo9ZIq4DofsYUgqI=",
           "dev": true
         }
       }
@@ -4661,7 +4692,7 @@
     "enzyme-adapter-utils": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.10.1.tgz",
-      "integrity": "sha512-oasinhhLoBuZsIkTe8mx0HiudtfErUtG0Ooe1FOplu/t4c9rOmyG5gtrBASK6u4whHIRWvv0cbZMElzNTR21SA==",
+      "integrity": "sha1-WCZO+hmnvv2/lk+3mBoQilRSrJY=",
       "dev": true,
       "requires": {
         "function.prototype.name": "^1.1.0",
@@ -4674,7 +4705,7 @@
         "object.fromentries": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
-          "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+          "integrity": "sha1-SaVD2SFR+Cd7OslgDx6TCxidMKs=",
           "dev": true,
           "requires": {
             "define-properties": "^1.1.2",
@@ -4686,7 +4717,7 @@
         "prop-types": {
           "version": "15.7.2",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
           "dev": true,
           "requires": {
             "loose-envify": "^1.4.0",
@@ -4697,7 +4728,7 @@
         "react-is": {
           "version": "16.8.4",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
-          "integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==",
+          "integrity": "sha1-kPM2pow6KaCWo9ZIq4DofsYUgqI=",
           "dev": true
         }
       }
@@ -5062,6 +5093,22 @@
             "isarray": "^1.0.0"
           }
         }
+      }
+    },
+    "eslint-plugin-jsx-a11y": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
+      "integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
+      "dev": true,
+      "requires": {
+        "aria-query": "^3.0.0",
+        "array-includes": "^3.0.3",
+        "ast-types-flow": "^0.0.7",
+        "axobject-query": "^2.0.2",
+        "damerau-levenshtein": "^1.0.4",
+        "emoji-regex": "^7.0.2",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.0.1"
       }
     },
     "eslint-plugin-node": {
@@ -6564,7 +6611,7 @@
     "grommet": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.5.5.tgz",
-      "integrity": "sha512-OxHuYaMGDVYQk7cuoqDSGs5BU33MqTGD5SzVnsKF9W344fequywrLZWGMiBxvgL7Z6ZY8LHjdlWisAlrbsbWPw==",
+      "integrity": "sha1-CNT8BUQBbnl9A+N0R/+3D+We8XQ=",
       "dev": true,
       "requires": {
         "css": "^2.2.3",
@@ -6582,7 +6629,7 @@
         "hoist-non-react-statics": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "integrity": "sha1-sJF48BIhhPuVrPUl2q7LTY9FlYs=",
           "dev": true,
           "requires": {
             "react-is": "^16.7.0"
@@ -6593,7 +6640,7 @@
     "grommet-icons": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/grommet-icons/-/grommet-icons-4.2.0.tgz",
-      "integrity": "sha512-HMPLQa2pgnCZFImUXwfq+79VizL6oyP2/AAfAzQDw57x/6qgWouoqoRrrt+2zodTjTxtKXxliBY1w/o5uC+DpA==",
+      "integrity": "sha1-e899Szf2lFFq3ghOJTbHKyJManY=",
       "dev": true,
       "requires": {
         "grommet-styles": "^0.2.0"
@@ -6602,7 +6649,7 @@
     "grommet-styles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/grommet-styles/-/grommet-styles-0.2.0.tgz",
-      "integrity": "sha512-0OMSYuGeyifYKpg4Gv2HzL8rUdd0ddnJ5LbCBKgDuloC71XIwr9g/Fxa6rs737MbPV7OZ4pEm4wvrjH4epzf1A==",
+      "integrity": "sha1-surCt+J0fLUjQ00hcozlI0+M5PQ=",
       "dev": true
     },
     "growl": {
@@ -6823,7 +6870,7 @@
     "html-element-map": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.0.tgz",
-      "integrity": "sha512-/SP6aOiM5Ai9zALvCxDubIeez0LvG3qP7R9GcRDnJEP/HBmv0A8A9K0o8+HFudcFt46+i921ANjzKsjPjb7Enw==",
+      "integrity": "sha1-GaQZQCJRU+zf6tdPhQkVT/HNwYs=",
       "dev": true,
       "requires": {
         "array-filter": "^1.0.0"
@@ -8360,7 +8407,7 @@
     "mobile-detect": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/mobile-detect/-/mobile-detect-1.4.3.tgz",
-      "integrity": "sha512-UaahPNLllQsstHOEHAmVnTHCMQrAS9eL5Qgdi50QrYz6UgGk+Xziz2udz2GN6NYcyODcPLnasC7a7s6R2DjiaQ==",
+      "integrity": "sha1-5Dajg59YB91NPNTggffTpR/9ot0=",
       "dev": true
     },
     "mocha": {
@@ -8431,7 +8478,7 @@
     "moo": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+      "integrity": "sha1-P4R6JvMc9iWpVqh/KxD7wBO/0Q4=",
       "dev": true
     },
     "move-concurrently": {
@@ -8495,7 +8542,7 @@
     "nearley": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
-      "integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+      "integrity": "sha1-d8KX0EGUHSaCkOyEtznQ7il+g6c=",
       "dev": true,
       "requires": {
         "commander": "^2.19.0",
@@ -8781,7 +8828,7 @@
     "object-inspect": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "integrity": "sha1-xwtsv3LydKq0w0wMgvUWe/gs8Vs=",
       "dev": true
     },
     "object-is": {
@@ -8808,7 +8855,7 @@
     "object.assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -9108,7 +9155,7 @@
     "parse5": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "integrity": "sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -9317,7 +9364,7 @@
     "polished": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/polished/-/polished-2.3.3.tgz",
-      "integrity": "sha512-59V4fDbdxtH4I1m9TWxFsoGJbC8nnOpUYo5uFmvMfKp9Qh+6suo4VMUle1TGIIUZIGxfkW+Rs485zPk0wcwR2Q==",
+      "integrity": "sha1-vbq6liuoJxsOEaoofyvv1Mh76Zo=",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.2.0"
@@ -9583,7 +9630,7 @@
     "prop-types": {
       "version": "15.7.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.1.tgz",
-      "integrity": "sha512-f8Lku2z9kERjOCcnDOPm68EBJAO2K00Q5mSgPAUE/gJuBgsYLbVy6owSrtcHj90zt8PvW+z0qaIIgsIhHOa1Qw==",
+      "integrity": "sha1-L6YeCmmdQotAMgEncz7ikx8F2dE=",
       "requires": {
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
@@ -9592,7 +9639,7 @@
         "react-is": {
           "version": "16.8.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.1.tgz",
-          "integrity": "sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA=="
+          "integrity": "sha1-qAFB4kbriUgk+08pAcDFDvMdTNs="
         }
       }
     },
@@ -9712,7 +9759,7 @@
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "integrity": "sha1-B0LpmkplUvRF1z4+4DKK8P8e3jk=",
       "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
@@ -9733,7 +9780,7 @@
     "randexp": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "integrity": "sha1-6YatXl4x2uE93W97MBmqfIf2DKM=",
       "dev": true,
       "requires": {
         "discontinuous-range": "1.0.0",
@@ -9797,7 +9844,7 @@
     "react": {
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/react/-/react-16.8.4.tgz",
-      "integrity": "sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==",
+      "integrity": "sha1-/fe9muU/A6nEzRo3FDLCBr4cR2g=",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -9823,7 +9870,7 @@
     "react-desc": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/react-desc/-/react-desc-4.1.2.tgz",
-      "integrity": "sha512-JAVe89uaLr0HZ0IKodnpTPNgNyJ/SPDQnl3VJPVwI+SpebmHvJiBNZEOwX201QmSbsVGqRY8ql/VFPlAx85WzA==",
+      "integrity": "sha1-g/xO3may1Frk72PBhCFHTVWXKWY=",
       "dev": true
     },
     "react-dev-utils": {
@@ -10007,7 +10054,7 @@
     "react-dom": {
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.4.tgz",
-      "integrity": "sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==",
+      "integrity": "sha1-EGGo4BorOwyBYAN0QcO/AKDjvEg=",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -10110,7 +10157,7 @@
     "react-test-renderer": {
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.4.tgz",
-      "integrity": "sha512-jQ9Tf/ilIGSr55Cz23AZ/7H3ABEdo9oy2zF9nDHZyhLHDSLKuoILxw2ifpBfuuwQvj4LCoqdru9iZf7gwFH28A==",
+      "integrity": "sha1-q+5MLDv5Z6iJKns393NwxVcNUyk=",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
@@ -10122,7 +10169,7 @@
         "react-is": {
           "version": "16.8.4",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
-          "integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==",
+          "integrity": "sha1-kPM2pow6KaCWo9ZIq4DofsYUgqI=",
           "dev": true
         }
       }
@@ -10269,7 +10316,7 @@
     "recompose": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
+      "integrity": "sha1-gnc2QbOSfox9JKDYfWWu66GKq9A=",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
@@ -10283,7 +10330,7 @@
         "hoist-non-react-statics": {
           "version": "2.5.5",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+          "integrity": "sha1-xZA89AnA39kI84jmGdhrnBF0y0c=",
           "dev": true
         }
       }
@@ -10857,7 +10904,7 @@
     "scheduler": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.4.tgz",
-      "integrity": "sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==",
+      "integrity": "sha1-j+8F56NYDHbANk0t9eVQ5MkUApg=",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -11435,6 +11482,56 @@
       "dev": true,
       "requires": {
         "concat-stream": "^1.5.0"
+      }
+    },
+    "standardx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/standardx/-/standardx-3.0.1.tgz",
+      "integrity": "sha512-HU4c9V/F6TAKAokrnClUIzuETYyVpO3iYs77stT29YRJu8HR0CQ7ypM2sgW1Qmn3+VPB6/eSy4aPMt8NYPtl3A==",
+      "dev": true,
+      "requires": {
+        "standard": "^12.0.1",
+        "standard-engine": "^10.0.0"
+      },
+      "dependencies": {
+        "deglob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/deglob/-/deglob-3.1.0.tgz",
+          "integrity": "sha512-al10l5QAYaM/PeuXkAr1Y9AQz0LCtWsnJG23pIgh44hDxHFOj36l6qvhfjnIWBYwZOqM1fXUFV9tkjL7JPdGvw==",
+          "dev": true,
+          "requires": {
+            "find-root": "^1.0.0",
+            "glob": "^7.0.5",
+            "ignore": "^5.0.0",
+            "pkg-config": "^1.1.0",
+            "run-parallel": "^1.1.2",
+            "uniq": "^1.0.1"
+          }
+        },
+        "ignore": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.6.tgz",
+          "integrity": "sha512-/+hp3kUf/Csa32ktIaj0OlRqQxrgs30n62M90UBpNd9k+ENEch5S+hmbW3DtcJGz3sYFTh4F3A6fQ0q7KWsp4w==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "standard-engine": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-10.0.0.tgz",
+          "integrity": "sha512-91BjmzIRZbFmyOY73R6vaDd/7nw5qDWsfpJW5/N+BCXFgmvreyfrRg7oBSu4ihL0gFGXfnwCImJm6j+sZDQQyw==",
+          "dev": true,
+          "requires": {
+            "deglob": "^3.0.0",
+            "get-stdin": "^6.0.0",
+            "minimist": "^1.1.0",
+            "pkg-conf": "^2.0.0"
+          }
+        }
       }
     },
     "state-toggle": {

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -105,6 +105,7 @@
     ],
     "global": [
       "expect"
-    ]
+    ],
+    "parser": "babel-eslint"
   }
 }

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -10,7 +10,7 @@
     "build": "rm -rf dist && webpack --config ./webpack.dist.js",
     "build-storybook": "build-storybook",
     "dev": "start-storybook -p 6006",
-    "lint": "standard --fix {.storybook,src,stories,test}/**/*.{js,jsx} | snazzy; exit 0",
+    "lint": "standardx --fix {.storybook,src,stories,test}/**/*.{js,jsx} | snazzy; exit 0",
     "prepublishOnly": "npm run test:ci && npm run build",
     "start": "echo 'Nothing to see here yet'",
     "test": "npm run _test && exit 0",
@@ -68,6 +68,7 @@
     "dirty-chai": "~2.0.1",
     "enzyme": "~3.9.0",
     "enzyme-adapter-react-16": "~1.11.2",
+    "eslint-plugin-jsx-a11y": "^6.2.1",
     "grommet": "~2.5.5",
     "grommet-icons": "~4.2.0",
     "jsdom": "~13.0.0",
@@ -80,7 +81,7 @@
     "sinon": "~7.1.1",
     "sinon-chai": "~3.3.0",
     "snazzy": "~8.0.0",
-    "standard": "~12.0.1",
+    "standardx": "^3.0.1",
     "styled-components": "~4.1.1",
     "styled-theming": "~2.2.0",
     "webpack": "~4.26.1",
@@ -90,10 +91,15 @@
     "node": ">=10",
     "npm": ">=5"
   },
+  "eslintConfig": {
+    "extends": [
+      "plugin:jsx-a11y/recommended"
+    ]
+  },
   "publishConfig": {
     "access": "public"
   },
-  "standard": {
+  "standardx": {
     "envs": [
       "mocha"
     ],


### PR DESCRIPTION
Replace standard with standardx.
Install the jsx-a11y plugin.
Configure the linter to use the recommended a11y rules.

Package:
app-project, lib-classifier, lib-react-components


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

