### PR TITLE
Allow asset prefix for app-project

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -42,9 +42,11 @@ spec:
           ports:
             - containerPort: 3000
           env:
-            - name: PANOPTES_ENV
-              value: production
+            - name: ASSET_PREFIX
+              value: https://fe-project.zooniverse.org
             - name: NODE_ENV
+              value: production
+            - name: PANOPTES_ENV
               value: production
 ---
 apiVersion: apps/v1

--- a/packages/app-project/server/server.js
+++ b/packages/app-project/server/server.js
@@ -3,8 +3,10 @@ const next = require('next')
 const pathMatch = require('path-match')
 const { parse } = require('url')
 
-const port = parseInt(process.env.PORT, 10) || 3000
+const assetPrefix = process.env.ASSET_PREFIX || ''
 const dev = process.env.NODE_ENV !== 'production'
+const port = parseInt(process.env.PORT, 10) || 3000
+
 const app = next({ dev })
 const handle = app.getRequestHandler()
 const route = pathMatch()
@@ -15,6 +17,7 @@ app.prepare()
   .then(() => {
     createServer((req, res) => {
       const { pathname, query } = parse(req.url, true)
+      app.setAssetPrefix(assetPrefix)
 
       // assigning `query` into the params means that we still
       // get the query string passed to our application


### PR DESCRIPTION
Following on from the setting for app-content-pages, this allows the setting of `assetPrefix` for the project app.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

