### PR TITLE
Ensure stats button is always teal

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDay.js
@@ -50,11 +50,12 @@ function FinishedForTheDay (props) {
             <Link href='/#projects' passHref>
               <StyledButton
                 label={(
-                  <Text size='small'>
+                  <Text size='medium'>
                     {counterpart('FinishedForTheDay.buttons.stats')}
                   </Text>
                 )}
                 primary
+                color='brand'
               />
             </Link>
           )}


### PR DESCRIPTION
Closes #739 .

Forces the stats button to be teal. There may be other cases where this comes up, but this covers the last affected button on the page.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

