### PR TITLE
Tab design fixes

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tabs/Tabs.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tabs/Tabs.js
@@ -52,13 +52,11 @@ function Tabs (props) {
     },
     tabs: {
       extend: `
-        button {
+        button[role="tab"] {
+          flex: 1 1 ${100 / props.children.length}%;
           &:disabled {
             cursor: not-allowed;
             opacity: 1;
-          }
-          &[role="tab"] {
-            flex: 1 1 ${100 / props.children.length}%;
           }
           &:enabled[aria-selected="false"] {
             &:focus,

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tabs/Tabs.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tabs/Tabs.js
@@ -8,6 +8,7 @@ function Tabs (props) {
   const { global: { colors }, mode } = props.theme
   const isLight = mode === 'light'
   const borderColor = isLight ? colors['light-3'] : colors['dark-1']
+  const activeTextColor = isLight ? 'black' : colors['light-1']
   const activeBackgroundColor = isLight ? colors['white'] : colors['dark-3']
   const hoverBackgroundColor = isLight
     ? {
@@ -47,7 +48,16 @@ function Tabs (props) {
         margin: 0;
         padding: 16px 20px;
         border-right: 1px solid ${borderColor};
+        button[aria-selected="true"] & {
+          color: ${activeTextColor};
+        }
       `,
+      hover: {
+        color: {
+          dark: 'dark-1',
+          light: 'dark-1'
+        }
+      },
       pad: 'small'
     },
     tabs: {
@@ -57,6 +67,9 @@ function Tabs (props) {
           &:disabled {
             cursor: not-allowed;
             opacity: 1;
+          }
+          &[aria-selected="true"] {
+            pointer-events: none;
           }
           &:enabled[aria-selected="false"] {
             &:focus,

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tabs/Tabs.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tabs/Tabs.js
@@ -47,19 +47,25 @@ function Tabs (props) {
         margin: 0;
         padding: 16px 20px;
         border-right: 1px solid ${borderColor};
-        button[aria-selected="false"] & {
-          &:focus,
-          &:hover {
-            background: linear-gradient(${hoverBackgroundColor.top}, ${hoverBackgroundColor.bottom});
-          }
-        }
       `,
       pad: 'small'
     },
     tabs: {
       extend: `
-        button[role="tab"] {
-          flex: 1 1 ${100 / props.children.length}%;
+        button {
+          &:disabled {
+            cursor: not-allowed;
+            opacity: 1;
+          }
+          &[role="tab"] {
+            flex: 1 1 ${100 / props.children.length}%;
+          }
+          &:enabled[aria-selected="false"] {
+            &:focus,
+            &:hover {
+              background: linear-gradient(${hoverBackgroundColor.top}, ${hoverBackgroundColor.bottom});
+            }
+          }
         }
       `,
       header: {


### PR DESCRIPTION
Package: lib-classifier

- [x] Restore opacity of disabled tabs and add `not-allowed` cursor
- [x] Only allow hover background change on enabled tabs
- [x] Active tab text should be black, inactive should be #5C5C5C
- [x] Active tab should have no hover state

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

