### PR TITLE
Add Google Tag Manager in production

### DIFF
--- a/packages/app-project/pages/_document.js
+++ b/packages/app-project/pages/_document.js
@@ -1,6 +1,14 @@
-import Document from 'next/document'
+import Document, { Head, Main, NextScript } from 'next/document'
 import React from 'react'
 import { ServerStyleSheet } from 'styled-components'
+
+const GA_TRACKING_ID = 'GTM-WDW6V4'
+
+const GA_TRACKING_SCRIPT = `
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${GA_TRACKING_ID}');
+`
+
+const isProduction = process.env.NODE_ENV === 'production'
 
 export default class MyDocument extends Document {
   static async getInitialProps (ctx) {
@@ -21,5 +29,31 @@ export default class MyDocument extends Document {
     } finally {
       sheet.seal()
     }
+  }
+
+  render () {
+    return (
+      <html>
+        {isProduction && (
+          <Head>
+            <script dangerouslySetInnerHTML={{ __html: GA_TRACKING_SCRIPT }} />
+          </Head>
+        )}
+        <body>
+          {isProduction && (
+            <noscript>
+              <iframe
+                height='0'
+                src={`https://www.googletagmanager.com/ns.html?id=${GA_TRACKING_ID}`}
+                style={{ display:'none', visibility:'hidden' }}
+                width='0'
+              />
+            </noscript>
+          )}
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
   }
 }


### PR DESCRIPTION
Package:

app-project

Closes #692 
cc #174 #217

Adds the GTM tags from https://developers.google.com/tag-manager/quickstart

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

