### PR TITLE
Add docker-compose to the classifier

### DIFF
--- a/packages/lib-classifier/README.md
+++ b/packages/lib-classifier/README.md
@@ -5,16 +5,17 @@ A standalone library for the Zooniverse project classifier, including state mana
 ## Contributing
 
 ### Docker
-- `docker-compose up` to run a server on http://localhost:8080.
-- `docker-compose down` to stop the dev server.
+- `docker-compose up` to run a server on http://localhost:8080 and the storybook on http://localhost:6006.
+- `docker-compose down` to stop the container.
 - `docker-compose run --rm dev test` to run the tests.
 
 ### Node/yarn
 ```sh
 yarn dev
+yarn storybook
 ```
 
-Starts a development server on port 3000 by default.
+Starts a development server on port 8080 and a Storybook on port 6006 by default.
 
 Use `yarn dev` to run a small development environment app at `localhost:8080`. Specific staging projects and workflows can be loaded by query param `localhost:8080?project=1233&workflow=2367`
 

--- a/packages/lib-classifier/README.md
+++ b/packages/lib-classifier/README.md
@@ -4,6 +4,18 @@ A standalone library for the Zooniverse project classifier, including state mana
 
 ## Contributing
 
+### Docker
+- `docker-compose up` to run a server on http://localhost:8080.
+- `docker-compose down` to stop the dev server.
+- `docker-compose run --rm dev test` to run the tests.
+
+### Node/yarn
+```sh
+yarn dev
+```
+
+Starts a development server on port 3000 by default.
+
 Use `yarn dev` to run a small development environment app at `localhost:8080`. Specific staging projects and workflows can be loaded by query param `localhost:8080?project=1233&workflow=2367`
 
 To add a local dependency, install it with yarn: `yarn add @zooniverse/package-name@X`. Note the `@X` - without a matching version number, yarn will attempt to find it in the npm registry.

--- a/packages/lib-classifier/docker-compose.yml
+++ b/packages/lib-classifier/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - "@zooniverse/classifier"
     command: ["dev"]
     ports:
-      - "3000:3000"
       - "6006:6006"
       - "8080:8080"
     environment:

--- a/packages/lib-classifier/docker-compose.yml
+++ b/packages/lib-classifier/docker-compose.yml
@@ -2,8 +2,7 @@ version: '3.2'
 
 services:
   dev:
-    build:
-      context: ../../
+    image: front-end-monorepo_dev:latest
     entrypoint:
       - "yarn"
       - "workspace"

--- a/packages/lib-classifier/docker-compose.yml
+++ b/packages/lib-classifier/docker-compose.yml
@@ -15,11 +15,6 @@ services:
       - "8080:8080"
     environment:
       - HOST=0.0.0.0
-      - AWS_REGION=${AWS_REGION}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
-      - AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN}
     volumes:
       - ../../:/usr/src
       - /usr/src/node_modules

--- a/packages/lib-classifier/docker-compose.yml
+++ b/packages/lib-classifier/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.2'
 services:
   dev:
     image: front-end-monorepo_dev:latest
+    build:
+      context: ../../
     entrypoint:
       - "yarn"
       - "workspace"

--- a/packages/lib-classifier/docker-compose.yml
+++ b/packages/lib-classifier/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.2'
+
+services:
+  dev:
+    build:
+      context: ../../
+    entrypoint:
+      - "yarn"
+      - "workspace"
+      - "@zooniverse/classifier"
+    command: ["dev"]
+    ports:
+      - "3000:3000"
+      - "6006:6006"
+      - "8080:8080"
+    environment:
+      - HOST=0.0.0.0
+      - AWS_REGION=${AWS_REGION}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+      - AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN}
+    volumes:
+      - ../../:/usr/src
+      - /usr/src/node_modules

--- a/packages/lib-classifier/docker-compose.yml
+++ b/packages/lib-classifier/docker-compose.yml
@@ -9,10 +9,21 @@ services:
       - "@zooniverse/classifier"
     command: ["dev"]
     ports:
-      - "6006:6006"
       - "8080:8080"
     environment:
       - HOST=0.0.0.0
+    volumes:
+      - ../../:/usr/src
+      - /usr/src/node_modules
+  storybook:
+    image: front-end-monorepo_dev:latest
+    entrypoint:
+      - "yarn"
+      - "workspace"
+      - "@zooniverse/classifier"
+    command: ["storybook"]
+    ports:
+      - "6006:6006"
     volumes:
       - ../../:/usr/src
       - /usr/src/node_modules

--- a/packages/lib-classifier/webpack.dev.js
+++ b/packages/lib-classifier/webpack.dev.js
@@ -17,9 +17,10 @@ const HtmlWebpackPluginConfig = new HtmlWebpackPlugin({
 module.exports = {
   devServer: {
     allowedHosts: [
+      'localhost',
       '.zooniverse.org'
     ],
-    host: process.env.HOST || "localhost"
+    host: process.env.HOST || 'localhost'
   },
   entry: [
     '@babel/polyfill',

--- a/packages/lib-classifier/webpack.dev.js
+++ b/packages/lib-classifier/webpack.dev.js
@@ -17,9 +17,9 @@ const HtmlWebpackPluginConfig = new HtmlWebpackPlugin({
 module.exports = {
   devServer: {
     allowedHosts: [
-      'localhost',
       '.zooniverse.org'
-    ]
+    ],
+    host: process.env.HOST || "localhost"
   },
   entry: [
     '@babel/polyfill',


### PR DESCRIPTION
Run webpack dev server and the storybook in a container using `docker-compose up`.
Shut down the running server with `docker-compose down`.
Run the tests with `docker-compose run --rm dev test`.

Browse the dev classifier on http://localhost:8080 and storybook on http://localhost:6006 as usual.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

