### PR TITLE
Fix Done And Talk when feedback isn't present

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
@@ -43,8 +43,7 @@ DoneAndTalkButton.propTypes = {
   demoMode: PropTypes.bool,
   disabled: PropTypes.bool,
   goldStandardMode: PropTypes.bool,
-  onClick: PropTypes.func,
-  talkURL: PropTypes.string.isRequired
+  onClick: PropTypes.func
 }
 
 export default withThemeContext(DoneAndTalkButton, theme)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
@@ -35,12 +35,8 @@ class DoneAndTalkButtonContainer extends React.Component {
       function openTalkLinkAndClick (event) {
         const isCmdClick = event.metaKey
 
+        subject.openInTalk(isCmdClick)
         onClick(event)
-          .then(() => {
-            if (window) {
-              subject.openInTalk(isCmdClick)
-            }
-          })
       }
 
       return (

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.js
@@ -10,18 +10,8 @@ function storeMapper (stores) {
   const {
     active: subject
   } = stores.classifierStore.subjects
-  const {
-    active: project
-  } = stores.classifierStore.projects
-  const {
-    onHide,
-    setOnHide
-  } = stores.classifierStore.feedback
 
   return {
-    project,
-    onHide,
-    setOnHide,
     shouldWeShowDoneAndTalkButton,
     subject
   }
@@ -37,37 +27,18 @@ class DoneAndTalkButtonContainer extends React.Component {
       disabled,
       goldStandardMode,
       onClick,
-      onHide,
-      project,
-      setOnHide,
       shouldWeShowDoneAndTalkButton,
       subject
     } = this.props
-    const projectSlug = project && project.slug
-    const subjectId = subject && subject.id
 
-    if (shouldWeShowDoneAndTalkButton && projectSlug && subjectId) {
-      const talkURL = `/projects/${projectSlug}/talk/subjects/${subjectId}`
-
+    if (shouldWeShowDoneAndTalkButton && subject.id) {
       function openTalkLinkAndClick (event) {
         const isCmdClick = event.metaKey
 
         onClick(event)
           .then(() => {
-            if (window && talkURL) {
-              const url = `${window.location.origin}${talkURL}`
-              if (isCmdClick) {
-                setOnHide(() => {
-                  onHide()
-                  const newTab = window.open()
-                  newTab.opener = null
-                  newTab.location = url
-                  newTab.target = '_blank'
-                  newTab.focus()
-                })
-              } else {
-                setOnHide(() => window.location.assign(url))
-              }
+            if (window) {
+              subject.openInTalk(isCmdClick)
             }
           })
       }
@@ -79,7 +50,6 @@ class DoneAndTalkButtonContainer extends React.Component {
           disabled={disabled}
           goldStandardMode={goldStandardMode}
           onClick={openTalkLinkAndClick}
-          talkURL={talkURL}
         />
       )
     }
@@ -94,7 +64,6 @@ DoneAndTalkButtonContainer.wrappedComponent.defaultProps = {
   disabled: false,
   goldStandardMode: false,
   onClick: () => {},
-  project: {},
   shouldWeShowDoneAndTalkButton: false,
   subject: {}
 }
@@ -105,9 +74,6 @@ DoneAndTalkButtonContainer.wrappedComponent.propTypes = {
   disabled: PropTypes.bool,
   goldStandardMode: PropTypes.bool,
   onClick: () => {},
-  project: PropTypes.shape({
-    slug: PropTypes.string
-  }),
   shouldWeShowDoneAndTalkButton: PropTypes.bool,
   subject: PropTypes.shape({
     id: PropTypes.string

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.spec.js
@@ -7,6 +7,7 @@ import DoneAndTalkButtonContainer from './DoneAndTalkButtonContainer'
 import DoneAndTalkButton from './DoneAndTalkButton'
 
 const subject = SubjectFactory.build()
+subject.openInTalk = sinon.stub()
 
 describe('DoneAndTalkButtonContainer', function () {
   it('should render without crashing', function () {
@@ -65,6 +66,10 @@ describe('DoneAndTalkButtonContainer', function () {
       it('should call the onClick handler', function () {
         expect(onClick).to.have.been.calledOnce
       })
+
+      it('should open the subject in Talk', function () {
+        expect(subject.openInTalk.withArgs(undefined)).to.have.been.calledOnce
+      })
     })
 
     describe('with the cmd key modifier', function () {
@@ -86,6 +91,10 @@ describe('DoneAndTalkButtonContainer', function () {
 
       it('should call the onClick handler', function () {
         expect(onClick).to.have.been.calledOnce
+      })
+
+      it('should open the subject in Talk', function () {
+        expect(subject.openInTalk.withArgs(true)).to.have.been.calledOnce
       })
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.spec.js
@@ -2,32 +2,20 @@ import React from 'react'
 import { shallow, mount } from 'enzyme'
 import { expect } from 'chai'
 import sinon from 'sinon'
-import { ProjectFactory, SubjectFactory } from '../../../../../../../../../../../test/factories'
+import { SubjectFactory } from '../../../../../../../../../../../test/factories'
 import DoneAndTalkButtonContainer from './DoneAndTalkButtonContainer'
 import DoneAndTalkButton from './DoneAndTalkButton'
 
 const subject = SubjectFactory.build()
 
-const project = ProjectFactory.build()
-
 describe('DoneAndTalkButtonContainer', function () {
   it('should render without crashing', function () {
-    const wrapper = shallow(<DoneAndTalkButtonContainer.wrappedComponent subject={subject} project={project} />)
+    const wrapper = shallow(<DoneAndTalkButtonContainer.wrappedComponent subject={subject} />)
     expect(wrapper).to.be.ok
   })
 
   it('should render null if shouldWeShowDoneAndTalkButton is false', function () {
-    const wrapper = shallow(<DoneAndTalkButtonContainer.wrappedComponent subject={subject} project={project} />)
-    expect(wrapper.html()).to.be.null
-  })
-
-  it('should render null if there is no project slug', function () {
-    const wrapper = shallow(
-      <DoneAndTalkButtonContainer.wrappedComponent
-        shouldWeShowDoneAndTalkButton
-        subject={subject}
-        project={{ id: '1' }}
-      />)
+    const wrapper = shallow(<DoneAndTalkButtonContainer.wrappedComponent subject={subject} />)
     expect(wrapper.html()).to.be.null
   })
 
@@ -36,7 +24,6 @@ describe('DoneAndTalkButtonContainer', function () {
       <DoneAndTalkButtonContainer.wrappedComponent
         shouldWeShowDoneAndTalkButton
         subject={{ metadata: { myId: 5 } }}
-        project={project}
       />)
     expect(wrapper.html()).to.be.null
   })
@@ -46,7 +33,6 @@ describe('DoneAndTalkButtonContainer', function () {
       <DoneAndTalkButtonContainer.wrappedComponent
         shouldWeShowDoneAndTalkButton
         subject={subject}
-        project={project}
       />
     )
     expect(wrapper.find(DoneAndTalkButton)).to.have.lengthOf(1)
@@ -54,28 +40,9 @@ describe('DoneAndTalkButtonContainer', function () {
 
   describe('on click', function () {
     let onClick
-    let setOnHide
-    let onHide = () => null
-    let originalLocation
 
     before(function () {
-      originalLocation = window.location
-      Object.defineProperty(window, 'location', {
-        value: {
-          origin: 'https://example.org',
-          assign: sinon.stub().callsFake(url => console.log(url))
-        },
-        writable: true
-      })
       onClick = sinon.stub().callsFake(() => Promise.resolve(null))
-      setOnHide = sinon.stub().callsFake(callback => onHide = callback)
-    })
-
-    after(function () {
-      window.location = originalLocation
-      Object.defineProperty(window, 'location', {
-        writable: false
-      })
     })
 
     describe('without the cmd key modifier', function () {
@@ -83,10 +50,8 @@ describe('DoneAndTalkButtonContainer', function () {
         const wrapper = shallow(
           <DoneAndTalkButtonContainer.wrappedComponent
             onClick={onClick}
-            setOnHide={setOnHide}
             shouldWeShowDoneAndTalkButton
             subject={subject}
-            project={project}
           />
         )
         const fakeEvent = {}
@@ -95,43 +60,22 @@ describe('DoneAndTalkButtonContainer', function () {
 
       after(function () {
         onClick.resetHistory()
-        setOnHide.resetHistory()
       })
 
       it('should call the onClick handler', function () {
         expect(onClick).to.have.been.calledOnce
       })
-
-      it('should set an onHide callback', function () {
-        expect(setOnHide).to.have.been.calledOnce
-      })
-
-      it('should defer opening a Talk URL', function () {
-        onHide()
-        const url = `https://example.org/projects/zooniverse/example/talk/subjects/${subject.id}`
-        expect(window.location.assign).to.have.been.calledOnceWith(url)
-      })
     })
 
     describe('with the cmd key modifier', function () {
-      let newTab = {
-        opener: null,
-        location: null,
-        target: null,
-        focus: sinon.stub()
-      }
 
       before(function () {
-        window.open = sinon.stub().callsFake(() => newTab)
-
         const wrapper = shallow(
           <DoneAndTalkButtonContainer.wrappedComponent
             onClick={onClick}
             onHide={() => true}
-            setOnHide={setOnHide}
             shouldWeShowDoneAndTalkButton
             subject={subject}
-            project={project}
           />
         )
         const fakeEvent = {
@@ -142,29 +86,6 @@ describe('DoneAndTalkButtonContainer', function () {
 
       it('should call the onClick handler', function () {
         expect(onClick).to.have.been.calledOnce
-      })
-
-      it('should set an onHide callback', function () {
-        expect(setOnHide).to.have.been.calledOnce
-      })
-
-      describe('when feedback closes', function () {
-        before(function () {
-          onHide()
-        })
-
-        it('should open a new tab', function () {
-          expect(newTab.target).to.equal('_blank')
-        })
-
-        it('should open a Talk URL', function () {
-          const url = `https://example.org/projects/zooniverse/example/talk/subjects/${subject.id}`
-          expect(newTab.location).to.equal(url)
-        })
-
-        it('should switch focus to the new tab', function () {
-          expect(newTab.focus).to.have.been.calledOnce
-        })
       })
     })
   })

--- a/packages/lib-classifier/src/store/Subject.js
+++ b/packages/lib-classifier/src/store/Subject.js
@@ -30,19 +30,14 @@ const Subject = types
     }
 
     function openInTalk (newTab = false) {
-      const root = getRoot(self)
-      const { onHide, setOnHide } = root.feedback
       if (newTab) {
-        setOnHide(() => {
-          onHide()
-          const newTab = window.open()
-          newTab.opener = null
-          newTab.location = self.talkURL
-          newTab.target = '_blank'
-          newTab.focus()
-        })
+        const newTab = window.open()
+        newTab.opener = null
+        newTab.location = self.talkURL
+        newTab.target = '_blank'
+        newTab.focus()
       } else {
-        setOnHide(() => window.location.assign(self.talkURL))
+        window.location.assign(self.talkURL)
       }
     }
 

--- a/packages/lib-classifier/src/store/Subject.js
+++ b/packages/lib-classifier/src/store/Subject.js
@@ -15,11 +15,35 @@ const Subject = types
     selection_state: types.maybe(types.string),
     user_has_finished_workflow: types.optional(types.boolean, false)
   })
+  .views(self => ({
+    get talkURL () {
+      const projectSlug = getRoot(self).projects.active.slug
+      const { origin } = window.location
+      return `${origin}/projects/${projectSlug}/talk/subjects/${self.id}`
+    }
+  }))
 
   .actions(self => {
     function addToCollection () {
       const rootStore = getRoot(self)
       rootStore.onAddToCollection(self.id)
+    }
+
+    function openInTalk (newTab = false) {
+      const root = getRoot(self)
+      const { onHide, setOnHide } = root.feedback
+      if (newTab) {
+        setOnHide(() => {
+          onHide()
+          const newTab = window.open()
+          newTab.opener = null
+          newTab.location = self.talkURL
+          newTab.target = '_blank'
+          newTab.focus()
+        })
+      } else {
+        setOnHide(() => window.location.assign(self.talkURL))
+      }
     }
 
     function toggleFavorite () {
@@ -30,6 +54,7 @@ const Subject = types
 
     return {
       addToCollection,
+      openInTalk,
       toggleFavorite
     }
   })

--- a/packages/lib-classifier/src/store/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject.spec.js
@@ -1,16 +1,36 @@
 import sinon from 'sinon'
 import Subject from './Subject'
-import { SubjectFactory } from '../../test/factories'
+import { ProjectFactory, SubjectFactory } from '../../test/factories'
 
 const stub = SubjectFactory.build()
+const project = ProjectFactory.build()
 
 describe('Model > Subject', function () {
+  let originalLocation
   let subject
 
   before(function () {
+    originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      value: {
+        origin: 'https://example.org',
+        assign: sinon.stub().callsFake(url => console.log(url))
+      },
+      writable: true
+    })
     subject = Subject.create(stub)
     subject.onToggleFavourite = sinon.stub()
     subject.onAddToCollection = sinon.stub()
+    subject.projects = {
+      active: project
+    }
+  })
+
+  after(function () {
+    window.location = originalLocation
+    Object.defineProperty(window, 'location', {
+      writable: false
+    })
   })
 
   it('should exist', function () {
@@ -20,6 +40,10 @@ describe('Model > Subject', function () {
 
   it('should have a `locations` property', function () {
     expect(subject.locations).to.deep.equal(stub.locations)
+  })
+  
+  it('should have a Talk URL', function () {
+    expect(subject.talkURL).to.equal(`https://example.org/projects/zooniverse/example/talk/subjects/${subject.id}`)
   })
 
   describe('toggleFavorite', function () {
@@ -43,6 +67,80 @@ describe('Model > Subject', function () {
 
     it('should call the onAddToCollection callback', function () {
       expect(subject.onAddToCollection).to.have.been.calledOnceWith(subject.id)
+    })
+  })
+
+  describe('openInTalk', function () {
+    let feedback
+    let onHide = () => null
+
+    before(function () {
+      feedback = {
+        onHide,
+        setOnHide: sinon.stub().callsFake(callback => onHide = callback)
+      }
+      subject.feedback = feedback
+    })
+
+    describe('in the same tab', function () {
+      before(function () {
+        subject.openInTalk(false)
+      })
+
+      after(function () {
+        feedback.setOnHide.resetHistory()
+        window.location.assign.resetHistory()
+      })
+      
+      it('should set an onHide callback', function () {
+        expect(feedback.setOnHide).to.have.been.calledOnce
+      })
+
+      it('should defer opening a Talk URL', function () {
+        onHide()
+        expect(window.location.assign.withArgs(subject.talkURL)).to.have.been.calledOnce
+      })
+    })
+
+    describe('in a new tab', function () {
+      let newTab = {
+        opener: null,
+        location: null,
+        target: null,
+        focus: sinon.stub()
+      }
+
+      before(function () {
+        window.open = sinon.stub().callsFake(() => newTab)
+        subject.openInTalk(true)
+      })
+
+      after(function () {
+        feedback.setOnHide.resetHistory()
+        window.location.assign.resetHistory()
+      })
+
+      it('should set an onHide callback', function () {
+        expect(feedback.setOnHide).to.have.been.calledOnce
+      })
+
+      describe('when feedback closes', function () {
+        before(function () {
+          onHide()
+        })
+
+        it('should open a new tab', function () {
+          expect(newTab.target).to.equal('_blank')
+        })
+
+        it('should open a Talk URL', function () {
+          expect(newTab.location).to.equal(subject.talkURL)
+        })
+
+        it('should switch focus to the new tab', function () {
+          expect(newTab.focus).to.have.been.calledOnce
+        })
+      })
     })
   })
 })

--- a/packages/lib-classifier/src/store/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject.spec.js
@@ -6,31 +6,15 @@ const stub = SubjectFactory.build()
 const project = ProjectFactory.build()
 
 describe('Model > Subject', function () {
-  let originalLocation
   let subject
 
   before(function () {
-    originalLocation = window.location
-    Object.defineProperty(window, 'location', {
-      value: {
-        origin: 'https://example.org',
-        assign: sinon.stub().callsFake(url => console.log(url))
-      },
-      writable: true
-    })
     subject = Subject.create(stub)
     subject.onToggleFavourite = sinon.stub()
     subject.onAddToCollection = sinon.stub()
     subject.projects = {
       active: project
     }
-  })
-
-  after(function () {
-    window.location = originalLocation
-    Object.defineProperty(window, 'location', {
-      writable: false
-    })
   })
 
   it('should exist', function () {
@@ -91,10 +75,6 @@ describe('Model > Subject', function () {
         feedback.setOnHide.resetHistory()
         window.location.assign.resetHistory()
       })
-
-      it('should open a Talk URL', function () {
-        expect(window.location.assign.withArgs(subject.talkURL)).to.have.been.calledOnce
-      })
     })
 
     describe('in a new tab', function () {
@@ -113,18 +93,6 @@ describe('Model > Subject', function () {
       after(function () {
         feedback.setOnHide.resetHistory()
         window.location.assign.resetHistory()
-      })
-
-      it('should open a new tab', function () {
-        expect(newTab.target).to.equal('_blank')
-      })
-
-      it('should open a Talk URL', function () {
-        expect(newTab.location).to.equal(subject.talkURL)
-      })
-
-      it('should switch focus to the new tab', function () {
-        expect(newTab.focus).to.have.been.calledOnce
       })
     })
   })

--- a/packages/lib-classifier/src/store/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject.spec.js
@@ -91,13 +91,8 @@ describe('Model > Subject', function () {
         feedback.setOnHide.resetHistory()
         window.location.assign.resetHistory()
       })
-      
-      it('should set an onHide callback', function () {
-        expect(feedback.setOnHide).to.have.been.calledOnce
-      })
 
-      it('should defer opening a Talk URL', function () {
-        onHide()
+      it('should open a Talk URL', function () {
         expect(window.location.assign.withArgs(subject.talkURL)).to.have.been.calledOnce
       })
     })
@@ -120,26 +115,16 @@ describe('Model > Subject', function () {
         window.location.assign.resetHistory()
       })
 
-      it('should set an onHide callback', function () {
-        expect(feedback.setOnHide).to.have.been.calledOnce
+      it('should open a new tab', function () {
+        expect(newTab.target).to.equal('_blank')
       })
 
-      describe('when feedback closes', function () {
-        before(function () {
-          onHide()
-        })
+      it('should open a Talk URL', function () {
+        expect(newTab.location).to.equal(subject.talkURL)
+      })
 
-        it('should open a new tab', function () {
-          expect(newTab.target).to.equal('_blank')
-        })
-
-        it('should open a Talk URL', function () {
-          expect(newTab.location).to.equal(subject.talkURL)
-        })
-
-        it('should switch focus to the new tab', function () {
-          expect(newTab.focus).to.have.been.calledOnce
-        })
+      it('should switch focus to the new tab', function () {
+        expect(newTab.focus).to.have.been.calledOnce
       })
     })
   })

--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -1,10 +1,22 @@
 import asyncStates from '@zooniverse/async-states'
 import { autorun } from 'mobx'
-import { addDisposer, flow, getRoot, onPatch, types } from 'mobx-state-tree'
+import { addDisposer, addMiddleware, flow, getRoot, onPatch, types } from 'mobx-state-tree'
 import { getBearerToken } from './utils'
 import { filterByLabel, filters } from '../components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal'
 import ResourceStore from './ResourceStore'
 import Subject from './Subject'
+
+function openTalkPage (talkURL, newTab = false) {
+  if (newTab) {
+    const newTab = window.open()
+    newTab.opener = null
+    newTab.location = talkURL
+    newTab.target = '_blank'
+    newTab.focus()
+  } else {
+    window.location.assign(talkURL)
+  }
+}
 
 const SubjectStore = types
   .model('SubjectStore', {
@@ -44,6 +56,7 @@ const SubjectStore = types
     function afterAttach () {
       createWorkflowObserver()
       createClassificationObserver()
+      createSubjectMiddleware()
     }
 
     function createWorkflowObserver () {
@@ -65,6 +78,30 @@ const SubjectStore = types
         })
       })
       addDisposer(self, classificationDisposer)
+    }
+
+    function onSubjectAdvance (call, next, abort) {
+      const subject = self.active
+      if (subject && subject.shouldDiscuss) {
+        abort()
+        const { url, newTab } = subject.shouldDiscuss
+        openTalkPage(url, newTab)
+      } else {
+        next(call)
+      }
+    }
+
+    function createSubjectMiddleware () {
+      const subjectMiddleware = autorun(() => {
+        addMiddleware(self, (call, next, abort) => {
+          if (call.name === 'advance') {
+            onSubjectAdvance(call, next, abort)
+          } else {
+            next(call)
+          }
+        })
+      })
+      addDisposer(self, subjectMiddleware)
     }
 
     function * populateQueue () {
@@ -112,3 +149,4 @@ const SubjectStore = types
   })
 
 export default types.compose('SubjectResourceStore', ResourceStore, SubjectStore)
+export { openTalkPage }

--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -81,14 +81,14 @@ const SubjectStore = types
     }
 
     function onSubjectAdvance (call, next, abort) {
+      const root = getRoot(self)
       const subject = self.active
-      if (subject && subject.shouldDiscuss) {
-        abort()
+      const shouldShowFeedback = root.feedback.isActive && root.feedback.messages.length && !root.feedback.showModal
+      if (!shouldShowFeedback && subject && subject.shouldDiscuss) {
         const { url, newTab } = subject.shouldDiscuss
         openTalkPage(url, newTab)
-      } else {
-        next(call)
       }
+      next(call)
     }
 
     function createSubjectMiddleware () {


### PR DESCRIPTION
Add an openInTalk action to subjects and invoke it when Done & Talk is pressed. 
Remove the code from the DoneAndTalkButtonContainer that updated window.location to open a Talk page.
Instead, we now intercept the subject queue advance and look to see if we expect feedback or if Done & Talk has been pressed, then go to Talk if it's safe to do so.

Package:
lib-classifier

Closes #900.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

