### PR TITLE
[WIP] simple BarChartViewer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/BarChartViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/BarChartViewer.js
@@ -1,0 +1,63 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { scaleLinear, scaleBand } from '../../helpers/d3'
+import Chart from '../SVGComponents/Chart'
+import Background from '../SVGComponents/Background'
+import Group from '../SVGComponents/Group'
+import Bar from './components/Bar'
+
+const BarChartViewer = React.forwardRef(function BarChartViewer({ backgroundFill, data, height, width }, ref) {
+  const yMax = height - 120
+  const xScale = scaleBand({
+    domain: data.map(datum => datum.label),
+    rangeRound: [0, width],
+    padding: 0.5
+  })
+  const yScale = scaleLinear({
+    domain: [0, Math.max(...data.map(datum => datum.value))],
+    rangeRound: [yMax, 0]
+  })
+  return (
+    <Chart ref={ref}>
+      <Background fill={backgroundFill} />
+      <Group>
+        {data.map((datum, index) => {
+          const { label, value } = datum
+          const key = `bar-${label}`
+          const barHeight = yMax - yScale(value)
+          const barWidth = xScale.bandwidth()
+          const x = xScale(label)
+          const y = yMax - barHeight
+          return (
+            <Bar
+              height={barHeight}
+              index={index}
+              key={key}
+              width={barWidth}
+              x={x}
+              y={y}
+            />
+          )
+        })}
+      </Group>
+    </Chart>
+  )
+})
+
+BarChartViewer.defaultProps = {
+  backgroundFill: 'white',
+  height: 200,
+  width: 200
+}
+
+BarChartViewer.propTypes = {
+  backgroundFill: PropTypes.string,
+  data: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.number.isRequired
+  })).isRequired,
+  height: PropTypes.number,
+  width: PropTypes.number
+}
+
+export default BarChartViewer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/BarChartViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/BarChartViewer.spec.js
@@ -1,0 +1,38 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import mockData from './mockData'
+
+import BarChartViewer from './BarChartViewer'
+import Chart from '../SVGComponents/Chart'
+import Background from '../SVGComponents/Background'
+import Group from '../SVGComponents/Group'
+import Bar from './components/Bar'
+
+const { data } = mockData
+
+describe('Component > BarChartViewer', function () {
+  it('should render without crashing', function () {
+    const wrapper = shallow(<BarChartViewer data={data} />)
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render a Chart', function () {
+    const wrapper = shallow(<BarChartViewer data={data} />)
+    expect(wrapper.find(Chart)).to.have.lengthOf(1)
+  })
+
+  it('should render a Background', function () {
+    const wrapper = shallow(<BarChartViewer data={data} />)
+    expect(wrapper.find(Background)).to.have.lengthOf(1)
+  })
+
+  it('should render a Group', function () {
+    const wrapper = shallow(<BarChartViewer data={data} />)
+    expect(wrapper.find(Group)).to.have.lengthOf(1)
+  })
+
+  it('should render a Bar for each item in the data array', function () {
+    const wrapper = shallow(<BarChartViewer data={data} />)
+    expect(wrapper.find(Bar)).to.have.lengthOf(data.length)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/BarChartViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/BarChartViewer.stories.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { withKnobs, text, number } from '@storybook/addon-knobs';
+import zooTheme from '@zooniverse/grommet-theme'
+import { Box, Grommet } from 'grommet'
+import BarChartViewer from './BarChartViewer'
+import mockData from './mockData'
+// import readme from './README.md'
+import backgrounds from '../../../../../../../.storybook/lib/backgrounds'
+
+// const config = {
+//   notes: {
+//     markdown: readme
+//   }
+// }
+
+// const darkThemeConfig = Object.assign({}, config, { backgrounds: backgrounds.darkDefault })
+
+const { data } = mockData
+
+const stories = storiesOf('BarChartViewer', module)
+
+stories.addDecorator(withKnobs)
+
+stories.add('light theme', () => {
+    return (
+      <Grommet theme={zooTheme}>
+        <Box height='medium' width='large'>
+          <BarChartViewer
+            backgroundFill={text('background fill', 'white')}
+            data={data}
+            height={number('height', 500)}
+            width={number('width', 500)}
+          />
+        </Box>
+      </Grommet>
+    )
+  })
+  .add('dark theme', () => {
+    const darkZooTheme = Object.assign({}, zooTheme, { dark: true })
+    return (
+      <Grommet theme={darkZooTheme}>
+        <Box height='medium' width='large'>
+          <BarChartViewer
+            backgroundFill={text('background fill', 'white')}
+            data={data}
+            height={number('height', 500)}
+            width={number('width', 500)}
+          />
+        </Box>
+      </Grommet>
+    )
+  })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/components/Bar/Bar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/components/Bar/Bar.js
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+function Bar({ fill, height, index, width, x, y, ...rest }) {
+  return (
+    <rect
+      fill={fill}
+      height={height}
+      index={index}
+      width={width}
+      x={x}
+      y={y}
+      {...rest}
+    />
+  )
+}
+
+Bar.defaultProps = {
+  fill: 'teal',
+  className: ''
+}
+
+Bar.propTypes = {
+  fill: PropTypes.string,
+  height: PropTypes.number.isRequired,
+  index: PropTypes.number.isRequired,
+  className: PropTypes.string,
+  width: PropTypes.number.isRequired,
+  x: PropTypes.number.isRequired,
+  y: PropTypes.number.isRequired
+}
+
+export default Bar

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/components/Bar/Bar.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/components/Bar/Bar.spec.js
@@ -1,0 +1,26 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import Bar from './Bar'
+
+describe('Component > Bar', function () {
+  it('should render without crashing', function () {
+    const wrapper = shallow(<Bar height={30} index={0} width={10} x={1} y={2} />)
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render a rect', function () {
+    const wrapper = shallow(<Bar height={30} index={0} width={10} x={1} y={2} />)
+    expect(wrapper.find('rect')).to.have.lengthOf(1)
+  })
+
+  it('should set the fill color by prop', function () {
+    const wrapper = shallow(<Bar fill='orange' height={30} index={0} width={10} x={1} y={2} />)
+    expect(wrapper.props().fill).to.equal('orange')
+  })
+
+  it('should pass along any other props', function () {
+    const wrapper = shallow(<Bar foo='bar' height={30} index={0} width={10} x={1} y={2} />)
+    expect(wrapper.props().foo).to.equal('bar')
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/components/Bar/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/components/Bar/index.js
@@ -1,0 +1,1 @@
+export { default } from './Bar'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/mockData.json
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/mockData.json
@@ -1,0 +1,30 @@
+{
+  "data": [
+      { "label": "A", "value": 0.08167 },
+      { "label": "B", "value": 0.01492 },
+      { "label": "C", "value": 0.02782 },
+      { "label": "D", "value": 0.04253 },
+      { "label": "E", "value": 0.12702 },
+      { "label": "F", "value": 0.02288 },
+      { "label": "G", "value": 0.02015 },
+      { "label": "H", "value": 0.06094 },
+      { "label": "I", "value": 0.06966 },
+      { "label": "J", "value": 0.00153 },
+      { "label": "K", "value": 0.00772 },
+      { "label": "L", "value": 0.04025 },
+      { "label": "M", "value": 0.02406 },
+      { "label": "N", "value": 0.06749 },
+      { "label": "O", "value": 0.07507 },
+      { "label": "P", "value": 0.01929 },
+      { "label": "Q", "value": 0.00095 },
+      { "label": "R", "value": 0.05987 },
+      { "label": "S", "value": 0.06327 },
+      { "label": "T", "value": 0.09056 },
+      { "label": "U", "value": 0.02758 },
+      { "label": "V", "value": 0.00978 },
+      { "label": "W", "value": 0.0236 },
+      { "label": "X", "value": 0.0015 },
+      { "label": "Y", "value": 0.01974 },
+      { "label": "Z", "value": 0.00074 }
+  ]
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Background/Background.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Background/Background.js
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+function Background({ fill, height, width, ...rest }) {
+  return (
+    <rect
+      fill={fill}
+      height={height}
+      width={width}
+      {...rest}
+    />
+  )
+}
+
+Background.defaultProps = {
+  fill: 'white',
+  height: '100%',
+  width: '100%'
+}
+
+Background.propTypes = {
+  fill: PropTypes.string,
+  height: PropTypes.string,
+  width: PropTypes.string
+}
+
+export default Background

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Background/Background.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Background/Background.spec.js
@@ -1,0 +1,26 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import Background from './Background'
+
+describe('Component > Background', function () {
+  it('should render without crashing', function () {
+    const wrapper = shallow(<Background />)
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render a rect', function () {
+    const wrapper = shallow(<Background />)
+    expect(wrapper.find('rect')).to.have.lengthOf(1)
+  })
+
+  it('should pass along any other props', function () {
+    const wrapper = shallow(<Background foo='bar' />)
+    expect(wrapper.props().foo).to.equal('bar')
+  })
+
+  it('should set the fill color by prop', function () {
+    const wrapper = shallow(<Background fill='black' />)
+    expect(wrapper.props().fill).to.equal('black')
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Background/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Background/index.js
@@ -1,0 +1,1 @@
+export { default } from './Background'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Chart/Chart.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Chart/Chart.js
@@ -1,0 +1,22 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+const Chart = React.forwardRef(function Chart({ children, height, width, ...rest }, ref) {
+  return (
+    <svg height={height} ref={ref} width={width} {...rest}>
+      {children}
+    </svg>
+  )
+})
+
+Chart.defaultProps = {
+  height: '100%', 
+  width: '100%'
+}
+
+Chart.propTypes = {
+  height: PropTypes.string,
+  width: PropTypes.string
+}
+
+export default Chart

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Chart/Chart.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Chart/Chart.spec.js
@@ -1,0 +1,26 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import Chart from './Chart'
+
+describe('Component > Chart', function () {
+  it('should render without crashing', function () {
+    const wrapper = shallow(<Chart><span /></Chart>)
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render an svg', function () {
+    const wrapper = shallow(<Chart><span /></Chart>)
+    expect(wrapper.find('svg')).to.have.lengthOf(1)
+  })
+
+  it('should render children', function () {
+    const wrapper = shallow(<Chart><span /></Chart>)
+    expect(wrapper.children()).to.have.lengthOf(1)
+  })
+
+  it('should pass along any other props', function () {
+    const wrapper = shallow(<Chart foo='bar'><span /></Chart>)
+    expect(wrapper.props().foo).to.equal('bar')
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Chart/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Chart/index.js
@@ -1,0 +1,1 @@
+export { default } from './Chart'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Group/Group.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Group/Group.js
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+function Group({ children, ...rest}) {
+  return (
+    <g {...rest}>
+      {children}
+    </g>
+  )
+}
+
+Group.defaultProps = {
+
+}
+
+Group.propTypes = {
+
+}
+
+export default Group

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Group/Group.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Group/Group.spec.js
@@ -1,0 +1,26 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import Group from './Group'
+
+describe('Component > Group', function () {
+  it('should render without crashing', function () {
+    const wrapper = shallow(<Group><span /></Group>)
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render an svg group', function () {
+    const wrapper = shallow(<Group><span /></Group>)
+    expect(wrapper.find('g')).to.have.lengthOf(1)
+  })
+
+  it('should render children', function () {
+    const wrapper = shallow(<Group><span /></Group>)
+    expect(wrapper.children()).to.have.lengthOf(1)
+  })
+
+  it('should pass along any other props', function () {
+    const wrapper = shallow(<Group foo='bar'><span /></Group>)
+    expect(wrapper.props().foo).to.equal('bar')
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Group/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Group/index.js
@@ -1,0 +1,1 @@
+export { default } from './Group'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/d3/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/d3/index.js
@@ -1,0 +1,2 @@
+export { default as scaleLinear } from './scaleLinear'
+export { default as scaleBand } from './scaleBand'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/d3/scaleBand.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/d3/scaleBand.js
@@ -1,0 +1,24 @@
+import { scaleBand } from 'd3'
+
+export default ({
+  range,
+  rangeRound,
+  domain,
+  padding,
+  paddingInner,
+  paddingOuter,
+  align
+}) => {
+  const scale = scaleBand()
+  scale.type = 'band'
+
+  if (range) scale.range(range)
+  if (rangeRound) scale.rangeRound(rangeRound)
+  if (domain) scale.domain(domain)
+  if (padding) scale.padding(padding)
+  if (paddingInner) scale.paddingInner(paddingInner)
+  if (paddingOuter) scale.paddingOuter(paddingOuter)
+  if (align) scale.align(align)
+
+  return scale
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/d3/scaleBand.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/d3/scaleBand.spec.js
@@ -1,0 +1,67 @@
+import scaleBand from './scaleBand'
+
+describe('Helper > d3 > scaleBand', function () {
+  it('should be a function', function () {
+    expect(scaleBand).to.be.a('function')
+  })
+
+  it('should return a d3 band scale', function () {
+    const scale = scaleBand({})
+    expect(scale.type).to.equal('band')
+  })
+
+  it('should set range', function () {
+    const scale = scaleBand({ range: [0, 10] })
+    const range = scale.range()
+    expect(range).to.have.lengthOf(2)
+    expect(range[0]).to.equal(0)
+    expect(range[1]).to.equal(10)
+  })
+
+  it('should set range and enable rounding', function () {
+    const scale = scaleBand({ rangeRound: [0, 10] })
+    const range = scale.range()
+    expect(range).to.have.lengthOf(2)
+    expect(range[0]).to.equal(0)
+    expect(range[1]).to.equal(10)
+    expect(scale.round()).to.be.true()
+  })
+
+  it('should set domain', function () {
+    const domainToSet = ['A', 'B', 'C']
+    const scale = scaleBand({ domain: domainToSet })
+    const domain = scale.domain()
+    expect(domain).to.have.lengthOf(3)
+    domain.forEach((unit, index) => {
+      expect(unit).to.equal(domainToSet[index])
+    })
+  })
+
+  it('should set padding', function () {
+    const paddingToSet = 0.5
+    const scale = scaleBand({ padding: paddingToSet })
+    const padding = scale.padding()
+    expect(padding).to.equal(paddingToSet)
+  })
+
+  it('should set paddingInner', function () {
+    const paddingToSet = 0.5
+    const scale = scaleBand({ paddingInner: paddingToSet })
+    const paddingInner = scale.paddingInner()
+    expect(paddingInner).to.equal(paddingToSet)
+  })
+
+  it('should set paddingOuter', function () {
+    const paddingToSet = 0.5
+    const scale = scaleBand({ paddingOuter: paddingToSet })
+    const paddingOuter = scale.paddingOuter()
+    expect(paddingOuter).to.equal(paddingToSet)
+  })
+
+  it('should set align', function () {
+    const alignToSet = 0.25
+    const scale = scaleBand({ align: alignToSet })
+    const align = scale.align()
+    expect(align).to.equal(alignToSet)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/d3/scaleLinear.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/d3/scaleLinear.js
@@ -1,0 +1,14 @@
+import { scaleLinear } from 'd3'
+
+export default ({ range, rangeRound, domain, nice = false, clamp = false }) => {
+  const scale = scaleLinear()
+  scale.type = 'linear'
+
+  if (range) scale.range(range)
+  if (rangeRound) scale.rangeRound(rangeRound)
+  if (domain) scale.domain(domain)
+  if (nice) scale.nice()
+  if (clamp) scale.clamp(true)
+
+  return scale
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/d3/scaleLinear.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/d3/scaleLinear.spec.js
@@ -1,0 +1,42 @@
+import scaleLinear from './scaleLinear'
+
+describe('Helper > d3 > scaleLinear', function () {
+  it('should be a function', function () {
+    expect(scaleLinear).to.be.a('function')
+  })
+
+  it('should return a d3 linear scale', function () {
+    const scale = scaleLinear({})
+    expect(scale.type).to.equal('linear')
+  })
+
+  it('should set range', function () {
+    const scale = scaleLinear({ range: [0, 10] })
+    const range = scale.range()
+    expect(range).to.have.lengthOf(2)
+    expect(range[0]).to.equal(0)
+    expect(range[1]).to.equal(10)
+  })
+
+  it('should set domain', function () {
+    const domainToSet = [0, 10, 20]
+    const scale = scaleLinear({ domain: domainToSet })
+    const domain = scale.domain()
+    expect(domain).to.have.lengthOf(3)
+    domain.forEach((unit, index) => {
+      expect(unit).to.equal(domainToSet[index])
+    })
+  })
+
+  it('should nice the domain', function () {
+    const scale = scaleLinear({ domain: [0.201470, 0.996679], nice: true })
+    const domain = scale.domain()
+    expect(domain[0]).to.equal(0.2)
+    expect(domain[1]).to.equal(1)
+  })
+
+  it('should set clamp', function () {
+    const scale = scaleLinear({ clamp: true })
+    expect(scale.clamp()).to.be.true()
+  })
+})


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
Initial pass at adding a read only bar chart. I'm taking a pretty different approach than what we did for the LCV. I've never felt totally comfortable handing over the rendering and manipulation of the DOM over the D3 and I find the code very hard to read, partly because of d3's chaining API.

Instead, I'm trying out only using React for DOM manipulation and rendering and only using D3 for the maths (which is more in line with a lot of the React+D3 libraries out there).

Conceptually, I'm borrowing really heavily from [vx](https://vx-demo.now.sh/). I believe it was potentially one of our candidates last fall when we were evaluating react+d3 libraries, but it was very young and was missing core features like zoom. Now it has at least zoom and may also have the rest of what we might need. 

This begs the question, do we continue rolling our own low level components and d3 use or do we adopt vx? If vx is missing anything, do we contribute back, fork it, or just continue our own code?

We're going to have more requests for complex data visualizations in the future and I'd like us to reevaluate adopting a react+d3 library to save us time. 

If we decide to try out vx in earnest, I could redo this PR with it. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

