### PR TITLE
Add tests for errors when loading subject images

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
@@ -7,12 +7,13 @@ import getViewer from './helpers/getViewer'
 
 function storeMapper (stores) {
   const { active: subject, loadingState } = stores.classifierStore.subjects
-  const { onSubjectReady, onError } = stores.classifierStore.subjectViewer
+  const { onSubjectReady, onError, loadingState: subjectReadyState } = stores.classifierStore.subjectViewer
   return {
     loadingState,
     onError,
     onSubjectReady,
-    subject
+    subject,
+    subjectReadyState
   }
 }
 
@@ -33,12 +34,13 @@ class SubjectViewer extends React.Component {
   }
 
   [asyncStates.success] () {
-    const { onError, onSubjectReady, subject } = this.props
+    const { onError, onSubjectReady, subject, subjectReadyState } = this.props
     const Viewer = getViewer(subject.viewer)
     return (
       <Viewer
         key={subject.id}
         subject={subject}
+        loadingState={subjectReadyState}
         onError={onError}
         onReady={onSubjectReady}
       />

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
@@ -7,9 +7,10 @@ import getViewer from './helpers/getViewer'
 
 function storeMapper (stores) {
   const { active: subject, loadingState } = stores.classifierStore.subjects
-  const { onSubjectReady } = stores.classifierStore.subjectViewer
+  const { onSubjectReady, onError } = stores.classifierStore.subjectViewer
   return {
     loadingState,
+    onError,
     onSubjectReady,
     subject
   }
@@ -32,12 +33,13 @@ class SubjectViewer extends React.Component {
   }
 
   [asyncStates.success] () {
-    const { onSubjectReady, subject } = this.props
+    const { onError, onSubjectReady, subject } = this.props
     const Viewer = getViewer(subject.viewer)
     return (
       <Viewer
         key={subject.id}
         subject={subject}
+        onError={onError}
         onReady={onSubjectReady}
       />
     )

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
@@ -6,13 +6,13 @@ import React from 'react'
 import getViewer from './helpers/getViewer'
 
 function storeMapper (stores) {
-  const { active: subject, loadingState } = stores.classifierStore.subjects
+  const { active: subject, loadingState: subjectQueueState } = stores.classifierStore.subjects
   const { onSubjectReady, onError, loadingState: subjectReadyState } = stores.classifierStore.subjectViewer
   return {
-    loadingState,
     onError,
     onSubjectReady,
     subject,
+    subjectQueueState,
     subjectReadyState
   }
 }
@@ -48,20 +48,20 @@ class SubjectViewer extends React.Component {
   }
 
   render () {
-    const { loadingState } = this.props
-    return this[loadingState]() || null
+    const { subjectQueueState } = this.props
+    return this[subjectQueueState]() || null
   }
 }
 
 SubjectViewer.wrappedComponent.propTypes = {
-  loadingState: PropTypes.oneOf(asyncStates.values),
+  subjectQueueState: PropTypes.oneOf(asyncStates.values),
   subject: PropTypes.shape({
     viewer: PropTypes.string
   })
 }
 
 SubjectViewer.wrappedComponent.defaultProps = {
-  loadingState: asyncStates.initialized
+  subjectQueueState: asyncStates.initialized
 }
 
 export default SubjectViewer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.spec.js
@@ -11,22 +11,22 @@ describe('Component > SubjectViewer', function () {
   })
 
   it('should render nothing if the subject store is initialized', function () {
-    const wrapper = shallow(<SubjectViewer.wrappedComponent loadingState={asyncStates.initialized} />)
+    const wrapper = shallow(<SubjectViewer.wrappedComponent subjectQueueState={asyncStates.initialized} />)
     expect(wrapper.type()).to.be.null
   })
 
   it('should render a loading indicator if the subject store is loading', function () {
-    const wrapper = shallow(<SubjectViewer.wrappedComponent loadingState={asyncStates.loading} />)
+    const wrapper = shallow(<SubjectViewer.wrappedComponent subjectQueueState={asyncStates.loading} />)
     expect(wrapper.text()).to.equal('Loading')
   })
 
   it('should render nothing if the subject store errors', function () {
-    const wrapper = shallow(<SubjectViewer.wrappedComponent loadingState={asyncStates.error} />)
+    const wrapper = shallow(<SubjectViewer.wrappedComponent subjectQueueState={asyncStates.error} />)
     expect(wrapper.type()).to.be.null
   })
 
   it('should render a subject viewer if the subject store successfully loads', function () {
-    const wrapper = shallow(<SubjectViewer.wrappedComponent loadingState={asyncStates.success} subject={{ viewer: 'singleImage' }} />)
+    const wrapper = shallow(<SubjectViewer.wrappedComponent subjectQueueState={asyncStates.success} subject={{ viewer: 'singleImage' }} />)
     expect(wrapper.find('SingleImageViewerContainer')).to.have.lengthOf(1)
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -10,13 +10,11 @@ class SingleImageViewerContainer extends React.Component {
     super()
     this.imageViewer = React.createRef()
     this.onLoad = this.onLoad.bind(this)
-    this.onError = this.onError.bind(this)
     this.state = {
       clientHeight: 0,
       clientWidth: 0,
       naturalHeight: 0,
-      naturalWidth: 0,
-      loading: asyncStates.initialized
+      naturalWidth: 0
     }
   }
 
@@ -35,7 +33,7 @@ class SingleImageViewerContainer extends React.Component {
   }
 
   async preloadImage () {
-    const { subject } = this.props
+    const { onError, subject } = this.props
     // TODO: Add polyfill for Object.values for IE
     this.setState({ loading: asyncStates.loading })
     try {
@@ -47,11 +45,10 @@ class SingleImageViewerContainer extends React.Component {
         clientHeight: svg.clientHeight,
         clientWidth: svg.clientWidth,
         naturalHeight: img.naturalHeight,
-        naturalWidth: img.naturalWidth,
-        loading: asyncStates.success
+        naturalWidth: img.naturalWidth
       })
     } catch (error) {
-      this.onError(error)
+      onError(error)
     }
   }
 
@@ -64,14 +61,8 @@ class SingleImageViewerContainer extends React.Component {
     onReady(fakeEvent)
   }
 
-  onError (error) {
-    console.error(error)
-    this.setState({ loading: asyncStates.error })
-  }
-
   render () {
-    const { loadingState } = this.state
-    const { subject } = this.props
+    const { loadingState, onError, subject } = this.props
     if (loadingState === asyncStates.error) {
       return (
         <div>Something went wrong.</div>
@@ -87,7 +78,7 @@ class SingleImageViewerContainer extends React.Component {
     return (
       <SingleImageViewer
         ref={this.imageViewer}
-        onError={this.onError}
+        onError={onError}
         onLoad={this.onLoad}
         url={imageUrl}
       />
@@ -96,6 +87,8 @@ class SingleImageViewerContainer extends React.Component {
 }
 
 SingleImageViewerContainer.propTypes = {
+  loadingState: PropTypes.string,
+  onError: PropTypes.func,
   onReady: PropTypes.func,
   subject: PropTypes.shape({
     locations: PropTypes.arrayOf(locationValidator)
@@ -104,6 +97,8 @@ SingleImageViewerContainer.propTypes = {
 
 SingleImageViewerContainer.defaultProps = {
   ImageObject: window.Image,
+  loadingState: asyncStates.initialized,
+  onError: () => true,
   onReady: () => true
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -24,9 +24,6 @@ class SingleImageViewerContainer extends React.Component {
     this.preloadImage()
   }
 
-  // TODO: store the subject image's naturalWidth, naturalHeight, clientWidth, and clientHeight
-  // in the classification metadata
-  // Using SVG image might need to be rethought
   fetchImage (url) {
     const { ImageObject } = this.props
     return new Promise((resolve, reject) => {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -10,16 +10,6 @@ class SingleImageViewerContainer extends React.Component {
     super()
     this.imageViewer = React.createRef()
     this.onLoad = this.onLoad.bind(this)
-    this.state = {
-      clientHeight: 0,
-      clientWidth: 0,
-      naturalHeight: 0,
-      naturalWidth: 0
-    }
-  }
-
-  componentDidMount () {
-    this.preloadImage()
   }
 
   fetchImage (url) {
@@ -32,33 +22,30 @@ class SingleImageViewerContainer extends React.Component {
     })
   }
 
-  async preloadImage () {
+  async getImageSize () {
     const { onError, subject } = this.props
     // TODO: Add polyfill for Object.values for IE
-    this.setState({ loading: asyncStates.loading })
-    try {
-      const imageUrl = Object.values(subject.locations[0])[0]
-      const img = await this.fetchImage(imageUrl)
-      const svg = this.imageViewer.current
-
-      this.setState({
-        clientHeight: svg.clientHeight,
-        clientWidth: svg.clientWidth,
-        naturalHeight: img.naturalHeight,
-        naturalWidth: img.naturalWidth
-      })
-    } catch (error) {
-      onError(error)
+    const imageUrl = Object.values(subject.locations[0])[0]
+    const img = await this.fetchImage(imageUrl)
+    const svg = this.imageViewer.current
+    return {
+      clientHeight: svg.clientHeight,
+      clientWidth: svg.clientWidth,
+      naturalHeight: img.naturalHeight,
+      naturalWidth: img.naturalWidth
     }
   }
 
-  onLoad (event) {
-    const { onReady } = this.props
-    const { clientHeight, clientWidth, naturalHeight, naturalWidth } = this.state
-    const { target } = event || {}
-    const newTarget = Object.assign({}, target, { clientHeight, clientWidth, naturalHeight, naturalWidth })
-    const fakeEvent = Object.assign({}, event, { target: newTarget })
-    onReady(fakeEvent)
+  async onLoad () {
+    const { onError, onReady } = this.props
+    try {
+      const { clientHeight, clientWidth, naturalHeight, naturalWidth } = await this.getImageSize()
+      const target = { clientHeight, clientWidth, naturalHeight, naturalWidth }
+      onReady({ target })
+    }
+    catch (error) {
+      onError(error)
+    }
   }
 
   render () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -42,8 +42,7 @@ class SingleImageViewerContainer extends React.Component {
       const { clientHeight, clientWidth, naturalHeight, naturalWidth } = await this.getImageSize()
       const target = { clientHeight, clientWidth, naturalHeight, naturalWidth }
       onReady({ target })
-    }
-    catch (error) {
+    } catch (error) {
       onError(error)
     }
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -21,7 +21,7 @@ class SingleImageViewerContainer extends React.Component {
   }
 
   componentDidMount () {
-    this.handleSubject()
+    this.preloadImage()
   }
 
   // TODO: store the subject image's naturalWidth, naturalHeight, clientWidth, and clientHeight
@@ -37,7 +37,7 @@ class SingleImageViewerContainer extends React.Component {
     })
   }
 
-  async handleSubject () {
+  async preloadImage () {
     const { subject } = this.props
     // TODO: Add polyfill for Object.values for IE
     this.setState({ loading: asyncStates.loading })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -99,23 +99,23 @@ describe('Component > SingleImageViewerContainer', function () {
     })
 
     it('should record the original image dimensions on load', function (done) {
-      setTimeout(function () {
-        const svg = wrapper.instance().imageViewer.current
-        const fakeEvent = {
-          target: {
-            clientHeight: 0,
-            clientWidth: 0
-          }
+      const svg = wrapper.instance().imageViewer.current
+      const fakeEvent = {
+        target: {
+          clientHeight: 0,
+          clientWidth: 0
         }
-        const expectedEvent = {
-          target: {
-            clientHeight: svg.clientHeight,
-            clientWidth: svg.clientWidth,
-            naturalHeight: height,
-            naturalWidth: width
-          }
+      }
+      const expectedEvent = {
+        target: {
+          clientHeight: svg.clientHeight,
+          clientWidth: svg.clientWidth,
+          naturalHeight: height,
+          naturalWidth: width
         }
-        imageWrapper.simulate('load', fakeEvent)
+      }
+      imageWrapper.simulate('load', fakeEvent)
+      setTimeout(function() {
         expect(onReady).to.have.been.calledOnceWith(expectedEvent)
         expect(onError).to.not.have.been.called
         done()
@@ -162,36 +162,36 @@ describe('Component > SingleImageViewerContainer', function () {
     })
 
     it('should log an error from the SVG image', function (done) {
+      const svg = wrapper.instance().imageViewer.current
+      const fakeSVGError = {
+        message: 'the SVG image failed to load'
+      }
+      imageWrapper.simulate('error', fakeSVGError)
       setTimeout(function() {
-        const svg = wrapper.instance().imageViewer.current
-        const fakeSVGError = {
-          message: 'the SVG image failed to load'
-        }
-        imageWrapper.simulate('error', fakeSVGError)
         expect(onError.withArgs(fakeSVGError)).to.have.been.calledOnce
         done()
       }, DELAY + 10)
     })
 
     it('should log an error from the HTML img', function (done) {
+      const svg = wrapper.instance().imageViewer.current
+      const fakeSVGError = {
+        message: 'the SVG image failed to load'
+      }
+      imageWrapper.simulate('error', fakeSVGError)
       setTimeout(function() {
-        const svg = wrapper.instance().imageViewer.current
-        const fakeSVGError = {
-          message: 'the SVG image failed to load'
-        }
-        imageWrapper.simulate('error', fakeSVGError)
         expect(onError.withArgs(HTMLImgError)).to.have.been.calledOnce
         done()
       }, DELAY + 10)
     })
 
     it('should not call onReady', function (done) {
+      const svg = wrapper.instance().imageViewer.current
+      const fakeSVGError = {
+        message: 'the SVG image failed to load'
+      }
+      imageWrapper.simulate('error', fakeSVGError)
       setTimeout(function() {
-        const svg = wrapper.instance().imageViewer.current
-        const fakeSVGError = {
-          message: 'the SVG image failed to load'
-        }
-        imageWrapper.simulate('error', fakeSVGError)
         expect(onReady).to.not.have.been.called
         done()
       }, DELAY + 10)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -10,7 +10,7 @@ describe('Component > SingleImageViewerContainer', function () {
   let wrapper
   const height = 200
   const width = 400
-  const DELAY = 100
+  const DELAY = 0
   const HTMLImgError = {
     message: 'The HTML img did not load'
   }
@@ -179,7 +179,7 @@ describe('Component > SingleImageViewerContainer', function () {
       setTimeout(function () {
         expect(onError.withArgs(HTMLImgError)).to.have.been.calledOnce
         done()
-      }, DELAY + 100)
+      }, DELAY + 10)
     })
 
     it('should not call onReady', function (done) {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -158,7 +158,6 @@ describe('Component > SingleImageViewerContainer', function () {
     })
 
     it('should log an error from an invalid SVG image', function (done) {
-      const svg = wrapper.instance().imageViewer.current
       const fakeSVGError = {
         message: 'the SVG image failed to load'
       }
@@ -184,7 +183,6 @@ describe('Component > SingleImageViewerContainer', function () {
     })
 
     it('should not call onReady', function (done) {
-      const svg = wrapper.instance().imageViewer.current
       const fakeSVGError = {
         message: 'the SVG image failed to load'
       }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -55,10 +55,6 @@ describe('Component > SingleImageViewerContainer', function () {
     it('should render null', function () {
       expect(wrapper.type()).to.equal(null)
     })
-
-    it('should throw an error', function () {
-      expect(onError).to.have.been.calledOnce
-    })
   })
 
   describe('with a valid subject', function () {
@@ -161,7 +157,7 @@ describe('Component > SingleImageViewerContainer', function () {
       expect(wrapper).to.be.ok
     })
 
-    it('should log an error from the SVG image', function (done) {
+    it('should log an error from an invalid SVG image', function (done) {
       const svg = wrapper.instance().imageViewer.current
       const fakeSVGError = {
         message: 'the SVG image failed to load'
@@ -173,16 +169,18 @@ describe('Component > SingleImageViewerContainer', function () {
       }, DELAY + 10)
     })
 
-    it('should log an error from the HTML img', function (done) {
-      const svg = wrapper.instance().imageViewer.current
-      const fakeSVGError = {
-        message: 'the SVG image failed to load'
+    it('should log an error from an invalid HTML img', function (done) {
+      const fakeEvent = {
+        target: {
+          clientHeight: 0,
+          clientWidth: 0
+        }
       }
-      imageWrapper.simulate('error', fakeSVGError)
+      imageWrapper.simulate('load', fakeEvent)
       setTimeout(function() {
         expect(onError.withArgs(HTMLImgError)).to.have.been.calledOnce
         done()
-      }, DELAY + 10)
+      }, DELAY + 100)
     })
 
     it('should not call onReady', function (done) {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -17,7 +17,7 @@ describe('Component > SingleImageViewerContainer', function () {
 
   // mock an image that loads after a delay of 0.1s
   class ValidImage {
-    constructor() {
+    constructor () {
       this.naturalHeight = height
       this.naturalWidth = width
       setTimeout(() => this.onload(), DELAY)
@@ -26,7 +26,7 @@ describe('Component > SingleImageViewerContainer', function () {
 
   // mock an image that errors after a delay of 0.1s
   class InvalidImage {
-    constructor() {
+    constructor () {
       this.naturalHeight = height
       this.naturalWidth = width
       setTimeout(() => this.onerror(HTMLImgError), DELAY)
@@ -111,7 +111,7 @@ describe('Component > SingleImageViewerContainer', function () {
         }
       }
       imageWrapper.simulate('load', fakeEvent)
-      setTimeout(function() {
+      setTimeout(function () {
         expect(onReady).to.have.been.calledOnceWith(expectedEvent)
         expect(onError).to.not.have.been.called
         done()
@@ -128,7 +128,7 @@ describe('Component > SingleImageViewerContainer', function () {
       const subject = {
         id: 'test',
         locations: [
-          { 'image/jpeg': ''}
+          { 'image/jpeg': '' }
         ]
       }
       wrapper = shallow(
@@ -163,7 +163,7 @@ describe('Component > SingleImageViewerContainer', function () {
         message: 'the SVG image failed to load'
       }
       imageWrapper.simulate('error', fakeSVGError)
-      setTimeout(function() {
+      setTimeout(function () {
         expect(onError.withArgs(fakeSVGError)).to.have.been.calledOnce
         done()
       }, DELAY + 10)
@@ -177,7 +177,7 @@ describe('Component > SingleImageViewerContainer', function () {
         }
       }
       imageWrapper.simulate('load', fakeEvent)
-      setTimeout(function() {
+      setTimeout(function () {
         expect(onError.withArgs(HTMLImgError)).to.have.been.calledOnce
         done()
       }, DELAY + 100)
@@ -189,7 +189,7 @@ describe('Component > SingleImageViewerContainer', function () {
         message: 'the SVG image failed to load'
       }
       imageWrapper.simulate('error', fakeSVGError)
-      setTimeout(function() {
+      setTimeout(function () {
         expect(onReady).to.not.have.been.called
         done()
       }, DELAY + 10)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -42,8 +42,10 @@ describe('Component > SingleImageViewerContainer', function () {
   })
 
   describe('without a subject', function () {
+    const onError = sinon.stub()
+
     before(function () {
-      wrapper = shallow(<SingleImageViewerContainer />)
+      wrapper = shallow(<SingleImageViewerContainer onError={onError} />)
     })
 
     it('should render without crashing', function () {
@@ -54,14 +56,15 @@ describe('Component > SingleImageViewerContainer', function () {
       expect(wrapper.type()).to.equal(null)
     })
 
-    it('should log an error in the console', function () {
-      expect(console.error).to.have.been.calledOnce
+    it('should throw an error', function () {
+      expect(onError).to.have.been.calledOnce
     })
   })
 
   describe('with a valid subject', function () {
     let imageWrapper
-    let onReady = sinon.stub()
+    const onReady = sinon.stub()
+    const onError = sinon.stub()
 
     before(function () {
       const subject = {
@@ -74,6 +77,7 @@ describe('Component > SingleImageViewerContainer', function () {
         <SingleImageViewerContainer
           ImageObject={ValidImage}
           subject={subject}
+          onError={onError}
           onReady={onReady}
         />
       )
@@ -113,6 +117,7 @@ describe('Component > SingleImageViewerContainer', function () {
         }
         imageWrapper.simulate('load', fakeEvent)
         expect(onReady).to.have.been.calledOnceWith(expectedEvent)
+        expect(onError).to.not.have.been.called
         done()
       }, DELAY + 10)
     })
@@ -120,7 +125,8 @@ describe('Component > SingleImageViewerContainer', function () {
 
   describe('with an invalid subject', function () {
     let imageWrapper
-    let onReady = sinon.stub()
+    const onReady = sinon.stub()
+    const onError = sinon.stub()
 
     before(function () {
       const subject = {
@@ -133,6 +139,7 @@ describe('Component > SingleImageViewerContainer', function () {
         <SingleImageViewerContainer
           ImageObject={InvalidImage}
           subject={subject}
+          onError={onError}
           onReady={onReady}
         />
       )
@@ -145,7 +152,8 @@ describe('Component > SingleImageViewerContainer', function () {
       }
     })
 
-    afterEach(function () {
+    after(function () {
+      onError.resetHistory()
       onReady.resetHistory()
     })
 
@@ -160,8 +168,7 @@ describe('Component > SingleImageViewerContainer', function () {
           message: 'the SVG image failed to load'
         }
         imageWrapper.simulate('error', fakeSVGError)
-        expect(wrapper.state('loading')).to.equal(asyncStates.error)
-        expect(console.error.withArgs(fakeSVGError)).to.have.been.calledOnce
+        expect(onError.withArgs(fakeSVGError)).to.have.been.calledOnce
         done()
       }, DELAY + 10)
     })
@@ -173,7 +180,7 @@ describe('Component > SingleImageViewerContainer', function () {
           message: 'the SVG image failed to load'
         }
         imageWrapper.simulate('error', fakeSVGError)
-        expect(console.error.withArgs(HTMLImgError)).to.have.been.calledOnce
+        expect(onError.withArgs(HTMLImgError)).to.have.been.calledOnce
         done()
       }, DELAY + 10)
     })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -110,12 +110,12 @@ describe('Component > SingleImageViewerContainer', function () {
           naturalWidth: width
         }
       }
-      imageWrapper.simulate('load', fakeEvent)
-      setTimeout(function () {
+      onReady.callsFake(function () {
         expect(onReady).to.have.been.calledOnceWith(expectedEvent)
         expect(onError).to.not.have.been.called
         done()
-      }, DELAY + 10)
+      })
+      imageWrapper.simulate('load', fakeEvent)
     })
   })
 
@@ -161,11 +161,11 @@ describe('Component > SingleImageViewerContainer', function () {
       const fakeSVGError = {
         message: 'the SVG image failed to load'
       }
-      imageWrapper.simulate('error', fakeSVGError)
-      setTimeout(function () {
+      onError.callsFake(function () {
         expect(onError.withArgs(fakeSVGError)).to.have.been.calledOnce
         done()
-      }, DELAY + 10)
+      })
+      imageWrapper.simulate('error', fakeSVGError)
     })
 
     it('should log an error from an invalid HTML img', function (done) {
@@ -175,22 +175,22 @@ describe('Component > SingleImageViewerContainer', function () {
           clientWidth: 0
         }
       }
-      imageWrapper.simulate('load', fakeEvent)
-      setTimeout(function () {
+      onError.callsFake(function () {
         expect(onError.withArgs(HTMLImgError)).to.have.been.calledOnce
         done()
-      }, DELAY + 10)
+      })
+      imageWrapper.simulate('load', fakeEvent)
     })
 
     it('should not call onReady', function (done) {
       const fakeSVGError = {
         message: 'the SVG image failed to load'
       }
-      imageWrapper.simulate('error', fakeSVGError)
-      setTimeout(function () {
+      onError.callsFake(function () {
         expect(onReady).to.not.have.been.called
         done()
-      }, DELAY + 10)
+      })
+      imageWrapper.simulate('error', fakeSVGError)
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -13,11 +13,11 @@ function storeMapper (stores) {
   const { loadingState } = stores.classifierStore.workflows
   const { active: step } = stores.classifierStore.workflowSteps
   const tasks = stores.classifierStore.workflowSteps.activeStepTasks
-  const { ready } = stores.classifierStore.subjectViewer
+  const { loadingState: subjectReadyState } = stores.classifierStore.subjectViewer
   return {
     loadingState,
-    ready,
     step,
+    subjectReadyState,
     tasks
   }
 }
@@ -39,7 +39,8 @@ export class Tasks extends React.Component {
   }
 
   [asyncStates.success] () {
-    const { ready, tasks } = this.props
+    const { subjectReadyState, tasks } = this.props
+    const ready = subjectReadyState === asyncStates.success
     if (tasks.length > 0) {
       // setting the wrapping box of the task component to a basis of 246px feels hacky,
       // but gets the area to be the same 453px height (or very close) as the subject area

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
@@ -52,7 +52,7 @@ describe('Tasks', function () {
         const wrapper = shallow(
           <Tasks.wrappedComponent
             loadingState={asyncStates.success}
-            ready={false}
+            subjectReadyState={asyncStates.loading}
             tasks={tasks}
           />
         )
@@ -69,7 +69,7 @@ describe('Tasks', function () {
         const wrapper = shallow(
           <Tasks.wrappedComponent
             loadingState={asyncStates.success}
-            ready
+            subjectReadyState={asyncStates.success}
             tasks={tasks}
           />
         )

--- a/packages/lib-classifier/src/store/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.js
@@ -1,3 +1,4 @@
+import asyncStates from '@zooniverse/async-states'
 import { autorun } from 'mobx'
 import { addDisposer, getRoot, types } from 'mobx-state-tree'
 
@@ -15,7 +16,7 @@ const SubjectViewer = types
     fullscreen: types.optional(types.boolean, false),
     move: types.optional(types.boolean, false),
     layout: types.optional(types.enumeration('layout', layouts.values), layouts.default),
-    ready: types.optional(types.boolean, false)
+    loadingState: types.optional(types.enumeration('loadingState', asyncStates.values), asyncStates.initialized)
   })
 
   .volatile(self => ({
@@ -69,6 +70,11 @@ const SubjectViewer = types
         self.fullscreen = false
       },
 
+      onError (error) {
+        console.error(error)
+        self.loadingState = asyncStates.error
+      },
+
       onSubjectReady (event) {
         const { target = {} } = event || {}
         const {
@@ -78,11 +84,11 @@ const SubjectViewer = types
           naturalWidth = 0
         } = target
         self.dimensions.push({ clientHeight, clientWidth, naturalHeight, naturalWidth })
-        self.ready = true
+        self.loadingState = asyncStates.success
       },
 
       resetSubject () {
-        self.ready = false
+        self.loadingState = asyncStates.loading
         self.dimensions = []
       },
 


### PR DESCRIPTION
Package:
lib-classifier

Mock a bad image for the single image viewer and stub console error logging. Test the component error handler for the cases where either the HTML `img` or the SVG `image` elements throw an error.

Rename `handleSubject` to `getImageSize`, to make its purpose clear.

Add an `onError` action to the subject viewer store and use that to handle subject viewer errors. Rename `SubjectViewerStore.ready` to `SubjectViewerStore.loadingState` and change it from a boolean to an enumeration of loading states.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

