### PR TITLE
Reduce tutorial height

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorialContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorialContainer.js
@@ -24,7 +24,7 @@ class SlideTutorialContainer extends React.Component {
       return (
         <ResponsiveContext.Consumer>
           {size => {
-            const height = (size === 'small') ? '100%' : '465px'
+            const height = (size === 'small') ? '100%' : '53vh'
             return (
               <SlideTutorial height={height} {...this.props} />
             )


### PR DESCRIPTION
Change the tutorial height from a fixed 465px to 53vh.

Package:
lib-classifier

This is a quick fix that stops the tutorial from resizing the subject viewer.
![Screenshot showing the tutorial much shorter next to the subject viewer.](https://user-images.githubusercontent.com/59547/56201712-65de9880-6039-11e9-9035-06e583dadab7.png)


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

