### PR TITLE
Turn off modality for the field guide

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideContainer.js
@@ -36,7 +36,9 @@ class FieldGuideContainer extends React.Component {
         <Modal
           active={showModal}
           closeFn={this.onClose.bind(this)}
+          modal={false}
           pad={{ horizontal: '30px', vertical: 'small' }}
+          position="right"
           title={counterpart('FieldGuide.title')}
         >
           <FieldGuide />

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideContainer.spec.js
@@ -5,16 +5,28 @@ import { Modal } from '@zooniverse/react-components'
 import FieldGuideContainer from './FieldGuideContainer'
 
 describe('Component > FieldGuideContainer', function () {
+  let wrapper
+
+  before(function () {
+    wrapper = shallow(<FieldGuideContainer.wrappedComponent setModalVisibility={() => { }} showModal={false} />)
+  })
+
   it('should render without crashing', function () {
-    const wrapper = shallow(<FieldGuideContainer.wrappedComponent setModalVisibility={() => {}} />)
     expect(wrapper).to.be.ok
   })
 
   it('should set the Modal active prop with the showModal prop', function () {
-    const wrapper = shallow(<FieldGuideContainer.wrappedComponent setModalVisibility={() => { }} showModal={false} />)
     expect(wrapper.find(Modal).props().active).to.be.false
     wrapper.setProps({ showModal: true })
     expect(wrapper.find(Modal).props().active).to.be.true
+  })
+
+  it('should not block interaction with the classifier', function () {
+    expect(wrapper.find(Modal).props().modal).to.be.false
+  })
+
+  it('should be positioned on the right', function () {
+    expect(wrapper.find(Modal).props().position).to.equal('right')
   })
 
   it('should call setModalVisibility onClose of the modal', function () {

--- a/packages/lib-react-components/src/Modal/WithLayer.js
+++ b/packages/lib-react-components/src/Modal/WithLayer.js
@@ -10,7 +10,7 @@ const StyledLayer = styled(Layer)`
 `
 
 function WithLayer (WrappedComponent) {
-  function HOC ({ active, className, closeFn, modal, ...props }) {
+  function HOC ({ active, className, closeFn, modal, position, ...props }) {
     if (!active) {
       return null
     }
@@ -19,6 +19,7 @@ function WithLayer (WrappedComponent) {
       <StyledLayer
         className={className}
         modal={modal}
+        position={position}
         onClickOutside={closeFn}
         onEsc={closeFn}
       >
@@ -31,13 +32,15 @@ function WithLayer (WrappedComponent) {
     active: PropTypes.bool,
     className: PropTypes.string,
     closeFn: PropTypes.func,
-    modal: PropTypes.bool
+    modal: PropTypes.bool,
+    position: PropTypes.string
   }
 
   HOC.defaultProps = {
     active: false,
     className: '',
-    modal: true
+    modal: true,
+    position: 'center'
   }
 
   return HOC


### PR DESCRIPTION
Package:
classifier, react-components

Allow interaction with the classifier while the field guide is open, and show the guide on the right.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

