### PR TITLE
Pass auth headers with collections delete requests

### DIFF
--- a/packages/lib-panoptes-js/src/resources/collections/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/collections/commonRequests.js
@@ -23,7 +23,7 @@ function removeSubjects (params) {
 
   if (typeof collectionId !== 'string') return raiseError('Collections remove link: collections id must be a string.', 'typeError')
 
-  return panoptes.del(`${endpoint}/${collectionId}/links/subjects/${subjects.join(',')}`, { authorization })
+  return panoptes.del(`${endpoint}/${collectionId}/links/subjects/${subjects.join(',')}`, {}, { authorization })
 }
 
 module.exports = { addSubjects, removeSubjects }

--- a/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
@@ -242,6 +242,7 @@ describe('Collections resource REST requests', function () {
 
     before(function () {
       scope = nock(config.host)
+        .matchHeader('authorization', 'Bearer 1234')
         .persist()
         .delete(`${endpoint}/10/links/subjects/2`)
         .query(true)
@@ -271,7 +272,7 @@ describe('Collections resource REST requests', function () {
     })
 
     it('should unlink the specified subjects', async function () {
-      const response = await collections.removeSubjects({ id: '10', subjects: ['2'] })
+      const response = await collections.removeSubjects({ id: '10', subjects: ['2'], authorization: 'Bearer 1234' })
       expect(response).to.be.ok
     })
   })


### PR DESCRIPTION
Pass auth headers properly when removing a subject from a collection.

Package:
lib-panoptes-js

Closes #707.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

