### PR TITLE
Alias react for dev environment

### DIFF
--- a/packages/lib-classifier/webpack.dev.js
+++ b/packages/lib-classifier/webpack.dev.js
@@ -52,6 +52,7 @@ module.exports = {
   resolve: {
     alias: {
       // adjust this path as needed depending on where your webpack config is
+      react: path.resolve('./node_modules/react'),
       'styled-components': path.resolve('./node_modules/styled-components')
     },
     modules: [


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
This fixes the crashing that was happening with the dev-classifier and React hooks. Apparently more than one React was loading even though the troubleshooting's guide suggestion on how to test this didn't log in a way to indicate more than one was loading. Basically we need to use aliases anytime we're symlinking in development it seems.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

