### PR TITLE
Refactor theme context HOC, use for tabs

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tabs/Tabs.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tabs/Tabs.js
@@ -1,22 +1,6 @@
-import { Grommet, Tabs as GrommetTabs } from 'grommet'
-import merge from 'lodash/merge'
-import { object } from 'prop-types'
-import React from 'react'
-import { withTheme } from 'styled-components'
+import { withThemeContext } from '@zooniverse/react-components'
+import { Tabs } from 'grommet'
 
 import tabsTheme from './theme'
 
-function Tabs (props) {
-  const mergedThemes = merge({}, props.theme, tabsTheme)
-  return (
-    <Grommet theme={mergedThemes}>
-      <GrommetTabs {...props} />
-    </Grommet>
-  )
-}
-
-Tabs.propTypes = {
-  theme: object
-}
-
-export default withTheme(Tabs)
+export default withThemeContext(Tabs, tabsTheme)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/NextButton/NextButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/NextButton/NextButton.js
@@ -1,5 +1,6 @@
+import { withThemeContext } from '@zooniverse/react-components'
 import counterpart from 'counterpart'
-import { Button, Text, ThemeContext } from 'grommet'
+import { Button, Text } from 'grommet'
 import { bool, func } from 'prop-types'
 import React from 'react'
 
@@ -42,13 +43,5 @@ NextButton.propTypes = {
   onClick: func.isRequired
 }
 
-function wrappedNextButton (props) {
-  return (
-    <ThemeContext.Extend value={nextButtonTheme}>
-      <NextButton {...props} />
-    </ThemeContext.Extend>
-  )
-}
-
-export default wrappedNextButton
+export default withThemeContext(NextButton, nextButtonTheme)
 export { NextButton }

--- a/packages/lib-react-components/src/helpers/withThemeContext/README.md
+++ b/packages/lib-react-components/src/helpers/withThemeContext/README.md
@@ -1,0 +1,21 @@
+# withThemeContext
+
+A HOC which accepts a component and a theme object, and returns the component
+wrapped in Grommet's `ThemeContext` component, with the theme passed into
+`ThemeContext`'s `value` prop.
+
+## Usage
+
+```js
+const theme = {
+  ...
+}
+
+class MyComponent extends React.Component {
+  render () {
+    ...
+  }
+}
+
+export default withThemeContext(MyComponent, theme)
+```

--- a/packages/lib-react-components/src/helpers/withThemeContext/index.js
+++ b/packages/lib-react-components/src/helpers/withThemeContext/index.js
@@ -1,0 +1,1 @@
+export { default } from './withThemeContext'

--- a/packages/lib-react-components/src/helpers/withThemeContext/withThemeContext.js
+++ b/packages/lib-react-components/src/helpers/withThemeContext/withThemeContext.js
@@ -1,0 +1,12 @@
+import { ThemeContext } from 'grommet'
+import React from 'react'
+
+function withThemeContext (WrappedComponent, theme) {
+  return props => (
+    <ThemeContext.Extend value={theme}>
+      <WrappedComponent {...props} />
+    </ThemeContext.Extend>
+  )
+}
+
+export default withThemeContext

--- a/packages/lib-react-components/src/helpers/withThemeContext/withThemeContext.spec.js
+++ b/packages/lib-react-components/src/helpers/withThemeContext/withThemeContext.spec.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import withThemeContext from './withThemeContext'
+
+describe('withThemeContext', function () {
+  function StubComponent () {
+    return <p>Hello</p>
+  }
+
+  let wrapper
+  const THEME = {}
+  const WithThemeContext = withThemeContext(StubComponent, THEME)
+
+  before(function () {
+    wrapper = shallow(<WithThemeContext />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok
+  })
+
+  it('should render the component passed as the first argument', function () {
+    expect(wrapper.find(StubComponent)).to.have.lengthOf(1)
+  })
+
+  it('should pass the theme argument as the `value` prop to a Grommet `ThemeContext`', function () {
+    // Note that as `ThemeContext` returns a `ContextConsumer`, we can't assert
+    // that we're actually getting a `ThemeContext` component rendered
+    expect(wrapper.prop('value')).to.equal(THEME)
+  })
+})

--- a/packages/lib-react-components/src/index.js
+++ b/packages/lib-react-components/src/index.js
@@ -10,4 +10,5 @@ export { default as ZooHeader } from './ZooHeader'
 export { default as ZooniverseLogo } from './ZooniverseLogo'
 
 export { default as pxToRem } from './helpers/pxToRem'
+export { default as withThemeContext } from './helpers/withThemeContext'
 export { default as getThumbnailSrc } from './Media/helpers/getThumbnailSrc'


### PR DESCRIPTION
~**This follows #769, which needs to be merged first**~

- Creates a HOC for using Grommet's `ThemeContext` component
- Refactors `NextButton` to use the HOC
- Refactors the `Tabs` component to use the HOC instead of creating a new `Grommet` context
