### PR TITLE
Use publication citation as link, instead of `view publication`

### DIFF
--- a/packages/app-content-pages/src/screens/Publications/components/Publication/Publication.js
+++ b/packages/app-content-pages/src/screens/Publications/components/Publication/Publication.js
@@ -9,10 +9,6 @@ const StyledBox = styled(Box)`
   overflow: hidden;
 `
 
-const StyledText = styled(Text)`
-  font-style: italic;
-`
-
 const Placeholder = (
   <Box
     align='center'
@@ -47,11 +43,8 @@ function Publication (props) {
         )}
       </StyledBox>
       <Box direction='column' gap='xxsmall'>
-        <StyledText>
-          {displayString}
-        </StyledText>
         <Anchor size='medium' href={url}>
-          View publication.
+          {displayString}
         </Anchor>
       </Box>
     </Box>


### PR DESCRIPTION
Closes #895.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

