### PR TITLE
Add domain to the cookie being set

### DIFF
--- a/packages/app-project/stores/UI.js
+++ b/packages/app-project/stores/UI.js
@@ -19,7 +19,11 @@ const UI = types
       const modeDisposer = autorun(() => {
         // process.browser doesn't exist in the jsdom test environment
         if (process.browser || process.env.BABEL_ENV === 'test') {
-          document.cookie = `mode=${self.mode}; path=/; max-age=31536000`
+          if (process.env.NODE_ENV === 'production') {
+            document.cookie = `mode=${self.mode}; path=/; domain=zooniverse.org; max-age=31536000`
+          } else {
+            document.cookie = `mode=${self.mode}; path=/; max-age=31536000`
+          }
         }
       })
       addDisposer(self, modeDisposer)


### PR DESCRIPTION
Package: app-project

Closes #903

Describe your changes:
Adds the domain to the cookie being set if in production. I'm not sure how to go about testing this.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

