### PR TITLE
Refactor how the cookie is being set and when

### DIFF
--- a/packages/app-project/stores/UI.js
+++ b/packages/app-project/stores/UI.js
@@ -1,5 +1,5 @@
 import { autorun } from 'mobx'
-import { addDisposer, types } from 'mobx-state-tree'
+import { addDisposer, onPatch, types } from 'mobx-state-tree'
 import { getCookie } from './helpers/cookie'
 
 const UI = types
@@ -17,16 +17,26 @@ const UI = types
 
     createModeObserver () {
       const modeDisposer = autorun(() => {
-        // process.browser doesn't exist in the jsdom test environment
-        if (process.browser || process.env.BABEL_ENV === 'test') {
+        onPatch(self, (patch) => {
+          const { path } = patch
+          if (path === '/mode') self.setCookie()
+        })
+      })
+      addDisposer(self, modeDisposer)
+    },
+
+    setCookie () {
+      // process.browser doesn't exist in the jsdom test environment
+      if (process.browser || process.env.BABEL_ENV === 'test') {
+        const storedMode = getCookie('mode')
+        if (self.mode !== storedMode) {
           if (process.env.NODE_ENV === 'production') {
             document.cookie = `mode=${self.mode}; path=/; domain=zooniverse.org; max-age=31536000`
           } else {
             document.cookie = `mode=${self.mode}; path=/; max-age=31536000`
           }
         }
-      })
-      addDisposer(self, modeDisposer)
+      }
     },
 
     setDarkMode () {

--- a/packages/app-project/stores/UI.spec.js
+++ b/packages/app-project/stores/UI.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai'
+import sinon from 'sinon'
 
 import UI from './UI'
 
@@ -22,12 +23,6 @@ describe('Stores > UI', function () {
     expect(store.mode).to.equal('light')
   })
 
-  it('should default to the stored mode in the cookie', function () {
-    store.setDarkMode()
-    store = UI.create()
-    expect(store.mode).to.equal('dark')
-  })
-
   it('should have a `setDarkMode` action', function () {
     expect(store.mode).to.equal('light')
     store.setDarkMode()
@@ -48,5 +43,48 @@ describe('Stores > UI', function () {
     expect(store.mode).to.equal('dark')
     store.toggleMode()
     expect(store.mode).to.equal('light')
+  })
+
+  describe('when using the cookie', function () {
+    let setCookieSpy
+    beforeEach(function () {
+      document.cookie = 'mode=; max-age=-99999999;'
+      store = UI.create()
+      setCookieSpy = sinon.spy(store, 'setCookie')
+    })
+
+    afterEach(function () {
+      setCookieSpy.resetHistory()
+    })
+
+    after(function () {
+      setCookieSpy.restore()
+    })
+
+    it('should not set the cookie on instantiation', function () {
+      expect(setCookieSpy).to.not.have.been.called()
+    })
+
+    it('should default to the stored mode in the cookie', function () {
+      store.setDarkMode()
+      expect(setCookieSpy).to.have.been.calledOnce()
+      setCookieSpy.resetHistory()
+      store = UI.create()
+      expect(store.mode).to.equal('dark')
+      expect(setCookieSpy).to.not.have.been.called()
+    })
+
+    it('should not update the cookie on instantiation if there is already one', function () {
+      document.cookie = 'mode=light; path=/; domain=zooniverse.org; max-age=31536000'
+      store = UI.create()
+      expect(setCookieSpy).to.not.have.been.called()
+    })
+
+    it('should update the cookie if the store mode does not equal the stored cookie mode', function () {
+      store.setLightMode()
+      expect(setCookieSpy).to.not.have.been.called()
+      store.setDarkMode()
+      expect(setCookieSpy).to.have.been.calledOnce()
+    })
   })
 })


### PR DESCRIPTION
Package: app-project

Closes #903 hopefully

Describe your changes:
I'm not totally sure if this will fix what we're observing on production. What is happening is that the cookie is present, but is being switched when the app loads from dark to light if the cookie is storing a dark mode. Presumably the cookie is being set regardless of the mode right now. I refactored the store to only set the cookie on the patch event of the store and added tests for this. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

