### PR TITLE
Use default theme sizes for paragraphs

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
@@ -16,10 +16,6 @@ const StyledButton = styled(Button)`
   margin: 0 10px 10px 0;
 `
 
-const StyledParagraph = styled(Paragraph)`
-  max-width: 100%;
-`
-
 const StyledBox = styled(Box)`
   margin: 0 -10px 0 0;
   max-width: 620px;
@@ -38,12 +34,11 @@ function FinishedForTheDay ({ imageSrc, projectName }) {
         >
           {counterpart('FinishedForTheDay.title')}
         </Heading>
-        <StyledParagraph
+        <Paragraph
           margin={{ bottom: 'small', top: 'none' }}
-          size='small'
         >
           {counterpart('FinishedForTheDay.text', { projectName })}
-        </StyledParagraph>
+        </Paragraph>
         <StyledBox direction='row' wrap>
           <StyledButton
             label={(

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
@@ -3,7 +3,7 @@ import React from 'react'
 
 import FinishedForTheDay from './FinishedForTheDay'
 import ProjectImage from './components/ProjectImage'
-
+import { Paragraph } from 'grommet'
 const projectName = 'Foobar'
 const imageSrc = 'foobar.jpg'
 
@@ -23,7 +23,7 @@ describe('Component > FinishedForTheDay', function () {
   })
 
   it('should contain some text', function () {
-    const para = wrapper.find('FinishedForTheDay__StyledParagraph')
+    const para = wrapper.find(Paragraph)
     expect(para).to.have.lengthOf(1)
     expect(para.text().length).to.be.ok()
   })

--- a/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatistics.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatistics.js
@@ -20,11 +20,7 @@ const NumbersGrid = styled.div`
   grid-gap: 12px;
 `
 
-const StyledParagraph = styled(Paragraph)`
-  max-width: 100%;
-`
-
-function ProjectStatistics ({
+function ProjectStatistics({
   className,
   classifications,
   completedSubjects,
@@ -43,9 +39,9 @@ function ProjectStatistics ({
       <MainGrid>
         <section>
           <Subtitle text={counterpart('ProjectStatistics.subtitle')} />
-          <StyledParagraph margin={{ bottom: 'small', top: 'none' }} size='small'>
+          <Paragraph margin={{ bottom: 'small', top: 'none' }}>
             {counterpart('ProjectStatistics.text')}
-          </StyledParagraph>
+          </Paragraph>
           <CompletionBar />
           <Text
             margin={{ top: 'small' }}


### PR DESCRIPTION
Package: app-project

Fixes

> body copy is too small, please make all body 14px

in #695 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

