### PR TITLE
Set asset prefix to correctly fetch resources

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -69,10 +69,8 @@ spec:
           ports:
             - containerPort: 3000
           env:
-            - name: PANOPTES_ENV
-              value: production
-            - name: NODE_ENV
-              value: production
+            - name: ASSET_PREFIX
+              value: https://fe-content-pages.zooniverse.org
             - name: CONTENTFUL_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -83,3 +81,7 @@ spec:
                 secretKeyRef:
                   name: contentful-conf
                   key: CONTENTFUL_SPACE_ID
+            - name: NODE_ENV
+              value: production
+            - name: PANOPTES_ENV
+              value: production

--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -9,9 +9,9 @@
     "_check": "check-engines && check-dependencies",
     "_test": "npm run _check && BABEL_ENV=test mocha",
     "build": "npm run _check && PANOPTES_ENV=production next build",
-    "dev": "npm run _check && PANOPTES_ENV=production next",
+    "dev": "npm run _check && PANOPTES_ENV=production node server/server.js",
     "lint": "npm run _check && standard --fix | snazzy; exit 0",
-    "start": "npm run _check && NODE_ENV=production next",
+    "start": "npm run _check && NODE_ENV=production node server/server.js",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "test": "npm run _test && exit 0",
     "test:ci": "npm run _test -- --reporter=min"

--- a/packages/app-content-pages/server/server.js
+++ b/packages/app-content-pages/server/server.js
@@ -1,0 +1,24 @@
+const next = require('next')
+const http = require('http')
+
+const assetPrefix = process.env.ASSET_PREFIX || ''
+const dev = process.env.NODE_ENV !== 'production'
+const port = parseInt(process.env.PORT, 10) || 3000
+
+const app = next({ dev })
+const handleNextRequests = app.getRequestHandler()
+
+app.prepare().then(() => {
+  const server = new http.Server((req, res) => {
+    app.setAssetPrefix(assetPrefix)
+    handleNextRequests(req, res)
+  })
+
+  server.listen(port, err => {
+    if (err) {
+      throw err
+    }
+
+    console.log(`> Ready on http://localhost:${port}`)
+  })
+})


### PR DESCRIPTION
Sets the asset prefix, so JS bundles are correctly fetched from the specific app subdomain, rather than falling back to `www.zooniverse.org` (where they don't exist)

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

