### PR TITLE
Refactor feedback metadata-to-rules

### DIFF
--- a/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.js
@@ -7,6 +7,9 @@ function metadataToRules (metadata = {}) {
     const stringValue = value.toString()
 
     if (prefix === '#feedback' && stringValue) {
+      if (isNaN(ruleIndex)) {
+        console.error('Subject metadata feedback ruleIndex is improperly formatted')
+      }
       const rule = result[ruleIndex] || {}
       rule[propKey] = value
       result[ruleIndex] = rule

--- a/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.js
@@ -8,7 +8,7 @@ function metadataToRules (metadata = {}) {
 
     if (prefix === '#feedback' && stringValue) {
       if (isNaN(ruleIndex)) {
-        console.error('Subject metadata feedback ruleIndex is improperly formatted')
+        console.error(`Subject metadata feedback rule index ${ruleIndex} is improperly formatted. The feedback rule index should be an integer.`)
       }
       const rule = result[ruleIndex] || {}
       rule[propKey] = value

--- a/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.spec.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.spec.js
@@ -5,10 +5,10 @@ describe('feedback: metadataToRules', function () {
   function mockSubjectWithRule (ruleID) {
     return {
       metadata: {
-        '#feedback_1_id': ruleID,
-        '#feedback_1_answer': '0',
-        '#feedback_1_failureMessage': 'Actually, this sound is from noise (background)',
-        '#feedback_1_successMessage': 'Correct!'
+        '#feedback_[1]_id': ruleID,
+        '#feedback_[1]_answer': '0',
+        '#feedback_[1]_failureMessage': 'Actually, this sound is from noise (background)',
+        '#feedback_[1]_successMessage': 'Correct!'
       }
     }
   }

--- a/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.spec.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.spec.js
@@ -60,7 +60,7 @@ describe('feedback: metadataToRules', function () {
       metadataToRules(improperMetadataSubject.metadata)
 
       expect(logError).to.have.been.calledThrice()
-      expect(logError).to.have.been.calledWith('Subject metadata feedback ruleIndex is improperly formatted')
+      expect(logError).to.have.been.calledWith('Subject metadata feedback rule index [1] is improperly formatted. The feedback rule index should be an integer.')
     })
   })
 })

--- a/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.spec.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.spec.js
@@ -1,14 +1,25 @@
 import { expect } from 'chai'
+import sinon from 'sinon'
 import metadataToRules from './metadata-to-rules'
 
 describe('feedback: metadataToRules', function () {
   function mockSubjectWithRule (ruleID) {
     return {
       metadata: {
+        '#feedback_1_id': ruleID,
+        '#feedback_1_answer': '0',
+        '#feedback_1_failureMessage': 'Actually, this sound is from noise (background)',
+        '#feedback_1_successMessage': 'Correct!'
+      }
+    }
+  }
+
+  function mockSubjectWithRuleNonIntegerN (ruleID) {
+    return {
+      metadata: {
         '#feedback_[1]_id': ruleID,
-        '#feedback_[1]_answer': '0',
-        '#feedback_[1]_failureMessage': 'Actually, this sound is from noise (background)',
-        '#feedback_[1]_successMessage': 'Correct!'
+        '#feedback_a_answer': '0',
+        '#feedback_1a2b_failureMessage': 'Actually, this sound is from noise (background)'
       }
     }
   }
@@ -32,5 +43,24 @@ describe('feedback: metadataToRules', function () {
     const subject = mockSubjectWithRule(0)
     const rules = metadataToRules(subject.metadata)
     expect(rules).to.deep.equal(expectedRules(0))
+  })
+
+  describe('with subject metadata feedback ruleIndex not an integer', function () {
+    let logError
+    before(function () {
+      logError = sinon.stub(console, 'error')
+    })
+
+    after(function () {
+      console.error.restore()
+    })
+
+    it('should console error with message', function () {
+      const improperMetadataSubject = mockSubjectWithRuleNonIntegerN(0)
+      metadataToRules(improperMetadataSubject.metadata)
+
+      expect(logError).to.have.been.calledThrice()
+      expect(logError).to.have.been.calledWith('Subject metadata feedback ruleIndex is improperly formatted')
+    })
   })
 })


### PR DESCRIPTION
Package: lib-classifier

If these changes make sense, we'll open a new PR (based on #1062), which will in turn take care of #1061.

I merged #1062 and it broke TESS' feedback. I think it's because before merge `metadata-to-rules` would return an array of feedback rule objects, but with the changes TESS' metadata feedback info returned something unexpected. Here is a related screenshot (note `falsy` output is before filtering on Boolean):
![Screen Shot 2019-08-07 at 4 27 04 PM](https://user-images.githubusercontent.com/12118751/62714311-ee57bf00-b9c3-11e9-811f-dead9174499a.png)

I have a few staging projects with LCV feedback, all of which worked with the changes. However, I didn't realize TESS includes subject metadata for feedback with headers like `feedback_[1]_id`, note the `ruleIndex` is `[1]` as opposed to just `1` or `abc` and I think that may have caused the issue, but I can't pinpoint exactly how or why.

staging project that works on `master` and on `falsy-feedback-values`: http://localhost:8080/?project=1810&workflow=3318
staging project that works on `master` but NOT on `falsy-feedback-values` (similar to TESS): http://localhost:8080/?project=1810&workflow=3351

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?

