### PR TITLE
[MST Upgrade] Update FieldGuideStore

### DIFF
--- a/packages/lib-classifier/src/store/FieldGuideStore.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.js
@@ -1,5 +1,5 @@
 import { autorun } from 'mobx'
-import { addDisposer, getRoot, types, flow } from 'mobx-state-tree'
+import { addDisposer, getRoot, isValidReference, types, flow } from 'mobx-state-tree'
 import asyncStates from '@zooniverse/async-states'
 import ResourceStore from './ResourceStore'
 import FieldGuide from './FieldGuide'
@@ -7,8 +7,8 @@ import Medium from './Medium'
 
 const FieldGuideStore = types
   .model('FieldGuideStore', {
-    active: types.maybe(types.reference(FieldGuide)),
-    activeMedium: types.maybe(types.reference(Medium)),
+    active: types.safeReference(FieldGuide),
+    activeMedium: types.safeReference(Medium),
     activeItemIndex: types.maybe(types.integer),
     attachedMedia: types.map(Medium),
     resources: types.map(FieldGuide),
@@ -23,12 +23,12 @@ const FieldGuideStore = types
 
     function createProjectObserver () {
       const projectDisposer = autorun(() => {
-        const project = getRoot(self).projects.active
-        if (project) {
+        const validProjectReference = isValidReference(() => getRoot(self).projects.active)
+        if (validProjectReference) {
           self.reset()
           self.fetchFieldGuide()
         }
-      })
+      }, { name: 'FieldGuideStore Project Observer autorun' })
       addDisposer(self, projectDisposer)
     }
 

--- a/packages/lib-classifier/src/store/FieldGuideStore.spec.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.spec.js
@@ -36,8 +36,7 @@ const fieldGuideWithoutIcon = FieldGuideFactory.build({
 const project = ProjectFactory.build()
 
 describe.only('Model > FieldGuideStore', function () {
-  let rootStore
-  function fetchFieldGuide () {
+  function fetchFieldGuide (rootStore) {
     sinon.stub(rootStore.fieldGuide, 'fetchFieldGuide')
     rootStore.projects.setResource(project)
     return rootStore.projects.setActive(project.id)
@@ -48,7 +47,7 @@ describe.only('Model > FieldGuideStore', function () {
   }
 
   function setupStores (clientStub) {
-    rootStore = RootStore.create({
+    const store = RootStore.create({
       classifications: {},
       dataVisAnnotating: {},
       drawing: {},
@@ -60,11 +59,9 @@ describe.only('Model > FieldGuideStore', function () {
       workflowSteps: {},
       userProjectPreferences: {}
     }, { client: clientStub })
-  }
 
-  afterEach(function () {
-    rootStore = null
-  })
+    return store
+  }
 
   it('should exist', function () {
     expect(FieldGuideStore).to.be.an('object')
@@ -72,7 +69,7 @@ describe.only('Model > FieldGuideStore', function () {
 
   it('should remain in an initialized state if there is no project', function () {
     const panoptesClientStub = { panoptes: { get: sinon.stub().callsFake(() => Promise.resolve(null)) } }
-    setupStores(panoptesClientStub)
+    const rootStore = setupStores(panoptesClientStub)
     expect(rootStore.tutorials.loadingState).to.equal(asyncStates.initialized)
     expect(rootStore.client.panoptes.get).to.have.not.been.called()
   })
@@ -87,9 +84,9 @@ describe.only('Model > FieldGuideStore', function () {
         })
       }
     }
-    setupStores(panoptesClientStub)
+    const rootStore = setupStores(panoptesClientStub)
 
-    fetchFieldGuide()
+    fetchFieldGuide(rootStore)
       .then(() => {
         const fieldGuideInStore = rootStore.fieldGuide.active
         expect(fieldGuideInStore.toJSON()).to.deep.equal(fieldGuide)
@@ -97,10 +94,6 @@ describe.only('Model > FieldGuideStore', function () {
   })
 
   describe('Actions > fetchFieldGuide', function () {
-    afterEach(function () {
-      rootStore = null
-    })
-
     it('should request for a field guide linked to the active project', function (done) {
       const panoptesClientStub = {
         panoptes: {
@@ -111,9 +104,9 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide()
+      fetchFieldGuide(rootStore)
         .then(() => {
           expect(rootStore.client.panoptes.get.withArgs('/field_guides', { project_id: project.id })).to.have.been.calledOnce()
         }).then(done, done)
@@ -129,11 +122,11 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
       const setResourceSpy = sinon.spy(rootStore.fieldGuide, 'setResource')
 
-      fetchFieldGuide()
+      fetchFieldGuide(rootStore)
         .then(() => {
           expect(setResourceSpy).to.have.not.been.called()
           expect(rootStore.fieldGuide.loadingState).to.equal(asyncStates.success)
@@ -152,7 +145,7 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
       sinon.stub(rootStore.fieldGuide, 'fetchFieldGuide')
 
@@ -178,12 +171,12 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
       const setResourceSpy = sinon.spy(rootStore.fieldGuide, 'setResource')
       const setActiveSpy = sinon.spy(rootStore.fieldGuide, 'setActive')
 
-      fetchFieldGuide()
+      fetchFieldGuide(rootStore)
         .then(() => {
           expect(setResourceSpy).to.have.been.calledOnceWith(fieldGuide)
           expect(setActiveSpy).to.have.been.calledOnceWith(fieldGuide.id)
@@ -201,9 +194,9 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide()
+      fetchFieldGuide(rootStore)
         .then(() => {
           expect(rootStore.fieldGuide.loadingState).to.equal(asyncStates.error)
         }).then(done, done)
@@ -211,10 +204,6 @@ describe.only('Model > FieldGuideStore', function () {
   })
 
   describe('Actions > fetchMedia', function () {
-    afterEach(function () {
-      rootStore = null
-    })
-
     it('should not call setMediaResources if there is no media in the response', function (done) {
       const panoptesClientStub = {
         panoptes: {
@@ -225,11 +214,11 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
       const setMediaResourcesSpy = sinon.spy(rootStore.fieldGuide, 'setMediaResources')
 
-      fetchFieldGuide()
+      fetchFieldGuide(rootStore)
         .then(() => {
           expect(setMediaResourcesSpy).to.have.not.been.called()
         }).then(() => {
@@ -247,11 +236,11 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
       const setMediaResourcesSpy = sinon.spy(rootStore.fieldGuide, 'setMediaResources')
 
-      fetchFieldGuide()
+      fetchFieldGuide(rootStore)
         .then(() => {
           expect(setMediaResourcesSpy).to.have.been.calledOnceWith([medium])
         }).then(() => {
@@ -261,10 +250,6 @@ describe.only('Model > FieldGuideStore', function () {
   })
 
   describe('Actions > setModalVisibility', function () {
-    afterEach(function () {
-      rootStore = null
-    })
-
     it('should set the modal visibility', function () {
       const panoptesClientStub = {
         panoptes: {
@@ -275,7 +260,7 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
       rootStore.fieldGuide.setModalVisibility(true)
       expect(rootStore.fieldGuide.showModal).to.be.true()
@@ -295,9 +280,9 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide().then(() => {
+      fetchFieldGuide(rootStore).then(() => {
         rootStore.fieldGuide.setActiveItemIndex(0)
         expect(rootStore.fieldGuide.activeItemIndex).to.be.undefined()
         expect(rootStore.fieldGuide.activeMedium).to.be.undefined()
@@ -314,9 +299,9 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide().then(() => {
+      fetchFieldGuide(rootStore).then(() => {
         rootStore.fieldGuide.setActiveItemIndex()
         expect(rootStore.fieldGuide.activeItemIndex).to.be.undefined()
         expect(rootStore.fieldGuide.activeMedium).to.be.undefined()
@@ -333,9 +318,9 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide().then(() => {
+      fetchFieldGuide(rootStore).then(() => {
         rootStore.fieldGuide.setActiveItemIndex(2)
         expect(rootStore.fieldGuide.activeItemIndex).to.be.undefined()
         expect(rootStore.fieldGuide.activeMedium).to.be.undefined()
@@ -352,9 +337,9 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide()
+      fetchFieldGuide(rootStore)
         .then(() => {
           fieldGuideWithItems.items.forEach((item, index) => {
             rootStore.fieldGuide.setActiveItemIndex(index)
@@ -373,9 +358,9 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide()
+      fetchFieldGuide(rootStore)
         .then(() => {
           rootStore.fieldGuide.setActiveItemIndex(0)
           expect(rootStore.fieldGuide.activeMedium.toJSON()).to.deep.equal(medium)
@@ -392,9 +377,9 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide().then(() => {
+      fetchFieldGuide(rootStore).then(() => {
         rootStore.fieldGuide.setActiveItemIndex(0)
         expect(rootStore.fieldGuide.activeItemIndex).to.equal(0)
         expect(rootStore.fieldGuide.activeMedium).to.be.undefined()
@@ -403,10 +388,6 @@ describe.only('Model > FieldGuideStore', function () {
   })
 
   describe('Actions > reset', function () {
-    afterEach(function () {
-      rootStore = null
-    })
-
     it('should reset the store', function (done) {
       const panoptesClientStub = {
         panoptes: {
@@ -417,9 +398,9 @@ describe.only('Model > FieldGuideStore', function () {
           })
         }
       }
-      setupStores(panoptesClientStub)
+      const rootStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide()
+      fetchFieldGuide(rootStore)
         .then(() => {
           rootStore.fieldGuide.setActiveItemIndex(0)
           rootStore.fieldGuide.setModalVisibility(true)

--- a/packages/lib-classifier/src/store/FieldGuideStore.spec.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.spec.js
@@ -2,7 +2,6 @@ import sinon from 'sinon'
 import asyncStates from '@zooniverse/async-states'
 
 import RootStore from './RootStore'
-import ProjectStore from './ProjectStore'
 import FieldGuideStore from './FieldGuideStore'
 
 import {
@@ -36,7 +35,7 @@ const fieldGuideWithoutIcon = FieldGuideFactory.build({
 
 const project = ProjectFactory.build()
 
-describe('Model > FieldGuideStore', function () {
+describe.only('Model > FieldGuideStore', function () {
   let rootStore
   function fetchFieldGuide () {
     sinon.stub(rootStore.fieldGuide, 'fetchFieldGuide')
@@ -48,35 +47,47 @@ describe('Model > FieldGuideStore', function () {
       })
   }
 
+  function setupStores (clientStub) {
+    rootStore = RootStore.create({
+      classifications: {},
+      dataVisAnnotating: {},
+      drawing: {},
+      feedback: {},
+      subjects: {},
+      subjectViewer: {},
+      tutorials: {},
+      workflows: {},
+      workflowSteps: {},
+      userProjectPreferences: {}
+    }, { client: clientStub })
+  }
+
+  afterEach(function () {
+    rootStore = null
+  })
+
   it('should exist', function () {
     expect(FieldGuideStore).to.be.an('object')
   })
 
   it('should remain in an initialized state if there is no project', function () {
-    rootStore = RootStore.create({
-      fieldGuide: FieldGuideStore.create(),
-      projects: ProjectStore.create()
-    }, { client: { panoptes: { get: sinon.stub().callsFake(() => Promise.resolve(null)) } } })
-
+    const panoptesClientStub = { panoptes: { get: sinon.stub().callsFake(() => Promise.resolve(null)) } }
+    setupStores(panoptesClientStub)
     expect(rootStore.tutorials.loadingState).to.equal(asyncStates.initialized)
     expect(rootStore.client.panoptes.get).to.have.not.been.called()
   })
 
   it('should set the field guide if there is a project', function (done) {
-    rootStore = RootStore.create({
-      fieldGuide: FieldGuideStore.create(),
-      projects: ProjectStore.create()
-    }, {
-      client: {
-        panoptes: {
-          get: sinon.stub().callsFake((url) => {
-            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-            if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-            return Promise.resolve({ body: null })
-          })
-        }
+    const panoptesClientStub = {
+      panoptes: {
+        get: sinon.stub().callsFake((url) => {
+          if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+          if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+          return Promise.resolve({ body: null })
+        })
       }
-    })
+    }
+    setupStores(panoptesClientStub)
 
     fetchFieldGuide()
       .then(() => {
@@ -86,21 +97,21 @@ describe('Model > FieldGuideStore', function () {
   })
 
   describe('Actions > fetchFieldGuide', function () {
+    afterEach(function () {
+      rootStore = null
+    })
+
     it('should request for a field guide linked to the active project', function (done) {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-              if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-              return Promise.resolve({ body: null })
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+            if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            return Promise.resolve({ body: null })
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
 
       fetchFieldGuide()
         .then(() => {
@@ -109,20 +120,16 @@ describe('Model > FieldGuideStore', function () {
     })
 
     it('should not request for media or set the resources if there are not a field guide in the response', function (done) {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [] } })
-              if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-              return Promise.resolve({ body: null })
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [] } })
+            if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            return Promise.resolve({ body: null })
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
 
       const setResourceSpy = sinon.spy(rootStore.fieldGuide, 'setResource')
 
@@ -136,20 +143,17 @@ describe('Model > FieldGuideStore', function () {
     })
 
     it('should request for the media if there is a field guide', function (done) {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-              if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-              return Promise.resolve({ body: null })
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+            if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            return Promise.resolve({ body: null })
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
+
       sinon.stub(rootStore.fieldGuide, 'fetchFieldGuide')
 
       rootStore.projects.setResource(project)
@@ -165,20 +169,16 @@ describe('Model > FieldGuideStore', function () {
     })
 
     it('should call setResource and setActive if there is a field guide', function (done) {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-              if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-              return Promise.resolve({ body: null })
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+            if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            return Promise.resolve({ body: null })
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
 
       const setResourceSpy = sinon.spy(rootStore.fieldGuide, 'setResource')
       const setActiveSpy = sinon.spy(rootStore.fieldGuide, 'setActive')
@@ -194,18 +194,14 @@ describe('Model > FieldGuideStore', function () {
     })
 
     it('should set the loadingState to error if the request errors', function (done) {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake(() => {
-              return Promise.reject(new Error('testing error state'))
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake(() => {
+            return Promise.reject(new Error('testing error state'))
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
 
       fetchFieldGuide()
         .then(() => {
@@ -215,21 +211,21 @@ describe('Model > FieldGuideStore', function () {
   })
 
   describe('Actions > fetchMedia', function () {
+    afterEach(function () {
+      rootStore = null
+    })
+
     it('should not call setMediaResources if there is no media in the response', function (done) {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-              if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-              return Promise.resolve({ body: null })
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+            if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            return Promise.resolve({ body: null })
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
 
       const setMediaResourcesSpy = sinon.spy(rootStore.fieldGuide, 'setMediaResources')
 
@@ -242,20 +238,16 @@ describe('Model > FieldGuideStore', function () {
     })
 
     it('should call setMediaResources if there is media in the response', function (done) {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-              if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
-              return Promise.resolve({ body: null })
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+            if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+            return Promise.resolve({ body: null })
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
 
       const setMediaResourcesSpy = sinon.spy(rootStore.fieldGuide, 'setMediaResources')
 
@@ -269,21 +261,21 @@ describe('Model > FieldGuideStore', function () {
   })
 
   describe('Actions > setModalVisibility', function () {
+    afterEach(function () {
+      rootStore = null
+    })
+
     it('should set the modal visibility', function () {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-              if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
-              return Promise.resolve({ body: null })
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+            if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+            return Promise.resolve({ body: null })
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
 
       rootStore.fieldGuide.setModalVisibility(true)
       expect(rootStore.fieldGuide.showModal).to.be.true()
@@ -294,20 +286,16 @@ describe('Model > FieldGuideStore', function () {
 
   describe('Actions > setActiveItemIndex', function () {
     it('should not set the active item if there is no field guide', function (done) {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [] } })
-              if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-              return Promise.resolve({ body: null })
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [] } })
+            if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            return Promise.resolve({ body: null })
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
 
       fetchFieldGuide().then(() => {
         rootStore.fieldGuide.setActiveItemIndex(0)
@@ -317,20 +305,16 @@ describe('Model > FieldGuideStore', function () {
     })
 
     it('should not set the active item if not called with an item index', function (done) {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-              if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
-              return Promise.resolve({ body: null })
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+            if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+            return Promise.resolve({ body: null })
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
 
       fetchFieldGuide().then(() => {
         rootStore.fieldGuide.setActiveItemIndex()
@@ -340,20 +324,16 @@ describe('Model > FieldGuideStore', function () {
     })
 
     it('should not set the active item if the item does not exist', function (done) {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-              if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
-              return Promise.resolve({ body: null })
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+            if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+            return Promise.resolve({ body: null })
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
 
       fetchFieldGuide().then(() => {
         rootStore.fieldGuide.setActiveItemIndex(2)
@@ -363,20 +343,16 @@ describe('Model > FieldGuideStore', function () {
     })
 
     it('should set the active item', function (done) {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-              if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
-              return Promise.resolve({ body: null })
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+            if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+            return Promise.resolve({ body: null })
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
 
       fetchFieldGuide()
         .then(() => {
@@ -388,20 +364,16 @@ describe('Model > FieldGuideStore', function () {
     })
 
     it('should set the active medium if the item has an icon', function (done) {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-              if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
-              return Promise.resolve({ body: null })
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+            if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+            return Promise.resolve({ body: null })
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
 
       fetchFieldGuide()
         .then(() => {
@@ -411,20 +383,16 @@ describe('Model > FieldGuideStore', function () {
     })
 
     it('should not set the active medium if the item does not have an icon', function (done) {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithoutIcon] } })
-              if (url === `/field_guides/${fieldGuideWithoutIcon.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-              return Promise.resolve({ body: null })
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithoutIcon] } })
+            if (url === `/field_guides/${fieldGuideWithoutIcon.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            return Promise.resolve({ body: null })
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
 
       fetchFieldGuide().then(() => {
         rootStore.fieldGuide.setActiveItemIndex(0)
@@ -435,21 +403,21 @@ describe('Model > FieldGuideStore', function () {
   })
 
   describe('Actions > reset', function () {
+    afterEach(function () {
+      rootStore = null
+    })
+
     it('should reset the store', function (done) {
-      rootStore = RootStore.create({
-        fieldGuide: FieldGuideStore.create(),
-        projects: ProjectStore.create()
-      }, {
-        client: {
-          panoptes: {
-            get: sinon.stub().callsFake((url) => {
-              if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
-              if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
-              return Promise.resolve({ body: null })
-            })
-          }
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuideWithItems] } })
+            if (url === `/field_guides/${fieldGuideWithItems.id}/attached_images`) return Promise.resolve({ body: { media: [medium] } })
+            return Promise.resolve({ body: null })
+          })
         }
-      })
+      }
+      setupStores(panoptesClientStub)
 
       fetchFieldGuide()
         .then(() => {


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
Updates the FieldGuideStore to work with the newer versions of MobX/MST:

- Updates `types.reference` to `types.safeReference`
  - Only `types.safeReference` can be undefined and implicitly uses `types.maybe`
  - Adds `isValidReference` check for the active project reference
  - Updates tests to instantiate stores we are not testing to an empty object. Uses the actual `RootStore` so the `afterAttach` lifecycle fires as expected for the stores we are testing. Note the `FieldGuideStore` is coupled with the `ProjectStore` in its lifecycle, so the `ProjectStore` instantiates as normal so the references work.

`only` is left in purposely so it can be more clearly seen that the tests for the `FieldGuideStore` are now passing.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

