### PR TITLE
[MST Upgrade] Update SubjectStore

### DIFF
--- a/packages/lib-classifier/src/store/ResourceStore.js
+++ b/packages/lib-classifier/src/store/ResourceStore.js
@@ -27,6 +27,7 @@ const ResourceStore = types
           self.loadingState = asyncStates.success
           return resource
         } else {
+          self.loadingState = asyncStates.success
           return undefined
         }
       } catch (error) {

--- a/packages/lib-classifier/src/store/ResourceStore.js
+++ b/packages/lib-classifier/src/store/ResourceStore.js
@@ -22,9 +22,13 @@ const ResourceStore = types
       try {
         const response = yield client.get(`/${type}/${id}`)
         self.headers = response.headers
-        const resource = response.body[type][0]
-        self.loadingState = asyncStates.success
-        return resource
+        if (response.body[type] && response.body[type].length > 0) {
+          const resource = response.body[type][0]
+          self.loadingState = asyncStates.success
+          return resource
+        } else {
+          return undefined
+        }
       } catch (error) {
         console.error(error)
         self.loadingState = asyncStates.error

--- a/packages/lib-classifier/src/store/Subject.js
+++ b/packages/lib-classifier/src/store/Subject.js
@@ -1,4 +1,4 @@
-import { getRoot, types } from 'mobx-state-tree'
+import { getRoot, isValidReference, types } from 'mobx-state-tree'
 import Resource from './Resource'
 import createLocationCounts from '../helpers/createLocationCounts'
 import subjectViewers from '../helpers/subjectViewers'
@@ -8,12 +8,12 @@ const Subject = types
     already_seen: types.optional(types.boolean, false),
     favorite: types.optional(types.boolean, false),
     finished_workflow: types.optional(types.boolean, false),
-    locations: types.frozen(),
-    metadata: types.frozen(),
+    locations: types.frozen([]),
+    metadata: types.frozen({}),
     retired: types.optional(types.boolean, false),
     selected_at: types.maybe(types.string),
     selection_state: types.maybe(types.string),
-    shouldDiscuss: types.frozen(),
+    shouldDiscuss: types.maybe(types.frozen()),
     user_has_finished_workflow: types.optional(types.boolean, false)
   })
 
