### PR TITLE
Add keyboard zoom to the image tools

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -1,6 +1,5 @@
 import { Box } from 'grommet'
-import { inject } from 'mobx-react'
-import { func, shape, string } from 'prop-types'
+import { shape, string } from 'prop-types'
 import React, { Component } from 'react'
 import { withTheme } from 'styled-components'
 
@@ -12,60 +11,7 @@ import ResetButton from './components/ResetButton'
 import RotateButton from './components/RotateButton'
 import ZoomInButton from './components/ZoomInButton'
 import ZoomOutButton from './components/ZoomOutButton'
-
-function storeMapper (stores) {
-  const {
-    zoomIn,
-    zoomOut
-  } = stores.classifierStore.subjectViewer
-
-  return {
-    zoomIn,
-    zoomOut
-  }
-}
-
-function withKeyZoom (WrappedComponent) {
-  return @inject(storeMapper)
-  class extends React.Component {
-    constructor () {
-      super()
-      this.onKeyDown = this.onKeyDown.bind(this)
-    }
-
-    onKeyDown (e) {
-      const { zoomIn, zoomOut } = this.props
-      switch (e.key) {
-        case '+':
-        case '=': {
-          zoomIn()
-          return true
-        }
-        case '-':
-        case '_': {
-          zoomOut()
-          return true
-        }
-        case 'ArrowRight': {
-          console.log('pan right')
-          return true
-        }
-        case 'ArrowLeft': {
-          console.log('pan left')
-          return true
-        }
-        default: {
-          return true
-        }
-      }
-    }
-
-    render () {
-      const { zoomIn, zoomOut, ...props } = this.props
-      return <WrappedComponent onKeyDown={this.onKeyDown} {...props} />
-    }
-  }
-}
+import withKeyZoom from '../withKeyZoom'
 
 @withTheme
 @withKeyZoom

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -13,6 +13,9 @@ import RotateButton from './components/RotateButton'
 import ZoomInButton from './components/ZoomInButton'
 import ZoomOutButton from './components/ZoomOutButton'
 
