### PR TITLE
Disallow at symbol in real name field

### DIFF
--- a/packages/app-project/src/components/AuthModal/components/RegisterForm/components/Form/Form.js
+++ b/packages/app-project/src/components/AuthModal/components/RegisterForm/components/Form/Form.js
@@ -177,7 +177,9 @@ function Form ({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, v
               name='realName'
               onChange={handleChange}
               onBlur={handleBlur}
+              pattern='[^@]+'
               placeholder={counterpart('RegisterForm.realNamePlaceholder')}
+              title={counterpart('RegisterForm.realNamePatternHelp')}
               type='text'
               value={values.realName}
             />

--- a/packages/app-project/src/components/AuthModal/components/RegisterForm/locales/en.json
+++ b/packages/app-project/src/components/AuthModal/components/RegisterForm/locales/en.json
@@ -18,6 +18,7 @@
     "privacyLink": "Read our privacy policy",
     "realName": "Real Name (Optional)",
     "realNameHelp": "We'll use this to give you credit in scientific papers, posters, etc.",
+    "realNamePatternHelp": "Enter a real name, not an email address", 
     "realNamePlaceholder": "e.g. Maggie Smith",
     "register": "Register",
     "registering": "Registering...",


### PR DESCRIPTION
Package: app-project

Closes #929

Describe your changes:
I've added a regex pattern for a browser based validation to the real name field. I decided to go the blacklist route rather than the whitelist route and blacklist the `@` symbol as a proxy for disallowing email address submissions. Other special characters and unicode characters may legitimately be used for real names and I think it'll be much harder to create a whitelist without error. I think it'll be unlikely someone will use `@` in a real name. If this is an acceptable approach, I'll open a parallel PR to update the currently used PFE form. 

Here's what I've made the message when the validation fails:

<img width="399" alt="Screen Shot 2019-06-18 at 1 41 56 PM" src="https://user-images.githubusercontent.com/5016731/59710971-be641a80-91cf-11e9-8f0a-3adc70134e68.png">


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

