### PR TITLE
Use contentful category titles

### DIFF
--- a/packages/app-content-pages/src/screens/Publications/Publications.js
+++ b/packages/app-content-pages/src/screens/Publications/Publications.js
@@ -22,6 +22,17 @@ const FORM_URL = 'https://docs.google.com/forms/d/e/1FAIpQLSdbAKVT2tGs1WfBqWNrMe
 function Publications (props) {
   const { className, data, filters } = props
 
+  // `Show all` isn't a Contentful category, so we need to manually add the
+  // translated string.
+  const filtersPlusShowAll = filters.reduce((acc, filter) => {
+    if (filter.slug === 'showAll') {
+      acc.push({ ...filter, title: counterpart(`Publications.showAll`) })
+    } else {
+      acc.push(filter)
+    }
+    return acc
+  }, [])
+
   const main = (
     <article>
       <Heading margin={{ top: 'none' }} size='small'>
@@ -44,11 +55,11 @@ function Publications (props) {
 
   const sidebar = (
     <Box gap='small'>
-      {filters.map(filter => (
+      {filtersPlusShowAll.map(filter => (
         <div key={filter.slug} >
           <StyledButton
             active={filter.active}
-            label={counterpart(`Publications.categories.${filter.slug}`)}
+            label={filter.title}
             onClick={filter.selectCategory}
             plain
           />
@@ -82,7 +93,8 @@ Publications.propTypes = {
   filters: arrayOf(shape({
     active: bool,
     selectCategory: func,
-    slug: string
+    slug: string,
+    title: string
   }))
 }
 

--- a/packages/app-content-pages/src/screens/Publications/locales/en.json
+++ b/packages/app-content-pages/src/screens/Publications/locales/en.json
@@ -1,16 +1,7 @@
 {
   "Publications": {
-    "categories": {
-      "climate": "Climate",
-      "humanities": "Humanities",
-      "medicine": "Medicine",
-      "meta": "Meta",
-      "nature": "Nature",
-      "physics": "Physics",
-      "showAll": "Show all",
-      "space": "Space"
-    },
     "description": "A list of academic publications that use Zooniverse-generated data.",
+    "showAll": "Show all",
     "title": "Publications"
   }
 }

--- a/packages/app-content-pages/src/shared/stores/Publications/Publications.js
+++ b/packages/app-content-pages/src/shared/stores/Publications/Publications.js
@@ -51,18 +51,20 @@ const Publications = types
     get uiFilters () {
       const filters = self.categories
         .map(category => {
-          const { id, slug } = category
+          const { id, slug, title } = category
           return {
             active: self.isActiveCategory(id),
             selectCategory: self.selectCategory.bind(this, id),
-            slug
+            slug,
+            title
           }
         })
 
       filters.unshift({
         active: !self.selectedCategory,
         selectCategory: self.selectCategory.bind(this, null),
-        slug: 'showAll'
+        slug: 'showAll',
+        title: 'Show All'
       })
 
       return filters


### PR DESCRIPTION
cc #876

This changes the store to return the category titles from Contentful, rather than translate them in the app. This means that everything on that page can be edited via the CMS.

Once a language selector is in place, we'll need to send the language code along with the request in Contentful, or store translations locally (probably more likely) - this is captured in #877