### PR TITLE
Fix dark theme controls

### DIFF
--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -204,6 +204,10 @@ const theme = deepFreeze({
         light: 'brand'
       }
     },
+    color: {
+      dark: 'accent-2',
+      light: 'brand'
+    },
     hover: {
       border: {
         color: {
@@ -416,6 +420,27 @@ const theme = deepFreeze({
     },
     extend: props => `margin: ${props.margin || '1em 0 1em 0'}`
   },
+  radioButton: {
+    check: {
+      color: {
+        dark: 'accent-2',
+        light: 'brand',
+      }
+    },
+    color: {
+      dark: 'accent-2',
+      light: 'brand',
+    },
+    icon: {
+      size: '15px',
+      extend: `
+        circle {
+          r: 10px;
+        }
+      `
+    },
+    size: '15px'
+  },
   text: {
     xsmall: {
       size: "12px",
@@ -447,27 +472,6 @@ const theme = deepFreeze({
       height: "38px",
       maxWidth: "100%"
     }
-  },
-  radioButton: {
-    check: {
-      color: {
-        dark: 'accent-2',
-        light: 'brand',
-      }
-    },
-    color: {
-      dark: 'accent-2',
-      light: 'brand',
-    },
-    icon: {
-      size: '15px',
-      extend: `
-        circle {
-          r: 10px;
-        }
-      `
-    },
-    size: '15px'
   }
 })
 

--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -441,6 +441,14 @@ const theme = deepFreeze({
     },
     size: '15px'
   },
+  select: {
+    icons: {
+      color: {
+        dark: 'accent-2',
+        light: 'brand',
+      }
+    }
+  },
   text: {
     xsmall: {
       size: "12px",

--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -449,9 +449,23 @@ const theme = deepFreeze({
     }
   },
   radioButton: {
+    check: {
+      color: {
+        dark: 'accent-2',
+        light: 'brand',
+      }
+    },
+    color: {
+      dark: 'accent-2',
+      light: 'brand',
+    },
     icon: {
       size: '15px',
-      extend: 'circle { r: 10px; }'
+      extend: `
+        circle {
+          r: 10px;
+        }
+      `
     },
     size: '15px'
   }


### PR DESCRIPTION
Uses `accent-2` for the dark theme controls, closes #852