### PR TITLE
Rebuild package-lock.json for content app

### DIFF
--- a/packages/app-content-pages/package-lock.json
+++ b/packages/app-content-pages/package-lock.json
@@ -2147,12 +2147,8371 @@
       "integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g=="
     },
     "@zooniverse/async-states": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@babel/core": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.2.2",
+            "@babel/helpers": "^7.2.0",
+            "@babel/parser": "^7.2.2",
+            "@babel/template": "^7.2.2",
+            "@babel/traverse": "^7.2.2",
+            "@babel/types": "^7.2.2",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.10",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.2.2",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.10",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/template": "^7.1.2",
+            "@babel/traverse": "^7.1.5",
+            "@babel/types": "^7.2.0"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.2.2",
+          "bundled": true
+        },
+        "@babel/template": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.2.2",
+            "@babel/types": "^7.2.2"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.2.2",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "@babel/parser": "^7.2.2",
+            "@babel/types": "^7.2.2",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/types": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.10",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "@zooniverse/standard": {
+          "bundled": true,
+          "requires": {
+            "babel-eslint": "^10.0.1",
+            "eslint-plugin-jsx-a11y": "^6.2.1",
+            "standard": "^12.0.1",
+            "standard-engine": "^10.0.0"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/highlight": "^7.0.0"
+              }
+            },
+            "@babel/generator": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.4.4",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.11",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+              }
+            },
+            "@babel/helper-function-name": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-get-function-arity": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-split-export-declaration": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.4.4"
+              }
+            },
+            "@babel/highlight": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+              }
+            },
+            "@babel/parser": {
+              "version": "7.4.5",
+              "bundled": true
+            },
+            "@babel/template": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.4.4",
+                "@babel/types": "^7.4.4"
+              }
+            },
+            "@babel/traverse": {
+              "version": "7.4.5",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.4.4",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.4.4",
+                "@babel/parser": "^7.4.5",
+                "@babel/types": "^7.4.4",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.11"
+              }
+            },
+            "@babel/types": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.11",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "acorn": {
+              "version": "6.1.1",
+              "bundled": true
+            },
+            "acorn-jsx": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "ajv": {
+              "version": "6.10.0",
+              "bundled": true,
+              "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "ajv-keywords": {
+              "version": "3.4.0",
+              "bundled": true
+            },
+            "ansi-escapes": {
+              "version": "3.2.0",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "argparse": {
+              "version": "1.0.10",
+              "bundled": true,
+              "requires": {
+                "sprintf-js": "~1.0.2"
+              }
+            },
+            "aria-query": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "ast-types-flow": "0.0.7",
+                "commander": "^2.11.0"
+              }
+            },
+            "array-includes": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.7.0"
+              }
+            },
+            "ast-types-flow": {
+              "version": "0.0.7",
+              "bundled": true
+            },
+            "axobject-query": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "ast-types-flow": "0.0.7"
+              }
+            },
+            "babel-code-frame": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "bundled": true
+                },
+                "chalk": {
+                  "version": "1.1.3",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "^2.2.1",
+                    "escape-string-regexp": "^1.0.2",
+                    "has-ansi": "^2.0.0",
+                    "strip-ansi": "^3.0.0",
+                    "supports-color": "^2.0.0"
+                  }
+                },
+                "js-tokens": {
+                  "version": "3.0.2",
+                  "bundled": true
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^2.0.0"
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "babel-eslint": {
+              "version": "10.0.1",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "eslint-scope": "3.7.1",
+                "eslint-visitor-keys": "^1.0.0"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "caller-path": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "callsites": "^0.2.0"
+              }
+            },
+            "callsites": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "chardet": {
+              "version": "0.4.2",
+              "bundled": true
+            },
+            "circular-json": {
+              "version": "0.3.3",
+              "bundled": true
+            },
+            "cli-cursor": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "restore-cursor": "^2.0.0"
+              }
+            },
+            "cli-width": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "bundled": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "bundled": true
+            },
+            "commander": {
+              "version": "2.20.0",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "contains-path": {
+              "version": "0.1.0",
+              "bundled": true
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "damerau-levenshtein": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "debug-log": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "define-properties": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "object-keys": "^1.0.12"
+              }
+            },
+            "deglob": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "find-root": "^1.0.0",
+                "glob": "^7.0.5",
+                "ignore": "^3.0.9",
+                "pkg-config": "^1.1.0",
+                "run-parallel": "^1.1.2",
+                "uniq": "^1.0.1"
+              },
+              "dependencies": {
+                "ignore": {
+                  "version": "3.3.10",
+                  "bundled": true
+                }
+              }
+            },
+            "doctrine": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2"
+              }
+            },
+            "emoji-regex": {
+              "version": "7.0.3",
+              "bundled": true
+            },
+            "error-ex": {
+              "version": "1.3.2",
+              "bundled": true,
+              "requires": {
+                "is-arrayish": "^0.2.1"
+              }
+            },
+            "es-abstract": {
+              "version": "1.13.0",
+              "bundled": true,
+              "requires": {
+                "es-to-primitive": "^1.2.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "is-callable": "^1.1.4",
+                "is-regex": "^1.0.4",
+                "object-keys": "^1.0.12"
+              }
+            },
+            "es-to-primitive": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "eslint": {
+              "version": "5.4.0",
+              "bundled": true,
+              "requires": {
+                "ajv": "^6.5.0",
+                "babel-code-frame": "^6.26.0",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^3.1.0",
+                "doctrine": "^2.1.0",
+                "eslint-scope": "^4.0.0",
+                "eslint-utils": "^1.3.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^4.0.0",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.2",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^5.2.0",
+                "is-resolvable": "^1.1.0",
+                "js-yaml": "^3.11.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.5",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "regexpp": "^2.0.0",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.5.0",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "^2.0.1",
+                "table": "^4.0.3",
+                "text-table": "^0.2.0"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "3.2.6",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "^2.1.1"
+                  }
+                },
+                "eslint-scope": {
+                  "version": "4.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "esrecurse": "^4.1.0",
+                    "estraverse": "^4.1.1"
+                  }
+                }
+              }
+            },
+            "eslint-config-standard": {
+              "version": "12.0.0",
+              "bundled": true
+            },
+            "eslint-config-standard-jsx": {
+              "version": "6.0.2",
+              "bundled": true
+            },
+            "eslint-import-resolver-node": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.6.9",
+                "resolve": "^1.5.0"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "eslint-module-utils": {
+              "version": "2.4.0",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.6.8",
+                "pkg-dir": "^2.0.0"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "eslint-plugin-es": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "eslint-utils": "^1.3.0",
+                "regexpp": "^2.0.1"
+              }
+            },
+            "eslint-plugin-import": {
+              "version": "2.14.0",
+              "bundled": true,
+              "requires": {
+                "contains-path": "^0.1.0",
+                "debug": "^2.6.8",
+                "doctrine": "1.5.0",
+                "eslint-import-resolver-node": "^0.3.1",
+                "eslint-module-utils": "^2.2.0",
+                "has": "^1.0.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.3",
+                "read-pkg-up": "^2.0.0",
+                "resolve": "^1.6.0"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.9",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "doctrine": {
+                  "version": "1.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "esutils": "^2.0.2",
+                    "isarray": "^1.0.0"
+                  }
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "eslint-plugin-jsx-a11y": {
+              "version": "6.2.1",
+              "bundled": true,
+              "requires": {
+                "aria-query": "^3.0.0",
+                "array-includes": "^3.0.3",
+                "ast-types-flow": "^0.0.7",
+                "axobject-query": "^2.0.2",
+                "damerau-levenshtein": "^1.0.4",
+                "emoji-regex": "^7.0.2",
+                "has": "^1.0.3",
+                "jsx-ast-utils": "^2.0.1"
+              }
+            },
+            "eslint-plugin-node": {
+              "version": "7.0.1",
+              "bundled": true,
+              "requires": {
+                "eslint-plugin-es": "^1.3.1",
+                "eslint-utils": "^1.3.1",
+                "ignore": "^4.0.2",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.8.1",
+                "semver": "^5.5.0"
+              }
+            },
+            "eslint-plugin-promise": {
+              "version": "4.0.1",
+              "bundled": true
+            },
+            "eslint-plugin-react": {
+              "version": "7.11.1",
+              "bundled": true,
+              "requires": {
+                "array-includes": "^3.0.3",
+                "doctrine": "^2.1.0",
+                "has": "^1.0.3",
+                "jsx-ast-utils": "^2.0.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "eslint-plugin-standard": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "eslint-scope": {
+              "version": "3.7.1",
+              "bundled": true,
+              "requires": {
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+              }
+            },
+            "eslint-utils": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "eslint-visitor-keys": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "espree": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "acorn": "^6.0.2",
+                "acorn-jsx": "^5.0.0",
+                "eslint-visitor-keys": "^1.0.0"
+              }
+            },
+            "esprima": {
+              "version": "4.0.1",
+              "bundled": true
+            },
+            "esquery": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "estraverse": "^4.0.0"
+              }
+            },
+            "esrecurse": {
+              "version": "4.2.1",
+              "bundled": true,
+              "requires": {
+                "estraverse": "^4.1.0"
+              }
+            },
+            "estraverse": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "external-editor": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
+              }
+            },
+            "fast-deep-equal": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "fast-json-stable-stringify": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "figures": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "escape-string-regexp": "^1.0.5"
+              }
+            },
+            "file-entry-cache": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
+              }
+            },
+            "find-root": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "flat-cache": {
+              "version": "1.3.4",
+              "bundled": true,
+              "requires": {
+                "circular-json": "^0.3.1",
+                "graceful-fs": "^4.1.2",
+                "rimraf": "~2.6.2",
+                "write": "^0.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "function-bind": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "functional-red-black-tree": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "get-stdin": {
+              "version": "6.0.0",
+              "bundled": true
+            },
+            "glob": {
+              "version": "7.1.4",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "globals": {
+              "version": "11.12.0",
+              "bundled": true
+            },
+            "graceful-fs": {
+              "version": "4.1.15",
+              "bundled": true
+            },
+            "has": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "function-bind": "^1.1.1"
+              }
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "has-symbols": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "hosted-git-info": {
+              "version": "2.7.1",
+              "bundled": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore": {
+              "version": "4.0.6",
+              "bundled": true
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "bundled": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "inquirer": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.1.0",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^5.5.2",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
+              }
+            },
+            "is-arrayish": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-callable": {
+              "version": "1.1.4",
+              "bundled": true
+            },
+            "is-date-object": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "is-promise": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "is-regex": {
+              "version": "1.0.4",
+              "bundled": true,
+              "requires": {
+                "has": "^1.0.1"
+              }
+            },
+            "is-resolvable": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-symbol": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "has-symbols": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "js-yaml": {
+              "version": "3.13.1",
+              "bundled": true,
+              "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+              }
+            },
+            "jsesc": {
+              "version": "2.5.2",
+              "bundled": true
+            },
+            "json-parse-better-errors": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.4.1",
+              "bundled": true
+            },
+            "json-stable-stringify-without-jsonify": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "jsx-ast-utils": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "array-includes": "^3.0.3"
+              }
+            },
+            "levn": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+              }
+            },
+            "load-json-file": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.11",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "mimic-fn": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "mute-stream": {
+              "version": "0.0.7",
+              "bundled": true
+            },
+            "natural-compare": {
+              "version": "1.4.0",
+              "bundled": true
+            },
+            "nice-try": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "normalize-package-data": {
+              "version": "2.5.0",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "object-keys": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "onetime": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
+              }
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "p-limit": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "path-is-inside": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "path-parse": {
+              "version": "1.0.6",
+              "bundled": true
+            },
+            "path-type": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pkg-conf": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "load-json-file": "^4.0.0"
+              },
+              "dependencies": {
+                "load-json-file": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "^4.1.2",
+                    "parse-json": "^4.0.0",
+                    "pify": "^3.0.0",
+                    "strip-bom": "^3.0.0"
+                  }
+                },
+                "parse-json": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "error-ex": "^1.3.1",
+                    "json-parse-better-errors": "^1.0.1"
+                  }
+                },
+                "pify": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "pkg-config": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "debug-log": "^1.0.0",
+                "find-root": "^1.0.0",
+                "xtend": "^4.0.1"
+              }
+            },
+            "pkg-dir": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.1.0"
+              }
+            },
+            "pluralize": {
+              "version": "7.0.0",
+              "bundled": true
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "progress": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.7.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+              }
+            },
+            "punycode": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "react-is": {
+              "version": "16.8.6",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^2.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^2.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^2.0.0"
+              }
+            },
+            "regexpp": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "require-uncached": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
+              }
+            },
+            "resolve": {
+              "version": "1.11.0",
+              "bundled": true,
+              "requires": {
+                "path-parse": "^1.0.6"
+              }
+            },
+            "resolve-from": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "restore-cursor": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.3",
+              "bundled": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "run-async": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "is-promise": "^2.1.0"
+              }
+            },
+            "run-parallel": {
+              "version": "1.1.9",
+              "bundled": true
+            },
+            "rxjs": {
+              "version": "5.5.12",
+              "bundled": true,
+              "requires": {
+                "symbol-observable": "1.0.1"
+              }
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "semver": {
+              "version": "5.7.0",
+              "bundled": true
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "shebang-regex": "^1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "slice-ansi": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "spdx-correct": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-exceptions": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-license-ids": {
+              "version": "3.0.4",
+              "bundled": true
+            },
+            "sprintf-js": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "standard": {
+              "version": "12.0.1",
+              "bundled": true,
+              "requires": {
+                "eslint": "~5.4.0",
+                "eslint-config-standard": "12.0.0",
+                "eslint-config-standard-jsx": "6.0.2",
+                "eslint-plugin-import": "~2.14.0",
+                "eslint-plugin-node": "~7.0.1",
+                "eslint-plugin-promise": "~4.0.0",
+                "eslint-plugin-react": "~7.11.1",
+                "eslint-plugin-standard": "~4.0.0",
+                "standard-engine": "~9.0.0"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true
+                },
+                "standard-engine": {
+                  "version": "9.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "deglob": "^2.1.0",
+                    "get-stdin": "^6.0.0",
+                    "minimist": "^1.1.0",
+                    "pkg-conf": "^2.0.0"
+                  }
+                }
+              }
+            },
+            "standard-engine": {
+              "version": "10.0.0",
+              "bundled": true,
+              "requires": {
+                "deglob": "^3.0.0",
+                "get-stdin": "^6.0.0",
+                "minimist": "^1.1.0",
+                "pkg-conf": "^2.0.0"
+              },
+              "dependencies": {
+                "deglob": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "find-root": "^1.0.0",
+                    "glob": "^7.0.5",
+                    "ignore": "^5.0.0",
+                    "pkg-config": "^1.1.0",
+                    "run-parallel": "^1.1.2",
+                    "uniq": "^1.0.1"
+                  }
+                },
+                "ignore": {
+                  "version": "5.1.2",
+                  "bundled": true
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true
+                }
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            },
+            "symbol-observable": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "table": {
+              "version": "4.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "^6.0.1",
+                "ajv-keywords": "^3.0.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
+                "slice-ansi": "1.0.0",
+                "string-width": "^2.1.1"
+              }
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            },
+            "tmp": {
+              "version": "0.0.33",
+              "bundled": true,
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            },
+            "to-fast-properties": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "~1.1.2"
+              }
+            },
+            "uniq": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "uri-js": {
+              "version": "4.2.2",
+              "bundled": true,
+              "requires": {
+                "punycode": "^2.1.0"
+              }
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+              }
+            },
+            "which": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "write": {
+              "version": "0.2.1",
+              "bundled": true,
+              "requires": {
+                "mkdirp": "^0.5.1"
+              }
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "acorn": {
+          "version": "6.0.4",
+          "bundled": true
+        },
+        "acorn-jsx": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "ajv": {
+          "version": "6.6.2",
+          "bundled": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "array-includes": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.7.0"
+          }
+        },
+        "assertion-error": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-helper-evaluate-path": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-helper-flip-expressions": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-is-nodes-equiv": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "babel-helper-is-void-0": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-mark-eval-scopes": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-remove-or-void": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-to-multiple-sequence-expressions": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-minify": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "babel-preset-minify": "^0.5.0",
+            "fs-readdir-recursive": "^1.1.0",
+            "lodash.pick": "^4.4.0",
+            "mkdirp": "^0.5.1",
+            "util.promisify": "^1.0.0",
+            "yargs-parser": "^10.0.0"
+          }
+        },
+        "babel-plugin-minify-builtins": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-plugin-minify-constant-folding": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0"
+          }
+        },
+        "babel-plugin-minify-dead-code-elimination": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0",
+            "babel-helper-mark-eval-scopes": "^0.4.3",
+            "babel-helper-remove-or-void": "^0.4.3",
+            "lodash.some": "^4.6.0"
+          }
+        },
+        "babel-plugin-minify-flip-comparisons": {
+          "version": "0.4.3",
+          "bundled": true,
+          "requires": {
+            "babel-helper-is-void-0": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-guarded-expressions": {
+          "version": "0.4.3",
+          "bundled": true,
+          "requires": {
+            "babel-helper-flip-expressions": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-infinity": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-minify-mangle-names": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-mark-eval-scopes": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-numeric-literals": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-minify-replace": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-plugin-minify-simplify": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-flip-expressions": "^0.4.3",
+            "babel-helper-is-nodes-equiv": "^0.0.1",
+            "babel-helper-to-multiple-sequence-expressions": "^0.5.0"
+          }
+        },
+        "babel-plugin-minify-type-constructors": {
+          "version": "0.4.3",
+          "bundled": true,
+          "requires": {
+            "babel-helper-is-void-0": "^0.4.3"
+          }
+        },
+        "babel-plugin-transform-inline-consecutive-adds": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-transform-member-expression-literals": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-merge-sibling-variables": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-minify-booleans": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-property-literals": {
+          "version": "6.9.4",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "babel-plugin-transform-regexp-constructors": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-transform-remove-console": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-remove-debugger": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-remove-undefined": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0"
+          }
+        },
+        "babel-plugin-transform-simplify-comparison-operators": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-undefined-to-void": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-preset-minify": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-minify-builtins": "^0.5.0",
+            "babel-plugin-minify-constant-folding": "^0.5.0",
+            "babel-plugin-minify-dead-code-elimination": "^0.5.0",
+            "babel-plugin-minify-flip-comparisons": "^0.4.3",
+            "babel-plugin-minify-guarded-expressions": "^0.4.3",
+            "babel-plugin-minify-infinity": "^0.4.3",
+            "babel-plugin-minify-mangle-names": "^0.5.0",
+            "babel-plugin-minify-numeric-literals": "^0.4.3",
+            "babel-plugin-minify-replace": "^0.5.0",
+            "babel-plugin-minify-simplify": "^0.5.0",
+            "babel-plugin-minify-type-constructors": "^0.4.3",
+            "babel-plugin-transform-inline-consecutive-adds": "^0.4.3",
+            "babel-plugin-transform-member-expression-literals": "^6.9.4",
+            "babel-plugin-transform-merge-sibling-variables": "^6.9.4",
+            "babel-plugin-transform-minify-booleans": "^6.9.4",
+            "babel-plugin-transform-property-literals": "^6.9.4",
+            "babel-plugin-transform-regexp-constructors": "^0.4.3",
+            "babel-plugin-transform-remove-console": "^6.9.4",
+            "babel-plugin-transform-remove-debugger": "^6.9.4",
+            "babel-plugin-transform-remove-undefined": "^0.5.0",
+            "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
+            "babel-plugin-transform-undefined-to-void": "^6.9.4",
+            "lodash.isplainobject": "^4.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "browser-stdout": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "buffer-from": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "caller-path": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "callsites": "^0.2.0"
+          }
+        },
+        "callsites": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "chai": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "assertion-error": "^1.0.1",
+            "check-error": "^1.0.1",
+            "deep-eql": "^3.0.0",
+            "get-func-name": "^2.0.0",
+            "pathval": "^1.0.0",
+            "type-detect": "^4.0.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "check-error": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "circular-json": {
+          "version": "0.3.3",
+          "bundled": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "commander": {
+          "version": "2.15.1",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "bundled": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "contains-path": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "convert-source-map": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "bundled": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "deep-eql": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "type-detect": "^4.0.0"
+          }
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "deglob": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "find-root": "^1.0.0",
+            "glob": "^7.0.5",
+            "ignore": "^3.0.9",
+            "pkg-config": "^1.1.0",
+            "run-parallel": "^1.1.2",
+            "uniq": "^1.0.1"
+          },
+          "dependencies": {
+            "ignore": {
+              "version": "3.3.10",
+              "bundled": true
+            }
+          }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "bundled": true
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.12.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "eslint": {
+          "version": "5.4.0",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.5.0",
+            "babel-code-frame": "^6.26.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^4.0.0",
+            "eslint-utils": "^1.3.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^4.0.0",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.7.0",
+            "ignore": "^4.0.2",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^5.2.0",
+            "is-resolvable": "^1.1.0",
+            "js-yaml": "^3.11.0",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.5",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^2.0.0",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.5.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "^2.0.1",
+            "table": "^4.0.3",
+            "text-table": "^0.2.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            }
+          }
+        },
+        "eslint-config-standard": {
+          "version": "12.0.0",
+          "bundled": true
+        },
+        "eslint-config-standard-jsx": {
+          "version": "6.0.2",
+          "bundled": true
+        },
+        "eslint-import-resolver-node": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.9",
+            "resolve": "^1.5.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-module-utils": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.8",
+            "pkg-dir": "^1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-plugin-es": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "eslint-utils": "^1.3.0",
+            "regexpp": "^2.0.1"
+          }
+        },
+        "eslint-plugin-import": {
+          "version": "2.14.0",
+          "bundled": true,
+          "requires": {
+            "contains-path": "^0.1.0",
+            "debug": "^2.6.8",
+            "doctrine": "1.5.0",
+            "eslint-import-resolver-node": "^0.3.1",
+            "eslint-module-utils": "^2.2.0",
+            "has": "^1.0.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.3",
+            "read-pkg-up": "^2.0.0",
+            "resolve": "^1.6.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "doctrine": {
+              "version": "1.5.0",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "isarray": "^1.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-plugin-node": {
+          "version": "7.0.1",
+          "bundled": true,
+          "requires": {
+            "eslint-plugin-es": "^1.3.1",
+            "eslint-utils": "^1.3.1",
+            "ignore": "^4.0.2",
+            "minimatch": "^3.0.4",
+            "resolve": "^1.8.1",
+            "semver": "^5.5.0"
+          }
+        },
+        "eslint-plugin-promise": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "eslint-plugin-react": {
+          "version": "7.11.1",
+          "bundled": true,
+          "requires": {
+            "array-includes": "^3.0.3",
+            "doctrine": "^2.1.0",
+            "has": "^1.0.3",
+            "jsx-ast-utils": "^2.0.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "eslint-plugin-standard": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "eslint-scope": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "eslint-visitor-keys": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "espree": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "^6.0.2",
+            "acorn-jsx": "^5.0.0",
+            "eslint-visitor-keys": "^1.0.0"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "esquery": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.0.0"
+          }
+        },
+        "esrecurse": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.1.0"
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "find-root": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "flat-cache": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "circular-json": "^0.3.1",
+            "graceful-fs": "^4.1.2",
+            "rimraf": "~2.6.2",
+            "write": "^0.2.1"
+          }
+        },
+        "fs-readdir-recursive": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "get-func-name": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "get-stdin": {
+          "version": "6.0.0",
+          "bundled": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.9.0",
+          "bundled": true
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "bundled": true
+        },
+        "growl": {
+          "version": "1.10.5",
+          "bundled": true
+        },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "he": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "hosted-git-info": {
+          "version": "2.7.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "inquirer": {
+          "version": "5.2.0",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
+        "is-resolvable": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "bundled": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "bundled": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "json-stable-stringify-without-jsonify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "json5": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "jsx-ast-utils": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "array-includes": "^3.0.3"
+          }
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "bundled": true
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "bundled": true
+        },
+        "lodash.pick": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lodash.some": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            }
+          }
+        },
+        "mocha": {
+          "version": "5.2.0",
+          "bundled": true,
+          "requires": {
+            "browser-stdout": "1.3.1",
+            "commander": "2.15.1",
+            "debug": "3.1.0",
+            "diff": "3.5.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.2",
+            "growl": "1.10.5",
+            "he": "1.1.1",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "supports-color": "5.4.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "5.4.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "nice-try": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-keys": {
+          "version": "1.0.12",
+          "bundled": true
+        },
+        "object.getownpropertydescriptors": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pathval": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "pkg-conf": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "load-json-file": "^4.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "pkg-config": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "debug-log": "^1.0.0",
+            "find-root": "^1.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^1.0.0"
+          }
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "bundled": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "progress": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "regexpp": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "caller-path": "^0.1.0",
+            "resolve-from": "^1.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.9.0",
+          "bundled": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.1.3"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.3",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
+        },
+        "run-parallel": {
+          "version": "1.1.9",
+          "bundled": true
+        },
+        "rxjs": {
+          "version": "5.5.12",
+          "bundled": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        },
+        "snazzy": {
+          "version": "8.0.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.3.0",
+            "inherits": "^2.0.1",
+            "minimist": "^1.1.1",
+            "readable-stream": "^3.0.2",
+            "standard-json": "^1.0.0",
+            "strip-ansi": "^4.0.0",
+            "text-table": "^0.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "spdx-correct": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "standard": {
+          "version": "12.0.1",
+          "bundled": true,
+          "requires": {
+            "eslint": "~5.4.0",
+            "eslint-config-standard": "12.0.0",
+            "eslint-config-standard-jsx": "6.0.2",
+            "eslint-plugin-import": "~2.14.0",
+            "eslint-plugin-node": "~7.0.1",
+            "eslint-plugin-promise": "~4.0.0",
+            "eslint-plugin-react": "~7.11.1",
+            "eslint-plugin-standard": "~4.0.0",
+            "standard-engine": "~9.0.0"
+          }
+        },
+        "standard-engine": {
+          "version": "9.0.0",
+          "bundled": true,
+          "requires": {
+            "deglob": "^2.1.0",
+            "get-stdin": "^6.0.0",
+            "minimist": "^1.1.0",
+            "pkg-conf": "^2.0.0"
+          }
+        },
+        "standard-json": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "^1.5.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "symbol-observable": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "table": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.0.1",
+            "ajv-keywords": "^3.0.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "bundled": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "bundled": true
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "uniq": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "util.promisify": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "object.getownpropertydescriptors": "^2.0.3"
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "bundled": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
     },
     "@zooniverse/grommet-theme": {
       "version": "2.0.0",
       "requires": {
         "deep-freeze": "~0.0.1"
+      },
+      "dependencies": {
+        "@babel/cli": {
+          "version": "7.2.3",
+          "bundled": true,
+          "requires": {
+            "chokidar": "^2.0.3",
+            "commander": "^2.8.1",
+            "convert-source-map": "^1.1.0",
+            "fs-readdir-recursive": "^1.1.0",
+            "glob": "^7.0.0",
+            "lodash": "^4.17.10",
+            "mkdirp": "^0.5.1",
+            "output-file-sync": "^2.0.0",
+            "slash": "^2.0.0",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/code-frame": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@babel/core": {
+          "version": "7.0.1",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.0.0",
+            "@babel/helpers": "^7.0.0",
+            "@babel/parser": "^7.0.0",
+            "@babel/template": "^7.0.0",
+            "@babel/traverse": "^7.0.0",
+            "@babel/types": "^7.0.0",
+            "convert-source-map": "^1.1.0",
+            "debug": "^3.1.0",
+            "json5": "^0.5.0",
+            "lodash": "^4.17.10",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "@babel/generator": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.2.2",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.10",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-explode-assignable-expression": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-call-delegate": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.0.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-define-map": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/types": "^7.0.0",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/helper-explode-assignable-expression": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-simple-access": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "@babel/template": "^7.2.2",
+            "@babel/types": "^7.2.2",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0",
+          "bundled": true
+        },
+        "@babel/helper-regex": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/helper-remap-async-to-generator": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-wrap-function": "^7.1.0",
+            "@babel/template": "^7.1.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.0.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-wrap-function": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/template": "^7.1.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.2.0"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/template": "^7.1.2",
+            "@babel/traverse": "^7.1.5",
+            "@babel/types": "^7.2.0"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.2.2",
+          "bundled": true
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-remap-async-to-generator": "^7.1.0",
+            "@babel/plugin-syntax-async-generators": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-json-strings": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-json-strings": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-optional-catch-binding": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0",
+            "regexpu-core": "^4.2.0"
+          }
+        },
+        "@babel/plugin-syntax-async-generators": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-json-strings": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-remap-async-to-generator": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-block-scoping": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/plugin-transform-classes": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-define-map": "^7.1.0",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/plugin-transform-computed-properties": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-destructuring": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0",
+            "regexpu-core": "^4.1.3"
+          }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-for-of": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-function-name": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-literals": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-modules-amd": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-simple-access": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-modules-umd": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-new-target": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-object-super": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-parameters": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-call-delegate": "^7.1.0",
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-regenerator": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerator-transform": "^0.13.3"
+          }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-spread": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-template-literals": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0",
+            "regexpu-core": "^4.1.3"
+          }
+        },
+        "@babel/preset-env": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+            "@babel/plugin-proposal-json-strings": "^7.0.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+            "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
+            "@babel/plugin-syntax-async-generators": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
+            "@babel/plugin-transform-arrow-functions": "^7.0.0",
+            "@babel/plugin-transform-async-to-generator": "^7.0.0",
+            "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+            "@babel/plugin-transform-block-scoping": "^7.0.0",
+            "@babel/plugin-transform-classes": "^7.0.0",
+            "@babel/plugin-transform-computed-properties": "^7.0.0",
+            "@babel/plugin-transform-destructuring": "^7.0.0",
+            "@babel/plugin-transform-dotall-regex": "^7.0.0",
+            "@babel/plugin-transform-duplicate-keys": "^7.0.0",
+            "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+            "@babel/plugin-transform-for-of": "^7.0.0",
+            "@babel/plugin-transform-function-name": "^7.0.0",
+            "@babel/plugin-transform-literals": "^7.0.0",
+            "@babel/plugin-transform-modules-amd": "^7.0.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+            "@babel/plugin-transform-modules-systemjs": "^7.0.0",
+            "@babel/plugin-transform-modules-umd": "^7.0.0",
+            "@babel/plugin-transform-new-target": "^7.0.0",
+            "@babel/plugin-transform-object-super": "^7.0.0",
+            "@babel/plugin-transform-parameters": "^7.0.0",
+            "@babel/plugin-transform-regenerator": "^7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+            "@babel/plugin-transform-spread": "^7.0.0",
+            "@babel/plugin-transform-sticky-regex": "^7.0.0",
+            "@babel/plugin-transform-template-literals": "^7.0.0",
+            "@babel/plugin-transform-typeof-symbol": "^7.0.0",
+            "@babel/plugin-transform-unicode-regex": "^7.0.0",
+            "browserslist": "^4.1.0",
+            "invariant": "^2.2.2",
+            "js-levenshtein": "^1.1.3",
+            "semver": "^5.3.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.2.2",
+            "@babel/types": "^7.2.2"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.2.2",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "@babel/parser": "^7.2.2",
+            "@babel/types": "^7.2.2",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.10"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.10",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "@zooniverse/standard": {
+          "bundled": true,
+          "requires": {
+            "babel-eslint": "^10.0.1",
+            "eslint-plugin-jsx-a11y": "^6.2.1",
+            "standard": "^12.0.1",
+            "standard-engine": "^10.0.0"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/highlight": "^7.0.0"
+              }
+            },
+            "@babel/generator": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.4.4",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.11",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+              }
+            },
+            "@babel/helper-function-name": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-get-function-arity": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-split-export-declaration": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.4.4"
+              }
+            },
+            "@babel/highlight": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+              }
+            },
+            "@babel/parser": {
+              "version": "7.4.5",
+              "bundled": true
+            },
+            "@babel/template": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.4.4",
+                "@babel/types": "^7.4.4"
+              }
+            },
+            "@babel/traverse": {
+              "version": "7.4.5",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.4.4",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.4.4",
+                "@babel/parser": "^7.4.5",
+                "@babel/types": "^7.4.4",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.11"
+              }
+            },
+            "@babel/types": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.11",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "acorn": {
+              "version": "6.1.1",
+              "bundled": true
+            },
+            "acorn-jsx": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "ajv": {
+              "version": "6.10.0",
+              "bundled": true,
+              "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "ajv-keywords": {
+              "version": "3.4.0",
+              "bundled": true
+            },
+            "ansi-escapes": {
+              "version": "3.2.0",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "argparse": {
+              "version": "1.0.10",
+              "bundled": true,
+              "requires": {
+                "sprintf-js": "~1.0.2"
+              }
+            },
+            "aria-query": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "ast-types-flow": "0.0.7",
+                "commander": "^2.11.0"
+              }
+            },
+            "array-includes": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.7.0"
+              }
+            },
+            "ast-types-flow": {
+              "version": "0.0.7",
+              "bundled": true
+            },
+            "axobject-query": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "ast-types-flow": "0.0.7"
+              }
+            },
+            "babel-code-frame": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+              },
+              "dependencies": {}
+            },
+            "babel-eslint": {
+              "version": "10.0.1",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "eslint-scope": "3.7.1",
+                "eslint-visitor-keys": "^1.0.0"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "caller-path": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "callsites": "^0.2.0"
+              }
+            },
+            "callsites": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "chardet": {
+              "version": "0.4.2",
+              "bundled": true
+            },
+            "circular-json": {
+              "version": "0.3.3",
+              "bundled": true
+            },
+            "cli-cursor": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "restore-cursor": "^2.0.0"
+              }
+            },
+            "cli-width": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "bundled": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "bundled": true
+            },
+            "commander": {
+              "version": "2.20.0",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "contains-path": {
+              "version": "0.1.0",
+              "bundled": true
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "damerau-levenshtein": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "debug-log": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "define-properties": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "object-keys": "^1.0.12"
+              }
+            },
+            "deglob": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "find-root": "^1.0.0",
+                "glob": "^7.0.5",
+                "ignore": "^3.0.9",
+                "pkg-config": "^1.1.0",
+                "run-parallel": "^1.1.2",
+                "uniq": "^1.0.1"
+              },
+              "dependencies": {}
+            },
+            "doctrine": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2"
+              }
+            },
+            "emoji-regex": {
+              "version": "7.0.3",
+              "bundled": true
+            },
+            "error-ex": {
+              "version": "1.3.2",
+              "bundled": true,
+              "requires": {
+                "is-arrayish": "^0.2.1"
+              }
+            },
+            "es-abstract": {
+              "version": "1.13.0",
+              "bundled": true,
+              "requires": {
+                "es-to-primitive": "^1.2.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "is-callable": "^1.1.4",
+                "is-regex": "^1.0.4",
+                "object-keys": "^1.0.12"
+              }
+            },
+            "es-to-primitive": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "eslint": {
+              "version": "5.4.0",
+              "bundled": true,
+              "requires": {
+                "ajv": "^6.5.0",
+                "babel-code-frame": "^6.26.0",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^3.1.0",
+                "doctrine": "^2.1.0",
+                "eslint-scope": "^4.0.0",
+                "eslint-utils": "^1.3.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^4.0.0",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.2",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^5.2.0",
+                "is-resolvable": "^1.1.0",
+                "js-yaml": "^3.11.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.5",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "regexpp": "^2.0.0",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.5.0",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "^2.0.1",
+                "table": "^4.0.3",
+                "text-table": "^0.2.0"
+              },
+              "dependencies": {}
+            },
+            "eslint-config-standard": {
+              "version": "12.0.0",
+              "bundled": true
+            },
+            "eslint-config-standard-jsx": {
+              "version": "6.0.2",
+              "bundled": true
+            },
+            "eslint-import-resolver-node": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.6.9",
+                "resolve": "^1.5.0"
+              },
+              "dependencies": {}
+            },
+            "eslint-module-utils": {
+              "version": "2.4.0",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.6.8",
+                "pkg-dir": "^2.0.0"
+              },
+              "dependencies": {}
+            },
+            "eslint-plugin-es": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "eslint-utils": "^1.3.0",
+                "regexpp": "^2.0.1"
+              }
+            },
+            "eslint-plugin-import": {
+              "version": "2.14.0",
+              "bundled": true,
+              "requires": {
+                "contains-path": "^0.1.0",
+                "debug": "^2.6.8",
+                "doctrine": "1.5.0",
+                "eslint-import-resolver-node": "^0.3.1",
+                "eslint-module-utils": "^2.2.0",
+                "has": "^1.0.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.3",
+                "read-pkg-up": "^2.0.0",
+                "resolve": "^1.6.0"
+              },
+              "dependencies": {}
+            },
+            "eslint-plugin-jsx-a11y": {
+              "version": "6.2.1",
+              "bundled": true,
+              "requires": {
+                "aria-query": "^3.0.0",
+                "array-includes": "^3.0.3",
+                "ast-types-flow": "^0.0.7",
+                "axobject-query": "^2.0.2",
+                "damerau-levenshtein": "^1.0.4",
+                "emoji-regex": "^7.0.2",
+                "has": "^1.0.3",
+                "jsx-ast-utils": "^2.0.1"
+              }
+            },
+            "eslint-plugin-node": {
+              "version": "7.0.1",
+              "bundled": true,
+              "requires": {
+                "eslint-plugin-es": "^1.3.1",
+                "eslint-utils": "^1.3.1",
+                "ignore": "^4.0.2",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.8.1",
+                "semver": "^5.5.0"
+              }
+            },
+            "eslint-plugin-promise": {
+              "version": "4.0.1",
+              "bundled": true
+            },
+            "eslint-plugin-react": {
+              "version": "7.11.1",
+              "bundled": true,
+              "requires": {
+                "array-includes": "^3.0.3",
+                "doctrine": "^2.1.0",
+                "has": "^1.0.3",
+                "jsx-ast-utils": "^2.0.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "eslint-plugin-standard": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "eslint-scope": {
+              "version": "3.7.1",
+              "bundled": true,
+              "requires": {
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+              }
+            },
+            "eslint-utils": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "eslint-visitor-keys": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "espree": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "acorn": "^6.0.2",
+                "acorn-jsx": "^5.0.0",
+                "eslint-visitor-keys": "^1.0.0"
+              }
+            },
+            "esprima": {
+              "version": "4.0.1",
+              "bundled": true
+            },
+            "esquery": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "estraverse": "^4.0.0"
+              }
+            },
+            "esrecurse": {
+              "version": "4.2.1",
+              "bundled": true,
+              "requires": {
+                "estraverse": "^4.1.0"
+              }
+            },
+            "estraverse": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "external-editor": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
+              }
+            },
+            "fast-deep-equal": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "fast-json-stable-stringify": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "figures": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "escape-string-regexp": "^1.0.5"
+              }
+            },
+            "file-entry-cache": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
+              }
+            },
+            "find-root": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "flat-cache": {
+              "version": "1.3.4",
+              "bundled": true,
+              "requires": {
+                "circular-json": "^0.3.1",
+                "graceful-fs": "^4.1.2",
+                "rimraf": "~2.6.2",
+                "write": "^0.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "function-bind": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "functional-red-black-tree": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "get-stdin": {
+              "version": "6.0.0",
+              "bundled": true
+            },
+            "glob": {
+              "version": "7.1.4",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "globals": {
+              "version": "11.12.0",
+              "bundled": true
+            },
+            "graceful-fs": {
+              "version": "4.1.15",
+              "bundled": true
+            },
+            "has": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "function-bind": "^1.1.1"
+              }
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "has-symbols": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "hosted-git-info": {
+              "version": "2.7.1",
+              "bundled": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore": {
+              "version": "4.0.6",
+              "bundled": true
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "bundled": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "inquirer": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.1.0",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^5.5.2",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
+              }
+            },
+            "is-arrayish": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-callable": {
+              "version": "1.1.4",
+              "bundled": true
+            },
+            "is-date-object": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "is-promise": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "is-regex": {
+              "version": "1.0.4",
+              "bundled": true,
+              "requires": {
+                "has": "^1.0.1"
+              }
+            },
+            "is-resolvable": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-symbol": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "has-symbols": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "js-yaml": {
+              "version": "3.13.1",
+              "bundled": true,
+              "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+              }
+            },
+            "jsesc": {
+              "version": "2.5.2",
+              "bundled": true
+            },
+            "json-parse-better-errors": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.4.1",
+              "bundled": true
+            },
+            "json-stable-stringify-without-jsonify": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "jsx-ast-utils": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "array-includes": "^3.0.3"
+              }
+            },
+            "levn": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+              }
+            },
+            "load-json-file": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.11",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "mimic-fn": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "mute-stream": {
+              "version": "0.0.7",
+              "bundled": true
+            },
+            "natural-compare": {
+              "version": "1.4.0",
+              "bundled": true
+            },
+            "nice-try": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "normalize-package-data": {
+              "version": "2.5.0",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "object-keys": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "onetime": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
+              }
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "p-limit": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "path-is-inside": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "path-parse": {
+              "version": "1.0.6",
+              "bundled": true
+            },
+            "path-type": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pkg-conf": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "load-json-file": "^4.0.0"
+              },
+              "dependencies": {}
+            },
+            "pkg-config": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "debug-log": "^1.0.0",
+                "find-root": "^1.0.0",
+                "xtend": "^4.0.1"
+              }
+            },
+            "pkg-dir": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.1.0"
+              }
+            },
+            "pluralize": {
+              "version": "7.0.0",
+              "bundled": true
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "progress": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.7.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+              }
+            },
+            "punycode": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "react-is": {
+              "version": "16.8.6",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^2.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^2.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^2.0.0"
+              }
+            },
+            "regexpp": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "require-uncached": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
+              }
+            },
+            "resolve": {
+              "version": "1.11.0",
+              "bundled": true,
+              "requires": {
+                "path-parse": "^1.0.6"
+              }
+            },
+            "resolve-from": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "restore-cursor": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.3",
+              "bundled": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "run-async": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "is-promise": "^2.1.0"
+              }
+            },
+            "run-parallel": {
+              "version": "1.1.9",
+              "bundled": true
+            },
+            "rxjs": {
+              "version": "5.5.12",
+              "bundled": true,
+              "requires": {
+                "symbol-observable": "1.0.1"
+              }
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "semver": {
+              "version": "5.7.0",
+              "bundled": true
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "shebang-regex": "^1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "slice-ansi": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "spdx-correct": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-exceptions": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-license-ids": {
+              "version": "3.0.4",
+              "bundled": true
+            },
+            "sprintf-js": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "standard": {
+              "version": "12.0.1",
+              "bundled": true,
+              "requires": {
+                "eslint": "~5.4.0",
+                "eslint-config-standard": "12.0.0",
+                "eslint-config-standard-jsx": "6.0.2",
+                "eslint-plugin-import": "~2.14.0",
+                "eslint-plugin-node": "~7.0.1",
+                "eslint-plugin-promise": "~4.0.0",
+                "eslint-plugin-react": "~7.11.1",
+                "eslint-plugin-standard": "~4.0.0",
+                "standard-engine": "~9.0.0"
+              },
+              "dependencies": {}
+            },
+            "standard-engine": {
+              "version": "10.0.0",
+              "bundled": true,
+              "requires": {
+                "deglob": "^3.0.0",
+                "get-stdin": "^6.0.0",
+                "minimist": "^1.1.0",
+                "pkg-conf": "^2.0.0"
+              },
+              "dependencies": {}
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              },
+              "dependencies": {}
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            },
+            "symbol-observable": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "table": {
+              "version": "4.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "^6.0.1",
+                "ajv-keywords": "^3.0.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
+                "slice-ansi": "1.0.0",
+                "string-width": "^2.1.1"
+              }
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            },
+            "tmp": {
+              "version": "0.0.33",
+              "bundled": true,
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            },
+            "to-fast-properties": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "~1.1.2"
+              }
+            },
+            "uniq": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "uri-js": {
+              "version": "4.2.2",
+              "bundled": true,
+              "requires": {
+                "punycode": "^2.1.0"
+              }
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+              }
+            },
+            "which": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "write": {
+              "version": "0.2.1",
+              "bundled": true,
+              "requires": {
+                "mkdirp": "^0.5.1"
+              }
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "acorn": {
+          "version": "6.0.4",
+          "bundled": true
+        },
+        "acorn-jsx": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "ajv": {
+          "version": "6.6.2",
+          "bundled": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "anymatch": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "array-includes": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.7.0"
+          }
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "async-each": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "atob": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-helper-evaluate-path": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-helper-flip-expressions": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-is-nodes-equiv": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "babel-helper-is-void-0": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-mark-eval-scopes": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-remove-or-void": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-to-multiple-sequence-expressions": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-plugin-minify-builtins": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-plugin-minify-constant-folding": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0"
+          }
+        },
+        "babel-plugin-minify-dead-code-elimination": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0",
+            "babel-helper-mark-eval-scopes": "^0.4.3",
+            "babel-helper-remove-or-void": "^0.4.3",
+            "lodash.some": "^4.6.0"
+          }
+        },
+        "babel-plugin-minify-flip-comparisons": {
+          "version": "0.4.3",
+          "bundled": true,
+          "requires": {
+            "babel-helper-is-void-0": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-guarded-expressions": {
+          "version": "0.4.3",
+          "bundled": true,
+          "requires": {
+            "babel-helper-flip-expressions": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-infinity": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-minify-mangle-names": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-mark-eval-scopes": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-numeric-literals": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-minify-replace": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-plugin-minify-simplify": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-flip-expressions": "^0.4.3",
+            "babel-helper-is-nodes-equiv": "^0.0.1",
+            "babel-helper-to-multiple-sequence-expressions": "^0.5.0"
+          }
+        },
+        "babel-plugin-minify-type-constructors": {
+          "version": "0.4.3",
+          "bundled": true,
+          "requires": {
+            "babel-helper-is-void-0": "^0.4.3"
+          }
+        },
+        "babel-plugin-transform-inline-consecutive-adds": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-transform-member-expression-literals": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-merge-sibling-variables": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-minify-booleans": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-property-literals": {
+          "version": "6.9.4",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "babel-plugin-transform-regexp-constructors": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-transform-remove-console": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-remove-debugger": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-remove-undefined": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0"
+          }
+        },
+        "babel-plugin-transform-simplify-comparison-operators": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-undefined-to-void": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-preset-minify": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-minify-builtins": "^0.5.0",
+            "babel-plugin-minify-constant-folding": "^0.5.0",
+            "babel-plugin-minify-dead-code-elimination": "^0.5.0",
+            "babel-plugin-minify-flip-comparisons": "^0.4.3",
+            "babel-plugin-minify-guarded-expressions": "^0.4.3",
+            "babel-plugin-minify-infinity": "^0.4.3",
+            "babel-plugin-minify-mangle-names": "^0.5.0",
+            "babel-plugin-minify-numeric-literals": "^0.4.3",
+            "babel-plugin-minify-replace": "^0.5.0",
+            "babel-plugin-minify-simplify": "^0.5.0",
+            "babel-plugin-minify-type-constructors": "^0.4.3",
+            "babel-plugin-transform-inline-consecutive-adds": "^0.4.3",
+            "babel-plugin-transform-member-expression-literals": "^6.9.4",
+            "babel-plugin-transform-merge-sibling-variables": "^6.9.4",
+            "babel-plugin-transform-minify-booleans": "^6.9.4",
+            "babel-plugin-transform-property-literals": "^6.9.4",
+            "babel-plugin-transform-regexp-constructors": "^0.4.3",
+            "babel-plugin-transform-remove-console": "^6.9.4",
+            "babel-plugin-transform-remove-debugger": "^6.9.4",
+            "babel-plugin-transform-remove-undefined": "^0.5.0",
+            "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
+            "babel-plugin-transform-undefined-to-void": "^6.9.4",
+            "lodash.isplainobject": "^4.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base": {
+          "version": "0.11.2",
+          "bundled": true,
+          "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.12.0",
+          "bundled": true,
+          "optional": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "browserslist": {
+          "version": "4.3.6",
+          "bundled": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000921",
+            "electron-to-chromium": "^1.3.92",
+            "node-releases": "^1.1.1"
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+          }
+        },
+        "caller-path": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "callsites": "^0.2.0"
+          }
+        },
+        "callsites": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000921",
+          "bundled": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "chokidar": {
+          "version": "2.0.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.0",
+            "braces": "^2.3.0",
+            "fsevents": "^1.2.2",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "lodash.debounce": "^4.0.8",
+            "normalize-path": "^2.1.1",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0",
+            "upath": "^1.0.5"
+          }
+        },
+        "circular-json": {
+          "version": "0.3.3",
+          "bundled": true
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "bundled": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "commander": {
+          "version": "2.19.0",
+          "bundled": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "contains-path": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "convert-source-map": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "bundled": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "deep-freeze": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "deglob": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "find-root": "^1.0.0",
+            "glob": "^7.0.5",
+            "ignore": "^3.0.9",
+            "pkg-config": "^1.1.0",
+            "run-parallel": "^1.1.2",
+            "uniq": "^1.0.1"
+          },
+          "dependencies": {
+            "ignore": {
+              "version": "3.3.10",
+              "bundled": true
+            }
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.94",
+          "bundled": true
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.12.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "eslint": {
+          "version": "5.4.0",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.5.0",
+            "babel-code-frame": "^6.26.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^4.0.0",
+            "eslint-utils": "^1.3.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^4.0.0",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.7.0",
+            "ignore": "^4.0.2",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^5.2.0",
+            "is-resolvable": "^1.1.0",
+            "js-yaml": "^3.11.0",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.5",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^2.0.0",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.5.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "^2.0.1",
+            "table": "^4.0.3",
+            "text-table": "^0.2.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-config-standard": {
+          "version": "12.0.0",
+          "bundled": true
+        },
+        "eslint-config-standard-jsx": {
+          "version": "6.0.2",
+          "bundled": true
+        },
+        "eslint-import-resolver-node": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.9",
+            "resolve": "^1.5.0"
+          }
+        },
+        "eslint-module-utils": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.8",
+            "pkg-dir": "^1.0.0"
+          }
+        },
+        "eslint-plugin-es": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "eslint-utils": "^1.3.0",
+            "regexpp": "^2.0.1"
+          }
+        },
+        "eslint-plugin-import": {
+          "version": "2.14.0",
+          "bundled": true,
+          "requires": {
+            "contains-path": "^0.1.0",
+            "debug": "^2.6.8",
+            "doctrine": "1.5.0",
+            "eslint-import-resolver-node": "^0.3.1",
+            "eslint-module-utils": "^2.2.0",
+            "has": "^1.0.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.3",
+            "read-pkg-up": "^2.0.0",
+            "resolve": "^1.6.0"
+          },
+          "dependencies": {
+            "doctrine": {
+              "version": "1.5.0",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "isarray": "^1.0.0"
+              }
+            }
+          }
+        },
+        "eslint-plugin-node": {
+          "version": "7.0.1",
+          "bundled": true,
+          "requires": {
+            "eslint-plugin-es": "^1.3.1",
+            "eslint-utils": "^1.3.1",
+            "ignore": "^4.0.2",
+            "minimatch": "^3.0.4",
+            "resolve": "^1.8.1",
+            "semver": "^5.5.0"
+          }
+        },
+        "eslint-plugin-promise": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "eslint-plugin-react": {
+          "version": "7.11.1",
+          "bundled": true,
+          "requires": {
+            "array-includes": "^3.0.3",
+            "doctrine": "^2.1.0",
+            "has": "^1.0.3",
+            "jsx-ast-utils": "^2.0.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "eslint-plugin-standard": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "eslint-scope": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "eslint-visitor-keys": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "espree": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "^6.0.2",
+            "acorn-jsx": "^5.0.0",
+            "eslint-visitor-keys": "^1.0.0"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "esquery": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.0.0"
+          }
+        },
+        "esrecurse": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.1.0"
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "find-root": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "flat-cache": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "circular-json": "^0.3.1",
+            "graceful-fs": "^4.1.2",
+            "rimraf": "~2.6.2",
+            "write": "^0.2.1"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "map-cache": "^0.2.2"
+          }
+        },
+        "fs-readdir-recursive": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fsevents": {
+          "version": "1.2.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "nan": "^2.9.2",
+            "node-pre-gyp": "^0.10.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "minipass": {
+              "version": "2.3.5",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.2.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.10.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.5",
+              "bundled": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "get-stdin": {
+          "version": "6.0.0",
+          "bundled": true
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "globals": {
+          "version": "11.9.0",
+          "bundled": true
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "bundled": true
+        },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.7.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "inquirer": {
+          "version": "5.2.0",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
+        "is-resolvable": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "js-levenshtein": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "bundled": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "bundled": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "json-stable-stringify-without-jsonify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "jsx-ast-utils": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "array-includes": "^3.0.3"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "bundled": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "bundled": true
+        },
+        "lodash.debounce": {
+          "version": "4.0.8",
+          "bundled": true,
+          "optional": true
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "bundled": true
+        },
+        "lodash.some": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "object-visit": "^1.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "nan": {
+          "version": "2.12.1",
+          "bundled": true,
+          "optional": true
+        },
+        "nanomatch": {
+          "version": "1.2.13",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "nice-try": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "node-releases": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "semver": "^5.3.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "object-keys": {
+          "version": "1.0.12",
+          "bundled": true
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.0"
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "output-file-sync": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "is-plain-obj": "^1.1.0",
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "path-dirname": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "pkg-conf": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "load-json-file": "^4.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "pkg-config": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "debug-log": "^1.0.0",
+            "find-root": "^1.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^1.0.0"
+          }
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "bundled": true
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "private": {
+          "version": "0.1.8",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "progress": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "regenerate": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "regenerate-unicode-properties": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerate": "^1.4.0"
+          }
+        },
+        "regenerator-transform": {
+          "version": "0.13.3",
+          "bundled": true,
+          "requires": {
+            "private": "^0.1.6"
+          }
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "regexpp": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "regexpu-core": {
+          "version": "4.4.0",
+          "bundled": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^7.0.0",
+            "regjsgen": "^0.5.0",
+            "regjsparser": "^0.6.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.0.2"
+          }
+        },
+        "regjsgen": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "regjsparser": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "0.5.0",
+              "bundled": true
+            }
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "repeat-element": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "caller-path": "^0.1.0",
+            "resolve-from": "^1.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.9.0",
+          "bundled": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "ret": {
+          "version": "0.1.15",
+          "bundled": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
+        },
+        "run-parallel": {
+          "version": "1.1.9",
+          "bundled": true
+        },
+        "rxjs": {
+          "version": "5.5.12",
+          "bundled": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ret": "~0.1.10"
+          }
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "slash": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.2.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "source-map-resolve": {
+          "version": "0.5.2",
+          "bundled": true,
+          "requires": {
+            "atob": "^2.1.1",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "spdx-correct": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "standard": {
+          "version": "12.0.1",
+          "bundled": true,
+          "requires": {
+            "eslint": "~5.4.0",
+            "eslint-config-standard": "12.0.0",
+            "eslint-config-standard-jsx": "6.0.2",
+            "eslint-plugin-import": "~2.14.0",
+            "eslint-plugin-node": "~7.0.1",
+            "eslint-plugin-promise": "~4.0.0",
+            "eslint-plugin-react": "~7.11.1",
+            "eslint-plugin-standard": "~4.0.0",
+            "standard-engine": "~9.0.0"
+          }
+        },
+        "standard-engine": {
+          "version": "9.0.0",
+          "bundled": true,
+          "requires": {
+            "deglob": "^2.1.0",
+            "get-stdin": "^6.0.0",
+            "minimist": "^1.1.0",
+            "pkg-conf": "^2.0.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "symbol-observable": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "table": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.0.1",
+            "ajv-keywords": "^3.0.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "bundled": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        },
+        "unicode-canonical-property-names-ecmascript": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "unicode-match-property-ecmascript": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "unicode-canonical-property-names-ecmascript": "^1.0.4",
+            "unicode-property-aliases-ecmascript": "^1.0.4"
+          }
+        },
+        "unicode-match-property-value-ecmascript": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "unicode-property-aliases-ecmascript": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "union-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
+              }
+            }
+          }
+        },
+        "uniq": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "bundled": true,
+              "requires": {
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "bundled": true
+            }
+          }
+        },
+        "upath": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "use": {
+          "version": "3.1.1",
+          "bundled": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        }
       }
     },
     "@zooniverse/panoptes-js": {
@@ -2160,6 +10519,4524 @@
       "requires": {
         "superagent": "~3.8.3",
         "url-parse": "~1.4.3"
+      },
+      "dependencies": {
+        "@sinonjs/commons": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "@sinonjs/formatio": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "samsam": "1.3.0"
+          }
+        },
+        "@sinonjs/samsam": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "@sinonjs/commons": "^1.0.2",
+            "array-from": "^2.1.1",
+            "lodash.get": "^4.4.2"
+          }
+        },
+        "@zooniverse/standard": {
+          "bundled": true,
+          "requires": {
+            "babel-eslint": "^10.0.1",
+            "eslint-plugin-jsx-a11y": "^6.2.1",
+            "standard": "^12.0.1",
+            "standard-engine": "^10.0.0"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/highlight": "^7.0.0"
+              }
+            },
+            "@babel/generator": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.4.4",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.11",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+              }
+            },
+            "@babel/helper-function-name": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-get-function-arity": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-split-export-declaration": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.4.4"
+              }
+            },
+            "@babel/highlight": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+              }
+            },
+            "@babel/parser": {
+              "version": "7.4.5",
+              "bundled": true
+            },
+            "@babel/template": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.4.4",
+                "@babel/types": "^7.4.4"
+              }
+            },
+            "@babel/traverse": {
+              "version": "7.4.5",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.4.4",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.4.4",
+                "@babel/parser": "^7.4.5",
+                "@babel/types": "^7.4.4",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.11"
+              }
+            },
+            "@babel/types": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.11",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "acorn": {
+              "version": "6.1.1",
+              "bundled": true
+            },
+            "acorn-jsx": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "ajv": {
+              "version": "6.10.0",
+              "bundled": true,
+              "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "ajv-keywords": {
+              "version": "3.4.0",
+              "bundled": true
+            },
+            "ansi-escapes": {
+              "version": "3.2.0",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "argparse": {
+              "version": "1.0.10",
+              "bundled": true,
+              "requires": {
+                "sprintf-js": "~1.0.2"
+              }
+            },
+            "aria-query": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "ast-types-flow": "0.0.7",
+                "commander": "^2.11.0"
+              }
+            },
+            "array-includes": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.7.0"
+              }
+            },
+            "ast-types-flow": {
+              "version": "0.0.7",
+              "bundled": true
+            },
+            "axobject-query": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "ast-types-flow": "0.0.7"
+              }
+            },
+            "babel-code-frame": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+              },
+              "dependencies": {}
+            },
+            "babel-eslint": {
+              "version": "10.0.1",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "eslint-scope": "3.7.1",
+                "eslint-visitor-keys": "^1.0.0"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "caller-path": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "callsites": "^0.2.0"
+              }
+            },
+            "callsites": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "chardet": {
+              "version": "0.4.2",
+              "bundled": true
+            },
+            "circular-json": {
+              "version": "0.3.3",
+              "bundled": true
+            },
+            "cli-cursor": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "restore-cursor": "^2.0.0"
+              }
+            },
+            "cli-width": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "bundled": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "bundled": true
+            },
+            "commander": {
+              "version": "2.20.0",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "contains-path": {
+              "version": "0.1.0",
+              "bundled": true
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "damerau-levenshtein": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "debug-log": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "define-properties": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "object-keys": "^1.0.12"
+              }
+            },
+            "deglob": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "find-root": "^1.0.0",
+                "glob": "^7.0.5",
+                "ignore": "^3.0.9",
+                "pkg-config": "^1.1.0",
+                "run-parallel": "^1.1.2",
+                "uniq": "^1.0.1"
+              },
+              "dependencies": {}
+            },
+            "doctrine": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2"
+              }
+            },
+            "emoji-regex": {
+              "version": "7.0.3",
+              "bundled": true
+            },
+            "error-ex": {
+              "version": "1.3.2",
+              "bundled": true,
+              "requires": {
+                "is-arrayish": "^0.2.1"
+              }
+            },
+            "es-abstract": {
+              "version": "1.13.0",
+              "bundled": true,
+              "requires": {
+                "es-to-primitive": "^1.2.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "is-callable": "^1.1.4",
+                "is-regex": "^1.0.4",
+                "object-keys": "^1.0.12"
+              }
+            },
+            "es-to-primitive": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "eslint": {
+              "version": "5.4.0",
+              "bundled": true,
+              "requires": {
+                "ajv": "^6.5.0",
+                "babel-code-frame": "^6.26.0",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^3.1.0",
+                "doctrine": "^2.1.0",
+                "eslint-scope": "^4.0.0",
+                "eslint-utils": "^1.3.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^4.0.0",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.2",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^5.2.0",
+                "is-resolvable": "^1.1.0",
+                "js-yaml": "^3.11.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.5",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "regexpp": "^2.0.0",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.5.0",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "^2.0.1",
+                "table": "^4.0.3",
+                "text-table": "^0.2.0"
+              },
+              "dependencies": {}
+            },
+            "eslint-config-standard": {
+              "version": "12.0.0",
+              "bundled": true
+            },
+            "eslint-config-standard-jsx": {
+              "version": "6.0.2",
+              "bundled": true
+            },
+            "eslint-import-resolver-node": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.6.9",
+                "resolve": "^1.5.0"
+              },
+              "dependencies": {}
+            },
+            "eslint-module-utils": {
+              "version": "2.4.0",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.6.8",
+                "pkg-dir": "^2.0.0"
+              },
+              "dependencies": {}
+            },
+            "eslint-plugin-es": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "eslint-utils": "^1.3.0",
+                "regexpp": "^2.0.1"
+              }
+            },
+            "eslint-plugin-import": {
+              "version": "2.14.0",
+              "bundled": true,
+              "requires": {
+                "contains-path": "^0.1.0",
+                "debug": "^2.6.8",
+                "doctrine": "1.5.0",
+                "eslint-import-resolver-node": "^0.3.1",
+                "eslint-module-utils": "^2.2.0",
+                "has": "^1.0.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.3",
+                "read-pkg-up": "^2.0.0",
+                "resolve": "^1.6.0"
+              },
+              "dependencies": {}
+            },
+            "eslint-plugin-jsx-a11y": {
+              "version": "6.2.1",
+              "bundled": true,
+              "requires": {
+                "aria-query": "^3.0.0",
+                "array-includes": "^3.0.3",
+                "ast-types-flow": "^0.0.7",
+                "axobject-query": "^2.0.2",
+                "damerau-levenshtein": "^1.0.4",
+                "emoji-regex": "^7.0.2",
+                "has": "^1.0.3",
+                "jsx-ast-utils": "^2.0.1"
+              }
+            },
+            "eslint-plugin-node": {
+              "version": "7.0.1",
+              "bundled": true,
+              "requires": {
+                "eslint-plugin-es": "^1.3.1",
+                "eslint-utils": "^1.3.1",
+                "ignore": "^4.0.2",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.8.1",
+                "semver": "^5.5.0"
+              }
+            },
+            "eslint-plugin-promise": {
+              "version": "4.0.1",
+              "bundled": true
+            },
+            "eslint-plugin-react": {
+              "version": "7.11.1",
+              "bundled": true,
+              "requires": {
+                "array-includes": "^3.0.3",
+                "doctrine": "^2.1.0",
+                "has": "^1.0.3",
+                "jsx-ast-utils": "^2.0.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "eslint-plugin-standard": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "eslint-scope": {
+              "version": "3.7.1",
+              "bundled": true,
+              "requires": {
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+              }
+            },
+            "eslint-utils": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "eslint-visitor-keys": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "espree": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "acorn": "^6.0.2",
+                "acorn-jsx": "^5.0.0",
+                "eslint-visitor-keys": "^1.0.0"
+              }
+            },
+            "esprima": {
+              "version": "4.0.1",
+              "bundled": true
+            },
+            "esquery": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "estraverse": "^4.0.0"
+              }
+            },
+            "esrecurse": {
+              "version": "4.2.1",
+              "bundled": true,
+              "requires": {
+                "estraverse": "^4.1.0"
+              }
+            },
+            "estraverse": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "external-editor": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
+              }
+            },
+            "fast-deep-equal": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "fast-json-stable-stringify": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "figures": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "escape-string-regexp": "^1.0.5"
+              }
+            },
+            "file-entry-cache": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
+              }
+            },
+            "find-root": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "flat-cache": {
+              "version": "1.3.4",
+              "bundled": true,
+              "requires": {
+                "circular-json": "^0.3.1",
+                "graceful-fs": "^4.1.2",
+                "rimraf": "~2.6.2",
+                "write": "^0.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "function-bind": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "functional-red-black-tree": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "get-stdin": {
+              "version": "6.0.0",
+              "bundled": true
+            },
+            "glob": {
+              "version": "7.1.4",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "globals": {
+              "version": "11.12.0",
+              "bundled": true
+            },
+            "graceful-fs": {
+              "version": "4.1.15",
+              "bundled": true
+            },
+            "has": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "function-bind": "^1.1.1"
+              }
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "has-symbols": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "hosted-git-info": {
+              "version": "2.7.1",
+              "bundled": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore": {
+              "version": "4.0.6",
+              "bundled": true
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "bundled": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "inquirer": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.1.0",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^5.5.2",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
+              }
+            },
+            "is-arrayish": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-callable": {
+              "version": "1.1.4",
+              "bundled": true
+            },
+            "is-date-object": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "is-promise": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "is-regex": {
+              "version": "1.0.4",
+              "bundled": true,
+              "requires": {
+                "has": "^1.0.1"
+              }
+            },
+            "is-resolvable": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-symbol": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "has-symbols": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "js-yaml": {
+              "version": "3.13.1",
+              "bundled": true,
+              "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+              }
+            },
+            "jsesc": {
+              "version": "2.5.2",
+              "bundled": true
+            },
+            "json-parse-better-errors": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.4.1",
+              "bundled": true
+            },
+            "json-stable-stringify-without-jsonify": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "jsx-ast-utils": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "array-includes": "^3.0.3"
+              }
+            },
+            "levn": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+              }
+            },
+            "load-json-file": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.11",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "mimic-fn": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "mute-stream": {
+              "version": "0.0.7",
+              "bundled": true
+            },
+            "natural-compare": {
+              "version": "1.4.0",
+              "bundled": true
+            },
+            "nice-try": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "normalize-package-data": {
+              "version": "2.5.0",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "object-keys": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "onetime": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
+              }
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "p-limit": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "path-is-inside": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "path-parse": {
+              "version": "1.0.6",
+              "bundled": true
+            },
+            "path-type": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pkg-conf": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "load-json-file": "^4.0.0"
+              },
+              "dependencies": {}
+            },
+            "pkg-config": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "debug-log": "^1.0.0",
+                "find-root": "^1.0.0",
+                "xtend": "^4.0.1"
+              }
+            },
+            "pkg-dir": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.1.0"
+              }
+            },
+            "pluralize": {
+              "version": "7.0.0",
+              "bundled": true
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "progress": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.7.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+              }
+            },
+            "punycode": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "react-is": {
+              "version": "16.8.6",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^2.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^2.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^2.0.0"
+              }
+            },
+            "regexpp": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "require-uncached": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
+              }
+            },
+            "resolve": {
+              "version": "1.11.0",
+              "bundled": true,
+              "requires": {
+                "path-parse": "^1.0.6"
+              }
+            },
+            "resolve-from": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "restore-cursor": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.3",
+              "bundled": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "run-async": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "is-promise": "^2.1.0"
+              }
+            },
+            "run-parallel": {
+              "version": "1.1.9",
+              "bundled": true
+            },
+            "rxjs": {
+              "version": "5.5.12",
+              "bundled": true,
+              "requires": {
+                "symbol-observable": "1.0.1"
+              }
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "semver": {
+              "version": "5.7.0",
+              "bundled": true
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "shebang-regex": "^1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "slice-ansi": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "spdx-correct": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-exceptions": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-license-ids": {
+              "version": "3.0.4",
+              "bundled": true
+            },
+            "sprintf-js": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "standard": {
+              "version": "12.0.1",
+              "bundled": true,
+              "requires": {
+                "eslint": "~5.4.0",
+                "eslint-config-standard": "12.0.0",
+                "eslint-config-standard-jsx": "6.0.2",
+                "eslint-plugin-import": "~2.14.0",
+                "eslint-plugin-node": "~7.0.1",
+                "eslint-plugin-promise": "~4.0.0",
+                "eslint-plugin-react": "~7.11.1",
+                "eslint-plugin-standard": "~4.0.0",
+                "standard-engine": "~9.0.0"
+              },
+              "dependencies": {}
+            },
+            "standard-engine": {
+              "version": "10.0.0",
+              "bundled": true,
+              "requires": {
+                "deglob": "^3.0.0",
+                "get-stdin": "^6.0.0",
+                "minimist": "^1.1.0",
+                "pkg-conf": "^2.0.0"
+              },
+              "dependencies": {}
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              },
+              "dependencies": {}
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            },
+            "symbol-observable": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "table": {
+              "version": "4.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "^6.0.1",
+                "ajv-keywords": "^3.0.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
+                "slice-ansi": "1.0.0",
+                "string-width": "^2.1.1"
+              }
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            },
+            "tmp": {
+              "version": "0.0.33",
+              "bundled": true,
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            },
+            "to-fast-properties": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "~1.1.2"
+              }
+            },
+            "uniq": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "uri-js": {
+              "version": "4.2.2",
+              "bundled": true,
+              "requires": {
+                "punycode": "^2.1.0"
+              }
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+              }
+            },
+            "which": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "write": {
+              "version": "0.2.1",
+              "bundled": true,
+              "requires": {
+                "mkdirp": "^0.5.1"
+              }
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "abab": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "acorn": {
+          "version": "5.7.3",
+          "bundled": true
+        },
+        "acorn-globals": {
+          "version": "4.3.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "^6.0.1",
+            "acorn-walk": "^6.0.1"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "6.0.4",
+              "bundled": true
+            }
+          }
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "acorn": "^3.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "acorn-walk": {
+          "version": "6.1.1",
+          "bundled": true
+        },
+        "ajv": {
+          "version": "6.6.2",
+          "bundled": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "array-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "array-from": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "array-includes": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.7.0"
+          }
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.4",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": "~2.1.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "assertion-error": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "async-limiter": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "atob": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.8.0",
+          "bundled": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base": {
+          "version": "0.11.2",
+          "bundled": true,
+          "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "bower-config": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.3",
+            "mout": "^1.0.0",
+            "optimist": "^0.6.1",
+            "osenv": "^0.1.3",
+            "untildify": "^2.1.0"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "browser-process-hrtime": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "browser-stdout": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "buffer-from": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+          }
+        },
+        "caller-path": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "callsites": "^0.2.0"
+          }
+        },
+        "callsites": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "chai": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "assertion-error": "^1.0.1",
+            "check-error": "^1.0.1",
+            "deep-eql": "^3.0.0",
+            "get-func-name": "^2.0.0",
+            "pathval": "^1.0.0",
+            "type-detect": "^4.0.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "check-dependencies": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "bower-config": "^1.4.0",
+            "chalk": "^2.1.0",
+            "findup-sync": "^2.0.0",
+            "lodash.camelcase": "^4.3.0",
+            "minimist": "^1.2.0",
+            "semver": "^5.4.1"
+          }
+        },
+        "check-engines": {
+          "version": "1.5.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "semver": ">=4.3.6"
+          }
+        },
+        "check-error": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "circular-json": {
+          "version": "0.3.3",
+          "bundled": true
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "bundled": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.7",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.11.0",
+          "bundled": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "bundled": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "contains-path": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "cookiejar": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "core-js": {
+          "version": "0.8.4",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "cssom": {
+          "version": "0.3.4",
+          "bundled": true
+        },
+        "cssstyle": {
+          "version": "0.2.37",
+          "bundled": true,
+          "requires": {
+            "cssom": "0.3.x"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "data-urls": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "abab": "^2.0.0",
+            "whatwg-mimetype": "^2.2.0",
+            "whatwg-url": "^7.0.0"
+          },
+          "dependencies": {
+            "abab": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "whatwg-url": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "bundled": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "deep-eql": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "type-detect": "^4.0.0"
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "deglob": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "find-root": "^1.0.0",
+            "glob": "^7.0.5",
+            "ignore": "^3.0.9",
+            "pkg-config": "^1.1.0",
+            "run-parallel": "^1.1.2",
+            "uniq": "^1.0.1"
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-file": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "diff": {
+          "version": "3.5.0",
+          "bundled": true
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "dom-walk": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "domexception": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.12.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "escodegen": {
+          "version": "1.11.0",
+          "bundled": true,
+          "requires": {
+            "esprima": "^3.1.3",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "eslint": {
+          "version": "4.18.2",
+          "bundled": true,
+          "requires": {
+            "ajv": "^5.3.0",
+            "babel-code-frame": "^6.22.0",
+            "chalk": "^2.1.0",
+            "concat-stream": "^1.6.0",
+            "cross-spawn": "^5.1.0",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^3.7.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^3.5.2",
+            "esquery": "^1.0.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.0.1",
+            "ignore": "^3.3.3",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^3.0.6",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.9.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.2",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.3.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "~2.0.1",
+            "table": "4.0.2",
+            "text-table": "~0.2.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "bundled": true,
+              "requires": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+              }
+            },
+            "fast-deep-equal": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.3.1",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-config-standard": {
+          "version": "11.0.0",
+          "bundled": true
+        },
+        "eslint-config-standard-jsx": {
+          "version": "5.0.0",
+          "bundled": true
+        },
+        "eslint-import-resolver-node": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.9",
+            "resolve": "^1.5.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-module-utils": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.8",
+            "pkg-dir": "^1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-plugin-import": {
+          "version": "2.9.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "^1.1.1",
+            "contains-path": "^0.1.0",
+            "debug": "^2.6.8",
+            "doctrine": "1.5.0",
+            "eslint-import-resolver-node": "^0.3.1",
+            "eslint-module-utils": "^2.1.1",
+            "has": "^1.0.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.3",
+            "read-pkg-up": "^2.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "doctrine": {
+              "version": "1.5.0",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "isarray": "^1.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-plugin-node": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "ignore": "^3.3.6",
+            "minimatch": "^3.0.4",
+            "resolve": "^1.3.3",
+            "semver": "^5.4.1"
+          }
+        },
+        "eslint-plugin-promise": {
+          "version": "3.7.0",
+          "bundled": true
+        },
+        "eslint-plugin-react": {
+          "version": "7.7.0",
+          "bundled": true,
+          "requires": {
+            "doctrine": "^2.0.2",
+            "has": "^1.0.1",
+            "jsx-ast-utils": "^2.0.1",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "eslint-plugin-standard": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "eslint-scope": {
+          "version": "3.7.3",
+          "bundled": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "espree": {
+          "version": "3.5.4",
+          "bundled": true,
+          "requires": {
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
+          }
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "bundled": true
+        },
+        "esquery": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.0.0"
+          }
+        },
+        "esrecurse": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.1.0"
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "expand-tilde": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "homedir-polyfill": "^1.0.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "find-root": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "findup-sync": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "detect-file": "^1.0.0",
+            "is-glob": "^3.1.0",
+            "micromatch": "^3.0.4",
+            "resolve-dir": "^1.0.1"
+          }
+        },
+        "flat-cache": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "circular-json": "^0.3.1",
+            "graceful-fs": "^4.1.2",
+            "rimraf": "~2.6.2",
+            "write": "^0.2.1"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "formidable": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "map-cache": "^0.2.2"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "get-func-name": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "get-stdin": {
+          "version": "6.0.0",
+          "bundled": true
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "global": {
+          "version": "4.3.2",
+          "bundled": true,
+          "requires": {
+            "min-document": "^2.19.0",
+            "process": "~0.5.1"
+          }
+        },
+        "global-modules": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
+          }
+        },
+        "global-prefix": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "expand-tilde": "^2.0.2",
+            "homedir-polyfill": "^1.0.1",
+            "ini": "^1.3.4",
+            "is-windows": "^1.0.1",
+            "which": "^1.2.14"
+          }
+        },
+        "globals": {
+          "version": "11.9.0",
+          "bundled": true
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "bundled": true
+        },
+        "growl": {
+          "version": "1.10.3",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "he": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "homedir-polyfill": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "parse-passwd": "^1.0.0"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.7.1",
+          "bundled": true
+        },
+        "html-encoding-sniffer": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "whatwg-encoding": "^1.0.1"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
+        "is-resolvable": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "bundled": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "4.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "jsdom": {
+          "version": "11.10.0",
+          "bundled": true,
+          "requires": {
+            "abab": "^1.0.4",
+            "acorn": "^5.3.0",
+            "acorn-globals": "^4.1.0",
+            "array-equal": "^1.0.0",
+            "cssom": ">= 0.3.2 < 0.4.0",
+            "cssstyle": ">= 0.2.37 < 0.3.0",
+            "data-urls": "^1.0.0",
+            "domexception": "^1.0.0",
+            "escodegen": "^1.9.0",
+            "html-encoding-sniffer": "^1.0.2",
+            "left-pad": "^1.2.0",
+            "nwmatcher": "^1.4.3",
+            "parse5": "4.0.0",
+            "pn": "^1.1.0",
+            "request": "^2.83.0",
+            "request-promise-native": "^1.0.5",
+            "sax": "^1.2.4",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^2.3.3",
+            "w3c-hr-time": "^1.0.1",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.3",
+            "whatwg-mimetype": "^2.1.0",
+            "whatwg-url": "^6.4.0",
+            "ws": "^4.0.0",
+            "xml-name-validator": "^3.0.0"
+          }
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "json-stable-stringify-without-jsonify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "jsx-ast-utils": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "array-includes": "^3.0.3"
+          }
+        },
+        "just-extend": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "bundled": true
+        },
+        "left-pad": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "bundled": true
+        },
+        "lodash.camelcase": {
+          "version": "4.3.0",
+          "bundled": true
+        },
+        "lodash.get": {
+          "version": "4.4.2",
+          "bundled": true
+        },
+        "lodash.sortby": {
+          "version": "4.7.0",
+          "bundled": true
+        },
+        "lolex": {
+          "version": "2.7.5",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "object-visit": "^1.0.0"
+          }
+        },
+        "methods": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "mime-db": {
+          "version": "1.37.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.21",
+          "bundled": true,
+          "requires": {
+            "mime-db": "~1.37.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "min-document": {
+          "version": "2.19.0",
+          "bundled": true,
+          "requires": {
+            "dom-walk": "^0.1.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            }
+          }
+        },
+        "mocha": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "browser-stdout": "1.3.1",
+            "commander": "2.11.0",
+            "debug": "3.1.0",
+            "diff": "3.5.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.2",
+            "growl": "1.10.3",
+            "he": "1.1.1",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "supports-color": "4.4.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "has-flag": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "4.4.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^2.0.0"
+              }
+            }
+          }
+        },
+        "mock-local-storage": {
+          "version": "1.1.8",
+          "bundled": true,
+          "requires": {
+            "core-js": "^0.8.3",
+            "global": "^4.3.2"
+          }
+        },
+        "mout": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "nanomatch": {
+          "version": "1.2.13",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "nise": {
+          "version": "1.4.8",
+          "bundled": true,
+          "requires": {
+            "@sinonjs/formatio": "^3.1.0",
+            "just-extend": "^4.0.2",
+            "lolex": "^2.3.2",
+            "path-to-regexp": "^1.7.0",
+            "text-encoding": "^0.6.4"
+          },
+          "dependencies": {
+            "@sinonjs/formatio": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "@sinonjs/samsam": "^2 || ^3"
+              }
+            }
+          }
+        },
+        "nock": {
+          "version": "10.0.6",
+          "bundled": true,
+          "requires": {
+            "chai": "^4.1.2",
+            "debug": "^4.1.0",
+            "deep-equal": "^1.0.0",
+            "json-stringify-safe": "^5.0.1",
+            "lodash": "^4.17.5",
+            "mkdirp": "^0.5.0",
+            "propagate": "^1.0.0",
+            "qs": "^6.5.1",
+            "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            }
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "nwmatcher": {
+          "version": "1.4.4",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "object-keys": {
+          "version": "1.0.12",
+          "bundled": true
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.0"
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "bundled": true
+            }
+          }
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "parse-passwd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "parse5": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "isarray": "0.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pathval": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "pkg-conf": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "load-json-file": "^4.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "pkg-config": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "debug-log": "^1.0.0",
+            "find-root": "^1.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^1.0.0"
+          }
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "bundled": true
+        },
+        "pn": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "process": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "progress": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "propagate": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "psl": {
+          "version": "1.1.31",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.6.0",
+          "bundled": true
+        },
+        "querystringify": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "repeat-element": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "request": {
+          "version": "2.88.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.2",
+              "bundled": true
+            },
+            "tough-cookie": {
+              "version": "2.4.3",
+              "bundled": true,
+              "requires": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+              }
+            }
+          }
+        },
+        "request-promise-core": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.13.1"
+          }
+        },
+        "request-promise-native": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "request-promise-core": "1.1.1",
+            "stealthy-require": "^1.1.0",
+            "tough-cookie": ">=2.3.3"
+          }
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "caller-path": "^0.1.0",
+            "resolve-from": "^1.0.0"
+          }
+        },
+        "requires-port": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "resolve": {
+          "version": "1.9.0",
+          "bundled": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-dir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "expand-tilde": "^2.0.0",
+            "global-modules": "^1.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "ret": {
+          "version": "0.1.15",
+          "bundled": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
+        },
+        "run-parallel": {
+          "version": "1.1.9",
+          "bundled": true
+        },
+        "rx-lite": {
+          "version": "4.0.8",
+          "bundled": true
+        },
+        "rx-lite-aggregates": {
+          "version": "4.0.8",
+          "bundled": true,
+          "requires": {
+            "rx-lite": "*"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ret": "~0.1.10"
+          }
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "samsam": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "sinon": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "@sinonjs/formatio": "^2.0.0",
+            "diff": "^3.5.0",
+            "lodash.get": "^4.4.2",
+            "lolex": "^2.4.2",
+            "nise": "^1.3.3",
+            "supports-color": "^5.4.0",
+            "type-detect": "^4.0.8"
+          }
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.2.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "snazzy": {
+          "version": "7.1.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.3.0",
+            "inherits": "^2.0.1",
+            "minimist": "^1.1.1",
+            "readable-stream": "^2.0.6",
+            "standard-json": "^1.0.0",
+            "strip-ansi": "^4.0.0",
+            "text-table": "^0.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "source-map-resolve": {
+          "version": "0.5.2",
+          "bundled": true,
+          "requires": {
+            "atob": "^2.1.1",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "spdx-correct": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "sshpk": {
+          "version": "1.15.2",
+          "bundled": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+          }
+        },
+        "standard": {
+          "version": "11.0.1",
+          "bundled": true,
+          "requires": {
+            "eslint": "~4.18.0",
+            "eslint-config-standard": "11.0.0",
+            "eslint-config-standard-jsx": "5.0.0",
+            "eslint-plugin-import": "~2.9.0",
+            "eslint-plugin-node": "~6.0.0",
+            "eslint-plugin-promise": "~3.7.0",
+            "eslint-plugin-react": "~7.7.0",
+            "eslint-plugin-standard": "~3.0.1",
+            "standard-engine": "~8.0.0"
+          }
+        },
+        "standard-engine": {
+          "version": "8.0.1",
+          "bundled": true,
+          "requires": {
+            "deglob": "^2.1.0",
+            "get-stdin": "^6.0.0",
+            "minimist": "^1.1.0",
+            "pkg-conf": "^2.0.0"
+          }
+        },
+        "standard-json": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "^1.5.0"
+          }
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "stealthy-require": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "superagent": {
+          "version": "3.8.3",
+          "bundled": true,
+          "requires": {
+            "component-emitter": "^1.2.0",
+            "cookiejar": "^2.1.0",
+            "debug": "^3.1.0",
+            "extend": "^3.0.0",
+            "form-data": "^2.3.1",
+            "formidable": "^1.2.0",
+            "methods": "^1.1.1",
+            "mime": "^1.4.1",
+            "qs": "^6.5.1",
+            "readable-stream": "^2.3.5"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "symbol-tree": {
+          "version": "3.2.2",
+          "bundled": true
+        },
+        "table": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "ajv": "^5.2.3",
+            "ajv-keywords": "^2.1.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "bundled": true,
+              "requires": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+              }
+            },
+            "fast-deep-equal": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.3.1",
+              "bundled": true
+            }
+          }
+        },
+        "text-encoding": {
+          "version": "0.6.4",
+          "bundled": true
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "bundled": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "bundled": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "bundled": true
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "union-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
+              }
+            }
+          }
+        },
+        "uniq": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "bundled": true,
+              "requires": {
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "bundled": true
+            }
+          }
+        },
+        "untildify": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "^1.0.0"
+          }
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "url-parse": {
+          "version": "1.4.4",
+          "bundled": true,
+          "requires": {
+            "querystringify": "^2.0.0",
+            "requires-port": "^1.0.0"
+          }
+        },
+        "use": {
+          "version": "3.1.1",
+          "bundled": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "bundled": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "w3c-hr-time": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "browser-process-hrtime": "^0.1.2"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "whatwg-encoding": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.24"
+          }
+        },
+        "whatwg-mimetype": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "whatwg-url": {
+          "version": "6.5.0",
+          "bundled": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "ws": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "xml-name-validator": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        }
       }
     },
     "@zooniverse/react-components": {
@@ -2181,6 +15058,13764 @@
         "remark-sub-super": "~1.0.16",
         "remark-toc": "~5.1.1",
         "unist-util-visit": "~1.4.0"
+      },
+      "dependencies": {
+        "@babel/cli": {
+          "version": "7.2.3",
+          "bundled": true,
+          "requires": {
+            "chokidar": "^2.0.3",
+            "commander": "^2.8.1",
+            "convert-source-map": "^1.1.0",
+            "fs-readdir-recursive": "^1.1.0",
+            "glob": "^7.0.0",
+            "lodash": "^4.17.10",
+            "mkdirp": "^0.5.1",
+            "output-file-sync": "^2.0.0",
+            "slash": "^2.0.0",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/code-frame": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@babel/core": {
+          "version": "7.1.6",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.1.6",
+            "@babel/helpers": "^7.1.5",
+            "@babel/parser": "^7.1.6",
+            "@babel/template": "^7.1.2",
+            "@babel/traverse": "^7.1.6",
+            "@babel/types": "^7.1.6",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.10",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "@babel/generator": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.2.2",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.10",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-explode-assignable-expression": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-builder-react-jsx": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0",
+            "esutils": "^2.0.0"
+          }
+        },
+        "@babel/helper-call-delegate": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.0.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-create-class-features-plugin": {
+          "version": "7.2.3",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-member-expression-to-functions": "^7.0.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.2.3"
+          }
+        },
+        "@babel/helper-define-map": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/types": "^7.0.0",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/helper-explode-assignable-expression": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-simple-access": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "@babel/template": "^7.2.2",
+            "@babel/types": "^7.2.2",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0",
+          "bundled": true
+        },
+        "@babel/helper-regex": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/helper-remap-async-to-generator": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-wrap-function": "^7.1.0",
+            "@babel/template": "^7.1.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.2.3",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.0.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/traverse": "^7.2.3",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-wrap-function": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/template": "^7.1.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.2.0"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/template": "^7.1.2",
+            "@babel/traverse": "^7.1.5",
+            "@babel/types": "^7.2.0"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.2.3",
+          "bundled": true
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-remap-async-to-generator": "^7.1.0",
+            "@babel/plugin-syntax-async-generators": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-class-properties": {
+          "version": "7.2.3",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-create-class-features-plugin": "^7.2.3",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-proposal-json-strings": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-json-strings": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
+          }
+        },
+        "@babel/plugin-proposal-optional-catch-binding": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0",
+            "regexpu-core": "^4.2.0"
+          }
+        },
+        "@babel/plugin-syntax-async-generators": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-flow": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-json-strings": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-jsx": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-remap-async-to-generator": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-block-scoping": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/plugin-transform-classes": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-define-map": "^7.1.0",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/plugin-transform-computed-properties": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-destructuring": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0",
+            "regexpu-core": "^4.1.3"
+          }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-flow-strip-types": {
+          "version": "7.2.3",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-flow": "^7.2.0"
+          }
+        },
+        "@babel/plugin-transform-for-of": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-function-name": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-literals": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-modules-amd": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-simple-access": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-modules-umd": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-new-target": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-object-super": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-parameters": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-call-delegate": "^7.1.0",
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-react-display-name": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-react-jsx": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-builder-react-jsx": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-jsx": "^7.2.0"
+          }
+        },
+        "@babel/plugin-transform-react-jsx-self": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-jsx": "^7.2.0"
+          }
+        },
+        "@babel/plugin-transform-react-jsx-source": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-jsx": "^7.2.0"
+          }
+        },
+        "@babel/plugin-transform-regenerator": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerator-transform": "^0.13.3"
+          }
+        },
+        "@babel/plugin-transform-runtime": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "resolve": "^1.8.1",
+            "semver": "^5.5.1"
+          }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-spread": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-template-literals": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0",
+            "regexpu-core": "^4.1.3"
+          }
+        },
+        "@babel/preset-env": {
+          "version": "7.1.6",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-proposal-async-generator-functions": "^7.1.0",
+            "@babel/plugin-proposal-json-strings": "^7.0.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+            "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
+            "@babel/plugin-syntax-async-generators": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
+            "@babel/plugin-transform-arrow-functions": "^7.0.0",
+            "@babel/plugin-transform-async-to-generator": "^7.1.0",
+            "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+            "@babel/plugin-transform-block-scoping": "^7.1.5",
+            "@babel/plugin-transform-classes": "^7.1.0",
+            "@babel/plugin-transform-computed-properties": "^7.0.0",
+            "@babel/plugin-transform-destructuring": "^7.0.0",
+            "@babel/plugin-transform-dotall-regex": "^7.0.0",
+            "@babel/plugin-transform-duplicate-keys": "^7.0.0",
+            "@babel/plugin-transform-exponentiation-operator": "^7.1.0",
+            "@babel/plugin-transform-for-of": "^7.0.0",
+            "@babel/plugin-transform-function-name": "^7.1.0",
+            "@babel/plugin-transform-literals": "^7.0.0",
+            "@babel/plugin-transform-modules-amd": "^7.1.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+            "@babel/plugin-transform-modules-systemjs": "^7.0.0",
+            "@babel/plugin-transform-modules-umd": "^7.1.0",
+            "@babel/plugin-transform-new-target": "^7.0.0",
+            "@babel/plugin-transform-object-super": "^7.1.0",
+            "@babel/plugin-transform-parameters": "^7.1.0",
+            "@babel/plugin-transform-regenerator": "^7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+            "@babel/plugin-transform-spread": "^7.0.0",
+            "@babel/plugin-transform-sticky-regex": "^7.0.0",
+            "@babel/plugin-transform-template-literals": "^7.0.0",
+            "@babel/plugin-transform-typeof-symbol": "^7.0.0",
+            "@babel/plugin-transform-unicode-regex": "^7.0.0",
+            "browserslist": "^4.1.0",
+            "invariant": "^2.2.2",
+            "js-levenshtein": "^1.1.3",
+            "semver": "^5.3.0"
+          }
+        },
+        "@babel/preset-flow": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-transform-flow-strip-types": "^7.0.0"
+          }
+        },
+        "@babel/preset-react": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-transform-react-display-name": "^7.0.0",
+            "@babel/plugin-transform-react-jsx": "^7.0.0",
+            "@babel/plugin-transform-react-jsx-self": "^7.0.0",
+            "@babel/plugin-transform-react-jsx-source": "^7.0.0"
+          }
+        },
+        "@babel/register": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.5.7",
+            "find-cache-dir": "^1.0.0",
+            "home-or-tmp": "^3.0.0",
+            "lodash": "^4.17.10",
+            "mkdirp": "^0.5.1",
+            "pirates": "^4.0.0",
+            "source-map-support": "^0.5.9"
+          }
+        },
+        "@babel/runtime": {
+          "version": "7.3.1",
+          "bundled": true,
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.2.2",
+            "@babel/types": "^7.2.2"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.2.3",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.2.2",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "@babel/parser": "^7.2.3",
+            "@babel/types": "^7.2.2",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.10"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.10",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "@emotion/cache": {
+          "version": "0.8.8",
+          "bundled": true,
+          "requires": {
+            "@emotion/sheet": "^0.8.1",
+            "@emotion/stylis": "^0.7.1",
+            "@emotion/utils": "^0.8.2"
+          }
+        },
+        "@emotion/core": {
+          "version": "0.13.1",
+          "bundled": true,
+          "requires": {
+            "@emotion/cache": "^0.8.8",
+            "@emotion/css": "^0.9.8",
+            "@emotion/serialize": "^0.9.1",
+            "@emotion/sheet": "^0.8.1",
+            "@emotion/utils": "^0.8.2"
+          }
+        },
+        "@emotion/css": {
+          "version": "0.9.8",
+          "bundled": true,
+          "requires": {
+            "@emotion/serialize": "^0.9.1",
+            "@emotion/utils": "^0.8.2"
+          }
+        },
+        "@emotion/hash": {
+          "version": "0.6.6",
+          "bundled": true
+        },
+        "@emotion/is-prop-valid": {
+          "version": "0.6.8",
+          "bundled": true,
+          "requires": {
+            "@emotion/memoize": "^0.6.6"
+          }
+        },
+        "@emotion/memoize": {
+          "version": "0.6.6",
+          "bundled": true
+        },
+        "@emotion/provider": {
+          "version": "0.11.2",
+          "bundled": true,
+          "requires": {
+            "@emotion/cache": "^0.8.8",
+            "@emotion/weak-memoize": "^0.1.3"
+          }
+        },
+        "@emotion/serialize": {
+          "version": "0.9.1",
+          "bundled": true,
+          "requires": {
+            "@emotion/hash": "^0.6.6",
+            "@emotion/memoize": "^0.6.6",
+            "@emotion/unitless": "^0.6.7",
+            "@emotion/utils": "^0.8.2"
+          }
+        },
+        "@emotion/sheet": {
+          "version": "0.8.1",
+          "bundled": true
+        },
+        "@emotion/styled": {
+          "version": "0.10.6",
+          "bundled": true,
+          "requires": {
+            "@emotion/styled-base": "^0.10.6"
+          }
+        },
+        "@emotion/styled-base": {
+          "version": "0.10.6",
+          "bundled": true,
+          "requires": {
+            "@emotion/is-prop-valid": "^0.6.8",
+            "@emotion/serialize": "^0.9.1",
+            "@emotion/utils": "^0.8.2"
+          }
+        },
+        "@emotion/stylis": {
+          "version": "0.7.1",
+          "bundled": true
+        },
+        "@emotion/unitless": {
+          "version": "0.6.7",
+          "bundled": true
+        },
+        "@emotion/utils": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "@emotion/weak-memoize": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "@fortawesome/fontawesome-common-types": {
+          "version": "0.2.12",
+          "bundled": true
+        },
+        "@fortawesome/fontawesome-svg-core": {
+          "version": "1.2.14",
+          "bundled": true,
+          "requires": {
+            "@fortawesome/fontawesome-common-types": "^0.2.14"
+          },
+          "dependencies": {
+            "@fortawesome/fontawesome-common-types": {
+              "version": "0.2.14",
+              "bundled": true
+            }
+          }
+        },
+        "@fortawesome/free-regular-svg-icons": {
+          "version": "5.7.0",
+          "bundled": true,
+          "requires": {
+            "@fortawesome/fontawesome-common-types": "^0.2.13"
+          },
+          "dependencies": {
+            "@fortawesome/fontawesome-common-types": {
+              "version": "0.2.13",
+              "bundled": true
+            }
+          }
+        },
+        "@fortawesome/free-solid-svg-icons": {
+          "version": "5.6.3",
+          "bundled": true,
+          "requires": {
+            "@fortawesome/fontawesome-common-types": "^0.2.12"
+          }
+        },
+        "@fortawesome/react-fontawesome": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "humps": "^2.0.1",
+            "prop-types": "^15.5.10"
+          }
+        },
+        "@icons/material": {
+          "version": "0.2.4",
+          "bundled": true
+        },
+        "@mapbox/hast-util-table-cell-style": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "unist-util-visit": "^1.3.0"
+          }
+        },
+        "@mrmlnc/readdir-enhanced": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "call-me-maybe": "^1.0.1",
+            "glob-to-regexp": "^0.3.0"
+          }
+        },
+        "@nodelib/fs.stat": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "@sinonjs/commons": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "@sinonjs/formatio": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "@sinonjs/samsam": "^2 || ^3"
+          }
+        },
+        "@sinonjs/samsam": {
+          "version": "2.1.3",
+          "bundled": true
+        },
+        "@storybook/addon-actions": {
+          "version": "4.1.11",
+          "bundled": true,
+          "requires": {
+            "@emotion/core": "^0.13.1",
+            "@emotion/provider": "^0.11.2",
+            "@emotion/styled": "^0.10.6",
+            "@storybook/addons": "4.1.11",
+            "@storybook/components": "4.1.11",
+            "@storybook/core-events": "4.1.11",
+            "core-js": "^2.5.7",
+            "deep-equal": "^1.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.11",
+            "make-error": "^1.3.5",
+            "prop-types": "^15.6.2",
+            "react-inspector": "^2.3.0",
+            "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "@storybook/addons": {
+              "version": "4.1.11",
+              "bundled": true,
+              "requires": {
+                "@storybook/channels": "4.1.11",
+                "@storybook/components": "4.1.11",
+                "global": "^4.3.2",
+                "util-deprecate": "^1.0.2"
+              }
+            },
+            "@storybook/channels": {
+              "version": "4.1.11",
+              "bundled": true
+            }
+          }
+        },
+        "@storybook/addon-backgrounds": {
+          "version": "4.1.4",
+          "bundled": true,
+          "requires": {
+            "@emotion/styled": "^0.10.6",
+            "@storybook/addons": "4.1.4",
+            "@storybook/core-events": "4.1.4",
+            "core-js": "^2.5.7",
+            "eventemitter3": "^3.1.0",
+            "global": "^4.3.2",
+            "prop-types": "^15.6.2",
+            "util-deprecate": "^1.0.2"
+          },
+          "dependencies": {
+            "@storybook/addons": {
+              "version": "4.1.4",
+              "bundled": true,
+              "requires": {
+                "@storybook/channels": "4.1.4",
+                "@storybook/components": "4.1.4",
+                "global": "^4.3.2",
+                "util-deprecate": "^1.0.2"
+              }
+            },
+            "@storybook/channels": {
+              "version": "4.1.4",
+              "bundled": true
+            },
+            "@storybook/components": {
+              "version": "4.1.4",
+              "bundled": true,
+              "requires": {
+                "@emotion/core": "^0.13.1",
+                "@emotion/provider": "^0.11.2",
+                "@emotion/styled": "^0.10.6",
+                "global": "^4.3.2",
+                "lodash": "^4.17.11",
+                "prop-types": "^15.6.2",
+                "react-inspector": "^2.3.0",
+                "react-split-pane": "^0.1.84",
+                "react-textarea-autosize": "^7.0.4",
+                "render-fragment": "^0.1.1"
+              }
+            },
+            "@storybook/core-events": {
+              "version": "4.1.4",
+              "bundled": true
+            }
+          }
+        },
+        "@storybook/addon-knobs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "requires": {
+            "@emotion/styled": "^0.10.6",
+            "@storybook/addons": "4.1.11",
+            "@storybook/components": "4.1.11",
+            "@storybook/core-events": "4.1.11",
+            "copy-to-clipboard": "^3.0.8",
+            "core-js": "^2.5.7",
+            "escape-html": "^1.0.3",
+            "fast-deep-equal": "^2.0.1",
+            "global": "^4.3.2",
+            "prop-types": "^15.6.2",
+            "qs": "^6.5.2",
+            "react-color": "^2.14.1",
+            "react-lifecycles-compat": "^3.0.4",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/addon-links": {
+          "version": "4.1.11",
+          "bundled": true,
+          "requires": {
+            "@storybook/addons": "4.1.11",
+            "@storybook/components": "4.1.11",
+            "@storybook/core-events": "4.1.11",
+            "core-js": "^2.5.7",
+            "global": "^4.3.2",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "@storybook/addon-notes": {
+          "version": "4.0.12",
+          "bundled": true,
+          "requires": {
+            "@emotion/styled": "^0.10.6",
+            "@storybook/addons": "4.0.8",
+            "marked": "^0.5.1",
+            "prop-types": "^15.6.2"
+          },
+          "dependencies": {
+            "@storybook/addons": {
+              "version": "4.0.8",
+              "bundled": true,
+              "requires": {
+                "@storybook/channels": "4.0.8",
+                "@storybook/components": "4.0.8",
+                "global": "^4.3.2",
+                "util-deprecate": "^1.0.2"
+              }
+            },
+            "@storybook/channels": {
+              "version": "4.0.8",
+              "bundled": true
+            },
+            "@storybook/components": {
+              "version": "4.0.8",
+              "bundled": true,
+              "requires": {
+                "@emotion/core": "^0.13.1",
+                "@emotion/provider": "^0.11.2",
+                "@emotion/styled": "^0.10.6",
+                "global": "^4.3.2",
+                "lodash": "^4.17.11",
+                "prop-types": "^15.6.2",
+                "react-inspector": "^2.3.0",
+                "react-split-pane": "^0.1.84",
+                "react-textarea-autosize": "^7.0.4",
+                "render-fragment": "^0.1.1"
+              }
+            },
+            "marked": {
+              "version": "0.5.2",
+              "bundled": true
+            }
+          }
+        },
+        "@storybook/addon-viewport": {
+          "version": "4.1.11",
+          "bundled": true,
+          "requires": {
+            "@emotion/styled": "^0.10.6",
+            "@storybook/addons": "4.1.11",
+            "@storybook/components": "4.1.11",
+            "@storybook/core-events": "4.1.11",
+            "core-js": "^2.5.7",
+            "global": "^4.3.2",
+            "prop-types": "^15.6.2",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/addons": {
+          "version": "4.1.11",
+          "bundled": true,
+          "requires": {
+            "@storybook/channels": "4.1.11",
+            "@storybook/components": "4.1.11",
+            "global": "^4.3.2",
+            "util-deprecate": "^1.0.2"
+          },
+          "dependencies": {
+            "@storybook/components": {
+              "version": "4.1.11",
+              "bundled": true,
+              "requires": {
+                "@emotion/core": "^0.13.1",
+                "@emotion/provider": "^0.11.2",
+                "@emotion/styled": "^0.10.6",
+                "global": "^4.3.2",
+                "lodash": "^4.17.11",
+                "prop-types": "^15.6.2",
+                "react-inspector": "^2.3.0",
+                "react-split-pane": "^0.1.84",
+                "react-textarea-autosize": "^7.0.4",
+                "render-fragment": "^0.1.1"
+              }
+            }
+          }
+        },
+        "@storybook/channel-postmessage": {
+          "version": "4.0.12",
+          "bundled": true,
+          "requires": {
+            "@storybook/channels": "4.0.12",
+            "global": "^4.3.2",
+            "json-stringify-safe": "^5.0.1"
+          },
+          "dependencies": {
+            "@storybook/channels": {
+              "version": "4.0.12",
+              "bundled": true
+            }
+          }
+        },
+        "@storybook/channels": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "@storybook/client-logger": {
+          "version": "4.0.12",
+          "bundled": true
+        },
+        "@storybook/components": {
+          "version": "4.1.11",
+          "bundled": true,
+          "requires": {
+            "@emotion/core": "^0.13.1",
+            "@emotion/provider": "^0.11.2",
+            "@emotion/styled": "^0.10.6",
+            "global": "^4.3.2",
+            "lodash": "^4.17.11",
+            "prop-types": "^15.6.2",
+            "react-inspector": "^2.3.0",
+            "react-split-pane": "^0.1.84",
+            "react-textarea-autosize": "^7.0.4",
+            "render-fragment": "^0.1.1"
+          }
+        },
+        "@storybook/core": {
+          "version": "4.0.12",
+          "bundled": true,
+          "requires": {
+            "@babel/plugin-proposal-class-properties": "^7.1.0",
+            "@babel/plugin-transform-regenerator": "^7.0.0",
+            "@babel/plugin-transform-runtime": "^7.1.0",
+            "@babel/preset-env": "^7.1.0",
+            "@babel/runtime": "^7.1.2",
+            "@emotion/core": "^0.13.1",
+            "@emotion/provider": "^0.11.2",
+            "@emotion/styled": "^0.10.6",
+            "@storybook/addons": "4.0.12",
+            "@storybook/channel-postmessage": "4.0.12",
+            "@storybook/client-logger": "4.0.12",
+            "@storybook/core-events": "4.0.12",
+            "@storybook/node-logger": "4.0.12",
+            "@storybook/ui": "4.0.12",
+            "airbnb-js-shims": "^1 || ^2",
+            "autoprefixer": "^9.3.1",
+            "babel-plugin-macros": "^2.4.2",
+            "babel-preset-minify": "^0.5.0",
+            "boxen": "^2.0.0",
+            "case-sensitive-paths-webpack-plugin": "^2.1.2",
+            "chalk": "^2.4.1",
+            "cli-table3": "0.5.1",
+            "commander": "^2.19.0",
+            "common-tags": "^1.8.0",
+            "core-js": "^2.5.7",
+            "css-loader": "^1.0.1",
+            "detect-port": "^1.2.3",
+            "dotenv-webpack": "^1.5.7",
+            "ejs": "^2.6.1",
+            "express": "^4.16.3",
+            "file-loader": "^2.0.0",
+            "file-system-cache": "^1.0.5",
+            "find-cache-dir": "^2.0.0",
+            "global": "^4.3.2",
+            "html-webpack-plugin": "^4.0.0-beta.2",
+            "inquirer": "^6.2.0",
+            "interpret": "^1.1.0",
+            "ip": "^1.1.5",
+            "json5": "^2.1.0",
+            "lazy-universal-dotenv": "^2.0.0",
+            "node-fetch": "^2.2.0",
+            "opn": "^5.4.0",
+            "postcss-flexbugs-fixes": "^4.1.0",
+            "postcss-loader": "^3.0.0",
+            "prop-types": "^15.6.2",
+            "qs": "^6.5.2",
+            "raw-loader": "^0.5.1",
+            "react-dev-utils": "^6.1.0",
+            "redux": "^4.0.1",
+            "resolve": "^1.8.1",
+            "semver": "^5.6.0",
+            "serve-favicon": "^2.5.0",
+            "shelljs": "^0.8.2",
+            "style-loader": "^0.23.1",
+            "svg-url-loader": "^2.3.2",
+            "terser-webpack-plugin": "^1.1.0",
+            "url-loader": "^1.1.2",
+            "webpack": "^4.23.1",
+            "webpack-dev-middleware": "^3.4.0",
+            "webpack-hot-middleware": "^2.24.3"
+          },
+          "dependencies": {
+            "@storybook/addons": {
+              "version": "4.0.12",
+              "bundled": true,
+              "requires": {
+                "@storybook/channels": "4.0.12",
+                "@storybook/components": "4.0.12",
+                "global": "^4.3.2",
+                "util-deprecate": "^1.0.2"
+              }
+            },
+            "@storybook/channels": {
+              "version": "4.0.12",
+              "bundled": true
+            },
+            "@storybook/components": {
+              "version": "4.0.12",
+              "bundled": true,
+              "requires": {
+                "@emotion/core": "^0.13.1",
+                "@emotion/provider": "^0.11.2",
+                "@emotion/styled": "^0.10.6",
+                "global": "^4.3.2",
+                "lodash": "^4.17.11",
+                "prop-types": "^15.6.2",
+                "react-inspector": "^2.3.0",
+                "react-split-pane": "^0.1.84",
+                "react-textarea-autosize": "^7.0.4",
+                "render-fragment": "^0.1.1"
+              }
+            },
+            "@storybook/core-events": {
+              "version": "4.0.12",
+              "bundled": true
+            },
+            "find-cache-dir": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^1.0.0",
+                "pkg-dir": "^3.0.0"
+              }
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "node-fetch": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "p-limit": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "pkg-dir": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^3.0.0"
+              }
+            }
+          }
+        },
+        "@storybook/core-events": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "@storybook/mantra-core": {
+          "version": "1.7.2",
+          "bundled": true,
+          "requires": {
+            "@storybook/react-komposer": "^2.0.1",
+            "@storybook/react-simple-di": "^1.2.1",
+            "babel-runtime": "6.x.x"
+          }
+        },
+        "@storybook/node-logger": {
+          "version": "4.0.12",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "npmlog": "^4.1.2"
+          }
+        },
+        "@storybook/podda": {
+          "version": "1.2.3",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.11.6",
+            "immutable": "^3.8.1"
+          }
+        },
+        "@storybook/react": {
+          "version": "4.0.12",
+          "bundled": true,
+          "requires": {
+            "@babel/preset-flow": "^7.0.0",
+            "@babel/preset-react": "^7.0.0",
+            "@babel/runtime": "^7.1.2",
+            "@emotion/styled": "^0.10.6",
+            "@storybook/core": "4.0.12",
+            "@storybook/node-logger": "4.0.12",
+            "babel-plugin-react-docgen": "^2.0.0",
+            "common-tags": "^1.8.0",
+            "global": "^4.3.2",
+            "lodash": "^4.17.11",
+            "mini-css-extract-plugin": "^0.4.4",
+            "prop-types": "^15.6.2",
+            "react-dev-utils": "^6.1.0",
+            "semver": "^5.6.0",
+            "webpack": "^4.23.1"
+          }
+        },
+        "@storybook/react-komposer": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "@storybook/react-stubber": "^1.0.0",
+            "babel-runtime": "^6.11.6",
+            "hoist-non-react-statics": "^1.2.0",
+            "lodash": "^4.17.11",
+            "shallowequal": "^1.1.0"
+          }
+        },
+        "@storybook/react-simple-di": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.x.x",
+            "create-react-class": "^15.6.2",
+            "hoist-non-react-statics": "1.x.x",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "@storybook/react-stubber": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.5.0"
+          }
+        },
+        "@storybook/ui": {
+          "version": "4.0.12",
+          "bundled": true,
+          "requires": {
+            "@emotion/core": "^0.13.1",
+            "@emotion/provider": "^0.11.2",
+            "@emotion/styled": "^0.10.6",
+            "@storybook/components": "4.0.12",
+            "@storybook/core-events": "4.0.12",
+            "@storybook/mantra-core": "^1.7.2",
+            "@storybook/podda": "^1.2.3",
+            "@storybook/react-komposer": "^2.0.5",
+            "deep-equal": "^1.0.1",
+            "events": "^3.0.0",
+            "fuse.js": "^3.3.0",
+            "global": "^4.3.2",
+            "keycode": "^2.2.0",
+            "lodash": "^4.17.11",
+            "prop-types": "^15.6.2",
+            "qs": "^6.5.2",
+            "react-fuzzy": "^0.5.2",
+            "react-lifecycles-compat": "^3.0.4",
+            "react-modal": "^3.6.1",
+            "react-treebeard": "^3.1.0"
+          },
+          "dependencies": {
+            "@storybook/components": {
+              "version": "4.0.12",
+              "bundled": true,
+              "requires": {
+                "@emotion/core": "^0.13.1",
+                "@emotion/provider": "^0.11.2",
+                "@emotion/styled": "^0.10.6",
+                "global": "^4.3.2",
+                "lodash": "^4.17.11",
+                "prop-types": "^15.6.2",
+                "react-inspector": "^2.3.0",
+                "react-split-pane": "^0.1.84",
+                "react-textarea-autosize": "^7.0.4",
+                "render-fragment": "^0.1.1"
+              }
+            },
+            "@storybook/core-events": {
+              "version": "4.0.12",
+              "bundled": true
+            }
+          }
+        },
+        "@types/node": {
+          "version": "10.12.18",
+          "bundled": true
+        },
+        "@types/unist": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "@types/vfile": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/unist": "*",
+            "@types/vfile-message": "*"
+          }
+        },
+        "@types/vfile-message": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/unist": "*"
+          }
+        },
+        "@webassemblyjs/ast": {
+          "version": "1.7.11",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/helper-module-context": "1.7.11",
+            "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+            "@webassemblyjs/wast-parser": "1.7.11"
+          }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+          "version": "1.7.11",
+          "bundled": true
+        },
+        "@webassemblyjs/helper-api-error": {
+          "version": "1.7.11",
+          "bundled": true
+        },
+        "@webassemblyjs/helper-buffer": {
+          "version": "1.7.11",
+          "bundled": true
+        },
+        "@webassemblyjs/helper-code-frame": {
+          "version": "1.7.11",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/wast-printer": "1.7.11"
+          }
+        },
+        "@webassemblyjs/helper-fsm": {
+          "version": "1.7.11",
+          "bundled": true
+        },
+        "@webassemblyjs/helper-module-context": {
+          "version": "1.7.11",
+          "bundled": true
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+          "version": "1.7.11",
+          "bundled": true
+        },
+        "@webassemblyjs/helper-wasm-section": {
+          "version": "1.7.11",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/helper-buffer": "1.7.11",
+            "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+            "@webassemblyjs/wasm-gen": "1.7.11"
+          }
+        },
+        "@webassemblyjs/ieee754": {
+          "version": "1.7.11",
+          "bundled": true,
+          "requires": {
+            "@xtuc/ieee754": "^1.2.0"
+          }
+        },
+        "@webassemblyjs/leb128": {
+          "version": "1.7.11",
+          "bundled": true,
+          "requires": {
+            "@xtuc/long": "4.2.1"
+          }
+        },
+        "@webassemblyjs/utf8": {
+          "version": "1.7.11",
+          "bundled": true
+        },
+        "@webassemblyjs/wasm-edit": {
+          "version": "1.7.11",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/helper-buffer": "1.7.11",
+            "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+            "@webassemblyjs/helper-wasm-section": "1.7.11",
+            "@webassemblyjs/wasm-gen": "1.7.11",
+            "@webassemblyjs/wasm-opt": "1.7.11",
+            "@webassemblyjs/wasm-parser": "1.7.11",
+            "@webassemblyjs/wast-printer": "1.7.11"
+          }
+        },
+        "@webassemblyjs/wasm-gen": {
+          "version": "1.7.11",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+            "@webassemblyjs/ieee754": "1.7.11",
+            "@webassemblyjs/leb128": "1.7.11",
+            "@webassemblyjs/utf8": "1.7.11"
+          }
+        },
+        "@webassemblyjs/wasm-opt": {
+          "version": "1.7.11",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/helper-buffer": "1.7.11",
+            "@webassemblyjs/wasm-gen": "1.7.11",
+            "@webassemblyjs/wasm-parser": "1.7.11"
+          }
+        },
+        "@webassemblyjs/wasm-parser": {
+          "version": "1.7.11",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/helper-api-error": "1.7.11",
+            "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+            "@webassemblyjs/ieee754": "1.7.11",
+            "@webassemblyjs/leb128": "1.7.11",
+            "@webassemblyjs/utf8": "1.7.11"
+          }
+        },
+        "@webassemblyjs/wast-parser": {
+          "version": "1.7.11",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/floating-point-hex-parser": "1.7.11",
+            "@webassemblyjs/helper-api-error": "1.7.11",
+            "@webassemblyjs/helper-code-frame": "1.7.11",
+            "@webassemblyjs/helper-fsm": "1.7.11",
+            "@xtuc/long": "4.2.1"
+          }
+        },
+        "@webassemblyjs/wast-printer": {
+          "version": "1.7.11",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/wast-parser": "1.7.11",
+            "@xtuc/long": "4.2.1"
+          }
+        },
+        "@xtuc/ieee754": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "@xtuc/long": {
+          "version": "4.2.1",
+          "bundled": true
+        },
+        "@zooniverse/grommet-theme": {
+          "bundled": true,
+          "requires": {
+            "deep-freeze": "~0.0.1"
+          },
+          "dependencies": {
+            "@babel/cli": {
+              "version": "7.2.3",
+              "bundled": true,
+              "requires": {
+                "chokidar": "^2.0.3",
+                "commander": "^2.8.1",
+                "convert-source-map": "^1.1.0",
+                "fs-readdir-recursive": "^1.1.0",
+                "glob": "^7.0.0",
+                "lodash": "^4.17.10",
+                "mkdirp": "^0.5.1",
+                "output-file-sync": "^2.0.0",
+                "slash": "^2.0.0",
+                "source-map": "^0.5.0"
+              }
+            },
+            "@babel/code-frame": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/highlight": "^7.0.0"
+              }
+            },
+            "@babel/core": {
+              "version": "7.0.1",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.0.0",
+                "@babel/helpers": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/template": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "convert-source-map": "^1.1.0",
+                "debug": "^3.1.0",
+                "json5": "^0.5.0",
+                "lodash": "^4.17.10",
+                "resolve": "^1.3.2",
+                "semver": "^5.4.1",
+                "source-map": "^0.5.0"
+              },
+              "dependencies": {}
+            },
+            "@babel/generator": {
+              "version": "7.2.2",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.2.2",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.10",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+              }
+            },
+            "@babel/helper-annotate-as-pure": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-builder-binary-assignment-operator-visitor": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-explode-assignable-expression": "^7.1.0",
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-call-delegate": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-hoist-variables": "^7.0.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-define-map": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "lodash": "^4.17.10"
+              }
+            },
+            "@babel/helper-explode-assignable-expression": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-function-name": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-get-function-arity": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-hoist-variables": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-member-expression-to-functions": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-module-imports": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-module-transforms": {
+              "version": "7.2.2",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-simple-access": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/template": "^7.2.2",
+                "@babel/types": "^7.2.2",
+                "lodash": "^4.17.10"
+              }
+            },
+            "@babel/helper-optimise-call-expression": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-plugin-utils": {
+              "version": "7.0.0",
+              "bundled": true
+            },
+            "@babel/helper-regex": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "lodash": "^4.17.10"
+              }
+            },
+            "@babel/helper-remap-async-to-generator": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-wrap-function": "^7.1.0",
+                "@babel/template": "^7.1.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-replace-supers": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-member-expression-to-functions": "^7.0.0",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-simple-access": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-split-export-declaration": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-wrap-function": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/template": "^7.1.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.2.0"
+              }
+            },
+            "@babel/helpers": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/template": "^7.1.2",
+                "@babel/traverse": "^7.1.5",
+                "@babel/types": "^7.2.0"
+              }
+            },
+            "@babel/highlight": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+              }
+            },
+            "@babel/parser": {
+              "version": "7.2.2",
+              "bundled": true
+            },
+            "@babel/plugin-proposal-async-generator-functions": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-remap-async-to-generator": "^7.1.0",
+                "@babel/plugin-syntax-async-generators": "^7.2.0"
+              }
+            },
+            "@babel/plugin-proposal-json-strings": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-json-strings": "^7.2.0"
+              }
+            },
+            "@babel/plugin-proposal-object-rest-spread": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+              }
+            },
+            "@babel/plugin-proposal-optional-catch-binding": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+              }
+            },
+            "@babel/plugin-proposal-unicode-property-regex": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.2.0"
+              }
+            },
+            "@babel/plugin-syntax-async-generators": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-syntax-json-strings": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-syntax-object-rest-spread": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-syntax-optional-catch-binding": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-arrow-functions": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-async-to-generator": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-remap-async-to-generator": "^7.1.0"
+              }
+            },
+            "@babel/plugin-transform-block-scoped-functions": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-block-scoping": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "lodash": "^4.17.10"
+              }
+            },
+            "@babel/plugin-transform-classes": {
+              "version": "7.2.2",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-define-map": "^7.1.0",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "globals": "^11.1.0"
+              }
+            },
+            "@babel/plugin-transform-computed-properties": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-destructuring": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-dotall-regex": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.1.3"
+              }
+            },
+            "@babel/plugin-transform-duplicate-keys": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-exponentiation-operator": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-for-of": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-function-name": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-literals": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-modules-amd": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-modules-commonjs": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-simple-access": "^7.1.0"
+              }
+            },
+            "@babel/plugin-transform-modules-systemjs": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-hoist-variables": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-modules-umd": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-new-target": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-object-super": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.1.0"
+              }
+            },
+            "@babel/plugin-transform-parameters": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-call-delegate": "^7.1.0",
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-regenerator": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "regenerator-transform": "^0.13.3"
+              }
+            },
+            "@babel/plugin-transform-shorthand-properties": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-spread": {
+              "version": "7.2.2",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-sticky-regex": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-template-literals": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-typeof-symbol": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+              }
+            },
+            "@babel/plugin-transform-unicode-regex": {
+              "version": "7.2.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.1.3"
+              }
+            },
+            "@babel/preset-env": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+                "@babel/plugin-proposal-json-strings": "^7.0.0",
+                "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
+                "@babel/plugin-syntax-async-generators": "^7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
+                "@babel/plugin-transform-arrow-functions": "^7.0.0",
+                "@babel/plugin-transform-async-to-generator": "^7.0.0",
+                "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+                "@babel/plugin-transform-block-scoping": "^7.0.0",
+                "@babel/plugin-transform-classes": "^7.0.0",
+                "@babel/plugin-transform-computed-properties": "^7.0.0",
+                "@babel/plugin-transform-destructuring": "^7.0.0",
+                "@babel/plugin-transform-dotall-regex": "^7.0.0",
+                "@babel/plugin-transform-duplicate-keys": "^7.0.0",
+                "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+                "@babel/plugin-transform-for-of": "^7.0.0",
+                "@babel/plugin-transform-function-name": "^7.0.0",
+                "@babel/plugin-transform-literals": "^7.0.0",
+                "@babel/plugin-transform-modules-amd": "^7.0.0",
+                "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+                "@babel/plugin-transform-modules-systemjs": "^7.0.0",
+                "@babel/plugin-transform-modules-umd": "^7.0.0",
+                "@babel/plugin-transform-new-target": "^7.0.0",
+                "@babel/plugin-transform-object-super": "^7.0.0",
+                "@babel/plugin-transform-parameters": "^7.0.0",
+                "@babel/plugin-transform-regenerator": "^7.0.0",
+                "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+                "@babel/plugin-transform-spread": "^7.0.0",
+                "@babel/plugin-transform-sticky-regex": "^7.0.0",
+                "@babel/plugin-transform-template-literals": "^7.0.0",
+                "@babel/plugin-transform-typeof-symbol": "^7.0.0",
+                "@babel/plugin-transform-unicode-regex": "^7.0.0",
+                "browserslist": "^4.1.0",
+                "invariant": "^2.2.2",
+                "js-levenshtein": "^1.1.3",
+                "semver": "^5.3.0"
+              }
+            },
+            "@babel/template": {
+              "version": "7.2.2",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.2.2",
+                "@babel/types": "^7.2.2"
+              }
+            },
+            "@babel/traverse": {
+              "version": "7.2.2",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.2.2",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/parser": "^7.2.2",
+                "@babel/types": "^7.2.2",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.10"
+              },
+              "dependencies": {}
+            },
+            "@babel/types": {
+              "version": "7.2.2",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.10",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "@zooniverse/standard": {
+              "bundled": true,
+              "requires": {
+                "babel-eslint": "^10.0.1",
+                "eslint-plugin-jsx-a11y": "^6.2.1",
+                "standard": "^12.0.1",
+                "standard-engine": "^10.0.0"
+              },
+              "dependencies": {}
+            },
+            "acorn": {
+              "version": "6.0.4",
+              "bundled": true
+            },
+            "acorn-jsx": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "ajv": {
+              "version": "6.6.2",
+              "bundled": true,
+              "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "ajv-keywords": {
+              "version": "3.2.0",
+              "bundled": true
+            },
+            "ansi-escapes": {
+              "version": "3.1.0",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "anymatch": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
+              }
+            },
+            "argparse": {
+              "version": "1.0.10",
+              "bundled": true,
+              "requires": {
+                "sprintf-js": "~1.0.2"
+              }
+            },
+            "arr-diff": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "arr-flatten": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "arr-union": {
+              "version": "3.1.0",
+              "bundled": true
+            },
+            "array-includes": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.7.0"
+              }
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "assign-symbols": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "async-each": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "atob": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "babel-code-frame": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+              },
+              "dependencies": {}
+            },
+            "babel-helper-evaluate-path": {
+              "version": "0.5.0",
+              "bundled": true
+            },
+            "babel-helper-flip-expressions": {
+              "version": "0.4.3",
+              "bundled": true
+            },
+            "babel-helper-is-nodes-equiv": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "babel-helper-is-void-0": {
+              "version": "0.4.3",
+              "bundled": true
+            },
+            "babel-helper-mark-eval-scopes": {
+              "version": "0.4.3",
+              "bundled": true
+            },
+            "babel-helper-remove-or-void": {
+              "version": "0.4.3",
+              "bundled": true
+            },
+            "babel-helper-to-multiple-sequence-expressions": {
+              "version": "0.5.0",
+              "bundled": true
+            },
+            "babel-plugin-minify-builtins": {
+              "version": "0.5.0",
+              "bundled": true
+            },
+            "babel-plugin-minify-constant-folding": {
+              "version": "0.5.0",
+              "bundled": true,
+              "requires": {
+                "babel-helper-evaluate-path": "^0.5.0"
+              }
+            },
+            "babel-plugin-minify-dead-code-elimination": {
+              "version": "0.5.0",
+              "bundled": true,
+              "requires": {
+                "babel-helper-evaluate-path": "^0.5.0",
+                "babel-helper-mark-eval-scopes": "^0.4.3",
+                "babel-helper-remove-or-void": "^0.4.3",
+                "lodash.some": "^4.6.0"
+              }
+            },
+            "babel-plugin-minify-flip-comparisons": {
+              "version": "0.4.3",
+              "bundled": true,
+              "requires": {
+                "babel-helper-is-void-0": "^0.4.3"
+              }
+            },
+            "babel-plugin-minify-guarded-expressions": {
+              "version": "0.4.3",
+              "bundled": true,
+              "requires": {
+                "babel-helper-flip-expressions": "^0.4.3"
+              }
+            },
+            "babel-plugin-minify-infinity": {
+              "version": "0.4.3",
+              "bundled": true
+            },
+            "babel-plugin-minify-mangle-names": {
+              "version": "0.5.0",
+              "bundled": true,
+              "requires": {
+                "babel-helper-mark-eval-scopes": "^0.4.3"
+              }
+            },
+            "babel-plugin-minify-numeric-literals": {
+              "version": "0.4.3",
+              "bundled": true
+            },
+            "babel-plugin-minify-replace": {
+              "version": "0.5.0",
+              "bundled": true
+            },
+            "babel-plugin-minify-simplify": {
+              "version": "0.5.0",
+              "bundled": true,
+              "requires": {
+                "babel-helper-flip-expressions": "^0.4.3",
+                "babel-helper-is-nodes-equiv": "^0.0.1",
+                "babel-helper-to-multiple-sequence-expressions": "^0.5.0"
+              }
+            },
+            "babel-plugin-minify-type-constructors": {
+              "version": "0.4.3",
+              "bundled": true,
+              "requires": {
+                "babel-helper-is-void-0": "^0.4.3"
+              }
+            },
+            "babel-plugin-transform-inline-consecutive-adds": {
+              "version": "0.4.3",
+              "bundled": true
+            },
+            "babel-plugin-transform-member-expression-literals": {
+              "version": "6.9.4",
+              "bundled": true
+            },
+            "babel-plugin-transform-merge-sibling-variables": {
+              "version": "6.9.4",
+              "bundled": true
+            },
+            "babel-plugin-transform-minify-booleans": {
+              "version": "6.9.4",
+              "bundled": true
+            },
+            "babel-plugin-transform-property-literals": {
+              "version": "6.9.4",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2"
+              }
+            },
+            "babel-plugin-transform-regexp-constructors": {
+              "version": "0.4.3",
+              "bundled": true
+            },
+            "babel-plugin-transform-remove-console": {
+              "version": "6.9.4",
+              "bundled": true
+            },
+            "babel-plugin-transform-remove-debugger": {
+              "version": "6.9.4",
+              "bundled": true
+            },
+            "babel-plugin-transform-remove-undefined": {
+              "version": "0.5.0",
+              "bundled": true,
+              "requires": {
+                "babel-helper-evaluate-path": "^0.5.0"
+              }
+            },
+            "babel-plugin-transform-simplify-comparison-operators": {
+              "version": "6.9.4",
+              "bundled": true
+            },
+            "babel-plugin-transform-undefined-to-void": {
+              "version": "6.9.4",
+              "bundled": true
+            },
+            "babel-preset-minify": {
+              "version": "0.5.0",
+              "bundled": true,
+              "requires": {
+                "babel-plugin-minify-builtins": "^0.5.0",
+                "babel-plugin-minify-constant-folding": "^0.5.0",
+                "babel-plugin-minify-dead-code-elimination": "^0.5.0",
+                "babel-plugin-minify-flip-comparisons": "^0.4.3",
+                "babel-plugin-minify-guarded-expressions": "^0.4.3",
+                "babel-plugin-minify-infinity": "^0.4.3",
+                "babel-plugin-minify-mangle-names": "^0.5.0",
+                "babel-plugin-minify-numeric-literals": "^0.4.3",
+                "babel-plugin-minify-replace": "^0.5.0",
+                "babel-plugin-minify-simplify": "^0.5.0",
+                "babel-plugin-minify-type-constructors": "^0.4.3",
+                "babel-plugin-transform-inline-consecutive-adds": "^0.4.3",
+                "babel-plugin-transform-member-expression-literals": "^6.9.4",
+                "babel-plugin-transform-merge-sibling-variables": "^6.9.4",
+                "babel-plugin-transform-minify-booleans": "^6.9.4",
+                "babel-plugin-transform-property-literals": "^6.9.4",
+                "babel-plugin-transform-regexp-constructors": "^0.4.3",
+                "babel-plugin-transform-remove-console": "^6.9.4",
+                "babel-plugin-transform-remove-debugger": "^6.9.4",
+                "babel-plugin-transform-remove-undefined": "^0.5.0",
+                "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
+                "babel-plugin-transform-undefined-to-void": "^6.9.4",
+                "lodash.isplainobject": "^4.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "base": {
+              "version": "0.11.2",
+              "bundled": true,
+              "requires": {
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
+              },
+              "dependencies": {}
+            },
+            "binary-extensions": {
+              "version": "1.12.0",
+              "bundled": true,
+              "optional": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "braces": {
+              "version": "2.3.2",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {}
+            },
+            "browserslist": {
+              "version": "4.3.6",
+              "bundled": true,
+              "requires": {
+                "caniuse-lite": "^1.0.30000921",
+                "electron-to-chromium": "^1.3.92",
+                "node-releases": "^1.1.1"
+              }
+            },
+            "builtin-modules": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "cache-base": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
+              }
+            },
+            "caller-path": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "callsites": "^0.2.0"
+              }
+            },
+            "callsites": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "caniuse-lite": {
+              "version": "1.0.30000921",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "2.4.1",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "chardet": {
+              "version": "0.4.2",
+              "bundled": true
+            },
+            "chokidar": {
+              "version": "2.0.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.0",
+                "braces": "^2.3.0",
+                "fsevents": "^1.2.2",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "lodash.debounce": "^4.0.8",
+                "normalize-path": "^2.1.1",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0",
+                "upath": "^1.0.5"
+              }
+            },
+            "circular-json": {
+              "version": "0.3.3",
+              "bundled": true
+            },
+            "class-utils": {
+              "version": "0.3.6",
+              "bundled": true,
+              "requires": {
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
+              },
+              "dependencies": {}
+            },
+            "cli-cursor": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "restore-cursor": "^2.0.0"
+              }
+            },
+            "cli-width": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "collection-visit": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "bundled": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "bundled": true
+            },
+            "commander": {
+              "version": "2.19.0",
+              "bundled": true
+            },
+            "component-emitter": {
+              "version": "1.2.1",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "contains-path": {
+              "version": "0.1.0",
+              "bundled": true
+            },
+            "convert-source-map": {
+              "version": "1.6.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.1"
+              }
+            },
+            "copy-descriptor": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "debug-log": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "decode-uri-component": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "deep-freeze": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "define-properties": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "object-keys": "^1.0.12"
+              }
+            },
+            "define-property": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
+              },
+              "dependencies": {}
+            },
+            "deglob": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "find-root": "^1.0.0",
+                "glob": "^7.0.5",
+                "ignore": "^3.0.9",
+                "pkg-config": "^1.1.0",
+                "run-parallel": "^1.1.2",
+                "uniq": "^1.0.1"
+              },
+              "dependencies": {}
+            },
+            "doctrine": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2"
+              }
+            },
+            "electron-to-chromium": {
+              "version": "1.3.94",
+              "bundled": true
+            },
+            "error-ex": {
+              "version": "1.3.2",
+              "bundled": true,
+              "requires": {
+                "is-arrayish": "^0.2.1"
+              }
+            },
+            "es-abstract": {
+              "version": "1.12.0",
+              "bundled": true,
+              "requires": {
+                "es-to-primitive": "^1.1.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.1",
+                "is-callable": "^1.1.3",
+                "is-regex": "^1.0.4"
+              }
+            },
+            "es-to-primitive": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "eslint": {
+              "version": "5.4.0",
+              "bundled": true,
+              "requires": {
+                "ajv": "^6.5.0",
+                "babel-code-frame": "^6.26.0",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^3.1.0",
+                "doctrine": "^2.1.0",
+                "eslint-scope": "^4.0.0",
+                "eslint-utils": "^1.3.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^4.0.0",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.2",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^5.2.0",
+                "is-resolvable": "^1.1.0",
+                "js-yaml": "^3.11.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.5",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "regexpp": "^2.0.0",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.5.0",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "^2.0.1",
+                "table": "^4.0.3",
+                "text-table": "^0.2.0"
+              },
+              "dependencies": {}
+            },
+            "eslint-config-standard": {
+              "version": "12.0.0",
+              "bundled": true
+            },
+            "eslint-config-standard-jsx": {
+              "version": "6.0.2",
+              "bundled": true
+            },
+            "eslint-import-resolver-node": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.6.9",
+                "resolve": "^1.5.0"
+              }
+            },
+            "eslint-module-utils": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.6.8",
+                "pkg-dir": "^1.0.0"
+              }
+            },
+            "eslint-plugin-es": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "eslint-utils": "^1.3.0",
+                "regexpp": "^2.0.1"
+              }
+            },
+            "eslint-plugin-import": {
+              "version": "2.14.0",
+              "bundled": true,
+              "requires": {
+                "contains-path": "^0.1.0",
+                "debug": "^2.6.8",
+                "doctrine": "1.5.0",
+                "eslint-import-resolver-node": "^0.3.1",
+                "eslint-module-utils": "^2.2.0",
+                "has": "^1.0.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.3",
+                "read-pkg-up": "^2.0.0",
+                "resolve": "^1.6.0"
+              },
+              "dependencies": {}
+            },
+            "eslint-plugin-node": {
+              "version": "7.0.1",
+              "bundled": true,
+              "requires": {
+                "eslint-plugin-es": "^1.3.1",
+                "eslint-utils": "^1.3.1",
+                "ignore": "^4.0.2",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.8.1",
+                "semver": "^5.5.0"
+              }
+            },
+            "eslint-plugin-promise": {
+              "version": "4.0.1",
+              "bundled": true
+            },
+            "eslint-plugin-react": {
+              "version": "7.11.1",
+              "bundled": true,
+              "requires": {
+                "array-includes": "^3.0.3",
+                "doctrine": "^2.1.0",
+                "has": "^1.0.3",
+                "jsx-ast-utils": "^2.0.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "eslint-plugin-standard": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "eslint-scope": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+              }
+            },
+            "eslint-utils": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "eslint-visitor-keys": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "espree": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "acorn": "^6.0.2",
+                "acorn-jsx": "^5.0.0",
+                "eslint-visitor-keys": "^1.0.0"
+              }
+            },
+            "esprima": {
+              "version": "4.0.1",
+              "bundled": true
+            },
+            "esquery": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "estraverse": "^4.0.0"
+              }
+            },
+            "esrecurse": {
+              "version": "4.2.1",
+              "bundled": true,
+              "requires": {
+                "estraverse": "^4.1.0"
+              }
+            },
+            "estraverse": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {}
+            },
+            "extend-shallow": {
+              "version": "3.0.2",
+              "bundled": true,
+              "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+              },
+              "dependencies": {}
+            },
+            "external-editor": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {}
+            },
+            "fast-deep-equal": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "fast-json-stable-stringify": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "figures": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "escape-string-regexp": "^1.0.5"
+              }
+            },
+            "file-entry-cache": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {}
+            },
+            "find-root": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "flat-cache": {
+              "version": "1.3.4",
+              "bundled": true,
+              "requires": {
+                "circular-json": "^0.3.1",
+                "graceful-fs": "^4.1.2",
+                "rimraf": "~2.6.2",
+                "write": "^0.2.1"
+              }
+            },
+            "for-in": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "fragment-cache": {
+              "version": "0.2.1",
+              "bundled": true,
+              "requires": {
+                "map-cache": "^0.2.2"
+              }
+            },
+            "fs-readdir-recursive": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fsevents": {
+              "version": "1.2.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.10.0"
+              },
+              "dependencies": {}
+            },
+            "function-bind": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "functional-red-black-tree": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "get-stdin": {
+              "version": "6.0.0",
+              "bundled": true
+            },
+            "get-value": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "glob": {
+              "version": "7.1.3",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "glob-parent": {
+              "version": "3.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
+              },
+              "dependencies": {}
+            },
+            "globals": {
+              "version": "11.9.0",
+              "bundled": true
+            },
+            "graceful-fs": {
+              "version": "4.1.15",
+              "bundled": true
+            },
+            "has": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "function-bind": "^1.1.1"
+              }
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "has-symbols": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "has-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
+              }
+            },
+            "has-values": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
+              },
+              "dependencies": {}
+            },
+            "hosted-git-info": {
+              "version": "2.7.1",
+              "bundled": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore": {
+              "version": "4.0.6",
+              "bundled": true
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "bundled": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "inquirer": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.1.0",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^5.5.2",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
+              }
+            },
+            "invariant": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {}
+            },
+            "is-arrayish": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-binary-path": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "binary-extensions": "^1.0.0"
+              }
+            },
+            "is-buffer": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "builtin-modules": "^1.0.0"
+              }
+            },
+            "is-callable": {
+              "version": "1.1.4",
+              "bundled": true
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {}
+            },
+            "is-date-object": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              },
+              "dependencies": {}
+            },
+            "is-extendable": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "is-extglob": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "4.0.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "is-extglob": "^2.1.1"
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {}
+            },
+            "is-plain-obj": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-plain-object": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "isobject": "^3.0.1"
+              }
+            },
+            "is-promise": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "is-regex": {
+              "version": "1.0.4",
+              "bundled": true,
+              "requires": {
+                "has": "^1.0.1"
+              }
+            },
+            "is-resolvable": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-symbol": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "has-symbols": "^1.0.0"
+              }
+            },
+            "is-windows": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "js-levenshtein": {
+              "version": "1.1.4",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "js-yaml": {
+              "version": "3.12.0",
+              "bundled": true,
+              "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+              }
+            },
+            "jsesc": {
+              "version": "2.5.2",
+              "bundled": true
+            },
+            "json-parse-better-errors": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.4.1",
+              "bundled": true
+            },
+            "json-stable-stringify-without-jsonify": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "json5": {
+              "version": "0.5.1",
+              "bundled": true
+            },
+            "jsx-ast-utils": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "array-includes": "^3.0.3"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true
+            },
+            "levn": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+              }
+            },
+            "load-json-file": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              },
+              "dependencies": {}
+            },
+            "lodash": {
+              "version": "4.17.11",
+              "bundled": true
+            },
+            "lodash.debounce": {
+              "version": "4.0.8",
+              "bundled": true,
+              "optional": true
+            },
+            "lodash.isplainobject": {
+              "version": "4.0.6",
+              "bundled": true
+            },
+            "lodash.some": {
+              "version": "4.6.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "map-cache": {
+              "version": "0.2.2",
+              "bundled": true
+            },
+            "map-visit": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "object-visit": "^1.0.0"
+              }
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            },
+            "mimic-fn": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mixin-deep": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
+              },
+              "dependencies": {}
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "mute-stream": {
+              "version": "0.0.7",
+              "bundled": true
+            },
+            "nan": {
+              "version": "2.12.1",
+              "bundled": true,
+              "optional": true
+            },
+            "nanomatch": {
+              "version": "1.2.13",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              }
+            },
+            "natural-compare": {
+              "version": "1.4.0",
+              "bundled": true
+            },
+            "nice-try": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "node-releases": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "semver": "^5.3.0"
+              }
+            },
+            "normalize-package-data": {
+              "version": "2.4.0",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
+            "normalize-path": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "object-copy": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
+              },
+              "dependencies": {}
+            },
+            "object-keys": {
+              "version": "1.0.12",
+              "bundled": true
+            },
+            "object-visit": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "isobject": "^3.0.0"
+              }
+            },
+            "object.pick": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "isobject": "^3.0.1"
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "onetime": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
+              }
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "output-file-sync": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.11",
+                "is-plain-obj": "^1.1.0",
+                "mkdirp": "^0.5.1"
+              }
+            },
+            "p-limit": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "pascalcase": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "path-dirname": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "path-is-inside": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "path-parse": {
+              "version": "1.0.6",
+              "bundled": true
+            },
+            "path-type": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pinkie": {
+              "version": "2.0.4",
+              "bundled": true
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "pinkie": "^2.0.0"
+              }
+            },
+            "pkg-conf": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "load-json-file": "^4.0.0"
+              },
+              "dependencies": {}
+            },
+            "pkg-config": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "debug-log": "^1.0.0",
+                "find-root": "^1.0.0",
+                "xtend": "^4.0.1"
+              }
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^1.0.0"
+              }
+            },
+            "pluralize": {
+              "version": "7.0.0",
+              "bundled": true
+            },
+            "posix-character-classes": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "private": {
+              "version": "0.1.8",
+              "bundled": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "progress": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.6.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
+              }
+            },
+            "punycode": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^2.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^2.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^2.0.0"
+              },
+              "dependencies": {}
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "readdirp": {
+              "version": "2.2.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "graceful-fs": "^4.1.11",
+                "micromatch": "^3.1.10",
+                "readable-stream": "^2.0.2"
+              }
+            },
+            "regenerate": {
+              "version": "1.4.0",
+              "bundled": true
+            },
+            "regenerate-unicode-properties": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "regenerate": "^1.4.0"
+              }
+            },
+            "regenerator-transform": {
+              "version": "0.13.3",
+              "bundled": true,
+              "requires": {
+                "private": "^0.1.6"
+              }
+            },
+            "regex-not": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+              }
+            },
+            "regexpp": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "regexpu-core": {
+              "version": "4.4.0",
+              "bundled": true,
+              "requires": {
+                "regenerate": "^1.4.0",
+                "regenerate-unicode-properties": "^7.0.0",
+                "regjsgen": "^0.5.0",
+                "regjsparser": "^0.6.0",
+                "unicode-match-property-ecmascript": "^1.0.4",
+                "unicode-match-property-value-ecmascript": "^1.0.2"
+              }
+            },
+            "regjsgen": {
+              "version": "0.5.0",
+              "bundled": true
+            },
+            "regjsparser": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "jsesc": "~0.5.0"
+              },
+              "dependencies": {}
+            },
+            "remove-trailing-separator": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "repeat-element": {
+              "version": "1.1.3",
+              "bundled": true
+            },
+            "repeat-string": {
+              "version": "1.6.1",
+              "bundled": true
+            },
+            "require-uncached": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
+              }
+            },
+            "resolve": {
+              "version": "1.9.0",
+              "bundled": true,
+              "requires": {
+                "path-parse": "^1.0.6"
+              }
+            },
+            "resolve-from": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "resolve-url": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "restore-cursor": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+              }
+            },
+            "ret": {
+              "version": "0.1.15",
+              "bundled": true
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "run-async": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "is-promise": "^2.1.0"
+              }
+            },
+            "run-parallel": {
+              "version": "1.1.9",
+              "bundled": true
+            },
+            "rxjs": {
+              "version": "5.5.12",
+              "bundled": true,
+              "requires": {
+                "symbol-observable": "1.0.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            },
+            "safe-regex": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "ret": "~0.1.10"
+              }
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "semver": {
+              "version": "5.6.0",
+              "bundled": true
+            },
+            "set-value": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
+              },
+              "dependencies": {}
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "shebang-regex": "^1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "slash": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "slice-ansi": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0"
+              }
+            },
+            "snapdragon": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
+              },
+              "dependencies": {}
+            },
+            "snapdragon-node": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
+              },
+              "dependencies": {}
+            },
+            "snapdragon-util": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.2.0"
+              },
+              "dependencies": {}
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "source-map-resolve": {
+              "version": "0.5.2",
+              "bundled": true,
+              "requires": {
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
+              }
+            },
+            "source-map-url": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "spdx-correct": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-exceptions": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-license-ids": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "split-string": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^3.0.0"
+              }
+            },
+            "sprintf-js": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "standard": {
+              "version": "12.0.1",
+              "bundled": true,
+              "requires": {
+                "eslint": "~5.4.0",
+                "eslint-config-standard": "12.0.0",
+                "eslint-config-standard-jsx": "6.0.2",
+                "eslint-plugin-import": "~2.14.0",
+                "eslint-plugin-node": "~7.0.1",
+                "eslint-plugin-promise": "~4.0.0",
+                "eslint-plugin-react": "~7.11.1",
+                "eslint-plugin-standard": "~4.0.0",
+                "standard-engine": "~9.0.0"
+              }
+            },
+            "standard-engine": {
+              "version": "9.0.0",
+              "bundled": true,
+              "requires": {
+                "deglob": "^2.1.0",
+                "get-stdin": "^6.0.0",
+                "minimist": "^1.1.0",
+                "pkg-conf": "^2.0.0"
+              },
+              "dependencies": {}
+            },
+            "static-extend": {
+              "version": "0.1.2",
+              "bundled": true,
+              "requires": {
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
+              },
+              "dependencies": {}
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              },
+              "dependencies": {}
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            },
+            "symbol-observable": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "table": {
+              "version": "4.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "^6.0.1",
+                "ajv-keywords": "^3.0.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
+                "slice-ansi": "1.0.0",
+                "string-width": "^2.1.1"
+              }
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            },
+            "tmp": {
+              "version": "0.0.33",
+              "bundled": true,
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            },
+            "to-fast-properties": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "to-object-path": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {}
+            },
+            "to-regex": {
+              "version": "3.0.2",
+              "bundled": true,
+              "requires": {
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
+              }
+            },
+            "to-regex-range": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+              }
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "~1.1.2"
+              }
+            },
+            "unicode-canonical-property-names-ecmascript": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "unicode-match-property-ecmascript": {
+              "version": "1.0.4",
+              "bundled": true,
+              "requires": {
+                "unicode-canonical-property-names-ecmascript": "^1.0.4",
+                "unicode-property-aliases-ecmascript": "^1.0.4"
+              }
+            },
+            "unicode-match-property-value-ecmascript": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "unicode-property-aliases-ecmascript": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "union-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
+              },
+              "dependencies": {}
+            },
+            "uniq": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "unset-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
+              },
+              "dependencies": {}
+            },
+            "upath": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "uri-js": {
+              "version": "4.2.2",
+              "bundled": true,
+              "requires": {
+                "punycode": "^2.1.0"
+              }
+            },
+            "urix": {
+              "version": "0.1.0",
+              "bundled": true
+            },
+            "use": {
+              "version": "3.1.1",
+              "bundled": true
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+              }
+            },
+            "which": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "write": {
+              "version": "0.2.1",
+              "bundled": true,
+              "requires": {
+                "mkdirp": "^0.5.1"
+              }
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "@zooniverse/standard": {
+          "bundled": true,
+          "requires": {
+            "babel-eslint": "^10.0.1",
+            "eslint-plugin-jsx-a11y": "^6.2.1",
+            "standard": "^12.0.1",
+            "standard-engine": "^10.0.0"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/highlight": "^7.0.0"
+              }
+            },
+            "@babel/generator": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.4.4",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.11",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+              }
+            },
+            "@babel/helper-function-name": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-get-function-arity": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.0.0"
+              }
+            },
+            "@babel/helper-split-export-declaration": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "@babel/types": "^7.4.4"
+              }
+            },
+            "@babel/highlight": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+              }
+            },
+            "@babel/parser": {
+              "version": "7.4.5",
+              "bundled": true
+            },
+            "@babel/template": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.4.4",
+                "@babel/types": "^7.4.4"
+              }
+            },
+            "@babel/traverse": {
+              "version": "7.4.5",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.4.4",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.4.4",
+                "@babel/parser": "^7.4.5",
+                "@babel/types": "^7.4.4",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.11"
+              }
+            },
+            "@babel/types": {
+              "version": "7.4.4",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.11",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "acorn": {
+              "version": "6.1.1",
+              "bundled": true
+            },
+            "acorn-jsx": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "ajv": {
+              "version": "6.10.0",
+              "bundled": true,
+              "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "ajv-keywords": {
+              "version": "3.4.0",
+              "bundled": true
+            },
+            "ansi-escapes": {
+              "version": "3.2.0",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "argparse": {
+              "version": "1.0.10",
+              "bundled": true,
+              "requires": {
+                "sprintf-js": "~1.0.2"
+              }
+            },
+            "aria-query": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "ast-types-flow": "0.0.7",
+                "commander": "^2.11.0"
+              }
+            },
+            "array-includes": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.7.0"
+              }
+            },
+            "ast-types-flow": {
+              "version": "0.0.7",
+              "bundled": true
+            },
+            "axobject-query": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "ast-types-flow": "0.0.7"
+              }
+            },
+            "babel-code-frame": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+              },
+              "dependencies": {}
+            },
+            "babel-eslint": {
+              "version": "10.0.1",
+              "bundled": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "eslint-scope": "3.7.1",
+                "eslint-visitor-keys": "^1.0.0"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "caller-path": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "callsites": "^0.2.0"
+              }
+            },
+            "callsites": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "chardet": {
+              "version": "0.4.2",
+              "bundled": true
+            },
+            "circular-json": {
+              "version": "0.3.3",
+              "bundled": true
+            },
+            "cli-cursor": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "restore-cursor": "^2.0.0"
+              }
+            },
+            "cli-width": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "bundled": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "bundled": true
+            },
+            "commander": {
+              "version": "2.20.0",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "contains-path": {
+              "version": "0.1.0",
+              "bundled": true
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "damerau-levenshtein": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "debug-log": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "define-properties": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "object-keys": "^1.0.12"
+              }
+            },
+            "deglob": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "find-root": "^1.0.0",
+                "glob": "^7.0.5",
+                "ignore": "^3.0.9",
+                "pkg-config": "^1.1.0",
+                "run-parallel": "^1.1.2",
+                "uniq": "^1.0.1"
+              },
+              "dependencies": {}
+            },
+            "doctrine": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2"
+              }
+            },
+            "emoji-regex": {
+              "version": "7.0.3",
+              "bundled": true
+            },
+            "error-ex": {
+              "version": "1.3.2",
+              "bundled": true,
+              "requires": {
+                "is-arrayish": "^0.2.1"
+              }
+            },
+            "es-abstract": {
+              "version": "1.13.0",
+              "bundled": true,
+              "requires": {
+                "es-to-primitive": "^1.2.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "is-callable": "^1.1.4",
+                "is-regex": "^1.0.4",
+                "object-keys": "^1.0.12"
+              }
+            },
+            "es-to-primitive": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "eslint": {
+              "version": "5.4.0",
+              "bundled": true,
+              "requires": {
+                "ajv": "^6.5.0",
+                "babel-code-frame": "^6.26.0",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^3.1.0",
+                "doctrine": "^2.1.0",
+                "eslint-scope": "^4.0.0",
+                "eslint-utils": "^1.3.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^4.0.0",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.2",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^5.2.0",
+                "is-resolvable": "^1.1.0",
+                "js-yaml": "^3.11.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.5",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "regexpp": "^2.0.0",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.5.0",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "^2.0.1",
+                "table": "^4.0.3",
+                "text-table": "^0.2.0"
+              },
+              "dependencies": {}
+            },
+            "eslint-config-standard": {
+              "version": "12.0.0",
+              "bundled": true
+            },
+            "eslint-config-standard-jsx": {
+              "version": "6.0.2",
+              "bundled": true
+            },
+            "eslint-import-resolver-node": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.6.9",
+                "resolve": "^1.5.0"
+              },
+              "dependencies": {}
+            },
+            "eslint-module-utils": {
+              "version": "2.4.0",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.6.8",
+                "pkg-dir": "^2.0.0"
+              },
+              "dependencies": {}
+            },
+            "eslint-plugin-es": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "eslint-utils": "^1.3.0",
+                "regexpp": "^2.0.1"
+              }
+            },
+            "eslint-plugin-import": {
+              "version": "2.14.0",
+              "bundled": true,
+              "requires": {
+                "contains-path": "^0.1.0",
+                "debug": "^2.6.8",
+                "doctrine": "1.5.0",
+                "eslint-import-resolver-node": "^0.3.1",
+                "eslint-module-utils": "^2.2.0",
+                "has": "^1.0.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.3",
+                "read-pkg-up": "^2.0.0",
+                "resolve": "^1.6.0"
+              },
+              "dependencies": {}
+            },
+            "eslint-plugin-jsx-a11y": {
+              "version": "6.2.1",
+              "bundled": true,
+              "requires": {
+                "aria-query": "^3.0.0",
+                "array-includes": "^3.0.3",
+                "ast-types-flow": "^0.0.7",
+                "axobject-query": "^2.0.2",
+                "damerau-levenshtein": "^1.0.4",
+                "emoji-regex": "^7.0.2",
+                "has": "^1.0.3",
+                "jsx-ast-utils": "^2.0.1"
+              }
+            },
+            "eslint-plugin-node": {
+              "version": "7.0.1",
+              "bundled": true,
+              "requires": {
+                "eslint-plugin-es": "^1.3.1",
+                "eslint-utils": "^1.3.1",
+                "ignore": "^4.0.2",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.8.1",
+                "semver": "^5.5.0"
+              }
+            },
+            "eslint-plugin-promise": {
+              "version": "4.0.1",
+              "bundled": true
+            },
+            "eslint-plugin-react": {
+              "version": "7.11.1",
+              "bundled": true,
+              "requires": {
+                "array-includes": "^3.0.3",
+                "doctrine": "^2.1.0",
+                "has": "^1.0.3",
+                "jsx-ast-utils": "^2.0.1",
+                "prop-types": "^15.6.2"
+              }
+            },
+            "eslint-plugin-standard": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "eslint-scope": {
+              "version": "3.7.1",
+              "bundled": true,
+              "requires": {
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+              }
+            },
+            "eslint-utils": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "eslint-visitor-keys": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "espree": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "acorn": "^6.0.2",
+                "acorn-jsx": "^5.0.0",
+                "eslint-visitor-keys": "^1.0.0"
+              }
+            },
+            "esprima": {
+              "version": "4.0.1",
+              "bundled": true
+            },
+            "esquery": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "estraverse": "^4.0.0"
+              }
+            },
+            "esrecurse": {
+              "version": "4.2.1",
+              "bundled": true,
+              "requires": {
+                "estraverse": "^4.1.0"
+              }
+            },
+            "estraverse": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "external-editor": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
+              }
+            },
+            "fast-deep-equal": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "fast-json-stable-stringify": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "figures": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "escape-string-regexp": "^1.0.5"
+              }
+            },
+            "file-entry-cache": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
+              }
+            },
+            "find-root": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "flat-cache": {
+              "version": "1.3.4",
+              "bundled": true,
+              "requires": {
+                "circular-json": "^0.3.1",
+                "graceful-fs": "^4.1.2",
+                "rimraf": "~2.6.2",
+                "write": "^0.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "function-bind": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "functional-red-black-tree": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "get-stdin": {
+              "version": "6.0.0",
+              "bundled": true
+            },
+            "glob": {
+              "version": "7.1.4",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "globals": {
+              "version": "11.12.0",
+              "bundled": true
+            },
+            "graceful-fs": {
+              "version": "4.1.15",
+              "bundled": true
+            },
+            "has": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "function-bind": "^1.1.1"
+              }
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "has-symbols": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "hosted-git-info": {
+              "version": "2.7.1",
+              "bundled": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore": {
+              "version": "4.0.6",
+              "bundled": true
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "bundled": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "inquirer": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.1.0",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^5.5.2",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
+              }
+            },
+            "is-arrayish": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-callable": {
+              "version": "1.1.4",
+              "bundled": true
+            },
+            "is-date-object": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "is-promise": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "is-regex": {
+              "version": "1.0.4",
+              "bundled": true,
+              "requires": {
+                "has": "^1.0.1"
+              }
+            },
+            "is-resolvable": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-symbol": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "has-symbols": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "js-yaml": {
+              "version": "3.13.1",
+              "bundled": true,
+              "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+              }
+            },
+            "jsesc": {
+              "version": "2.5.2",
+              "bundled": true
+            },
+            "json-parse-better-errors": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.4.1",
+              "bundled": true
+            },
+            "json-stable-stringify-without-jsonify": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "jsx-ast-utils": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "array-includes": "^3.0.3"
+              }
+            },
+            "levn": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+              }
+            },
+            "load-json-file": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.11",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+              }
+            },
+            "mimic-fn": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "mute-stream": {
+              "version": "0.0.7",
+              "bundled": true
+            },
+            "natural-compare": {
+              "version": "1.4.0",
+              "bundled": true
+            },
+            "nice-try": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "normalize-package-data": {
+              "version": "2.5.0",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "object-keys": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "onetime": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
+              }
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "p-limit": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "path-is-inside": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "path-parse": {
+              "version": "1.0.6",
+              "bundled": true
+            },
+            "path-type": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pkg-conf": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "load-json-file": "^4.0.0"
+              },
+              "dependencies": {}
+            },
+            "pkg-config": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "debug-log": "^1.0.0",
+                "find-root": "^1.0.0",
+                "xtend": "^4.0.1"
+              }
+            },
+            "pkg-dir": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.1.0"
+              }
+            },
+            "pluralize": {
+              "version": "7.0.0",
+              "bundled": true
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "progress": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "prop-types": {
+              "version": "15.7.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+              }
+            },
+            "punycode": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "react-is": {
+              "version": "16.8.6",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^2.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^2.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^2.0.0"
+              }
+            },
+            "regexpp": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "require-uncached": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
+              }
+            },
+            "resolve": {
+              "version": "1.11.0",
+              "bundled": true,
+              "requires": {
+                "path-parse": "^1.0.6"
+              }
+            },
+            "resolve-from": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "restore-cursor": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.3",
+              "bundled": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "run-async": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "is-promise": "^2.1.0"
+              }
+            },
+            "run-parallel": {
+              "version": "1.1.9",
+              "bundled": true
+            },
+            "rxjs": {
+              "version": "5.5.12",
+              "bundled": true,
+              "requires": {
+                "symbol-observable": "1.0.1"
+              }
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "semver": {
+              "version": "5.7.0",
+              "bundled": true
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "shebang-regex": "^1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "slice-ansi": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "spdx-correct": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-exceptions": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-license-ids": {
+              "version": "3.0.4",
+              "bundled": true
+            },
+            "sprintf-js": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "standard": {
+              "version": "12.0.1",
+              "bundled": true,
+              "requires": {
+                "eslint": "~5.4.0",
+                "eslint-config-standard": "12.0.0",
+                "eslint-config-standard-jsx": "6.0.2",
+                "eslint-plugin-import": "~2.14.0",
+                "eslint-plugin-node": "~7.0.1",
+                "eslint-plugin-promise": "~4.0.0",
+                "eslint-plugin-react": "~7.11.1",
+                "eslint-plugin-standard": "~4.0.0",
+                "standard-engine": "~9.0.0"
+              },
+              "dependencies": {}
+            },
+            "standard-engine": {
+              "version": "10.0.0",
+              "bundled": true,
+              "requires": {
+                "deglob": "^3.0.0",
+                "get-stdin": "^6.0.0",
+                "minimist": "^1.1.0",
+                "pkg-conf": "^2.0.0"
+              },
+              "dependencies": {}
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              },
+              "dependencies": {}
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            },
+            "symbol-observable": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "table": {
+              "version": "4.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "^6.0.1",
+                "ajv-keywords": "^3.0.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
+                "slice-ansi": "1.0.0",
+                "string-width": "^2.1.1"
+              }
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            },
+            "tmp": {
+              "version": "0.0.33",
+              "bundled": true,
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            },
+            "to-fast-properties": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "~1.1.2"
+              }
+            },
+            "uniq": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "uri-js": {
+              "version": "4.2.2",
+              "bundled": true,
+              "requires": {
+                "punycode": "^2.1.0"
+              }
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+              }
+            },
+            "which": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "write": {
+              "version": "0.2.1",
+              "bundled": true,
+              "requires": {
+                "mkdirp": "^0.5.1"
+              }
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "abab": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "accepts": {
+          "version": "1.3.5",
+          "bundled": true,
+          "requires": {
+            "mime-types": "~2.1.18",
+            "negotiator": "0.6.1"
+          }
+        },
+        "acorn": {
+          "version": "5.7.3",
+          "bundled": true
+        },
+        "acorn-dynamic-import": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "^5.0.0"
+          }
+        },
+        "acorn-globals": {
+          "version": "4.3.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "^6.0.1",
+            "acorn-walk": "^6.0.1"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "6.0.4",
+              "bundled": true
+            }
+          }
+        },
+        "acorn-walk": {
+          "version": "6.1.1",
+          "bundled": true
+        },
+        "address": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "airbnb-js-shims": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "array-includes": "^3.0.3",
+            "array.prototype.flat": "^1.2.1",
+            "array.prototype.flatmap": "^1.2.1",
+            "es5-shim": "^4.5.10",
+            "es6-shim": "^0.35.3",
+            "function.prototype.name": "^1.1.0",
+            "object.entries": "^1.0.4",
+            "object.fromentries": "^1.0.0",
+            "object.getownpropertydescriptors": "^2.0.3",
+            "object.values": "^1.0.4",
+            "promise.prototype.finally": "^3.1.0",
+            "string.prototype.matchall": "^3.0.0",
+            "string.prototype.padend": "^3.0.0",
+            "string.prototype.padstart": "^3.0.0",
+            "symbol.prototype.description": "^1.0.0"
+          }
+        },
+        "ajv": {
+          "version": "6.6.2",
+          "bundled": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-errors": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "ajv-keywords": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "ansi-align": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^3.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^4.0.0"
+              }
+            }
+          }
+        },
+        "ansi-colors": {
+          "version": "3.2.3",
+          "bundled": true
+        },
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "ansi-html": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "anymatch": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          }
+        },
+        "app-root-dir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          },
+          "dependencies": {
+            "sprintf-js": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "array-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "array-filter": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "array-flatten": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "array-includes": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.7.0"
+          }
+        },
+        "array-map": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "array-reduce": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "array.prototype.flat": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.10.0",
+            "function-bind": "^1.1.1"
+          }
+        },
+        "array.prototype.flatmap": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.10.0",
+            "function-bind": "^1.1.1"
+          }
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.4",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": "~2.1.0"
+          }
+        },
+        "asn1.js": {
+          "version": "4.10.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "assert": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "util": "0.10.3"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "util": {
+              "version": "0.10.3",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.1"
+              }
+            }
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "assertion-error": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ast-types": {
+          "version": "0.11.6",
+          "bundled": true
+        },
+        "async": {
+          "version": "2.6.1",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "async-each": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "async-limiter": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "atob": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "autoprefixer": {
+          "version": "9.4.3",
+          "bundled": true,
+          "requires": {
+            "browserslist": "^4.3.6",
+            "caniuse-lite": "^1.0.30000921",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^7.0.6",
+            "postcss-value-parser": "^3.3.1"
+          }
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.8.0",
+          "bundled": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-helper-evaluate-path": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-helper-flip-expressions": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-is-nodes-equiv": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "babel-helper-is-void-0": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-mark-eval-scopes": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-remove-or-void": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-to-multiple-sequence-expressions": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-loader": {
+          "version": "8.0.4",
+          "bundled": true,
+          "requires": {
+            "find-cache-dir": "^1.0.0",
+            "loader-utils": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "util.promisify": "^1.0.0"
+          }
+        },
+        "babel-plugin-macros": {
+          "version": "2.4.3",
+          "bundled": true,
+          "requires": {
+            "cosmiconfig": "^5.0.5",
+            "resolve": "^1.8.1"
+          }
+        },
+        "babel-plugin-minify-builtins": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-plugin-minify-constant-folding": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0"
+          }
+        },
+        "babel-plugin-minify-dead-code-elimination": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0",
+            "babel-helper-mark-eval-scopes": "^0.4.3",
+            "babel-helper-remove-or-void": "^0.4.3",
+            "lodash.some": "^4.6.0"
+          }
+        },
+        "babel-plugin-minify-flip-comparisons": {
+          "version": "0.4.3",
+          "bundled": true,
+          "requires": {
+            "babel-helper-is-void-0": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-guarded-expressions": {
+          "version": "0.4.3",
+          "bundled": true,
+          "requires": {
+            "babel-helper-flip-expressions": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-infinity": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-minify-mangle-names": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-mark-eval-scopes": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-numeric-literals": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-minify-replace": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-plugin-minify-simplify": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-flip-expressions": "^0.4.3",
+            "babel-helper-is-nodes-equiv": "^0.0.1",
+            "babel-helper-to-multiple-sequence-expressions": "^0.5.0"
+          }
+        },
+        "babel-plugin-minify-type-constructors": {
+          "version": "0.4.3",
+          "bundled": true,
+          "requires": {
+            "babel-helper-is-void-0": "^0.4.3"
+          }
+        },
+        "babel-plugin-react-docgen": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.10",
+            "react-docgen": "^3.0.0-rc.1"
+          }
+        },
+        "babel-plugin-styled-components": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-module-imports": "^7.0.0",
+            "babel-plugin-syntax-jsx": "^6.18.0",
+            "lodash": "^4.17.10"
+          }
+        },
+        "babel-plugin-syntax-jsx": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-inline-consecutive-adds": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-transform-member-expression-literals": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-merge-sibling-variables": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-minify-booleans": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-property-literals": {
+          "version": "6.9.4",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "babel-plugin-transform-regexp-constructors": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-transform-remove-console": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-remove-debugger": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-remove-undefined": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0"
+          }
+        },
+        "babel-plugin-transform-simplify-comparison-operators": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-undefined-to-void": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-preset-minify": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-minify-builtins": "^0.5.0",
+            "babel-plugin-minify-constant-folding": "^0.5.0",
+            "babel-plugin-minify-dead-code-elimination": "^0.5.0",
+            "babel-plugin-minify-flip-comparisons": "^0.4.3",
+            "babel-plugin-minify-guarded-expressions": "^0.4.3",
+            "babel-plugin-minify-infinity": "^0.4.3",
+            "babel-plugin-minify-mangle-names": "^0.5.0",
+            "babel-plugin-minify-numeric-literals": "^0.4.3",
+            "babel-plugin-minify-replace": "^0.5.0",
+            "babel-plugin-minify-simplify": "^0.5.0",
+            "babel-plugin-minify-type-constructors": "^0.4.3",
+            "babel-plugin-transform-inline-consecutive-adds": "^0.4.3",
+            "babel-plugin-transform-member-expression-literals": "^6.9.4",
+            "babel-plugin-transform-merge-sibling-variables": "^6.9.4",
+            "babel-plugin-transform-minify-booleans": "^6.9.4",
+            "babel-plugin-transform-property-literals": "^6.9.4",
+            "babel-plugin-transform-regexp-constructors": "^0.4.3",
+            "babel-plugin-transform-remove-console": "^6.9.4",
+            "babel-plugin-transform-remove-debugger": "^6.9.4",
+            "babel-plugin-transform-remove-undefined": "^0.5.0",
+            "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
+            "babel-plugin-transform-undefined-to-void": "^6.9.4",
+            "lodash.isplainobject": "^4.0.6"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+          },
+          "dependencies": {
+            "regenerator-runtime": {
+              "version": "0.11.1",
+              "bundled": true
+            }
+          }
+        },
+        "bail": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base": {
+          "version": "0.11.2",
+          "bundled": true,
+          "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "base64-js": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "big.js": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "binary-extensions": {
+          "version": "1.12.0",
+          "bundled": true
+        },
+        "bluebird": {
+          "version": "3.5.3",
+          "bundled": true
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "bundled": true
+        },
+        "body-parser": {
+          "version": "1.18.3",
+          "bundled": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "http-errors": "~1.6.3",
+            "iconv-lite": "0.4.23",
+            "on-finished": "~2.3.0",
+            "qs": "6.5.2",
+            "raw-body": "2.3.3",
+            "type-is": "~1.6.16"
+          },
+          "dependencies": {
+            "iconv-lite": {
+              "version": "0.4.23",
+              "bundled": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "qs": {
+              "version": "6.5.2",
+              "bundled": true
+            }
+          }
+        },
+        "boolbase": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "boxen": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "ansi-align": "^3.0.0",
+            "camelcase": "^5.0.0",
+            "chalk": "^2.4.1",
+            "cli-boxes": "^1.0.0",
+            "string-width": "^3.0.0",
+            "term-size": "^1.2.0",
+            "widest-line": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^4.0.0"
+              }
+            }
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "brorand": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "browser-process-hrtime": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "browser-stdout": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "browserify-aes": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "browserify-cipher": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "browserify-aes": "^1.0.4",
+            "browserify-des": "^1.0.0",
+            "evp_bytestokey": "^1.0.0"
+          }
+        },
+        "browserify-des": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.1",
+            "des.js": "^1.0.0",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.1.2"
+          }
+        },
+        "browserify-rsa": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "randombytes": "^2.0.1"
+          }
+        },
+        "browserify-sign": {
+          "version": "4.0.4",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.1",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.2",
+            "elliptic": "^6.0.0",
+            "inherits": "^2.0.1",
+            "parse-asn1": "^5.0.0"
+          }
+        },
+        "browserify-zlib": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "pako": "~1.0.5"
+          }
+        },
+        "browserslist": {
+          "version": "4.3.6",
+          "bundled": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000921",
+            "electron-to-chromium": "^1.3.92",
+            "node-releases": "^1.1.1"
+          }
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "bundled": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "buffer-from": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "buffer-xor": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "builtin-status-codes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "bytes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "cacache": {
+          "version": "11.3.1",
+          "bundled": true,
+          "requires": {
+            "bluebird": "^3.5.1",
+            "chownr": "^1.0.1",
+            "figgy-pudding": "^3.1.0",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "lru-cache": "^4.1.3",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^6.0.0",
+            "unique-filename": "^1.1.0",
+            "y18n": "^4.0.0"
+          }
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+          }
+        },
+        "call-me-maybe": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "caller-callsite": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "callsites": "^2.0.0"
+          }
+        },
+        "caller-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "caller-callsite": "^2.0.0"
+          }
+        },
+        "callsites": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "camel-case": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "no-case": "^2.2.0",
+            "upper-case": "^1.1.1"
+          }
+        },
+        "camelcase": {
+          "version": "5.0.0",
+          "bundled": true
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000923",
+          "bundled": true
+        },
+        "case-sensitive-paths-webpack-plugin": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "ccount": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "chai": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "assertion-error": "^1.1.0",
+            "check-error": "^1.0.2",
+            "deep-eql": "^3.0.1",
+            "get-func-name": "^2.0.0",
+            "pathval": "^1.1.0",
+            "type-detect": "^4.0.5"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "change-emitter": {
+          "version": "0.1.6",
+          "bundled": true
+        },
+        "character-entities": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "character-entities-html4": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "character-entities-legacy": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "character-reference-invalid": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "chardet": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "check-error": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cheerio": {
+          "version": "1.0.0-rc.2",
+          "bundled": true,
+          "requires": {
+            "css-select": "~1.2.0",
+            "dom-serializer": "~0.1.0",
+            "entities": "~1.1.1",
+            "htmlparser2": "^3.9.1",
+            "lodash": "^4.15.0",
+            "parse5": "^3.0.1"
+          },
+          "dependencies": {
+            "domhandler": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "domelementtype": "1"
+              }
+            },
+            "htmlparser2": {
+              "version": "3.10.1",
+              "bundled": true,
+              "requires": {
+                "domelementtype": "^1.3.1",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^3.1.1"
+              }
+            },
+            "readable-stream": {
+              "version": "3.2.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            }
+          }
+        },
+        "chokidar": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.0",
+            "braces": "^2.3.0",
+            "fsevents": "^1.2.2",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "lodash.debounce": "^4.0.8",
+            "normalize-path": "^2.1.1",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0",
+            "upath": "^1.0.5"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "chrome-trace-event": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "cipher-base": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "bundled": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "classnames": {
+          "version": "2.2.6",
+          "bundled": true
+        },
+        "clean-css": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "source-map": "~0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "cli-boxes": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "cli-table3": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "colors": "^1.1.2",
+            "object-assign": "^4.1.0",
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "collapse-white-space": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "colors": {
+          "version": "1.3.3",
+          "bundled": true,
+          "optional": true
+        },
+        "combined-stream": {
+          "version": "1.0.7",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "comma-separated-tokens": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "trim": "0.0.1"
+          }
+        },
+        "commander": {
+          "version": "2.19.0",
+          "bundled": true
+        },
+        "common-tags": {
+          "version": "1.8.0",
+          "bundled": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "bundled": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "date-now": "^0.1.4"
+          }
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "constants-browserify": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "content-disposition": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "content-type": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "convert-source-map": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "copy-concurrently": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.1",
+            "fs-write-stream-atomic": "^1.0.8",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.0"
+          }
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "copy-to-clipboard": {
+          "version": "3.0.8",
+          "bundled": true,
+          "requires": {
+            "toggle-selection": "^1.0.3"
+          }
+        },
+        "core-js": {
+          "version": "2.6.1",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cosmiconfig": {
+          "version": "5.0.7",
+          "bundled": true,
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.9.0",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "counterpart": {
+          "version": "0.18.6",
+          "bundled": true,
+          "requires": {
+            "date-names": "^0.1.11",
+            "except": "^0.1.3",
+            "extend": "^3.0.0",
+            "pluralizers": "^0.1.7",
+            "sprintf-js": "^1.0.3"
+          }
+        },
+        "create-ecdh": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "elliptic": "^6.0.0"
+          }
+        },
+        "create-hash": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "md5.js": "^1.3.4",
+            "ripemd160": "^2.0.1",
+            "sha.js": "^2.4.0"
+          }
+        },
+        "create-hmac": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.3",
+            "create-hash": "^1.1.0",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+          }
+        },
+        "create-react-class": {
+          "version": "15.6.3",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.9",
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "create-react-context": {
+          "version": "0.2.3",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.0",
+            "gud": "^1.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "crypto-browserify": {
+          "version": "3.12.0",
+          "bundled": true,
+          "requires": {
+            "browserify-cipher": "^1.0.0",
+            "browserify-sign": "^4.0.0",
+            "create-ecdh": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.0",
+            "diffie-hellman": "^5.0.0",
+            "inherits": "^2.0.1",
+            "pbkdf2": "^3.0.3",
+            "public-encrypt": "^4.0.0",
+            "randombytes": "^2.0.0",
+            "randomfill": "^1.0.3"
+          }
+        },
+        "css": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "source-map": "^0.6.1",
+            "source-map-resolve": "^0.5.2",
+            "urix": "^0.1.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "css-color-keywords": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "css-loader": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "css-selector-tokenizer": "^0.7.0",
+            "icss-utils": "^2.1.0",
+            "loader-utils": "^1.0.2",
+            "lodash": "^4.17.11",
+            "postcss": "^6.0.23",
+            "postcss-modules-extract-imports": "^1.2.0",
+            "postcss-modules-local-by-default": "^1.2.0",
+            "postcss-modules-scope": "^1.1.0",
+            "postcss-modules-values": "^1.3.0",
+            "postcss-value-parser": "^3.3.0",
+            "source-list-map": "^2.0.0"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "6.0.23",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "css-select": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "boolbase": "~1.0.0",
+            "css-what": "2.1",
+            "domutils": "1.5.1",
+            "nth-check": "~1.0.1"
+          }
+        },
+        "css-selector-tokenizer": {
+          "version": "0.7.1",
+          "bundled": true,
+          "requires": {
+            "cssesc": "^0.1.0",
+            "fastparse": "^1.1.1",
+            "regexpu-core": "^1.0.0"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "0.5.0",
+              "bundled": true
+            },
+            "regexpu-core": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
+              }
+            },
+            "regjsgen": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "regjsparser": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "jsesc": "~0.5.0"
+              }
+            }
+          }
+        },
+        "css-to-react-native": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "css-color-keywords": "^1.0.0",
+            "fbjs": "^0.8.5",
+            "postcss-value-parser": "^3.3.0"
+          }
+        },
+        "css-what": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "cssesc": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "cssom": {
+          "version": "0.3.4",
+          "bundled": true
+        },
+        "cssstyle": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "cssom": "0.3.x"
+          }
+        },
+        "cyclist": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "data-urls": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "abab": "^2.0.0",
+            "whatwg-mimetype": "^2.2.0",
+            "whatwg-url": "^7.0.0"
+          }
+        },
+        "date-names": {
+          "version": "0.1.12",
+          "bundled": true
+        },
+        "date-now": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "dedent": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "deep-eql": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "type-detect": "^4.0.0"
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "deepmerge": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "depd": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "des.js": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "detab": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "repeat-string": "^1.5.4"
+          }
+        },
+        "detect-port": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "address": "^1.0.1",
+            "debug": "^2.6.0"
+          }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "bundled": true
+        },
+        "diffie-hellman": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "miller-rabin": "^4.0.0",
+            "randombytes": "^2.0.0"
+          }
+        },
+        "dir-glob": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "path-type": "^3.0.0"
+          }
+        },
+        "dirty-chai": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "discontinuous-range": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "dom-converter": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "utila": "~0.4"
+          }
+        },
+        "dom-helpers": {
+          "version": "3.4.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "dom-serializer": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "~1.1.1",
+            "entities": "~1.1.1"
+          },
+          "dependencies": {
+            "domelementtype": {
+              "version": "1.1.3",
+              "bundled": true
+            }
+          }
+        },
+        "dom-walk": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "domain-browser": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "domelementtype": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "domexception": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "domhandler": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "domutils": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "dotenv": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "dotenv-expand": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "dotenv-webpack": {
+          "version": "1.5.7",
+          "bundled": true,
+          "requires": {
+            "dotenv": "^5.0.1"
+          }
+        },
+        "duplexer": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "duplexify": {
+          "version": "3.6.1",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "ee-first": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ejs": {
+          "version": "2.6.1",
+          "bundled": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.95",
+          "bundled": true
+        },
+        "elliptic": {
+          "version": "6.4.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.2",
+          "bundled": true
+        },
+        "emojis-list": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "encodeurl": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "~0.4.13"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "enhanced-resolve": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.4.0",
+            "tapable": "^1.0.0"
+          }
+        },
+        "entities": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "enzyme": {
+          "version": "3.9.0",
+          "bundled": true,
+          "requires": {
+            "array.prototype.flat": "^1.2.1",
+            "cheerio": "^1.0.0-rc.2",
+            "function.prototype.name": "^1.1.0",
+            "has": "^1.0.3",
+            "html-element-map": "^1.0.0",
+            "is-boolean-object": "^1.0.0",
+            "is-callable": "^1.1.4",
+            "is-number-object": "^1.0.3",
+            "is-regex": "^1.0.4",
+            "is-string": "^1.0.4",
+            "is-subset": "^0.1.1",
+            "lodash.escape": "^4.0.1",
+            "lodash.isequal": "^4.5.0",
+            "object-inspect": "^1.6.0",
+            "object-is": "^1.0.1",
+            "object.assign": "^4.1.0",
+            "object.entries": "^1.0.4",
+            "object.values": "^1.0.4",
+            "raf": "^3.4.0",
+            "rst-selector-parser": "^2.2.3",
+            "string.prototype.trim": "^1.1.2"
+          }
+        },
+        "enzyme-adapter-react-16": {
+          "version": "1.11.2",
+          "bundled": true,
+          "requires": {
+            "enzyme-adapter-utils": "^1.10.1",
+            "object.assign": "^4.1.0",
+            "object.values": "^1.1.0",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.4",
+            "react-test-renderer": "^16.0.0-0",
+            "semver": "^5.6.0"
+          },
+          "dependencies": {
+            "object.values": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.12.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3"
+              }
+            },
+            "prop-types": {
+              "version": "15.7.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+              }
+            },
+            "react-is": {
+              "version": "16.8.4",
+              "bundled": true
+            }
+          }
+        },
+        "enzyme-adapter-utils": {
+          "version": "1.10.1",
+          "bundled": true,
+          "requires": {
+            "function.prototype.name": "^1.1.0",
+            "object.assign": "^4.1.0",
+            "object.fromentries": "^2.0.0",
+            "prop-types": "^15.7.2",
+            "semver": "^5.6.0"
+          },
+          "dependencies": {
+            "object.fromentries": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.11.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.1"
+              }
+            },
+            "prop-types": {
+              "version": "15.7.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+              }
+            },
+            "react-is": {
+              "version": "16.8.4",
+              "bundled": true
+            }
+          }
+        },
+        "errno": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "prr": "~1.0.1"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.12.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "es5-shim": {
+          "version": "4.5.12",
+          "bundled": true
+        },
+        "es6-shim": {
+          "version": "0.35.4",
+          "bundled": true
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "escodegen": {
+          "version": "1.11.0",
+          "bundled": true,
+          "requires": {
+            "esprima": "^3.1.3",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "3.1.3",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "eslint-scope": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "esrecurse": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.1.0"
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "etag": {
+          "version": "1.8.1",
+          "bundled": true
+        },
+        "eventemitter3": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "events": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "eventsource": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "original": ">=0.0.5"
+          }
+        },
+        "evp_bytestokey": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "md5.js": "^1.3.4",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "except": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "indexof": "0.0.1"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "exenv": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "expand-tilde": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "homedir-polyfill": "^1.0.1"
+          }
+        },
+        "express": {
+          "version": "4.16.4",
+          "bundled": true,
+          "requires": {
+            "accepts": "~1.3.5",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.18.3",
+            "content-disposition": "0.5.2",
+            "content-type": "~1.0.4",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "finalhandler": "1.1.1",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "~2.0.4",
+            "qs": "6.5.2",
+            "range-parser": "~1.2.0",
+            "safe-buffer": "5.1.2",
+            "send": "0.16.2",
+            "serve-static": "1.13.2",
+            "setprototypeof": "1.1.0",
+            "statuses": "~1.4.0",
+            "type-is": "~1.6.16",
+            "utils-merge": "1.0.1",
+            "vary": "~1.1.2"
+          },
+          "dependencies": {
+            "qs": {
+              "version": "6.5.2",
+              "bundled": true
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "external-editor": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "chardet": "^0.7.0",
+            "iconv-lite": "^0.4.24",
+            "tmp": "^0.0.33"
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "fast-glob": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "^2.2.1",
+            "@nodelib/fs.stat": "^1.1.2",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^4.0.0",
+            "merge2": "^1.2.3",
+            "micromatch": "^3.1.10"
+          }
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "fastparse": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "faye-websocket": {
+          "version": "0.11.1",
+          "bundled": true,
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
+        },
+        "fbjs": {
+          "version": "0.8.17",
+          "bundled": true,
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "1.2.7",
+              "bundled": true
+            }
+          }
+        },
+        "figgy-pudding": {
+          "version": "3.5.1",
+          "bundled": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "file-loader": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "loader-utils": "^1.0.2",
+            "schema-utils": "^1.0.0"
+          }
+        },
+        "file-system-cache": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "bluebird": "^3.3.5",
+            "fs-extra": "^0.30.0",
+            "ramda": "^0.21.0"
+          }
+        },
+        "filesize": {
+          "version": "3.6.1",
+          "bundled": true
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "finalhandler": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.4.0",
+            "unpipe": "~1.0.0"
+          }
+        },
+        "find-cache-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "flush-write-stream": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.4"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "formik": {
+          "version": "1.5.7",
+          "bundled": true,
+          "requires": {
+            "create-react-context": "^0.2.2",
+            "deepmerge": "^2.1.1",
+            "hoist-non-react-statics": "^3.3.0",
+            "lodash": "^4.17.11",
+            "lodash-es": "^4.17.11",
+            "prop-types": "^15.6.1",
+            "react-fast-compare": "^2.0.1",
+            "tiny-warning": "^1.0.2",
+            "tslib": "^1.9.3"
+          },
+          "dependencies": {
+            "hoist-non-react-statics": {
+              "version": "3.3.0",
+              "bundled": true,
+              "requires": {
+                "react-is": "^16.7.0"
+              }
+            }
+          }
+        },
+        "forwarded": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "map-cache": "^0.2.2"
+          }
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "from2": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "0.30.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs-readdir-recursive": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fsevents": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "nan": "^2.9.2",
+            "node-pre-gyp": "^0.10.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.5.1",
+              "bundled": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.21",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": "^2.1.0"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "optional": true
+            },
+            "minipass": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.2.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.10.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.0",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.1.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.1.10",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.5.1",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "function.prototype.name": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "is-callable": "^1.1.3"
+          }
+        },
+        "fuse.js": {
+          "version": "3.3.0",
+          "bundled": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "get-func-name": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "github-slugger": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "emoji-regex": ">=6.0.0 <=6.1.1"
+          },
+          "dependencies": {
+            "emoji-regex": {
+              "version": "6.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "glob-to-regexp": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "global": {
+          "version": "4.3.2",
+          "bundled": true,
+          "requires": {
+            "min-document": "^2.19.0",
+            "process": "~0.5.1"
+          }
+        },
+        "global-modules": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
+          }
+        },
+        "global-modules-path": {
+          "version": "2.3.1",
+          "bundled": true
+        },
+        "global-prefix": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "expand-tilde": "^2.0.2",
+            "homedir-polyfill": "^1.0.1",
+            "ini": "^1.3.4",
+            "is-windows": "^1.0.1",
+            "which": "^1.2.14"
+          }
+        },
+        "globals": {
+          "version": "11.9.0",
+          "bundled": true
+        },
+        "globby": {
+          "version": "8.0.1",
+          "bundled": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          },
+          "dependencies": {
+            "slash": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "bundled": true
+        },
+        "grommet": {
+          "version": "2.7.0",
+          "bundled": true,
+          "requires": {
+            "css": "^2.2.3",
+            "grommet-icons": "^4.2.0",
+            "grommet-styles": "^0.2.0",
+            "hoist-non-react-statics": "^3.2.0",
+            "markdown-to-jsx": "^6.9.1",
+            "polished": "^2.2.0",
+            "prop-types": "^15.7.2",
+            "react-desc": "^4.1.2",
+            "recompose": "^0.30.0"
+          },
+          "dependencies": {
+            "hoist-non-react-statics": {
+              "version": "3.3.0",
+              "bundled": true,
+              "requires": {
+                "react-is": "^16.7.0"
+              }
+            },
+            "prop-types": {
+              "version": "15.7.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+              },
+              "dependencies": {
+                "react-is": {
+                  "version": "16.8.6",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "grommet-icons": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "grommet-styles": "^0.2.0"
+          }
+        },
+        "grommet-styles": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "growl": {
+          "version": "1.10.5",
+          "bundled": true
+        },
+        "gud": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "gzip-size": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "duplexer": "^0.1.1",
+            "pify": "^3.0.0"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "hash-base": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.1"
+          }
+        },
+        "hast-to-hyperscript": {
+          "version": "6.0.0",
+          "bundled": true,
+          "requires": {
+            "comma-separated-tokens": "^1.0.0",
+            "property-information": "^5.0.0",
+            "space-separated-tokens": "^1.0.0",
+            "style-to-object": "^0.2.1",
+            "unist-util-is": "^2.0.0",
+            "web-namespaces": "^1.1.2"
+          }
+        },
+        "hast-util-is-element": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "hast-util-sanitize": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "xtend": "^4.0.1"
+          }
+        },
+        "hast-util-to-html": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "ccount": "^1.0.0",
+            "comma-separated-tokens": "^1.0.1",
+            "hast-util-is-element": "^1.0.0",
+            "hast-util-whitespace": "^1.0.0",
+            "html-void-elements": "^1.0.0",
+            "property-information": "^5.0.0",
+            "space-separated-tokens": "^1.0.0",
+            "stringify-entities": "^1.0.1",
+            "unist-util-is": "^2.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "hast-util-whitespace": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "he": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "hmac-drbg": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "hash.js": "^1.0.3",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.1"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "home-or-tmp": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "homedir-polyfill": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "parse-passwd": "^1.0.0"
+          }
+        },
+        "html-element-map": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "array-filter": "^1.0.0"
+          },
+          "dependencies": {
+            "array-filter": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "html-encoding-sniffer": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "whatwg-encoding": "^1.0.1"
+          }
+        },
+        "html-entities": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "html-minifier": {
+          "version": "3.5.21",
+          "bundled": true,
+          "requires": {
+            "camel-case": "3.0.x",
+            "clean-css": "4.2.x",
+            "commander": "2.17.x",
+            "he": "1.2.x",
+            "param-case": "2.1.x",
+            "relateurl": "0.2.x",
+            "uglify-js": "3.4.x"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.17.1",
+              "bundled": true
+            }
+          }
+        },
+        "html-void-elements": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "html-webpack-plugin": {
+          "version": "4.0.0-beta.5",
+          "bundled": true,
+          "requires": {
+            "html-minifier": "^3.5.20",
+            "loader-utils": "^1.1.0",
+            "lodash": "^4.17.11",
+            "pretty-error": "^2.1.1",
+            "tapable": "^1.1.0",
+            "util.promisify": "1.0.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "1",
+            "domhandler": "2.1",
+            "domutils": "1.1",
+            "readable-stream": "1.0"
+          },
+          "dependencies": {
+            "domutils": {
+              "version": "1.1.6",
+              "bundled": true,
+              "requires": {
+                "domelementtype": "1"
+              }
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true
+            }
+          }
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "bundled": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "http-parser-js": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "https-browserify": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "humps": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "icss-replace-symbols": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "icss-utils": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "postcss": "^6.0.1"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "6.0.23",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "ieee754": {
+          "version": "1.1.12",
+          "bundled": true
+        },
+        "iferr": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "bundled": true
+        },
+        "immer": {
+          "version": "1.7.2",
+          "bundled": true
+        },
+        "immutable": {
+          "version": "3.8.2",
+          "bundled": true
+        },
+        "import-cwd": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "import-from": "^2.1.0"
+          }
+        },
+        "import-fresh": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "caller-path": "^2.0.0",
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "import-from": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "import-local": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "pkg-dir": "^3.0.0",
+            "resolve-cwd": "^2.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "pkg-dir": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^3.0.0"
+              }
+            }
+          }
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "indexof": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "inquirer": {
+          "version": "6.2.1",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.10",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.1.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^5.0.0",
+            "through": "^2.3.6"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              },
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^4.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "4.0.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "interpret": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "ip": {
+          "version": "1.1.5",
+          "bundled": true
+        },
+        "ipaddr.js": {
+          "version": "1.8.0",
+          "bundled": true
+        },
+        "is-absolute-url": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-alphabetical": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-alphanumeric": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-alphanumerical": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "is-alphabetical": "^1.0.0",
+            "is-decimal": "^1.0.0"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-boolean-object": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "is-callable": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-decimal": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "is-directory": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "is-dom": {
+          "version": "1.0.9",
+          "bundled": true
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-hexadecimal": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-number-object": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
+        "is-root": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-string": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "is-subset": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-whitespace-character": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-word-character": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-wsl": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "node-fetch": "^1.0.1",
+            "whatwg-fetch": ">=0.10.0"
+          }
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "js-levenshtein": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "bundled": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "jsdom": {
+          "version": "13.0.0",
+          "bundled": true,
+          "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^6.0.2",
+            "acorn-globals": "^4.3.0",
+            "array-equal": "^1.0.0",
+            "cssom": "^0.3.4",
+            "cssstyle": "^1.1.1",
+            "data-urls": "^1.0.1",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.11.0",
+            "html-encoding-sniffer": "^1.0.2",
+            "nwsapi": "^2.0.9",
+            "parse5": "5.1.0",
+            "pn": "^1.1.0",
+            "request": "^2.88.0",
+            "request-promise-native": "^1.0.5",
+            "saxes": "^3.1.3",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^2.4.3",
+            "w3c-hr-time": "^1.0.1",
+            "w3c-xmlserializer": "^1.0.0",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.2.0",
+            "whatwg-url": "^7.0.0",
+            "ws": "^6.1.0",
+            "xml-name-validator": "^3.0.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "6.0.4",
+              "bundled": true
+            },
+            "parse5": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "bundled": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "json3": {
+          "version": "3.3.2",
+          "bundled": true
+        },
+        "json5": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "just-extend": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "keycode": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "bundled": true
+        },
+        "klaw": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.9"
+          }
+        },
+        "lazy-universal-dotenv": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "app-root-dir": "^1.0.2",
+            "core-js": "^2.5.7",
+            "dotenv": "^6.0.0",
+            "dotenv-expand": "^4.2.0"
+          },
+          "dependencies": {
+            "dotenv": {
+              "version": "6.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "loader-runner": {
+          "version": "2.3.1",
+          "bundled": true
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0"
+          },
+          "dependencies": {
+            "json5": {
+              "version": "0.5.1",
+              "bundled": true
+            }
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "bundled": true
+        },
+        "lodash-es": {
+          "version": "4.17.11",
+          "bundled": true
+        },
+        "lodash.debounce": {
+          "version": "4.0.8",
+          "bundled": true
+        },
+        "lodash.escape": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "lodash.flattendeep": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lodash.get": {
+          "version": "4.4.2",
+          "bundled": true
+        },
+        "lodash.isequal": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "bundled": true
+        },
+        "lodash.some": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "lodash.sortby": {
+          "version": "4.7.0",
+          "bundled": true
+        },
+        "lodash.toarray": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lolex": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "longest-streak": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "lower-case": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "make-error": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "map-age-cleaner": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "p-defer": "^1.0.0"
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "object-visit": "^1.0.0"
+          }
+        },
+        "markdown-escapes": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "markdown-table": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "markdown-to-jsx": {
+          "version": "6.9.4",
+          "bundled": true,
+          "requires": {
+            "prop-types": "^15.6.2",
+            "unquote": "^1.1.0"
+          }
+        },
+        "material-colors": {
+          "version": "1.2.6",
+          "bundled": true
+        },
+        "md5.js": {
+          "version": "1.3.5",
+          "bundled": true,
+          "requires": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.1.2"
+          }
+        },
+        "mdast-util-compact": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "unist-util-visit": "^1.1.0"
+          }
+        },
+        "mdast-util-definitions": {
+          "version": "1.2.3",
+          "bundled": true,
+          "requires": {
+            "unist-util-visit": "^1.0.0"
+          }
+        },
+        "mdast-util-to-hast": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "collapse-white-space": "^1.0.0",
+            "detab": "^2.0.0",
+            "mdast-util-definitions": "^1.2.0",
+            "mdurl": "^1.0.1",
+            "trim": "0.0.1",
+            "trim-lines": "^1.0.0",
+            "unist-builder": "^1.0.1",
+            "unist-util-generated": "^1.1.0",
+            "unist-util-position": "^3.0.0",
+            "unist-util-visit": "^1.1.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "mdast-util-to-string": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "mdast-util-toc": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "github-slugger": "^1.1.1",
+            "mdast-util-to-string": "^1.0.2",
+            "unist-util-visit": "^1.1.0"
+          }
+        },
+        "mdurl": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "mem": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^1.1.0"
+          }
+        },
+        "memoize-one": {
+          "version": "4.0.3",
+          "bundled": true
+        },
+        "memory-fs": {
+          "version": "0.4.1",
+          "bundled": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "merge2": {
+          "version": "1.2.3",
+          "bundled": true
+        },
+        "methods": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "miller-rabin": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.0.0",
+            "brorand": "^1.0.1"
+          }
+        },
+        "mime": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "mime-db": {
+          "version": "1.37.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.21",
+          "bundled": true,
+          "requires": {
+            "mime-db": "~1.37.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "min-document": {
+          "version": "2.19.0",
+          "bundled": true,
+          "requires": {
+            "dom-walk": "^0.1.0"
+          }
+        },
+        "mini-css-extract-plugin": {
+          "version": "0.4.5",
+          "bundled": true,
+          "requires": {
+            "loader-utils": "^1.1.0",
+            "schema-utils": "^1.0.0",
+            "webpack-sources": "^1.1.0"
+          }
+        },
+        "minimalistic-assert": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "minimalistic-crypto-utils": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          },
+          "dependencies": {
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mississippi": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
+          }
+        },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "mocha": {
+          "version": "5.2.0",
+          "bundled": true,
+          "requires": {
+            "browser-stdout": "1.3.1",
+            "commander": "2.15.1",
+            "debug": "3.1.0",
+            "diff": "3.5.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.2",
+            "growl": "1.10.5",
+            "he": "1.1.1",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "supports-color": "5.4.0"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.15.1",
+              "bundled": true
+            },
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "he": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "5.4.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "moo": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "move-concurrently": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "nan": {
+          "version": "2.12.1",
+          "bundled": true,
+          "optional": true
+        },
+        "nanomatch": {
+          "version": "1.2.13",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "nearley": {
+          "version": "2.16.0",
+          "bundled": true,
+          "requires": {
+            "commander": "^2.19.0",
+            "moo": "^0.4.3",
+            "railroad-diagrams": "^1.0.0",
+            "randexp": "0.4.6",
+            "semver": "^5.4.1"
+          }
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "neo-async": {
+          "version": "2.6.0",
+          "bundled": true
+        },
+        "nice-try": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "nise": {
+          "version": "1.4.8",
+          "bundled": true,
+          "requires": {
+            "@sinonjs/formatio": "^3.1.0",
+            "just-extend": "^4.0.2",
+            "lolex": "^2.3.2",
+            "path-to-regexp": "^1.7.0",
+            "text-encoding": "^0.6.4"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "lolex": {
+              "version": "2.7.5",
+              "bundled": true
+            },
+            "path-to-regexp": {
+              "version": "1.7.0",
+              "bundled": true,
+              "requires": {
+                "isarray": "0.0.1"
+              }
+            }
+          }
+        },
+        "no-case": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "lower-case": "^1.1.1"
+          }
+        },
+        "node-dir": {
+          "version": "0.1.17",
+          "bundled": true,
+          "requires": {
+            "minimatch": "^3.0.2"
+          }
+        },
+        "node-emoji": {
+          "version": "1.8.1",
+          "bundled": true,
+          "requires": {
+            "lodash.toarray": "^4.4.0"
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "bundled": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        },
+        "node-libs-browser": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "assert": "^1.1.1",
+            "browserify-zlib": "^0.2.0",
+            "buffer": "^4.3.0",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "^1.0.0",
+            "crypto-browserify": "^3.11.0",
+            "domain-browser": "^1.1.1",
+            "events": "^1.0.0",
+            "https-browserify": "^1.0.0",
+            "os-browserify": "^0.3.0",
+            "path-browserify": "0.0.0",
+            "process": "^0.11.10",
+            "punycode": "^1.2.4",
+            "querystring-es3": "^0.2.0",
+            "readable-stream": "^2.3.3",
+            "stream-browserify": "^2.0.1",
+            "stream-http": "^2.7.2",
+            "string_decoder": "^1.0.0",
+            "timers-browserify": "^2.0.4",
+            "tty-browserify": "0.0.0",
+            "url": "^0.11.0",
+            "util": "^0.10.3",
+            "vm-browserify": "0.0.4"
+          },
+          "dependencies": {
+            "events": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "process": {
+              "version": "0.11.10",
+              "bundled": true
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true
+            }
+          }
+        },
+        "node-modules-regexp": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "node-releases": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "semver": "^5.3.0"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "normalize-range": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "nth-check": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "boolbase": "~1.0.0"
+          }
+        },
+        "num2fraction": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "nwsapi": {
+          "version": "2.0.9",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "object-inspect": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "object-is": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-keys": {
+          "version": "1.0.12",
+          "bundled": true
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.0"
+          }
+        },
+        "object.assign": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
+          }
+        },
+        "object.entries": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.6.1",
+            "function-bind": "^1.1.0",
+            "has": "^1.0.1"
+          }
+        },
+        "object.fromentries": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.11.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1"
+          }
+        },
+        "object.getownpropertydescriptors": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.1"
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "object.values": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.6.1",
+            "function-bind": "^1.1.0",
+            "has": "^1.0.1"
+          }
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "opn": {
+          "version": "5.4.0",
+          "bundled": true,
+          "requires": {
+            "is-wsl": "^1.1.0"
+          }
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
+          }
+        },
+        "original": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "url-parse": "^1.4.3"
+          }
+        },
+        "os-browserify": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "execa": "^0.10.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "execa": {
+              "version": "0.10.0",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              }
+            }
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "output-file-sync": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "is-plain-obj": "^1.1.0",
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "p-defer": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-is-promise": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "pako": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "parallel-transform": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "cyclist": "~0.2.2",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.1.5"
+          }
+        },
+        "param-case": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
+        },
+        "parse-asn1": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "asn1.js": "^4.0.0",
+            "browserify-aes": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.0",
+            "pbkdf2": "^3.0.3"
+          }
+        },
+        "parse-entities": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "parse-passwd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "parseurl": {
+          "version": "1.3.2",
+          "bundled": true
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "path-browserify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "path-dirname": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pathval": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "pbkdf2": {
+          "version": "3.0.17",
+          "bundled": true,
+          "requires": {
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4",
+            "ripemd160": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+          }
+        },
+        "peer-deps-externals-webpack-plugin": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "pirates": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "node-modules-regexp": "^1.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        },
+        "pkg-up": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        },
+        "pluralizers": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "pn": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "polished": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime": "^7.2.0"
+          }
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "postcss": {
+          "version": "7.0.7",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.5.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-flexbugs-fixes": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "postcss": "^7.0.0"
+          }
+        },
+        "postcss-load-config": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "cosmiconfig": "^4.0.0",
+            "import-cwd": "^2.0.0"
+          },
+          "dependencies": {
+            "cosmiconfig": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "is-directory": "^0.3.1",
+                "js-yaml": "^3.9.0",
+                "parse-json": "^4.0.0",
+                "require-from-string": "^2.0.1"
+              }
+            }
+          }
+        },
+        "postcss-loader": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "loader-utils": "^1.1.0",
+            "postcss": "^7.0.0",
+            "postcss-load-config": "^2.0.0",
+            "schema-utils": "^1.0.0"
+          }
+        },
+        "postcss-modules-extract-imports": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "postcss": "^6.0.1"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "6.0.23",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-modules-local-by-default": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "css-selector-tokenizer": "^0.7.0",
+            "postcss": "^6.0.1"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "6.0.23",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-modules-scope": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "css-selector-tokenizer": "^0.7.0",
+            "postcss": "^6.0.1"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "6.0.23",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-modules-values": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "icss-replace-symbols": "^1.1.0",
+            "postcss": "^6.0.1"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "6.0.23",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "bundled": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "pretty-error": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "renderkid": "^2.0.1",
+            "utila": "~0.4"
+          }
+        },
+        "private": {
+          "version": "0.1.8",
+          "bundled": true
+        },
+        "process": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "bundled": true,
+          "requires": {
+            "asap": "~2.0.3"
+          }
+        },
+        "promise-inflight": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "promise.prototype.finally": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.9.0",
+            "function-bind": "^1.1.1"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.1",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          },
+          "dependencies": {
+            "react-is": {
+              "version": "16.8.1",
+              "bundled": true
+            }
+          }
+        },
+        "property-information": {
+          "version": "5.0.1",
+          "bundled": true,
+          "requires": {
+            "xtend": "^4.0.1"
+          }
+        },
+        "proxy-addr": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "forwarded": "~0.1.2",
+            "ipaddr.js": "1.8.0"
+          }
+        },
+        "prr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "psl": {
+          "version": "1.1.31",
+          "bundled": true
+        },
+        "public-encrypt": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "parse-asn1": "^5.0.0",
+            "randombytes": "^2.0.1",
+            "safe-buffer": "^5.1.2"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "pumpify": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+              }
+            }
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.6.0",
+          "bundled": true
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "querystringify": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "raf": {
+          "version": "3.4.1",
+          "bundled": true,
+          "requires": {
+            "performance-now": "^2.1.0"
+          }
+        },
+        "railroad-diagrams": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ramda": {
+          "version": "0.21.0",
+          "bundled": true
+        },
+        "randexp": {
+          "version": "0.4.6",
+          "bundled": true,
+          "requires": {
+            "discontinuous-range": "1.0.0",
+            "ret": "~0.1.10"
+          }
+        },
+        "randombytes": {
+          "version": "2.0.6",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "randomfill": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "randombytes": "^2.0.5",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "raw-body": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.23",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "iconv-lite": {
+              "version": "0.4.23",
+              "bundled": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            }
+          }
+        },
+        "raw-loader": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "react": {
+          "version": "16.8.4",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.13.4"
+          }
+        },
+        "react-color": {
+          "version": "2.17.0",
+          "bundled": true,
+          "requires": {
+            "@icons/material": "^0.2.4",
+            "lodash": ">4.17.4",
+            "material-colors": "^1.2.1",
+            "prop-types": "^15.5.10",
+            "reactcss": "^1.2.0",
+            "tinycolor2": "^1.4.1"
+          }
+        },
+        "react-desc": {
+          "version": "4.1.2",
+          "bundled": true
+        },
+        "react-dev-utils": {
+          "version": "6.1.1",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0",
+            "address": "1.0.3",
+            "browserslist": "4.1.1",
+            "chalk": "2.4.1",
+            "cross-spawn": "6.0.5",
+            "detect-port-alt": "1.1.6",
+            "escape-string-regexp": "1.0.5",
+            "filesize": "3.6.1",
+            "find-up": "3.0.0",
+            "global-modules": "1.0.0",
+            "globby": "8.0.1",
+            "gzip-size": "5.0.0",
+            "immer": "1.7.2",
+            "inquirer": "6.2.0",
+            "is-root": "2.0.0",
+            "loader-utils": "1.1.0",
+            "opn": "5.4.0",
+            "pkg-up": "2.0.0",
+            "react-error-overlay": "^5.1.0",
+            "recursive-readdir": "2.2.2",
+            "shell-quote": "1.6.1",
+            "sockjs-client": "1.1.5",
+            "strip-ansi": "4.0.0",
+            "text-table": "0.2.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "browserslist": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "caniuse-lite": "^1.0.30000884",
+                "electron-to-chromium": "^1.3.62",
+                "node-releases": "^1.0.0-alpha.11"
+              }
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "detect-port-alt": {
+              "version": "1.1.6",
+              "bundled": true,
+              "requires": {
+                "address": "^1.0.1",
+                "debug": "^2.6.0"
+              }
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "inquirer": {
+              "version": "6.2.0",
+              "bundled": true,
+              "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^3.0.0",
+                "figures": "^2.0.0",
+                "lodash": "^4.17.10",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^6.1.0",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "react-docgen": {
+          "version": "3.0.0-rc.2",
+          "bundled": true,
+          "requires": {
+            "@babel/parser": "^7.1.3",
+            "@babel/runtime": "^7.0.0",
+            "async": "^2.1.4",
+            "commander": "^2.19.0",
+            "doctrine": "^2.0.0",
+            "node-dir": "^0.1.10",
+            "recast": "^0.16.0"
+          }
+        },
+        "react-dom": {
+          "version": "16.8.4",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.13.4"
+          }
+        },
+        "react-error-overlay": {
+          "version": "5.1.0",
+          "bundled": true
+        },
+        "react-fast-compare": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "react-fuzzy": {
+          "version": "0.5.2",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.23.0",
+            "classnames": "^2.2.5",
+            "fuse.js": "^3.0.1",
+            "prop-types": "^15.5.9"
+          }
+        },
+        "react-inspector": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "is-dom": "^1.0.9",
+            "prop-types": "^15.6.1"
+          }
+        },
+        "react-is": {
+          "version": "16.7.0",
+          "bundled": true
+        },
+        "react-lifecycles-compat": {
+          "version": "3.0.4",
+          "bundled": true
+        },
+        "react-modal": {
+          "version": "3.8.1",
+          "bundled": true,
+          "requires": {
+            "exenv": "^1.2.0",
+            "prop-types": "^15.5.10",
+            "react-lifecycles-compat": "^3.0.0",
+            "warning": "^3.0.0"
+          }
+        },
+        "react-progressive-image": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "react-resize-detector": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.11",
+            "lodash-es": "^4.17.11",
+            "prop-types": "^15.6.2",
+            "resize-observer-polyfill": "^1.5.0"
+          }
+        },
+        "react-split-pane": {
+          "version": "0.1.85",
+          "bundled": true,
+          "requires": {
+            "prop-types": "^15.5.10",
+            "react": "^16.6.3",
+            "react-dom": "^16.6.3",
+            "react-lifecycles-compat": "^3.0.4",
+            "react-style-proptype": "^3.0.0"
+          }
+        },
+        "react-style-proptype": {
+          "version": "3.2.2",
+          "bundled": true,
+          "requires": {
+            "prop-types": "^15.5.4"
+          }
+        },
+        "react-test-renderer": {
+          "version": "16.8.4",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-is": "^16.8.4",
+            "scheduler": "^0.13.4"
+          },
+          "dependencies": {
+            "react-is": {
+              "version": "16.8.4",
+              "bundled": true
+            }
+          }
+        },
+        "react-textarea-autosize": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.5.1",
+          "bundled": true,
+          "requires": {
+            "dom-helpers": "^3.3.1",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "react-treebeard": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@emotion/core": "^0.13.1",
+            "@emotion/styled": "^0.10.6",
+            "deep-equal": "^1.0.1",
+            "prop-types": "^15.6.2",
+            "shallowequal": "^1.1.0",
+            "velocity-react": "^1.4.1"
+          }
+        },
+        "reactcss": {
+          "version": "1.2.3",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "recast": {
+          "version": "0.16.1",
+          "bundled": true,
+          "requires": {
+            "ast-types": "0.11.6",
+            "esprima": "~4.0.0",
+            "private": "~0.1.5",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "bundled": true,
+          "requires": {
+            "resolve": "^1.1.6"
+          }
+        },
+        "recompose": {
+          "version": "0.30.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          },
+          "dependencies": {
+            "hoist-non-react-statics": {
+              "version": "2.5.5",
+              "bundled": true
+            }
+          }
+        },
+        "recursive-readdir": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "redux": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "symbol-observable": "^1.2.0"
+          }
+        },
+        "regenerate": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "regenerate-unicode-properties": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerate": "^1.4.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "bundled": true
+        },
+        "regenerator-transform": {
+          "version": "0.13.3",
+          "bundled": true,
+          "requires": {
+            "private": "^0.1.6"
+          }
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "regexp.prototype.flags": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2"
+          }
+        },
+        "regexpu-core": {
+          "version": "4.4.0",
+          "bundled": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^7.0.0",
+            "regjsgen": "^0.5.0",
+            "regjsparser": "^0.6.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.0.2"
+          }
+        },
+        "regjsgen": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "regjsparser": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "0.5.0",
+              "bundled": true
+            }
+          }
+        },
+        "rehype-stringify": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "hast-util-to-html": "^5.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "relateurl": {
+          "version": "0.2.7",
+          "bundled": true
+        },
+        "remark": {
+          "version": "10.0.1",
+          "bundled": true,
+          "requires": {
+            "remark-parse": "^6.0.0",
+            "remark-stringify": "^6.0.0",
+            "unified": "^7.0.0"
+          }
+        },
+        "remark-emoji": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "node-emoji": "^1.8.1",
+            "unist-util-visit": "^1.4.0"
+          }
+        },
+        "remark-external-links": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "is-absolute-url": "^2.1.0",
+            "mdast-util-definitions": "^1.2.3",
+            "space-separated-tokens": "^1.1.2",
+            "unist-util-visit": "^1.4.0"
+          }
+        },
+        "remark-parse": {
+          "version": "6.0.3",
+          "bundled": true,
+          "requires": {
+            "collapse-white-space": "^1.0.2",
+            "is-alphabetical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-whitespace-character": "^1.0.0",
+            "is-word-character": "^1.0.0",
+            "markdown-escapes": "^1.0.0",
+            "parse-entities": "^1.1.0",
+            "repeat-string": "^1.5.4",
+            "state-toggle": "^1.0.0",
+            "trim": "0.0.1",
+            "trim-trailing-lines": "^1.0.0",
+            "unherit": "^1.0.4",
+            "unist-util-remove-position": "^1.0.0",
+            "vfile-location": "^2.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "remark-react": {
+          "version": "5.0.1",
+          "bundled": true,
+          "requires": {
+            "@mapbox/hast-util-table-cell-style": "^0.1.3",
+            "hast-to-hyperscript": "^6.0.0",
+            "hast-util-sanitize": "^1.0.0",
+            "mdast-util-to-hast": "^4.0.0"
+          }
+        },
+        "remark-rehype": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "mdast-util-to-hast": "^4.0.0"
+          }
+        },
+        "remark-slug": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "github-slugger": "^1.0.0",
+            "mdast-util-to-string": "^1.0.0",
+            "unist-util-visit": "^1.0.0"
+          }
+        },
+        "remark-stringify": {
+          "version": "6.0.4",
+          "bundled": true,
+          "requires": {
+            "ccount": "^1.0.0",
+            "is-alphanumeric": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-whitespace-character": "^1.0.0",
+            "longest-streak": "^2.0.1",
+            "markdown-escapes": "^1.0.0",
+            "markdown-table": "^1.1.0",
+            "mdast-util-compact": "^1.0.0",
+            "parse-entities": "^1.0.2",
+            "repeat-string": "^1.5.4",
+            "state-toggle": "^1.0.0",
+            "stringify-entities": "^1.0.1",
+            "unherit": "^1.0.4",
+            "xtend": "^4.0.1"
+          }
+        },
+        "remark-sub-super": {
+          "version": "1.0.17",
+          "bundled": true
+        },
+        "remark-toc": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "mdast-util-toc": "^3.0.0",
+            "remark-slug": "^5.0.0"
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "render-fragment": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "renderkid": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "css-select": "^1.1.0",
+            "dom-converter": "~0.2",
+            "htmlparser2": "~3.3.0",
+            "strip-ansi": "^3.0.0",
+            "utila": "^0.4.0"
+          }
+        },
+        "repeat-element": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "replace-ext": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "request": {
+          "version": "2.88.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.2",
+              "bundled": true
+            },
+            "tough-cookie": {
+              "version": "2.4.3",
+              "bundled": true,
+              "requires": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+              }
+            }
+          }
+        },
+        "request-promise-core": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.13.1"
+          }
+        },
+        "request-promise-native": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "request-promise-core": "1.1.1",
+            "stealthy-require": "^1.1.0",
+            "tough-cookie": ">=2.3.3"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-from-string": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "requires-port": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "resize-observer-polyfill": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "resolve": {
+          "version": "1.9.0",
+          "bundled": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-cwd": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "resolve-dir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "expand-tilde": "^2.0.0",
+            "global-modules": "^1.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "ret": {
+          "version": "0.1.15",
+          "bundled": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "ripemd160": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "rst-selector-parser": {
+          "version": "2.2.3",
+          "bundled": true,
+          "requires": {
+            "lodash.flattendeep": "^4.4.0",
+            "nearley": "^2.7.10"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
+        },
+        "run-queue": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.1"
+          }
+        },
+        "rxjs": {
+          "version": "6.3.3",
+          "bundled": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ret": "~0.1.10"
+          }
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "saxes": {
+          "version": "3.1.4",
+          "bundled": true,
+          "requires": {
+            "xmlchars": "^1.3.1"
+          }
+        },
+        "scheduler": {
+          "version": "0.13.4",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true
+        },
+        "send": {
+          "version": "0.16.2",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "~1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.4.0"
+          }
+        },
+        "serialize-javascript": {
+          "version": "1.5.0",
+          "bundled": true
+        },
+        "serve-favicon": {
+          "version": "2.5.0",
+          "bundled": true,
+          "requires": {
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "ms": "2.1.1",
+            "parseurl": "~1.3.2",
+            "safe-buffer": "5.1.1"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.13.2",
+          "bundled": true,
+          "requires": {
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.2",
+            "send": "0.16.2"
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "sha.js": {
+          "version": "2.4.11",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "shallowequal": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "shell-quote": {
+          "version": "1.6.1",
+          "bundled": true,
+          "requires": {
+            "array-filter": "~0.0.0",
+            "array-map": "~0.0.0",
+            "array-reduce": "~0.0.0",
+            "jsonify": "~0.0.0"
+          }
+        },
+        "shelljs": {
+          "version": "0.8.3",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
+          }
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "sinon": {
+          "version": "7.1.1",
+          "bundled": true,
+          "requires": {
+            "@sinonjs/commons": "^1.2.0",
+            "@sinonjs/formatio": "^3.0.0",
+            "@sinonjs/samsam": "^2.1.2",
+            "diff": "^3.5.0",
+            "lodash.get": "^4.4.2",
+            "lolex": "^3.0.0",
+            "nise": "^1.4.6",
+            "supports-color": "^5.5.0",
+            "type-detect": "^4.0.8"
+          }
+        },
+        "sinon-chai": {
+          "version": "3.3.0",
+          "bundled": true
+        },
+        "slash": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.2.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "sockjs-client": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.6",
+            "eventsource": "0.1.6",
+            "faye-websocket": "~0.11.0",
+            "inherits": "^2.0.1",
+            "json3": "^3.3.2",
+            "url-parse": "^1.1.8"
+          }
+        },
+        "source-list-map": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "source-map-resolve": {
+          "version": "0.5.2",
+          "bundled": true,
+          "requires": {
+            "atob": "^2.1.1",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map-support": {
+          "version": "0.5.9",
+          "bundled": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "space-separated-tokens": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "trim": "0.0.1"
+          }
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "sshpk": {
+          "version": "1.15.2",
+          "bundled": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+          }
+        },
+        "ssri": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1"
+          }
+        },
+        "state-toggle": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "stealthy-require": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "stream-browserify": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "~2.0.1",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "stream-each": {
+          "version": "1.2.3",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "stream-http": {
+          "version": "2.8.3",
+          "bundled": true,
+          "requires": {
+            "builtin-status-codes": "^3.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.3.6",
+            "to-arraybuffer": "^1.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "stream-shift": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string.prototype.matchall": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.12.0",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "regexp.prototype.flags": "^1.2.0"
+          }
+        },
+        "string.prototype.padend": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.4.3",
+            "function-bind": "^1.0.2"
+          }
+        },
+        "string.prototype.padstart": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.4.3",
+            "function-bind": "^1.0.2"
+          }
+        },
+        "string.prototype.trim": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.0",
+            "function-bind": "^1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "stringify-entities": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "character-entities-html4": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "style-loader": {
+          "version": "0.23.1",
+          "bundled": true,
+          "requires": {
+            "loader-utils": "^1.1.0",
+            "schema-utils": "^1.0.0"
+          }
+        },
+        "style-to-object": {
+          "version": "0.2.2",
+          "bundled": true,
+          "requires": {
+            "css": "2.2.4"
+          }
+        },
+        "styled-components": {
+          "version": "4.1.3",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@emotion/is-prop-valid": "^0.7.3",
+            "@emotion/unitless": "^0.7.0",
+            "babel-plugin-styled-components": ">= 1",
+            "css-to-react-native": "^2.2.2",
+            "memoize-one": "^4.0.0",
+            "prop-types": "^15.5.4",
+            "react-is": "^16.6.0",
+            "stylis": "^3.5.0",
+            "stylis-rule-sheet": "^0.0.10",
+            "supports-color": "^5.5.0"
+          },
+          "dependencies": {
+            "@emotion/is-prop-valid": {
+              "version": "0.7.3",
+              "bundled": true,
+              "requires": {
+                "@emotion/memoize": "0.7.1"
+              }
+            },
+            "@emotion/memoize": {
+              "version": "0.7.1",
+              "bundled": true
+            },
+            "@emotion/unitless": {
+              "version": "0.7.3",
+              "bundled": true
+            }
+          }
+        },
+        "styled-theming": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "stylis": {
+          "version": "3.5.4",
+          "bundled": true
+        },
+        "stylis-rule-sheet": {
+          "version": "0.0.10",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "svg-url-loader": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "file-loader": "1.1.11",
+            "loader-utils": "1.1.0"
+          },
+          "dependencies": {
+            "file-loader": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "loader-utils": "^1.0.2",
+                "schema-utils": "^0.4.5"
+              }
+            },
+            "schema-utils": {
+              "version": "0.4.7",
+              "bundled": true,
+              "requires": {
+                "ajv": "^6.1.0",
+                "ajv-keywords": "^3.1.0"
+              }
+            }
+          }
+        },
+        "symbol-observable": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "symbol-tree": {
+          "version": "3.2.2",
+          "bundled": true
+        },
+        "symbol.prototype.description": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
+        },
+        "tapable": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          },
+          "dependencies": {
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "term-size": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "execa": "^0.7.0"
+          }
+        },
+        "terser": {
+          "version": "3.13.1",
+          "bundled": true,
+          "requires": {
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.6"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.17.1",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "terser-webpack-plugin": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "cacache": "^11.0.2",
+            "find-cache-dir": "^2.0.0",
+            "schema-utils": "^1.0.0",
+            "serialize-javascript": "^1.4.0",
+            "source-map": "^0.6.1",
+            "terser": "^3.8.1",
+            "webpack-sources": "^1.1.0",
+            "worker-farm": "^1.5.2"
+          },
+          "dependencies": {
+            "find-cache-dir": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^1.0.0",
+                "pkg-dir": "^3.0.0"
+              }
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "pkg-dir": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^3.0.0"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "text-encoding": {
+          "version": "0.6.4",
+          "bundled": true
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "through2": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        },
+        "timers-browserify": {
+          "version": "2.0.10",
+          "bundled": true,
+          "requires": {
+            "setimmediate": "^1.0.4"
+          }
+        },
+        "tiny-warning": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "tinycolor2": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "bundled": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        },
+        "to-arraybuffer": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "toggle-selection": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "bundled": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "trim": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "trim-lines": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "trim-trailing-lines": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "trough": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "tslib": {
+          "version": "1.9.3",
+          "bundled": true
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "bundled": true
+        },
+        "type-is": {
+          "version": "1.6.16",
+          "bundled": true,
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "~2.1.18"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "ua-parser-js": {
+          "version": "0.7.19",
+          "bundled": true
+        },
+        "uglify-js": {
+          "version": "3.4.9",
+          "bundled": true,
+          "requires": {
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.17.1",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "unherit": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "xtend": "^4.0.1"
+          }
+        },
+        "unicode-canonical-property-names-ecmascript": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "unicode-match-property-ecmascript": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "unicode-canonical-property-names-ecmascript": "^1.0.4",
+            "unicode-property-aliases-ecmascript": "^1.0.4"
+          }
+        },
+        "unicode-match-property-value-ecmascript": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "unicode-property-aliases-ecmascript": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "unified": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "@types/vfile": "^3.0.0",
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "trough": "^1.0.0",
+            "vfile": "^3.0.0",
+            "x-is-string": "^0.1.0"
+          }
+        },
+        "union-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
+              }
+            }
+          }
+        },
+        "unique-filename": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "unique-slug": "^2.0.0"
+          }
+        },
+        "unique-slug": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "imurmurhash": "^0.1.4"
+          }
+        },
+        "unist-builder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4.1.0"
+          }
+        },
+        "unist-util-generated": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "unist-util-is": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "unist-util-position": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "unist-util-remove-position": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "unist-util-visit": "^1.1.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "unist-util-visit": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "unist-util-is": "^2.1.2"
+          }
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "unquote": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "bundled": true,
+              "requires": {
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "bundled": true
+            }
+          }
+        },
+        "upath": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "upper-case": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "url": {
+          "version": "0.11.0",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "bundled": true
+            }
+          }
+        },
+        "url-loader": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "loader-utils": "^1.1.0",
+            "mime": "^2.0.3",
+            "schema-utils": "^1.0.0"
+          },
+          "dependencies": {
+            "mime": {
+              "version": "2.4.0",
+              "bundled": true
+            }
+          }
+        },
+        "url-parse": {
+          "version": "1.4.4",
+          "bundled": true,
+          "requires": {
+            "querystringify": "^2.0.0",
+            "requires-port": "^1.0.0"
+          }
+        },
+        "use": {
+          "version": "3.1.1",
+          "bundled": true
+        },
+        "util": {
+          "version": "0.10.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "util.promisify": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "object.getownpropertydescriptors": "^2.0.3"
+          }
+        },
+        "utila": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "utils-merge": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "bundled": true
+        },
+        "v8-compile-cache": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "vary": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "velocity-animate": {
+          "version": "1.5.2",
+          "bundled": true
+        },
+        "velocity-react": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.5",
+            "prop-types": "^15.5.8",
+            "react-transition-group": "^2.0.0",
+            "velocity-animate": "^1.4.0"
+          }
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "vfile": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "is-buffer": "^2.0.0",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^1.0.0",
+            "vfile-message": "^1.0.0"
+          },
+          "dependencies": {
+            "is-buffer": {
+              "version": "2.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "vfile-location": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "vfile-message": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "unist-util-stringify-position": "^1.1.1"
+          }
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "bundled": true,
+          "requires": {
+            "indexof": "0.0.1"
+          }
+        },
+        "w3c-hr-time": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "browser-process-hrtime": "^0.1.2"
+          }
+        },
+        "w3c-xmlserializer": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "domexception": "^1.0.1",
+            "webidl-conversions": "^4.0.2",
+            "xml-name-validator": "^3.0.0"
+          }
+        },
+        "warning": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "watchpack": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "chokidar": "^2.0.2",
+            "graceful-fs": "^4.1.2",
+            "neo-async": "^2.5.0"
+          }
+        },
+        "web-namespaces": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "webpack": {
+          "version": "4.26.1",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.7.11",
+            "@webassemblyjs/helper-module-context": "1.7.11",
+            "@webassemblyjs/wasm-edit": "1.7.11",
+            "@webassemblyjs/wasm-parser": "1.7.11",
+            "acorn": "^5.6.2",
+            "acorn-dynamic-import": "^3.0.0",
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0",
+            "chrome-trace-event": "^1.0.0",
+            "enhanced-resolve": "^4.1.0",
+            "eslint-scope": "^4.0.0",
+            "json-parse-better-errors": "^1.0.2",
+            "loader-runner": "^2.3.0",
+            "loader-utils": "^1.1.0",
+            "memory-fs": "~0.4.1",
+            "micromatch": "^3.1.8",
+            "mkdirp": "~0.5.0",
+            "neo-async": "^2.5.0",
+            "node-libs-browser": "^2.0.0",
+            "schema-utils": "^0.4.4",
+            "tapable": "^1.1.0",
+            "terser-webpack-plugin": "^1.1.0",
+            "watchpack": "^1.5.0",
+            "webpack-sources": "^1.3.0"
+          },
+          "dependencies": {
+            "schema-utils": {
+              "version": "0.4.7",
+              "bundled": true,
+              "requires": {
+                "ajv": "^6.1.0",
+                "ajv-keywords": "^3.1.0"
+              }
+            }
+          }
+        },
+        "webpack-cli": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "cross-spawn": "^6.0.5",
+            "enhanced-resolve": "^4.1.0",
+            "global-modules-path": "^2.3.0",
+            "import-local": "^2.0.0",
+            "interpret": "^1.1.0",
+            "loader-utils": "^1.1.0",
+            "supports-color": "^5.5.0",
+            "v8-compile-cache": "^2.0.2",
+            "yargs": "^12.0.2"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            }
+          }
+        },
+        "webpack-dev-middleware": {
+          "version": "3.4.0",
+          "bundled": true,
+          "requires": {
+            "memory-fs": "~0.4.1",
+            "mime": "^2.3.1",
+            "range-parser": "^1.0.3",
+            "webpack-log": "^2.0.0"
+          },
+          "dependencies": {
+            "mime": {
+              "version": "2.4.0",
+              "bundled": true
+            }
+          }
+        },
+        "webpack-hot-middleware": {
+          "version": "2.24.3",
+          "bundled": true,
+          "requires": {
+            "ansi-html": "0.0.7",
+            "html-entities": "^1.2.0",
+            "querystring": "^0.2.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "webpack-log": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-colors": "^3.0.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "webpack-sources": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "websocket-driver": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "http-parser-js": ">=0.4.0",
+            "websocket-extensions": ">=0.1.1"
+          }
+        },
+        "websocket-extensions": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "whatwg-encoding": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.24"
+          }
+        },
+        "whatwg-fetch": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "whatwg-mimetype": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "whatwg-url": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "widest-line": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "worker-farm": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "errno": "~0.1.7"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "ws": {
+          "version": "6.1.2",
+          "bundled": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        },
+        "x-is-string": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "xml-name-validator": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "xmlchars": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "bundled": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "bundled": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "@zooniverse/standard": {
@@ -2191,6 +28826,1310 @@
         "eslint-plugin-jsx-a11y": "^6.2.1",
         "standard": "^12.0.1",
         "standard-engine": "^10.0.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.4.4",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.4.4",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.4.5",
+          "bundled": true
+        },
+        "@babel/template": {
+          "version": "7.4.4",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.4.4",
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.4.5",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.4",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.4.5",
+            "@babel/types": "^7.4.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/types": {
+          "version": "7.4.4",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "acorn": {
+          "version": "6.1.1",
+          "bundled": true
+        },
+        "acorn-jsx": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "ajv": {
+          "version": "6.10.0",
+          "bundled": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.4.0",
+          "bundled": true
+        },
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "aria-query": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "ast-types-flow": "0.0.7",
+            "commander": "^2.11.0"
+          }
+        },
+        "array-includes": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.7.0"
+          }
+        },
+        "ast-types-flow": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "axobject-query": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "ast-types-flow": "0.0.7"
+          }
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
+          },
+          "dependencies": {}
+        },
+        "babel-eslint": {
+          "version": "10.0.1",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.0.0",
+            "@babel/traverse": "^7.0.0",
+            "@babel/types": "^7.0.0",
+            "eslint-scope": "3.7.1",
+            "eslint-visitor-keys": "^1.0.0"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "caller-path": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "callsites": "^0.2.0"
+          }
+        },
+        "callsites": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "circular-json": {
+          "version": "0.3.3",
+          "bundled": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "commander": {
+          "version": "2.20.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "contains-path": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "bundled": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "damerau-levenshtein": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "bundled": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "deglob": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "find-root": "^1.0.0",
+            "glob": "^7.0.5",
+            "ignore": "^3.0.9",
+            "pkg-config": "^1.1.0",
+            "run-parallel": "^1.1.2",
+            "uniq": "^1.0.1"
+          },
+          "dependencies": {}
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "bundled": true
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.13.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-keys": "^1.0.12"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "eslint": {
+          "version": "5.4.0",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.5.0",
+            "babel-code-frame": "^6.26.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^4.0.0",
+            "eslint-utils": "^1.3.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^4.0.0",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.7.0",
+            "ignore": "^4.0.2",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^5.2.0",
+            "is-resolvable": "^1.1.0",
+            "js-yaml": "^3.11.0",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.5",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^2.0.0",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.5.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "^2.0.1",
+            "table": "^4.0.3",
+            "text-table": "^0.2.0"
+          },
+          "dependencies": {}
+        },
+        "eslint-config-standard": {
+          "version": "12.0.0",
+          "bundled": true
+        },
+        "eslint-config-standard-jsx": {
+          "version": "6.0.2",
+          "bundled": true
+        },
+        "eslint-import-resolver-node": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.9",
+            "resolve": "^1.5.0"
+          },
+          "dependencies": {}
+        },
+        "eslint-module-utils": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.8",
+            "pkg-dir": "^2.0.0"
+          },
+          "dependencies": {}
+        },
+        "eslint-plugin-es": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "eslint-utils": "^1.3.0",
+            "regexpp": "^2.0.1"
+          }
+        },
+        "eslint-plugin-import": {
+          "version": "2.14.0",
+          "bundled": true,
+          "requires": {
+            "contains-path": "^0.1.0",
+            "debug": "^2.6.8",
+            "doctrine": "1.5.0",
+            "eslint-import-resolver-node": "^0.3.1",
+            "eslint-module-utils": "^2.2.0",
+            "has": "^1.0.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.3",
+            "read-pkg-up": "^2.0.0",
+            "resolve": "^1.6.0"
+          },
+          "dependencies": {}
+        },
+        "eslint-plugin-jsx-a11y": {
+          "version": "6.2.1",
+          "bundled": true,
+          "requires": {
+            "aria-query": "^3.0.0",
+            "array-includes": "^3.0.3",
+            "ast-types-flow": "^0.0.7",
+            "axobject-query": "^2.0.2",
+            "damerau-levenshtein": "^1.0.4",
+            "emoji-regex": "^7.0.2",
+            "has": "^1.0.3",
+            "jsx-ast-utils": "^2.0.1"
+          }
+        },
+        "eslint-plugin-node": {
+          "version": "7.0.1",
+          "bundled": true,
+          "requires": {
+            "eslint-plugin-es": "^1.3.1",
+            "eslint-utils": "^1.3.1",
+            "ignore": "^4.0.2",
+            "minimatch": "^3.0.4",
+            "resolve": "^1.8.1",
+            "semver": "^5.5.0"
+          }
+        },
+        "eslint-plugin-promise": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "eslint-plugin-react": {
+          "version": "7.11.1",
+          "bundled": true,
+          "requires": {
+            "array-includes": "^3.0.3",
+            "doctrine": "^2.1.0",
+            "has": "^1.0.3",
+            "jsx-ast-utils": "^2.0.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "eslint-plugin-standard": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "eslint-scope": {
+          "version": "3.7.1",
+          "bundled": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "eslint-visitor-keys": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "espree": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "^6.0.2",
+            "acorn-jsx": "^5.0.0",
+            "eslint-visitor-keys": "^1.0.0"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "esquery": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.0.0"
+          }
+        },
+        "esrecurse": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.1.0"
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "find-root": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "flat-cache": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "circular-json": "^0.3.1",
+            "graceful-fs": "^4.1.2",
+            "rimraf": "~2.6.2",
+            "write": "^0.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "get-stdin": {
+          "version": "6.0.0",
+          "bundled": true
+        },
+        "glob": {
+          "version": "7.1.4",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "bundled": true
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "bundled": true
+        },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "hosted-git-info": {
+          "version": "2.7.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "inquirer": {
+          "version": "5.2.0",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-callable": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
+        "is-resolvable": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.13.1",
+          "bundled": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "bundled": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "json-stable-stringify-without-jsonify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "jsx-ast-utils": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "array-includes": "^3.0.3"
+          }
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "nice-try": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "pkg-conf": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "load-json-file": "^4.0.0"
+          },
+          "dependencies": {}
+        },
+        "pkg-config": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "debug-log": "^1.0.0",
+            "find-root": "^1.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "bundled": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "progress": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "react-is": {
+          "version": "16.8.6",
+          "bundled": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "regexpp": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "caller-path": "^0.1.0",
+            "resolve-from": "^1.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.11.0",
+          "bundled": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
+        },
+        "run-parallel": {
+          "version": "1.1.9",
+          "bundled": true
+        },
+        "rxjs": {
+          "version": "5.5.12",
+          "bundled": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          }
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "bundled": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "spdx-correct": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.4",
+          "bundled": true
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "standard": {
+          "version": "12.0.1",
+          "bundled": true,
+          "requires": {
+            "eslint": "~5.4.0",
+            "eslint-config-standard": "12.0.0",
+            "eslint-config-standard-jsx": "6.0.2",
+            "eslint-plugin-import": "~2.14.0",
+            "eslint-plugin-node": "~7.0.1",
+            "eslint-plugin-promise": "~4.0.0",
+            "eslint-plugin-react": "~7.11.1",
+            "eslint-plugin-standard": "~4.0.0",
+            "standard-engine": "~9.0.0"
+          },
+          "dependencies": {}
+        },
+        "standard-engine": {
+          "version": "10.0.0",
+          "bundled": true,
+          "requires": {
+            "deglob": "^3.0.0",
+            "get-stdin": "^6.0.0",
+            "minimist": "^1.1.0",
+            "pkg-conf": "^2.0.0"
+          },
+          "dependencies": {}
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          },
+          "dependencies": {}
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "symbol-observable": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "table": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.0.1",
+            "ajv-keywords": "^3.0.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "bundled": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        },
+        "uniq": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        }
       }
     },
     "abab": {
@@ -6321,25 +34260,24 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+          "resolved": false,
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "optional": true,
           "requires": {
@@ -6349,15 +34287,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6365,37 +34301,34 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "optional": true,
           "requires": {
@@ -6404,25 +34337,25 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "resolved": false,
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
@@ -6431,13 +34364,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
@@ -6453,7 +34386,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "resolved": false,
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "optional": true,
           "requires": {
@@ -6467,13 +34400,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "resolved": false,
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "optional": true,
           "requires": {
@@ -6482,7 +34415,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
@@ -6491,7 +34424,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
@@ -6501,51 +34434,46 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6553,7 +34481,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+          "resolved": false,
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "optional": true,
           "requires": {
@@ -6562,22 +34490,21 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+          "resolved": false,
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "optional": true,
           "requires": {
@@ -6588,7 +34515,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+          "resolved": false,
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "optional": true,
           "requires": {
@@ -6606,7 +34533,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
@@ -6616,13 +34543,13 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+          "resolved": false,
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "optional": true,
           "requires": {
@@ -6632,7 +34559,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
@@ -6644,40 +34571,38 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
@@ -6687,19 +34612,19 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "resolved": false,
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "optional": true,
           "requires": {
@@ -6711,7 +34636,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
@@ -6719,7 +34644,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
@@ -6734,7 +34659,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "resolved": false,
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "optional": true,
           "requires": {
@@ -6743,45 +34668,43 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "optional": true
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "resolved": false,
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6790,7 +34713,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
@@ -6799,22 +34722,21 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "resolved": false,
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "optional": true,
           "requires": {
@@ -6829,13 +34751,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "resolved": false,
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "optional": true,
           "requires": {
@@ -6844,15 +34766,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "optional": true
+          "resolved": false,
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },


### PR DESCRIPTION
Package: app-content-app, app-project

Describe your changes:
I didn't catch that #952 didn't have a rebuilt lock for the content app.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

