### PR TITLE
Record subject image dimensions on load

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -57,10 +57,10 @@ function storeMapper (stores) {
 @inject(storeMapper)
 @observer
 class LightCurveViewer extends Component {
-  constructor () {
-    super()
+  constructor (props) {
+    super(props)
 
-    this.svgContainer = React.createRef()
+    this.svgContainer = props.forwardRef
 
     // D3 Selection elements
     this.d3annotationsLayer = null
@@ -714,6 +714,8 @@ LightCurveViewer.wrappedComponent.propTypes = {
 }
 
 LightCurveViewer.wrappedComponent.defaultProps = {
+  forwardRef: React.createRef(),
+
   dataExtent: { x: [-1, 1], y: [-1, 1] },
   dataPoints: [[]],
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
@@ -83,8 +83,7 @@ class LightCurveViewerContainer extends Component {
 
   onLoad (rawData) {
     const { onReady } = this.props
-    // TODO: find a cleaner way to get the container node for the viewer.
-    const target = this.viewer.current.wrappedInstance.svgContainer.current
+    const target = this.viewer.current
     this.setState({
       dataExtent: {
         x: d3.extent(rawData.x),
@@ -114,7 +113,7 @@ class LightCurveViewerContainer extends Component {
 
     return (
       <LightCurveViewer
-        ref={this.viewer}
+        forwardRef={this.viewer}
         dataExtent={this.state.dataExtent}
         dataPoints={this.state.dataPoints}
         drawFeedbackBrushes={this.props.drawFeedbackBrushes}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
@@ -13,6 +13,7 @@ import withKeyZoom from '../../../withKeyZoom'
 class LightCurveViewerContainer extends Component {
   constructor () {
     super()
+    this.viewer = React.createRef()
     this.state = {
       loading: asyncStates.initialized,
       dataExtent: {
@@ -82,6 +83,8 @@ class LightCurveViewerContainer extends Component {
 
   onLoad (rawData) {
     const { onReady } = this.props
+    // TODO: find a cleaner way to get the container node for the viewer.
+    const target = this.viewer.current.wrappedInstance.svgContainer.current
     this.setState({
       dataExtent: {
         x: d3.extent(rawData.x),
@@ -90,7 +93,9 @@ class LightCurveViewerContainer extends Component {
       dataPoints: zip(rawData.x, rawData.y),
       loading: asyncStates.success
     },
-    onReady)
+    function () {
+      onReady({ target })
+    })
   }
 
   onError (error) {
@@ -109,6 +114,7 @@ class LightCurveViewerContainer extends Component {
 
     return (
       <LightCurveViewer
+        ref={this.viewer}
         dataExtent={this.state.dataExtent}
         dataPoints={this.state.dataPoints}
         drawFeedbackBrushes={this.props.drawFeedbackBrushes}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -9,9 +9,9 @@ const SVG = styled.svg`
   width: 100%;
 `
 
-function SingleImageViewer ({ onError, onLoad, url }) {
+const SingleImageViewer = React.forwardRef(function SingleImageViewer ({ onError, onLoad, url }, ref) {
   return (
-    <SVG>
+    <SVG ref={ref}>
       <image
         height='100%'
         width='100%'
@@ -22,7 +22,7 @@ function SingleImageViewer ({ onError, onLoad, url }) {
       <InteractionLayer />
     </SVG>
   )
-}
+})
 
 SingleImageViewer.defaultProps = {
   onError: () => true,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -8,10 +8,11 @@ import locationValidator from '../../helpers/locationValidator'
 class SingleImageViewerContainer extends React.Component {
   constructor () {
     super()
+    this.onLoad = this.onLoad.bind(this)
     this.onError = this.onError.bind(this)
     this.state = {
-      height: null,
-      width: null,
+      naturalHeight: null,
+      naturalWidth: null,
       loading: asyncStates.initialized
     }
   }
@@ -42,13 +43,22 @@ class SingleImageViewerContainer extends React.Component {
       const img = await this.fetchImage(imageUrl)
 
       this.setState({
-        height: img.height,
-        width: img.width,
+        naturalHeight: img.naturalHeight,
+        naturalWidth: img.naturalWidth,
         loading: asyncStates.success
       })
     } catch (error) {
       this.onError(error)
     }
+  }
+
+  onLoad (event) {
+    const { onReady } = this.props
+    const { naturalHeight, naturalWidth } = this.state
+    const { target } = event || {}
+    const newTarget = Object.assign({}, target, { naturalHeight, naturalWidth })
+    const fakeEvent = Object.assign({}, event, { target: newTarget })
+    onReady(fakeEvent)
   }
 
   onError (error) {
@@ -58,7 +68,7 @@ class SingleImageViewerContainer extends React.Component {
 
   render () {
     const { loadingState } = this.state
-    const { onReady, subject } = this.props
+    const { subject } = this.props
     if (loadingState === asyncStates.error) {
       return (
         <div>Something went wrong.</div>
@@ -74,7 +84,7 @@ class SingleImageViewerContainer extends React.Component {
     return (
       <SingleImageViewer
         onError={this.onError}
-        onLoad={onReady}
+        onLoad={this.onLoad}
         url={imageUrl}
       />
     )

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -8,9 +8,12 @@ import locationValidator from '../../helpers/locationValidator'
 class SingleImageViewerContainer extends React.Component {
   constructor () {
     super()
+    this.imageViewer = React.createRef()
     this.onLoad = this.onLoad.bind(this)
     this.onError = this.onError.bind(this)
     this.state = {
+      clientHeight: 0,
+      clientWidth: 0,
       naturalHeight: null,
       naturalWidth: null,
       loading: asyncStates.initialized
@@ -41,8 +44,11 @@ class SingleImageViewerContainer extends React.Component {
     try {
       const imageUrl = Object.values(subject.locations[0])[0]
       const img = await this.fetchImage(imageUrl)
+      const svg = this.imageViewer.current
 
       this.setState({
+        clientHeight: svg.clientHeight,
+        clientWidth: svg.clientWidth,
         naturalHeight: img.naturalHeight,
         naturalWidth: img.naturalWidth,
         loading: asyncStates.success
@@ -54,9 +60,9 @@ class SingleImageViewerContainer extends React.Component {
 
   onLoad (event) {
     const { onReady } = this.props
-    const { naturalHeight, naturalWidth } = this.state
+    const { clientHeight, clientWidth, naturalHeight, naturalWidth } = this.state
     const { target } = event || {}
-    const newTarget = Object.assign({}, target, { naturalHeight, naturalWidth })
+    const newTarget = Object.assign({}, target, { clientHeight, clientWidth, naturalHeight, naturalWidth })
     const fakeEvent = Object.assign({}, event, { target: newTarget })
     onReady(fakeEvent)
   }
@@ -83,6 +89,7 @@ class SingleImageViewerContainer extends React.Component {
     const imageUrl = Object.values(subject.locations[0])[0]
     return (
       <SingleImageViewer
+        ref={this.imageViewer}
         onError={this.onError}
         onLoad={this.onLoad}
         url={imageUrl}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -27,7 +27,7 @@ class SingleImageViewerContainer extends React.Component {
   fetchImage (url) {
     const { ImageObject } = this.props
     return new Promise((resolve, reject) => {
-      let img = new ImageObject()
+      const img = new ImageObject()
       img.onload = () => resolve(img)
       img.onerror = reject
       img.src = url
@@ -37,9 +37,9 @@ class SingleImageViewerContainer extends React.Component {
   async handleSubject () {
     const { subject } = this.props
     // TODO: Add polyfill for Object.values for IE
-    const imageUrl = Object.values(subject.locations[0])[0]
     this.setState({ loading: asyncStates.loading })
     try {
+      const imageUrl = Object.values(subject.locations[0])[0]
       const img = await this.fetchImage(imageUrl)
 
       this.setState({

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -14,8 +14,8 @@ class SingleImageViewerContainer extends React.Component {
     this.state = {
       clientHeight: 0,
       clientWidth: 0,
-      naturalHeight: null,
-      naturalWidth: null,
+      naturalHeight: 0,
+      naturalWidth: 0,
       loading: asyncStates.initialized
     }
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -53,6 +53,12 @@ describe('Component > SingleImageViewerContainer', function () {
         />
       )
       imageWrapper = wrapper.find(SingleImageViewer)
+      wrapper.instance().imageViewer = {
+        current: {
+          clientHeight: 100,
+          clientWidth: 200
+        }
+      }
     })
 
     afterEach(function () {
@@ -65,6 +71,7 @@ describe('Component > SingleImageViewerContainer', function () {
 
     it('should record the original image dimensions on load', function (done) {
       setTimeout(function() {
+        const svg = wrapper.instance().imageViewer.current
         const fakeEvent = {
           target: {
             clientHeight: 0,
@@ -73,8 +80,8 @@ describe('Component > SingleImageViewerContainer', function () {
         }
         const expectedEvent = {
           target: {
-            clientHeight: 0,
-            clientWidth: 0,
+            clientHeight: svg.clientHeight,
+            clientWidth: svg.clientWidth,
             naturalHeight: height,
             naturalWidth: width
           }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -5,22 +5,36 @@ import React from 'react'
 import SingleImageViewerContainer from './SingleImageViewerContainer'
 import SingleImageViewer from './SingleImageViewer'
 
-let wrapper
-
 describe('Component > SingleImageViewerContainer', function () {
-  beforeEach(function () {
-    wrapper = shallow(<SingleImageViewerContainer />)
-  })
+  let wrapper
+  const height = 200
+  const width = 400
 
-  it('should render without crashing', function () {
-    expect(wrapper).to.be.ok
-  })
+  // mock an image that loads after a delay of 0.1s
+  class MockImage {
+    constructor() {
+      this.naturalHeight = height
+      this.naturalWidth = width
+      setTimeout(() => this.onload(), 100)
+    }
+  }
 
-  it('should render null if there is no subject prop', function () {
-    expect(wrapper.type()).to.equal(null)
-  })
+  describe('without a subject', function () {
+    beforeEach(function () {
+      wrapper = shallow(<SingleImageViewerContainer />)
+    })
 
-  describe('SingleImageViewer', function () {
+    it('should render without crashing', function () {
+      expect(wrapper).to.be.ok
+    })
+
+    it('should render null', function () {
+      expect(wrapper.type()).to.equal(null)
+    })
+  })
+  
+
+  describe('with a subject', function () {
     let imageWrapper
     let onReady = sinon.stub()
 
@@ -33,6 +47,7 @@ describe('Component > SingleImageViewerContainer', function () {
       }
       wrapper = shallow(
         <SingleImageViewerContainer
+          ImageObject={MockImage}
           subject={subject}
           onReady={onReady}
         />
@@ -44,9 +59,30 @@ describe('Component > SingleImageViewerContainer', function () {
       onReady.resetHistory()
     })
 
-    it('should call onReady on image load', function () {
-      imageWrapper.simulate('load')
-      expect(onReady).to.have.been.calledOnce
+    it('should render without crashing', function () {
+      expect(wrapper).to.be.ok
+    })
+
+    it('should record the original image dimensions on load', function (done) {
+      setTimeout(function() {
+        const fakeEvent = {
+          target: {
+            clientHeight: 0,
+            clientWidth: 0
+          }
+        }
+        const expectedEvent = {
+          target: {
+            clientHeight: 0,
+            clientWidth: 0,
+            naturalHeight: height,
+            naturalWidth: width
+          }
+        }
+        imageWrapper.simulate('load', fakeEvent)
+        expect(onReady).to.have.been.calledOnceWith(expectedEvent)
+        done()
+      }, 150)
     })
   })
 })

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -132,7 +132,7 @@ const ClassificationStore = types
 
     function completeClassification () {
       const classification = self.active
-      const subjectDimensions = getRoot(self).subjectViewer.dimensions.toJSON()
+      const subjectDimensions = toJS(getRoot(self).subjectViewer.dimensions)
 
       const metadata = {
         finishedAt: (new Date()).toISOString(),

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -132,10 +132,12 @@ const ClassificationStore = types
 
     function completeClassification () {
       const classification = self.active
+      const subjectDimensions = getRoot(self).subjectViewer.dimensions.toJSON()
 
       const metadata = {
-        session: sessionUtils.getSessionID(),
         finishedAt: (new Date()).toISOString(),
+        session: sessionUtils.getSessionID(),
+        subjectDimensions,
         viewport: {
           width: window.innerWidth,
           height: window.innerHeight

--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -2,6 +2,7 @@ import sinon from 'sinon'
 import ClassificationStore from './ClassificationStore'
 import FeedbackStore from './FeedbackStore'
 import Subject from './Subject'
+import SubjectViewerStore from './SubjectViewerStore'
 
 import { toJS } from 'mobx'
 import { getEnv, types } from 'mobx-state-tree'
@@ -12,6 +13,7 @@ const RootStub = types
     feedback: FeedbackStore,
     projects: types.frozen(),
     subjects: types.frozen(),
+    subjectViewer: SubjectViewerStore,
     workflows: types.frozen()
   })
   .views(self => ({
@@ -59,6 +61,7 @@ describe('Model > ClassificationStore', function () {
       feedback: { isActive: false },
       projects: { active: projectStub },
       subjects: { active: undefined },
+      subjectViewer: {},
       workflows: { active: workflowStub }
     })
     classifications = rootStore.classifications
@@ -142,6 +145,7 @@ describe('Model > ClassificationStore', function () {
           feedback,
           projects: { active: projectStub },
           subjects: { active: subject },
+          subjectViewer: {},
           workflows: { active: workflowStub }
         },
         {

--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -100,6 +100,7 @@ describe('Model > ClassificationStore', function () {
     let classifications
     let event
     let feedback
+    let subjectViewer
     let onComplete
     let feedbackStub
 
@@ -157,9 +158,16 @@ describe('Model > ClassificationStore', function () {
       }
       onComplete = sinon.stub()
       classifications.setOnComplete(onComplete)
+      subjectViewer = rootStore.subjectViewer
     })
 
     beforeEach(function () {
+      subjectViewer.onSubjectReady({
+        target: {
+          naturalHeight: 200,
+          naturalWidth: 400
+        }
+      })
       classifications.createClassification(subject)
       classifications.addAnnotation(0, { type: 'single', taskKey: 'T0' })
       classifications.completeClassification(event)
@@ -168,6 +176,7 @@ describe('Model > ClassificationStore', function () {
     afterEach(function () {
       onComplete.resetHistory()
       feedback.update.resetHistory()
+      subjectViewer.resetSubject()
     })
 
     after(function () {
@@ -199,6 +208,10 @@ describe('Model > ClassificationStore', function () {
       it('should have a feedback key', function () {
         const { rules } = feedbackStub
         expect(metadata.feedback).to.eql(rules)
+      })
+
+      it('should record subject dimensions', function () {
+        expect(metadata.subjectDimensions).to.eql(subjectViewer.dimensions)
       })
     })
   })

--- a/packages/lib-classifier/src/store/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.js
@@ -63,7 +63,9 @@ const SubjectViewer = types
         self.fullscreen = false
       },
 
-      onSubjectReady () {
+      onSubjectReady (event) {
+        const { naturalHeight, naturalWidth } = event.target || {}
+        console.log(naturalHeight, naturalWidth)
         self.ready = true
       },
 

--- a/packages/lib-classifier/src/store/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.js
@@ -6,6 +6,12 @@ import layouts from '../helpers/layouts'
 const SubjectViewer = types
   .model('SubjectViewer', {
     annotate: types.optional(types.boolean, true),
+    dimensions: types.array(types.frozen({
+      clientHeight: types.integer,
+      clientWidth: types.integer,
+      naturalHeight: types.integer,
+      naturalWidth: types.integer
+    })),
     fullscreen: types.optional(types.boolean, false),
     move: types.optional(types.boolean, false),
     layout: types.optional(types.enumeration('layout', layouts.values), layouts.default),
@@ -65,8 +71,8 @@ const SubjectViewer = types
 
       onSubjectReady (event) {
         const { target } = event || {}
-        const { naturalHeight, naturalWidth } = target || {}
-        console.log(naturalHeight, naturalWidth)
+        const { clientHeight = 0, clientWidth = 0, naturalHeight = 0, naturalWidth = 0 } = target || {}
+        self.dimensions.push({ clientHeight, clientWidth, naturalHeight, naturalWidth })
         self.ready = true
       },
 

--- a/packages/lib-classifier/src/store/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.js
@@ -70,8 +70,13 @@ const SubjectViewer = types
       },
 
       onSubjectReady (event) {
-        const { target } = event || {}
-        const { clientHeight = 0, clientWidth = 0, naturalHeight = 0, naturalWidth = 0 } = target || {}
+        const { target = {} } = event || {}
+        const {
+          clientHeight = 0,
+          clientWidth = 0,
+          naturalHeight = 0,
+          naturalWidth = 0
+        } = target
         self.dimensions.push({ clientHeight, clientWidth, naturalHeight, naturalWidth })
         self.ready = true
       },

--- a/packages/lib-classifier/src/store/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.js
@@ -64,7 +64,8 @@ const SubjectViewer = types
       },
 
       onSubjectReady (event) {
-        const { naturalHeight, naturalWidth } = event.target || {}
+        const { target } = event || {}
+        const { naturalHeight, naturalWidth } = target || {}
         console.log(naturalHeight, naturalWidth)
         self.ready = true
       },

--- a/packages/lib-classifier/src/store/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.js
@@ -40,7 +40,7 @@ const SubjectViewer = types
       const subjectDisposer = autorun(() => {
         const subject = getRoot(self).subjects.active
         if (subject) {
-          self.resetSubjectReady()
+          self.resetSubject()
         }
       })
       addDisposer(self, subjectDisposer)
@@ -76,8 +76,9 @@ const SubjectViewer = types
         self.ready = true
       },
 
-      resetSubjectReady () {
+      resetSubject () {
         self.ready = false
+        self.dimensions = []
       },
 
       resetView () {

--- a/packages/lib-classifier/test/enzyme-config.js
+++ b/packages/lib-classifier/test/enzyme-config.js
@@ -3,5 +3,5 @@ import Adapter from 'enzyme-adapter-react-16'
 
 Enzyme.configure({
   adapter: new Adapter(),
-  disableLifecycleMethods: true
+  disableLifecycleMethods: false
 })


### PR DESCRIPTION
Get image dimensions from the HTML image preloader. Create a new, fake event and fake target on SVG image load, since the originals are read-only. Pass the fake event, with the HTML image dimensions, to the subject viewer store via the onReady event handler.

Todo:
- [x] Enable React lifecycle testing.
- [x] Mock window.Image and test the preloader.
- [x] ~~Record dimensions for SVG data images.~~
- [x] Pass image dimensions from the subject viewer to the current classification.
- [x] Record client rendered dimensions too (this might be optional.)

Package:
lib-classifier

Closes #201.
Closes #304.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

