### PR TITLE
Set save prefix to `~`

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -4,3 +4,4 @@
 
 lastUpdateCheck 1562187057591
 yarn-path ".yarn/releases/yarn-1.16.0.js"
+save-prefix "~"

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   "bugs": "https://github.com/zooniverse/front-end-monorepo/issues",
   "version": "0.0.1",
   "devDependencies": {
-    "coveralls": "^3.0.2",
-    "lerna": "^3.13.4",
-    "nyc": "^14.1.0",
-    "plop": "^2.1.0",
-    "snazzy": "^8.0.0"
+    "coveralls": "~3.0.4",
+    "lerna": "~3.15.0",
+    "nyc": "~14.1.1",
+    "plop": "~2.4.0",
+    "snazzy": "~8.0.0"
   },
   "scripts": {
     "bootstrap": "./bin/bootstrap.sh",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5953,7 +5953,7 @@ counterpart@~0.18.6:
     pluralizers "^0.1.7"
     sprintf-js "^1.0.3"
 
-coveralls@^3.0.2:
+coveralls@~3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.4.tgz#f50233c9c62fd0973f710fce85fd19dba24cff4b"
   integrity sha512-eyqUWA/7RT0JagiL0tThVhjbIjoiEUyWCjtUJoOPcWoeofP5WK/jb2OJYoBFrR6DvplR+AxOyuBqk4JHkk5ykA==
@@ -10282,7 +10282,7 @@ lcov-parse@^0.0.10:
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
   integrity sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=
 
-lerna@^3.13.4:
+lerna@~3.15.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.15.0.tgz#b044dba8138d7a1a8dd48ac1d80e7541bdde0d1f"
   integrity sha512-kRIQ3bgzkmew5/WZQ0C9WjH0IUf3ZmTNnBwTHfXgLkVY7td0lbwMQFD7zehflUn0zG4ou54o/gn+IfjF0ti/5A==
@@ -11842,7 +11842,7 @@ nwsapi@^2.0.9, nwsapi@^2.1.4:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.4.tgz#e006a878db23636f8e8a67d33ca0e4edf61a842f"
   integrity sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==
 
-nyc@^14.1.0:
+nyc@~14.1.1:
   version "14.1.1"
   resolved "https://registry.yarnpkg.com/nyc/-/nyc-14.1.1.tgz#151d64a6a9f9f5908a1b73233931e4a0a3075eeb"
   integrity sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==
@@ -12603,7 +12603,7 @@ pkg-up@2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-plop@^2.1.0:
+plop@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/plop/-/plop-2.4.0.tgz#3b529b20ea07a8a803ae7e1853e86c50d5277df5"
   integrity sha512-Kl69KofCKE5eZcyA7UOyig9eZF8/AzvuXG2wUpaUkeXfSnrpUzw/MRVTS4g7uPz2tz/6/CroOYzc1YJm2WKwhw==


### PR DESCRIPTION
via https://github.com/zooniverse/front-end-monorepo/pull/991#pullrequestreview-259075330

- Sets the default version prefix to tilde
- Bump top level packages, use tildes

## How to test

1. `cd` to the project root dir
1. Run `yarn add left-pad -W`
1. Open up the `package.json` and verify the version prefix
1. Trash your changes to `package.json` and `yarn.lock` (obvs)