### PR TITLE
Hide disabled tools

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/FullscreenButton/FullscreenButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/FullscreenButton/FullscreenButtonContainer.js
@@ -33,10 +33,12 @@ class FullscreenButtonContainer extends React.Component {
 
   render () {
     const { disabled, fullscreen } = this.props
+    if (disabled) {
+      return null
+    }
     return (
       <FullscreenButton
         active={fullscreen}
-        disabled={disabled}
         onClick={this.onClick}
       />
     )

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButtonContainer.js
@@ -19,8 +19,11 @@ function storeMapper (stores) {
 class RotateButtonContainer extends React.Component {
   render () {
     const { disabled, rotate } = this.props
+    if (disabled) {
+      return null
+    }
     return (
-      <RotateButton disabled={disabled} onClick={rotate} />
+      <RotateButton onClick={rotate} />
     )
   }
 }


### PR DESCRIPTION
Package: lib-classifier

Closes #732.

Describe your changes:
- until rotate and fullscreen buttons implemented, hides `disabled` buttons by returning `null`
- [the Button component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js) will be refactored for a tooltip, and as part of that refactor we will revisit if/how we will disable a button

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

