### PR TITLE
Use min-height instead of fixed height

### DIFF
--- a/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
+++ b/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
@@ -9,6 +9,10 @@ import CloseIcon from '../CloseIcon'
 
 counterpart.registerTranslations('en', en)
 
+const StyledBox = styled(Box)`
+  min-height: 30px;
+`
+
 const Heading = styled.h2`
   color: white;
   font-size: 1rem;
@@ -35,13 +39,12 @@ const StyledButton = styled(Button)`
 
 function ModalHeading ({ className, closeFn, title }) {
   return (
-    <Box
+    <StyledBox
       align='center'
       background='brand'
       className={className}
       direction='row'
       gap='large'
-      height='30px'
       justify='between'
       pad={{ horizontal: 'medium', vertical: 'none' }}
     >
@@ -54,7 +57,7 @@ function ModalHeading ({ className, closeFn, title }) {
       >
         <CloseIcon />
       </StyledButton>
-    </Box>
+    </StyledBox>
   )
 }
 


### PR DESCRIPTION
Package: lib-react-components

Fixes modal header issues noted in this comment: https://github.com/zooniverse/front-end-monorepo/issues/746#issuecomment-487744230

Describe your changes:
Use min-height instead of a fixed height

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

