### PR TITLE
Make minimum subject queue size configurable

### DIFF
--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -6,6 +6,8 @@ import { filterByLabel, filters } from '../components/Classifier/components/Meta
 import ResourceStore from './ResourceStore'
 import Subject from './Subject'
 
+const MINIMUM_QUEUE_SIZE = 3
+
 function openTalkPage (talkURL, newTab = false) {
   if (newTab) {
     const newTab = window.open()
@@ -103,7 +105,7 @@ const SubjectStore = types
       const nextSubject = self.resources.values().next().value
       self.active = nextSubject && nextSubject.id
 
-      if (self.resources.size < 3) {
+      if (self.resources.size < MINIMUM_QUEUE_SIZE) {
         console.log('Fetching more subjects')
         self.populateQueue()
       }
@@ -154,4 +156,4 @@ const SubjectStore = types
   })
 
 export default types.compose('SubjectResourceStore', ResourceStore, SubjectStore)
-export { openTalkPage }
+export { openTalkPage, MINIMUM_QUEUE_SIZE }

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon'
 import RootStore from './RootStore'
-import { openTalkPage } from './SubjectStore'
+import { openTalkPage, MINIMUM_QUEUE_SIZE } from './SubjectStore'
 import { ProjectFactory, SubjectFactory, WorkflowFactory } from '../../test/factories'
 import { Factory } from 'rosie'
 import stubPanoptesJs from '../../test/stubPanoptesJs'
@@ -77,9 +77,10 @@ describe('Model > SubjectStore', function () {
         })
 
         it('should request more subjects', function () {
-          while (rootStore.subjects.resources.size > 2) {
+          while (rootStore.subjects.resources.size > MINIMUM_QUEUE_SIZE) {
             rootStore.subjects.advance()
           }
+          rootStore.subjects.advance()
           // Once for initialization and once after the queue has been advanced to less than 3 subjects
           expect(rootStore.subjects.populateQueue).to.have.been.calledTwice()
         })


### PR DESCRIPTION
Move the minimum subject queue size into a constant and update tests.

Package:
lib-classifier

Towards #1042.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

