### PR TITLE
Remove test script

### DIFF
--- a/packages/tools-standard/package.json
+++ b/packages/tools-standard/package.json
@@ -17,7 +17,6 @@
     "zoo-standard": "./bin/cmd.js"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
     "babel-eslint": "^10.0.1",


### PR DESCRIPTION
The test script error blocks tests from running across the repo, so get rid of it.

Package:
tools-standard

Closes #915 .

Remove the error that zooniverse/standard throws when running `npm test`.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

