### PR TITLE
Clean up withKeyZoom HOC tests

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.spec.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { expect } from 'chai'
 import sinon from 'sinon'
+import { Provider } from 'mobx-react'
 import withKeyZoom from './withKeyZoom'
 
 describe('withKeyZoom', function () {
@@ -12,25 +13,27 @@ describe('withKeyZoom', function () {
   const onPan = sinon.stub()
   const zoomIn = sinon.stub()
   const zoomOut = sinon.stub()
-  const context = {
-    mobxStores: {
-      classifierStore: {
-        subjectViewer: {
-          onPan,
-          zoomIn,
-          zoomOut
-        }
-      }
+  const classifierStore = {
+    subjectViewer: {
+      onPan,
+      zoomIn,
+      zoomOut
     }
   }
   let wrapper
+  let wrappedComponent
 
   before(function () {
-    wrapper = mount(<WithZoom />, { context })
+    wrapper = mount(
+      <Provider classifierStore={classifierStore}>
+        <WithZoom />
+      </Provider>
+    )
+    wrappedComponent = wrapper.find(StubComponent)
   })
 
   it('should add an onKeyDown handler to wrapped components', function () {
-    expect(wrapper.find(StubComponent).props().onKeyDown).to.exist
+    expect(wrappedComponent.prop('onKeyDown')).to.exist
   })
 
   describe('on key down', function () {
@@ -77,7 +80,7 @@ describe('withKeyZoom', function () {
         const fakeEvent = {
           key
         }
-        wrapper.find(StubComponent).props().onKeyDown(fakeEvent)
+        wrappedComponent.prop('onKeyDown')(fakeEvent)
         expect(handler).to.have.been.calledOnce
       })
     })


### PR DESCRIPTION
Use a provider to add the mock store, then get the wrapped component and test expected behaviour against that.

Package:
lib-classifier

Just a couple of small changes to make the tests cleaner, after reading up on how to test Higher Order Components in MobX and React.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

