### PR TITLE
Fix undefined error with metadata button

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
@@ -51,8 +51,7 @@ export default class MetaTools extends React.Component {
 
     return (
       <Box className={className} direction="row-responsive" gap='small'>
-        {isThereMetadata &&
-          <MetadataButton onClick={onClick} />}
+        <MetadataButton disabled={!isThereMetadata} onClick={this.toggleMetadataModal} />
         {isThereMetadata &&
           <MetadataModal
             active={this.state.showMetadataModal}

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/CollectionsButton/CollectionsButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/CollectionsButton/CollectionsButton.spec.js
@@ -34,7 +34,7 @@ describe('Component > CollectionsButton', function () {
     expect(onClick).to.have.been.calledOnce
   })
 
-  describe ('when disabled', function () {
+  describe('when disabled', function () {
     const onClick = sinon.stub()
     wrapper = shallow(
       <CollectionsButton

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/FavouritesButton/FavouritesButton.spec.js
@@ -51,11 +51,11 @@ describe('Component > FavouritesButton', function () {
 
     it('should be checked', function () {
       const checked = wrapper.childAt(0).prop('aria-checked')
-      expect(checked).to.equal(true)
+      expect(checked).to.be.true
     })
   })
 
-  describe ('when disabled', function () {
+  describe('when disabled', function () {
     const onClick = sinon.stub()
     wrapper = shallow(
       <FavouritesButton

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/MetadataButton/MetadataButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/MetadataButton/MetadataButton.js
@@ -14,9 +14,10 @@ const StyledInfoIcon = styled(InfoIcon)`
 `
 
 export default function MetadataButton (props) {
-  const { onClick } = props
+  const { disabled, onClick } = props
   return (
     <PlainButton
+      disabled={disabled}
       icon={<StyledInfoIcon color='#5C5C5C' />}
       margin={{ vertical: '5px', horizontal: 'none' }}
       text={counterpart('MetadataButton.label')}
@@ -25,6 +26,11 @@ export default function MetadataButton (props) {
   )
 }
 
+MetadataButton.defaultProps = {
+  disabled: false,
+}
+
 MetadataButton.propTypes = {
+  disabled: PropTypes.bool, 
   onClick: PropTypes.func
 }

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/MetadataButton/MetadataButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/MetadataButton/MetadataButton.spec.js
@@ -2,18 +2,33 @@ import React from 'react'
 import { mount, shallow } from 'enzyme'
 import { expect } from 'chai'
 import sinon from 'sinon'
+import { PlainButton } from '@zooniverse/react-components'
 import MetadataButton from './MetadataButton'
 
 describe('MetadataButton', function () {
-  const onClickSpy = sinon.spy()
   it('should render without crashing', function () {
     const wrapper = shallow(<MetadataButton />)
     expect(wrapper).to.be.ok
   })
 
   it('should call props.onClick when button is clicked', function () {
-    const wrapper = mount(<MetadataButton onClick={onClickSpy} />)
-    wrapper.find('button').simulate('click')
+    const onClickSpy = sinon.spy()
+    const wrapper = shallow(<MetadataButton onClick={onClickSpy} />)
+    wrapper.find(PlainButton).simulate('click')
     expect(onClickSpy.calledOnce).to.be.true
+  })
+
+  describe('when disabled', function () {
+    it('should not be clickable', function () {
+      const onClickSpy = sinon.stub()
+      const wrapper = mount(
+        <MetadataButton
+          disabled
+          onClick={onClickSpy}
+        />
+      )
+      wrapper.find('button').simulate('click')
+      expect(onClickSpy).to.not.have.been.called
+    })
   })
 })


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
I rebase incorrectly a few minutes ago which left an undefined function type error. This fixes that issue and makes the metadata button more consistent with the rest of the metatools buttons by using the disabled prop rather than hide the button if there is no metadata.

Can be tested for disabled-ness with this project: http://localhost:8080/?project=272

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