@@ -45,26 +45,33 @@ const Subject = types
 
   .views(self => ({
     get talkURL () {
-      const projectSlug = getRoot(self).projects.active.slug
-      const { origin } = window.location
-      return `${origin}/projects/${projectSlug}/talk/subjects/${self.id}`
+      const validProjectReference = isValidReference(() => getRoot(self).projects.active)
+      if (validProjectReference) {
+        const projectSlug = getRoot(self).projects.active.slug
+        const { origin } = window.location
+        return `${origin}/projects/${projectSlug}/talk/subjects/${self.id}`
+      }
+
+      return ''
     },
 
     get viewer () {
-      const counts = createLocationCounts(self)
-
-      const workflow = getRoot(self).workflows.active
-      const configuration = (workflow && workflow.configuration) || {}
       let viewer = null
+      const counts = createLocationCounts(self)
+      const validWorkflowReference = isValidReference(() => getRoot(self).workflows.active)
+      if (validWorkflowReference) {
+        const workflow = getRoot(self).workflows.active
+        const configuration = workflow.configuration
 
-      // If the Workflow configuration specifies a subject viewer, use that.
-      // Otherwise, take a guess using the Subject.
+        // If the Workflow configuration specifies a subject viewer, use that.
+        // Otherwise, take a guess using the Subject.
 
-      if (configuration.subject_viewer === 'lightcurve') {
-        viewer = subjectViewers.lightCurve
-      } else if (counts.total === 1) {
-        if (counts.images) {
-          viewer = subjectViewers.singleImage
+        if (configuration.subject_viewer === 'lightcurve') {
+          viewer = subjectViewers.lightCurve
+        } else if (counts.total === 1) {
+          if (counts.images) {
+            viewer = subjectViewers.singleImage
+          }
         }
       }
 

--- a/packages/lib-classifier/src/store/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject.spec.js
@@ -60,11 +60,11 @@ describe.only('Model > Subject', function () {
 
     it('should reutrn the light curve viewer if the workflow configuration is defined', function () {
       const dataSubject = SubjectFactory.build({ location: [{ 'application/json': 'https://foo.bar/data.json' }]})
-      const subjectStore = Subject.create(dataSubject)
-      subjectStore.workflows = WorkflowStore.create({})
-      subjectStore.workflows.setResource(workflowWithConfig)
-      subjectStore.workflows.setActive(workflowWithConfig.id)
-      expect(subjectStore.viewer).to.equal(subjectViewers.lightCurve)
+      const subjectResourceStore = Subject.create(dataSubject)
+      subjectResourceStore.workflows = WorkflowStore.create({})
+      subjectResourceStore.workflows.setResource(workflowWithConfig)
+      subjectResourceStore.workflows.setActive(workflowWithConfig.id)
+      expect(subjectResourceStore.viewer).to.equal(subjectViewers.lightCurve)
     })
   })
 

--- a/packages/lib-classifier/src/store/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject.spec.js
@@ -58,7 +58,7 @@ describe.only('Model > Subject', function () {
       expect(subjectStore.viewer).to.equal(subjectViewers.singleImage)
     })
 
-    it('should reutrn the light curve viewer if the workflow configuration is defined', function () {
+    it('should return the light curve viewer if the workflow configuration is defined', function () {
       const dataSubject = SubjectFactory.build({ location: [{ 'application/json': 'https://foo.bar/data.json' }]})
       const subjectResourceStore = Subject.create(dataSubject)
       subjectResourceStore.workflows = WorkflowStore.create({})

--- a/packages/lib-classifier/src/store/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject.spec.js
@@ -91,4 +91,35 @@ describe.only('Model > Subject', function () {
       expect(subject.onAddToCollection.withArgs(subject.id)).to.have.been.calledOnce()
     })
   })
+
+  describe('Actions > openInTalk', function () {
+    let url
+
+    before (function () {
+      url = `https://example.org/projects/${project.slug}/talk/subjects/${subject.id}`
+    })
+
+    function testOpenInTalk (newTab) {
+      const subject = Subject.create(stub)
+      subject.projects = ProjectStore.create({})
+      subject.projects.setResource(project)
+      subject.projects.setActive(project.id)
+      subject.openInTalk(newTab)
+      expect(subject.shouldDiscuss).to.eql({ newTab, url })
+    }
+
+    describe('in the same tab', function () {
+      
+      it('should set the shouldDiscuss property', function () {
+        testOpenInTalk(false)
+      })
+    })
+
+    describe('in a new tab', function () {
+
+      it('should set the shouldDiscuss property', function () {
+        testOpenInTalk(true)
+      })
+    })
+  })
 })

--- a/packages/lib-classifier/src/store/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject.spec.js
@@ -1,20 +1,23 @@
 import sinon from 'sinon'
 import Subject from './Subject'
-import { ProjectFactory, SubjectFactory } from '../../test/factories'
+import ProjectStore from './ProjectStore'
+import WorkflowStore from './WorkflowStore'
+import { ProjectFactory, SubjectFactory, WorkflowFactory } from '../../test/factories'
+import subjectViewers from '../helpers/subjectViewers'
 
 const stub = SubjectFactory.build()
-const project = ProjectFactory.build()
+const workflow = WorkflowFactory.build()
+const workflowWithConfig = WorkflowFactory.build({ configuration: { subject_viewer: 'lightcurve' } })
+const project = ProjectFactory.build({}, { activeWorkflowId: workflow.id })
 
-describe('Model > Subject', function () {
+describe.only('Model > Subject', function () {
   let subject
 
   before(function () {
     subject = Subject.create(stub)
     subject.onToggleFavourite = sinon.stub()
     subject.onAddToCollection = sinon.stub()
-    subject.projects = {
-      active: project
-    }
+
   })
 
   it('should exist', function () {
@@ -26,11 +29,46 @@ describe('Model > Subject', function () {
     expect(subject.locations).to.deep.equal(stub.locations)
   })
 
-  it('should have a Talk URL', function () {
-    expect(subject.talkURL).to.equal(`https://example.org/projects/zooniverse/example/talk/subjects/${subject.id}`)
+  describe('Views > talkURL', function () {
+    before(function() {
+      subject.projects = ProjectStore.create({})
+      subject.projects.setResource(project)
+      subject.projects.setActive(project.id)
+    })
+
+    it('should have a Talk URL', function () {
+      expect(subject.talkURL).to.equal(`https://example.org/projects/${project.slug}/talk/subjects/${subject.id}`)
+    })
   })
 
-  describe('toggleFavorite', function () {
+  describe('Views > viewer', function () {
+    it('should return null as default', function () {
+      subject.workflows = WorkflowStore.create({})
+      subject.workflows.setResource(workflow)
+      subject.workflows.setActive(workflow.id)
+      expect(subject.viewer).to.be.null()
+    })
+
+    it('should return the single image viewer for subjects with a single image location', function () {
+      const singleImageSubject = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+      const subjectStore = Subject.create(singleImageSubject)
+      subjectStore.workflows = WorkflowStore.create({})
+      subjectStore.workflows.setResource(workflow)
+      subjectStore.workflows.setActive(workflow.id)
+      expect(subjectStore.viewer).to.equal(subjectViewers.singleImage)
+    })
+
+    it('should reutrn the light curve viewer if the workflow configuration is defined', function () {
+      const dataSubject = SubjectFactory.build({ location: [{ 'application/json': 'https://foo.bar/data.json' }]})
+      const subjectStore = Subject.create(dataSubject)
+      subjectStore.workflows = WorkflowStore.create({})
+      subjectStore.workflows.setResource(workflowWithConfig)
+      subjectStore.workflows.setActive(workflowWithConfig.id)
+      expect(subjectStore.viewer).to.equal(subjectViewers.lightCurve)
+    })
+  })
+
+  describe('Actions > toggleFavorite', function () {
     before(function () {
       subject.toggleFavorite()
     })
@@ -40,60 +78,17 @@ describe('Model > Subject', function () {
     })
 
     it('should call the onToggleFavourite callback', function () {
-      expect(subject.onToggleFavourite).to.have.been.calledOnceWith(subject.id, subject.favorite)
+      expect(subject.onToggleFavourite.withArgs(subject.id, subject.favorite)).to.have.been.calledOnce()
     })
   })
 
-  describe('addToCollection', function () {
+  describe('Actions > addToCollection', function () {
     before(function () {
       subject.addToCollection()
     })
 
     it('should call the onAddToCollection callback', function () {
-      expect(subject.onAddToCollection).to.have.been.calledOnceWith(subject.id)
-    })
-  })
-
-  describe('openInTalk', function () {
-    let feedback
-    let onHide = () => null
-
-    before(function () {
-      feedback = {
-        onHide,
-        setOnHide: sinon.stub().callsFake(callback => { onHide = callback })
-      }
-      subject.feedback = feedback
-    })
-
-    describe('in the same tab', function () {
-      before(function () {
-        subject.openInTalk(false)
-      })
-
-      after(function () {
-        feedback.setOnHide.resetHistory()
-        window.location.assign.resetHistory()
-      })
-    })
-
-    describe('in a new tab', function () {
-      let newTab = {
-        opener: null,
-        location: null,
-        target: null,
-        focus: sinon.stub()
-      }
-
-      before(function () {
-        window.open = sinon.stub().callsFake(() => newTab)
-        subject.openInTalk(true)
-      })
-
-      after(function () {
-        feedback.setOnHide.resetHistory()
-        window.location.assign.resetHistory()
-      })
+      expect(subject.onAddToCollection.withArgs(subject.id)).to.have.been.calledOnce()
     })
   })
 })

--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -1,6 +1,6 @@
 import asyncStates from '@zooniverse/async-states'
 import { autorun } from 'mobx'
-import { addDisposer, addMiddleware, flow, getRoot, onPatch, types } from 'mobx-state-tree'
+import { addDisposer, addMiddleware, flow, getRoot, isValidReference, onPatch, types } from 'mobx-state-tree'
 import { getBearerToken } from './utils'
 import { filterByLabel, filters } from '../components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal'
 import ResourceStore from './ResourceStore'
@@ -20,14 +20,15 @@ function openTalkPage (talkURL, newTab = false) {
 
 const SubjectStore = types
   .model('SubjectStore', {
-    active: types.maybe(types.reference(Subject)),
-    resources: types.optional(types.map(Subject), {}),
+    active: types.safeReference(Subject),
+    resources: types.map(Subject),
     type: types.optional(types.string, 'subjects')
   })
 
   .views(self => ({
     get isThereMetadata () {
-      if (self.active) {
+      const validSubjectReference = isValidReference(() => self.active)
+      if (validSubjectReference) {
         const filteredMetadata = Object.keys(self.active.metadata)
           .filter((label) => filterByLabel(label, filters))
         return filteredMetadata.length > 0
@@ -39,35 +40,36 @@ const SubjectStore = types
 
   .actions(self => {
     function advance () {
-      if (self.active) {
+      const validSubjectReference = isValidReference(() => self.active)
+      if (validSubjectReference) {
         const idToRemove = self.active.id
         self.resources.delete(idToRemove)
-        self.active = undefined
       }
+
+      const nextSubject = self.resources.values().next().value
+      self.active = nextSubject && nextSubject.id
 
       if (self.resources.size < 3) {
         console.log('Fetching more subjects')
         self.populateQueue()
       }
-
-      const nextSubject = self.resources.values().next().value
-      self.active = nextSubject && nextSubject.id
     }
 
     function afterAttach () {
       createWorkflowObserver()
       createClassificationObserver()
       createSubjectMiddleware()
+      createQueueLoadObserver()
     }
 
     function createWorkflowObserver () {
       const workflowDisposer = autorun(() => {
-        const root = getRoot(self)
-        if (root.workflows && root.workflows.active) {
+        const validWorkflowReference = isValidReference(() => getRoot(self).workflows.active)
+        if (validWorkflowReference) {
           self.reset()
           self.populateQueue()
         }
-      })
+      }, { name: 'SubjectStore Workflow Observer autorun' })
       addDisposer(self, workflowDisposer)
     }
 
@@ -77,19 +79,25 @@ const SubjectStore = types
           const { path, value } = patch
           if (path === '/classifications/loadingState' && value === 'posting') self.advance()
         })
-      })
+      }, { name: 'SubjectStore Classification Observer autorun' })
       addDisposer(self, classificationDisposer)
     }
 
     function onSubjectAdvance (call, next, abort) {
       const root = getRoot(self)
-      const subject = self.active
-      const shouldShowFeedback = root.feedback.isActive && root.feedback.messages.length && !root.feedback.showModal
-      if (!shouldShowFeedback && subject && subject.shouldDiscuss) {
-        const { url, newTab } = subject.shouldDiscuss
-        openTalkPage(url, newTab)
+      const validSubjectReference = isValidReference(() => self.active)
+      if (validSubjectReference) {
+        const subject = self.active
+        const shouldShowFeedback = root.feedback.isActive && root.feedback.messages.length && !root.feedback.showModal
+        if (!shouldShowFeedback && subject && subject.shouldDiscuss) {
+          const { url, newTab } = subject.shouldDiscuss
+          openTalkPage(url, newTab)
+        } else {
+          next(call)
+        }
+      } else {
+        next(call)
       }
-      next(call)
     }
 
     function createSubjectMiddleware () {
@@ -101,51 +109,63 @@ const SubjectStore = types
             next(call)
           }
         })
-      })
+      }, { name: 'SubjectStore Middleware autorun' })
       addDisposer(self, subjectMiddleware)
+    }
+
+    function createQueueLoadObserver() {
+      const selfDisposer = autorun(() => {
+        onPatch(getRoot(self), (patch) => {
+          const { path, value } = patch
+          const validSubjectReference = isValidReference(() => self.active)
+          if (path === '/subjects/loadingState' &&
+            value === 'success' &&
+            self.resources.size > 0 &&
+            !validSubjectReference
+          ) {
+            self.advance()
+          }
+        })
+      }, { name: 'SubjectStore queue Observer autorun' })
+      addDisposer(self, selfDisposer)
     }
 
     function * populateQueue () {
       const root = getRoot(self)
       const client = root.client.panoptes
-      const workflowId = root.workflows.active.id
-      self.loadingState = asyncStates.loading
+      const validWorkflowReference = isValidReference(() => root.workflows.active)
+      if (validWorkflowReference) {
+        const workflowId = root.workflows.active.id
+        self.loadingState = asyncStates.loading
 
-      try {
-        const { authClient } = getRoot(self)
-        const authorization = yield getBearerToken(authClient)
-        const response = yield client.get(`/subjects/queued`, { workflow_id: workflowId }, { authorization })
+        try {
+          const { authClient } = getRoot(self)
+          const authorization = yield getBearerToken(authClient)
+          const response = yield client.get(`/subjects/queued`, { workflow_id: workflowId }, { authorization })
 
-        if (response.body.subjects && response.body.subjects.length > 0) {
-          response.body.subjects.forEach(subject => {
-            self.resources.put(subject)
-          })
-
-          if (!self.active) {
-            self.advance()
+          if (response.body.subjects && response.body.subjects.length > 0) {
+            response.body.subjects.forEach(subject => {
+              self.resources.put(subject)
+            })
           }
-        }
 
-        self.loadingState = asyncStates.success
-      } catch (error) {
-        console.error(error)
-        self.loadingState = asyncStates.error
+          self.loadingState = asyncStates.success
+        } catch (error) {
+          console.error(error)
+          self.loadingState = asyncStates.error
+        }
       }
     }
 
     function reset () {
-      self.active = undefined
       self.resources.clear()
     }
 
-    // We set ResourceStore methods we don't want to expose as `undefined`
     return {
       advance,
       afterAttach,
-      fetchResource: undefined,
       populateQueue: flow(populateQueue),
-      reset,
-      setActive: undefined
+      reset
     }
   })
 

--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -92,9 +92,8 @@ const SubjectStore = types
         if (!shouldShowFeedback && subject && subject.shouldDiscuss) {
           const { url, newTab } = subject.shouldDiscuss
           openTalkPage(url, newTab)
-        } else {
-          next(call)
         }
+        next(call)
       } else {
         next(call)
       }

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -57,13 +57,9 @@ describe.only('Model > SubjectStore', function () {
       })
 
       beforeEach(function () {
-        rootStore.subjects.populateQueue.resetHistory()
         while (rootStore.subjects.resources.size > 2) {
           rootStore.subjects.advance()
         }
-      })
-
-      afterEach(function () {
       })
 
       after(function () {
@@ -71,13 +67,34 @@ describe.only('Model > SubjectStore', function () {
       })
 
       it('should request more subjects', function () {
-        expect(rootStore.subjects.populateQueue).to.have.been.calledOnce()
+        // Once for initialization and once after the queue has been advanced to less than 3 subjects
+        expect(rootStore.subjects.populateQueue).to.have.been.calledTwice()
       })
 
-      it('should request more subjects when the initial queue response only has less than 3 subjects', function () {
-        const clientStub = stubPanoptesJs({ workflows: workflow, subjects: shortListSubjects })
-        rootStore = setupStores(clientStub)
-        expect(rootStore.subjects.populateQueue).to.have.been.calledOnce()
+      describe('when the initial response has less than three subjects', function () {
+        let rootStore
+        before(function () {
+          const clientStub = stubPanoptesJs({ workflows: workflow, subjects: shortListSubjects })
+          rootStore = setupStores(clientStub)
+        })
+
+        it('should request more subjects', function () {
+          // Once for initialization and again since less than three subjects in initial response
+          expect(rootStore.subjects.populateQueue).to.have.been.calledTwice()
+        })
+      })
+
+      describe('when the initial response has no subjects', function () {
+        let rootStore
+        before(function () {
+          const clientStub = stubPanoptesJs({ workflows: workflow, subjects: [] })
+          rootStore = setupStores(clientStub)
+        })
+
+        it('should request more subjects', function () {
+          // Once for initialization
+          expect(rootStore.subjects.populateQueue).to.have.been.calledOnce()
+        })
       })
     })
 

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -92,6 +92,11 @@ describe.only('Model > SubjectStore', function () {
           // Once for initialization
           expect(rootStore.subjects.populateQueue).to.have.been.calledOnce()
         })
+
+        it('should not advance the queue', function () {
+          expect(rootStore.subjects.resources.size).to.equal(0)
+          expect(rootStore.subjects.active).to.be.undefined()
+        })
       })
     })
 

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -56,17 +56,14 @@ describe.only('Model > SubjectStore', function () {
         rootStore = setupStores()
       })
 
-      beforeEach(function () {
-        while (rootStore.subjects.resources.size > 2) {
-          rootStore.subjects.advance()
-        }
-      })
-
       after(function () {
         rootStore.subjects.populateQueue.restore()
       })
 
       it('should request more subjects', function () {
+        while (rootStore.subjects.resources.size > 2) {
+          rootStore.subjects.advance()
+        }
         // Once for initialization and once after the queue has been advanced to less than 3 subjects
         expect(rootStore.subjects.populateQueue).to.have.been.calledTwice()
       })
@@ -101,7 +98,7 @@ describe.only('Model > SubjectStore', function () {
     describe('after emptying the queue', function () {
       let rootStore
       before(function () {
-        const clientStub = stubPanoptesJs({ workflows: workflow, subjects: [] })
+        const clientStub = stubPanoptesJs({ workflows: workflow, subjects })
         rootStore = setupStores(clientStub)
       })
 

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -34,14 +34,16 @@ describe.only('Model > SubjectStore', function () {
     return store
   }
   describe('Actions > advance', function () {
-    it('should make the next subject in the queue active when calling `advance()`', function (done) {
-      const rootStore = setupStores()
-      rootStore.subjects.populateQueue().then(() => {
-        expect(rootStore.subjects.active.id).to.equal(rootStore.subjects.resources.values().next().value.id)
-        rootStore.subjects.advance()
-        expect(rootStore.subjects.active.id).to.equal(rootStore.subjects.resources.values().next().value.id)
-        expect(rootStore.subjects.resources.get('1')).to.be.undefined()
-      }).then(done, done)
+    let rootStore
+    before(function () {
+      rootStore = setupStores()
+    })
+
+    it('should make the next subject in the queue active when calling `advance()`', function () {
+      expect(rootStore.subjects.active.id).to.equal(rootStore.subjects.resources.values().next().value.id)
+      rootStore.subjects.advance()
+      expect(rootStore.subjects.active.id).to.equal(rootStore.subjects.resources.values().next().value.id)
+      expect(rootStore.subjects.resources.get('1')).to.be.undefined()
     })
 
     describe('with less than three subjects in the queue', function () {
@@ -51,17 +53,20 @@ describe.only('Model > SubjectStore', function () {
       before(function () {
         rootStore = setupStores()
         populateSpy = sinon.spy(rootStore.subjects, 'populateQueue')
+
+      })
+
+      beforeEach(function () {
+        while (rootStore.subjects.resources.size > 2) {
+          rootStore.subjects.advance()
+        }
       })
 
       after(function () {
         rootStore.subjects.populateQueue.restore()
-        rootStore = null
       })
 
       it('should request more subjects', function () {
-        while (rootStore.subjects.resources.size > 2) {
-          rootStore.subjects.advance()
-        }
         expect(populateSpy).to.have.been.calledOnce()
       })
     })
@@ -69,19 +74,17 @@ describe.only('Model > SubjectStore', function () {
     describe('after emptying the queue', function () {
       let rootStore
       before(function () {
-        sinon.stub(clientStub.panoptes, 'get').callsFake(() => Promise.resolve({ body: [] }))
-        rootStore = setupStores()
+        const clientStub = stubPanoptesJs({ workflows: workflow, subjects: [] })
+        rootStore = setupStores(clientStub)
       })
 
-      after(function () {
-        clientStub.panoptes.get.restore()
-        rootStore = null
-      })
-
-      it('should leave the active subject empty', function () {
+      beforeEach(function () {
         while (rootStore.subjects.resources.size > 0) {
           rootStore.subjects.advance()
         }
+      })
+
+      it('should leave the active subject empty', function () {
         expect(rootStore.subjects.resources.size).to.equal(0)
         expect(rootStore.subjects.active).to.be.undefined()
       })
@@ -89,22 +92,17 @@ describe.only('Model > SubjectStore', function () {
   })
 
   describe('Views > isThereMetadata', function () {
-    let rootStore
-    afterEach(function () {
-      rootStore = null
-    })
-
     it('should return false when there is not an active queue subject', function (done) {
       const getStub = stubPanoptesJs({ subjects: [] })
 
-      rootStore = setupStores(getStub)
+      const rootStore = setupStores(getStub)
       rootStore.subjects.populateQueue().then(() => {
         expect(rootStore.subjects.isThereMetadata).to.be.false()
       }).then(done, done)
     })
 
     it('should return false if the active subject does not have metadata', function (done) {
-      rootStore = setupStores()
+      const rootStore = setupStores()
       rootStore.subjects.populateQueue().then(() => {
         expect(Object.keys(rootStore.subjects.active.metadata)).to.have.lengthOf(0)
         expect(rootStore.subjects.isThereMetadata).to.be.false()
@@ -115,7 +113,7 @@ describe.only('Model > SubjectStore', function () {
       const subjectWithHiddenMetadata = SubjectFactory.build({ metadata: { '#foo': 'bar' } })
       const getStub = stubPanoptesJs({ subjects: subjectWithHiddenMetadata })
 
-      rootStore = setupStores(getStub)
+      const rootStore = setupStores(getStub)
       rootStore.subjects.populateQueue().then(() => {
         const metadataKeys = Object.keys(rootStore.subjects.active.metadata)
         expect(metadataKeys).to.have.lengthOf(1)
@@ -128,7 +126,7 @@ describe.only('Model > SubjectStore', function () {
       const subjectWithMetadata = SubjectFactory.build({ metadata: { foo: 'bar' } })
       const getStub = stubPanoptesJs({ subjects: subjectWithMetadata })
 
-      rootStore = setupStores(getStub)
+      const rootStore = setupStores(getStub)
       rootStore.subjects.populateQueue().then(() => {
         expect(Object.keys(rootStore.subjects.active.metadata)).to.have.lengthOf(1)
         expect(rootStore.subjects.isThereMetadata).to.be.true()

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -1,46 +1,41 @@
 import sinon from 'sinon'
-import ProjectStore from './ProjectStore'
 import RootStore from './RootStore'
-import SubjectStore, { openTalkPage } from './SubjectStore'
-import WorkflowStore from './WorkflowStore'
+import { openTalkPage } from './SubjectStore'
 import { ProjectFactory, SubjectFactory, WorkflowFactory } from '../../test/factories'
 import { Factory } from 'rosie'
-
-let rootStore
+import stubPanoptesJs from '../../test/stubPanoptesJs'
 
 const project = ProjectFactory.build()
 const workflow = WorkflowFactory.build({ id: project.configuration.default_workflow })
 const subjects = Factory.buildList('subject', 10)
 
-const clientStub = {
-  panoptes: {
-    get () {
-      return Promise.resolve({
-        body: {
-          subjects
-        }
-      })
-    }
-  }
-}
+const clientStub = stubPanoptesJs({ subjects, workflows: workflow })
 
-describe('Model > SubjectStore', function () {
-  function setupStores (rootStore) {
-    sinon.stub(rootStore.classifications, 'createClassification')
-    rootStore.projects.setResource(project)
-    rootStore.workflows.setResource(workflow)
-    rootStore.workflows.setActive(workflow.id)
+describe.only('Model > SubjectStore', function () {
+  function setupStores(panoptesClientStub = clientStub) {
+    const store = RootStore.create({
+      classifications: {},
+      dataVisAnnotating: {},
+      drawing: {},
+      feedback: {},
+      fieldGuide: {},
+      subjectViewer: {},
+      tutorials: {},
+      workflowSteps: {},
+      userProjectPreferences: {}
+    }, {
+        client: panoptesClientStub,
+        authClient: { checkBearerToken: () => Promise.resolve(), checkCurrent: () => Promise.resolve() }
+      })
+    store.projects.setResource(project)
+    store.projects.setActive(project.id)
+    store.workflows.setResource(workflow)
+    store.workflows.setActive(workflow.id)
+    return store
   }
   describe('Actions > advance', function () {
-    before(function () {
-      rootStore = RootStore.create(
-        { projects: ProjectStore.create(), subjects: SubjectStore.create(), workflows: WorkflowStore.create() },
-        { client: clientStub }
-      )
-    })
-
     it('should make the next subject in the queue active when calling `advance()`', function (done) {
-      setupStores(rootStore)
+      const rootStore = setupStores()
       rootStore.subjects.populateQueue().then(() => {
         expect(rootStore.subjects.active.id).to.equal(rootStore.subjects.resources.values().next().value.id)
         rootStore.subjects.advance()
@@ -51,97 +46,78 @@ describe('Model > SubjectStore', function () {
 
     describe('with less than three subjects in the queue', function () {
       let populateSpy
+      let rootStore
 
       before(function () {
+        rootStore = setupStores()
         populateSpy = sinon.spy(rootStore.subjects, 'populateQueue')
-        while (rootStore.subjects.resources.size > 2) {
-          rootStore.subjects.advance()
-        }
       })
 
       after(function () {
         rootStore.subjects.populateQueue.restore()
+        rootStore = null
       })
 
       it('should request more subjects', function () {
+        while (rootStore.subjects.resources.size > 2) {
+          rootStore.subjects.advance()
+        }
         expect(populateSpy).to.have.been.calledOnce()
       })
     })
 
     describe('after emptying the queue', function () {
+      let rootStore
       before(function () {
         sinon.stub(clientStub.panoptes, 'get').callsFake(() => Promise.resolve({ body: [] }))
-        while (rootStore.subjects.resources.size > 0) {
-          rootStore.subjects.advance()
-        }
+        rootStore = setupStores()
       })
 
       after(function () {
         clientStub.panoptes.get.restore()
+        rootStore = null
       })
 
       it('should leave the active subject empty', function () {
+        while (rootStore.subjects.resources.size > 0) {
+          rootStore.subjects.advance()
+        }
         expect(rootStore.subjects.resources.size).to.equal(0)
         expect(rootStore.subjects.active).to.be.undefined()
       })
     })
   })
 
-  describe('Views > isThereMetadata', function (done) {
-    it('should return false when there is not an active queue subject', function () {
-      rootStore = RootStore.create(
-        { projects: ProjectStore.create(), subjects: SubjectStore.create(), workflows: WorkflowStore.create() },
-        { client: {
-          panoptes: {
-            get: () => {
-              return Promise.resolve({
-                body: { subjects: [] }
-              })
-            }
-          }
-        }
-        }
-      )
+  describe('Views > isThereMetadata', function () {
+    let rootStore
+    afterEach(function () {
+      rootStore = null
+    })
 
-      setupStores(rootStore)
+    it('should return false when there is not an active queue subject', function (done) {
+      const getStub = stubPanoptesJs({ subjects: [] })
+
+      rootStore = setupStores(getStub)
       rootStore.subjects.populateQueue().then(() => {
         expect(rootStore.subjects.isThereMetadata).to.be.false()
       }).then(done, done)
     })
 
     it('should return false if the active subject does not have metadata', function (done) {
-      rootStore = RootStore.create(
-        { projects: ProjectStore.create(), subjects: SubjectStore.create(), workflows: WorkflowStore.create() },
-        { client: clientStub }
-      )
-
-      setupStores(rootStore)
+      rootStore = setupStores()
       rootStore.subjects.populateQueue().then(() => {
-        expect(Object.keys(rootStore.subjects.active.toJSON().metadata)).to.have.lengthOf(0)
+        expect(Object.keys(rootStore.subjects.active.metadata)).to.have.lengthOf(0)
         expect(rootStore.subjects.isThereMetadata).to.be.false()
       }).then(done, done)
     })
 
     it('should return false if the active subject only has hidden metadata', function (done) {
       const subjectWithHiddenMetadata = SubjectFactory.build({ metadata: { '#foo': 'bar' } })
-      rootStore = RootStore.create(
-        { projects: ProjectStore.create(), subjects: SubjectStore.create(), workflows: WorkflowStore.create() },
-        {
-          client: {
-            panoptes: {
-              get: () => {
-                return Promise.resolve({
-                  body: { subjects: [subjectWithHiddenMetadata] }
-                })
-              }
-            }
-          }
-        }
-      )
+      const getStub = stubPanoptesJs({ subjects: subjectWithHiddenMetadata })
 
-      setupStores(rootStore)
+      rootStore = setupStores(getStub)
       rootStore.subjects.populateQueue().then(() => {
-        const metadataKeys = Object.keys(rootStore.subjects.active.toJSON().metadata)
+        const metadataKeys = Object.keys(rootStore.subjects.active.metadata)
         expect(metadataKeys).to.have.lengthOf(1)
         expect(metadataKeys[0]).to.equal('#foo')
         expect(rootStore.subjects.isThereMetadata).to.be.false()
@@ -150,24 +126,11 @@ describe('Model > SubjectStore', function () {
 
     it('should return true if the active subject has metadata', function (done) {
       const subjectWithMetadata = SubjectFactory.build({ metadata: { foo: 'bar' } })
-      rootStore = RootStore.create(
-        { projects: ProjectStore.create(), subjects: SubjectStore.create(), workflows: WorkflowStore.create() },
-        {
-          client: {
-            panoptes: {
-              get: () => {
-                return Promise.resolve({
-                  body: { subjects: [subjectWithMetadata] }
-                })
-              }
-            }
-          }
-        }
-      )
+      const getStub = stubPanoptesJs({ subjects: subjectWithMetadata })
 
-      setupStores(rootStore)
+      rootStore = setupStores(getStub)
       rootStore.subjects.populateQueue().then(() => {
-        expect(Object.keys(rootStore.subjects.active.toJSON().metadata)).to.have.lengthOf(1)
+        expect(Object.keys(rootStore.subjects.active.metadata)).to.have.lengthOf(1)
         expect(rootStore.subjects.isThereMetadata).to.be.true()
       }).then(done, done)
     })

--- a/packages/lib-classifier/test/factories/SubjectFactory.js
+++ b/packages/lib-classifier/test/factories/SubjectFactory.js
@@ -1,5 +1,6 @@
 import { Factory } from 'rosie'
 
+// TODO: Make the factory configurable for number of locations
 const subject = Factory.define('subject')
   .sequence('id', (id) => { return id.toString() })
   .attr('already_seen', false)

--- a/packages/lib-classifier/test/stubPanoptesJs/stubPanoptesJs.js
+++ b/packages/lib-classifier/test/stubPanoptesJs/stubPanoptesJs.js
@@ -3,7 +3,8 @@ function createResponse (url, factories) {
   // Assuming url is in the format '/resource_type/resource_id'
   const endpoint = url.split('/')[1]
   const response = {}
-  response[endpoint] = [factories[endpoint]]
+  const resources = (Array.isArray(factories[endpoint])) ? factories[endpoint] : [factories[endpoint]]
+  response[endpoint] = resources
   return Promise.resolve({ body: response })
 }
 


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
This updates the SubjectStore and SubjectResource model as well as fix a few bugs:

For `ResourceStore`:
- Added check to make sure the response body has length before storing it

For `SubjectResource`:
- Added `isValidReference` existential checks for project and workflows
- Updated test and added tests for the viewer view getter
- ~Removed cruft describe blocks~

For `SubjectStore`:
- `types.reference` is now `types.safeReference`
- Removed unnecessary `types.optional` around the `types.map`
- Added `isValidReference` for the existential checks for the store's `active` property that is a reference
- Removed the actions set to `undefined` in the returned object for the actions. MST will just simply throw an undefined type error, so don't do this.
- A refactor to deal with bugs with the subject advance middleware, an explanation:

The original middleware:
```
    function onSubjectAdvance (call, next, abort) {
      const root = getRoot(self)
      const subject = self.active
      const shouldShowFeedback = root.feedback.isActive && root.feedback.messages.length && !root.feedback.showModal
      if (!shouldShowFeedback && subject && subject.shouldDiscuss) {
        const { url, newTab } = subject.shouldDiscuss
        openTalkPage(url, newTab)
      }
      next(call)
    }
```

now should have an existential check of the active reference otherwise MST will error on the first time this is called, so changed to:

```
    function onSubjectAdvance (call, next, abort) {
      const root = getRoot(self)
      const validSubjectReference = isValidReference(() => self.active)
      if (validSubjectReference) {
        const subject = self.active
        const shouldShowFeedback = root.feedback.isActive && root.feedback.messages.length && !root.feedback.showModal
        if (!shouldShowFeedback && subject && subject.shouldDiscuss) {
          const { url, newTab } = subject.shouldDiscuss
          openTalkPage(url, newTab)
        }
        next(call)
      }
    }
```

But, when `advance` is first called on the initial queue load and thus this middleware, there isn't a valid active reference yet by this point because the middleware intercepts before we let the `advance` action remove and set the new active subject. We have to intercept it first because we want to potentially browse to talk before the next subject is made active. Because there isn't an active reference yet, neither `next` or `abort` is called and MST will error.

So, to resolve this, you could add:

```
    function onSubjectAdvance (call, next, abort) {
      const root = getRoot(self)
      const validSubjectReference = isValidReference(() => self.active)
      if (validSubjectReference) {
        const subject = self.active
        const shouldShowFeedback = root.feedback.isActive && root.feedback.messages.length && !root.feedback.showModal
        if (!shouldShowFeedback && subject && subject.shouldDiscuss) {
          const { url, newTab } = subject.shouldDiscuss
          openTalkPage(url, newTab)
        }
        next(call)
      } else {
        next(call)
      }
    }
```

But in test, this caused an infinite loop: `populateQueue` called `advance` when there was no active reference, then interrupted by middleware, which calls `advance` when there is no active reference, which calls `populateQueue` when there's less than 3 subjects because this is called before the active reference is set, then `populateQueue` calls `advance`, etc.

To resolve this, I decided to remove the direct call to advance the queue from the `populateQueue` call and instead added an observer for the queue itself. The queue will only be called to be advanced if we have successfully populated the queue, we have a queue, and there is no active reference.

We might want to also consider removing the call to `populateQueue` from `advance` and instead have the subject store observe itself in this case as well, but this is working now.

Left in `only` for the relevant updated tests to show they're passing.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

