### PR TITLE
Add random number to data-mask ID

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
@@ -38,7 +38,7 @@ class FeedbackModal extends React.Component {
     if (showViewer) {
       FeedbackViewer = getFeedbackViewer(applicableRules)
     }
-    const messageContainerHeight = showViewer ? '200px' : '100%'
+    const messageContainerHeight = showViewer ? '400px' : '100%'
 
     if (showModal) {
       return (
@@ -48,23 +48,21 @@ class FeedbackModal extends React.Component {
           title={label}
         >
           <>
-            <Box
-              height='large'
-              width='large'
-            >
-              {showViewer && (
-                <Box height='100%'>
-                  <FeedbackViewer />
-                </Box>)}
-              <Box height={messageContainerHeight} overflow='scroll'>
-                <ul>
-                  {messages.map(message =>
-                    <li key={Math.random()}>
-                      {message}
-                    </li>
-                  )}
-                </ul>
-              </Box>
+            {showViewer && (
+              <Box
+                height='400px'
+                width='600px'
+              >
+                <FeedbackViewer />
+              </Box>)}
+            <Box height={messageContainerHeight} overflow='scroll'>
+              <ul>
+                {messages.map(message =>
+                  <li key={Math.random()}>
+                    {message}
+                  </li>
+                )}
+              </ul>
             </Box>
             <Box pad={{ top: 'small' }}>
               <Button

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -455,7 +455,7 @@ class LightCurveViewer extends Component {
     */
     this.d3svg.call(addDataLayer)
     this.d3dataLayer = this.d3svg.select('.data-layer')
-    this.d3svg.call(addDataMask, props.outerMargin)
+    this.d3svg.call(addDataMask, props.outerMargin, props.id)
     this.d3dataMask = this.d3svg.select('.data-mask')
 
     /*
@@ -706,6 +706,7 @@ LightCurveViewer.wrappedComponent.propTypes = {
     fontSize: PropTypes.string
   }),
 
+  id: PropTypes.number,
   // Store-mapped Properties
   interactionMode: PropTypes.oneOf(['annotate', 'move']),
   setOnZoom: PropTypes.func.isRequired,
@@ -741,6 +742,7 @@ LightCurveViewer.wrappedComponent.defaultProps = {
     fontSize: '0.75rem'
   },
 
+  id: Math.random(),
   interactionMode: '',
   setOnZoom: (type, zoomValue) => {},
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addDataMask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addDataMask.js
@@ -1,7 +1,7 @@
 export default function addDataMask (selection, outerMargin) {
   return selection
     .append('clipPath')
-    .attr('id', 'data-mask')
+    .attr('id', `data-mask-${Math.random()}`)
     .append('rect')
     .attr('class', 'data-mask')
     .attr('transform', `translate(${outerMargin}, ${outerMargin})`)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addDataMask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addDataMask.js
@@ -1,7 +1,7 @@
-export default function addDataMask (selection, outerMargin) {
+export default function addDataMask (selection, outerMargin, id = Math.random()) {
   return selection
     .append('clipPath')
-    .attr('id', `data-mask-${Math.random()}`)
+    .attr('id', `data-mask-${id}`)
     .append('rect')
     .attr('class', 'data-mask')
     .attr('transform', `translate(${outerMargin}, ${outerMargin})`)


### PR DESCRIPTION
Package: lib-classifier

Closes #851 .

Describe your changes:
- the data-mask from the initial subject viewer was being applied to the feedback viewer, this adds a random number to the data-mask id to differentiate
- small edits to Feedback Modal sizing

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

