### PR TITLE
Add docker to app-content-pages

### DIFF
--- a/packages/app-content-pages/README.md
+++ b/packages/app-content-pages/README.md
@@ -21,8 +21,14 @@ To get the credentials, go to https://app.contentful.com/spaces/jt90kyhvp0qv/api
 
 ### Running in development
 
+####Docker
+- `docker-compose up` to run a server on http://localhost:3000.
+- `docker-compose down` to stop the dev server.
+- `docker-compose run --rm dev test` to run the tests.
+
+####Node/yarn
 ```sh
-npm run dev
+yarn dev
 ```
 
 Starts a development server on port 3000 by default.
@@ -31,7 +37,7 @@ Starts a development server on port 3000 by default.
 
 
 ```sh
-npm run storybook
+yarn storybook
 ```
 
 Starts a Storybook server on port 9001 by default.

--- a/packages/app-content-pages/docker-compose.yml
+++ b/packages/app-content-pages/docker-compose.yml
@@ -2,8 +2,7 @@ version: '3.2'
 
 services:
   dev:
-    build:
-      context: ../../
+    image: front-end-monorepo_dev:latest
     entrypoint:
       - "yarn"
       - "workspace"

--- a/packages/app-content-pages/docker-compose.yml
+++ b/packages/app-content-pages/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.2'
 services:
   dev:
     image: front-end-monorepo_dev:latest
+    build:
+      context: ../../
     entrypoint:
       - "yarn"
       - "workspace"

--- a/packages/app-content-pages/docker-compose.yml
+++ b/packages/app-content-pages/docker-compose.yml
@@ -11,8 +11,7 @@ services:
     command: ["dev"]
     ports:
       - "3000:3000"
-      - "6006:6006"
-      - "8080:8080"
+      - "9001:9001"
     environment:
       - HOST=0.0.0.0
       - AWS_REGION=${AWS_REGION}

--- a/packages/app-content-pages/docker-compose.yml
+++ b/packages/app-content-pages/docker-compose.yml
@@ -12,13 +12,6 @@ services:
     ports:
       - "3000:3000"
       - "9001:9001"
-    environment:
-      - HOST=0.0.0.0
-      - AWS_REGION=${AWS_REGION}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
-      - AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN}
     volumes:
       - ../../:/usr/src
       - /usr/src/node_modules

--- a/packages/app-content-pages/docker-compose.yml
+++ b/packages/app-content-pages/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.2'
+
+services:
+  dev:
+    build:
+      context: ../../
+    entrypoint:
+      - "yarn"
+      - "workspace"
+      - "@zooniverse/fe-content-pages"
+    command: ["dev"]
+    ports:
+      - "3000:3000"
+      - "6006:6006"
+      - "8080:8080"
+    environment:
+      - HOST=0.0.0.0
+      - AWS_REGION=${AWS_REGION}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+      - AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN}
+    volumes:
+      - ../../:/usr/src
+      - /usr/src/node_modules


### PR DESCRIPTION
Add a docker-compose file to the content pages app.
`docker-compose up` to run a server on  http://localhost:3000.
`docker-compose down` to stop the dev server.
`docker-compose run --rm dev test` to run the tests.
`docker-compose run --rm --service-ports dev storybook` to run the storybook on http://localhost:9001.

Package:
app-content-pages


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

