### PR TITLE
Ensure dark theme field guide has correct title color

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/components/SpacedHeading/SpacedHeading.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/components/SpacedHeading/SpacedHeading.js
@@ -13,7 +13,7 @@ function SpacedHeading (props) {
   const { children, className, level } = props
   return (
     <StyledHeading className={className} level={level} size='medium' {...props}>
-      <SpacedText color='black' weight='bold'>
+      <SpacedText color={{ dark: 'white', light: 'black' }} weight='bold'>
         {children}
       </SpacedText>
     </StyledHeading>


### PR DESCRIPTION
Sets the field guide titles to white in dark mode.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

