### PR TITLE
Fix shadowing in the SubjectStore tests

### DIFF
--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -39,7 +39,7 @@ describe('Model > SubjectStore', function () {
   describe('Actions > advance', function () {
     describe('with a full queue', function () {
       let rootStore
-      let firstSubject
+      let previousSubject
       let initialSize
 
       before(function () {
@@ -47,7 +47,7 @@ describe('Model > SubjectStore', function () {
       })
 
       beforeEach(function () {
-        firstSubject = rootStore.subjects.resources.values().next().value.id
+        previousSubject = rootStore.subjects.resources.values().next().value.id
         initialSize = rootStore.subjects.resources.size
         rootStore.subjects.advance()
       })
@@ -59,8 +59,8 @@ describe('Model > SubjectStore', function () {
       it('should make the next subject in the queue active', function () {
         const currentSubject = rootStore.subjects.resources.values().next().value.id
         expect(rootStore.subjects.active.id).to.equal(currentSubject)
-        expect(rootStore.subjects.resources.get(firstSubject)).to.be.undefined()
-        expect(firstSubject).to.not.equal(currentSubject)
+        expect(rootStore.subjects.resources.get(previousSubject)).to.be.undefined()
+        expect(previousSubject).to.not.equal(currentSubject)
       })
     })
 

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -12,7 +12,7 @@ const shortListSubjects = Factory.buildList('subject', 2)
 
 const clientStub = stubPanoptesJs({ subjects, workflows: workflow })
 
-describe.only('Model > SubjectStore', function () {
+describe('Model > SubjectStore', function () {
   function setupStores(panoptesClientStub = clientStub) {
     const store = RootStore.create({
       classifications: {},

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -12,7 +12,7 @@ const shortListSubjects = Factory.buildList('subject', 2)
 
 const clientStub = stubPanoptesJs({ subjects, workflows: workflow })
 
-describe('Model > SubjectStore', function () {
+describe.only('Model > SubjectStore', function () {
   function setupStores(panoptesClientStub = clientStub) {
     const store = RootStore.create({
       classifications: {},
@@ -44,10 +44,13 @@ describe('Model > SubjectStore', function () {
       })
 
       it('should make the next subject in the queue active', function () {
-        expect(rootStore.subjects.active.id).to.equal(rootStore.subjects.resources.values().next().value.id)
+        const firstSubject = rootStore.subjects.resources.values().next().value.id
+        expect(rootStore.subjects.active.id).to.equal(firstSubject)
         rootStore.subjects.advance()
-        expect(rootStore.subjects.active.id).to.equal(rootStore.subjects.resources.values().next().value.id)
-        expect(rootStore.subjects.resources.get('1')).to.be.undefined()
+        const secondSubject = rootStore.subjects.resources.values().next().value.id
+        expect(rootStore.subjects.active.id).to.equal(secondSubject)
+        expect(rootStore.subjects.resources.get(firstSubject)).to.be.undefined()
+        expect(firstSubject).to.not.equal(secondSubject)
       })
 
       it('should reduce the queue size by one', function () {

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -58,22 +58,24 @@ describe('Model > SubjectStore', function () {
     })
 
     describe('with less than three subjects in the queue', function () {
-      let rootStore
+      describe('when the initial response has ten subjects', function () {
+        let rootStore
 
-      before(function () {
-        rootStore = setupStores()
-      })
+        before(function () {
+          rootStore = setupStores()
+        })
 
-      after(function () {
-        rootStore.subjects.populateQueue.restore()
-      })
+        after(function () {
+          rootStore.subjects.populateQueue.restore()
+        })
 
-      it('should request more subjects', function () {
-        while (rootStore.subjects.resources.size > 2) {
-          rootStore.subjects.advance()
-        }
-        // Once for initialization and once after the queue has been advanced to less than 3 subjects
-        expect(rootStore.subjects.populateQueue).to.have.been.calledTwice()
+        it('should request more subjects', function () {
+          while (rootStore.subjects.resources.size > 2) {
+            rootStore.subjects.advance()
+          }
+          // Once for initialization and once after the queue has been advanced to less than 3 subjects
+          expect(rootStore.subjects.populateQueue).to.have.been.calledTwice()
+        })
       })
 
       describe('when the initial response has less than three subjects', function () {

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -39,24 +39,28 @@ describe('Model > SubjectStore', function () {
   describe('Actions > advance', function () {
     describe('with a full queue', function () {
       let rootStore
+      let firstSubject
+      let initialSize
+
       before(function () {
         rootStore = setupStores()
       })
 
-      it('should make the next subject in the queue active', function () {
-        const firstSubject = rootStore.subjects.resources.values().next().value.id
-        expect(rootStore.subjects.active.id).to.equal(firstSubject)
+      beforeEach(function () {
+        firstSubject = rootStore.subjects.resources.values().next().value.id
+        initialSize = rootStore.subjects.resources.size
         rootStore.subjects.advance()
-        const secondSubject = rootStore.subjects.resources.values().next().value.id
-        expect(rootStore.subjects.active.id).to.equal(secondSubject)
-        expect(rootStore.subjects.resources.get(firstSubject)).to.be.undefined()
-        expect(firstSubject).to.not.equal(secondSubject)
       })
 
       it('should reduce the queue size by one', function () {
-        const expectedSize = rootStore.subjects.resources.size - 1
-        rootStore.subjects.advance()
-        expect(rootStore.subjects.resources.size).to.equal(expectedSize)
+        expect(rootStore.subjects.resources.size).to.equal(initialSize - 1)
+      })
+
+      it('should make the next subject in the queue active', function () {
+        const currentSubject = rootStore.subjects.resources.values().next().value.id
+        expect(rootStore.subjects.active.id).to.equal(currentSubject)
+        expect(rootStore.subjects.resources.get(firstSubject)).to.be.undefined()
+        expect(firstSubject).to.not.equal(currentSubject)
       })
     })
 

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -37,16 +37,24 @@ describe('Model > SubjectStore', function () {
     return store
   }
   describe('Actions > advance', function () {
-    let rootStore
-    before(function () {
-      rootStore = setupStores()
-    })
+    describe('with a full queue', function () {
+      let rootStore
+      before(function () {
+        rootStore = setupStores()
+      })
 
-    it('should make the next subject in the queue active when calling `advance()`', function () {
-      expect(rootStore.subjects.active.id).to.equal(rootStore.subjects.resources.values().next().value.id)
-      rootStore.subjects.advance()
-      expect(rootStore.subjects.active.id).to.equal(rootStore.subjects.resources.values().next().value.id)
-      expect(rootStore.subjects.resources.get('1')).to.be.undefined()
+      it('should make the next subject in the queue active', function () {
+        expect(rootStore.subjects.active.id).to.equal(rootStore.subjects.resources.values().next().value.id)
+        rootStore.subjects.advance()
+        expect(rootStore.subjects.active.id).to.equal(rootStore.subjects.resources.values().next().value.id)
+        expect(rootStore.subjects.resources.get('1')).to.be.undefined()
+      })
+
+      it('should reduce the queue size by one', function () {
+        const expectedSize = rootStore.subjects.resources.size - 1
+        rootStore.subjects.advance()
+        expect(rootStore.subjects.resources.size).to.equal(expectedSize)
+      })
     })
 
     describe('with less than three subjects in the queue', function () {


### PR DESCRIPTION
Adds a describe block to make sure every declaration of rootStore is locally scoped to a function.
Adds a test to check that advancing the queue reduces its size by one.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

