### PR TITLE
Make user login prop required. Pass it along in app-project

### DIFF
--- a/packages/app-project/src/components/ZooHeaderWrapper/ZooHeaderWrapperContainer.js
+++ b/packages/app-project/src/components/ZooHeaderWrapper/ZooHeaderWrapperContainer.js
@@ -12,6 +12,7 @@ function storeMapper (stores) {
     user
   }
 }
+
 @withRouter
 @inject(storeMapper)
 @observer
@@ -26,7 +27,7 @@ class ZooHeaderWrapperContainer extends Component {
   createUserProp () {
     const { user } = this.props
     return (user.isLoggedIn)
-      ? { 'display_name': user['display_name'] }
+      ? { display_name: user.display_name, login: user.login }
       : {}
   }
 
@@ -87,6 +88,7 @@ ZooHeaderWrapperContainer.propTypes = {
   user: shape({
     clear: func,
     display_name: string,
+    login: string,
     isLoggedIn: bool
   })
 }

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.js
@@ -136,6 +136,7 @@ ZooHeader.propTypes = {
   unreadMessages: PropTypes.number,
   unreadNotifications: PropTypes.number,
   user: PropTypes.shape({
-    display_name: PropTypes.string
+    display_name: PropTypes.string.isRequired,
+    login: PropTypes.string.isRequired
   }).isRequired
 }

--- a/packages/lib-react-components/src/ZooHeader/components/SignedInUserNavigation/SignedInUserNavigation.js
+++ b/packages/lib-react-components/src/ZooHeader/components/SignedInUserNavigation/SignedInUserNavigation.js
@@ -108,7 +108,7 @@ SignedInUserNavigation.propTypes = {
   unreadMessages: PropTypes.number,
   unreadNotifications: PropTypes.number,
   user: PropTypes.shape({
-    display_name: PropTypes.string,
-    login: PropTypes.string
+    display_name: PropTypes.string.isRequired,
+    login: PropTypes.string.isRequired
   }).isRequired
 }

--- a/packages/lib-react-components/src/ZooHeader/components/UserMenu/UserMenu.js
+++ b/packages/lib-react-components/src/ZooHeader/components/UserMenu/UserMenu.js
@@ -52,7 +52,7 @@ export default function UserMenu ({ signOut, user }) {
 UserMenu.propTypes = {
   signOut: PropTypes.func.isRequired,
   user: PropTypes.shape({
-    display_name: PropTypes.string,
-    login: PropTypes.string
+    display_name: PropTypes.string.isRequired,
+    login: PropTypes.string.isRequired
   }).isRequired
 }


### PR DESCRIPTION
Package: lib-react-components, app-project

Describe your changes:
I noticed that the links to the user's profile and collections was broken in the header menu. I'm not sure what would be a good check and test for this beyond setting it as required in the prop types. I don't think it'd be a good idea to not render the menu or certain links if the user login was undefined like it was before. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

