### PR TITLE
Add selected_at to subjects

### DIFF
--- a/packages/lib-classifier/src/store/Classification.js
+++ b/packages/lib-classifier/src/store/Classification.js
@@ -19,6 +19,7 @@ const ClassificationMetadata = types.model('ClassificationMetadata', {
     already_seen: types.optional(types.boolean, false),
     finished_workflow: types.optional(types.boolean, false),
     retired: types.optional(types.boolean, false),
+    selected_at: types.maybe(types.string),
     selection_state: types.maybe(types.string),
     user_has_finished_workflow: types.optional(types.boolean, false)
   }),

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -74,6 +74,7 @@ const ClassificationStore = types
             already_seen: subject.already_seen,
             finished_workflow: subject.finished_workflow,
             retired: subject.retired,
+            selected_at: subject.selected_at,
             selection_state: subject.selection_state,
             user_has_finished_workflow: subject.user_has_finished_workflow
           },

--- a/packages/lib-classifier/src/store/Subject.js
+++ b/packages/lib-classifier/src/store/Subject.js
@@ -11,6 +11,7 @@ const Subject = types
     locations: types.frozen(),
     metadata: types.frozen(),
     retired: types.optional(types.boolean, false),
+    selected_at: types.maybe(types.string),
     selection_state: types.maybe(types.string),
     user_has_finished_workflow: types.optional(types.boolean, false)
   })

--- a/packages/lib-classifier/test/factories/SubjectFactory.js
+++ b/packages/lib-classifier/test/factories/SubjectFactory.js
@@ -13,6 +13,7 @@ const subject = Factory.define('subject')
   })
   .attr('metadata', {})
   .attr('retired', false)
+  .attr('selected_at', "2019-04-11T11:16:29.063Z")
   .attr('selection_state', '')
   .attr('user_has_finished_workflow', false)
 


### PR DESCRIPTION
Add selected_at to the subject model, and copy it across to new classifications.

Package:
lib-classifier


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

