### PR TITLE
Bump Grommet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2186,7 +2186,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -3622,7 +3622,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },

--- a/packages/app-project/package-lock.json
+++ b/packages/app-project/package-lock.json
@@ -1345,7 +1345,7 @@
 				"@babel/plugin-transform-modules-commonjs": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
-					"integrity": "sha1-xPGTP1mR1RRenPrR39hI6hcn9AQ=",
+					"integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-module-transforms": "^7.1.0",
@@ -1413,7 +1413,7 @@
 				"json5": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-					"integrity": "sha1-56DGLEgoXGKNIKELhcibuAfDKFA=",
+					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
 					"dev": true,
 					"requires": {
 						"minimist": "^1.2.0"
@@ -1428,13 +1428,13 @@
 				"node-fetch": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-					"integrity": "sha1-Gh2UC7+5FqHT4CGfA36J5x+MX6U=",
+					"integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
 					"dev": true
 				},
 				"resolve": {
 					"version": "1.10.0",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-					"integrity": "sha1-O9qur0XMB/N1ZW39LlTtCBCxAbo=",
+					"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
 					"dev": true,
 					"requires": {
 						"path-parse": "^1.0.6"
@@ -4101,7 +4101,7 @@
 				"parse5": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-					"integrity": "sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=",
+					"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
 					"dev": true,
 					"requires": {
 						"@types/node": "*"
@@ -4654,7 +4654,7 @@
 		"css": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-			"integrity": "sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=",
+			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
 			"requires": {
 				"inherits": "^2.0.3",
 				"source-map": "^0.6.1",
@@ -5616,7 +5616,7 @@
 		"enzyme": {
 			"version": "3.9.0",
 			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.9.0.tgz",
-			"integrity": "sha1-K0kfBsqWbrVrZRAGjHiUp+C+OQk=",
+			"integrity": "sha512-JqxI2BRFHbmiP7/UFqvsjxTirWoM1HfeaJrmVSZ9a1EADKkZgdPcAuISPMpoUiHlac9J4dYt81MC5BBIrbJGMg==",
 			"dev": true,
 			"requires": {
 				"array.prototype.flat": "^1.2.1",
@@ -5645,7 +5645,7 @@
 		"enzyme-adapter-react-16": {
 			"version": "1.11.2",
 			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.11.2.tgz",
-			"integrity": "sha1-jv6vsn6WhzpUkv3vP0I2kxguudQ=",
+			"integrity": "sha512-2ruTTCPRb0lPuw/vKTXGVZVBZqh83MNDnakMhzxhpJcIbneEwNy2Cv0KvL97pl57/GOazJHflWNLjwWhex5AAA==",
 			"dev": true,
 			"requires": {
 				"enzyme-adapter-utils": "^1.10.1",
@@ -5660,7 +5660,7 @@
 		"enzyme-adapter-utils": {
 			"version": "1.10.1",
 			"resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.10.1.tgz",
-			"integrity": "sha1-WCZO+hmnvv2/lk+3mBoQilRSrJY=",
+			"integrity": "sha512-oasinhhLoBuZsIkTe8mx0HiudtfErUtG0Ooe1FOplu/t4c9rOmyG5gtrBASK6u4whHIRWvv0cbZMElzNTR21SA==",
 			"dev": true,
 			"requires": {
 				"function.prototype.name": "^1.1.0",
@@ -5673,7 +5673,7 @@
 				"object.fromentries": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
-					"integrity": "sha1-SaVD2SFR+Cd7OslgDx6TCxidMKs=",
+					"integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
 					"dev": true,
 					"requires": {
 						"define-properties": "^1.1.2",
@@ -6915,7 +6915,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -6933,11 +6934,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -6950,15 +6953,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -7061,7 +7067,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -7071,6 +7078,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -7083,17 +7091,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -7110,6 +7121,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -7182,7 +7194,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -7192,6 +7205,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -7267,7 +7281,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -7297,6 +7312,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -7314,6 +7330,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -7352,11 +7369,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},
@@ -7552,18 +7571,17 @@
 			}
 		},
 		"grommet": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/grommet/-/grommet-2.5.5.tgz",
-			"integrity": "sha1-CNT8BUQBbnl9A+N0R/+3D+We8XQ=",
+			"version": "2.6.6",
+			"resolved": "https://registry.npmjs.org/grommet/-/grommet-2.6.6.tgz",
+			"integrity": "sha512-NeHYTG2ROBB9DWfih2YAvsG9Q2U9PQOVPSQ0RGPsDJ8o9yfrbDFSpGmfam58oE+MC/5Hx5iBvlUrGVg+VXQgEw==",
 			"requires": {
 				"css": "^2.2.3",
 				"grommet-icons": "^4.2.0",
 				"grommet-styles": "^0.2.0",
 				"hoist-non-react-statics": "^3.2.0",
-				"markdown-to-jsx": "^6.6.6",
-				"mobile-detect": "^1.4.3",
+				"markdown-to-jsx": "^6.9.1",
 				"polished": "^2.2.0",
-				"prop-types": "^15.5.10",
+				"prop-types": "^15.7.2",
 				"react-desc": "^4.1.2",
 				"recompose": "^0.30.0"
 			}
@@ -7571,7 +7589,7 @@
 		"grommet-icons": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/grommet-icons/-/grommet-icons-4.2.0.tgz",
-			"integrity": "sha1-e899Szf2lFFq3ghOJTbHKyJManY=",
+			"integrity": "sha512-HMPLQa2pgnCZFImUXwfq+79VizL6oyP2/AAfAzQDw57x/6qgWouoqoRrrt+2zodTjTxtKXxliBY1w/o5uC+DpA==",
 			"requires": {
 				"grommet-styles": "^0.2.0"
 			}
@@ -7742,7 +7760,7 @@
 		"hoist-non-react-statics": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-			"integrity": "sha1-sJF48BIhhPuVrPUl2q7LTY9FlYs=",
+			"integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
 			"requires": {
 				"react-is": "^16.7.0"
 			}
@@ -7772,7 +7790,7 @@
 		"html-element-map": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.0.tgz",
-			"integrity": "sha1-GaQZQCJRU+zf6tdPhQkVT/HNwYs=",
+			"integrity": "sha512-/SP6aOiM5Ai9zALvCxDubIeez0LvG3qP7R9GcRDnJEP/HBmv0A8A9K0o8+HFudcFt46+i921ANjzKsjPjb7Enw==",
 			"dev": true,
 			"requires": {
 				"array-filter": "^1.0.0"
@@ -8821,9 +8839,9 @@
 			}
 		},
 		"markdown-to-jsx": {
-			"version": "6.9.2",
-			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.9.2.tgz",
-			"integrity": "sha512-Rjd3AvcGjrwkjGGLrYNa2+4mnsEfu9LZqcafQU3I37f1gB3qOxstQ35T4/jDZyqmi3f6kzGIsz7/ijpxzp52FA==",
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.9.4.tgz",
+			"integrity": "sha512-Fvx2ZhiknGmcLsWVjIq6MmiN9gcCot8w+jzwN2mLXZcQsJGRN3Zes5Sp5M9YNIzUy/sDyuOTjimFdtAcvvmAPQ==",
 			"requires": {
 				"prop-types": "^15.6.2",
 				"unquote": "^1.1.0"
@@ -9082,11 +9100,6 @@
 				"mkdirp": "^0.5.0"
 			}
 		},
-		"mobile-detect": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/mobile-detect/-/mobile-detect-1.4.3.tgz",
-			"integrity": "sha512-UaahPNLllQsstHOEHAmVnTHCMQrAS9eL5Qgdi50QrYz6UgGk+Xziz2udz2GN6NYcyODcPLnasC7a7s6R2DjiaQ=="
-		},
 		"mobx": {
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/mobx/-/mobx-5.5.2.tgz",
@@ -9178,7 +9191,7 @@
 		"moo": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-			"integrity": "sha1-P4R6JvMc9iWpVqh/KxD7wBO/0Q4=",
+			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
 			"dev": true
 		},
 		"mout": {
@@ -9248,7 +9261,7 @@
 		"nearley": {
 			"version": "2.16.0",
 			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
-			"integrity": "sha1-d8KX0EGUHSaCkOyEtznQ7il+g6c=",
+			"integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -9335,7 +9348,7 @@
 				"@babel/runtime": {
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
-					"integrity": "sha1-gciZNfRkdwb8VFQRRea07P70uOM=",
+					"integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
 					"requires": {
 						"regenerator-runtime": "^0.12.0"
 					}
@@ -9343,7 +9356,7 @@
 				"hoist-non-react-statics": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.2.0.tgz",
-					"integrity": "sha1-0hufxytQ/cOMXYj24sUvLC2+XuI=",
+					"integrity": "sha512-3IascCRfaEkbmHjJnUxWSspIUE1okLPjGTMVXW8zraUo1t3yg1BadKAxAGILHwgoBzmMnzrgeeaDGBvpuPz6dA==",
 					"requires": {
 						"react-is": "^16.3.2"
 					}
@@ -9381,7 +9394,7 @@
 				"find-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"requires": {
 						"locate-path": "^3.0.0"
 					}
@@ -9389,7 +9402,7 @@
 				"locate-path": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
@@ -9406,7 +9419,7 @@
 				"p-locate": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"requires": {
 						"p-limit": "^2.0.0"
 					}
@@ -9414,7 +9427,7 @@
 				"p-try": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha1-hQgLuHxkaI+keZb+j3376CEXYLE="
+					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
 				},
 				"prop-types": {
 					"version": "15.6.2",
@@ -9668,7 +9681,7 @@
 		"object-inspect": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-			"integrity": "sha1-xwtsv3LydKq0w0wMgvUWe/gs8Vs=",
+			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
 			"dev": true
 		},
 		"object-is": {
@@ -10575,7 +10588,7 @@
 		"raf": {
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-			"integrity": "sha1-B0LpmkplUvRF1z4+4DKK8P8e3jk=",
+			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
 			"dev": true,
 			"requires": {
 				"performance-now": "^2.1.0"
@@ -10596,7 +10609,7 @@
 		"randexp": {
 			"version": "0.4.6",
 			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha1-6YatXl4x2uE93W97MBmqfIf2DKM=",
+			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
 			"dev": true,
 			"requires": {
 				"discontinuous-range": "1.0.0",
@@ -10657,7 +10670,7 @@
 		"react": {
 			"version": "16.8.4",
 			"resolved": "https://registry.npmjs.org/react/-/react-16.8.4.tgz",
-			"integrity": "sha1-/fe9muU/A6nEzRo3FDLCBr4cR2g=",
+			"integrity": "sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -10912,7 +10925,7 @@
 		"react-dom": {
 			"version": "16.8.4",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.4.tgz",
-			"integrity": "sha1-EGGo4BorOwyBYAN0QcO/AKDjvEg=",
+			"integrity": "sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -10995,7 +11008,7 @@
 		"react-test-renderer": {
 			"version": "16.8.4",
 			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.4.tgz",
-			"integrity": "sha1-q+5MLDv5Z6iJKns393NwxVcNUyk=",
+			"integrity": "sha512-jQ9Tf/ilIGSr55Cz23AZ/7H3ABEdo9oy2zF9nDHZyhLHDSLKuoILxw2ifpBfuuwQvj4LCoqdru9iZf7gwFH28A==",
 			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1",
@@ -11117,7 +11130,7 @@
 		"recompose": {
 			"version": "0.30.0",
 			"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-			"integrity": "sha1-gnc2QbOSfox9JKDYfWWu66GKq9A=",
+			"integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
 				"change-emitter": "^0.1.2",
@@ -11130,7 +11143,7 @@
 				"hoist-non-react-statics": {
 					"version": "2.5.5",
 					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-					"integrity": "sha1-xZA89AnA39kI84jmGdhrnBF0y0c="
+					"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
 				}
 			}
 		},
@@ -11293,7 +11306,7 @@
 			"dependencies": {
 				"jsesc": {
 					"version": "0.5.0",
-					"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
 			}
@@ -11692,7 +11705,7 @@
 		"scheduler": {
 			"version": "0.13.4",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.4.tgz",
-			"integrity": "sha1-j+8F56NYDHbANk0t9eVQ5MkUApg=",
+			"integrity": "sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -12747,7 +12760,7 @@
 				"css-select": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
-					"integrity": "sha1-q0OGzsnh9miFVWSxfDcztDsqXt4=",
+					"integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
 					"dev": true,
 					"requires": {
 						"boolbase": "^1.0.0",
@@ -12759,7 +12772,7 @@
 				"domutils": {
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-					"integrity": "sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=",
+					"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
 					"dev": true,
 					"requires": {
 						"dom-serializer": "0",

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -32,7 +32,7 @@
     "counterpart": "~0.18.6",
     "d3": "~5.9.1",
     "graphql-request": "~1.8.2",
-    "grommet": "~2.5.5",
+    "grommet": "~2.6.6",
     "grommet-icons": "~4.2.0",
     "lodash": "~4.17.11",
     "mobx": "~5.5.0",

--- a/packages/lib-classifier/package-lock.json
+++ b/packages/lib-classifier/package-lock.json
@@ -1434,7 +1434,7 @@
     "array.prototype.flat": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
-      "integrity": "sha1-gS248CytJNP6tl3WfqvjuJA0lKQ=",
+      "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -1520,7 +1520,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
@@ -1597,7 +1597,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -2764,7 +2764,7 @@
     "css": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-      "integrity": "sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -2776,7 +2776,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -3480,7 +3480,7 @@
     "domhandler": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
         "domelementtype": "1"
@@ -3601,7 +3601,7 @@
     "enzyme": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.9.0.tgz",
-      "integrity": "sha1-K0kfBsqWbrVrZRAGjHiUp+C+OQk=",
+      "integrity": "sha512-JqxI2BRFHbmiP7/UFqvsjxTirWoM1HfeaJrmVSZ9a1EADKkZgdPcAuISPMpoUiHlac9J4dYt81MC5BBIrbJGMg==",
       "dev": true,
       "requires": {
         "array.prototype.flat": "^1.2.1",
@@ -3630,7 +3630,7 @@
     "enzyme-adapter-react-16": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.11.2.tgz",
-      "integrity": "sha1-jv6vsn6WhzpUkv3vP0I2kxguudQ=",
+      "integrity": "sha512-2ruTTCPRb0lPuw/vKTXGVZVBZqh83MNDnakMhzxhpJcIbneEwNy2Cv0KvL97pl57/GOazJHflWNLjwWhex5AAA==",
       "dev": true,
       "requires": {
         "enzyme-adapter-utils": "^1.10.1",
@@ -3645,7 +3645,7 @@
     "enzyme-adapter-utils": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.10.1.tgz",
-      "integrity": "sha1-WCZO+hmnvv2/lk+3mBoQilRSrJY=",
+      "integrity": "sha512-oasinhhLoBuZsIkTe8mx0HiudtfErUtG0Ooe1FOplu/t4c9rOmyG5gtrBASK6u4whHIRWvv0cbZMElzNTR21SA==",
       "dev": true,
       "requires": {
         "function.prototype.name": "^1.1.0",
@@ -3934,7 +3934,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -4488,7 +4488,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -4701,7 +4701,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4722,12 +4723,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4742,17 +4745,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4869,7 +4875,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4881,6 +4888,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4895,6 +4903,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4902,12 +4911,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4926,6 +4937,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5006,7 +5018,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5018,6 +5031,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5103,7 +5117,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5139,6 +5154,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5158,6 +5174,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5201,12 +5218,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5219,7 +5238,7 @@
     "function.prototype.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
-      "integrity": "sha1-i9djzAr4YKhZzF1JOE10uTLNIyc=",
+      "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -5341,7 +5360,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
@@ -5354,7 +5373,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -5366,19 +5385,18 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "grommet": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.5.5.tgz",
-      "integrity": "sha1-CNT8BUQBbnl9A+N0R/+3D+We8XQ=",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.6.6.tgz",
+      "integrity": "sha512-NeHYTG2ROBB9DWfih2YAvsG9Q2U9PQOVPSQ0RGPsDJ8o9yfrbDFSpGmfam58oE+MC/5Hx5iBvlUrGVg+VXQgEw==",
       "dev": true,
       "requires": {
         "css": "^2.2.3",
         "grommet-icons": "^4.2.0",
         "grommet-styles": "^0.2.0",
         "hoist-non-react-statics": "^3.2.0",
-        "markdown-to-jsx": "^6.6.6",
-        "mobile-detect": "^1.4.3",
+        "markdown-to-jsx": "^6.9.1",
         "polished": "^2.2.0",
-        "prop-types": "^15.5.10",
+        "prop-types": "^15.7.2",
         "react-desc": "^4.1.2",
         "recompose": "^0.30.0"
       }
@@ -5386,7 +5404,7 @@
     "grommet-icons": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/grommet-icons/-/grommet-icons-4.2.0.tgz",
-      "integrity": "sha1-e899Szf2lFFq3ghOJTbHKyJManY=",
+      "integrity": "sha512-HMPLQa2pgnCZFImUXwfq+79VizL6oyP2/AAfAzQDw57x/6qgWouoqoRrrt+2zodTjTxtKXxliBY1w/o5uC+DpA==",
       "dev": true,
       "requires": {
         "grommet-styles": "^0.2.0"
@@ -5395,7 +5413,7 @@
     "grommet-styles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/grommet-styles/-/grommet-styles-0.2.0.tgz",
-      "integrity": "sha1-surCt+J0fLUjQ00hcozlI0+M5PQ=",
+      "integrity": "sha512-0OMSYuGeyifYKpg4Gv2HzL8rUdd0ddnJ5LbCBKgDuloC71XIwr9g/Fxa6rs737MbPV7OZ4pEm4wvrjH4epzf1A==",
       "dev": true
     },
     "growl": {
@@ -5667,7 +5685,7 @@
     "htmlparser2": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "dev": true,
       "requires": {
         "domelementtype": "^1.3.1",
@@ -5699,7 +5717,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -5728,7 +5746,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
       "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
       "dev": true,
       "requires": {
@@ -6524,7 +6542,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -6536,7 +6554,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -6714,9 +6732,9 @@
       }
     },
     "markdown-to-jsx": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.9.3.tgz",
-      "integrity": "sha512-iXteiv317VZd1vk/PBH5MWMD4r0XWekoWCHRVVadBcnCtxavhtfV1UaEaQgq9KyckTv31L60ASh5ZVVrOh37Qg==",
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.9.4.tgz",
+      "integrity": "sha512-Fvx2ZhiknGmcLsWVjIq6MmiN9gcCot8w+jzwN2mLXZcQsJGRN3Zes5Sp5M9YNIzUy/sDyuOTjimFdtAcvvmAPQ==",
       "dev": true,
       "requires": {
         "prop-types": "^15.6.2",
@@ -6736,7 +6754,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -6939,12 +6957,6 @@
         }
       }
     },
-    "mobile-detect": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/mobile-detect/-/mobile-detect-1.4.3.tgz",
-      "integrity": "sha1-5Dajg59YB91NPNTggffTpR/9ot0=",
-      "dev": true
-    },
     "mobx": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-5.1.2.tgz",
@@ -7060,7 +7072,7 @@
     "moo": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-      "integrity": "sha1-P4R6JvMc9iWpVqh/KxD7wBO/0Q4=",
+      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
       "dev": true
     },
     "mout": {
@@ -7151,7 +7163,7 @@
     "nearley": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
-      "integrity": "sha1-d8KX0EGUHSaCkOyEtznQ7il+g6c=",
+      "integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
       "dev": true,
       "requires": {
         "commander": "^2.19.0",
@@ -7378,7 +7390,7 @@
     "object-inspect": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha1-xwtsv3LydKq0w0wMgvUWe/gs8Vs=",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
       "dev": true
     },
     "object-is": {
@@ -7405,7 +7417,7 @@
     "object.assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -7417,7 +7429,7 @@
     "object.entries": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha1-ICT8bWuiRq7ji9sP/Vz7zzcbdRk=",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -7429,7 +7441,7 @@
     "object.fromentries": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
-      "integrity": "sha1-SaVD2SFR+Cd7OslgDx6TCxidMKs=",
+      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -7460,7 +7472,7 @@
     "object.values": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-      "integrity": "sha1-v2gQ712j5TJXkOqqK+IT6oRiTak=",
+      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -7721,7 +7733,7 @@
     "parse5": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -7807,7 +7819,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -8219,7 +8231,7 @@
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha1-B0LpmkplUvRF1z4+4DKK8P8e3jk=",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
@@ -8234,7 +8246,7 @@
     "randexp": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha1-6YatXl4x2uE93W97MBmqfIf2DKM=",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
       "dev": true,
       "requires": {
         "discontinuous-range": "1.0.0",
@@ -8309,7 +8321,7 @@
     "react-desc": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/react-desc/-/react-desc-4.1.2.tgz",
-      "integrity": "sha1-g/xO3may1Frk72PBhCFHTVWXKWY=",
+      "integrity": "sha512-JAVe89uaLr0HZ0IKodnpTPNgNyJ/SPDQnl3VJPVwI+SpebmHvJiBNZEOwX201QmSbsVGqRY8ql/VFPlAx85WzA==",
       "dev": true
     },
     "react-dom": {
@@ -8419,7 +8431,7 @@
     "recompose": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha1-gnc2QbOSfox9JKDYfWWu66GKq9A=",
+      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
@@ -8643,7 +8655,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -9798,7 +9810,7 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ=",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
       "dev": true
     },
     "symbol-tree": {
@@ -9968,7 +9980,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -65,7 +65,7 @@
     "enzyme": "~3.9.0",
     "enzyme-adapter-react-16": "~1.11.2",
     "eslint-plugin-jsx-a11y": "^6.2.1",
-    "grommet": "~2.5.5",
+    "grommet": "~2.6.6",
     "grommet-icons": "~4.2.0",
     "html-webpack-plugin": "~3.2.0",
     "jsdom": "~13.0.0",

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -38,7 +38,7 @@
     "@zooniverse/grommet-theme": "~2.0.0",
     "@zooniverse/panoptes-js": "~0.0.1",
     "@zooniverse/react-components": "~0.7.1",
-    "grommet": "~2.5.x",
+    "grommet": "~2.6.x",
     "grommet-icons": "~4.2.x",
     "react": "~16.8.x",
     "react-dom": "~16.8.x",

--- a/packages/lib-grommet-theme/package.json
+++ b/packages/lib-grommet-theme/package.json
@@ -17,7 +17,7 @@
     "deep-freeze": "~0.0.1"
   },
   "peerDependencies": {
-    "grommet": "~2.5.x"
+    "grommet": "~2.6.x"
   },
   "devDependencies": {
     "@babel/cli": "~7.2.0",

--- a/packages/lib-react-components/package-lock.json
+++ b/packages/lib-react-components/package-lock.json
@@ -2746,7 +2746,7 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
@@ -3125,7 +3125,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -3162,7 +3162,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -3207,7 +3207,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -3434,7 +3434,7 @@
         "domhandler": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-          "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
+          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "dev": true,
           "requires": {
             "domelementtype": "1"
@@ -3443,7 +3443,7 @@
         "htmlparser2": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-          "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
+          "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
           "dev": true,
           "requires": {
             "domelementtype": "^1.3.1",
@@ -3457,7 +3457,7 @@
         "readable-stream": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha1-3hfyKYZMEgqfVpRXVuTzLEBFJF0=",
+          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -3913,7 +3913,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -3926,7 +3926,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -4357,7 +4357,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -4617,7 +4617,7 @@
     "enzyme": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.9.0.tgz",
-      "integrity": "sha1-K0kfBsqWbrVrZRAGjHiUp+C+OQk=",
+      "integrity": "sha512-JqxI2BRFHbmiP7/UFqvsjxTirWoM1HfeaJrmVSZ9a1EADKkZgdPcAuISPMpoUiHlac9J4dYt81MC5BBIrbJGMg==",
       "dev": true,
       "requires": {
         "array.prototype.flat": "^1.2.1",
@@ -4646,7 +4646,7 @@
     "enzyme-adapter-react-16": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.11.2.tgz",
-      "integrity": "sha1-jv6vsn6WhzpUkv3vP0I2kxguudQ=",
+      "integrity": "sha512-2ruTTCPRb0lPuw/vKTXGVZVBZqh83MNDnakMhzxhpJcIbneEwNy2Cv0KvL97pl57/GOazJHflWNLjwWhex5AAA==",
       "dev": true,
       "requires": {
         "enzyme-adapter-utils": "^1.10.1",
@@ -4661,7 +4661,7 @@
         "object.values": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-          "integrity": "sha1-v2gQ712j5TJXkOqqK+IT6oRiTak=",
+          "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
           "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
@@ -4673,7 +4673,7 @@
         "prop-types": {
           "version": "15.7.2",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
           "dev": true,
           "requires": {
             "loose-envify": "^1.4.0",
@@ -4684,7 +4684,7 @@
         "react-is": {
           "version": "16.8.4",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
-          "integrity": "sha1-kPM2pow6KaCWo9ZIq4DofsYUgqI=",
+          "integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==",
           "dev": true
         }
       }
@@ -4692,7 +4692,7 @@
     "enzyme-adapter-utils": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.10.1.tgz",
-      "integrity": "sha1-WCZO+hmnvv2/lk+3mBoQilRSrJY=",
+      "integrity": "sha512-oasinhhLoBuZsIkTe8mx0HiudtfErUtG0Ooe1FOplu/t4c9rOmyG5gtrBASK6u4whHIRWvv0cbZMElzNTR21SA==",
       "dev": true,
       "requires": {
         "function.prototype.name": "^1.1.0",
@@ -4705,7 +4705,7 @@
         "object.fromentries": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
-          "integrity": "sha1-SaVD2SFR+Cd7OslgDx6TCxidMKs=",
+          "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
           "dev": true,
           "requires": {
             "define-properties": "^1.1.2",
@@ -4717,7 +4717,7 @@
         "prop-types": {
           "version": "15.7.2",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
           "dev": true,
           "requires": {
             "loose-envify": "^1.4.0",
@@ -4728,7 +4728,7 @@
         "react-is": {
           "version": "16.8.4",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
-          "integrity": "sha1-kPM2pow6KaCWo9ZIq4DofsYUgqI=",
+          "integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==",
           "dev": true
         }
       }
@@ -5646,7 +5646,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -5820,7 +5820,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5844,13 +5845,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5867,19 +5870,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6010,7 +6016,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6024,6 +6031,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6040,6 +6048,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6048,13 +6057,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6075,6 +6086,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6163,7 +6175,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6177,6 +6190,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6272,7 +6286,8 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6314,6 +6329,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6335,6 +6351,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6383,13 +6400,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6609,19 +6628,18 @@
       "dev": true
     },
     "grommet": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.5.5.tgz",
-      "integrity": "sha1-CNT8BUQBbnl9A+N0R/+3D+We8XQ=",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.6.6.tgz",
+      "integrity": "sha512-NeHYTG2ROBB9DWfih2YAvsG9Q2U9PQOVPSQ0RGPsDJ8o9yfrbDFSpGmfam58oE+MC/5Hx5iBvlUrGVg+VXQgEw==",
       "dev": true,
       "requires": {
         "css": "^2.2.3",
         "grommet-icons": "^4.2.0",
         "grommet-styles": "^0.2.0",
         "hoist-non-react-statics": "^3.2.0",
-        "markdown-to-jsx": "^6.6.6",
-        "mobile-detect": "^1.4.3",
+        "markdown-to-jsx": "^6.9.1",
         "polished": "^2.2.0",
-        "prop-types": "^15.5.10",
+        "prop-types": "^15.7.2",
         "react-desc": "^4.1.2",
         "recompose": "^0.30.0"
       },
@@ -6629,10 +6647,29 @@
         "hoist-non-react-statics": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-          "integrity": "sha1-sJF48BIhhPuVrPUl2q7LTY9FlYs=",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
           "dev": true,
           "requires": {
             "react-is": "^16.7.0"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          },
+          "dependencies": {
+            "react-is": {
+              "version": "16.8.6",
+              "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+              "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+              "dev": true
+            }
           }
         }
       }
@@ -6640,7 +6677,7 @@
     "grommet-icons": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/grommet-icons/-/grommet-icons-4.2.0.tgz",
-      "integrity": "sha1-e899Szf2lFFq3ghOJTbHKyJManY=",
+      "integrity": "sha512-HMPLQa2pgnCZFImUXwfq+79VizL6oyP2/AAfAzQDw57x/6qgWouoqoRrrt+2zodTjTxtKXxliBY1w/o5uC+DpA==",
       "dev": true,
       "requires": {
         "grommet-styles": "^0.2.0"
@@ -6649,7 +6686,7 @@
     "grommet-styles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/grommet-styles/-/grommet-styles-0.2.0.tgz",
-      "integrity": "sha1-surCt+J0fLUjQ00hcozlI0+M5PQ=",
+      "integrity": "sha512-0OMSYuGeyifYKpg4Gv2HzL8rUdd0ddnJ5LbCBKgDuloC71XIwr9g/Fxa6rs737MbPV7OZ4pEm4wvrjH4epzf1A==",
       "dev": true
     },
     "growl": {
@@ -6870,7 +6907,7 @@
     "html-element-map": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.0.tgz",
-      "integrity": "sha1-GaQZQCJRU+zf6tdPhQkVT/HNwYs=",
+      "integrity": "sha512-/SP6aOiM5Ai9zALvCxDubIeez0LvG3qP7R9GcRDnJEP/HBmv0A8A9K0o8+HFudcFt46+i921ANjzKsjPjb7Enw==",
       "dev": true,
       "requires": {
         "array-filter": "^1.0.0"
@@ -8122,9 +8159,9 @@
       "integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw=="
     },
     "markdown-to-jsx": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.9.2.tgz",
-      "integrity": "sha512-Rjd3AvcGjrwkjGGLrYNa2+4mnsEfu9LZqcafQU3I37f1gB3qOxstQ35T4/jDZyqmi3f6kzGIsz7/ijpxzp52FA==",
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.9.4.tgz",
+      "integrity": "sha512-Fvx2ZhiknGmcLsWVjIq6MmiN9gcCot8w+jzwN2mLXZcQsJGRN3Zes5Sp5M9YNIzUy/sDyuOTjimFdtAcvvmAPQ==",
       "dev": true,
       "requires": {
         "prop-types": "^15.6.2",
@@ -8204,7 +8241,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -8404,12 +8441,6 @@
         "minimist": "0.0.8"
       }
     },
-    "mobile-detect": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/mobile-detect/-/mobile-detect-1.4.3.tgz",
-      "integrity": "sha1-5Dajg59YB91NPNTggffTpR/9ot0=",
-      "dev": true
-    },
     "mocha": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
@@ -8478,7 +8509,7 @@
     "moo": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-      "integrity": "sha1-P4R6JvMc9iWpVqh/KxD7wBO/0Q4=",
+      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
       "dev": true
     },
     "move-concurrently": {
@@ -8542,7 +8573,7 @@
     "nearley": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
-      "integrity": "sha1-d8KX0EGUHSaCkOyEtznQ7il+g6c=",
+      "integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
       "dev": true,
       "requires": {
         "commander": "^2.19.0",
@@ -8828,7 +8859,7 @@
     "object-inspect": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha1-xwtsv3LydKq0w0wMgvUWe/gs8Vs=",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
       "dev": true
     },
     "object-is": {
@@ -8855,7 +8886,7 @@
     "object.assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -9112,7 +9143,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
@@ -9155,7 +9186,7 @@
     "parse5": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -9364,7 +9395,7 @@
     "polished": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/polished/-/polished-2.3.3.tgz",
-      "integrity": "sha1-vbq6liuoJxsOEaoofyvv1Mh76Zo=",
+      "integrity": "sha512-59V4fDbdxtH4I1m9TWxFsoGJbC8nnOpUYo5uFmvMfKp9Qh+6suo4VMUle1TGIIUZIGxfkW+Rs485zPk0wcwR2Q==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.2.0"
@@ -9630,7 +9661,7 @@
     "prop-types": {
       "version": "15.7.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.1.tgz",
-      "integrity": "sha1-L6YeCmmdQotAMgEncz7ikx8F2dE=",
+      "integrity": "sha512-f8Lku2z9kERjOCcnDOPm68EBJAO2K00Q5mSgPAUE/gJuBgsYLbVy6owSrtcHj90zt8PvW+z0qaIIgsIhHOa1Qw==",
       "requires": {
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
@@ -9639,7 +9670,7 @@
         "react-is": {
           "version": "16.8.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.1.tgz",
-          "integrity": "sha1-qAFB4kbriUgk+08pAcDFDvMdTNs="
+          "integrity": "sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA=="
         }
       }
     },
@@ -9759,7 +9790,7 @@
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha1-B0LpmkplUvRF1z4+4DKK8P8e3jk=",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
@@ -9780,7 +9811,7 @@
     "randexp": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha1-6YatXl4x2uE93W97MBmqfIf2DKM=",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
       "dev": true,
       "requires": {
         "discontinuous-range": "1.0.0",
@@ -9844,7 +9875,7 @@
     "react": {
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/react/-/react-16.8.4.tgz",
-      "integrity": "sha1-/fe9muU/A6nEzRo3FDLCBr4cR2g=",
+      "integrity": "sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -9870,7 +9901,7 @@
     "react-desc": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/react-desc/-/react-desc-4.1.2.tgz",
-      "integrity": "sha1-g/xO3may1Frk72PBhCFHTVWXKWY=",
+      "integrity": "sha512-JAVe89uaLr0HZ0IKodnpTPNgNyJ/SPDQnl3VJPVwI+SpebmHvJiBNZEOwX201QmSbsVGqRY8ql/VFPlAx85WzA==",
       "dev": true
     },
     "react-dev-utils": {
@@ -10054,7 +10085,7 @@
     "react-dom": {
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.4.tgz",
-      "integrity": "sha1-EGGo4BorOwyBYAN0QcO/AKDjvEg=",
+      "integrity": "sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -10157,7 +10188,7 @@
     "react-test-renderer": {
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.4.tgz",
-      "integrity": "sha1-q+5MLDv5Z6iJKns393NwxVcNUyk=",
+      "integrity": "sha512-jQ9Tf/ilIGSr55Cz23AZ/7H3ABEdo9oy2zF9nDHZyhLHDSLKuoILxw2ifpBfuuwQvj4LCoqdru9iZf7gwFH28A==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
@@ -10169,7 +10200,7 @@
         "react-is": {
           "version": "16.8.4",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
-          "integrity": "sha1-kPM2pow6KaCWo9ZIq4DofsYUgqI=",
+          "integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==",
           "dev": true
         }
       }
@@ -10316,7 +10347,7 @@
     "recompose": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha1-gnc2QbOSfox9JKDYfWWu66GKq9A=",
+      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
@@ -10330,7 +10361,7 @@
         "hoist-non-react-statics": {
           "version": "2.5.5",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha1-xZA89AnA39kI84jmGdhrnBF0y0c=",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
           "dev": true
         }
       }
@@ -10904,7 +10935,7 @@
     "scheduler": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.4.tgz",
-      "integrity": "sha1-j+8F56NYDHbANk0t9eVQ5MkUApg=",
+      "integrity": "sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -11037,7 +11068,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -11574,7 +11605,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -69,7 +69,7 @@
     "enzyme": "~3.9.0",
     "enzyme-adapter-react-16": "~1.11.2",
     "eslint-plugin-jsx-a11y": "^6.2.1",
-    "grommet": "~2.5.5",
+    "grommet": "~2.6.6",
     "grommet-icons": "~4.2.0",
     "jsdom": "~13.0.0",
     "mocha": "~5.2.0",

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@zooniverse/grommet-theme": "~2.0.0",
-    "grommet": "~2.5.x",
+    "grommet": "~2.6.x",
     "grommet-icons": "~4.2.x",
     "react": "~16.8.x",
     "react-dom": "~16.8.x",


### PR DESCRIPTION
Package: fe-project, lib-classifier, lib-grommet-theme, lib-react-components

Upgrades Grommet to v2.6.6, which includes:
- fixed theme issue on grommet button
- DataTable overflow issue
- active theme support
- custom drop overflow

Might help with a few little issues we're having, at minimum good to stay current.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

