### PR TITLE
Add components for related projects modal

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 
 import en from './locales/en'
 import ProjectImage from './components/ProjectImage'
+import RelatedProjects from './components/RelatedProjects'
 import ContentBox from '../../../../shared/components/ContentBox'
 
 counterpart.registerTranslations('en', en)
@@ -54,14 +55,7 @@ function FinishedForTheDay ({ imageSrc, projectName }) {
             onClick={() => console.info('click')}
             primary
           />
-          <StyledButton
-            onClick={() => console.info('click')}
-            label={(
-              <Text size='small'>
-                {counterpart('FinishedForTheDay.buttons.anotherProject')}
-              </Text>
-            )}
-          />
+          <RelatedProjects />
         </StyledBox>
       </ContentBox>
     </Grid>

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
@@ -3,6 +3,7 @@ import React from 'react'
 
 import FinishedForTheDay from './FinishedForTheDay'
 import ProjectImage from './components/ProjectImage'
+import RelatedProjects from './components/RelatedProjects'
 
 const projectName = 'Foobar'
 const imageSrc = 'foobar.jpg'
@@ -32,8 +33,8 @@ describe('Component > FinishedForTheDay', function () {
     // We'll test this by link, and that link isn't hooked up yet
   })
 
-  xit('should contain an other projects button', function () {
-    // We'll test this by link, and that link isn't hooked up yet
+  it('should contain a related projects button', function () {
+    expect(wrapper.find(RelatedProjects)).to.have.lengthOf(1)
   })
 
   it('should not contain a `ProjectImage` if there\'s no `imgSrc` prop', function () {

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/RelatedProjectsContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/RelatedProjectsContainer.js
@@ -1,0 +1,28 @@
+import React, { Component } from 'react'
+
+import RelatedProjectsButton from './components/RelatedProjectsButton'
+import RelatedProjectsModal from './components/RelatedProjectsModal'
+
+class RelatedProjectsContainer extends Component {
+  state = {
+    modalActive: false
+  }
+
+  closeModal = () => this.setState({ modalActive: false })
+
+  openModal = () => this.setState({ modalActive: true })
+
+  render () {
+    return (
+      <>
+        <RelatedProjectsButton onClick={this.openModal} />
+        <RelatedProjectsModal
+          active={this.state.modalActive}
+          closeFn={this.closeModal}
+        />
+      </>
+    )
+  }
+}
+
+export default RelatedProjectsContainer

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/RelatedProjectsContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/RelatedProjectsContainer.spec.js
@@ -1,0 +1,32 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import RelatedProjectsContainer from './RelatedProjectsContainer'
+import RelatedProjectsButton from './components/RelatedProjectsButton'
+import RelatedProjectsModal from './components/RelatedProjectsModal'
+
+let wrapper
+
+describe('Component > RelatedProjectsContainer', function () {
+  before(function () {
+    wrapper = shallow(<RelatedProjectsContainer />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render the `RelatedProjectsButton` component', function () {
+    expect(wrapper.find(RelatedProjectsButton)).to.have.lengthOf(1)
+  })
+
+  it('should render the `RelatedProjectsModal` component', function () {
+    expect(wrapper.find(RelatedProjectsModal)).to.have.lengthOf(1)
+  })
+
+  it('should pass an `active` prop to `RelatedProjectsModal` when the `RelatedProjectsButton` is clicked', function () {
+    expect(wrapper.find(RelatedProjectsModal).prop('active')).to.be.false()
+    wrapper.find(RelatedProjectsButton).simulate('click')
+    expect(wrapper.find(RelatedProjectsModal).prop('active')).to.be.true()
+  })
+})

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsButton/RelatedProjectsButton.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsButton/RelatedProjectsButton.js
@@ -1,0 +1,37 @@
+import counterpart from 'counterpart'
+import { Button, Text } from 'grommet'
+import { func } from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
+
+const StyledButton = styled(Button)`
+  border-width: 1px;
+  flex: 1 1 300px;
+  margin: 0 10px 10px 0;
+`
+
+function RelatedProjectsButton (props) {
+  const { onClick } = props
+  const buttonText = counterpart('RelatedProjectsButton.label')
+  return (
+    <StyledButton
+      a11yTitle={buttonText}
+      onClick={onClick}
+      label={(
+        <Text size='small'>
+          {buttonText}
+        </Text>
+      )}
+    />
+  )
+}
+
+RelatedProjectsButton.propTypes = {
+  onClick: func.isRequired
+}
+
+export default RelatedProjectsButton

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsButton/RelatedProjectsButton.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsButton/RelatedProjectsButton.spec.js
@@ -1,0 +1,29 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import sinon from 'sinon'
+
+import RelatedProjectsButton from './RelatedProjectsButton'
+
+let wrapper
+const onClick = sinon.stub()
+
+describe('Component > RelatedProjectsButton', function () {
+  before(function () {
+    wrapper = shallow(<RelatedProjectsButton
+      onClick={onClick}
+    />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should have an `a11yTitle` prop', function () {
+    expect(wrapper.prop('a11yTitle')).to.be.ok()
+  })
+
+  it('should call the `onClick` function prop on click', function () {
+    wrapper.simulate('click')
+    expect(onClick).to.have.been.calledOnce()
+  })
+})

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsButton/index.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './RelatedProjectsButton'

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsButton/locales/en.json
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsButton/locales/en.json
@@ -1,0 +1,5 @@
+{
+  "RelatedProjectsButton": {
+    "label": "Find another project"
+  }
+}

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/RelatedProjectsModal.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/RelatedProjectsModal.js
@@ -1,0 +1,58 @@
+import { Modal } from '@zooniverse/react-components'
+import counterpart from 'counterpart'
+import { Box, Heading } from 'grommet'
+import { array, bool, func, string } from 'prop-types'
+import React from 'react'
+
+import ProjectCard from './components/ProjectCard'
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
+
+const DUMMY_PROJECT = {
+  name: 'foobar',
+  description: 'blurb blurb blurb blurb',
+  image: 'https://via.placeholder.com/300x188.png',
+  url: 'http://foo.com/bar'
+}
+
+// We use the array index as a key in the map further down as the dummy projects
+// are identical.
+const PROJECTS = [DUMMY_PROJECT, DUMMY_PROJECT, DUMMY_PROJECT]
+
+function RelatedProjectsModal (props) {
+  const { active, closeFn, projects, projectTitle } = props
+  return (
+    <Modal
+      active={active}
+      closeFn={closeFn}
+      title={counterpart('RelatedProjectsModal.relatedProjects')}
+    >
+      <Heading level='3' margin={{ bottom: 'xsmall', top: 'none' }}>
+        {counterpart('RelatedProjectsModal.title', { project: projectTitle })}
+      </Heading>
+      <Box as='p' margin={{ bottom: 'small', top: 'none' }}>
+        {counterpart('RelatedProjectsModal.hereAreSomeOthers')}
+      </Box>
+      <Box direction='row' gap='small'>
+        {projects.map((project, index) => (
+          <ProjectCard key={index} {...project} />)
+        )}
+      </Box>
+    </Modal>
+  )
+}
+
+RelatedProjectsModal.propTypes = {
+  active: bool,
+  closeFn: func,
+  projects: array,
+  projectTitle: string
+}
+
+RelatedProjectsModal.defaultProps = {
+  active: false,
+  projects: PROJECTS
+}
+
+export default RelatedProjectsModal

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/RelatedProjectsModal.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/RelatedProjectsModal.spec.js
@@ -1,0 +1,41 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import sinon from 'sinon'
+
+import RelatedProjectsModal from './RelatedProjectsModal'
+import ProjectCard from './components/ProjectCard'
+
+let wrapper
+
+const CLOSE_FN = sinon.stub()
+
+const PROJECTS = [
+  { name: 'foo' },
+  { name: 'bar' },
+  { name: 'baz' }
+]
+
+describe('Component > RelatedProjectsModal', function () {
+  before(function () {
+    wrapper = shallow(<RelatedProjectsModal
+      closeFn={CLOSE_FN}
+      projects={PROJECTS}
+    />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should pass the a `title` prop to the modal', function () {
+    expect(wrapper.prop('title')).to.be.ok()
+  })
+
+  it('should pass down a `closeFn` prop to the modal', function () {
+    expect(wrapper.prop('closeFn')).to.equal(CLOSE_FN)
+  })
+
+  it('should render a `<ProjectCard />` for each project passed as a prop', function () {
+    expect(wrapper.find(ProjectCard)).to.have.lengthOf(PROJECTS.length)
+  })
+})

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/RelatedProjectsModalContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/RelatedProjectsModalContainer.js
@@ -1,0 +1,31 @@
+import { inject, observer } from 'mobx-react'
+import { string } from 'prop-types'
+import React, { Component } from 'react'
+
+import RelatedProjectsModal from './RelatedProjectsModal'
+
+function storeMapper (stores) {
+  return {
+    projectTitle: stores.store.project['display_name']
+  }
+}
+
+@inject(storeMapper)
+@observer
+class RelatedProjectsModalContainer extends Component {
+  render () {
+    const { projectTitle } = this.props
+    return (
+      <RelatedProjectsModal
+        projectTitle={projectTitle}
+        {...this.props}
+      />
+    )
+  }
+}
+
+RelatedProjectsModalContainer.propTypes = {
+  projectTitle: string.isRequired
+}
+
+export default RelatedProjectsModalContainer

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/RelatedProjectsModalContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/RelatedProjectsModalContainer.spec.js
@@ -1,0 +1,42 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import RelatedProjectsModalContainer from './RelatedProjectsModalContainer'
+import RelatedProjectsModal from './RelatedProjectsModal'
+
+let wrapper
+let componentWrapper
+
+let PROJECT_TITLE = 'foobar'
+let OTHER_PROPS = {
+  foo: 'bar',
+  baz: 'qux'
+}
+
+describe('Component > RelatedProjectsModalContainer', function () {
+  before(function () {
+    wrapper = shallow(<RelatedProjectsModalContainer.wrappedComponent
+      projectTitle={PROJECT_TITLE}
+      {...OTHER_PROPS}
+    />)
+    componentWrapper = wrapper.find(RelatedProjectsModal)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render the `RelatedProjectsModal` component', function () {
+    expect(componentWrapper).to.have.lengthOf(1)
+  })
+
+  it('should pass down a `projectTitle` prop', function () {
+    expect(componentWrapper.prop('projectTitle')).to.equal(PROJECT_TITLE)
+  })
+
+  it('should pass down its received props', function () {
+    Object.entries(OTHER_PROPS).forEach(([key, value]) => {
+      expect(componentWrapper.prop(key)).to.equal(value)
+    })
+  })
+})

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/components/ProjectCard/ProjectCard.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/components/ProjectCard/ProjectCard.js
@@ -1,0 +1,59 @@
+import { Media, SpacedText } from '@zooniverse/react-components'
+import counterpart from 'counterpart'
+import { Box, Button, Text } from 'grommet'
+import { string } from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
+
+const StyledButton = styled(Button)`
+  border-radius: 4px;
+  border-width: 1px;
+`
+
+function ProjectCard (props) {
+  const { description, image, name, url } = props
+  return (
+    <Box border={{ color: 'light-4' }} width='300px'>
+      <Media src={image} />
+      <Box pad='small'>
+        <Box
+          border={{ color: 'light-4', side: 'bottom' }}
+          margin={{ bottom: 'xsmall' }}
+          pad={{ bottom: 'xsmall' }}
+        >
+          <SpacedText weight='bold'>
+            {name}
+          </SpacedText>
+        </Box>
+        <Box as='p' margin={{ top: 'none', bottom: 'small' }}>
+          <Text>
+            {description}
+          </Text>
+        </Box>
+        <StyledButton
+          alignSelf='start'
+          color='neutral-4'
+          label={
+            <Text size='small'>
+              {counterpart('ProjectCard.viewProject')}
+            </Text>
+          }
+          href={url}
+        />
+      </Box>
+    </Box>
+  )
+}
+
+ProjectCard.propTypes = {
+  description: string.isRequired,
+  image: string.isRequired,
+  name: string.isRequired,
+  url: string.isRequired
+}
+
+export default ProjectCard

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/components/ProjectCard/ProjectCard.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/components/ProjectCard/ProjectCard.spec.js
@@ -1,0 +1,55 @@
+import { render, shallow } from 'enzyme'
+import React from 'react'
+
+import ProjectCard from './ProjectCard'
+
+let wrapper
+
+const DESCRIPTION = 'description'
+const IMAGE = 'https://foo.com/bar/image.png'
+const NAME = 'project name'
+const URL = 'https://foo.com/bar'
+
+const projectCard = (
+  <ProjectCard
+    description={DESCRIPTION}
+    image={IMAGE}
+    name={NAME}
+    url={URL}
+  />
+)
+
+describe('Component > ProjectCard', function () {
+  before(function () {
+    wrapper = render(projectCard)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should include a link to the project', function () {
+    const linkWrapper = wrapper.find('a')
+    expect(linkWrapper.prop('href')).to.equal(URL)
+  })
+
+  it('should include the project image', function () {
+    const imageWrapper = shallow(projectCard).find('Media')
+    expect(imageWrapper.prop('src')).to.equal(IMAGE)
+  })
+
+  it('should include the project name', function () {
+    const text = wrapper.text()
+    expect(text).to.include(NAME)
+  })
+
+  it('should include the project description', function () {
+    const text = wrapper.text()
+    expect(text).to.include(DESCRIPTION)
+  })
+
+  it('should include a link to the project', function () {
+    const linkWrapper = wrapper.find('a')
+    expect(linkWrapper.prop('href')).to.equal(URL)
+  })
+})

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/components/ProjectCard/index.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/components/ProjectCard/index.js
@@ -1,0 +1,1 @@
+export { default } from './ProjectCard'

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/components/ProjectCard/locales/en.json
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/components/ProjectCard/locales/en.json
@@ -1,0 +1,5 @@
+{
+  "ProjectCard": {
+    "viewProject": "View Project"
+  }
+}

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/index.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './RelatedProjectsModalContainer'

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/locales/en.json
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/locales/en.json
@@ -1,0 +1,7 @@
+{
+  "RelatedProjectsModal": {
+    "hereAreSomeOthers": "Here are some other Zooniverse projects you might enjoy",
+    "relatedProjects": "Related Projects",
+    "title": "Love %(project)s?"
+  }
+}

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/index.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/index.js
@@ -1,0 +1,1 @@
+export { default } from './RelatedProjectsContainer'


### PR DESCRIPTION
Package:

app-project

Adds the UI for the related projects modal. I'm going to do the selection strategy in a separate PR.

<img width="1037" alt="Screenshot 2019-04-11 13 01 14" src="https://user-images.githubusercontent.com/2725841/55955684-f001b800-5c59-11e9-9894-18bba57379b6.png">

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

