### PR TITLE
Remove the subjectId prop from the subject viewer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
@@ -36,7 +36,6 @@ class SubjectViewer extends React.Component {
       <Viewer
         key={subject.id}
         subject={subject}
-        subjectId={subject.id}
       />
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
@@ -28,11 +28,11 @@ class LightCurveViewerContainer extends Component {
   }
 
   componentDidUpdate (prevProps) {
-    const { subject, subjectId } = this.props
-    const prevSubject = prevProps.subject
-    const prevSubjectId = prevProps.subjectId
+    const { subject } = this.props
+    const prevSubjectId = prevProps.subject && prevProps.subject.id
+    const subjectChanged = subject && (subject.id !== prevSubjectId)
 
-    if (subject && (!prevSubject || prevSubjectId !== subjectId)) {
+    if (subjectChanged) {
       this.handleSubject()
     }
   }


### PR DESCRIPTION
Following on from #720, this removes the subjectId prop from the subject viewer and simplifies the check to see if the subject has changed on component update.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

