### PR TITLE
Theme: Update changelog. Add postversion script

### DIFF
--- a/packages/lib-grommet-theme/CHANGELOG.md
+++ b/packages/lib-grommet-theme/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.0.0] 2019-08-19
+## [2.1.0] 2019-08-20
+### Added
+- Zooniverse colors, fonts, and brand styles for specific components
+
+## [2.0.0] 2018-12
 ### Added
 
-- Theme object using Zooniverse brand structured using Grommet's theme convention
+- Initial theme object structured using Grommet's theme convention

--- a/packages/lib-grommet-theme/package.json
+++ b/packages/lib-grommet-theme/package.json
@@ -3,10 +3,11 @@
   "description": "A Zooniverse theme for the Grommet React library",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "src/index.js",
   "scripts": {
-    "lint": "zoo-standard --fix | snazzy"
+    "lint": "zoo-standard --fix | snazzy",
+    "postversion": "git push && git push --tags && npm publish"
   },
   "dependencies": {
     "deep-freeze": "~0.0.1"


### PR DESCRIPTION
Package: lib-grommet-theme

Adds a postversion script to push up the new version tag and publish. Updates the changelog. 


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
