### PR TITLE
Remove hover state from disabled buttons

### DIFF
--- a/packages/lib-react-components/src/PlainButton/PlainButton.js
+++ b/packages/lib-react-components/src/PlainButton/PlainButton.js
@@ -22,7 +22,7 @@ export const StyledPlainButton = styled(Button)`
   }
 
   &:focus,
-  &:hover {
+  &:enabled:hover {
     color: ${props => determineColor(props.theme)};
     text-decoration: underline;
   }

--- a/packages/lib-react-components/src/PlainButton/PlainButton.stories.js
+++ b/packages/lib-react-components/src/PlainButton/PlainButton.stories.js
@@ -36,3 +36,9 @@ storiesOf('PlainButton', module)
       <PlainButton icon={<Add />} text={text('Text', 'Click me')} />
     </Grommet>
   ), config)
+
+  .add('Disabled', () => (
+    <Grommet theme={zooTheme}>
+      <PlainButton disabled={true} onClick={undefined} text={text('Text', 'Click me')} />
+    </Grommet>
+  ), config)


### PR DESCRIPTION
Removes the :hover styling from disabled buttons. Adds a disabled button to the storybook.

Package:
lib-react-components


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

