### PR TITLE
[MST Upgrade] Update ResourceStore

### DIFF
--- a/packages/lib-classifier/src/store/ResourceStore.js
+++ b/packages/lib-classifier/src/store/ResourceStore.js
@@ -6,8 +6,8 @@ import Resource from './Resource'
 const ResourceStore = types
   .model('ResourceStore', {
     active: types.safeReference(Resource),
-    headers: types.optional(types.frozen({
-      // etag: types.string // setting this is causing the store to be set with a MST type and thus defined. Maybe a bug?
+    headers: types.optional(types.model({
+      etag: types.maybe(types.string)
     }), {}),
     resources: types.map(Resource),
     loadingState: types.optional(types.enumeration('loadingState', asyncStates.values), asyncStates.initialized),

--- a/packages/lib-classifier/src/store/ResourceStore.js
+++ b/packages/lib-classifier/src/store/ResourceStore.js
@@ -5,10 +5,10 @@ import Resource from './Resource'
 
 const ResourceStore = types
   .model('ResourceStore', {
-    active: types.maybe(types.reference(Resource)),
-    headers: types.maybe(types.frozen({
+    active: types.safeReference(Resource),
+    headers: types.optional(types.frozen({
       // etag: types.string // setting this is causing the store to be set with a MST type and thus defined. Maybe a bug?
-    })),
+    }), {}),
     resources: types.map(Resource),
     loadingState: types.optional(types.enumeration('loadingState', asyncStates.values), asyncStates.initialized),
     type: types.string
@@ -34,7 +34,6 @@ const ResourceStore = types
 
     reset () {
       self.headers = undefined
-      self.active = undefined
       self.resources.clear()
     },
 

--- a/packages/lib-classifier/src/store/ResourceStore.spec.js
+++ b/packages/lib-classifier/src/store/ResourceStore.spec.js
@@ -45,7 +45,7 @@ const clientStub = {
 }
 sinon.spy(clientStub.panoptes, 'get')
 
-describe.only('Model > ResourceStore', function () {
+describe('Model > ResourceStore', function () {
   before(function () {
     resourceStore = ResourceStore.create(resourcesStub)
     RootStub.create({ resources: resourceStore }, { client: clientStub })
@@ -71,7 +71,7 @@ describe.only('Model > ResourceStore', function () {
     resetStore.reset()
     expect(resetStore.resources.size).to.equal(0)
     expect(resetStore.active).to.be.undefined()
-    expect(Object.keys(resourceStore.headers)).to.have.lengthOf(0)
+    expect(resetStore.headers.etag).to.be.undefined()
   })
 
   it('should use an existing resources object when `setActive` is called', async function () {
@@ -88,7 +88,7 @@ describe.only('Model > ResourceStore', function () {
 
   it('should set the headers object when a successful get request is made', async function () {
     resourceStore.reset()
-    expect(Object.keys(resourceStore.headers)).to.have.lengthOf(0)
+    expect(resourceStore.headers.etag).to.be.undefined()
     await resourceStore.setActive('789')
     expect(resourceStore.headers).to.include({ etag: etagStub })
   })

--- a/packages/lib-classifier/src/store/ResourceStore.spec.js
+++ b/packages/lib-classifier/src/store/ResourceStore.spec.js
@@ -45,7 +45,7 @@ const clientStub = {
 }
 sinon.spy(clientStub.panoptes, 'get')
 
-describe('Model > ResourceStore', function () {
+describe.only('Model > ResourceStore', function () {
   before(function () {
     resourceStore = ResourceStore.create(resourcesStub)
     RootStub.create({ resources: resourceStore }, { client: clientStub })
@@ -77,7 +77,7 @@ describe('Model > ResourceStore', function () {
   it('should use an existing resources object when `setActive` is called', async function () {
     await resourceStore.setActive('456')
     expect(resourceStore.active).to.deep.equal(resourcesStub.resources['456'])
-    expect(clientStub.panoptes.get.notCalled).to.be.true()
+    expect(clientStub.panoptes.get).to.have.not.been.called()
   })
 
   it('should fetch a missing resource object when `setActive` is called', async function () {

--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -15,18 +15,18 @@ import UserProjectPreferencesStore from './UserProjectPreferencesStore'
 
 const RootStore = types
   .model('RootStore', {
-    classifications: types.optional(ClassificationStore, ClassificationStore.create()),
-    dataVisAnnotating: types.optional(DataVisAnnotatingStore, DataVisAnnotatingStore.create()),
-    drawing: types.optional(DrawingStore, DrawingStore.create()),
-    feedback: types.optional(FeedbackStore, FeedbackStore.create()),
-    fieldGuide: types.optional(FieldGuideStore, FieldGuideStore.create()),
-    projects: types.optional(ProjectStore, ProjectStore.create()),
-    subjects: types.optional(SubjectStore, SubjectStore.create()),
-    subjectViewer: types.optional(SubjectViewerStore, SubjectViewerStore.create()),
-    tutorials: types.optional(TutorialStore, TutorialStore.create()),
-    workflows: types.optional(WorkflowStore, WorkflowStore.create()),
-    workflowSteps: types.optional(WorkflowStepStore, WorkflowStepStore.create()),
-    userProjectPreferences: types.optional(UserProjectPreferencesStore, UserProjectPreferencesStore.create())
+    classifications: types.optional(ClassificationStore, () => ClassificationStore.create({})),
+    dataVisAnnotating: types.optional(DataVisAnnotatingStore, () => DataVisAnnotatingStore.create({})),
+    drawing: types.optional(DrawingStore, () => DrawingStore.create({})),
+    feedback: types.optional(FeedbackStore, () => FeedbackStore.create({})),
+    fieldGuide: types.optional(FieldGuideStore, () => FieldGuideStore.create({})),
+    projects: types.optional(ProjectStore, () => ProjectStore.create({})),
+    subjects: types.optional(SubjectStore, () => SubjectStore.create({})),
+    subjectViewer: types.optional(SubjectViewerStore, () => SubjectViewerStore.create({})),
+    tutorials: types.optional(TutorialStore, () => TutorialStore.create({})),
+    workflows: types.optional(WorkflowStore, () => WorkflowStore.create({})),
+    workflowSteps: types.optional(WorkflowStepStore, () => WorkflowStepStore.create({})),
+    userProjectPreferences: types.optional(UserProjectPreferencesStore, () => UserProjectPreferencesStore.create({}))
   })
 
   .volatile(self => {

--- a/packages/lib-classifier/src/store/RootStore.spec.js
+++ b/packages/lib-classifier/src/store/RootStore.spec.js
@@ -21,7 +21,7 @@ describe('Model > RootStore', function () {
     'fieldGuide',
     'projects',
     'subjects',
-    'subjectViewer', 
+    'subjectViewer',
     'tutorials',
     'workflows',
     'workflowSteps',

--- a/packages/lib-classifier/src/store/RootStore.spec.js
+++ b/packages/lib-classifier/src/store/RootStore.spec.js
@@ -15,13 +15,17 @@ describe('Model > RootStore', function () {
 
   const stores = [
     'classifications',
+    'dataVisAnnotating',
     'drawing',
+    'feedback',
+    'fieldGuide',
     'projects',
     'subjects',
-    'subjectViewer',
+    'subjectViewer', 
     'tutorials',
     'workflows',
-    'workflowSteps'
+    'workflowSteps',
+    'userProjectPreferences'
   ]
 
   stores.forEach(function (store) {

--- a/packages/lib-classifier/src/store/WorkflowStepStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.spec.js
@@ -15,7 +15,7 @@ const ROOT_STORE = types
   .model('RootStore', {
     classifications: types.frozen({}),
     workflows: types.frozen({}),
-    workflowSteps: types.optional(WorkflowStepStore, WorkflowStepStore.create())
+    workflowSteps: types.optional(WorkflowStepStore, () => WorkflowStepStore.create({}))
   })
 
 describe('Model > WorkflowStepStore', function () {


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
This updates the reference to `safeReference` and fixes the headers to be an optional type with a default. Fixes one broken test, with `only` left in on purpose to show tests are now passing.

Note that setting active to undefined in the reset action is removed. This is because `safeReference` now handles this for us. When the referenced data is removed from the associated map, it'll automatically set the reference to undefined.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

