### PR TITLE
Light Curve Viewer - add missing Data Layer ID, fix randomised IDs

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -453,9 +453,10 @@ class LightCurveViewer extends Component {
     data points from appearing outside of the 'middle' of the chart, i.e.
     prevents <circle>s from appearing in the margins of the container.
     */
-    this.d3svg.call(addDataLayer)
+    const uniqueId = props.id || Math.floor(Math.random() * 1000000);
+    this.d3svg.call(addDataLayer, uniqueId)
     this.d3dataLayer = this.d3svg.select('.data-layer')
-    this.d3svg.call(addDataMask, props.outerMargin, props.id)
+    this.d3svg.call(addDataMask, props.outerMargin, uniqueId)
     this.d3dataMask = this.d3svg.select('.data-mask')
 
     /*
@@ -742,7 +743,7 @@ LightCurveViewer.wrappedComponent.defaultProps = {
     fontSize: '0.75rem'
   },
 
-  id: Math.random(),
+  id: undefined,  // Specify a unique ID for each LCV; required to distinguish data-masks. WARNING: do not apply Math.random() here, as the random value will be set at the class level, and therefore be the same for each instance of the LCV.
   interactionMode: '',
   setOnZoom: (type, zoomValue) => {},
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addDataLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addDataLayer.js
@@ -1,6 +1,6 @@
-export default function addDataLayer (selection) {
+export default function addDataLayer (selection, id = 0) {
   return selection
     .append('g')
     .attr('class', 'data-layer')
-    .attr('clip-path', 'url(#data-mask)')
+    .attr('clip-path', `url(#data-mask-${id})`)
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addDataMask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addDataMask.js
@@ -1,4 +1,4 @@
-export default function addDataMask (selection, outerMargin, id = Math.random()) {
+export default function addDataMask (selection, outerMargin, id = 0) {
   return selection
     .append('clipPath')
     .attr('id', `data-mask-${id}`)


### PR DESCRIPTION
## PR Overview

package: `lib-classifier`

This PR follows up on PR #866, which generates a random ID for each instance of a Light Curve Viewer, to prevent multiple Data Mask `clipPath`s from having identity collisions. (See Issue #851 )

This PR addresses two things:

1. It adds the randomly generated ID to the `<g.data-layer>`.

![Screen Shot 2019-05-23 at 14 48 28](https://user-images.githubusercontent.com/13952701/58260101-c74b0300-7d6d-11e9-91d8-1b94227ea120.png)
_Without this PR, `<clipPath#data-mask-0.407396...>` is defined with a unique ID, but the `<g.data-layer>` is still looking for the old `<clipPath#data-mask>` (without the unique ID)_

![Screen Shot 2019-05-23 at 14 47 47](https://user-images.githubusercontent.com/13952701/58260352-3294d500-7d6e-11e9-881c-6fab2a4f9f66.png)
_As a result, the clipPath is ignored altogether, and the data points in the Data Layer are rendered outside the intended Data Mask._

2. it fixes the issue where the _randomly generated ID is the same for every instance_ of the LCV.

### Dev Notes

@mcbouslog So this is something interesting I found out: if you set a random value in the `reactComponent.defaultProps`, that random value is rolled _only once._

For example...
```
class TwentySidedDice extends React.Component {
  render () {
    return this.props.rolledNumber
  }
}

TwentySidedDice.defaultProps = {
  rolledNumber: Math.floor(Math.random() * 20) + 1
};

class DnDDiceRolls extends React.Component {
  render () {
    return (
      <>
        <TwentySidedDice /> ,
        <TwentySidedDice /> ,
        <TwentySidedDice rolledNumber="100" /> ,
        <TwentySidedDice /> ,
        <TwentySidedDice /> !
      <>
    );
  }
}

// <DnDDiceRolls /> will render, for example... 8, 8, 100, 8, 8!
```

It appears that the `Math.random()` is _resolved_ as soon as the Class is defined, meaning the `.defaultProps` is a property of the _class, not the instance._ 

For more: https://stackoverflow.com/questions/37819128/random-data-in-defaultprops

Apologies for not catching this in #866!

Also, side note, I changed `Math.random()` to `Math.floor(Math.random() * 1000000)` because 1. I just like round numbers, and 2. I have issues accepting any data value with a `.` dot, because throughout my whole youth I struggled to understand how it was used to end sentences. You could say it was a difficult period.

### Status

Ready for review. When testing, please ensure that:
1. the data points aren't rendered outside the data mask (i.e. there should be a small 10px-ish padding from the edge of the LCV where data points won't render)
2. two different Light Curves (i.e. the main one in the Classifier, and the one in the Feedback Modal) should display their data points fully in the space available, and not be mysteriously cut off as in #851 .