### PR TITLE
Set message container height if viewer is present

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
@@ -38,6 +38,7 @@ class FeedbackModal extends React.Component {
     if (showViewer) {
       FeedbackViewer = getFeedbackViewer(applicableRules)
     }
+    const messageContainerHeight = showViewer ? '200px' : '100%'
 
     if (showModal) {
       return (
@@ -52,10 +53,10 @@ class FeedbackModal extends React.Component {
               width='medium'
             >
               {showViewer && (
-                  <Box height='100%'>
-                    <FeedbackViewer />
-                  </Box>)}
-              <Box overflow='scroll'>
+                <Box height='100%'>
+                  <FeedbackViewer />
+                </Box>)}
+              <Box height={messageContainerHeight} overflow='scroll'>
                 <ul>
                   {messages.map(message =>
                     <li key={Math.random()}>

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
@@ -49,8 +49,8 @@ class FeedbackModal extends React.Component {
         >
           <>
             <Box
-              height='medium'
-              width='medium'
+              height='large'
+              width='large'
             >
               {showViewer && (
                 <Box height='100%'>


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
Sets message container to a smaller fixed height if the viewer is present. Makes the modal itself larger:

<img width="1430" alt="Screen Shot 2019-05-17 at 10 39 48 AM" src="https://user-images.githubusercontent.com/5016731/57939689-79775c00-7890-11e9-822d-51bc8006acbf.png">


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

