### PR TITLE
Add a key to the subject viewer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
@@ -34,6 +34,7 @@ class SubjectViewer extends React.Component {
     const Viewer = getViewer(subject.viewer)
     return (
       <Viewer
+        key={subject.id}
         subject={subject}
         subjectId={subject.id}
       />


### PR DESCRIPTION
Key the viewer by subject ID, forcing it to unmount and remount for each subject.

Package:
lib-classifier

Closes #719.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

