### PR TITLE
Add some ops links

### DIFF
--- a/packages/app-content-pages/README.md
+++ b/packages/app-content-pages/README.md
@@ -1,6 +1,11 @@
 # Zooniverse Front End - Content Pages
 
-A [Next.js](https://github.com/zeit/next.js) app for handling the content pages
+A [Next.js](https://github.com/zeit/next.js) app for handling the content pages.
+
+## Ops
+
+- [Jenkins](https://jenkins.zooniverse.org/job/Zooniverse%20GitHub/job/front-end-monorepo/)
+- [New Relic](https://rpm.newrelic.com/accounts/23619/applications/319037799)
 
 ## Getting started
 

--- a/packages/app-project/README.md
+++ b/packages/app-project/README.md
@@ -2,6 +2,11 @@
 
 A [Next.js](https://github.com/zeit/next.js) app for handling the project routes, including classification.
 
+## Ops
+
+- [Jenkins](https://jenkins.zooniverse.org/job/Zooniverse%20GitHub/job/front-end-monorepo/)
+- [New Relic](https://rpm.newrelic.com/accounts/23619/applications/319037531)
+
 ## Getting started
 
 This package should be cloned as part of the [front-end-monorepo](https://github.com/zooniverse/front-end-monorepo).


### PR DESCRIPTION
Add some ops service links to app readmes

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

