### PR TITLE
Add missing classname to ZooHeader

### DIFF
--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.js
@@ -1,8 +1,6 @@
+import { Anchor, Box } from 'grommet'
 import React from 'react'
 import PropTypes from 'prop-types'
-
-import { Anchor, Box } from 'grommet'
-
 import styled from 'styled-components'
 import zooTheme from '@zooniverse/grommet-theme'
 
@@ -41,6 +39,7 @@ export default function ZooHeader (props) {
   const {
     adminNavLinkLabel,
     adminNavLinkURL,
+    className,
     isAdmin,
     isNarrow,
     mainHeaderNavListLabels,
@@ -56,6 +55,7 @@ export default function ZooHeader (props) {
   return (
     <StyledHeader
       background='black'
+      className={className}
       direction='row'
       fill='horizontal'
       justify='between'
@@ -126,6 +126,7 @@ ZooHeader.defaultProps = {
 ZooHeader.propTypes = {
   adminNavLinkLabel: PropTypes.string,
   adminNavLinkURL: PropTypes.string,
+  className: PropTypes.string,
   isAdmin: PropTypes.bool,
   isNarrow: PropTypes.bool,
   mainHeaderNavListLabels: PropTypes.arrayOf(PropTypes.string),


### PR DESCRIPTION
Adds missing classname prop to ZooHeader

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

