### PR TITLE
Handle empty subject queues properly

### DIFF
--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -50,7 +50,8 @@ const SubjectStore = types
         self.populateQueue()
       }
 
-      self.active = self.resources.values().next().value.id
+      const nextSubject = self.resources.values().next().value
+      self.active = nextSubject && nextSubject.id
     }
 
     function afterAttach () {

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -82,6 +82,7 @@ describe('Model > SubjectStore', function () {
 
       it('should leave the active subject empty', function () {
         expect(rootStore.subjects.resources.size).to.equal(0)
+        expect(rootStore.subjects.active).to.be.undefined
       })
     })
   })

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -25,6 +25,11 @@ const clientStub = {
 }
 
 describe('Model > SubjectStore', function () {
+  function setupStores(rootStore) {
+      rootStore.projects.setResource(project)
+      rootStore.workflows.setResource(workflow)
+      rootStore.workflows.setActive(workflow.id)
+  }
   describe('Actions > advance', function () {
     before(function () {
       rootStore = RootStore.create(
@@ -34,9 +39,7 @@ describe('Model > SubjectStore', function () {
     })
 
     it('should make the next subject in the queue active when calling `advance()`', function (done) {
-      rootStore.projects.setResource(project)
-      rootStore.workflows.setResource(workflow)
-      rootStore.workflows.setActive(workflow.id)
+      setupStores(rootStore)
       rootStore.subjects.populateQueue().then(() => {
         expect(rootStore.subjects.active.id).to.equal(rootStore.subjects.resources.values().next().value.id)
         rootStore.subjects.advance()
@@ -98,9 +101,7 @@ describe('Model > SubjectStore', function () {
         }
       )
 
-      rootStore.projects.setResource(project)
-      rootStore.workflows.setResource(workflow)
-      rootStore.workflows.setActive(workflow.id)
+      setupStores(rootStore)
       rootStore.subjects.populateQueue().then(() => {
         expect(rootStore.subjects.isThereMetadata).to.be.false
       }).then(done, done)
@@ -112,9 +113,7 @@ describe('Model > SubjectStore', function () {
         { client: clientStub }
       )
 
-      rootStore.projects.setResource(project)
-      rootStore.workflows.setResource(workflow)
-      rootStore.workflows.setActive(workflow.id)
+      setupStores(rootStore)
       rootStore.subjects.populateQueue().then(() => {
         expect(Object.keys(rootStore.subjects.active.toJSON().metadata)).to.have.lengthOf(0)
         expect(rootStore.subjects.isThereMetadata).to.be.false
@@ -138,9 +137,7 @@ describe('Model > SubjectStore', function () {
         }
       )
 
-      rootStore.projects.setResource(project)
-      rootStore.workflows.setResource(workflow)
-      rootStore.workflows.setActive(workflow.id)
+      setupStores(rootStore)
       rootStore.subjects.populateQueue().then(() => {
         const metadataKeys = Object.keys(rootStore.subjects.active.toJSON().metadata)
         expect(metadataKeys).to.have.lengthOf(1)
@@ -166,9 +163,7 @@ describe('Model > SubjectStore', function () {
         }
       )
 
-      rootStore.projects.setResource(project)
-      rootStore.workflows.setResource(workflow)
-      rootStore.workflows.setActive(workflow.id)
+      setupStores(rootStore)
       rootStore.subjects.populateQueue().then(() => {
         expect(Object.keys(rootStore.subjects.active.toJSON().metadata)).to.have.lengthOf(1)
         expect(rootStore.subjects.isThereMetadata).to.be.true

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -26,6 +26,7 @@ const clientStub = {
 
 describe('Model > SubjectStore', function () {
   function setupStores(rootStore) {
+      sinon.stub(rootStore.classifications, 'createClassification')
       rootStore.projects.setResource(project)
       rootStore.workflows.setResource(workflow)
       rootStore.workflows.setActive(workflow.id)


### PR DESCRIPTION
Add some tests:
- [x] Expect the queue to rebuild with less than three subjects.
- [x] Expect empty queues to be handled properly while waiting for new subjects.
- [x] Fix the type error for active subjects when the subject queue is empty.

Package:
lib-classifier

Closes #904.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

