### PR TITLE
Set minimum mocked subject ID to 1 in random tests

### DIFF
--- a/packages/lib-panoptes-js/src/resources/subjects/helpers.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/helpers.js
@@ -6,7 +6,7 @@ function getRandomID (min, max) {
 }
 
 function buildQueuedSubjectResource () {
-  const randomId = getRandomID(0, 100)
+  const randomId = getRandomID(1, 100)
 
   return {
     already_seen: false,


### PR DESCRIPTION
Stop the subject generator test from generating subjects with IDs of 0.

Package:
lib-panoptes-js

Closes #676.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

