### PR TITLE
Add default props for pan/zoom callbacks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
@@ -17,8 +17,8 @@ function storeMapper (stores) {
 }
 
 function withKeyZoom (WrappedComponent) {
-  return @inject(storeMapper)
-  class extends React.Component {
+  @inject(storeMapper)
+  class KeyZoom extends React.Component {
     constructor () {
       super()
       this.onKeyDown = this.onKeyDown.bind(this)
@@ -56,6 +56,12 @@ function withKeyZoom (WrappedComponent) {
       return <WrappedComponent onKeyDown={this.onKeyDown} {...props} />
     }
   }
+  KeyZoom.defaultProps = {
+    onPan: () => true,
+    zoomIn: () => true,
+    zoomOut: () => true
+  }
+  return KeyZoom
 }
 
 export default withKeyZoom


### PR DESCRIPTION
Add default props so that withKeyZoom doesn't crash if expected callbacks aren't defined.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

