### PR TITLE
Disable related projects button

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
@@ -7,14 +7,14 @@ import Link from 'next/link'
 
 import en from './locales/en'
 import ProjectImage from './components/ProjectImage'
-import RelatedProjects from './components/RelatedProjects'
+// import RelatedProjects from './components/RelatedProjects'
 import ContentBox from '../../../../shared/components/ContentBox'
 
 counterpart.registerTranslations('en', en)
 
 const StyledButton = styled(Button)`
   border-width: 1px;
-  flex: 1 1 300px;
+  flex: 0 1 300px;
   margin: 0 10px 10px 0;
   text-align: center;
 `
@@ -24,6 +24,7 @@ const StyledBox = styled(Box)`
   max-width: 620px;
 `
 
+// TODO: Add `<RelatedProjects />` back in once API is up
 function FinishedForTheDay ({ imageSrc, isLoggedIn, projectName }) {
   const columns = (imageSrc) ? ['1/4', 'auto'] : ['auto']
 
@@ -43,7 +44,7 @@ function FinishedForTheDay ({ imageSrc, isLoggedIn, projectName }) {
           {counterpart('FinishedForTheDay.text', { projectName })}
         </Paragraph>
         <StyledBox direction='row' wrap>
-          {isLoggedIn &&
+          {isLoggedIn && (
             <Link href='/#projects' passHref>
               <StyledButton
                 label={(
@@ -53,8 +54,8 @@ function FinishedForTheDay ({ imageSrc, isLoggedIn, projectName }) {
                 )}
                 primary
               />
-            </Link>}
-          <RelatedProjects />
+            </Link>
+          )}
         </StyledBox>
       </ContentBox>
     </Grid>

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.spec.js
@@ -30,7 +30,8 @@ describe('Component > FinishedForTheDay', function () {
     expect(para.text().length).to.be.ok()
   })
 
-  it('should contain a related projects button', function () {
+  // TODO: Add `<RelatedProjects />` back in once API is up
+  xit('should contain a related projects button', function () {
     expect(wrapper.find(RelatedProjects)).to.have.lengthOf(1)
   })
 

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/locales/en.json
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/locales/en.json
@@ -4,7 +4,7 @@
       "anotherProject": "Find another project",
       "stats": "See your stats"
     },
-    "text": "Your answers are saved for the research team while you're working. See your stats and return to the %(projectName)s home page, or find another project to contribute to.",
+    "text": "Your answers are saved for the research team while you're working. See your stats and return to the %(projectName)s home page.",
     "title": "Finished for the day?"
   }
 }


### PR DESCRIPTION
Package: app-project

I'm writing a tiny API for finding related projects, but it's not quite ready to go yet. In the meantime, let's remove this button in order to get the app out of the door.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

