### PR TITLE
Update Feedback modal button label

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
@@ -64,7 +64,7 @@ class FeedbackModal extends React.Component {
             <Box pad={{ top: 'small' }}>
               <Button
                 onClick={hideFeedback}
-                label={counterpart('FeedbackModal.close')}
+                label={counterpart('FeedbackModal.keepClassifying')}
                 primary
               />
             </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/locales/en.json
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/locales/en.json
@@ -1,6 +1,6 @@
 {
   "FeedbackModal": {
-    "close": "Close",
+    "keepClassifying": "Keep Classifying",
     "label": "Feedback" 
   }
 }


### PR DESCRIPTION
Package: lib-classifier

For #774

Describe your changes:
Updates the Feedback's modal button to say 'Keep Classifying' per #774 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

