### PR TITLE
Refactor ClassifyPage classifier area and components for mobile view

### DIFF
--- a/packages/app-project/src/components/ProjectName/ProjectName.js
+++ b/packages/app-project/src/components/ProjectName/ProjectName.js
@@ -1,27 +1,34 @@
-import { SpacedText } from '@zooniverse/react-components'
-import { Box } from 'grommet'
+import { SpacedText, withResponsiveContext } from '@zooniverse/react-components'
 import { string } from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 
 const StyledText = styled(SpacedText)`
+  text-align: center;
   transform: rotate(180deg);
   writing-mode: vertical-lr;
 `
 
 function ProjectName (props) {
-  const { projectName } = props
+  const { projectName, screenSize } = props
+
+  if (screenSize === 'small') return null
+
   return (
-    <Box pad={{ bottom: 'small', left: 'small', top: 'medium' }}>
-      <StyledText color={{ dark: 'white', light: 'black' }} size='medium' weight='bold'>
-        {projectName}
-      </StyledText>
-    </Box>
+    <StyledText
+      color={{ dark: 'white', light: 'black' }}
+      size='medium'
+      weight='bold'
+    >
+      {projectName}
+    </StyledText>
   )
 }
 
 ProjectName.propTypes = {
-  projectName: string
+  projectName: string.isRequired,
+  screenSize: string.isRequired
 }
 
-export default ProjectName
+export default withResponsiveContext(ProjectName)
+export { ProjectName }

--- a/packages/app-project/src/components/ProjectName/ProjectName.spec.js
+++ b/packages/app-project/src/components/ProjectName/ProjectName.spec.js
@@ -1,14 +1,14 @@
 import { shallow } from 'enzyme'
 import React from 'react'
 
