### PR TITLE
Move collections modal into classify container

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -1,9 +1,8 @@
 import { Box, Grid } from 'grommet'
 import dynamic from 'next/dynamic'
-import { string } from 'prop-types'
+import { func, string } from 'prop-types'
 import React from 'react'
 
-import CollectionsModal from './components/CollectionsModal'
 import ProjectStatistics from '../../shared/components/ProjectStatistics'
 import ConnectWithProject from '../../shared/components/ConnectWithProject'
 
@@ -16,18 +15,12 @@ const ClassifierWrapper = dynamic(() =>
 )
 
 function ClassifyPage (props) {
-  const collectionsModal = React.createRef()
-  function addToCollection (subjectId) {
-    collectionsModal.current.wrappedInstance.open(subjectId)
-  }
+  const { addToCollection } = props
   return (
     <Box
       background={props.mode === 'light' ? 'light-1' : 'dark-1'}
       pad={{ top: 'medium' }}
     >
-      <CollectionsModal
-        ref={collectionsModal}
-      />
       <Grid gap='medium' margin='medium'>
         <ClassifierWrapper
           onAddToCollection={addToCollection}
@@ -41,6 +34,7 @@ function ClassifyPage (props) {
 }
 
 ClassifyPage.propTypes = {
+  addToCollection: func,
   mode: string
 }
 

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
@@ -4,7 +4,6 @@ import React from 'react'
 import ClassifyPage from './ClassifyPage'
 import FinishedForTheDay from './components/FinishedForTheDay'
 import ProjectStatistics from '../../shared/components/ProjectStatistics'
-import CollectionsModal from './components/CollectionsModal'
 
 let wrapper
 
@@ -23,9 +22,5 @@ describe('Component > ClassifyPage', function () {
 
   it('should render the `ProjectStatistics` component', function () {
     expect(wrapper.find(ProjectStatistics)).to.have.lengthOf(1)
-  })
-
-  it('should render the `CollectionsModal` component', function () {
-    expect(wrapper.find(CollectionsModal)).to.have.lengthOf(1)
   })
 })

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -3,6 +3,7 @@ import { string } from 'prop-types'
 import React, { Component } from 'react'
 
 import ClassifyPage from './ClassifyPage'
+import CollectionsModal from './components/CollectionsModal'
 
 function storeMapper (stores) {
   const { mode } = stores.store.ui
@@ -14,8 +15,28 @@ function storeMapper (stores) {
 @inject(storeMapper)
 @observer
 class ClassifyPageContainer extends Component {
+  constructor() {
+    super()
+    this.collectionsModal = React.createRef()
+    this.addToCollection = this.addToCollection.bind(this)
+  }
+
+  addToCollection (subjectId) {
+    this.collectionsModal.current.wrappedInstance.open(subjectId)
+  }
+
   render () {
-    return <ClassifyPage {...this.props} />
+    return (
+      <>
+        <CollectionsModal
+          ref={this.collectionsModal}
+        />
+        <ClassifyPage
+          addToCollection = {this.addToCollection}
+          {...this.props}
+        />
+      </>
+    )
   }
 }
 

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.spec.js
@@ -3,6 +3,7 @@ import React from 'react'
 
 import ClassifyPageContainer from './ClassifyPageContainer'
 import ClassifyPage from './ClassifyPage'
+import CollectionsModal from './components/CollectionsModal'
 
 let wrapper
 let componentWrapper
@@ -19,5 +20,9 @@ describe('Component > ClassifyPageContainer', function () {
 
   it('should render the `ClassifyPage` component', function () {
     expect(componentWrapper).to.have.lengthOf(1)
+  })
+
+  it('should render the `CollectionsModal` component', function () {
+    expect(wrapper.find(CollectionsModal)).to.have.lengthOf(1)
   })
 })


### PR DESCRIPTION
Move the collections modal into the classify page container. This fixes a bug where the collectionsModal ref was lost if you logged in after loading the page, causing the Add To Collection button to crash the classifier.

Package:
app-project

Fixes the bug mentioned in this comment: https://github.com/zooniverse/front-end-monorepo/pull/690#issuecomment-482125976

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

