### PR TITLE
Add snazzy formatting back to the linter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
     "@babel/generator": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+      "integrity": "sha1-F0ohXrhD/DksftyqvqqHPebo8EE=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.4.4",
@@ -49,7 +49,7 @@
     "@babel/helper-split-export-declaration": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+      "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.4.4"
@@ -69,13 +69,13 @@
     "@babel/parser": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
-      "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==",
+      "integrity": "sha1-WXcSlDG4/jNHFzDSVc6GVK4SULY=",
       "dev": true
     },
     "@babel/template": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+      "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -86,7 +86,7 @@
     "@babel/traverse": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
-      "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
+      "integrity": "sha1-B3bwOPbXg2GGC2gjiH1POTcTP+g=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -120,7 +120,7 @@
     "@babel/types": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+      "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -131,7 +131,7 @@
     "@lerna/add": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.13.3.tgz",
-      "integrity": "sha512-T3/Lsbo9ZFq+vL3ssaHxA8oKikZAPTJTGFe4CRuQgWCDd/M61+51jeWsngdaHpwzSSRDRjxg8fJTG10y10pnfA==",
+      "integrity": "sha1-9MFnSDl4DkWPBCbU97bQp3uaKuk=",
       "dev": true,
       "requires": {
         "@lerna/bootstrap": "3.13.3",
@@ -149,7 +149,7 @@
     "@lerna/batch-packages": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.13.0.tgz",
-      "integrity": "sha512-TgLBTZ7ZlqilGnzJ3xh1KdAHcySfHytgNRTdG9YomfriTU6kVfp1HrXxKJYVGs7ClPUNt2CTFEOkw0tMBronjw==",
+      "integrity": "sha1-aX/eW+KIIq+dncovdQJQuQqJoAA=",
       "dev": true,
       "requires": {
         "@lerna/package-graph": "3.13.0",
@@ -160,7 +160,7 @@
     "@lerna/bootstrap": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.13.3.tgz",
-      "integrity": "sha512-2XzijnLHRZOVQh8pwS7+5GR3cG4uh+EiLrWOishCq2TVzkqgjaS3GGBoef7KMCXfWHoLqAZRr/jEdLqfETLVqg==",
+      "integrity": "sha1-oOXkZt5cEAtJ1VjTkTkgT8TbXJU=",
       "dev": true,
       "requires": {
         "@lerna/batch-packages": "3.13.0",
@@ -192,7 +192,7 @@
     "@lerna/changed": {
       "version": "3.13.4",
       "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.13.4.tgz",
-      "integrity": "sha512-9lfOyRVObasw6L/z7yCSfsEl1QKy0Eamb8t2Krg1deIoAt+cE3JXOdGGC1MhOSli+7f/U9LyLXjJzIOs/pc9fw==",
+      "integrity": "sha1-xp2KB5mZ5JYR3ViYfwhDe67oGtQ=",
       "dev": true,
       "requires": {
         "@lerna/collect-updates": "3.13.3",
@@ -205,7 +205,7 @@
     "@lerna/check-working-tree": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.13.3.tgz",
-      "integrity": "sha512-LoGZvTkne+V1WpVdCTU0XNzFKsQa2AiAFKksGRT0v8NQj6VAPp0jfVYDayTqwaWt2Ne0OGKOFE79Y5LStOuhaQ==",
+      "integrity": "sha1-g2o//UQToprKkszKShFeT5cQmZI=",
       "dev": true,
       "requires": {
         "@lerna/describe-ref": "3.13.3",
@@ -215,7 +215,7 @@
     "@lerna/child-process": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.13.3.tgz",
-      "integrity": "sha512-3/e2uCLnbU+bydDnDwyadpOmuzazS01EcnOleAnuj9235CU2U97DH6OyoG1EW/fU59x11J+HjIqovh5vBaMQjQ==",
+      "integrity": "sha1-bAhO5cyp/J4E1r9Pw/dD7Sb/GQw=",
       "dev": true,
       "requires": {
         "chalk": "^2.3.1",
@@ -226,7 +226,7 @@
     "@lerna/clean": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.13.3.tgz",
-      "integrity": "sha512-xmNauF1PpmDaKdtA2yuRc23Tru4q7UMO6yB1a/TTwxYPYYsAWG/CBK65bV26J7x4RlZtEv06ztYGMa9zh34UXA==",
+      "integrity": "sha1-VnOhI44HEtMXEefk6MuWQYkdquo=",
       "dev": true,
       "requires": {
         "@lerna/command": "3.13.3",
@@ -242,7 +242,7 @@
     "@lerna/cli": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.13.0.tgz",
-      "integrity": "sha512-HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==",
+      "integrity": "sha1-PXs1f914GEI+loGnt/Kr0QbIomY=",
       "dev": true,
       "requires": {
         "@lerna/global-options": "3.13.0",
@@ -254,7 +254,7 @@
     "@lerna/collect-updates": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.13.3.tgz",
-      "integrity": "sha512-sTpALOAxli/ZS+Mjq6fbmjU9YXqFJ2E4FrE1Ijl4wPC5stXEosg2u0Z1uPY+zVKdM+mOIhLxPVdx83rUgRS+Cg==",
+      "integrity": "sha1-YWZI2lnwr/So5gJXeVzEbKaSHt0=",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.13.3",
@@ -267,7 +267,7 @@
     "@lerna/command": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.13.3.tgz",
-      "integrity": "sha512-WHFIQCubJV0T8gSLRNr6exZUxTswrh+iAtJCb86SE0Sa+auMPklE8af7w2Yck5GJfewmxSjke3yrjNxQrstx7w==",
+      "integrity": "sha1-WyCz9QciRXNVEDngRgvDbDn36dE=",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.13.3",
@@ -285,7 +285,7 @@
     "@lerna/conventional-commits": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.13.0.tgz",
-      "integrity": "sha512-BeAgcNXuocmLhPxnmKU2Vy8YkPd/Uo+vu2i/p3JGsUldzrPC8iF3IDxH7fuXpEFN2Nfogu7KHachd4tchtOppA==",
+      "integrity": "sha1-h3qiJco0zKYcMeoCpaYpavdOEUQ=",
       "dev": true,
       "requires": {
         "@lerna/validation-error": "3.13.0",
@@ -303,7 +303,7 @@
     "@lerna/create": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.13.3.tgz",
-      "integrity": "sha512-4M5xT1AyUMwt1gCDph4BfW3e6fZmt0KjTa3FoXkUotf/w/eqTsc2IQ+ULz2+gOFQmtuNbqIZEOK3J4P9ArJJ/A==",
+      "integrity": "sha1-be0ULFS3886oZBPDY3sGcCe39V0=",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.13.3",
@@ -329,7 +329,7 @@
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
           "dev": true
         }
       }
@@ -337,7 +337,7 @@
     "@lerna/create-symlink": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.13.0.tgz",
-      "integrity": "sha512-PTvg3jAAJSAtLFoZDsuTMv1wTOC3XYIdtg54k7uxIHsP8Ztpt+vlilY/Cni0THAqEMHvfiToel76Xdta4TU21Q==",
+      "integrity": "sha1-4BEzCC/gQHeXEslgaDyzonK2eAk=",
       "dev": true,
       "requires": {
         "cmd-shim": "^2.0.2",
@@ -348,7 +348,7 @@
     "@lerna/describe-ref": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.13.3.tgz",
-      "integrity": "sha512-5KcLTvjdS4gU5evW8ESbZ0BF44NM5HrP3dQNtWnOUSKJRgsES8Gj0lq9AlB2+YglZfjEftFT03uOYOxnKto4Uw==",
+      "integrity": "sha1-EzGFE2E/akB9N/xdwCXsLPtwVgY=",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.13.3",
@@ -358,7 +358,7 @@
     "@lerna/diff": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.13.3.tgz",
-      "integrity": "sha512-/DRS2keYbnKaAC+5AkDyZRGkP/kT7v1GlUS0JGZeiRDPQ1H6PzhX09EgE5X6nj0Ytrm0sUasDeN++CDVvgaI+A==",
+      "integrity": "sha1-iDyzqDqVbb/CwXvJoVZGil0/rhc=",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.13.3",
@@ -370,7 +370,7 @@
     "@lerna/exec": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.13.3.tgz",
-      "integrity": "sha512-c0bD4XqM96CTPV8+lvkxzE7mkxiFyv/WNM4H01YvvbFAJzk+S4Y7cBtRkIYFTfkFZW3FLo8pEgtG1ONtIdM+tg==",
+      "integrity": "sha1-XS7aP25YTy8VsRXopLW8lgul3oU=",
       "dev": true,
       "requires": {
         "@lerna/batch-packages": "3.13.0",
@@ -384,7 +384,7 @@
     "@lerna/filter-options": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.13.3.tgz",
-      "integrity": "sha512-DbtQX4eRgrBz1wCFWRP99JBD7ODykYme9ykEK79+RrKph40znhJQRlLg4idogj6IsUEzwo1OHjihCzSfnVo6Cg==",
+      "integrity": "sha1-qkKkq3iDe4psQni6hx0n6S13xU8=",
       "dev": true,
       "requires": {
         "@lerna/collect-updates": "3.13.3",
@@ -395,7 +395,7 @@
     "@lerna/filter-packages": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.13.0.tgz",
-      "integrity": "sha512-RWiZWyGy3Mp7GRVBn//CacSnE3Kw82PxE4+H6bQ3pDUw/9atXn7NRX+gkBVQIYeKamh7HyumJtyOKq3Pp9BADQ==",
+      "integrity": "sha1-9TcSSefhoVko5eiMVEokLgFiwhw=",
       "dev": true,
       "requires": {
         "@lerna/validation-error": "3.13.0",
@@ -406,7 +406,7 @@
     "@lerna/get-npm-exec-opts": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.13.0.tgz",
-      "integrity": "sha512-Y0xWL0rg3boVyJk6An/vurKzubyJKtrxYv2sj4bB8Mc5zZ3tqtv0ccbOkmkXKqbzvNNF7VeUt1OJ3DRgtC/QZw==",
+      "integrity": "sha1-0bVSywCIGZ/D5+Em+RTjmgjfnqU=",
       "dev": true,
       "requires": {
         "npmlog": "^4.1.2"
@@ -415,7 +415,7 @@
     "@lerna/get-packed": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/get-packed/-/get-packed-3.13.0.tgz",
-      "integrity": "sha512-EgSim24sjIjqQDC57bgXD9l22/HCS93uQBbGpkzEOzxAVzEgpZVm7Fm1t8BVlRcT2P2zwGnRadIvxTbpQuDPTg==",
+      "integrity": "sha1-M15A1388GFWqJIWH0+Cy2PSwbhY=",
       "dev": true,
       "requires": {
         "fs-extra": "^7.0.0",
@@ -443,7 +443,7 @@
     "@lerna/github-client": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.13.3.tgz",
-      "integrity": "sha512-fcJkjab4kX0zcLLSa/DCUNvU3v8wmy2c1lhdIbL7s7gABmDcV0QZq93LhnEee3VkC9UpnJ6GKG4EkD7eIifBnA==",
+      "integrity": "sha1-vPm0/0C90QTLQM0lcyLwUrQbuc4=",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.13.3",
@@ -456,13 +456,13 @@
     "@lerna/global-options": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.13.0.tgz",
-      "integrity": "sha512-SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ==",
+      "integrity": "sha1-IXZiKQ2watnPLEnY4xAO4o6uuuE=",
       "dev": true
     },
     "@lerna/has-npm-version": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.13.3.tgz",
-      "integrity": "sha512-mQzoghRw4dBg0R9FFfHrj0TH0glvXyzdEZmYZ8Isvx5BSuEEwpsryoywuZSdppcvLu8o7NAdU5Tac8cJ/mT52w==",
+      "integrity": "sha1-Fn4/YCovtY+E+Tz13zlwXKZDKi0=",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.13.3",
@@ -472,7 +472,7 @@
     "@lerna/import": {
       "version": "3.13.4",
       "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.13.4.tgz",
-      "integrity": "sha512-dn6eNuPEljWsifBEzJ9B6NoaLwl/Zvof7PBUPA4hRyRlqG5sXRn6F9DnusMTovvSarbicmTURbOokYuotVWQQA==",
+      "integrity": "sha1-6aGDG4/tM/PL6rO4THIsk3Gi6vc=",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.13.3",
@@ -488,7 +488,7 @@
     "@lerna/init": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.13.3.tgz",
-      "integrity": "sha512-bK/mp0sF6jT0N+c+xrbMCqN4xRoiZCXQzlYsyACxPK99KH/mpHv7hViZlTYUGlYcymtew6ZC770miv5A9wF9hA==",
+      "integrity": "sha1-69Ui/um519Oy2ssCYerdtIJoUf8=",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.13.3",
@@ -501,7 +501,7 @@
     "@lerna/link": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.13.3.tgz",
-      "integrity": "sha512-IHhtdhA0KlIdevCsq6WHkI2rF3lHWHziJs2mlrEWAKniVrFczbELON1KJAgdJS1k3kAP/WeWVqmIYZ2hJDxMvg==",
+      "integrity": "sha1-ERJNSgyNC3l1L72jur7f1i3VeEc=",
       "dev": true,
       "requires": {
         "@lerna/command": "3.13.3",
@@ -514,7 +514,7 @@
     "@lerna/list": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.13.3.tgz",
-      "integrity": "sha512-rLRDsBCkydMq2FL6WY1J/elvnXIjxxRtb72lfKHdvDEqVdquT5Qgt9ci42hwjmcocFwWcFJgF6BZozj5pbc13A==",
+      "integrity": "sha1-+pOGTUPK3rTNVApOeKUohsV9vnQ=",
       "dev": true,
       "requires": {
         "@lerna/command": "3.13.3",
@@ -526,7 +526,7 @@
     "@lerna/listable": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.13.0.tgz",
-      "integrity": "sha512-liYJ/WBUYP4N4MnSVZuLUgfa/jy3BZ02/1Om7xUY09xGVSuNVNEeB8uZUMSC+nHqFHIsMPZ8QK9HnmZb1E/eTA==",
+      "integrity": "sha1-urwYRCxZC1Sc8JZtINdf6gZlmNQ=",
       "dev": true,
       "requires": {
         "@lerna/batch-packages": "3.13.0",
@@ -537,7 +537,7 @@
     "@lerna/log-packed": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.13.0.tgz",
-      "integrity": "sha512-Rmjrcz+6aM6AEcEVWmurbo8+AnHOvYtDpoeMMJh9IZ9SmZr2ClXzmD7wSvjTQc8BwOaiWjjC/ukcT0UYA2m7wg==",
+      "integrity": "sha1-SXtfaSqNDj9mkSXal7Da39nkgPM=",
       "dev": true,
       "requires": {
         "byte-size": "^4.0.3",
@@ -549,7 +549,7 @@
     "@lerna/npm-conf": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.13.0.tgz",
-      "integrity": "sha512-Jg2kANsGnhg+fbPEzE0X9nX5oviEAvWj0nYyOkcE+cgWuT7W0zpnPXC4hA4C5IPQGhwhhh0IxhWNNHtjTuw53g==",
+      "integrity": "sha1-a0NO11/3V+jBQ4G5u/5dXd7BNKc=",
       "dev": true,
       "requires": {
         "config-chain": "^1.1.11",
@@ -559,7 +559,7 @@
     "@lerna/npm-dist-tag": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.13.0.tgz",
-      "integrity": "sha512-mcuhw34JhSRFrbPn0vedbvgBTvveG52bR2lVE3M3tfE8gmR/cKS/EJFO4AUhfRKGCTFn9rjaSEzlFGYV87pemQ==",
+      "integrity": "sha1-Sey+DoLL5K1KjqbeESmCv2xObNQ=",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1",
@@ -571,7 +571,7 @@
     "@lerna/npm-install": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.13.3.tgz",
-      "integrity": "sha512-7Jig9MLpwAfcsdQ5UeanAjndChUjiTjTp50zJ+UZz4CbIBIDhoBehvNMTCL2G6pOEC7sGEg6sAqJINAqred6Tg==",
+      "integrity": "sha1-mwmFJzLlHBbS4GD/L9i/u7Sc97o=",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.13.3",
@@ -586,7 +586,7 @@
     "@lerna/npm-publish": {
       "version": "3.13.2",
       "resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.13.2.tgz",
-      "integrity": "sha512-HMucPyEYZfom5tRJL4GsKBRi47yvSS2ynMXYxL3kO0ie+j9J7cb0Ir8NmaAMEd3uJWJVFCPuQarehyfTDZsSxg==",
+      "integrity": "sha1-rXE8pvkahSaH19Dhvaf5xm3yF2g=",
       "dev": true,
       "requires": {
         "@lerna/run-lifecycle": "3.13.0",
@@ -602,7 +602,7 @@
     "@lerna/npm-run-script": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.13.3.tgz",
-      "integrity": "sha512-qR4o9BFt5hI8Od5/DqLalOJydnKpiQFEeN0h9xZi7MwzuX1Ukwh3X22vqsX4YRbipIelSFtrDzleNVUm5jj0ow==",
+      "integrity": "sha1-m7Y4ntcM1QaQXWsFtuqzNrQmbK8=",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.13.3",
@@ -613,7 +613,7 @@
     "@lerna/output": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.13.0.tgz",
-      "integrity": "sha512-7ZnQ9nvUDu/WD+bNsypmPG5MwZBwu86iRoiW6C1WBuXXDxM5cnIAC1m2WxHeFnjyMrYlRXM9PzOQ9VDD+C15Rg==",
+      "integrity": "sha1-Pe18yQiyephyIopjDZUK7a56SYk=",
       "dev": true,
       "requires": {
         "npmlog": "^4.1.2"
@@ -622,7 +622,7 @@
     "@lerna/pack-directory": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/@lerna/pack-directory/-/pack-directory-3.13.1.tgz",
-      "integrity": "sha512-kXnyqrkQbCIZOf1054N88+8h0ItC7tUN5v9ca/aWpx298gsURpxUx/1TIKqijL5TOnHMyIkj0YJmnH/PyBVLKA==",
+      "integrity": "sha1-WtTQlF+Gpkj1ZeJNU8HgG7OpEtE=",
       "dev": true,
       "requires": {
         "@lerna/get-packed": "3.13.0",
@@ -655,7 +655,7 @@
     "@lerna/package": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.13.0.tgz",
-      "integrity": "sha512-kSKO0RJQy093BufCQnkhf1jB4kZnBvL7kK5Ewolhk5gwejN+Jofjd8DGRVUDUJfQ0CkW1o6GbUeZvs8w8VIZDg==",
+      "integrity": "sha1-S67rxJpX/JsxBizFn17jg4RCn8g=",
       "dev": true,
       "requires": {
         "load-json-file": "^4.0.0",
@@ -666,7 +666,7 @@
     "@lerna/package-graph": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.13.0.tgz",
-      "integrity": "sha512-3mRF1zuqFE1HEFmMMAIggXy+f+9cvHhW/jzaPEVyrPNLKsyfJQtpTNzeI04nfRvbAh+Gd2aNksvaW/w3xGJnnw==",
+      "integrity": "sha1-YHBi+NLOIrFfjUoGI/OEc25n92A=",
       "dev": true,
       "requires": {
         "@lerna/validation-error": "3.13.0",
@@ -677,7 +677,7 @@
     "@lerna/project": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.13.1.tgz",
-      "integrity": "sha512-/GoCrpsCCTyb9sizk1+pMBrIYchtb+F1uCOn3cjn9yenyG/MfYEnlfrbV5k/UDud0Ei75YBLbmwCbigHkAKazQ==",
+      "integrity": "sha1-vOiQ9gGHvZULzzbAS1JgZC4pXnk=",
       "dev": true,
       "requires": {
         "@lerna/package": "3.13.0",
@@ -697,7 +697,7 @@
     "@lerna/prompt": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.13.0.tgz",
-      "integrity": "sha512-P+lWSFokdyvYpkwC3it9cE0IF2U5yy2mOUbGvvE4iDb9K7TyXGE+7lwtx2thtPvBAfIb7O13POMkv7df03HJeA==",
+      "integrity": "sha1-U1cUYrs/U5nMHKbTNaQR/gk0JqU=",
       "dev": true,
       "requires": {
         "inquirer": "^6.2.0",
@@ -707,7 +707,7 @@
     "@lerna/publish": {
       "version": "3.13.4",
       "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.13.4.tgz",
-      "integrity": "sha512-v03pabiPlqCDwX6cVNis1PDdT6/jBgkVb5Nl4e8wcJXevIhZw3ClvtI94gSZu/wdoVFX0RMfc8QBVmaimSO0qg==",
+      "integrity": "sha1-JbZ4woURCJen/FGYo1vfqdt/nME=",
       "dev": true,
       "requires": {
         "@lerna/batch-packages": "3.13.0",
@@ -745,7 +745,7 @@
     "@lerna/pulse-till-done": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/pulse-till-done/-/pulse-till-done-3.13.0.tgz",
-      "integrity": "sha512-1SOHpy7ZNTPulzIbargrgaJX387csN7cF1cLOGZiJQA6VqnS5eWs2CIrG8i8wmaUavj2QlQ5oEbRMVVXSsGrzA==",
+      "integrity": "sha1-yOnOW6+vENkwpn1+0My12Vj+ARA=",
       "dev": true,
       "requires": {
         "npmlog": "^4.1.2"
@@ -754,7 +754,7 @@
     "@lerna/resolve-symlink": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.13.0.tgz",
-      "integrity": "sha512-Lc0USSFxwDxUs5JvIisS8JegjA6SHSAWJCMvi2osZx6wVRkEDlWG2B1JAfXUzCMNfHoZX0/XX9iYZ+4JIpjAtg==",
+      "integrity": "sha1-PmgJ71O2P+kUgUv6BxzWgBLiL7s=",
       "dev": true,
       "requires": {
         "fs-extra": "^7.0.0",
@@ -765,7 +765,7 @@
     "@lerna/rimraf-dir": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.13.3.tgz",
-      "integrity": "sha512-d0T1Hxwu3gpYVv73ytSL+/Oy8JitsmvOYUR5ouRSABsmqS7ZZCh5t6FgVDDGVXeuhbw82+vuny1Og6Q0k4ilqw==",
+      "integrity": "sha1-Oo5xMX/ehTiT7wJivJu6ahgLcic=",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.13.3",
@@ -777,7 +777,7 @@
     "@lerna/run": {
       "version": "3.13.3",
       "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.13.3.tgz",
-      "integrity": "sha512-ygnLIfIYS6YY1JHWOM4CsdZiY8kTYPsDFOLAwASlRnlAXF9HiMT08GFXLmMHIblZJ8yJhsM2+QgraCB0WdxzOQ==",
+      "integrity": "sha1-B4HILSJe9uheKNPnY/f8CQo3aiE=",
       "dev": true,
       "requires": {
         "@lerna/batch-packages": "3.13.0",
@@ -794,7 +794,7 @@
     "@lerna/run-lifecycle": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.13.0.tgz",
-      "integrity": "sha512-oyiaL1biZdjpmjh6X/5C4w07wNFyiwXSSHH5GQB4Ay4BPwgq9oNhCcxRoi0UVZlZ1YwzSW8sTwLgj8emkIo3Yg==",
+      "integrity": "sha1-2INe6DQl7e5A9oelX4G1AjVNMmE=",
       "dev": true,
       "requires": {
         "@lerna/npm-conf": "3.13.0",
@@ -806,7 +806,7 @@
     "@lerna/run-parallel-batches": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.13.0.tgz",
-      "integrity": "sha512-bICFBR+cYVF1FFW+Tlm0EhWDioTUTM6dOiVziDEGE1UZha1dFkMYqzqdSf4bQzfLS31UW/KBd/2z8jy2OIjEjg==",
+      "integrity": "sha1-Ana7TnzQmVKX24LRNMor0I1j4xE=",
       "dev": true,
       "requires": {
         "p-map": "^1.2.0",
@@ -816,7 +816,7 @@
     "@lerna/symlink-binary": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.13.0.tgz",
-      "integrity": "sha512-obc4Y6jxywkdaCe+DB0uTxYqP0IQ8mFWvN+k/YMbwH4G2h7M7lCBWgPy8e7xw/50+1II9tT2sxgx+jMus1sTJg==",
+      "integrity": "sha1-NqlBXUaK/LgQV1ApaQL28ACpaA0=",
       "dev": true,
       "requires": {
         "@lerna/create-symlink": "3.13.0",
@@ -828,7 +828,7 @@
     "@lerna/symlink-dependencies": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.13.0.tgz",
-      "integrity": "sha512-7CyN5WYEPkbPLbqHBIQg/YiimBzb5cIGQB0E9IkLs3+racq2vmUNQZn38LOaazQacAA83seB+zWSxlI6H+eXSg==",
+      "integrity": "sha1-dsI+yr2ngk25igVhNk8SK0V1Cc8=",
       "dev": true,
       "requires": {
         "@lerna/create-symlink": "3.13.0",
@@ -843,13 +843,13 @@
     "@lerna/timer": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/timer/-/timer-3.13.0.tgz",
-      "integrity": "sha512-RHWrDl8U4XNPqY5MQHkToWS9jHPnkLZEt5VD+uunCKTfzlxGnRCr3/zVr8VGy/uENMYpVP3wJa4RKGY6M0vkRw==",
+      "integrity": "sha1-vNCQRVHbFuCDZNbBjl4hYPyHB4E=",
       "dev": true
     },
     "@lerna/validation-error": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.13.0.tgz",
-      "integrity": "sha512-SiJP75nwB8GhgwLKQfdkSnDufAaCbkZWJqEDlKOUPUvVOplRGnfL+BPQZH5nvq2BYSRXsksXWZ4UHVnQZI/HYA==",
+      "integrity": "sha1-yGuPB8WrlTn3db2KVJdukm83WcM=",
       "dev": true,
       "requires": {
         "npmlog": "^4.1.2"
@@ -858,7 +858,7 @@
     "@lerna/version": {
       "version": "3.13.4",
       "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.13.4.tgz",
-      "integrity": "sha512-pptWUEgN/lUTQZu34+gfH1g4Uhs7TDKRcdZY9A4T9k6RTOwpKC2ceLGiXdeR+ZgQJAey2C4qiE8fo5Z6Rbc6QA==",
+      "integrity": "sha1-6iOyZL69pCXMv83NHeE+9Fo5Dlk=",
       "dev": true,
       "requires": {
         "@lerna/batch-packages": "3.13.0",
@@ -888,7 +888,7 @@
     "@lerna/write-log-file": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.13.0.tgz",
-      "integrity": "sha512-RibeMnDPvlL8bFYW5C8cs4mbI3AHfQef73tnJCQ/SgrXZHehmHnsyWUiE7qDQCAo+B1RfTapvSyFF69iPj326A==",
+      "integrity": "sha1-t42eTPwTSai+ZNkTJMTIGZ6CKiY=",
       "dev": true,
       "requires": {
         "npmlog": "^4.1.2",
@@ -926,7 +926,7 @@
         "is-plain-object": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "integrity": "sha1-R7/F2htdUNZBEIBsGZNZSC51qSg=",
           "dev": true,
           "requires": {
             "isobject": "^4.0.0"
@@ -935,7 +935,7 @@
         "isobject": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "integrity": "sha1-PxyRVec7GSAiqAgZus0DQ3EWl7A=",
           "dev": true
         }
       }
@@ -943,7 +943,7 @@
     "@octokit/plugin-enterprise-rest": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-2.2.2.tgz",
-      "integrity": "sha512-CTZr64jZYhGWNTDGlSJ2mvIlFsm9OEO3LqWn9I/gmoHI4jRBp4kpHoFYNemG4oA75zUAcmbuWblb7jjP877YZw==",
+      "integrity": "sha1-wOIgZ6BD4Z+W/5x4MuKjAZ+b51w=",
       "dev": true
     },
     "@octokit/request": {
@@ -963,7 +963,7 @@
         "is-plain-object": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "integrity": "sha1-R7/F2htdUNZBEIBsGZNZSC51qSg=",
           "dev": true,
           "requires": {
             "isobject": "^4.0.0"
@@ -972,7 +972,7 @@
         "isobject": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "integrity": "sha1-PxyRVec7GSAiqAgZus0DQ3EWl7A=",
           "dev": true
         }
       }
@@ -1000,7 +1000,7 @@
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "integrity": "sha1-MgjB8I06TZkmGrZPkjArwV4RHKA=",
       "dev": true,
       "requires": {
         "jsonparse": "^1.2.0",
@@ -1010,13 +1010,13 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
       "dev": true
     },
     "agent-base": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "integrity": "sha1-2J5ZmfeXh1Z0wH2H8mD8Qeg+jKk=",
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
@@ -1025,7 +1025,7 @@
     "agentkeepalive": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
-      "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+      "integrity": "sha1-oROSTdP6JKC8O3gQjEUMKr7gD2c=",
       "dev": true,
       "requires": {
         "humanize-ms": "^1.2.1"
@@ -1067,7 +1067,7 @@
     "append-transform": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+      "integrity": "sha1-BGpSrlgqIovXL1is++KWfGeHWas=",
       "dev": true,
       "requires": {
         "default-require-extensions": "^2.0.0"
@@ -1076,7 +1076,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
       "dev": true
     },
     "archy": {
@@ -1088,7 +1088,7 @@
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
       "dev": true,
       "requires": {
         "delegates": "^1.0.0",
@@ -1309,13 +1309,13 @@
     "before-after-hook": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
-      "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==",
+      "integrity": "sha1-K2vyPcpPMuYo/SdHwQo3x0pLSE0=",
       "dev": true
     },
     "bluebird": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+      "integrity": "sha1-1sxmFZXeMNWzr1/O3TwLPvbsVxQ=",
       "dev": true
     },
     "brace-expansion": {
@@ -1388,7 +1388,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "builtins": {
@@ -1406,13 +1406,13 @@
     "byte-size": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-4.0.4.tgz",
-      "integrity": "sha512-82RPeneC6nqCdSwCX2hZUz3JPOvN5at/nTEw/CMf05Smu3Hrpo9Psb7LjN+k+XndNArG1EY8L4+BM3aTM4BCvw==",
+      "integrity": "sha1-KdOBcJ9BquDYnGMfHIGuyIzUCyM=",
       "dev": true
     },
     "cacache": {
       "version": "11.3.2",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
-      "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+      "integrity": "sha1-LYHjCOPSWMo4Eltna5iyrJzmm/o=",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.3",
@@ -1451,7 +1451,7 @@
     "caching-transform": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
-      "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
+      "integrity": "sha1-YB1GuR7Kh2h6KB5xzvmXkbDvynA=",
       "dev": true,
       "requires": {
         "hasha": "^3.0.0",
@@ -1463,7 +1463,7 @@
         "make-dir": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
           "dev": true,
           "requires": {
             "pify": "^4.0.1",
@@ -1473,7 +1473,7 @@
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
           "dev": true
         }
       }
@@ -1587,13 +1587,13 @@
     "chownr": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+      "integrity": "sha1-VHJri4//TfBTxCGH6AH7RBLfFJQ=",
       "dev": true
     },
     "ci-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+      "integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc=",
       "dev": true
     },
     "class-utils": {
@@ -1643,7 +1643,7 @@
     "cliui": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
       "dev": true,
       "requires": {
         "string-width": "^2.1.1",
@@ -1666,7 +1666,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -1805,7 +1805,7 @@
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -1817,7 +1817,7 @@
     "config-chain": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+      "integrity": "sha1-D96NCRIA616AjK8l/mGMAvSOTvo=",
       "dev": true,
       "requires": {
         "ini": "^1.3.4",
@@ -1843,7 +1843,7 @@
     "conventional-changelog-angular": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
-      "integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
+      "integrity": "sha1-KZ/dQ99aHwlSg6wWru37CmguyrA=",
       "dev": true,
       "requires": {
         "compare-func": "^1.3.1",
@@ -1853,7 +1853,7 @@
     "conventional-changelog-core": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.2.2.tgz",
-      "integrity": "sha512-cssjAKajxaOX5LNAJLB+UOcoWjAIBvXtDMedv/58G+YEmAXMNfC16mmPl0JDOuVJVfIqM0nqQiZ8UCm8IXbE0g==",
+      "integrity": "sha1-3kHmtKcQEaGLzuWOdE9vjw58KcA=",
       "dev": true,
       "requires": {
         "conventional-changelog-writer": "^4.0.5",
@@ -1874,7 +1874,7 @@
         "through2": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "integrity": "sha1-OSducTwzAu3544jdnIEt07glvVo=",
           "dev": true,
           "requires": {
             "readable-stream": "2 || 3"
@@ -1885,13 +1885,13 @@
     "conventional-changelog-preset-loader": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.1.1.tgz",
-      "integrity": "sha512-K4avzGMLm5Xw0Ek/6eE3vdOXkqnpf9ydb68XYmCc16cJ99XMMbc2oaNMuPwAsxVK6CC1yA4/I90EhmWNj0Q6HA==",
+      "integrity": "sha1-ZbtgBUfFbVYn0jE1FUvNmpB2aMQ=",
       "dev": true
     },
     "conventional-changelog-writer": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.5.tgz",
-      "integrity": "sha512-g/Myp4MaJ1A+f7Ai+SnVhkcWtaHk6flw0SYN7A+vQ+MTu0+gSovQWs4Pg4NtcNUcIztYQ9YHsoxHP+GGQplI7Q==",
+      "integrity": "sha1-+544S7KU6Oip8laKP00eEZU9hkE=",
       "dev": true,
       "requires": {
         "compare-func": "^1.3.1",
@@ -1909,7 +1909,7 @@
         "through2": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "integrity": "sha1-OSducTwzAu3544jdnIEt07glvVo=",
           "dev": true,
           "requires": {
             "readable-stream": "2 || 3"
@@ -1920,7 +1920,7 @@
     "conventional-commits-filter": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.2.tgz",
-      "integrity": "sha512-WpGKsMeXfs21m1zIw4s9H5sys2+9JccTzpN6toXtxhpw2VNF2JUXwIakthKBy+LN4DvJm+TzWhxOMWOs1OFCFQ==",
+      "integrity": "sha1-8SL4n7zVu4Hiry/KwCVNBi0QOcE=",
       "dev": true,
       "requires": {
         "lodash.ismatch": "^4.4.0",
@@ -1930,7 +1930,7 @@
     "conventional-commits-parser": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.2.tgz",
-      "integrity": "sha512-y5eqgaKR0F6xsBNVSQ/5cI5qIF3MojddSUi1vKIggRkqUTbkqFKH9P5YX/AT1BVZp9DtSzBTIkvjyVLotLsVog==",
+      "integrity": "sha1-EpVZDdGV9k9T1vjrfEERS7mmB0I=",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.4",
@@ -1945,7 +1945,7 @@
         "through2": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "integrity": "sha1-OSducTwzAu3544jdnIEt07glvVo=",
           "dev": true,
           "requires": {
             "readable-stream": "2 || 3"
@@ -1956,7 +1956,7 @@
     "conventional-recommended-bump": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-4.1.1.tgz",
-      "integrity": "sha512-JT2vKfSP9kR18RXXf55BRY1O3AHG8FPg5btP3l7LYfcWJsiXI6MCf30DepQ98E8Qhowvgv7a8iev0J1bEDkTFA==",
+      "integrity": "sha1-NwFPre2iZ9Bgfi/IESTahApYUSc=",
       "dev": true,
       "requires": {
         "concat-stream": "^2.0.0",
@@ -1972,7 +1972,7 @@
         "concat-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+          "integrity": "sha1-QUz1r3kKSMYKub5FJ9VtXkETPLE=",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -1984,7 +1984,7 @@
         "readable-stream": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "integrity": "sha1-y4ARqtAC63F78EApH+uoVpyYb7k=",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -1997,7 +1997,7 @@
     "convert-source-map": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -2006,7 +2006,7 @@
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
       "dev": true,
       "requires": {
         "aproba": "^1.1.1",
@@ -2038,7 +2038,7 @@
     "cosmiconfig": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
-      "integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
+      "integrity": "sha1-RQOOTSin/nhyA67enCW8pKCLEsg=",
       "dev": true,
       "requires": {
         "import-fresh": "^2.0.0",
@@ -2064,7 +2064,7 @@
     "cp-file": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
-      "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
+      "integrity": "sha1-QNXqSh3vKprN0HulwLAkbvc9wQ0=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -2077,7 +2077,7 @@
         "make-dir": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
           "dev": true,
           "requires": {
             "pify": "^4.0.1",
@@ -2087,7 +2087,7 @@
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
           "dev": true
         }
       }
@@ -2095,7 +2095,7 @@
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
       "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
@@ -2141,7 +2141,7 @@
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "integrity": "sha1-puN0maTZqc+F71hyBE1ikByYia4=",
       "dev": true
     },
     "debug": {
@@ -2198,7 +2198,7 @@
     "deepmerge": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
-      "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==",
+      "integrity": "sha1-WO9GOlfAjTdlR/iGn9xbzulX9E4=",
       "dev": true
     },
     "default-require-extensions": {
@@ -2312,7 +2312,7 @@
     "deprecation": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-1.0.1.tgz",
-      "integrity": "sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==",
+      "integrity": "sha1-LfebeQBXUhgIFre24HnL2ASQ1xE=",
       "dev": true
     },
     "detect-file": {
@@ -2359,7 +2359,7 @@
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
       "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
@@ -2374,7 +2374,7 @@
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.0.0",
@@ -2396,7 +2396,7 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
       "dev": true
     },
     "encoding": {
@@ -2411,7 +2411,7 @@
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -2426,7 +2426,7 @@
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -2435,13 +2435,13 @@
     "es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "integrity": "sha1-njr0B0Wd7tR+mpH5uIWoTrBcVh0=",
       "dev": true
     },
     "es6-promise": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+      "integrity": "sha1-toXt2CWIhjZepitX0w3ij63Nl08=",
       "dev": true
     },
     "es6-promisify": {
@@ -2474,7 +2474,7 @@
     "execa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
       "dev": true,
       "requires": {
         "cross-spawn": "^6.0.0",
@@ -2679,7 +2679,7 @@
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+      "integrity": "sha1-hiRwESkBxyeg5JWoB0S9W6odZ5A=",
       "dev": true
     },
     "figures": {
@@ -2717,7 +2717,7 @@
     "find-cache-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
@@ -2728,7 +2728,7 @@
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -2737,7 +2737,7 @@
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -2747,7 +2747,7 @@
         "make-dir": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
           "dev": true,
           "requires": {
             "pify": "^4.0.1",
@@ -2757,7 +2757,7 @@
         "p-limit": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -2766,7 +2766,7 @@
         "p-locate": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -2775,19 +2775,19 @@
         "p-try": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
           "dev": true
         },
         "pkg-dir": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
           "dev": true,
           "requires": {
             "find-up": "^3.0.0"
@@ -2838,7 +2838,7 @@
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
-      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+      "integrity": "sha1-jdfYc6G6vCB9lOrQwuDkQnbr8ug=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -2883,7 +2883,7 @@
         "lru-cache": {
           "version": "4.1.5",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -2937,7 +2937,7 @@
     "fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -2948,7 +2948,7 @@
     "fs-minipass": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "integrity": "sha1-BsJ3IYRU7CiN93raVKA7hwKqy50=",
       "dev": true,
       "requires": {
         "minipass": "^2.2.1"
@@ -2991,13 +2991,13 @@
     "genfun": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
-      "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
+      "integrity": "sha1-ndlxCgaQClxKW/V6yl2k5S/nZTc=",
       "dev": true
     },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
       "dev": true
     },
     "get-pkg-repo": {
@@ -3192,7 +3192,7 @@
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
@@ -3216,7 +3216,7 @@
     "git-raw-commits": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
-      "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
+      "integrity": "sha1-2Srd90RAwUvMXIPszj+3+KeRGLU=",
       "dev": true,
       "requires": {
         "dargs": "^4.0.1",
@@ -3247,7 +3247,7 @@
     "git-semver-tags": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.2.tgz",
-      "integrity": "sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==",
+      "integrity": "sha1-9QbsB8qt4ZGsDI1aIb24ExtJNOM=",
       "dev": true,
       "requires": {
         "meow": "^4.0.0",
@@ -3257,7 +3257,7 @@
     "git-up": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
-      "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+      "integrity": "sha1-yy7whmU2QOch0gQv4xBIV9iQB8A=",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
@@ -3267,7 +3267,7 @@
     "git-url-parse": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
-      "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+      "integrity": "sha1-r/Gol8NsyTaZJwWHvqPby7uV3mc=",
       "dev": true,
       "requires": {
         "git-up": "^4.0.0"
@@ -3339,7 +3339,7 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
       "dev": true
     },
     "globby": {
@@ -3360,7 +3360,7 @@
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA=",
       "dev": true
     },
     "growl": {
@@ -3489,19 +3489,19 @@
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
       "dev": true
     },
     "http-cache-semantics": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+      "integrity": "sha1-ObDhat2bYFvwqe89nar0hDtMrNI=",
       "dev": true
     },
     "http-proxy-agent": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "integrity": "sha1-5IIb7vWyFCogJr1zkm/lN2McVAU=",
       "dev": true,
       "requires": {
         "agent-base": "4",
@@ -3511,7 +3511,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -3533,7 +3533,7 @@
     "https-proxy-agent": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
       "dev": true,
       "requires": {
         "agent-base": "^4.1.0",
@@ -3543,7 +3543,7 @@
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -3552,7 +3552,7 @@
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
           "dev": true
         }
       }
@@ -3590,7 +3590,7 @@
     "ignore-walk": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "integrity": "sha1-qD5i59JyrA47VRqqgoMaGbafgvg=",
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
@@ -3617,7 +3617,7 @@
     "import-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+      "integrity": "sha1-Xk/9wD9P5sAJxnKb6yljHC+CJ7w=",
       "dev": true,
       "requires": {
         "pkg-dir": "^2.0.0",
@@ -3661,7 +3661,7 @@
     "init-package-json": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
-      "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
+      "integrity": "sha1-Rf/i9hCoyhNPK9HbVjeyNQcPbL4=",
       "dev": true,
       "requires": {
         "glob": "^7.1.1",
@@ -3756,7 +3756,7 @@
     "invert-kv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
       "dev": true
     },
     "ip": {
@@ -3810,7 +3810,7 @@
     "is-ci": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+      "integrity": "sha1-43ecjuF/zPQoSI9uKBGH8uYyhBw=",
       "dev": true,
       "requires": {
         "ci-info": "^1.5.0"
@@ -3992,7 +3992,7 @@
     "is-ssh": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
-      "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+      "integrity": "sha1-80moyt0k5lKYA3pSLPdSDy6BoPM=",
       "dev": true,
       "requires": {
         "protocols": "^1.1.0"
@@ -4085,13 +4085,13 @@
     "istanbul-lib-coverage": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+      "integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=",
       "dev": true
     },
     "istanbul-lib-hook": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
-      "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
+      "integrity": "sha1-yVaV84PU+PYN8fBCUqlVDhW1sTM=",
       "dev": true,
       "requires": {
         "append-transform": "^1.0.0"
@@ -4100,7 +4100,7 @@
     "istanbul-lib-instrument": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
-      "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+      "integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
       "dev": true,
       "requires": {
         "@babel/generator": "^7.4.0",
@@ -4115,7 +4115,7 @@
         "semver": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-          "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+          "integrity": "sha1-BeNZ7lceWtftZBpu7B5Ue6Ut6mU=",
           "dev": true
         }
       }
@@ -4123,7 +4123,7 @@
     "istanbul-lib-report": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+      "integrity": "sha1-WoETzXRtQ8SInro2qxDn1QybTzM=",
       "dev": true,
       "requires": {
         "istanbul-lib-coverage": "^2.0.5",
@@ -4134,7 +4134,7 @@
         "make-dir": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
           "dev": true,
           "requires": {
             "pify": "^4.0.1",
@@ -4144,13 +4144,13 @@
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
           "dev": true
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -4161,7 +4161,7 @@
     "istanbul-lib-source-maps": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+      "integrity": "sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -4174,7 +4174,7 @@
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -4183,7 +4183,7 @@
         "make-dir": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
           "dev": true,
           "requires": {
             "pify": "^4.0.1",
@@ -4193,19 +4193,19 @@
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
           "dev": true
         },
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
           "dev": true
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -4213,7 +4213,7 @@
     "istanbul-reports": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.4.tgz",
-      "integrity": "sha512-QCHGyZEK0bfi9GR215QSm+NJwFKEShbtc7tfbUdLAEzn3kKhLDDZqvljn8rPZM9v8CEOhzL1nlYoO4r1ryl67w==",
+      "integrity": "sha1-Tg0N3w8K1bSaMUBp0xtPBq/kmtM=",
       "dev": true,
       "requires": {
         "handlebars": "^4.1.2"
@@ -4250,7 +4250,7 @@
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
     "json-schema": {
@@ -4307,7 +4307,7 @@
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
       "dev": true,
       "requires": {
         "invert-kv": "^2.0.0"
@@ -4322,7 +4322,7 @@
     "lerna": {
       "version": "3.13.4",
       "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.13.4.tgz",
-      "integrity": "sha512-qTp22nlpcgVrJGZuD7oHnFbTk72j2USFimc2Pj4kC0/rXmcU2xPtCiyuxLl8y6/6Lj5g9kwEuvKDZtSXujjX/A==",
+      "integrity": "sha1-AwJsEcVkPzQf2kLk+xiC4t815ss=",
       "dev": true,
       "requires": {
         "@lerna/add": "3.13.3",
@@ -4347,7 +4347,7 @@
     "libnpmaccess": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.1.tgz",
-      "integrity": "sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==",
+      "integrity": "sha1-Wzqd5iHyk9QlGRqi53kQL4QWf6g=",
       "dev": true,
       "requires": {
         "aproba": "^2.0.0",
@@ -4359,7 +4359,7 @@
         "aproba": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+          "integrity": "sha1-UlILiuW1aSFbNU78DKo/4eRaitw=",
           "dev": true
         }
       }
@@ -4367,7 +4367,7 @@
     "libnpmpublish": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.1.tgz",
-      "integrity": "sha512-nefbvJd/wY38zdt+b9SHL6171vqBrMtZ56Gsgfd0duEKb/pB8rDT4/ObUQLrHz1tOfht1flt2zM+UGaemzAG5g==",
+      "integrity": "sha1-/wxrsLStK9oq0fX7pnYKSvNxJfA=",
       "dev": true,
       "requires": {
         "aproba": "^2.0.0",
@@ -4384,7 +4384,7 @@
         "aproba": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+          "integrity": "sha1-UlILiuW1aSFbNU78DKo/4eRaitw=",
           "dev": true
         }
       }
@@ -4543,7 +4543,7 @@
     "lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "requires": {
         "yallist": "^3.0.2"
@@ -4552,13 +4552,13 @@
     "macos-release": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
-      "integrity": "sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==",
+      "integrity": "sha1-q1jVXdRxTwoFrUsOkPQ3D+9c3qg=",
       "dev": true
     },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
       "dev": true,
       "requires": {
         "pify": "^3.0.0"
@@ -4567,7 +4567,7 @@
     "make-fetch-happen": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz",
-      "integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
+      "integrity": "sha1-FBSXy4ePJDupMTbIPYq6EsIWwIM=",
       "dev": true,
       "requires": {
         "agentkeepalive": "^3.4.1",
@@ -4586,7 +4586,7 @@
         "lru-cache": {
           "version": "4.1.5",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -4613,7 +4613,7 @@
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
       "dev": true,
       "requires": {
         "p-defer": "^1.0.0"
@@ -4643,7 +4643,7 @@
     "mem": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
       "dev": true,
       "requires": {
         "map-age-cleaner": "^0.1.1",
@@ -4654,7 +4654,7 @@
         "mimic-fn": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
           "dev": true
         }
       }
@@ -4662,7 +4662,7 @@
     "meow": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-      "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+      "integrity": "sha1-1IWY9vSxRy81v2MXqVlFrONH+XU=",
       "dev": true,
       "requires": {
         "camelcase-keys": "^4.0.0",
@@ -4679,7 +4679,7 @@
     "merge-source-map": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+      "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
@@ -4688,7 +4688,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -4759,7 +4759,7 @@
     "minimist-options": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "integrity": "sha1-+6TIGRM54T7PTWG+sD8HAQPz2VQ=",
       "dev": true,
       "requires": {
         "arrify": "^1.0.1",
@@ -4769,7 +4769,7 @@
     "minipass": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "integrity": "sha1-ys6+SSAiSX9law8PUeJoKp7S2Eg=",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.2",
@@ -4779,7 +4779,7 @@
     "minizlib": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "integrity": "sha1-3SfqYTYkPHyIBoToZyuzpF/ZthQ=",
       "dev": true,
       "requires": {
         "minipass": "^2.2.1"
@@ -4788,7 +4788,7 @@
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+      "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
       "dev": true,
       "requires": {
         "concat-stream": "^1.5.0",
@@ -4844,7 +4844,7 @@
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+      "integrity": "sha1-s5OfpgVUZHTj4+PGPWS9Q7TuYCI=",
       "dev": true
     },
     "move-concurrently": {
@@ -4913,13 +4913,13 @@
     "nested-error-stacks": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
-      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
+      "integrity": "sha1-D73PPhP+SZR4EoBST4uWsM3/nGE=",
       "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
     },
     "no-case": {
@@ -4934,13 +4934,13 @@
     "node-fetch": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
-      "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==",
+      "integrity": "sha1-gCjEn8EZG7pWoHrcbiqVRkSkhQE=",
       "dev": true
     },
     "node-fetch-npm": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
-      "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
+      "integrity": "sha1-cljJBGGC3KNFtCCO2pGNrzNpf/c=",
       "dev": true,
       "requires": {
         "encoding": "^0.1.11",
@@ -4951,7 +4951,7 @@
     "node-gyp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-4.0.0.tgz",
-      "integrity": "sha512-2XiryJ8sICNo6ej8d0idXDEMKfVfFK7kekGCtJAuelGsYHQxhj13KTf95swTCN2dZ/4lTfZ84Fu31jqJEEgjWA==",
+      "integrity": "sha1-lyZUr05d0M0qGQgbS0b+BEK6b0U=",
       "dev": true,
       "requires": {
         "glob": "^7.0.3",
@@ -5015,7 +5015,7 @@
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -5027,19 +5027,19 @@
     "normalize-url": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+      "integrity": "sha1-suHE3E98bVd0PfczpPWXjRhlBVk=",
       "dev": true
     },
     "npm-bundled": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+      "integrity": "sha1-57qarc75YrthJI+RchzZMrP+a90=",
       "dev": true
     },
     "npm-lifecycle": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-2.1.1.tgz",
-      "integrity": "sha512-+Vg6I60Z75V/09pdcH5iUo/99Q/vop35PaI99elvxk56azSVVsdsSsS/sXqKDNwbRRNN1qSxkcO45ZOu0yOWew==",
+      "integrity": "sha1-ACfAlkbw/TRsXJM3e9q6WcZ0j98=",
       "dev": true,
       "requires": {
         "byline": "^5.0.0",
@@ -5055,7 +5055,7 @@
     "npm-package-arg": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
-      "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
+      "integrity": "sha1-Fa4eJ1ilAn77TCUFVLhac323/ME=",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.6.0",
@@ -5067,7 +5067,7 @@
     "npm-packlist": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-      "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+      "integrity": "sha1-GQZM35iNqA6jzuRVM4edkBkrv7w=",
       "dev": true,
       "requires": {
         "ignore-walk": "^3.0.1",
@@ -5077,7 +5077,7 @@
     "npm-pick-manifest": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz",
-      "integrity": "sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==",
+      "integrity": "sha1-MhEdKpViY4uyyPK/J/fzCSyPrkA=",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1",
@@ -5088,7 +5088,7 @@
     "npm-registry-fetch": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.9.0.tgz",
-      "integrity": "sha512-srwmt8YhNajAoSAaDWndmZgx89lJwIZ1GWxOuckH4Coek4uHv5S+o/l9FLQe/awA+JwTnj4FJHldxhlXdZEBmw==",
+      "integrity": "sha1-RNhBeA4oM/BqzLNEiPjHRQ0aaFY=",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.4",
@@ -5102,7 +5102,7 @@
         "lru-cache": {
           "version": "4.1.5",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -5129,7 +5129,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
@@ -5180,19 +5180,19 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
           "dev": true
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -5201,19 +5201,19 @@
         "get-caller-file": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -5223,7 +5223,7 @@
         "make-dir": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
           "dev": true,
           "requires": {
             "pify": "^4.0.1",
@@ -5233,7 +5233,7 @@
         "p-limit": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -5241,8 +5241,8 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -5251,25 +5251,25 @@
         "p-try": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
           "dev": true
         },
         "require-main-filename": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -5280,7 +5280,7 @@
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -5403,7 +5403,7 @@
     "octokit-pagination-methods": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
-      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+      "integrity": "sha1-z0cu3J1VEFX573P25CtNu0yAvqQ=",
       "dev": true
     },
     "once": {
@@ -5482,7 +5482,7 @@
     "os-locale": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
       "dev": true,
       "requires": {
         "execa": "^1.0.0",
@@ -5493,7 +5493,7 @@
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
-      "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+      "integrity": "sha1-3sGdlmKW4c1i1wGlpm7h3ernCAE=",
       "dev": true,
       "requires": {
         "macos-release": "^2.2.0",
@@ -5509,7 +5509,7 @@
     "osenv": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
       "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
@@ -5531,13 +5531,13 @@
     "p-is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "integrity": "sha1-kYzrrqJIpiz3/6uOO8qMX4gvxC4=",
       "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
       "dev": true,
       "requires": {
         "p-try": "^1.0.0"
@@ -5597,7 +5597,7 @@
     "package-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
-      "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
+      "integrity": "sha1-UBg/LTbJ4+Uo6gqGBd/1fOl2+I4=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.15",
@@ -5609,7 +5609,7 @@
     "pacote": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.0.tgz",
-      "integrity": "sha512-aUplXozRbzhaJO48FaaeClmN+2Mwt741MC6M3bevIGZwdCaP7frXzbUOfOWa91FPHoLITzG0hYaKY363lxO3bg==",
+      "integrity": "sha1-hfMBOj9t1RwQiwzKvT3oEC3frto=",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.3",
@@ -5714,7 +5714,7 @@
     "parse-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
-      "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+      "integrity": "sha1-DsdpcElJd4yzuO2l6ZTDIHOhrf8=",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
@@ -5724,7 +5724,7 @@
     "parse-url": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
-      "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+      "integrity": "sha1-mcQIT8Eb4UFB76QbPRF6lvy5Un8=",
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
@@ -5905,7 +5905,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
       "dev": true
     },
     "promise-inflight": {
@@ -5942,13 +5942,13 @@
     "protocols": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
-      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
+      "integrity": "sha1-lfeIpPDpebKR/+/PVjatET0DfTI=",
       "dev": true
     },
     "protoduck": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
-      "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
+      "integrity": "sha1-A8NlnKGAB7aaUP2Cp+vMUWJhFR8=",
       "dev": true,
       "requires": {
         "genfun": "^5.0.0"
@@ -5969,7 +5969,7 @@
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -5979,7 +5979,7 @@
     "pumpify": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
       "dev": true,
       "requires": {
         "duplexify": "^3.6.0",
@@ -5990,7 +5990,7 @@
         "pump": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -6044,7 +6044,7 @@
     "read-package-json": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
-      "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
+      "integrity": "sha1-LoLr2fYTuqbS6+Oqcs7+P2jkH0o=",
       "dev": true,
       "requires": {
         "glob": "^7.1.1",
@@ -6057,7 +6057,7 @@
     "read-package-tree": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.2.tgz",
-      "integrity": "sha512-rW3XWUUkhdKmN2JKB4FL563YAgtINifso5KShykufR03nJ5loGFlkUMe1g/yxmqX073SoYYTsgXu7XdDinKZuA==",
+      "integrity": "sha1-S2oO8tlDweo2pXghTJp/a3Qk96g=",
       "dev": true,
       "requires": {
         "debuglog": "^1.0.1",
@@ -6091,7 +6091,7 @@
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
       "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
@@ -6253,7 +6253,7 @@
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
       "dev": true
     },
     "resolve-url": {
@@ -6422,7 +6422,7 @@
     "smart-buffer": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
-      "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
+      "integrity": "sha1-UgeFjDgVzGkRBwPGuU5GwVY0OV0=",
       "dev": true
     },
     "snake-case": {
@@ -6541,10 +6541,53 @@
         }
       }
     },
+    "snazzy": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/snazzy/-/snazzy-8.0.0.tgz",
+      "integrity": "sha512-59GS69hQD8FvJoNGeDz8aZtbYhkCFxCPQB1BFzAWiVVwPmS/J6Vjaku0k6tGNsdSxQ0kAlButdkn8bPR2hLcBw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "inherits": "^2.0.1",
+        "minimist": "^1.1.1",
+        "readable-stream": "^3.0.2",
+        "standard-json": "^1.0.0",
+        "strip-ansi": "^4.0.0",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "socks": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
-      "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
+      "integrity": "sha1-reOI6ebYf9sRZJwVdGxXiSKliD4=",
       "dev": true,
       "requires": {
         "ip": "^1.1.5",
@@ -6554,7 +6597,7 @@
     "socks-proxy-agent": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
-      "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+      "integrity": "sha1-PImR8xRbJ5nnDhG9X7yLGWMRY4Y=",
       "dev": true,
       "requires": {
         "agent-base": "~4.2.1",
@@ -6598,7 +6641,7 @@
     "spawn-wrap": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
-      "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+      "integrity": "sha1-z/WOc6giRhe2Vhq9wyWG6gyCJIw=",
       "dev": true,
       "requires": {
         "foreground-child": "^1.5.6",
@@ -6612,7 +6655,7 @@
     "spdx-correct": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -6622,13 +6665,13 @@
     "spdx-exceptions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -6638,13 +6681,13 @@
     "spdx-license-ids": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
+      "integrity": "sha1-dezRqI3owYTvAV6vtRtbSL/RG7E=",
       "dev": true
     },
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "dev": true,
       "requires": {
         "through": "2"
@@ -6662,7 +6705,7 @@
     "split2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "integrity": "sha1-GGsldbz4PoW30YRldWI47k7kJJM=",
       "dev": true,
       "requires": {
         "through2": "^2.0.2"
@@ -6694,10 +6737,19 @@
     "ssri": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
+      }
+    },
+    "standard-json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/standard-json/-/standard-json-1.0.3.tgz",
+      "integrity": "sha512-lhMP+KREBcfyyMe2ObJlEjJ0lc0ItA9uny83d9ZL6ggYtB79DuaAKCxJVoiflg5EV3D2rpuWn+n4+zXjWXk0sQ==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.5.0"
       }
     },
     "static-extend": {
@@ -6724,7 +6776,7 @@
     "stream-each": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
-      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+      "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -6751,7 +6803,7 @@
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -6787,7 +6839,7 @@
     "strong-log-transformer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
-      "integrity": "sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==",
+      "integrity": "sha1-D17XjTJeBCGsb5D38Q5pHWrjrhA=",
       "dev": true,
       "requires": {
         "duplexer": "^0.1.1",
@@ -6817,7 +6869,7 @@
     "tar": {
       "version": "4.4.8",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+      "integrity": "sha1-sZ7sP94qluZGZt+f20DFyhvDdH0=",
       "dev": true,
       "requires": {
         "chownr": "^1.1.1",
@@ -6852,7 +6904,7 @@
     "test-exclude": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
-      "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+      "integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
       "dev": true,
       "requires": {
         "glob": "^7.1.3",
@@ -6864,7 +6916,7 @@
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -6873,7 +6925,7 @@
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -6883,7 +6935,7 @@
         "p-limit": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -6892,7 +6944,7 @@
         "p-locate": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -6901,13 +6953,13 @@
         "p-try": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "read-pkg-up": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-          "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+          "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
           "dev": true,
           "requires": {
             "find-up": "^3.0.0",
@@ -6917,7 +6969,7 @@
         "require-main-filename": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
           "dev": true
         }
       }
@@ -6925,7 +6977,13 @@
     "text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
-      "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+      "integrity": "sha1-GFPkX+45yUXOb2w2stZZtaq8KiY=",
+      "dev": true
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "through": {
@@ -6937,7 +6995,7 @@
     "through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
@@ -7159,7 +7217,7 @@
     "unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
       "dev": true,
       "requires": {
         "unique-slug": "^2.0.0"
@@ -7168,7 +7226,7 @@
     "unique-slug": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
-      "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+      "integrity": "sha1-Xp7cbRzo+yZNsYpQfvm9hURFHKY=",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
@@ -7186,7 +7244,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
       "dev": true
     },
     "unset-value": {
@@ -7301,7 +7359,7 @@
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
@@ -7340,13 +7398,13 @@
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60=",
       "dev": true
     },
     "whatwg-url": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-      "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+      "integrity": "sha1-/ekm+lSlmfOt+C3/Jan3vgLcbt0=",
       "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
@@ -7372,7 +7430,7 @@
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
@@ -7381,7 +7439,7 @@
     "windows-release": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
-      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+      "integrity": "sha1-gSLa1a/DA9gzQiOAaAp5zfqReF8=",
       "dev": true,
       "requires": {
         "execa": "^1.0.0"
@@ -7412,7 +7470,7 @@
     "write-file-atomic": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
-      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+      "integrity": "sha1-pxgXBt+6F4VdIhFAqcBuFfzdh7k=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -7437,7 +7495,7 @@
     "write-pkg": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.2.0.tgz",
-      "integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
+      "integrity": "sha1-DheP6Xgg04mokovHlTXb5ows/yE=",
       "dev": true,
       "requires": {
         "sort-keys": "^2.0.0",
@@ -7453,19 +7511,19 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
       "dev": true
     },
     "yallist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+      "integrity": "sha1-tLBJ4xS+VF486AIjbWzSLNkcPek=",
       "dev": true
     },
     "yargs": {
       "version": "12.0.5",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+      "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
       "dev": true,
       "requires": {
         "cliui": "^4.0.0",
@@ -7491,7 +7549,7 @@
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -7506,7 +7564,7 @@
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -7516,7 +7574,7 @@
         "p-limit": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -7525,7 +7583,7 @@
         "p-locate": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -7534,13 +7592,13 @@
         "p-try": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -7561,7 +7619,7 @@
     "yargs-parser": {
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+      "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
@@ -7571,7 +7629,7 @@
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "coveralls": "^3.0.2",
     "lerna": "^3.13.4",
     "nyc": "^14.1.0",
-    "plop": "^2.1.0"
+    "plop": "^2.1.0",
+    "snazzy": "^8.0.0"
   },
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",

--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -10,7 +10,7 @@
     "_test": "npm run _check && BABEL_ENV=test mocha",
     "build": "npm run _check && PANOPTES_ENV=production next build",
     "dev": "npm run _check && PANOPTES_ENV=production node server/server.js",
-    "lint": "zoo-standard --fix",
+    "lint": "zoo-standard --fix | snazzy",
     "start": "npm run _check && NODE_ENV=production node server/server.js",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "test": "npm run _test && exit 0",

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -11,7 +11,7 @@
     "_test": "npm run _check && BABEL_ENV=test mocha",
     "build": "npm run _check && PANOPTES_ENV=production next build",
     "dev": "npm run _check && npm run _serve",
-    "lint": "zoo-standard --fix",
+    "lint": "zoo-standard --fix | snazzy",
     "start": "npm run _check && NODE_ENV=production npm run _serve",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "test": "npm run _test && exit 0",

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -10,7 +10,7 @@
     "_test": "npm run _check && NODE_PATH=. NODE_ENV=test mocha",
     "build": "npm run _check && webpack --config webpack.dist.js",
     "dev": "npm run _check && webpack-dev-server --config webpack.dev.js",
-    "lint": "zoo-standard --fix",
+    "lint": "zoo-standard --fix | snazzy",
     "start": "npm run _check && PANOPTES_ENV=production npm run dev",
     "test": "npm run _test && exit 0",
     "test:ci": "npm run _test -- --reporter=min"

--- a/packages/lib-grommet-theme/package.json
+++ b/packages/lib-grommet-theme/package.json
@@ -10,7 +10,7 @@
     "build": "babel src --out-dir dist",
     "build:watch": "npm run build -- --watch",
     "clean": "rm -rf dist",
-    "lint": "zoo-standard --fix",
+    "lint": "zoo-standard --fix | snazzy",
     "start": "npm run build:watch"
   },
   "dependencies": {

--- a/packages/lib-panoptes-js/package.json
+++ b/packages/lib-panoptes-js/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "_check": "check-engines && check-dependencies",
     "_test": "npm run _check && NODE_ENV=test mocha",
-    "lint": "zoo-standard --fix",
+    "lint": "zoo-standard --fix | snazzy",
     "test": "npm run _test && exit 0",
     "test:ci": "npm run _test -- --reporter=min"
   },

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -10,7 +10,7 @@
     "build": "rm -rf dist && webpack --config ./webpack.dist.js",
     "build-storybook": "build-storybook",
     "dev": "start-storybook -p 6006",
-    "lint": "zoo-standard --fix {.storybook,src,stories,test}/**/*.{js,jsx}",
+    "lint": "zoo-standard --fix {.storybook,src,stories,test}/**/*.{js,jsx} | snazzy",
     "prepublishOnly": "npm run test:ci && npm run build",
     "start": "echo 'Nothing to see here yet'",
     "test": "npm run _test && exit 0",


### PR DESCRIPTION
Package:
All

Following on from #898, this installs snazzy globally and adds it back into the linter scripts for each package.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

