### PR TITLE
Make the minimum subject queue size configurable

### DIFF
--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -18,6 +18,8 @@ function openTalkPage (talkURL, newTab = false) {
   }
 }
 
+const MINIMUM_QUEUE_SIZE = 2
+
 const SubjectStore = types
   .model('SubjectStore', {
     active: types.maybe(types.reference(Subject)),
@@ -45,7 +47,7 @@ const SubjectStore = types
         self.active = undefined
       }
 
-      if (self.resources.size < 3) {
+      if (self.resources.size < MINIMUM_QUEUE_SIZE) {
         console.log('Fetching more subjects')
         self.populateQueue()
       }
@@ -150,4 +152,4 @@ const SubjectStore = types
   })
 
 export default types.compose('SubjectResourceStore', ResourceStore, SubjectStore)
-export { openTalkPage }
+export { openTalkPage, MINIMUM_QUEUE_SIZE }

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon'
 import ProjectStore from './ProjectStore'
 import RootStore from './RootStore'
-import SubjectStore, { openTalkPage } from './SubjectStore'
+import SubjectStore, { openTalkPage, MINIMUM_QUEUE_SIZE } from './SubjectStore'
 import WorkflowStore from './WorkflowStore'
 import { ProjectFactory, SubjectFactory, WorkflowFactory } from '../../test/factories'
 import { Factory } from 'rosie'
@@ -49,14 +49,15 @@ describe('Model > SubjectStore', function () {
       }).then(done, done)
     })
 
-    describe('with less than three subjects in the queue', function () {
+    describe(`with less than ${MINIMUM_QUEUE_SIZE} subjects in the queue`, function () {
       let populateSpy
 
       before(function () {
         populateSpy = sinon.spy(rootStore.subjects, 'populateQueue')
-        while (rootStore.subjects.resources.size > 2) {
+        while (rootStore.subjects.resources.size >= MINIMUM_QUEUE_SIZE) {
           rootStore.subjects.advance()
         }
+        rootStore.subjects.advance()
       })
 
       after(function () {


### PR DESCRIPTION
Adds MINIMUM_QUEUE_SIZE to the subject queue, sets it to 2 and updates the tests to use it.
Fixes a couple of errors that came up when changing the tests. It turns out I didn't declare `rootStore` properly in #909 and the tests were all sharing the same mock store state.
Adds a couple of tests to check that advancing the queue reduces the queue size by one, and that advancing the queue works even if the store is empty.

Package:
lib-classifier

Closes #1042 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

