### PR TITLE
Update line heights for paragraphs and span texts

### DIFF
--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -353,22 +353,22 @@ const theme = deepFreeze({
     },
     medium: {
       size: '14px',
-      height: '22px',
+      height: '18px',
       maxWidth: '100%'
     },
     large: {
       size: '18px',
-      height: '26px',
+      height: '22px',
       maxWidth: '100%'
     },
     xlarge: {
       size: '22px',
-      height: '30px',
+      height: '26px',
       maxWidth: '100%'
     },
     xxlarge: {
       size: '26px',
-      height: '34px',
+      height: '30px',
       maxWidth: '100%'
     },
     extend: props => `margin: ${props.margin || '1em 0 1em 0'}`
@@ -376,32 +376,32 @@ const theme = deepFreeze({
   text: {
     xsmall: {
       size: "12px",
-      height: "18px",
+      height: "16px",
       maxWidth: "100%"
     },
     small: {
-      size: "14px",
-      height: "20px",
+      size: "12px",
+      height: "16px",
       maxWidth: "100%"
     },
     medium: {
-      size: "18px",
-      height: "24px",
+      size: "14px",
+      height: "28px",
       maxWidth: "100%"
     },
     large: {
       size: "22px",
-      height: "28px",
+      height: "26px",
       maxWidth: "100%"
     },
     xlarge: {
       size: "26px",
-      height: "32px",
+      height: "30px",
       maxWidth: "100%"
     },
     xxlarge: {
       size: "34px",
-      height: "40px",
+      height: "38px",
       maxWidth: "100%"
     }
   },


### PR DESCRIPTION
Package:

Closes #666 

Describe your changes:
Updates the theme's line-height settings for paragraphs and span texts according to @beckyrother's input in #666 

Medium size is Grommet's default and with a font-size: 14px and line-height of 18px, I set the rest of the sizes to follow a 4px difference. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

