### PR TITLE
switch to 1 staging replica

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: zooniverse-org-project-staging
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: zooniverse-org-project-staging


### PR DESCRIPTION
No need to pay the overhead to run additional staging services, keep it lean.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

