### PR TITLE
Use explicit return in functional setState. Add test

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/Metadata.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/Metadata.js
@@ -15,7 +15,7 @@ export default class Metadata extends React.Component {
   }
 
   toggleMetadataModal () {
-    this.setState(prevState => { showMetadataModal: !prevState.showMetadataModal })
+    this.setState((prevState) => { return { showMetadataModal: !prevState.showMetadataModal }})
   }
 
   render () {

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/Metadata.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/Metadata.spec.js
@@ -37,5 +37,11 @@ describe('Metadata', function () {
     it('should not disable the MetadataButton', function () {
       expect(wrapper.find(MetadataButton).props().disabled).to.be.false
     })
+
+    it('should set showMetadataModel state when the toggle handler is called', function () {
+      expect(wrapper.state().showMetadataModal).to.be.false
+      wrapper.find(MetadataButton).simulate('click')
+      expect(wrapper.state().showMetadataModal).to.be.true
+    })
   })
 })


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
Fixes a regression introduced in #779 and adds a test to cover what broke. Apparently you can't use implicit returns in functional setState calls?

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

