### PR TITLE
Set default padding for button in the theme

### DIFF
--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -168,6 +168,9 @@ const theme = deepFreeze({
   button: {
     border: {
       radius: '0px'
+    },
+    padding: {
+      vertical: '9px'
     }
   },
   checkBox: {

--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -170,7 +170,9 @@ const theme = deepFreeze({
       radius: '0px'
     },
     padding: {
-      vertical: '9px'
+       // Accounting for the border width. Grommet's default border width is 2px
+      horizontal: props => `${parseInt(props.theme.global.edgeSize.small) - 2}px`,
+      vertical: props => `${parseInt(props.theme.global.edgeSize.xsmall) - 1}px`
     }
   },
   checkBox: {


### PR DESCRIPTION
Package: lib-grommet-theme

Closes #772

Describe your changes:
Sets the default padding for the button component in the theme.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

