### PR TITLE
Add support to restricted names list

### DIFF
--- a/packages/lib-react-components/src/Markdownz/Markdownz.js
+++ b/packages/lib-react-components/src/Markdownz/Markdownz.js
@@ -125,7 +125,7 @@ Markdownz.defaultProps = {
   baseURI: '',
   components: {},
   projectSlug: '',
-  restrictedUserNames: ['admins', 'moderators', 'researchers', 'scientists', 'team'],
+  restrictedUserNames: ['admins', 'moderators', 'researchers', 'scientists', 'team', 'support'],
   settings: {}
 }
 

--- a/packages/lib-react-components/src/Markdownz/Markdownz.spec.js
+++ b/packages/lib-react-components/src/Markdownz/Markdownz.spec.js
@@ -218,8 +218,10 @@ describe('<Markdownz />', function () {
     })
 
     it('should return false if the symbol is @ and the resource is in the props.restrictedUserNames array', function () {
-      wrapper.instance().shouldResourceBeLinkable('team', '@')
-      expect(shouldResourceBeLinkableSpy).to.have.returned(false)
+      wrapper.instance().props.restrictedUserNames.forEach((username) => {
+        wrapper.instance().shouldResourceBeLinkable(username, '@')
+        expect(shouldResourceBeLinkableSpy).to.have.returned(false)
+      })
     })
   })
 


### PR DESCRIPTION
Package: lib-react-components

Parallel to zooniverse/markdownz#83

Describe your changes:
Adds support to the restricted usernames list. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

