### PR TITLE
Replace lipsum text in stats box

### DIFF
--- a/packages/app-project/src/shared/components/ConnectWithProject/ConnectWithProject.js
+++ b/packages/app-project/src/shared/components/ConnectWithProject/ConnectWithProject.js
@@ -15,7 +15,7 @@ function ConnectWithProject ({ className, projectName, urls }) {
       className={className}
       title={counterpart('ConnectWithProject.title', { projectName })}
     >
-      <Grid columns={['1fr', '1fr']} gap='small' rows={['1fr']}>
+      <Grid columns={['1fr', '1fr']} gap='medium' rows={['1fr']}>
         {urls.map(urlObject =>
           <ProjectLink
             key={urlObject.url}

--- a/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/ProjectLink.js
+++ b/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/ProjectLink.js
@@ -19,11 +19,11 @@ const StyledAnchor = styled(Anchor)`
 function ProjectLink ({ className, urlObject }) {
   const { IconComponent, label, type, url } = formatUrlObject(urlObject)
   return (
-    <Box className={className} direction='row' margin={{ bottom: 'small' }}>
+    <Box className={className} direction='row'>
       <Box margin={{ right: '15px' }}>
         <IconComponent color='dark-5' size='medium' />
       </Box>
-      <Box>
+      <Box gap='xxsmall'>
         <SpacedText>
           <Link href={url} passHref>
             <StyledAnchor size='small'>

--- a/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatistics.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatistics.js
@@ -21,6 +21,7 @@ const NumbersGrid = styled.div`
 `
 
 const StyledParagraph = styled(Paragraph)`
+  line-height: 22px;
   max-width: 100%;
 `
 
@@ -45,9 +46,9 @@ function ProjectStatistics ({
           <Subtitle text={counterpart('ProjectStatistics.subtitle')} />
           <StyledParagraph
             margin={{ bottom: 'small', top: 'none' }}
-            size='small'
+            size='medium'
           >
-            {counterpart('ProjectStatistics.text')}
+            {counterpart('ProjectStatistics.text', { projectName })}
           </StyledParagraph>
           <CompletionBar />
           <Text margin={{ top: 'small' }} size='small' weight='bold'>

--- a/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/Subtitle.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/Subtitle.js
@@ -1,14 +1,23 @@
-import { Text } from 'grommet'
+import { Heading } from 'grommet'
 import { withResponsiveContext } from '@zooniverse/react-components'
 import { object, oneOfType, string } from 'prop-types'
 import React from 'react'
+import styled from 'styled-components'
+
+const StyledHeading = styled(Heading)`
+  font-size: 14px;
+  line-height: 22px;
+`
 
 function Subtitle ({ margin, mode, screenSize, text, ...props }) {
-  const textMargin = (screenSize === 'small') ? { top: 'none', bottom: 'xsmall' } : margin
+  const textMargin = (screenSize === 'small')
+    ? { bottom: 'xsmall', top: 'none' }
+    : margin
+
   return (
-    <Text {...props} margin={textMargin}>
+    <StyledHeading level='3' margin={textMargin}>
       {text}
-    </Text>
+    </StyledHeading>
   )
 }
 
@@ -16,17 +25,13 @@ Subtitle.propTypes = {
   margin: oneOfType([object, string]),
   screenSize: string,
   size: string,
-  tag: string,
   text: string.isRequired,
-  weight: string
 }
 
 Subtitle.defaultProps = {
-  margin: 'none',
+  margin: '0',
   screenSize: '',
   size: 'small',
-  tag: 'h3',
-  weight: 'bold'
 }
 
 export default withResponsiveContext(Subtitle)

--- a/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/Subtitle.spec.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/components/Subtitle/Subtitle.spec.js
@@ -19,7 +19,7 @@ describe('Component > Subtitle', function () {
 
   it('should use the margin prop if the screen size is greater than small', function () {
     wrapper = shallow(<Subtitle screenSize='medium' text={TEXT} />)
-    expect(wrapper.props().margin).to.equal('none')
+    expect(wrapper.props().margin).to.equal('0')
   })
 
   it('should set the margin to an object if the screen size is equal or less than small', function () {

--- a/packages/app-project/src/shared/components/ProjectStatistics/locales/en.json
+++ b/packages/app-project/src/shared/components/ProjectStatistics/locales/en.json
@@ -6,7 +6,7 @@
     "percentComplete": "Percent complete",
     "subjects": "Subjects",
     "subtitle": "Keep track of the progress you and your fellow volunteers have made on this project.",
-    "text": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
+    "text": "Every click counts! Join %(projectName)s's community to complete this project and help researchers produce important results. Click \"View more stats\" to see even more stats.",
     "title": "%(projectName)s Statistics",
     "viewMoreStats": "View more stats",
     "volunteers": "Volunteers"

--- a/packages/app-project/src/shared/components/WidgetHeading/WidgetHeading.js
+++ b/packages/app-project/src/shared/components/WidgetHeading/WidgetHeading.js
@@ -1,23 +1,28 @@
 import { SpacedText } from '@zooniverse/react-components'
-import { Box, Heading } from 'grommet'
+import { Heading } from 'grommet'
 import { string } from 'prop-types'
 import React from 'react'
+import styled from 'styled-components'
+
+const StyledHeading = styled(Heading)`
+  font-size: 14px;
+  line-height: 22px;
+`
 
 function WidgetHeading (props) {
   const { level, text } = props
   return (
-    <Heading level={level} margin='none'>
+    <StyledHeading level={level} margin='none'>
       <SpacedText
         color={{
           dark: 'light-1',
           light: 'black'
         }}
-        size='medium'
         weight='bold'
       >
         {text}
       </SpacedText>
-    </Heading>
+    </StyledHeading>
   )
 }
 


### PR DESCRIPTION
<img width="972" alt="Screenshot 2019-05-22 21 30 16" src="https://user-images.githubusercontent.com/2725841/58206621-f499a180-7cd8-11e9-8e28-3f8697f4d46c.png">

Closes #845.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

