### PR TITLE
Temporarily disable the stats widget

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -29,9 +29,9 @@ function ClassifyPage (props) {
       </Grid>
 
       <FinishedForTheDay />
-      <Grid columns={['auto', 'auto', 'auto']} gap='medium'>
+      {false && <Grid columns={['auto', 'auto', 'auto']} gap='medium'>
         <YourStats />
-      </Grid>
+      </Grid>}
       <ProjectStatistics />
       <ConnectWithProject />
     </Box>

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
@@ -36,7 +36,7 @@ describe('Component > ClassifyPage', function () {
     expect(wrapper.find(ProjectName)).to.have.lengthOf(1)
   })
 
-  it('should render the `YourStats` component', function () {
+  xit('should render the `YourStats` component', function () {
     expect(wrapper.find(YourStats)).to.have.lengthOf(1)
   })
 


### PR DESCRIPTION
Temporarily disables the stats widget, as it's not really required for the TESS production launch.

cc #38 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

