### PR TITLE
Add link for user stats only if logged in

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
@@ -3,6 +3,7 @@ import { Box, Button, Grid, Heading, Paragraph, Text } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
+import Link from 'next/link'
 
 import en from './locales/en'
 import ProjectImage from './components/ProjectImage'
@@ -15,6 +16,7 @@ const StyledButton = styled(Button)`
   border-width: 1px;
   flex: 1 1 300px;
   margin: 0 10px 10px 0;
+  text-align: center;
 `
 
 const StyledBox = styled(Box)`
@@ -22,7 +24,7 @@ const StyledBox = styled(Box)`
   max-width: 620px;
 `
 
-function FinishedForTheDay ({ imageSrc, projectName }) {
+function FinishedForTheDay ({ imageSrc, isLoggedIn, projectName }) {
   const columns = (imageSrc) ? ['1/4', 'auto'] : ['auto']
 
   return (
@@ -41,15 +43,17 @@ function FinishedForTheDay ({ imageSrc, projectName }) {
           {counterpart('FinishedForTheDay.text', { projectName })}
         </Paragraph>
         <StyledBox direction='row' wrap>
-          <StyledButton
-            label={(
-              <Text size='small'>
-                {counterpart('FinishedForTheDay.buttons.stats')}
-              </Text>
-            )}
-            onClick={() => console.info('click')}
-            primary
-          />
+          {isLoggedIn &&
+            <Link href='/#projects' passHref>
+              <StyledButton
+                label={(
+                  <Text size='small'>
+                    {counterpart('FinishedForTheDay.buttons.stats')}
+                  </Text>
+                )}
+                primary
+              />
+            </Link>}
           <RelatedProjects />
         </StyledBox>
       </ContentBox>
@@ -59,11 +63,13 @@ function FinishedForTheDay ({ imageSrc, projectName }) {
 
 FinishedForTheDay.propTypes = {
   imageSrc: PropTypes.string,
-  projectName: PropTypes.string.isRequired
+  isLoggedIn: PropTypes.bool,
+  projectName: PropTypes.string.isRequired,
 }
 
 FinishedForTheDay.defaultProps = {
-  imageSrc: ''
+  imageSrc: '',
+  isLoggedIn: false,
 }
 
 export default FinishedForTheDay

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
@@ -30,10 +30,6 @@ describe('Component > FinishedForTheDay', function () {
     expect(para.text().length).to.be.ok()
   })
 
-  xit('should contain a stats button', function () {
-    // We'll test this by link, and that link isn't hooked up yet
-  })
-
   it('should contain a related projects button', function () {
     expect(wrapper.find(RelatedProjects)).to.have.lengthOf(1)
   })
@@ -47,5 +43,22 @@ describe('Component > FinishedForTheDay', function () {
     const projectImageWrapper = wrapper.find(ProjectImage)
     expect(projectImageWrapper).to.have.lengthOf(1)
     expect(projectImageWrapper.prop('imageSrc')).to.equal(imageSrc)
+  })
+
+  describe('stats link', function () {
+    before(function () {
+      wrapper = shallow(<FinishedForTheDay projectName={projectName} />)
+    })
+
+    it('should not render the link if the user is not logged in', function () {
+      expect(wrapper.find('Link')).to.have.lengthOf(0)
+    })
+
+    it('should render the link if the user is logged in', function () {
+      wrapper.setProps({ isLoggedIn: true })
+      const link = wrapper.find('Link')
+      expect(link).to.have.lengthOf(1)
+      expect(link.props().href).to.equal('/#projects')
+    })
   })
 })

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.js
@@ -5,9 +5,10 @@ import React, { Component } from 'react'
 import FinishedForTheDay from './FinishedForTheDay'
 
 function storeMapper (stores) {
-  const { project } = stores.store
+  const { project, user } = stores.store
   return {
     imageSrc: project.background.src || '',
+    isLoggedIn: user.isLoggedIn,
     projectName: project['display_name']
   }
 }
@@ -16,10 +17,11 @@ function storeMapper (stores) {
 @observer
 class FinishedForTheDayContainer extends Component {
   render () {
-    const { imageSrc, projectName } = this.props
+    const { imageSrc, isLoggedIn, projectName } = this.props
     return (
       <FinishedForTheDay
         imageSrc={imageSrc}
+        isLoggedIn={isLoggedIn}
         projectName={projectName}
       />
     )
@@ -28,6 +30,7 @@ class FinishedForTheDayContainer extends Component {
 
 FinishedForTheDayContainer.propTypes = {
   imageSrc: PropTypes.string,
+  isLoggedIn: PropTypes.bool,
   projectName: PropTypes.string.isRequired
 }
 
@@ -35,6 +38,8 @@ FinishedForTheDayContainer.propTypes = {
 // something going on with the store execution order which leaves it undefined
 // without one.
 FinishedForTheDayContainer.defaultProps = {
+  imageSrc: '',
+  isLoggedIn: false,
   projectName: ''
 }
 

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsButton/RelatedProjectsButton.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsButton/RelatedProjectsButton.js
@@ -12,6 +12,7 @@ const StyledButton = styled(Button)`
   border-width: 1px;
   flex: 1 1 300px;
   margin: 0 10px 10px 0;
+  max-width: 300px;
 `
 
 function RelatedProjectsButton (props) {


### PR DESCRIPTION
Package: app-project

Describe your changes:
Wraps the button with a Link and passes the href to the `/#projects` anchor on the signed in home page (Grommet Buttons render as anchors with button styling if they have an href prop). Only show it if the user is signed in. Adds tests. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

