### PR TITLE
Disable add to collections for anonymous users

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
@@ -9,9 +9,11 @@ import CollectionsButton from './components/CollectionsButton'
 
 function storeMapper(stores) {
   const { active: subject, isThereMetadata } = stores.classifierStore.subjects
+  const upp = stores.classifierStore.userProjectPreferences.active
   return {
     isThereMetadata,
-    subject
+    subject,
+    upp
   }
 }
 
@@ -45,7 +47,7 @@ export default class MetaTools extends React.Component {
   }
 
   render () {
-    const { className, isThereMetadata, subject } = this.props
+    const { className, isThereMetadata, subject, upp } = this.props
     return (
       <Box className={className} direction="row">
         {isThereMetadata &&
@@ -58,9 +60,11 @@ export default class MetaTools extends React.Component {
           />}
         <FavouritesButton
           checked={subject && subject.favorite}
+          disabled={!upp}
           onClick={this.toggleFavourites}
         />
         <CollectionsButton
+          disabled={!upp}
           onClick={this.addToCollection}
         />
       </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/CollectionsButton/CollectionsButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/CollectionsButton/CollectionsButton.js
@@ -20,25 +20,28 @@ export const Collect = styled(CollectionsIcon)`
 `
 
 export default function CollectionsButton (props) {
-  const { onClick, theme } = props
+  const { disabled, onClick, theme } = props
   return (
     <ThemeProvider theme={{ mode: theme }}>
       <PlainButton
+        disabled={disabled}
         icon={<Collect />}
         margin={{ vertical: 'small', left: 'none', right: 'medium' }}
         text={counterpart('CollectionsButton.add')}
-        onClick={onClick}
+        onClick={disabled ? undefined : onClick}
       />
     </ThemeProvider>
   )
 }
 
 CollectionsButton.propTypes = {
+  disabled: PropTypes.bool,
   onClick: PropTypes.func,
   theme: PropTypes.string
 }
 
 CollectionsButton.defaultProps = {
+  disabled: false,
   onClick: () => false,
   theme: 'light'
 }

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/CollectionsButton/CollectionsButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/CollectionsButton/CollectionsButton.spec.js
@@ -33,4 +33,19 @@ describe('Component > CollectionsButton', function () {
     wrapper.find(PlainButton).simulate('click')
     expect(onClick).to.have.been.calledOnce
   })
+
+  describe ('when disabled', function () {
+    const onClick = sinon.stub()
+    wrapper = shallow(
+      <CollectionsButton
+        disabled
+        onClick={onClick}
+      />
+    )
+
+    it('should not be clickable', function () {
+      wrapper.find(PlainButton).simulate('click')
+      expect(onClick).to.not.have.been.called
+    })
+  })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.js
@@ -22,17 +22,18 @@ export const Favourite = styled(HeartIcon)`
 `
 
 export default function FavouritesButton (props) {
-  const { checked, onClick, theme } = props
+  const { checked, disabled, onClick, theme } = props
   const label = checked ? 'FavouritesButton.remove' : 'FavouritesButton.add'
   return (
     <ThemeProvider theme={{ mode: theme }}>
       <PlainButton
         aria-checked={checked}
+        disabled={disabled}
         icon={<Favourite filled={checked ? 'true' : undefined} />}
         margin={{ vertical: 'small', left: 'none', right: 'medium' }}
         role='checkbox'
         text={counterpart(label)}
-        onClick={onClick}
+        onClick={disabled ? undefined : onClick}
       />
     </ThemeProvider>
   )
@@ -40,12 +41,14 @@ export default function FavouritesButton (props) {
 
 FavouritesButton.propTypes = {
   checked: PropTypes.bool,
+  disabled: PropTypes.bool,
   theme: PropTypes.string,
   onClick: PropTypes.func
 }
 
 FavouritesButton.defaultProps = {
   checked: false,
+  disabled: false,
   onClick: () => false,
   theme: 'light'
 }

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.spec.js
@@ -54,4 +54,19 @@ describe('Component > FavouritesButton', function () {
       expect(checked).to.equal(true)
     })
   })
+
+  describe ('when disabled', function () {
+    const onClick = sinon.stub()
+    wrapper = shallow(
+      <FavouritesButton
+        disabled
+        onClick={onClick}
+      />
+    )
+
+    it('should not be clickable', function () {
+      wrapper.find(PlainButton).simulate('click')
+      expect(onClick).to.not.have.been.called
+    })
+  })
 })


### PR DESCRIPTION
Disable 'add to collections' or 'add to favourites' if there's no logged-in user.

Package:
lib-classifier

Closes #658.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

