### PR TITLE
Basic feedback reducer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.js
@@ -7,6 +7,7 @@ import counterpart from 'counterpart'
 import en from './locales/en'
 
 import getFeedbackViewer from './helpers/getFeedbackViewer'
+import reduceFeedbackMessages from './helpers/reduceFeedbackMessages'
 
 counterpart.registerTranslations('en', en)
 
@@ -35,10 +36,14 @@ class FeedbackModal extends React.Component {
     const { applicableRules, hideFeedback, hideSubjectViewer, messages, showModal } = this.props
     const showViewer = !hideSubjectViewer && applicableRules && applicableRules.length > 0
     let FeedbackViewer = null
+
     if (showViewer) {
       FeedbackViewer = getFeedbackViewer(applicableRules)
     }
+
     const messageContainerHeight = showViewer ? '400px' : '100%'
+
+    const reducedMessages = reduceFeedbackMessages(messages)
 
     if (showModal) {
       return (
@@ -57,9 +62,9 @@ class FeedbackModal extends React.Component {
               </Box>)}
             <Box height={messageContainerHeight} overflow='scroll'>
               <ul>
-                {messages.map(message =>
+                {reducedMessages.map(message =>
                   <li key={Math.random()}>
-                    {message}
+                    {message.text} <small>({message.count} { message.count === 1 ? 'match' : 'matches' })</small>
                   </li>
                 )}
               </ul>

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/FeedbackModal.spec.js
@@ -50,6 +50,12 @@ describe('FeedbackModal', function () {
     expect(list).to.have.lengthOf(3)
   })
 
+  it('should reduce duplicate messages', function () {
+    const wrapper = shallow(<FeedbackModal.wrappedComponent showModal messages={['Yay!', 'Yay!', 'Yay!']} />)
+    const list = wrapper.find('li')
+    expect(list).to.have.lengthOf(1)
+  })
+
   it('should call hideFeedback on close', function () {
     const hideFeedbackStub = sinon.stub()
     const wrapper = shallow(<FeedbackModal.wrappedComponent showModal messages={['Yay!', 'Good Job', 'Try Again']} hideFeedback={hideFeedbackStub} />)

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/index.js
@@ -1,1 +1,2 @@
 export { default } from './getFeedbackViewer'
+export { default } from './reduceFeedbackMessages'

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/reduceFeedbackMessages.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/reduceFeedbackMessages.js
@@ -1,0 +1,19 @@
+function reduceFeedbackMessages (messages) {
+  let result = []
+
+  if (messages && messages.length) {
+    result = messages.reduce((acc, message) => {
+      const messageExists = acc.find(obj => obj.text === message)
+      if (messageExists) {
+        messageExists.count++
+      } else {
+        acc.push({ text: message, count: 1 })
+      }
+      return acc
+    }, [])
+  }
+
+  return result
+}
+
+export default reduceFeedbackMessages

--- a/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/reduceFeedbackMessages.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Feedback/helpers/reduceFeedbackMessages.spec.js
@@ -1,0 +1,23 @@
+import reduceFeedbackMessages from './reduceFeedbackMessages'
+
+const FEEDBACK_MESSAGES = [
+  'foo',
+  'foo',
+  'foo',
+  'bar',
+  'bar',
+]
+
+describe('Helpers > reduceFeedbackMessages', function () {
+  it('should exist', function () {
+    expect(reduceFeedbackMessages).to.be.a('function')
+  })
+
+  it('should reduce an array of messages to a collection of unique messages with counts', function () {
+    const reduced = reduceFeedbackMessages(FEEDBACK_MESSAGES)
+    expect(reduced).to.deep.equal([
+      { text: 'foo', count: 3 },
+      { text: 'bar', count: 2 },
+    ])
+  })
+})


### PR DESCRIPTION
Adds a basic reducer to show each feedback message once, with a number of matches next to it.

<img width="625" alt="Screenshot 2019-05-30 15 22 56" src="https://user-images.githubusercontent.com/2725841/58639444-d6dac680-82ee-11e9-8d91-d6af939bc3c5.png">


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

