### PR TITLE
Make the default for UI mode to be from the cookie value

### DIFF
--- a/packages/app-project/stores/UI.js
+++ b/packages/app-project/stores/UI.js
@@ -1,19 +1,24 @@
 import { autorun } from 'mobx'
 import { addDisposer, types } from 'mobx-state-tree'
+import { getCookie } from './helpers/cookie'
 
 const UI = types
   .model('UI', {
-    mode: types.optional(types.enumeration('mode', ['light', 'dark']), 'light')
+    mode: types.optional(types.enumeration('mode', ['light', 'dark']), () => {
+      const mode = getCookie('mode')
+      return mode || 'light'
+    })
   })
 
   .actions(self => ({
-    afterAttach () {
+    afterCreate () {
       self.createModeObserver()
     },
 
     createModeObserver () {
       const modeDisposer = autorun(() => {
-        if (process.browser) {
+        // process.browser doesn't exist in the jsdom test environment
+        if (process.browser || process.env.BABEL_ENV === 'test') {
           document.cookie = `mode=${self.mode}; path=/; max-age=31536000`
         }
       })

--- a/packages/app-project/stores/UI.spec.js
+++ b/packages/app-project/stores/UI.spec.js
@@ -6,6 +6,7 @@ describe('Stores > UI', function () {
   let store
 
   beforeEach(function () {
+    document.cookie = 'mode=; max-age=-99999999;'
     store = UI.create()
   })
 
@@ -17,8 +18,14 @@ describe('Stores > UI', function () {
     expect(store.mode).to.be.ok()
   })
 
-  it('should default to the light mode', function () {
+  it('should default to the light mode if there is no stored mode in the cookie', function () {
     expect(store.mode).to.equal('light')
+  })
+
+  it('should default to the stored mode in the cookie', function () {
+    store.setDarkMode()
+    store = UI.create()
+    expect(store.mode).to.equal('dark')
   })
 
   it('should have a `setDarkMode` action', function () {

--- a/packages/app-project/stores/helpers/cookie.js
+++ b/packages/app-project/stores/helpers/cookie.js
@@ -1,0 +1,11 @@
+// Borrowed from https://stackoverflow.com/a/25490531/5372931
+export function getCookie (name) {
+  // process.browser doesn't exist in the jsdom test environment
+  if (process.browser || process.env.BABEL_ENV === 'test') {
+    const value = document.cookie.match('(^|[^;]+)\\s*' + name + '\\s*=\\s*([^;]+)')
+
+    return value ? value.pop() : ''
+  }
+
+  return ''
+}


### PR DESCRIPTION
Package: app-project

Closes #903

Describe your changes:
Checks for a value in the cookie and if not present, then defaults to light mode. The easiest way I found to test this manually is to compare the local running app to production and toggle the light and dark modes and then open the site in a new tab. 

I also change the MST lifecycle method that adds the observer to `afterCreate` because it is not depending on any kind of parent tree value.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

