### PR TITLE
Initialise ui.mode with a valid value

### DIFF
--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -38,7 +38,7 @@ export default class MyApp extends App {
 
     if (pageProps.isServer) {
       // cookie is in the next.js context req object
-      const mode = getCookie(context, 'mode') || ''
+      const mode = getCookie(context, 'mode') || undefined
       const store = initStore(pageProps.isServer, {
         ui: {
           mode


### PR DESCRIPTION
Setting ui.mode to an empty string creates an invalid snapshot for the UI model.

Package:
app-project


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

