### PR TITLE
Add specs for subject queue advance

### DIFF
--- a/packages/lib-classifier/src/store/FeedbackStore.spec.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.spec.js
@@ -58,6 +58,11 @@ describe('Model > FeedbackStore', function () {
       reducer: sinon.stub().callsFake(rule => rule)
     }
   })
+
+  after(function () {
+    helpers.isFeedbackActive.restore()
+    helpers.generateRules.restore()
+  })
   
   describe('existance', function () {
     it('should exist', function () {

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -38,15 +38,11 @@ describe('Model > SubjectStore', function () {
   }
   describe('Actions > advance', function () {
     describe('with a full queue', function () {
-      let rootStore
+      const rootStore = setupStores()
       let previousSubjectID
       let initialSize
 
       before(function () {
-        rootStore = setupStores()
-      })
-
-      beforeEach(function () {
         previousSubjectID = rootStore.subjects.active && rootStore.subjects.active.id
         initialSize = rootStore.subjects.resources.size
         rootStore.subjects.advance()

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -39,7 +39,7 @@ describe('Model > SubjectStore', function () {
   describe('Actions > advance', function () {
     describe('with a full queue', function () {
       let rootStore
-      let previousSubject
+      let previousSubjectID
       let initialSize
 
       before(function () {
@@ -47,20 +47,27 @@ describe('Model > SubjectStore', function () {
       })
 
       beforeEach(function () {
-        previousSubject = rootStore.subjects.resources.values().next().value.id
+        previousSubjectID = rootStore.subjects.active && rootStore.subjects.active.id
         initialSize = rootStore.subjects.resources.size
         rootStore.subjects.advance()
+      })
+
+      it('should make the next subject in the queue active', function () {
+        const currentSubjectID = rootStore.subjects.active && rootStore.subjects.active.id
+        expect(currentSubjectID).to.equal(subjects[1].id)
       })
 
       it('should reduce the queue size by one', function () {
         expect(rootStore.subjects.resources.size).to.equal(initialSize - 1)
       })
 
-      it('should make the next subject in the queue active', function () {
-        const currentSubject = rootStore.subjects.resources.values().next().value.id
-        expect(rootStore.subjects.active.id).to.equal(currentSubject)
-        expect(rootStore.subjects.resources.get(previousSubject)).to.be.undefined()
-        expect(previousSubject).to.not.equal(currentSubject)
+      it('should remove the active subject from the queue', function () {
+        expect(rootStore.subjects.resources.get(previousSubjectID)).to.be.undefined()
+      })
+
+      it('should change the active subject', function () {
+        const currentSubjectID = rootStore.subjects.active && rootStore.subjects.active.id
+        expect(currentSubjectID).to.not.equal(previousSubjectID)
       })
     })
 

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -13,7 +13,7 @@ const shortListSubjects = Factory.buildList('subject', 2)
 const clientStub = stubPanoptesJs({ subjects: longListSubjects, workflows: workflow })
 
 describe('Model > SubjectStore', function () {
-  function mockStores(panoptesClientStub = clientStub) {
+  function mockSubjectStore(panoptesClientStub = clientStub) {
     const store = RootStore.create({
       classifications: {},
       dataVisAnnotating: {},
@@ -34,11 +34,11 @@ describe('Model > SubjectStore', function () {
     store.projects.setActive(project.id)
     store.workflows.setResource(workflow)
     store.workflows.setActive(workflow.id)
-    return store
+    return store.subjects
   }
   describe('Actions > advance', function () {
     describe('with a full queue', function () {
-      const { subjects } = mockStores()
+      const subjects = mockSubjectStore()
       let previousSubjectID
       let initialSize
 
@@ -69,15 +69,13 @@ describe('Model > SubjectStore', function () {
 
     describe('with less than three subjects in the queue', function () {
       describe('when the initial response has ten subjects', function () {
-        const { subjects } = mockStores()
+        const subjects = mockSubjectStore()
 
         it('should request more subjects', function () {
           while (subjects.resources.size > MINIMUM_QUEUE_SIZE) {
             subjects.advance()
-            console.log(subjects.resources.size)
           }
           subjects.advance()
-          console.log(subjects.resources.size)
           // Once for initialization and once after the queue has been advanced to less than 3 subjects
           expect(subjects.populateQueue).to.have.been.calledTwice()
         })
@@ -85,7 +83,7 @@ describe('Model > SubjectStore', function () {
 
       describe('when the initial response has less than three subjects', function () {
         const clientStub = stubPanoptesJs({ workflows: workflow, subjects: shortListSubjects })
-        const { subjects } = mockStores(clientStub)
+        const subjects = mockSubjectStore(clientStub)
 
         it('should request more subjects', function () {
           // Once for initialization and again since less than three subjects in initial response
@@ -95,7 +93,7 @@ describe('Model > SubjectStore', function () {
 
       describe('when the initial response has no subjects', function () {
         const clientStub = stubPanoptesJs({ workflows: workflow, subjects: [] })
-        const { subjects } = mockStores(clientStub)
+        const subjects = mockSubjectStore(clientStub)
 
         it('should request more subjects', function () {
           // Once for initialization
@@ -111,7 +109,7 @@ describe('Model > SubjectStore', function () {
 
     describe('after emptying the queue', function () {
       const clientStub = stubPanoptesJs({ workflows: workflow, subjects })
-      const { subjects } = mockStores(clientStub)
+      const subjects = mockSubjectStore(clientStub)
 
       beforeEach(function () {
         while (subjects.resources.size > 0) {
@@ -130,14 +128,14 @@ describe('Model > SubjectStore', function () {
     it('should return false when there is not an active queue subject', function (done) {
       const getStub = stubPanoptesJs({ subjects: [] })
 
-      const { subjects } = mockStores(getStub)
+      const subjects = mockSubjectStore(getStub)
       subjects.populateQueue().then(() => {
         expect(subjects.isThereMetadata).to.be.false()
       }).then(done, done)
     })
 
     it('should return false if the active subject does not have metadata', function (done) {
-      const { subjects } = mockStores()
+      const subjects = mockSubjectStore()
       subjects.populateQueue().then(() => {
         expect(Object.keys(subjects.active.metadata)).to.have.lengthOf(0)
         expect(subjects.isThereMetadata).to.be.false()
@@ -148,7 +146,7 @@ describe('Model > SubjectStore', function () {
       const subjectWithHiddenMetadata = SubjectFactory.build({ metadata: { '#foo': 'bar' } })
       const getStub = stubPanoptesJs({ subjects: subjectWithHiddenMetadata })
 
-      const { subjects } = mockStores(getStub)
+      const subjects = mockSubjectStore(getStub)
       subjects.populateQueue().then(() => {
         const metadataKeys = Object.keys(subjects.active.metadata)
         expect(metadataKeys).to.have.lengthOf(1)
@@ -161,7 +159,7 @@ describe('Model > SubjectStore', function () {
       const subjectWithMetadata = SubjectFactory.build({ metadata: { foo: 'bar' } })
       const getStub = stubPanoptesJs({ subjects: subjectWithMetadata })
 
-      const { subjects } = mockStores(getStub)
+      const subjects = mockSubjectStore(getStub)
       subjects.populateQueue().then(() => {
         expect(Object.keys(subjects.active.metadata)).to.have.lengthOf(1)
         expect(subjects.isThereMetadata).to.be.true()


### PR DESCRIPTION
Package:
lib-classifier

This adds a couple of missing specs for `subjectStore.advance()`. Advancing the queue should:
- make the next subject in the queue active.
- remove the current active subject.
- reduce the size of the queue by one.
- change the active subject.

I've also removed `values().next()` in favour of using `subjectStore.active` to get the active subject, but tests are still failing and I can't see why.

`rootStore` is removed fro the subject store tests, and `setupStores` is renamed, to avoid name collisions with other store tests.

Tests will pass if the subject store tests are run in isolation.

EDIT: tests pass if `rootStore.subjects.advance()` is only called once so I've edited some of the tests to do that.

UPDATE: Feedback helpers were stubbed to enable feedback. Restoring the helpers has (hopefully) fixed tests that failed because feedback aborted the subject queue advance.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
