### PR TITLE
Add keyboard pan controls

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -18,6 +18,7 @@ import setDataPointStyle from './d3/setDataPointStyle'
 const ZOOM_IN_VALUE = 1.2
 const ZOOM_OUT_VALUE = 0.8
 const ZOOMING_TIME = 100 // milliseconds
+const PAN_DISTANCE = 20
 
 function storeMapper (stores) {
   const {
@@ -416,8 +417,8 @@ class LightCurveViewer extends Component {
     this.zoom.scaleTo(this.d3interfaceLayer.transition().duration(ZOOMING_TIME), zoomValue)
   }
 
-  pan (value) {
-    this.zoom.translateBy(this.d3interfaceLayer.transition().duration(ZOOMING_TIME), value, 0)
+  pan (xMultiplier) {
+    this.zoom.translateBy(this.d3interfaceLayer.transition().duration(ZOOMING_TIME), xMultiplier * PAN_DISTANCE, 0)
   }
 
   /*

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -24,6 +24,7 @@ function storeMapper (stores) {
     enableAnnotate,
     enableMove,
     interactionMode, // string: indicates if the Classifier is in 'annotate' (default) mode or 'move' mode
+    setOnPan,
     setOnZoom // func: sets onZoom event handler
   } = stores.classifierStore.subjectViewer
 
@@ -46,6 +47,7 @@ function storeMapper (stores) {
     enableAnnotate,
     enableMove,
     interactionMode,
+    setOnPan,
     setOnZoom,
     toolIndex
   }
@@ -100,6 +102,7 @@ class LightCurveViewer extends Component {
   componentDidMount () {
     this.initChart()
     this.props.setOnZoom(this.handleToolbarZoom.bind(this))
+    this.props.setOnPan(this.pan.bind(this))
   }
 
   componentDidUpdate (prevProps) {
@@ -411,6 +414,10 @@ class LightCurveViewer extends Component {
 
   zoomTo (zoomValue) {
     this.zoom.scaleTo(this.d3interfaceLayer.transition().duration(ZOOMING_TIME), zoomValue)
+  }
+
+  pan (value) {
+    this.zoom.translateBy(this.d3interfaceLayer.transition().duration(ZOOMING_TIME), value, 0)
   }
 
   /*

--- a/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
@@ -4,11 +4,13 @@ import React, { Component } from 'react'
 
 function storeMapper (stores) {
   const {
+    onPan,
     zoomIn,
     zoomOut
   } = stores.classifierStore.subjectViewer
 
   return {
+    onPan,
     zoomIn,
     zoomOut
   }
@@ -23,7 +25,7 @@ function withKeyZoom (WrappedComponent) {
     }
 
     onKeyDown (e) {
-      const { zoomIn, zoomOut } = this.props
+      const { onPan, zoomIn, zoomOut } = this.props
       switch (e.key) {
         case '+':
         case '=': {
@@ -36,11 +38,11 @@ function withKeyZoom (WrappedComponent) {
           return true
         }
         case 'ArrowRight': {
-          console.log('pan right')
+          onPan(20)
           return true
         }
         case 'ArrowLeft': {
-          console.log('pan left')
+          onPan(-20)
           return true
         }
         default: {
@@ -50,7 +52,7 @@ function withKeyZoom (WrappedComponent) {
     }
 
     render () {
-      const { zoomIn, zoomOut, ...props } = this.props
+      const { onPan, zoomIn, zoomOut, ...props } = this.props
       return <WrappedComponent onKeyDown={this.onKeyDown} {...props} />
     }
   }

--- a/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
@@ -38,11 +38,11 @@ function withKeyZoom (WrappedComponent) {
           return true
         }
         case 'ArrowRight': {
-          onPan(20)
+          onPan(-1, 0)
           return true
         }
         case 'ArrowLeft': {
-          onPan(-20)
+          onPan(1, 0)
           return true
         }
         default: {

--- a/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.spec.js
@@ -47,12 +47,12 @@ describe('withKeyZoom', function () {
       {
         key: 'ArrowRight',
         name: 'pan right',
-        handler: onPan.withArgs(20)
+        handler: onPan.withArgs(-1,0)
       },
       {
         key: 'ArrowLeft',
         name: 'pan left',
-        handler: onPan.withArgs(-20)
+        handler: onPan.withArgs(1,0)
       }
     ]
 

--- a/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.spec.js
@@ -20,6 +20,7 @@ describe('withKeyZoom', function () {
   })
 
   describe('on key down', function () {
+    const onPan = sinon.stub()
     const zoomIn = sinon.stub()
     const zoomOut = sinon.stub()
     const bindings = [
@@ -43,11 +44,22 @@ describe('withKeyZoom', function () {
         name: 'zoomOut',
         handler: zoomOut
       },
+      {
+        key: 'ArrowRight',
+        name: 'pan right',
+        handler: onPan.withArgs(20)
+      },
+      {
+        key: 'ArrowLeft',
+        name: 'pan left',
+        handler: onPan.withArgs(-20)
+      }
     ]
 
     before(function () {
       wrapper = shallow(
         <WithZoom.wrappedComponent
+          onPan={onPan}
           zoomIn={zoomIn}
           zoomOut={zoomOut}
         />)

--- a/packages/lib-classifier/src/store/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.js
@@ -16,7 +16,8 @@ const SubjectViewer = types
     - 'type': 'zoomin', 'zoomout', 'zoomto'
     - 'zoomValue' defines amount zoomed in/out, or current zoom value of 'zoomto'.
      */
-    onZoom: function (type, zoomValue) {}
+    onZoom: function (type, zoomValue) {},
+    onPan: function (value) {}
   }))
 
   .views(self => ({
@@ -60,6 +61,10 @@ const SubjectViewer = types
 
     setOnZoom (callback) {
       self.onZoom = callback
+    },
+
+    setOnPan (callback) {
+      self.onPan = callback
     },
 
     zoomIn () {


### PR DESCRIPTION
Add an onPan callback to the light curve viewer.
Wire up the left and right arrow keys to call onPan.
Update the tests for withKeyZoom to include left and right panning.

Package:
lib-classifier

Closes #722.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

