### PR TITLE
Fix Next.js document so it correctly renders <Head>

### DIFF
--- a/packages/app-project/pages/_document.js
+++ b/packages/app-project/pages/_document.js
@@ -34,11 +34,11 @@ export default class MyDocument extends Document {
   render () {
     return (
       <html>
-        {isProduction && (
-          <Head>
+        <Head>
+          {isProduction && (
             <script dangerouslySetInnerHTML={{ __html: GA_TRACKING_SCRIPT }} />
-          </Head>
-        )}
+          )}
+        </Head>
         <body>
           {isProduction && (
             <noscript>


### PR DESCRIPTION
## PR Overview

Package: `app-project`
Fixes #710 

This PR fixes an issue where - if the website is hosted on a server that _isn't_ set to `NODE_ENV=production` - then visual styling elements aren't displayed properly.

Basically, you see this...

![Screen Shot 2019-04-12 at 13 59 41](https://user-images.githubusercontent.com/13952701/56039732-d7160700-5d2c-11e9-92a2-8f9e78035153.png)

...instead of this...

![Screen Shot 2019-04-12 at 14 10 54](https://user-images.githubusercontent.com/13952701/56039736-da10f780-5d2c-11e9-96d2-a2d3c804be71.png)

### Details

Currently, in `app-project/pages/_document.js`, the `<Head>` element isn't rendered at all if the web server's NODE_ENV isn't set to production. The lack of a Next.js `<Head>` in these instances basically screwed up style injections for the `app-project` website, causing all sorts of visual shenanigans.

Side note, this means that the website always looks fine if the dev has `NODE_ENV` set to production on their machine, or on the actual production server.

### Status

Ready for review!
