### PR TITLE
Override how img are rendered in the field guide

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.js
@@ -1,4 +1,4 @@
-import { Markdownz } from '@zooniverse/react-components'
+import { Markdownz, Media } from '@zooniverse/react-components'
 import counterpart from 'counterpart'
 import { Button, Box, Heading, Paragraph } from 'grommet'
 import { FormPrevious } from 'grommet-icons'
@@ -34,6 +34,7 @@ const markdownComponents = {
   h4: (nodeProps) => <SpacedHeading level='4'>{nodeProps.children}</SpacedHeading>,
   h5: (nodeProps) => <SpacedHeading level='5'>{nodeProps.children}</SpacedHeading>,
   h6: (nodeProps) => <SpacedHeading level='6'>{nodeProps.children}</SpacedHeading>,
+  img: (nodeProps) => <Media alt={nodeProps.alt} src={nodeProps.src} height="200px" />,
   p: (nodeProps) => <Paragraph margin={{ bottom: 'none', top: 'xxsmall' }}>{nodeProps.children}</Paragraph>
 }
 


### PR DESCRIPTION
Package: lib-classifier

Closes #875

Describe your changes:
This doesn't fix the issue in the way #875 suggests. The underlying remark dependency does sanitization on the src attributes of html and there's no way to customize it to allow for a regex to parse it. This is probably for the best for security reasons. Instead, let's override how images are rendered in the field guide and disallow resizing via markdown syntax and set a fixed height that the thumbnail service will use. This fixes how the images render to a much nicer size for TESS. Long term, though, we might consider the reverse solution and adding a markdown-it plugin for the old Markdownz to support resizing syntax in the alt tag area of the markup. 

Check it out locally: http://localhost:3000/projects/trouille/planet-hunters-tess-beta/classify?env=production

And here's a screenshot:
<img width="559" alt="Screen Shot 2019-05-28 at 1 40 29 PM" src="https://user-images.githubusercontent.com/5016731/58503430-3fd70880-814e-11e9-9a1a-3d2eb9a98b92.png">

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