-import ProjectName from './ProjectName'
+import { ProjectName } from './ProjectName'
 
 let wrapper
 const PROJECT_NAME = 'Foobar'
 
 describe('Component > ProjectName', function () {
   before(function () {
-    wrapper = shallow(<ProjectName projectName={PROJECT_NAME} />)
+    wrapper = shallow(<ProjectName screenSize='medium' projectName={PROJECT_NAME} />)
   })
 
   it('should render without crashing', function () {
@@ -17,5 +17,10 @@ describe('Component > ProjectName', function () {
 
   it('should render the `name` prop', function () {
     expect(wrapper.text()).to.include(PROJECT_NAME)
+  })
+
+  it('should render null if props.screenSize is small', function () {
+    wrapper.setProps({ screenSize: 'small' })
+    expect(wrapper.html()).to.be.null()
   })
 })

--- a/packages/app-project/src/components/ThemeModeToggle/ThemeModeToggle.js
+++ b/packages/app-project/src/components/ThemeModeToggle/ThemeModeToggle.js
@@ -1,6 +1,6 @@
-import { SpacedText } from '@zooniverse/react-components'
+import { SpacedText, withResponsiveContext } from '@zooniverse/react-components'
 import counterpart from 'counterpart'
-import { Button, Box } from 'grommet'
+import { Button } from 'grommet'
 import { Info } from 'grommet-icons'
 import { func, string } from 'prop-types'
 import React from 'react'
@@ -14,42 +14,44 @@ const StyledButton = styled(Button)`
   white-space: nowrap;
 
   > div {
-    flex-direction: column-reverse;
+    flex-direction: ${(props) => (props.screenSize === 'small') ? 'row' : 'column-reverse'};
   }
 `
 
 const StyledInfo = styled(Info)`
-  transform: rotate(270deg);
-  margin-top: 6px;
+  height: 1em;
+  transform: ${(props) => (props.screensize === 'small') ? 'none' : 'rotate(270deg)'};
+  margin-top: ${(props) => (props.screensize === 'small') ? '0' : '6px'};
+  width: 1em;
 `
 
 const StyledText = styled(SpacedText)`
-  transform: rotate(180deg);
-  writing-mode: vertical-lr;
+  transform: ${(props) => (props.screenSize === 'small') ? 'none' : 'rotate(180deg)'};
+  writing-mode: ${(props) => (props.screenSize === 'small') ? 'unset' : 'vertical-lr'};
 `
 
 function ThemeModeToggle (props) {
-  const { onClick, theme: { dark } } = props
+  const { onClick, screenSize, theme: { dark } } = props
   const text = dark
     ? counterpart('ThemeModeToggle.switchToLight')
     : counterpart('ThemeModeToggle.switchToDark')
 
   const Label = (
-    <StyledText color={{ dark: 'accent-2', light: 'neutral-2' }} size='medium'>
+    <StyledText color={{ dark: 'accent-2', light: 'neutral-2' }} screenSize={screenSize} size='medium'>
       {text}
     </StyledText>
   )
 
   return (
-    <Box pad={{ top: 'medium', right: 'small', bottom: 'medium' }}>
-      <StyledButton
-        a11yTitle={text}
-        icon={<StyledInfo />}
-        label={Label}
-        onClick={onClick}
-        plain
-      />
-    </Box>
+    <StyledButton
+      a11yTitle={text}
+      gap='xsmall'
+      icon={<StyledInfo screensize={screenSize} />}
+      label={Label}
+      onClick={onClick}
+      plain
+      screenSize={screenSize}
+    />
   )
 }
 
@@ -58,4 +60,4 @@ ThemeModeToggle.propTypes = {
   onClick: func
 }
 
-export default withTheme(ThemeModeToggle)
+export default withTheme(withResponsiveContext(ThemeModeToggle))

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -1,7 +1,8 @@
 import { Box, Grid } from 'grommet'
 import dynamic from 'next/dynamic'
-import { func } from 'prop-types'
+import { func, string } from 'prop-types'
 import React from 'react'
+import { withResponsiveContext } from '@zooniverse/react-components'
 
 import FinishedForTheDay from './components/FinishedForTheDay'
 import ThemeModeToggle from '../../components/ThemeModeToggle'
@@ -14,34 +15,34 @@ const ClassifierWrapper = dynamic(() =>
 )
 
 function ClassifyPage (props) {
-  const { addToCollection } = props
+  const { addToCollection, screenSize } = props
+  const responsiveColumns = (screenSize === 'small') ? ['auto'] : ['1em', 'auto', '1em']
+
   return (
-    <Grid columns={['auto', 'auto', 'auto']}>
-      <ProjectName />
-      <Box
-        gap='medium'
-        pad={{
-          horizontal: 'small',
-          vertical: 'medium'
-        }}>
+    <Box gap='medium' pad={{ horizontal: 'small', vertical: 'medium'}}>
+      <Grid columns={responsiveColumns} gap='small'>
+        <ProjectName />
         <ClassifierWrapper
           onAddToCollection={addToCollection}
         />
-        <FinishedForTheDay />
-        <Grid columns={['auto', 'auto', 'auto']} gap='medium'>
-          <YourStats />
-        </Grid>
-        <ProjectStatistics />
-        <ConnectWithProject />
-      </Box>
-      <ThemeModeToggle />
-    </Grid>
+        <ThemeModeToggle />
+      </Grid>
+
+      <FinishedForTheDay />
+      <Grid columns={['auto', 'auto', 'auto']} gap='medium'>
+        <YourStats />
+      </Grid>
+      <ProjectStatistics />
+      <ConnectWithProject />
+    </Box>
 
   )
 }
 
 ClassifyPage.propTypes = {
-  addToCollection: func
+  addToCollection: func,
+  screenSize: string
 }
 
-export default ClassifyPage
+export default withResponsiveContext(ClassifyPage)
+export { ClassifyPage }

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
@@ -1,8 +1,12 @@
 import { shallow } from 'enzyme'
 import React from 'react'
 
-import ClassifyPage from './ClassifyPage'
+import { ClassifyPage } from './ClassifyPage'
 import FinishedForTheDay from './components/FinishedForTheDay'
+import ThemeModeToggle from '../../components/ThemeModeToggle'
+import ProjectName from '../../components/ProjectName'
+import YourStats from './components/YourStats'
+import ConnectWithProject from '../../shared/components/ConnectWithProject'
 import ProjectStatistics from '../../shared/components/ProjectStatistics'
 
 let wrapper
@@ -22,5 +26,21 @@ describe('Component > ClassifyPage', function () {
 
   it('should render the `ProjectStatistics` component', function () {
     expect(wrapper.find(ProjectStatistics)).to.have.lengthOf(1)
+  })
+
+  it('should render the `ThemeModeToggle` component', function () {
+    expect(wrapper.find(ThemeModeToggle)).to.have.lengthOf(1)
+  })
+
+  it('should render the `ProjectName` component', function () {
+    expect(wrapper.find(ProjectName)).to.have.lengthOf(1)
+  })
+
+  it('should render the `YourStats` component', function () {
+    expect(wrapper.find(YourStats)).to.have.lengthOf(1)
+  })
+
+  it('should render the `ConnectWithProject` component', function () {
+    expect(wrapper.find(ConnectWithProject)).to.have.lengthOf(1)
   })
 })


### PR DESCRIPTION
Package: app-project

Describe your changes:
This refactors the ClassifyPage to hide the project name and to stack the theme toggle below the classifier on small screens.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

