### PR TITLE
Additional tutorial style fixes

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
@@ -33,15 +33,18 @@ function SlideTutorial (props) {
       pad={pad}
       width={width}
     >
-      {isThereMedia &&
-        <Media
-          alt={counterpart('SlideTutorial.alt', { activeStep })}
-          fit='cover'
-          height={200}
-          src={medium.src}
-        />}
-      <Heading level='3' margin='20px 0 10px 0'>{counterpart('SlideTutorial.heading', { projectDisplayName })}</Heading>
-      <StyledMarkdownWrapper aria-live='polite' autoFocus height='100%' overflow='auto'>
+      <StyledMarkdownWrapper aria-live='polite' autoFocus height='100%' overflow={{ horizontal: 'hidden', vertical: 'auto' }}>
+        {isThereMedia &&
+          <Media
+            alt={counterpart('SlideTutorial.alt', { activeStep })}
+            fit='cover'
+            height={200}
+            src={medium.src}
+          />}
+        {activeStep === 0 &&
+          <Heading level='3' margin='20px 0 10px 0'>
+            {counterpart('SlideTutorial.heading', { projectDisplayName })}
+          </Heading>}
         {/* TODO: translation */}
         <Markdownz>{step.content}</Markdownz>
       </StyledMarkdownWrapper>

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
@@ -42,7 +42,7 @@ function SlideTutorial (props) {
             src={medium.src}
           />}
         {activeStep === 0 &&
-          <Heading level='3' margin='20px 0 10px 0'>
+          <Heading level='3' margin={{ bottom: 'xsmall', top: 'small' }}>
             {counterpart('SlideTutorial.heading', { projectDisplayName })}
           </Heading>}
         {/* TODO: translation */}

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/StepNavigation/StepNavigation.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/StepNavigation/StepNavigation.js
@@ -10,18 +10,31 @@ import en from './locales/en'
 counterpart.registerTranslations('en', en)
 
 const StyledButton = styled(Button)`
-  padding: 12px;
+  &:first-of-type {
+    margin: 0 15px 0 0;
+    padding: 0;
+  }
+
+  &:last-of-type {
+    margin: 0;
+    padding: 0;
+  }
 `
 
 const StyledRadioButtonGroup = styled(RadioButtonGroup)`
   position: relative;
-  margin-left: 20px;
 
-  > label > span {
-    height: 0;
-    overflow: hidden;
-    position: absolute;
-    width: 0;
+  > label {
+    > span {
+        height: 0;
+        overflow: hidden;
+        position: absolute;
+        width: 0;
+      }
+
+    > div {
+      margin-right: 15px;
+    }
   }
 `
 
@@ -60,7 +73,7 @@ class StepNavigation extends React.Component {
         }
       })
       return (
-        <Box as='nav' align='center' className={className} direction='row' justify='center' margin={{ top: '30px' }}>
+        <Box align='center' className={className} direction='row' justify='center' margin={{ top: '30px' }}>
           <StyledButton
             a11yTitle={counterpart('StepNavigation.previous')}
             data-index={prevStep}

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/StepNavigation/StepNavigation.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/StepNavigation/StepNavigation.js
@@ -73,7 +73,7 @@ class StepNavigation extends React.Component {
         }
       })
       return (
-        <Box align='center' className={className} direction='row' justify='center' margin={{ top: '30px' }}>
+        <Box align='center' className={className} direction='row' justify='center' margin={{ top: 'medium' }}>
           <StyledButton
             a11yTitle={counterpart('StepNavigation.previous')}
             data-index={prevStep}

--- a/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
+++ b/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
@@ -41,8 +41,9 @@ function ModalHeading ({ className, closeFn, title }) {
       className={className}
       direction='row'
       gap='large'
+      height='30px'
       justify='between'
-      pad={{ horizontal: 'medium', vertical: 'xsmall' }}
+      pad={{ horizontal: 'medium', vertical: 'none' }}
     >
       <Heading>
         {title}


### PR DESCRIPTION
Package: lib-classifier, lib-react-components

Describe your changes:
Fixes these items from #695

- Pagination dots are too far apart, arrows are even farther. There should be 5px between each element
- Between the teal bar and the top of the H2 should just be 30px.
- Why does 'Planet Finders BETA Tutorial' appear on each slide
- The entire contents of the tutorial should scroll, not just the text part
- the tutorial doesn't scroll when it's in the tab state



# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

