### PR TITLE
panoptes.js: fix linter errors and warnings

### DIFF
--- a/packages/lib-panoptes-js/package-lock.json
+++ b/packages/lib-panoptes-js/package-lock.json
@@ -715,6 +715,12 @@
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
 		},
+		"dirty-chai": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz",
+			"integrity": "sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w==",
+			"dev": true
+		},
 		"dom-walk": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
@@ -2680,6 +2686,12 @@
 				"nise": "^1.4.10",
 				"supports-color": "^5.5.0"
 			}
+		},
+		"sinon-chai": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
+			"integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
+			"dev": true
 		},
 		"snapdragon": {
 			"version": "0.8.2",

--- a/packages/lib-panoptes-js/package.json
+++ b/packages/lib-panoptes-js/package.json
@@ -23,11 +23,13 @@
     "chai": "~4.2.0",
     "check-dependencies": "~1.1.0",
     "check-engines": "~1.5.0",
+    "dirty-chai": "^2.0.1",
     "jsdom": "~15.1.1",
     "mocha": "~6.1.4",
     "mock-local-storage": "~1.1.8",
     "nock": "~10.0.6",
-    "sinon": "~7.3.2"
+    "sinon": "~7.3.2",
+    "sinon-chai": "^3.3.0"
   },
   "engines": {
     "node": ">=10"

--- a/packages/lib-panoptes-js/src/config.spec.js
+++ b/packages/lib-panoptes-js/src/config.spec.js
@@ -1,5 +1,3 @@
-/* global jsdom */
-
 const { expect } = require('chai')
 const { JSDOM } = require('jsdom')
 const { config, locationMatch } = require('./config')

--- a/packages/lib-panoptes-js/src/panoptes.spec.js
+++ b/packages/lib-panoptes-js/src/panoptes.spec.js
@@ -33,7 +33,7 @@ describe('panoptes.js', function () {
 
     it('should add the query object to the URL if defined', async function () {
       const response = await panoptes.get(endpoint, { page: '2', page_size: '30' })
-      expect(response.req.path.includes('?page=2&page_size=30')).to.be.true
+      expect(response.req.path.includes('?page=2&page_size=30')).to.be.true()
     })
 
     it('should error if query params are defined but are not an object', async function () {
@@ -166,14 +166,14 @@ describe('panoptes.js', function () {
         .reply(200, expectedResponse)
 
       const response = await panoptes[method].apply(this, methodArgs)
-      expect(response.request.url.includes(mockAPIHost)).to.be.true
+      expect(response.request.url.includes(mockAPIHost)).to.be.true()
     })
   }
 
   function testConfigHost (method, endpoint, update = null) {
     it('should use the host defined in the config if a host parameter isn\'t defined', async function () {
       const response = await panoptes[method](endpoint, update)
-      expect(response.request.url.includes(config.host)).to.be.true
+      expect(response.request.url.includes(config.host)).to.be.true()
     })
   }
 
@@ -204,7 +204,7 @@ describe('panoptes.js', function () {
   function testHttpCache (method, endpoint, update = null) {
     it('should add the http_cache default query params to the request', async function () {
       const response = await panoptes[method](endpoint, update)
-      expect(response.req.path.includes('?http_cache=true')).to.be.true
+      expect(response.req.path.includes('?http_cache=true')).to.be.true()
     })
   }
 
@@ -212,7 +212,7 @@ describe('panoptes.js', function () {
     it('should add the admin default query param if flag is found in local storage', async function () {
       localStorage.setItem('adminFlag', true)
       const response = await panoptes[method](endpoint, update)
-      expect(response.req.path.includes('?admin=true')).to.be.true
+      expect(response.req.path.includes('?admin=true')).to.be.true()
       localStorage.removeItem('adminFlag')
     })
   }

--- a/packages/lib-panoptes-js/src/panoptes.spec.js
+++ b/packages/lib-panoptes-js/src/panoptes.spec.js
@@ -5,14 +5,12 @@ const { config } = require('./config')
 const panoptes = require('./panoptes')
 
 describe('panoptes.js', function () {
-  let scope
-
   describe('get', function () {
     const endpoint = '/projects'
     const expectedResponse = { id: '2' }
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .get(uri => uri.includes(endpoint))
         .query(true)
@@ -53,7 +51,7 @@ describe('panoptes.js', function () {
     const expectedResponse = { id: '3' }
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .post(uri => uri.includes(endpoint))
         .query(true)
@@ -87,7 +85,7 @@ describe('panoptes.js', function () {
     const expectedResponse = { id: '3', display_name: 'My project' }
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .put(uri => uri.includes(endpoint))
         .query(true)
@@ -125,7 +123,7 @@ describe('panoptes.js', function () {
     const expectedResponse = { status: 204 }
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .delete(uri => uri.includes(endpoint))
         .query(true)
@@ -163,8 +161,7 @@ describe('panoptes.js', function () {
       const nockMethod = isDel ? 'delete' : method
       const methodArgs = [endpoint, update, null, mockAPIHost]
 
-      const mockAPIHostScope = nock(mockAPIHost)
-        [nockMethod](uri => uri.includes(endpoint))
+      nock(mockAPIHost)[nockMethod](uri => uri.includes(endpoint))
         .query(true)
         .reply(200, expectedResponse)
 

--- a/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
@@ -225,7 +225,7 @@ describe('Collections resource REST requests', function () {
 
     it('should add subjects to the specified collection', async function () {
       const response = await collections.addSubjects({ id: '10', subjects })
-      expect(response).to.be.ok
+      expect(response).to.be.ok()
     })
   })
 
@@ -265,7 +265,7 @@ describe('Collections resource REST requests', function () {
 
     it('should unlink the specified subjects', async function () {
       const response = await collections.removeSubjects({ id: '10', subjects: ['2'], authorization: 'Bearer 1234' })
-      expect(response).to.be.ok
+      expect(response).to.be.ok()
     })
   })
 })

--- a/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.spec.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const nock = require('nock')
 
 const { config } = require('../../config')
-const { resources, responses } = require('./mocks')
+const { responses } = require('./mocks')
 const { endpoint } = require('./helpers')
 const collections = require('./index')
 
@@ -10,10 +10,9 @@ describe('Collections resource REST requests', function () {
   describe('get', function () {
     describe('with a collection ID', function () {
       const expectedGetResponse = responses.get.collection
-      let scope
 
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .persist()
           .get(`${endpoint}/10`)
           .query(true)
@@ -46,10 +45,9 @@ describe('Collections resource REST requests', function () {
         owner: 'test',
         http_cache: 'true'
       }
-      let scope
 
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .persist()
           .get(`${endpoint}`)
           .query(query)
@@ -68,10 +66,9 @@ describe('Collections resource REST requests', function () {
 
     describe('with an authorization param', function () {
       const expectedGetResponse = responses.get.collection
-      let scope
 
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .persist()
           .get(uri => uri.includes(endpoint))
           .query(true)
@@ -95,10 +92,9 @@ describe('Collections resource REST requests', function () {
     }
     const expectedPutResponse = Object.assign({}, responses.get.collection, data)
     const requestBody = { collections: data }
-    let scope
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .put(`${endpoint}/10`, requestBody)
         .query(true)
@@ -144,10 +140,9 @@ describe('Collections resource REST requests', function () {
     }
     const changes = Object.assign({}, data, { links })
     const payload = { collections: changes }
-    let scope
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .post(`${endpoint}`, payload)
         .query(true)
@@ -166,10 +161,9 @@ describe('Collections resource REST requests', function () {
 
   describe('delete', function () {
     const expectedDeleteResponse = {}
-    let scope
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .delete(`${endpoint}/10`)
         .query(true)
@@ -198,10 +192,9 @@ describe('Collections resource REST requests', function () {
   describe('add subjects', function () {
     const expectedAddResponse = responses.get.collection
     const subjects = ['2']
-    let scope
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .post(`${endpoint}/10/links/subjects`, { subjects })
         .query(true)
@@ -238,10 +231,9 @@ describe('Collections resource REST requests', function () {
 
   describe('remove subjects', function () {
     const expectedDeleteResponse = {}
-    let scope
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .matchHeader('authorization', 'Bearer 1234')
         .persist()
         .delete(`${endpoint}/10/links/subjects/2`)

--- a/packages/lib-panoptes-js/src/resources/projects/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/projects/commonRequests.spec.js
@@ -4,17 +4,15 @@ const nock = require('nock')
 const projects = require('./index')
 const { endpoint } = require('./helpers')
 const { config } = require('../../config')
-const { resources, responses } = require('./mocks')
+const { responses } = require('./mocks')
 
 describe('Projects resource common requests', function () {
-  let scope
-
   describe('getBySlug', function () {
     const expectedGetResponse = responses.get.project
     const expectedNotFoundResponse = responses.get.queryNotFound
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .get(uri => uri.includes(endpoint))
         .query(true)
@@ -72,10 +70,9 @@ describe('Projects resource common requests', function () {
 
   describe('getWithLinkedResources', function () {
     const expectedGetResponseWithLinkedResources = responses.get.projectWithLinkedResources
-    const expectedNotFoundResponse = responses.get.queryNotFound
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .get(uri => uri.includes(endpoint))
         .query(true)
@@ -102,7 +99,7 @@ describe('Projects resource common requests', function () {
 
     describe('using project slug query parameter', function () {
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .persist()
           .get(uri => uri.includes(endpoint))
           .query(true)
@@ -139,7 +136,7 @@ describe('Projects resource common requests', function () {
 
     describe('using project id', function () {
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .get(uri => uri.includes(endpoint))
           .query(true)
           .reply(200, expectedGetResponseWithLinkedResources)

--- a/packages/lib-panoptes-js/src/resources/projects/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/projects/rest.spec.js
@@ -7,8 +7,6 @@ const { config } = require('../../config')
 const { responses } = require('./mocks')
 
 describe('Projects resource REST requests', function () {
-  let scope
-
   describe('create', function () {
     const expectedResponse = responses.post.createdProject
 
@@ -17,7 +15,7 @@ describe('Projects resource REST requests', function () {
     let reqBody
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .post(
           uri => uri.includes(endpoint),
@@ -38,7 +36,7 @@ describe('Projects resource REST requests', function () {
 
     it('should have sent the expected data params with an added { private: true }', async function () {
       const projectDisplayName = { display_name: 'My project' }
-      const response = await projects.create({ data: projectDisplayName })
+      await projects.create({ data: projectDisplayName })
       expect(reqBody).to.eql(Object.assign({}, { private: true }, projectDisplayName))
     })
 
@@ -53,7 +51,7 @@ describe('Projects resource REST requests', function () {
       const expectedGetAllResponse = responses.get.projects
 
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .persist()
           .get(uri => uri.includes(endpoint))
           .query(true)
@@ -79,7 +77,7 @@ describe('Projects resource REST requests', function () {
       const expectedGetSingleResponse = responses.get.project
 
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .persist()
           .get(uri => uri.includes(endpoint))
           .query(true)
@@ -122,7 +120,7 @@ describe('Projects resource REST requests', function () {
     const update = { researcher_quote: 'Try my project!' }
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .put(uri => uri.includes(endpoint))
         .query(true)
@@ -175,7 +173,7 @@ describe('Projects resource REST requests', function () {
     const responseStatus = 204
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .delete(uri => uri.includes(endpoint))
         .query(true)

--- a/packages/lib-panoptes-js/src/resources/projects/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/projects/rest.spec.js
@@ -101,7 +101,7 @@ describe('Projects resource REST requests', function () {
       it('should include query params with the request if defined', async function () {
         const queryParams = { page: '2' }
         const response = await projects.get({ id: '2', query: queryParams })
-        expect(response.req.path.includes('?page=2')).to.be.true
+        expect(response.req.path.includes('?page=2')).to.be.true()
       })
 
       it('should error if id arugment is not a string', async function () {

--- a/packages/lib-panoptes-js/src/resources/subjects/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/commonRequests.spec.js
@@ -56,7 +56,7 @@ describe('Subjects resource common requests', function () {
 
     it('should use the subject set id in the request query params if defined', async function () {
       const response = await subjects.getSubjectQueue({ subjectSetId: '40', workflowId: '10' })
-      expect(response.req.path.includes('subject_set_id=40')).to.be.true
+      expect(response.req.path.includes('subject_set_id=40')).to.be.true()
     })
 
     it('should add the Authorization header to the request if param is defined', async function () {

--- a/packages/lib-panoptes-js/src/resources/subjects/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/commonRequests.spec.js
@@ -2,17 +2,16 @@ const { expect } = require('chai')
 const nock = require('nock')
 
 const { config } = require('../../config')
-const { resources, responses } = require('./mocks')
+const { responses } = require('./mocks')
 const { queuedEndpoint } = require('./helpers')
 const subjects = require('./index')
 
 describe('Subjects resource common requests', function () {
   describe('getSubjectQueue', function () {
     const expectedGetResponse = responses.get.subjectQueue
-    let scope
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .get(uri => uri.includes(queuedEndpoint))
         .query(true)

--- a/packages/lib-panoptes-js/src/resources/subjects/helpers.spec.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/helpers.spec.js
@@ -4,7 +4,7 @@ describe('Subjects Helpers', function () {
   describe('buildQueuedSubjectResource', function () {
     it('should return a mocked subject resource object', function () {
       const subject = buildQueuedSubjectResource()
-      expect(subject).to.exist
+      expect(subject).to.exist()
       expect(subject).to.be.an.instanceOf(Object)
     })
 

--- a/packages/lib-panoptes-js/src/resources/subjects/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/subjects/rest.spec.js
@@ -2,17 +2,16 @@ const { expect } = require('chai')
 const nock = require('nock')
 
 const { config } = require('../../config')
-const { resources, responses } = require('./mocks')
+const { responses } = require('./mocks')
 const { endpoint } = require('./helpers')
 const subjects = require('./index')
 
 describe('Subjects resource REST requests', function () {
   describe('get', function () {
     const expectedGetResponse = responses.get.subject
-    let scope
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .get(uri => uri.includes(endpoint))
         .query(true)

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
@@ -7,13 +7,11 @@ const { config } = require('../../config')
 const { resources, responses } = require('./mocks')
 
 describe('Tutorials resource common requests', function () {
-  let scope
-
   describe('getAttachedImages', function () {
     const expectedGetResponse = responses.get.attachedImage
 
     before(function () {
-      scope = nock(config.host)
+      nock(config.host)
         .persist()
         .get(uri => uri.includes(endpoint))
         .query(true)
@@ -54,7 +52,7 @@ describe('Tutorials resource common requests', function () {
       const expectedGetResponse = responses.get.tutorialWithImages
 
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .persist()
           .get(uri => uri.includes(endpoint))
           .query(true)
@@ -85,7 +83,7 @@ describe('Tutorials resource common requests', function () {
       const expectedGetResponse = responses.get.tutorialsWithImages
 
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .persist()
           .get(uri => uri.includes(endpoint))
           .query(true)
@@ -116,7 +114,7 @@ describe('Tutorials resource common requests', function () {
   describe('getTutorials', function () {
     describe('by tutorial id', function () {
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .persist()
           .get(uri => uri.includes(endpoint))
           .query(true)
@@ -127,6 +125,7 @@ describe('Tutorials resource common requests', function () {
             if (uri.includes(resources.minicourse.id)) {
               return responses.get.minicourse
             }
+            return null
           })
       })
 
@@ -155,7 +154,7 @@ describe('Tutorials resource common requests', function () {
       const expectedGetResponse = responses.get.allTutorialsForWorkflow
 
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .persist()
           .get(uri => uri.includes(endpoint))
           .query(true)
@@ -193,7 +192,7 @@ describe('Tutorials resource common requests', function () {
       const expectedGetResponse = responses.get.minicourse
 
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .persist()
           .get(uri => uri.includes(endpoint))
           .query(true)
@@ -219,7 +218,7 @@ describe('Tutorials resource common requests', function () {
       const expectedGetResponse = responses.get.minicourse
 
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .persist()
           .get(uri => uri.includes(endpoint))
           .query(true)

--- a/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/commonRequests.spec.js
@@ -38,7 +38,7 @@ describe('Tutorials resource common requests', function () {
 
     it('should use query params if defined', async function () {
       const response = await tutorials.getAttachedImages({ id: '1', query: { page: '2' } })
-      expect(response.req.path.includes('page=2')).to.be.true
+      expect(response.req.path.includes('page=2')).to.be.true()
     })
 
     it('should add the Authorization header to the request if param is defined', async function () {
@@ -65,12 +65,12 @@ describe('Tutorials resource common requests', function () {
 
       it('should use a default include query param', async function () {
         const response = await tutorials.getWithImages({ id: '1' })
-        expect(response.req.path.includes('include=attached_images')).to.be.true
+        expect(response.req.path.includes('include=attached_images')).to.be.true()
       })
 
       it('should include any other query params if defined', async function () {
         const response = await tutorials.getWithImages({ id: '1', query: { page: '2' } })
-        expect(response.req.path.includes('page=2')).to.be.true
+        expect(response.req.path.includes('page=2')).to.be.true()
       })
 
       it('should return the expected response', async function () {
@@ -96,12 +96,12 @@ describe('Tutorials resource common requests', function () {
 
       it('should use a default include query param', async function () {
         const response = await tutorials.getWithImages({ workflowId: '10' })
-        expect(response.req.path.includes('include=attached_images')).to.be.true
+        expect(response.req.path.includes('include=attached_images')).to.be.true()
       })
 
       it('should include any other query params if defined', async function () {
         const response = await tutorials.getWithImages({ workflowId: '10', query: { page: '2' } })
-        expect(response.req.path.includes('page=2')).to.be.true
+        expect(response.req.path.includes('page=2')).to.be.true()
       })
 
       it('should return the expected response', async function () {
@@ -174,7 +174,7 @@ describe('Tutorials resource common requests', function () {
 
       it('should use the workflow id as the query param', async function () {
         const response = await tutorials.getTutorials({ workflowId: '10' })
-        expect(response.req.path.includes('workflow_id=10')).to.be.true
+        expect(response.req.path.includes('workflow_id=10')).to.be.true()
       })
 
       it('should not return minicourse kind tutorials', async function () {
@@ -210,7 +210,7 @@ describe('Tutorials resource common requests', function () {
 
       it('should set a default query parameter for kind', async function () {
         const response = await tutorials.getMinicourses({ id: '52' })
-        expect(response.req.path.includes('kind=mini-course')).to.be.true
+        expect(response.req.path.includes('kind=mini-course')).to.be.true()
       })
     })
 
@@ -236,12 +236,12 @@ describe('Tutorials resource common requests', function () {
 
       it('should set a default query parameter for kind', async function () {
         const response = await tutorials.getMinicourses({ workflowId: '10' })
-        expect(response.req.path.includes('kind=mini-course')).to.be.true
+        expect(response.req.path.includes('kind=mini-course')).to.be.true()
       })
 
       it('should use the workflow id as the query param', async function () {
         const response = await tutorials.getTutorials({ workflowId: '10' })
-        expect(response.req.path.includes('workflow_id=10')).to.be.true
+        expect(response.req.path.includes('workflow_id=10')).to.be.true()
       })
     })
   })

--- a/packages/lib-panoptes-js/src/resources/tutorials/rest.spec.js
+++ b/packages/lib-panoptes-js/src/resources/tutorials/rest.spec.js
@@ -2,20 +2,18 @@ const { expect } = require('chai')
 const nock = require('nock')
 
 const { config } = require('../../config')
-const { resources, responses } = require('./mocks')
+const { responses } = require('./mocks')
 const { endpoint } = require('./helpers')
 const tutorials = require('./index')
 
 describe('Tutorials resource REST requests', function () {
-  let scope
-
   describe('get', function () {
     const expectedGetAllResponse = responses.get.tutorials
     const expectedGetSingleResponse = responses.get.tutorial
 
     describe('by workflow id', function () {
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .persist()
           .get(uri => uri.includes(endpoint))
           .query(true)
@@ -57,7 +55,7 @@ describe('Tutorials resource REST requests', function () {
 
     describe('by tutorial id', function () {
       before(function () {
-        scope = nock(config.host)
+        nock(config.host)
           .persist()
           .get(uri => uri.includes(endpoint))
           .query(true)

--- a/packages/lib-panoptes-js/src/utilityFunctions/index.js
+++ b/packages/lib-panoptes-js/src/utilityFunctions/index.js
@@ -34,7 +34,7 @@ function raiseError (errorMessage, errorClass) {
 }
 
 function isParamTypeInvalid (param, type) {
-  if (param && typeof param !== type) return true
+  if (param) return (typeof param !== type)
 
   return false
 }

--- a/packages/lib-panoptes-js/test/chai-config.js
+++ b/packages/lib-panoptes-js/test/chai-config.js
@@ -1,0 +1,6 @@
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const sinonChai = require('sinon-chai')
+
+chai.use(dirtyChai)
+chai.use(sinonChai)

--- a/packages/lib-panoptes-js/test/mocha.opts
+++ b/packages/lib-panoptes-js/test/mocha.opts
@@ -3,5 +3,6 @@
 --require mock-local-storage
 --reporter spec
 --ui bdd
+--file ./test/chai-config.js
 
 ./src/**/*.spec.js


### PR DESCRIPTION
Fix a bunch of eslint errors, mostly variables that are declared but not used.
Also installs `dirty-chai` and updates chai expectations to use function calls.

Package:
lib-panoptes-js


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

