### PR TITLE
Update start up information in README

### DIFF
--- a/packages/lib-classifier/README.md
+++ b/packages/lib-classifier/README.md
@@ -4,7 +4,7 @@ A standalone library for the Zooniverse project classifier, including state mana
 
 ## Contributing
 
-Use `npm run dev` to run a small development environment app at `localhost:3000`. Specific staging projects and workflows can be loaded by query param `localhost:3000?project=1233&workflow=2367`
+Use `yarn dev` to run a small development environment app at `localhost:8080`. Specific staging projects and workflows can be loaded by query param `localhost:8080?project=1233&workflow=2367`
 
 To add a local dependency, install it with yarn: `yarn add @zooniverse/package-name@X`. Note the `@X` - without a matching version number, yarn will attempt to find it in the npm registry.
 


### PR DESCRIPTION
Updated the local host information as well as updated with yarn information.

Package:

Closes # .

Describe your changes:
Minor updates to the lib-classifier README.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

