### PR TITLE
Disable task area while subject is loading

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
@@ -7,8 +7,10 @@ import getViewer from './helpers/getViewer'
 
 function storeMapper (stores) {
   const { active: subject, loadingState } = stores.classifierStore.subjects
+  const { onSubjectReady } = stores.classifierStore.subjectViewer
   return {
     loadingState,
+    onSubjectReady,
     subject
   }
 }
@@ -30,13 +32,13 @@ class SubjectViewer extends React.Component {
   }
 
   [asyncStates.success] () {
-    const { subject } = this.props
+    const { onSubjectReady, subject } = this.props
     const Viewer = getViewer(subject.viewer)
     return (
       <Viewer
         key={subject.id}
         subject={subject}
-        onReady={(event) => console.log('LOADED', event)}
+        onReady={onSubjectReady}
       />
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
@@ -36,6 +36,7 @@ class SubjectViewer extends React.Component {
       <Viewer
         key={subject.id}
         subject={subject}
+        onReady={(event) => console.log('LOADED', event)}
       />
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
@@ -63,31 +63,41 @@ class LightCurveViewerContainer extends Component {
       } else {
         // Get the JSON data, or (as a failsafe) parse the JSON data if the
         // response is returned as a string
-        this.setState({ loading: asyncStates.success })
         return response.body || JSON.parse(response.text)
       }
     } catch (error) {
-      this.setState({
-        loading: asyncStates.error,
-        data: null
-      })
-      return error
+      return this.onError(error)
     }
   }
 
   async handleSubject () {
     try {
       const rawData = await this.requestData()
-      this.setState({
-        dataExtent: {
-          x: d3.extent(rawData.x),
-          y: d3.extent(rawData.y)
-        },
-        dataPoints: zip(rawData.x, rawData.y)
-      })
+      this.onLoad(rawData)
+      
     } catch (error) {
       console.error(error)
     }
+  }
+
+  onLoad (rawData) {
+    this.setState({
+      dataExtent: {
+        x: d3.extent(rawData.x),
+        y: d3.extent(rawData.y)
+      },
+      dataPoints: zip(rawData.x, rawData.y),
+      loading: asyncStates.success
+    })
+    this.props.onReady()
+  }
+
+  onError (error) {
+    this.setState({
+      loading: asyncStates.error,
+      data: null
+    })
+    return error
   }
 
   render () {
@@ -108,7 +118,12 @@ class LightCurveViewerContainer extends Component {
   }
 }
 
+LightCurveViewerContainer.defaultProps = {
+  onReady: () => true
+}
+
 LightCurveViewerContainer.propTypes = {
+  onReady: PropTypes.func,
   subject: PropTypes.shape({
     locations: PropTypes.arrayOf(locationValidator)
   }),

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
@@ -81,6 +81,7 @@ class LightCurveViewerContainer extends Component {
   }
 
   onLoad (rawData) {
+    const { onReady } = this.props
     this.setState({
       dataExtent: {
         x: d3.extent(rawData.x),
@@ -88,8 +89,8 @@ class LightCurveViewerContainer extends Component {
       },
       dataPoints: zip(rawData.x, rawData.y),
       loading: asyncStates.success
-    })
-    this.props.onReady()
+    },
+    onReady)
   }
 
   onError (error) {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -9,20 +9,29 @@ const SVG = styled.svg`
   width: 100%;
 `
 
-function SingleImageViewer ({ url }) {
+function SingleImageViewer ({ onError, onLoad, url }) {
   return (
     <SVG>
       <image
         height='100%'
         width='100%'
         xlinkHref={url}
+        onError={onError}
+        onLoad={onLoad}
       />
       <InteractionLayer />
     </SVG>
   )
 }
 
+SingleImageViewer.defaultProps = {
+  onError: () => true,
+  onLoad: () => true
+}
+
 SingleImageViewer.propTypes = {
+  onError: PropTypes.func,
+  onLoad: PropTypes.func,
   url: PropTypes.string.isRequired
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -8,7 +8,6 @@ import locationValidator from '../../helpers/locationValidator'
 class SingleImageViewerContainer extends React.Component {
   constructor () {
     super()
-    this.onLoad = this.onLoad.bind(this)
     this.onError = this.onError.bind(this)
     this.state = {
       height: null,
@@ -52,10 +51,6 @@ class SingleImageViewerContainer extends React.Component {
     }
   }
 
-  onLoad (event) {
-    this.props.onReady(event)
-  }
-
   onError (error) {
     console.error(error)
     this.setState({ loading: asyncStates.error })
@@ -79,7 +74,7 @@ class SingleImageViewerContainer extends React.Component {
     return (
       <SingleImageViewer
         onError={this.onError}
-        onLoad={this.onLoad}
+        onLoad={onReady}
         url={imageUrl}
       />
     )

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -8,6 +8,8 @@ import locationValidator from '../../helpers/locationValidator'
 class SingleImageViewerContainer extends React.Component {
   constructor () {
     super()
+    this.onLoad = this.onLoad.bind(this)
+    this.onError = this.onError.bind(this)
     this.state = {
       height: null,
       width: null,
@@ -16,20 +18,7 @@ class SingleImageViewerContainer extends React.Component {
   }
 
   componentDidMount () {
-    if (this.props.subject) {
-      this.handleSubject()
-    }
-  }
-
-  componentDidUpdate (prevProps) {
-    // Casting to JSON fixes reference issue from MST store
-    // A more robust solution might be to have a getter view function defined on the model
-    const prevSubject = prevProps.subject.toJSON()
-    const subject = this.props.subject.toJSON()
-
-    if (subject && (!prevSubject || prevSubject.id !== subject.id)) {
-      this.handleSubject()
-    }
+    this.handleSubject()
   }
 
   // TODO: store the subject image's naturalWidth, naturalHeight, clientWidth, and clientHeight
@@ -59,14 +48,22 @@ class SingleImageViewerContainer extends React.Component {
         loading: asyncStates.success
       })
     } catch (error) {
-      console.error(error)
-      this.setState({ loading: asyncStates.error })
+      this.onError(error)
     }
+  }
+
+  onLoad (event) {
+    this.props.onReady(event)
+  }
+
+  onError (error) {
+    console.error(error)
+    this.setState({ loading: asyncStates.error })
   }
 
   render () {
     const { loadingState } = this.state
-    const { subject } = this.props
+    const { onReady, subject } = this.props
     if (loadingState === asyncStates.error) {
       return (
         <div>Something went wrong.</div>
@@ -80,19 +77,25 @@ class SingleImageViewerContainer extends React.Component {
     // TODO: Add polyfill for Object.values for IE
     const imageUrl = Object.values(subject.locations[0])[0]
     return (
-      <SingleImageViewer url={imageUrl} />
+      <SingleImageViewer
+        onError={this.onError}
+        onLoad={this.onLoad}
+        url={imageUrl}
+      />
     )
   }
 }
 
 SingleImageViewerContainer.propTypes = {
+  onReady: PropTypes.func,
   subject: PropTypes.shape({
     locations: PropTypes.arrayOf(locationValidator)
   })
 }
 
 SingleImageViewerContainer.defaultProps = {
-  ImageObject: window.Image
+  ImageObject: window.Image,
+  onReady: () => true
 }
 
 export default SingleImageViewerContainer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -1,7 +1,9 @@
 import { shallow } from 'enzyme'
+import sinon from 'sinon'
 import React from 'react'
 
 import SingleImageViewerContainer from './SingleImageViewerContainer'
+import SingleImageViewer from './SingleImageViewer'
 
 let wrapper
 
@@ -16,5 +18,35 @@ describe('Component > SingleImageViewerContainer', function () {
 
   it('should render null if there is no subject prop', function () {
     expect(wrapper.type()).to.equal(null)
+  })
+
+  describe('SingleImageViewer', function () {
+    let imageWrapper
+    let onReady = sinon.stub()
+
+    before(function () {
+      const subject = {
+        id: 'test',
+        locations: [
+          { 'image/jpeg': 'https://some.domain/image.jpg'}
+        ]
+      }
+      wrapper = shallow(
+        <SingleImageViewerContainer
+          subject={subject}
+          onReady={onReady}
+        />
+      )
+      imageWrapper = wrapper.find(SingleImageViewer)
+    })
+
+    afterEach(function () {
+      onReady.resetHistory()
+    })
+
+    it('should call onReady on image load', function () {
+      imageWrapper.simulate('load')
+      expect(onReady).to.have.been.calledOnce
+    })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -13,8 +13,10 @@ function storeMapper (stores) {
   const { loadingState } = stores.classifierStore.workflows
   const { active: step } = stores.classifierStore.workflowSteps
   const tasks = stores.classifierStore.workflowSteps.activeStepTasks
+  const { ready } = stores.classifierStore.subjectViewer
   return {
     loadingState,
+    ready,
     step,
     tasks
   }
@@ -37,7 +39,10 @@ export class Tasks extends React.Component {
   }
 
   [asyncStates.success] () {
-    const { tasks } = this.props
+    const { ready, tasks } = this.props
+    if (!ready) {
+      return this[asyncStates.loading]()
+    }
     if (tasks.length > 0) {
       // setting the wrapping box of the task component to a basis of 246px feels hacky,
       // but gets the area to be the same 453px height (or very close) as the subject area
@@ -52,7 +57,7 @@ export class Tasks extends React.Component {
               if (TaskComponent) {
                 return (
                   <Box key={task.taskKey} basis='246px'>
-                    <TaskComponent task={task} {...this.props} />
+                    <TaskComponent disabled={!ready} task={task} {...this.props} />
                   </Box>
                 )
               }
@@ -60,7 +65,7 @@ export class Tasks extends React.Component {
               return (<Paragraph>Task component could not be rendered.</Paragraph>)
             })}
             <TaskHelp />
-            <TaskNavButtons />
+            <TaskNavButtons disabled={!ready} />
           </Box>
       </ThemeProvider>
       )
@@ -77,12 +82,14 @@ export class Tasks extends React.Component {
 
 Tasks.wrappedComponent.propTypes = {
   loadingState: PropTypes.oneOf(asyncStates.values),
+  ready: PropTypes.bool,
   tasks: PropTypes.arrayOf(PropTypes.object),
   theme: PropTypes.string,
 }
 
 Tasks.wrappedComponent.defaultProps = {
   loadingState: asyncStates.initialized,
+  ready: false,
   tasks: [],
   theme: 'light',
 }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -40,9 +40,6 @@ export class Tasks extends React.Component {
 
   [asyncStates.success] () {
     const { ready, tasks } = this.props
-    if (!ready) {
-      return this[asyncStates.loading]()
-    }
     if (tasks.length > 0) {
       // setting the wrapping box of the task component to a basis of 246px feels hacky,
       // but gets the area to be the same 453px height (or very close) as the subject area

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
@@ -26,7 +26,7 @@ describe('Tasks', function () {
   })
 
   it('should render null if the workflow is load but has no tasks', function () {
-    const wrapper = shallow(<Tasks.wrappedComponent loadingState={asyncStates.success} />)
+    const wrapper = shallow(<Tasks.wrappedComponent loadingState={asyncStates.success} ready={true} />)
     expect(wrapper.type()).to.be.null
   })
 
@@ -39,7 +39,7 @@ describe('Tasks', function () {
       type: 'single'
     }]
 
-    const wrapper = shallow(<Tasks.wrappedComponent loadingState={asyncStates.success} tasks={tasks} />)
+    const wrapper = shallow(<Tasks.wrappedComponent loadingState={asyncStates.success} ready={true} tasks={tasks} />)
     // Is there a better way to do this?
     expect(wrapper.find('inject-SingleChoiceTask')).to.have.lengthOf(1)
   })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
@@ -5,6 +5,14 @@ import { Tasks } from './Tasks'
 import asyncStates from '@zooniverse/async-states'
 
 describe('Tasks', function () {
+  const tasks = [{
+    answers: [{ label: 'yes' }, { label: 'no' }],
+    question: 'Is there a cat?',
+    required: true,
+    taskKey: 'init',
+    type: 'single'
+  }]
+
   it('should render without crashing', function () {
     const wrapper = shallow(<Tasks.wrappedComponent />)
     expect(wrapper).to.be.ok
@@ -31,16 +39,46 @@ describe('Tasks', function () {
   })
 
   it('should render the correct task component if the workflow is loaded', function () {
-    const tasks = [{
-      answers: [{ label: 'yes' }, { label: 'no' }],
-      question: 'Is there a cat?',
-      required: true,
-      taskKey: 'init',
-      type: 'single'
-    }]
-
     const wrapper = shallow(<Tasks.wrappedComponent loadingState={asyncStates.success} ready={true} tasks={tasks} />)
     // Is there a better way to do this?
     expect(wrapper.find('inject-SingleChoiceTask')).to.have.lengthOf(1)
+  })
+
+  describe('task components', function () {
+    let taskWrapper
+
+    describe('while the subject is loading', function () {
+      before(function () {
+        const wrapper = shallow(
+          <Tasks.wrappedComponent
+            loadingState={asyncStates.success}
+            ready={false}
+            tasks={tasks}
+          />
+        )
+        taskWrapper = wrapper.find('inject-SingleChoiceTask')
+      })
+
+      it('should be disabled', function () {
+        expect(taskWrapper.prop('disabled')).to.be.true
+      })
+    })
+
+    describe('when the subject viewer is ready', function () {
+      before(function () {
+        const wrapper = shallow(
+          <Tasks.wrappedComponent
+            loadingState={asyncStates.success}
+            ready={true}
+            tasks={tasks}
+          />
+        )
+        taskWrapper = wrapper.find('inject-SingleChoiceTask')
+      })
+
+      it('should be enabled', function () {
+        expect(taskWrapper.prop('disabled')).to.be.false
+      })
+    })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/MultipleChoiceTask/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/MultipleChoiceTask/MultipleChoiceTask.js
@@ -54,6 +54,7 @@ class MultipleChoiceTask extends React.Component {
   render () {
     const {
       annotations,
+      disabled,
       task
     } = this.props
     let annotation
@@ -61,7 +62,10 @@ class MultipleChoiceTask extends React.Component {
       annotation = annotations.get(task.taskKey)
     }
     return (
-      <StyledFieldset autoFocus={(annotation && annotation.value && annotation.value.length === 0)}>
+      <StyledFieldset
+        autoFocus={(annotation && annotation.value && annotation.value.length === 0)}
+        disabled={disabled}
+      >
         <StyledText size='small' tag='legend'>
           <Markdownz>
             {task.question}
@@ -73,6 +77,7 @@ class MultipleChoiceTask extends React.Component {
             <TaskInputField
               autoFocus={checked}
               checked={checked}
+              disabled={disabled}
               index={index}
               key={`${task.taskKey}_${index}`}
               label={answer.label}
@@ -91,12 +96,14 @@ class MultipleChoiceTask extends React.Component {
 MultipleChoiceTask.wrappedComponent.defaultProps = {
   addAnnotation: () => {},
   annotations: observable.map(),
+  disabled: false,
   task: {}
 }
 
 MultipleChoiceTask.wrappedComponent.propTypes = {
   addAnnotation: PropTypes.func,
   annotations: MobXPropTypes.observableMap,
+  disabled: PropTypes.bool,
   task: PropTypes.shape({
     answers: PropTypes.arrayOf(PropTypes.shape({
       label: PropTypes.string

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/SingleChoiceTask/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/SingleChoiceTask/SingleChoiceTask.js
@@ -47,6 +47,7 @@ class SingleChoiceTask extends React.Component {
     const {
       annotations,
       className,
+      disabled,
       task
     } = this.props
     let annotation
@@ -55,7 +56,10 @@ class SingleChoiceTask extends React.Component {
     }
 
     return (
-      <StyledFieldSet className={className}>
+      <StyledFieldSet
+        className={className}
+        disabled={disabled}
+      >
         <StyledText size='small' tag='legend'>
           <Markdownz>
             {task.question}
@@ -68,6 +72,7 @@ class SingleChoiceTask extends React.Component {
             <TaskInputField
               autoFocus={checked}
               checked={checked}
+              disabled={disabled}
               index={index}
               key={`${task.taskKey}_${index}`}
               label={answer.label}
@@ -86,12 +91,14 @@ class SingleChoiceTask extends React.Component {
 SingleChoiceTask.wrappedComponent.defaultProps = {
   addAnnotation: () => {},
   annotations: observable.map(),
+  disabled: false,
   task: {}
 }
 
 SingleChoiceTask.wrappedComponent.propTypes = {
   addAnnotation: PropTypes.func,
   annotations: MobXPropTypes.observableMap,
+  disabled: PropTypes.bool,
   task: PropTypes.shape({
     answers: PropTypes.arrayOf(PropTypes.shape({
       label: PropTypes.string

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskInputField/TaskInputField.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskInputField/TaskInputField.js
@@ -64,17 +64,6 @@ export const StyledTaskLabel = styled.span`
   display: flex;
   margin: ${pxToRem(10)} 0;
   padding: 5px 2ch;
-  
-  &:hover {
-    background: linear-gradient(${HOVER.gradientTop}, ${HOVER.gradientBottom});
-    border-width: 2px;
-    border-style: solid;
-    border-left-color: transparent;
-    border-right-color: transparent;
-    border-top-color: ${HOVER.gradientTop};
-    border-bottom-color: ${HOVER.gradientBottom};
-    color: ${HOVER.color};
-  }
 `
 
 export const StyledTaskInputField = styled.label`
@@ -83,6 +72,17 @@ export const StyledTaskInputField = styled.label`
   input {
     opacity: 0.01;
     position: absolute;
+  }
+
+  input:enabled + ${StyledTaskLabel}:hover {
+    background: linear-gradient(${HOVER.gradientTop}, ${HOVER.gradientBottom});
+    border-width: 2px;
+    border-style: solid;
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-top-color: ${HOVER.gradientTop};
+    border-bottom-color: ${HOVER.gradientBottom};
+    color: ${HOVER.color};
   }
 
   input:focus + ${StyledTaskLabel} {
@@ -96,7 +96,7 @@ export const StyledTaskInputField = styled.label`
     color: ${HOVER.color};
   }
 
-  input:active + ${StyledTaskLabel} {
+  input:enabled:active + ${StyledTaskLabel} {
     background: linear-gradient(${HOVER.gradientTop}, ${HOVER.gradientBottom});
     border-width: 2px;
     border-style: solid;
@@ -127,6 +127,7 @@ export function TaskInputField (props) {
     autoFocus,
     checked,
     className,
+    disabled,
     index,
     label,
     labelIcon,
@@ -144,6 +145,7 @@ export function TaskInputField (props) {
         <input
           autoFocus={autoFocus}
           checked={checked}
+          disabled={disabled}
           name={name}
           onChange={onChange}
           type={type}
@@ -160,6 +162,7 @@ export function TaskInputField (props) {
 TaskInputField.defaultProps = {
   autoFocus: false,
   checked: false,
+  disabled: false,
   className: '',
   label: '',
   labelIcon: null,
@@ -173,6 +176,7 @@ TaskInputField.propTypes = {
   autoFocus: PropTypes.bool,
   checked: PropTypes.bool,
   className: PropTypes.string,
+  disabled: PropTypes.bool,
   index: PropTypes.number.isRequired,
   label: PropTypes.string,
   labelIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.object]),

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskInputField/TaskInputField.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskInputField/TaskInputField.spec.js
@@ -42,6 +42,12 @@ describe('TaskInputField', function () {
       wrapper.setProps({ className: 'active' })
       expect(wrapper.find(StyledTaskInputField).props().className).to.include('active')
     })
+
+    it('should disable the form input when disabled', function () {
+      expect(wrapper.find('input').prop('disabled')).to.be.false
+      wrapper.setProps({ disabled: true })
+      expect(wrapper.find('input').prop('disabled')).to.be.true
+    })
   })
 
   describe('onChange method', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
@@ -9,6 +9,7 @@ import BackButton from './components/BackButton'
 
 export default function TaskNavButtons (props) {
   const goldStandardMode = props.classification ? props.classification.goldStandard : false
+  const disabled = props.disabled || props.waitingForAnswer
 
   if (props.showNextButton) {
     return (
@@ -21,7 +22,7 @@ export default function TaskNavButtons (props) {
         <NextButton
           autoFocus={false}
           onClick={props.goToNextStep}
-          disabled={props.waitingForAnswer}
+          disabled={disabled}
         />
       </Box>
     )
@@ -53,7 +54,7 @@ export default function TaskNavButtons (props) {
         flex='grow'
         goldStandardMode={goldStandardMode}
         onClick={props.onSubmit}
-        disabled={props.waitingForAnswer}
+        disabled={disabled}
       />
       <DoneButton
         completed={props.completed}
@@ -61,7 +62,7 @@ export default function TaskNavButtons (props) {
         flex='grow'
         goldStandardMode={goldStandardMode}
         onClick={props.onSubmit}
-        disabled={props.waitingForAnswer}
+        disabled={disabled}
       />
     </Box>
   )
@@ -72,6 +73,7 @@ TaskNavButtons.defaultProps = {
   autoFocus: false,
   completed: false,
   demoMode: false,
+  disabled: false,
   goToPreviousStep: () => {},
   onSubmit: () => {},
   nextSubject: () => {},
@@ -86,6 +88,7 @@ TaskNavButtons.propTypes = {
   autoFocus: PropTypes.bool,
   completed: PropTypes.bool,
   demoMode: PropTypes.bool,
+  disabled: PropTypes.bool,
   goToPreviousStep: PropTypes.func,
   nextSubject: PropTypes.func,
   onSubmit: PropTypes.func,

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.spec.js
@@ -22,7 +22,7 @@ describe('TaskNavButtons', function () {
 
   describe('when props.showNextButton is true', function () {
     let wrapper
-    before(function () {
+    beforeEach(function () {
       wrapper = shallow(<TaskNavButtons classification={classification} goToNextStep={() => {}} showNextButton />)
     })
 
@@ -44,6 +44,11 @@ describe('TaskNavButtons', function () {
       wrapper.setProps({ waitingForAnswer: true })
       expect(wrapper.find(NextButton).prop('disabled')).to.be.true
     })
+
+    it('should disable the Next button when disabled.', function () {
+      wrapper.setProps({ disabled: true })
+      expect(wrapper.find(NextButton).prop('disabled')).to.be.true
+    })
   })
 
   describe('when props.completed is true and props.showNextButton is false', function () {
@@ -59,7 +64,7 @@ describe('TaskNavButtons', function () {
 
   describe('the default rendering', function () {
     let wrapper
-    before(function () {
+    beforeEach(function () {
       wrapper = shallow(<TaskNavButtons classification={classification} />)
     })
 
@@ -79,6 +84,21 @@ describe('TaskNavButtons', function () {
     it('should disable the Done button when waiting for a required answer.', function () {
       wrapper.setProps({ waitingForAnswer: true })
       expect(wrapper.find(DoneButton).prop('disabled')).to.be.true
+    })
+
+    it('should disable the Done & Talk button when waiting for a required answer.', function () {
+      wrapper.setProps({ waitingForAnswer: true })
+      expect(wrapper.find(DoneAndTalkButton).prop('disabled')).to.be.true
+    })
+
+    it('should disable the Done button when disabled.', function () {
+      wrapper.setProps({ disabled: true })
+      expect(wrapper.find(DoneButton).prop('disabled')).to.be.true
+    })
+
+    it('should disable the Done & Talk button when disabled.', function () {
+      wrapper.setProps({ disabled: true })
+      expect(wrapper.find(DoneAndTalkButton).prop('disabled')).to.be.true
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.js
@@ -81,10 +81,11 @@ class TaskNavButtonsContainer extends React.Component {
   }
 
   render () {
-    const { isThereANextStep, isThereAPreviousStep } = this.props
+    const { disabled, isThereANextStep, isThereAPreviousStep } = this.props
 
     return (
       <TaskNavButtons
+        disabled={disabled}
         goToNextStep={this.goToNextStep.bind(this)}
         goToPreviousStep={this.goToPreviousStep.bind(this)}
         showBackButton={isThereAPreviousStep()}
@@ -98,6 +99,7 @@ class TaskNavButtonsContainer extends React.Component {
 TaskNavButtonsContainer.wrappedComponent.defaultProps = {
   completeClassification: () => {},
   createDefaultAnnotation: () => {},
+  disabled: false,
   selectStep: () => {},
   tasks: []
 }
@@ -108,6 +110,7 @@ TaskNavButtonsContainer.wrappedComponent.propTypes = {
   }),
   completeClassification: PropTypes.func,
   createDefaultAnnotation: PropTypes.func,
+  disabled: PropTypes.bool,
   showBackButton: PropTypes.bool,
   showNextButton: PropTypes.bool,
   selectStep: PropTypes.func,

--- a/packages/lib-classifier/src/store/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.js
@@ -63,6 +63,10 @@ const SubjectViewer = types
         self.fullscreen = false
       },
 
+      onSubjectReady () {
+        self.ready = true
+      },
+
       resetSubject () {
         self.ready = false
       },

--- a/packages/lib-classifier/src/store/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.js
@@ -34,7 +34,7 @@ const SubjectViewer = types
       const subjectDisposer = autorun(() => {
         const subject = getRoot(self).subjects.active
         if (subject) {
-          self.resetSubject()
+          self.resetSubjectReady()
         }
       })
       addDisposer(self, subjectDisposer)
@@ -67,7 +67,7 @@ const SubjectViewer = types
         self.ready = true
       },
 
-      resetSubject () {
+      resetSubjectReady () {
         self.ready = false
       },
 

--- a/packages/lib-classifier/src/store/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.js
@@ -1,4 +1,5 @@
-import { types } from 'mobx-state-tree'
+import { autorun } from 'mobx'
+import { addDisposer, getRoot, types } from 'mobx-state-tree'
 
 import layouts from '../helpers/layouts'
 
@@ -7,7 +8,8 @@ const SubjectViewer = types
     annotate: types.optional(types.boolean, true),
     fullscreen: types.optional(types.boolean, false),
     move: types.optional(types.boolean, false),
-    layout: types.optional(types.enumeration('layout', layouts.values), layouts.default)
+    layout: types.optional(types.enumeration('layout', layouts.values), layouts.default),
+    ready: types.optional(types.boolean, false)
   })
 
   .volatile(self => ({
@@ -27,55 +29,75 @@ const SubjectViewer = types
     }
   }))
 
-  .actions(self => ({
-    enableAnnotate () {
-      self.annotate = true
-      self.move = false
-    },
-
-    enableFullscreen () {
-      self.fullscreen = true
-    },
-
-    enableMove () {
-      self.annotate = false
-      self.move = true
-    },
-
-    disableFullscreen () {
-      self.fullscreen = false
-    },
-
-    resetView () {
-      console.log('resetting view')
-      self.onZoom && self.onZoom('zoomto', 1.0)
-    },
-
-    rotate () {
-      console.log('rotating subject')
-    },
-
-    setLayout (layout = layouts.DefaultLayout) {
-      self.layout = layout
-    },
-
-    setOnZoom (callback) {
-      self.onZoom = callback
-    },
-
-    setOnPan (callback) {
-      self.onPan = callback
-    },
-
-    zoomIn () {
-      console.log('zooming in')
-      self.onZoom && self.onZoom('zoomin', 1)
-    },
-
-    zoomOut () {
-      console.log('zooming out')
-      self.onZoom && self.onZoom('zoomout', -1)
+  .actions(self => {
+    function createSubjectObserver () {
+      const subjectDisposer = autorun(() => {
+        const subject = getRoot(self).subjects.active
+        if (subject) {
+          self.resetSubject()
+        }
+      })
+      addDisposer(self, subjectDisposer)
     }
-  }))
+
+    return {
+      afterAttach () {
+        createSubjectObserver()
+      },
+
+      enableAnnotate () {
+        self.annotate = true
+        self.move = false
+      },
+
+      enableFullscreen () {
+        self.fullscreen = true
+      },
+
+      enableMove () {
+        self.annotate = false
+        self.move = true
+      },
+
+      disableFullscreen () {
+        self.fullscreen = false
+      },
+
+      resetSubject () {
+        self.ready = false
+      },
+
+      resetView () {
+        console.log('resetting view')
+        self.onZoom && self.onZoom('zoomto', 1.0)
+      },
+
+      rotate () {
+        console.log('rotating subject')
+      },
+
+      setLayout (layout = layouts.DefaultLayout) {
+        self.layout = layout
+      },
+
+      setOnZoom (callback) {
+        self.onZoom = callback
+      },
+
+      setOnPan (callback) {
+        self.onPan = callback
+      },
+
+      zoomIn () {
+        console.log('zooming in')
+        self.onZoom && self.onZoom('zoomin', 1)
+      },
+
+      zoomOut () {
+        console.log('zooming out')
+        self.onZoom && self.onZoom('zoomout', -1)
+      }
+    }
+  })
 
 export default SubjectViewer


### PR DESCRIPTION
- [x] Add a `ready` flag ro the subject viewer store. Reset it to false for each new subject. Add an `onReady` handler to subject viewers, which fires on load for images, or after JSON data has loaded and parsed for data subjects.
- [x] Add a disabled prop to task nav buttons.
- [x] Add a disabled prop to tasks.
- [x] Disable tasks while subject data is loading.

Package:
lib-classifier

Closes #511 .

Describe your changes:


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

