### PR TITLE
Use withArgs for spies

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/CollectionsModalContainer.spec.js
@@ -63,7 +63,7 @@ describe('Component > CollectionsModalContainer', function () {
       })
 
       it('should fetch a list of collections filtered by name', function () {
-        expect(searchCollections).to.have.been.calledOnceWith(query)
+        expect(searchCollections.withArgs(query)).to.have.been.calledOnce()
       })
     })
 
@@ -91,7 +91,7 @@ describe('Component > CollectionsModalContainer', function () {
         })
 
         it('should add subjects to the selected collection', function () {
-          expect(addSubjects).to.have.been.calledOnceWith('1', [subjectId])
+          expect(addSubjects.withArgs('1', [subjectId])).to.have.been.calledOnce()
         })
 
         it('should close the modal', function () {
@@ -154,9 +154,10 @@ describe('Component > CollectionsModalContainer', function () {
         })
 
         it('should create a new collection with that name', function () {
-          expect(createCollection).to.have.been.calledOnceWith(query, [
+          const createSpy = createCollection.withArgs(query, [
             subjectId
           ])
+          expect(createSpy).to.have.been.calledOnce()
         })
 
         it('should close the modal', function () {

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/CreateCollection/CreateCollection.spec.js
@@ -51,11 +51,12 @@ describe('Component > CreateCollection', function () {
     })
 
     it('should call the onChange callback', function () {
-      textInput.props().onChange()
-      expect(onChange).to.have.been.calledOnceWith({
+      const changeSpy = onChange.withArgs({
         display_name: 'Test One',
         private: true
       })
+      textInput.props().onChange()
+      expect(changeSpy).to.have.been.calledOnce()
     })
   })
 
@@ -75,11 +76,12 @@ describe('Component > CreateCollection', function () {
     })
 
     it('should call the onChange callback', function () {
-      checkbox.props().onChange()
-      expect(onChange).to.have.been.calledOnceWith({
+      const changeSpy = onChange.withArgs({
         display_name: 'Test One',
         private: true
       })
+      checkbox.props().onChange()
+      expect(changeSpy).to.have.been.calledOnce()
     })
   })
 

--- a/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/CollectionsModal/components/SelectCollection/SelectCollection.spec.js
@@ -55,12 +55,13 @@ describe('Component > SelectCollection', function () {
 
     it('should call the onSearch callback', function () {
       const searchText = 'Hello'
-      select.simulate('search', searchText)
-      expect(onSearch).to.have.been.calledOnceWith({
+      const searchSpy = onSearch.withArgs({
         favorite: false,
         current_user_roles: 'owner,collaborator,contributor',
         search: searchText
       })
+      select.simulate('search', searchText)
+      expect(searchSpy).to.have.been.calledOnce()
     })
     it('should display the selected collection', function () {
       const collection = { id: '1', display_name: 'Selected collection' }


### PR DESCRIPTION
Use withArgs to create specific spies in tests, rather than using calledOnceWith.

Package:
app-project


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

