### PR TITLE
Add back support for customization of onBlur

### DIFF
--- a/packages/app-project/src/components/AuthModal/shared/components/withCustomFormik/README.md
+++ b/packages/app-project/src/components/AuthModal/shared/components/withCustomFormik/README.md
@@ -8,7 +8,7 @@ and
 
 > Since form state is inherently local and ephemeral, Formik does not use external state management libraries like Redux or MobX. This also makes Formik easy to adopt incrementally and keeps bundle size to a minimum.
 
-`withCustomFormik` is the same as the built in `withFormik` except it includes support for custom a onChange handler.
+`withCustomFormik` is the same as the built in `withFormik` except it includes support for custom onChange and onBlur event handlers.
 
 ## Usage
 
@@ -105,11 +105,11 @@ class MyFormContainer extends React.Component {
 }
 ```
 
-These props get passed to the `<Formik>` component inside the `withFormik` HOC. Please read the Formik API docs on more information about these and other props: https://jaredpalmer.com/formik/docs/api/formik
+These props get passed to the `<Formik>` component inside the `withCustomFormik` HOC. Please read the Formik API docs on more information about these and other props: https://jaredpalmer.com/formik/docs/api/formik
 
 ### Customizing the onChange handler
 
-Formik does not directly support customization of the onChange handler. The `withFormik` HOC here supports an `onChange` prop that get passed along and added to a function that will call the Formik's `handleChange` handler as well as the custom `onChange` prop. The prop are called with the DOM event as well as the rest of the Formik props, so you can do something like an async validation on the change event:
+Formik does not directly support customization of the onChange handler. The `withCustomFormik` HOC here supports `onChange` and `onBlur` props that get passed along and added to a function that will call the Formik's `handleChange` and `handleBlur` handlers as well as the custom `onChange` and `onBlur` props. The props are called with the DOM event as well as the rest of the Formik props, so you can do something like an async validation on the change event:
 
 ``` js
 // import of withCustomFormik(MyForm)

--- a/packages/app-project/src/components/AuthModal/shared/components/withCustomFormik/withCustomFormik.js
+++ b/packages/app-project/src/components/AuthModal/shared/components/withCustomFormik/withCustomFormik.js
@@ -7,7 +7,13 @@ function withCustomFormik (WrappedComponent) {
     constructor () {
       super()
 
+      this.handleBlurWithCallback = this.handleBlurWithCallback.bind(this)
       this.handleChangeWithCallback = this.handleChangeWithCallback.bind(this)
+    }
+
+    handleBlurWithCallback(event, formikProps) {
+      formikProps.handleBlur(event)
+      this.props.onBlur(event, formikProps)
     }
 
     handleChangeWithCallback (event, formikProps) {
@@ -18,10 +24,15 @@ function withCustomFormik (WrappedComponent) {
     renderForm (props, ref) {
       // render the wrapped form but override handleChange with a custom callback
       const {
+        handleBlur,
         handleChange,
         ...rest
       } = props
-      const { handleChangeWithCallback } = this
+      const { handleBlurWithCallback, handleChangeWithCallback } = this
+
+      function handleCustomBlur (event) {
+        handleBlurWithCallback(event, props)
+      }
 
       function handleCustomChange (event) {
         handleChangeWithCallback(event, props)
@@ -29,6 +40,7 @@ function withCustomFormik (WrappedComponent) {
 
       return (
         <WrappedComponent
+          handleBlur={handleCustomBlur}
           handleChange={handleCustomChange}
           ref={ref}
           {...rest}
@@ -52,11 +64,13 @@ function withCustomFormik (WrappedComponent) {
 
   FormikHOC.defaultProps = {
     forwardedRef: null,
+    onBlur: () => {},
     onChange: () => {}
   }
 
   FormikHOC.propTypes = {
     initialValues: PropTypes.object.isRequired,
+    onBlur: PropTypes.func,
     onChange: PropTypes.func,
     onSubmit: PropTypes.func.isRequired
   }

--- a/packages/app-project/src/components/AuthModal/shared/components/withCustomFormik/withCustomFormik.spec.js
+++ b/packages/app-project/src/components/AuthModal/shared/components/withCustomFormik/withCustomFormik.spec.js
@@ -61,10 +61,12 @@ describe('Higher Order Component > withCustomFormik', function () {
   })
 
   describe('the wrapped form', function () {
+    const onBlurStub = sinon.stub()
     const onChangeStub = sinon.stub()
     const wrapper = mount(
       <WrappedMockForm
         initialValues={initialValues}
+        onBlur={onBlurStub}
         onChange={onChangeStub}
         onSubmit={onSubmit}
       />
@@ -83,6 +85,7 @@ describe('Higher Order Component > withCustomFormik', function () {
       values: {
         testInput: 'foo'
       },
+      handleBlur: sinon.stub(),
       handleChange: sinon.stub(),
       handleSubmit: sinon.stub()
     }
@@ -91,7 +94,7 @@ describe('Higher Order Component > withCustomFormik', function () {
     
     Object.keys(mockInnerProps).forEach(function (key) {
       it(`should pass ${key} to the wrapped form`, function () {
-        expect(mockForm.prop(key)).to.exist
+        expect(mockForm.prop(key)).to.exist()
       })
     })
 
@@ -100,7 +103,7 @@ describe('Higher Order Component > withCustomFormik', function () {
     })
 
     it('should have a values object', function () {
-      expect(mockForm.props().values).to.exist
+      expect(mockForm.props().values).to.exist()
       expect(mockForm.props().values).to.equal(mockInnerProps.values)
     })
     
@@ -109,6 +112,11 @@ describe('Higher Order Component > withCustomFormik', function () {
       expect(mockInnerProps.handleChange.withArgs(eventMock)).to.have.been.calledOnce()
       expect(onChangeStub.withArgs(eventMock, mockInnerProps)).to.have.been.calledOnce()
     })
-    
+
+    it('should call the custom blur handler on blur', function () {
+      mockForm.props().handleBlur(eventMock)
+      expect(mockInnerProps.handleBlur.withArgs(eventMock)).to.have.been.calledOnce()
+      expect(onBlurStub.withArgs(eventMock, mockInnerProps)).to.have.been.calledOnce()
+    })
   })
 })


### PR DESCRIPTION
Package: app-project

Describe your changes:
As a follow up, I checked to see if onBlur is on working with the `withCustomFormik` HOC with the refactor from #918 and it does now! Tests are passing for it, so I now I have confidence it can be used with the login form.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

