### PR TITLE
Set light and dark background for drop container in theme

### DIFF
--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -119,6 +119,12 @@ const theme = deepFreeze({
       }
     },
     colors,
+    drop: {
+      background: {
+        dark: 'dark-1',
+        light: 'light-1'
+      }
+    },
     edgeSize: {
       xxsmall: '5px',
       xsmall: `10px`,


### PR DESCRIPTION
Package: lib-grommet-theme

Closes #855

Describe your changes:
Sets the light and dark background colors for the drop. This can be checked with the Select component in the collections modal in the app-project.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

