### PR TITLE
Fix field guide, metadata, help and tutorial for dark theme

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/Banner/Banner.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/Banner/Banner.js
@@ -1,7 +1,7 @@
 import { SpacedText } from '@zooniverse/react-components'
 import counterpart from 'counterpart'
 import { Box, Button, Drop } from 'grommet'
-import { array, bool, oneOf, oneOfType, shape, string } from 'prop-types'
+import { array, bool, oneOfType, shape, string } from 'prop-types'
 import React, { Component, createRef } from 'react'
 import styled, { withTheme } from 'styled-components'
 import posed, { PoseGroup } from 'react-pose'
@@ -59,7 +59,7 @@ class Banner extends Component {
       background,
       bannerText,
       className,
-      theme: { mode },
+      theme: { dark },
       show,
       tooltipText
     } = this.props
@@ -101,7 +101,7 @@ class Banner extends Component {
                 <Box direction='column' margin='xsmall'>
                   <Triangle />
                   <Box
-                    background={mode === 'light' ? 'white' : 'dark-2'}
+                    background={dark ? 'dark-2' : 'white'}
                     pad='small'
                   >
                     <TooltipText text={tooltipText} />
@@ -121,7 +121,7 @@ Banner.propTypes = {
   bannerText: string.isRequired,
   show: bool,
   theme: shape({
-    mode: oneOf(['dark', 'light'])
+    dark: bool
   }),
   tooltipText: oneOfType([
     array,
@@ -130,7 +130,10 @@ Banner.propTypes = {
 }
 
 Banner.defaultProps = {
-  show: false
+  show: false,
+  theme: {
+    dark: false
+  }
 }
 
 export default withTheme(Banner)

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/Banner/Banner.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/Banner/Banner.spec.js
@@ -7,16 +7,12 @@ let wrapper
 
 const BANNER_TEXT = 'Foobar'
 const TOOLTIP_TEXT = 'Baz'
-const THEME = {
-  mode: 'light'
-}
 
 const COMPONENT = (
   <Banner
     background='red'
     bannerText={BANNER_TEXT}
     show
-    theme={THEME}
     tooltipText={TOOLTIP_TEXT}
   />
 )

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/Banner/components/Triangle/Triangle.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/Banner/components/Triangle/Triangle.js
@@ -1,5 +1,5 @@
 import { Box } from 'grommet'
-import { oneOf, shape, string } from 'prop-types'
+import { bool, shape, string } from 'prop-types'
 import React from 'react'
 import styled, { withTheme } from 'styled-components'
 
@@ -13,8 +13,7 @@ const SVG = styled.svg`
 
 function Triangle (props) {
   const { theme } = props
-  const { colors } = theme.global
-  const fill = (theme.mode === 'light') ? colors.white : colors['dark-2']
+  const fill = theme.dark ? theme.global.colors['dark-2'] : theme.global.colors.white
 
   return (
     <Box
@@ -38,8 +37,20 @@ Triangle.propTypes = {
         white: string
       })
     }),
-    mode: oneOf(['dark', 'light'])
+    dark: bool
   })
+}
+
+Triangle.defaultProps = {
+  theme: {
+    dark: false,
+    global: {
+      colors: {
+        'dark-2': '',
+        white: ''
+      }
+    }
+  }
 }
 
 export default withTheme(Triangle)

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { inject, observer } from 'mobx-react'
 import { Button, Box } from 'grommet'
+import { withTheme } from 'styled-components'
 import { Modal } from '@zooniverse/react-components'
 import counterpart from 'counterpart'
 import en from './locales/en'
@@ -27,12 +28,13 @@ function storeMapper (stores) {
   }
 }
 
+@withTheme
 @inject(storeMapper)
 @observer
 class FeedbackModal extends React.Component {
   render () {
     const label = counterpart('FeedbackModal.label')
-    const { applicableRules, hideFeedback, hideSubjectViewer, messages, showModal } = this.props
+    const { applicableRules, hideFeedback, hideSubjectViewer, messages, showModal, theme } = this.props
     const showViewer = !hideSubjectViewer && applicableRules && applicableRules.length > 0
     let FeedbackViewer = null
     if (showViewer) {
@@ -44,6 +46,7 @@ class FeedbackModal extends React.Component {
         <Modal
           active={showModal}
           closeFn={hideFeedback}
+          theme={theme}
           title={label}
         >
           <>

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideContainer.js
@@ -3,6 +3,7 @@ import counterpart from 'counterpart'
 import React from 'react'
 import PropTypes from 'prop-types'
 import { inject, observer } from 'mobx-react'
+import { withTheme } from 'styled-components'
 import FieldGuideButton from './components/FieldGuideButton'
 import FieldGuide from './components/FieldGuide'
 import en from './locales/en'
@@ -17,6 +18,7 @@ function storeMapper (stores) {
   }
 }
 
+@withTheme
 @inject(storeMapper)
 @observer
 class FieldGuideContainer extends React.Component {
@@ -27,7 +29,8 @@ class FieldGuideContainer extends React.Component {
 
   render () {
     const {
-      showModal
+      showModal,
+      theme
     } = this.props
 
     return (
@@ -39,6 +42,7 @@ class FieldGuideContainer extends React.Component {
           modal={false}
           pad='medium'
           position='right'
+          theme={theme}
           title={counterpart('FieldGuide.title')}
         >
           <FieldGuide />

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/Metadata.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/Metadata.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import MetadataButton from './components/MetadataButton'
-import { MetadataModal } from './components/MetadataModal'
+import MetadataModal from './components/MetadataModal'
 
 export default class Metadata extends React.Component {
   constructor () {

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/Metadata.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/Metadata.spec.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import Metadata from './Metadata'
 import MetadataButton from './components/MetadataButton'
+import MetadataModal from './components/MetadataModal'
 
 describe('Metadata', function () {
   it('should render without crashing', function () {
@@ -16,7 +17,7 @@ describe('Metadata', function () {
     })
 
     it('should not render the MetadataModal', function () {
-      expect(wrapper.find('MetadataModal')).to.have.lengthOf(0)
+      expect(wrapper.find(MetadataModal)).to.have.lengthOf(0)
     })
 
     it('should disable the MetadataButton', function () {
@@ -31,7 +32,7 @@ describe('Metadata', function () {
     })
 
     it('should render the MetadataModal', function () {
-      expect(wrapper.find('MetadataModal')).to.have.lengthOf(1)
+      expect(wrapper.find(MetadataModal)).to.have.lengthOf(1)
     })
 
     it('should not disable the MetadataButton', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.js
@@ -3,7 +3,7 @@ import counterpart from 'counterpart'
 import { Box, DataTable, Text } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled from 'styled-components'
+import styled, { withTheme } from 'styled-components'
 import filterByLabel, { filters } from './filterByLabel'
 import en from './locales/en'
 
@@ -39,13 +39,14 @@ export function formatValue (value) {
   return ''
 }
 
-export default function MetadataModal (props) {
+export function MetadataModal (props) {
   const {
     active,
     closeFn,
     filters,
     metadata,
-    prefixes
+    prefixes,
+    theme
   } = props
 
   const columns = [{
@@ -73,6 +74,7 @@ export default function MetadataModal (props) {
     <Modal
       active={active}
       closeFn={closeFn}
+      theme={theme}
       title={counterpart('MetadataModal.title')}
     >
       <Box height='medium' overflow='auto'>
@@ -100,3 +102,5 @@ MetadataModal.propTypes = {
   metadata: PropTypes.object.isRequired,
   prefixes: PropTypes.arrayOf(PropTypes.string)
 }
+
+export default withTheme(MetadataModal)

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.spec.js
@@ -3,7 +3,9 @@ import { shallow } from 'enzyme'
 import { expect } from 'chai'
 import { Modal } from '@zooniverse/react-components'
 
-import MetadataModal from './MetadataModal'
+import { MetadataModal } from './MetadataModal'
+
+let wrapper
 
 const metadata = {
   id: '1',
@@ -13,34 +15,32 @@ const metadata = {
 }
 
 describe('MetadataModal', function () {
+  before(function () {
+    wrapper = shallow(<MetadataModal metadata={metadata} />)
+  })
+
   it('should render without crashing', function () {
-    const wrapper = shallow(<MetadataModal metadata={metadata} />)
     expect(wrapper).to.be.ok
   })
 
   it('should render a Modal', function () {
-    const wrapper = shallow(<MetadataModal metadata={metadata} />)
     expect(wrapper.find(Modal)).to.have.lengthOf(1)
   })
 
   it('should render a styled Grommet DataTable', function () {
-    const wrapper = shallow(<MetadataModal metadata={metadata} />)
     expect(wrapper.find('Styled(DataTable)')).to.have.lengthOf(1)
   })
 
   it('should render the correct number of table rows', function () {
-    const wrapper = shallow(<MetadataModal metadata={metadata} />)
     expect(wrapper.find('Styled(DataTable)').props().data).to.have.lengthOf(Object.keys(metadata).length - 2)
   })
 
   it('should add the +tab+ prefix to metadata urls', function () {
-    const wrapper = shallow(<MetadataModal metadata={metadata} />)
     const href = wrapper.find('Styled(DataTable)').props().data[1]
     expect(href.value.props.children.includes('+tab+')).to.be.true
   })
 
   it('should not render metadata prefixed with # or !', function () {
-    const wrapper = shallow(<MetadataModal metadata={metadata} />)
     wrapper.find('Styled(DataTable)').props().data.forEach((datum) => {
       expect(datum.label.includes('#')).to.be.false
       expect(datum.label.includes('!')).to.be.false

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/index.js
@@ -1,4 +1,4 @@
 import { filters } from './filterByLabel'
-export { default as MetadataModal } from './MetadataModal'
+export { default } from './MetadataModal'
 export { default as filterByLabel } from './filterByLabel'
 export { filters }

--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.js
@@ -3,6 +3,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
 import { ResponsiveContext } from 'grommet'
+import { withTheme } from 'styled-components'
 import { Modal } from '@zooniverse/react-components'
 import asyncStates from '@zooniverse/async-states'
 import SlideTutorial from '../SlideTutorial'
@@ -20,6 +21,7 @@ function storeMapper (stores) {
   }
 }
 
+@withTheme
 @inject(storeMapper)
 @observer
 class ModalTutorial extends React.Component {
@@ -35,7 +37,7 @@ class ModalTutorial extends React.Component {
   }
 
   render () {
-    const { loadingState, showModal, tutorial } = this.props
+    const { loadingState, showModal, theme, tutorial } = this.props
     if (loadingState === asyncStates.success && tutorial) {
       return (
         <Modal

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskHelp/TaskHelp.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskHelp/TaskHelp.js
@@ -4,7 +4,7 @@ import { Button, Box } from 'grommet'
 import { inject, observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled from 'styled-components'
+import styled, { withTheme } from 'styled-components'
 
 import en from './locales/en'
 
@@ -23,6 +23,7 @@ function storeMapper (stores) {
   }
 }
 
+@withTheme
 @inject(storeMapper)
 @observer
 class TaskHelp extends React.Component {
@@ -36,7 +37,7 @@ class TaskHelp extends React.Component {
 
   render () {
     const label = counterpart('TaskHelp.label')
-    const { isThereTaskHelp, tasks } = this.props
+    const { isThereTaskHelp, tasks, theme } = this.props
 
     if (isThereTaskHelp) {
       return (
@@ -51,6 +52,7 @@ class TaskHelp extends React.Component {
           <Modal
             active={this.state.showModal}
             closeFn={() => this.setState({ showModal: false })}
+            theme={theme}
             title={label}
           >
             <>

--- a/packages/lib-react-components/src/Modal/Modal.js
+++ b/packages/lib-react-components/src/Modal/Modal.js
@@ -1,18 +1,19 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import { Grommet } from 'grommet'
 
 import WithLayer from './WithLayer'
 import ModalBody from './components/ModalBody'
 import ModalHeading from './components/ModalHeading'
 
-function Modal ({ children, className, closeFn, pad, title }) {
+function Modal ({ children, className, closeFn, pad, theme, title }) {
   return (
-    <React.Fragment>
+    <Grommet theme={theme}>
       <ModalHeading className={className} closeFn={closeFn} title={title} />
       <ModalBody className={className} pad={pad}>
         {children}
       </ModalBody>
-    </React.Fragment>
+    </Grommet>
   )
 }
 


### PR DESCRIPTION
Package: lib-classifier, lib-react-components

Closes #643 

Describe your changes:
- temporary solution until issue related to React or Grommet can be sorted
- passes updated theme as prop to Modal component
- adds `<Grommet theme={theme} />` to Modal component

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

