### PR TITLE
Make sure field guide item icons stay the same size. Consistent padding.

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideContainer.js
@@ -37,7 +37,7 @@ class FieldGuideContainer extends React.Component {
           active={showModal}
           closeFn={this.onClose.bind(this)}
           modal={false}
-          pad={{ horizontal: '30px', vertical: 'small' }}
+          pad='medium'
           position="right"
           title={counterpart('FieldGuide.title')}
         >

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItems/FieldGuideItemAnchor.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItems/FieldGuideItemAnchor.js
@@ -19,7 +19,7 @@ export function AnchorLabel({ className, icons, item }) {
       direction='column'
       width='100px'
     >
-      <FieldGuideItemIcon alt={item.title} height='100' icon={icon} width='100' />
+      <FieldGuideItemIcon alt={item.title} fit='cover' height='100px' icon={icon} width='100px' />
       <Markdownz>
         {item.title}
       </Markdownz>


### PR DESCRIPTION
Package: lib-classifier

Closes issues associated with the field guide listed in #695 

- Item icons consistently render at 100px by 100px
- Padding is consistently 30px all around now. 

You can use PH: Beta project to test http://localhost:8080/?project=1862
# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

