### PR TITLE
Fix field guide titles

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.js
@@ -24,7 +24,7 @@ const StyledButton = styled(Button)`
 `
 
 const markdownTitleComponent = {
-  h3: (nodeProps) => <Heading level='3' margin='none'>{nodeProps.children}</Heading>
+  h3: (nodeProps) => <SpacedHeading level='3' margin='none'>{nodeProps.children}</SpacedHeading>
 }
 
 const markdownComponents = {
@@ -58,7 +58,7 @@ class FieldGuideItem extends React.Component {
           border={{ color: 'light-5', side: 'bottom' }}
           direction='row'
           flex={{ grow: 1, shrink: 0 }}
-          pad={{ bottom: 'small' }}
+          pad={{ bottom: 'xsmall' }}
         >
           <StyledButton
             a11yTitle={counterpart('FieldGuideItem.ariaTitle')}

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.js
@@ -1,4 +1,3 @@
-import zooTheme from '@zooniverse/grommet-theme'
 import { Markdownz } from '@zooniverse/react-components'
 import counterpart from 'counterpart'
 import { Button, Box, Heading, Paragraph } from 'grommet'
@@ -25,7 +24,7 @@ const StyledButton = styled(Button)`
 `
 
 const markdownTitleComponent = {
-  h3: (nodeProps) => <Heading level='3' margin='none'>{nodeProps.children}</Heading>,
+  h3: (nodeProps) => <Heading level='3' margin='none'>{nodeProps.children}</Heading>
 }
 
 const markdownComponents = {

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.js
@@ -1,14 +1,16 @@
-import { Button, Box } from 'grommet'
-import { FormPrevious } from 'grommet-icons'
-import styled from 'styled-components'
-import React from 'react'
-import { Markdownz } from '@zooniverse/react-components'
 import zooTheme from '@zooniverse/grommet-theme'
-import PropTypes from 'prop-types'
+import { Markdownz } from '@zooniverse/react-components'
+import counterpart from 'counterpart'
+import { Button, Box, Heading, Paragraph } from 'grommet'
+import { FormPrevious } from 'grommet-icons'
 import { observable } from 'mobx'
 import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
+import PropTypes from 'prop-types'
+import React from 'react'
+import styled, { withTheme } from 'styled-components'
+
+import SpacedHeading from './components/SpacedHeading'
 import FieldGuideItemIcon from '../FieldGuideItemIcon'
-import counterpart from 'counterpart'
 import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
@@ -17,29 +19,24 @@ const StyledButton = styled(Button)`
   padding: 0;
 
   &:hover > svg, &:focus > svg {
-    fill: ${zooTheme.global.colors['dark-5']};
-    stroke: ${zooTheme.global.colors['dark-5']};
+    fill: ${props => props.theme.global.colors['dark-5']};
+    stroke: ${props => props.theme.global.colors['dark-5']};
   }
 `
 
-const FieldGuideItemHeader = styled(Box)`
-  > h3 {
-    margin: 0;
-  }
-`
+const markdownTitleComponent = {
+  h3: (nodeProps) => <Heading level='3' margin='none'>{nodeProps.children}</Heading>,
+}
 
-const FieldGuideItemContent = styled(Box)`
-  > h1, h2, h3, h4, h5, h6 {
-    font-size: 14px;
-    letter-spacing: 1.5px;
-    line-height: 17px;
-    margin: 5px 0;
-  }
-
-  > p {
-    margin: 5px 0;
-  }
-`
+const markdownComponents = {
+  h1: (nodeProps) => <SpacedHeading level='1'>{nodeProps.children}</SpacedHeading>,
+  h2: (nodeProps) => <SpacedHeading level='2'>{nodeProps.children}</SpacedHeading>,
+  h3: (nodeProps) => <SpacedHeading level='3'>{nodeProps.children}</SpacedHeading>,
+  h4: (nodeProps) => <SpacedHeading level='4'>{nodeProps.children}</SpacedHeading>,
+  h5: (nodeProps) => <SpacedHeading level='5'>{nodeProps.children}</SpacedHeading>,
+  h6: (nodeProps) => <SpacedHeading level='6'>{nodeProps.children}</SpacedHeading>,
+  p: (nodeProps) => <Paragraph margin={{ bottom: 'none', top: 'xxsmall' }}>{nodeProps.children}</Paragraph>
+}
 
 function storeMapper (stores) {
   const { setActiveItemIndex, attachedMedia: icons } = stores.classifierStore.fieldGuide
@@ -49,8 +46,6 @@ function storeMapper (stores) {
   }
 }
 
-@inject(storeMapper)
-@observer
 class FieldGuideItem extends React.Component {
   render () {
     const { className, icons, item, setActiveItemIndex } = this.props
@@ -58,7 +53,8 @@ class FieldGuideItem extends React.Component {
 
     return (
       <Box className={className}>
-        <FieldGuideItemHeader
+
+        <Box
           align='center'
           border={{ color: 'light-5', side: 'bottom' }}
           direction='row'
@@ -72,31 +68,44 @@ class FieldGuideItem extends React.Component {
             onClick={() => setActiveItemIndex()}
             plain
           />
-          <Markdownz>
+          <Markdownz components={markdownTitleComponent}>
             {`### ${item.title}`}
           </Markdownz>
-        </FieldGuideItemHeader>
-        <FieldGuideItemContent direction='column' overflow='auto'>
-          <FieldGuideItemIcon icon={icon} height='140' margin={{ top: 'small', bottom: '35px' }} viewBox='0 0 200 100' />
-          <Markdownz>
+        </Box>
+
+        <Box direction='column' overflow='auto'>
+          <FieldGuideItemIcon
+            icon={icon}
+            height='140'
+            margin={{ top: 'small', bottom: '35px' }}
+            viewBox='0 0 200 100'
+          />
+          <Markdownz components={markdownComponents}>
             {item.content}
           </Markdownz>
-        </FieldGuideItemContent>
+        </Box>
+
       </Box>
     )
   }
 }
 
-FieldGuideItem.wrappedComponent.defaultProps = {
+FieldGuideItem.defaultProps = {
   className: '',
   icons: observable.map()
 }
 
-FieldGuideItem.wrappedComponent.propTypes = {
+FieldGuideItem.propTypes = {
   className: PropTypes.string,
   icons: MobXPropTypes.observableMap,
   item: PropTypes.object.isRequired,
   setActiveItemIndex: PropTypes.func.isRequired
 }
 
-export default FieldGuideItem
+@inject(storeMapper)
+@withTheme
+@observer
+class DecoratedFieldGuideItem extends FieldGuideItem { }
+
+export default DecoratedFieldGuideItem
+export { FieldGuideItem }

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.spec.js
@@ -1,16 +1,16 @@
-import { shallow, mount } from 'enzyme'
-import sinon from 'sinon'
-import React from 'react'
-import { observable } from 'mobx'
-import { Button } from 'grommet'
 import { Markdownz, Media } from '@zooniverse/react-components'
-import FieldGuideItem from './FieldGuideItem'
+import { shallow, mount } from 'enzyme'
+import { Button } from 'grommet'
+import { observable } from 'mobx'
+import React from 'react'
+import sinon from 'sinon'
+
+import { FieldGuideItem } from './FieldGuideItem'
 import FieldGuideItemIcon from '../FieldGuideItemIcon'
 import { FieldGuideMediumFactory } from '../../../../../../../../../test/factories'
 
 const medium = FieldGuideMediumFactory.build()
-const attachedMedia = observable.map()
-attachedMedia.set(medium.id, medium)
+const attachedMedia = observable.map().set(medium.id, medium)
 const item = {
   title: 'Cat',
   icon: medium.id,
@@ -20,7 +20,7 @@ const item = {
 describe('Component > FieldGuideItem', function () {
   it('should render without crashing', function () {
     const wrapper = shallow(
-      <FieldGuideItem.wrappedComponent
+      <FieldGuideItem
         icons={attachedMedia}
         item={item}
         setActiveItemIndex={() => { }}
@@ -31,7 +31,7 @@ describe('Component > FieldGuideItem', function () {
   it('should call setActiveItemIndex when the previous button is clicked', function () {
     const setActiveItemIndexSpy = sinon.spy()
     const wrapper = mount(
-      <FieldGuideItem.wrappedComponent
+      <FieldGuideItem
         icons={attachedMedia}
         item={item}
         setActiveItemIndex={setActiveItemIndexSpy}
@@ -42,7 +42,7 @@ describe('Component > FieldGuideItem', function () {
 
   it('should render the item title as markdown', function () {
     const wrapper = shallow(
-      <FieldGuideItem.wrappedComponent
+      <FieldGuideItem
         icons={attachedMedia}
         item={item}
         setActiveItemIndex={() => {}}
@@ -53,7 +53,7 @@ describe('Component > FieldGuideItem', function () {
 
   it('should render the item content as markdown', function () {
     const wrapper = shallow(
-      <FieldGuideItem.wrappedComponent
+      <FieldGuideItem
         icons={attachedMedia}
         item={item}
         setActiveItemIndex={() => { }}
@@ -64,7 +64,7 @@ describe('Component > FieldGuideItem', function () {
 
   it('should render a FieldGuideItemIcon component for the icon', function () {
     const wrapper = shallow(
-      <FieldGuideItem.wrappedComponent
+      <FieldGuideItem
         icons={attachedMedia}
         item={item}
         setActiveItemIndex={() => { }}

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/components/SpacedHeading/SpacedHeading.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/components/SpacedHeading/SpacedHeading.js
@@ -1,0 +1,30 @@
+import { SpacedText } from '@zooniverse/react-components'
+import { Heading } from 'grommet'
+import { node, string } from 'prop-types'
+import React from 'react'
+import styled from 'styled-components'
+
+const StyledHeading = styled(Heading)`
+  font-size: 100%;
+  line-height: 1;
+`
+
+function SpacedHeading (props) {
+  const { children, className, level } = props
+  return (
+    <StyledHeading className={className} level={level} size='medium'>
+      <SpacedText color='black' weight='bold'>
+        {children}
+      </SpacedText>
+    </StyledHeading>
+  )
+}
+
+
+SpacedHeading.propTypes = {
+  children: node,
+  className: string,
+  level: string
+}
+
+export default SpacedHeading

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/components/SpacedHeading/SpacedHeading.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/components/SpacedHeading/SpacedHeading.js
@@ -12,7 +12,7 @@ const StyledHeading = styled(Heading)`
 function SpacedHeading (props) {
   const { children, className, level } = props
   return (
-    <StyledHeading className={className} level={level} size='medium'>
+    <StyledHeading className={className} level={level} size='medium' {...props}>
       <SpacedText color='black' weight='bold'>
         {children}
       </SpacedText>

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/components/SpacedHeading/SpacedHeading.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/components/SpacedHeading/SpacedHeading.js
@@ -20,7 +20,6 @@ function SpacedHeading (props) {
   )
 }
 
-
 SpacedHeading.propTypes = {
   children: node,
   className: string,

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/components/SpacedHeading/SpacedHeading.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/components/SpacedHeading/SpacedHeading.spec.js
@@ -1,0 +1,21 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import SpacedHeading from './SpacedHeading'
+
+let wrapper
+
+const MOCK_PROPS = {
+  children: 'Foobar',
+  level: '1'
+}
+
+describe('Component > SpacedHeading', function () {
+  before(function () {
+    wrapper = shallow(<SpacedHeading {...MOCK_PROPS} />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/components/SpacedHeading/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/components/SpacedHeading/index.js
@@ -1,0 +1,1 @@
+export { default } from './SpacedHeading'

--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -204,6 +204,10 @@ const theme = deepFreeze({
         light: 'brand'
       }
     },
+    color: {
+      dark: 'accent-2',
+      light: 'brand'
+    },
     hover: {
       border: {
         color: {
@@ -416,6 +420,35 @@ const theme = deepFreeze({
     },
     extend: props => `margin: ${props.margin || '1em 0 1em 0'}`
   },
+  radioButton: {
+    check: {
+      color: {
+        dark: 'accent-2',
+        light: 'brand',
+      }
+    },
+    color: {
+      dark: 'accent-2',
+      light: 'brand',
+    },
+    icon: {
+      size: '15px',
+      extend: `
+        circle {
+          r: 10px;
+        }
+      `
+    },
+    size: '15px'
+  },
+  select: {
+    icons: {
+      color: {
+        dark: 'accent-2',
+        light: 'brand',
+      }
+    }
+  },
   text: {
     xsmall: {
       size: "12px",
@@ -447,13 +480,6 @@ const theme = deepFreeze({
       height: "38px",
       maxWidth: "100%"
     }
-  },
-  radioButton: {
-    icon: {
-      size: '15px',
-      extend: 'circle { r: 10px; }'
-    },
-    size: '15px'
   }
 })
 


### PR DESCRIPTION
Closes #856.

Does a minor refactor as well to use the `Markdownz` component prop instead of styled-components (as it's basically styling a Grommet component anyway), and uses the `theme` prop from `withTheme` instead of importing the zooTheme directly

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