+const PLUS = 187
+const MINUS = 189
+
 function storeMapper (stores) {
   const {
     zoomIn,
@@ -32,11 +35,11 @@ class ImageToolbar extends Component {
     const { theme: { mode }, zoomIn, zoomOut, ...props } = this.props
     function onKeyDown (e) {
       switch (e.which) {
-        case 187: {
+        case PLUS: {
           zoomIn()
           return true
         }
-        case 189: {
+        case MINUS: {
           zoomOut()
           return true
         }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -1,5 +1,6 @@
 import { Box } from 'grommet'
-import { shape, string } from 'prop-types'
+import { inject } from 'mobx-react'
+import { func, shape, string } from 'prop-types'
 import React, { Component } from 'react'
 import { withTheme } from 'styled-components'
 
@@ -12,13 +13,41 @@ import RotateButton from './components/RotateButton'
 import ZoomInButton from './components/ZoomInButton'
 import ZoomOutButton from './components/ZoomOutButton'
 
+function storeMapper (stores) {
+  const {
+    zoomIn,
+    zoomOut
+  } = stores.classifierStore.subjectViewer
+
+  return {
+    zoomIn,
+    zoomOut
+  }
+}
+
 @withTheme
+@inject(storeMapper)
 class ImageToolbar extends Component {
   render () {
-    const { theme: { mode }, ...props } = this.props
+    const { theme: { mode }, zoomIn, zoomOut, ...props } = this.props
+    function onKeyDown (e) {
+      switch (e.which) {
+        case 187: {
+          zoomIn()
+          return true
+        }
+        case 189: {
+          zoomOut()
+          return true
+        }
+        default: {
+          return true
+        }
+      }
+    }
 
     return (
-      <Box as='aside' {...props}>
+      <Box as='aside' {...props} onKeyDown={onKeyDown}>
         <Box
           background={{
             dark: 'dark-3',
@@ -46,10 +75,16 @@ class ImageToolbar extends Component {
   }
 }
 
+ImageToolbar.defaultProps = {
+  zoomIn: () => true,
+  zoomOut: () => true
+}
 ImageToolbar.propTypes = {
   theme: shape({
     mode: string
-  })
+  }),
+  zoomIn: func,
+  zoomOut: func
 }
 
 export default ImageToolbar

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -46,6 +46,14 @@ function withKeyZoom (WrappedComponent) {
           zoomOut()
           return true
         }
+        case 'ArrowRight': {
+          console.log('pan right')
+          return true
+        }
+        case 'ArrowLeft': {
+          console.log('pan left')
+          return true
+        }
         default: {
           return true
         }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -28,26 +28,33 @@ function storeMapper (stores) {
 function withKeyZoom (WrappedComponent) {
   return @inject(storeMapper)
   class extends React.Component {
-    render () {
-      const { zoomIn, zoomOut, ...props } = this.props
-      function onKeyDown (e) {
-        switch (e.key) {
-          case '+':
-          case '=': {
-            zoomIn()
-            return true
-          }
-          case '-':
-          case '_': {
-            zoomOut()
-            return true
-          }
-          default: {
-            return true
-          }
+    constructor () {
+      super()
+      this.onKeyDown = this.onKeyDown.bind(this)
+    }
+
+    onKeyDown (e) {
+      const { zoomIn, zoomOut } = this.props
+      switch (e.key) {
+        case '+':
+        case '=': {
+          zoomIn()
+          return true
+        }
+        case '-':
+        case '_': {
+          zoomOut()
+          return true
+        }
+        default: {
+          return true
         }
       }
-      return <WrappedComponent onKeyDown={onKeyDown} {...props} />
+    }
+
+    render () {
+      const { zoomIn, zoomOut, ...props } = this.props
+      return <WrappedComponent onKeyDown={this.onKeyDown} {...props} />
     }
   }
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -94,16 +94,10 @@ class ImageToolbar extends Component {
   }
 }
 
-ImageToolbar.defaultProps = {
-  zoomIn: () => true,
-  zoomOut: () => true
-}
 ImageToolbar.propTypes = {
   theme: shape({
     mode: string
-  }),
-  zoomIn: func,
-  zoomOut: func
+  })
 }
 
 export default ImageToolbar

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -13,8 +13,6 @@ import RotateButton from './components/RotateButton'
 import ZoomInButton from './components/ZoomInButton'
 import ZoomOutButton from './components/ZoomOutButton'
 
-const PLUS = 187
-const MINUS = 189
 
 function storeMapper (stores) {
   const {
@@ -28,29 +26,41 @@ function storeMapper (stores) {
   }
 }
 
-@withTheme
-@inject(storeMapper)
-class ImageToolbar extends Component {
-  render () {
-    const { theme: { mode }, zoomIn, zoomOut, ...props } = this.props
-    function onKeyDown (e) {
-      switch (e.which) {
-        case PLUS: {
-          zoomIn()
-          return true
+function withKeyZoom (WrappedComponent) {
+  return @inject(storeMapper)
+    class extends React.Component {
+      render() {
+        const { zoomIn, zoomOut, ...props } = this.props
+        function onKeyDown (e) {
+          switch (e.key) {
+            case '+':
+            case '=': {
+              zoomIn()
+              return true
+            }
+            case '-':
+            case '_': {
+              zoomOut()
+              return true
+            }
+            default: {
+              return true
+            }
+          }
         }
-        case MINUS: {
-          zoomOut()
-          return true
-        }
-        default: {
-          return true
-        }
+        return <WrappedComponent onKeyDown={onKeyDown} {...props} />;
       }
     }
+}
+
+@withTheme
+@withKeyZoom
+class ImageToolbar extends Component {
+  render () {
+    const { theme: { mode }, ...props } = this.props
 
     return (
-      <Box as='aside' {...props} onKeyDown={onKeyDown}>
+      <Box as='aside' {...props}>
         <Box
           background={{
             dark: 'dark-3',

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -13,7 +13,6 @@ import RotateButton from './components/RotateButton'
 import ZoomInButton from './components/ZoomInButton'
 import ZoomOutButton from './components/ZoomOutButton'
 
-
 function storeMapper (stores) {
   const {
     zoomIn,
@@ -28,29 +27,29 @@ function storeMapper (stores) {
 
 function withKeyZoom (WrappedComponent) {
   return @inject(storeMapper)
-    class extends React.Component {
-      render() {
-        const { zoomIn, zoomOut, ...props } = this.props
-        function onKeyDown (e) {
-          switch (e.key) {
-            case '+':
-            case '=': {
-              zoomIn()
-              return true
-            }
-            case '-':
-            case '_': {
-              zoomOut()
-              return true
-            }
-            default: {
-              return true
-            }
+  class extends React.Component {
+    render () {
+      const { zoomIn, zoomOut, ...props } = this.props
+      function onKeyDown (e) {
+        switch (e.key) {
+          case '+':
+          case '=': {
+            zoomIn()
+            return true
+          }
+          case '-':
+          case '_': {
+            zoomOut()
+            return true
+          }
+          default: {
+            return true
           }
         }
-        return <WrappedComponent onKeyDown={onKeyDown} {...props} />;
       }
+      return <WrappedComponent onKeyDown={onKeyDown} {...props} />
     }
+  }
 }
 
 @withTheme

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
@@ -7,7 +7,9 @@ import request from 'superagent'
 
 import LightCurveViewer from './LightCurveViewer'
 import locationValidator from '../../helpers/locationValidator'
+import withKeyZoom from '../../../withKeyZoom'
 
+@withKeyZoom
 class LightCurveViewerContainer extends Component {
   constructor () {
     super()

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.spec.js
@@ -7,7 +7,7 @@ let wrapper
 
 describe('Component > LightCurveViewerContainer', function () {
   beforeEach(function () {
-    wrapper = shallow(<LightCurveViewerContainer />)
+    wrapper = shallow(<LightCurveViewerContainer.wrappedComponent />)
   })
 
   it('should render without crashing', function () {
@@ -15,6 +15,6 @@ describe('Component > LightCurveViewerContainer', function () {
   })
 
   it('should render null if there is no subject prop', function () {
-    expect(wrapper.type()).to.equal(null)
+    expect(wrapper.dive().type()).to.be.null
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/index.js
@@ -1,0 +1,1 @@
+export { default } from './withKeyZoom'

--- a/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
@@ -1,0 +1,59 @@
+import { inject } from 'mobx-react'
+import { func, shape, string } from 'prop-types'
+import React, { Component } from 'react'
+
+function storeMapper (stores) {
+  const {
+    zoomIn,
+    zoomOut
+  } = stores.classifierStore.subjectViewer
+
+  return {
+    zoomIn,
+    zoomOut
+  }
+}
+
+function withKeyZoom (WrappedComponent) {
+  return @inject(storeMapper)
+  class extends React.Component {
+    constructor () {
+      super()
+      this.onKeyDown = this.onKeyDown.bind(this)
+    }
+
+    onKeyDown (e) {
+      const { zoomIn, zoomOut } = this.props
+      switch (e.key) {
+        case '+':
+        case '=': {
+          zoomIn()
+          return true
+        }
+        case '-':
+        case '_': {
+          zoomOut()
+          return true
+        }
+        case 'ArrowRight': {
+          console.log('pan right')
+          return true
+        }
+        case 'ArrowLeft': {
+          console.log('pan left')
+          return true
+        }
+        default: {
+          return true
+        }
+      }
+    }
+
+    render () {
+      const { zoomIn, zoomOut, ...props } = this.props
+      return <WrappedComponent onKeyDown={this.onKeyDown} {...props} />
+    }
+  }
+}
+
+export default withKeyZoom

--- a/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.spec.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { expect } from 'chai'
+import sinon from 'sinon'
+import withKeyZoom from './withKeyZoom'
+
+describe('withKeyZoom', function () {
+  function StubComponent () {
+    return <p>Hello</p>
+  }
+  const WithZoom = withKeyZoom(StubComponent)
+  let wrapper
+
+  before(function () {
+    wrapper = shallow(<WithZoom.wrappedComponent />)
+  })
+
+  it('should add an onKeyDown handler to wrapped components', function () {
+    expect(wrapper.props().onKeyDown).to.exist
+  })
+
+  describe('on key down', function () {
+    const zoomIn = sinon.stub()
+    const zoomOut = sinon.stub()
+    const bindings = [
+      {
+        key: '+',
+        name: 'zoomIn',
+        handler: zoomIn
+      },
+      {
+        key: '=',
+        name: 'zoomIn',
+        handler: zoomIn
+      },
+      {
+        key: '-',
+        name: 'zoomOut',
+        handler: zoomOut
+      },
+      {
+        key: '_',
+        name: 'zoomOut',
+        handler: zoomOut
+      },
+    ]
+
+    before(function () {
+      wrapper = shallow(
+        <WithZoom.wrappedComponent
+          zoomIn={zoomIn}
+          zoomOut={zoomOut}
+        />)
+    })
+
+    afterEach(function () {
+      zoomIn.resetHistory()
+      zoomOut.resetHistory()
+    })
+
+    bindings.forEach(function ({ key, name, handler }) {
+      it(`should call ${name} for ${key}`, function () {
+        const fakeEvent = {
+          key
+        }
+        wrapper.simulate('keydown', fakeEvent)
+        expect(handler).to.have.been.calledOnce
+      })
+    })
+  })
+})


### PR DESCRIPTION
Add +/- keys as zoom controls when the image toolbar has focus.
Stub out handlers for the left and right cursor keys.
Add a keydown listener to the light curve viewer.

Package:
lib-classifier


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

