### PR TITLE
[MST Upgrade] Update FieldGuideStore and tests

### DIFF
--- a/packages/lib-classifier/src/store/FieldGuideStore.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.js
@@ -17,32 +17,31 @@ const FieldGuideStore = types
   })
 
   .actions(self => {
-    function afterAttach () {
+    function afterAttach() {
       createProjectObserver()
     }
 
-    function createProjectObserver () {
+    function createProjectObserver() {
       const projectDisposer = autorun(() => {
         const validProjectReference = isValidReference(() => getRoot(self).projects.active)
         if (validProjectReference) {
+          const project = getRoot(self).projects.active
           self.reset()
-          self.fetchFieldGuide()
+          self.fetchFieldGuide(project.id)
         }
       }, { name: 'FieldGuideStore Project Observer autorun' })
       addDisposer(self, projectDisposer)
     }
 
-    function reset () {
-      self.active = undefined
+    function reset() {
       self.resources.clear()
-      self.activeMedium = undefined
       self.attachedMedia.clear()
       self.activeItemIndex = undefined
       self.showModal = false
     }
 
     // TODO: this might need to paginate for field guides that have 20+ items
-    const fetchMedia = flow(function * fetchMedia (fieldGuide) {
+    const fetchMedia = flow(function* fetchMedia(fieldGuide) {
       const { type } = self
       const client = getRoot(self).client.panoptes
       if (fieldGuide) {
@@ -55,24 +54,25 @@ const FieldGuideStore = types
         } catch (error) {
           // We're not setting the store state to error because
           // we do not want to prevent the field guide from rendering
-          console.error(error)
+          if (process.browser) {
+            console.error(error)
+          }
         }
       }
     })
 
-    function setMediaResources (media) {
+    function setMediaResources(media) {
       media.forEach(medium => self.attachedMedia.put(medium))
     }
 
     // TODO: move req in panoptes.js
-    function * fetchFieldGuide () {
+    function* fetchFieldGuide(projectID) {
       const { type } = self
-      const project = getRoot(self).projects.active
       const client = getRoot(self).client.panoptes
 
       self.loadingState = asyncStates.loading
       try {
-        const response = yield client.get(`/${type}`, { project_id: project.id })
+        const response = yield client.get(`/${type}`, { project_id: projectID })
         const fieldGuide = response.body[type][0]
         if (fieldGuide) {
           yield fetchMedia(fieldGuide)
@@ -83,22 +83,27 @@ const FieldGuideStore = types
           self.loadingState = asyncStates.success
         }
       } catch (error) {
-        console.error(error)
+        if (process.browser) {
+          console.error(error)
+        }
         self.loadingState = asyncStates.error
       }
     }
 
-    function setModalVisibility (boolean) {
+    function setModalVisibility(boolean) {
       self.showModal = boolean
     }
 
-    function setActiveItemIndex (index) {
-      const fieldGuide = self.active
-      if (fieldGuide && index + 1 <= fieldGuide.items.length && fieldGuide.items[index]) {
-        if (fieldGuide.items[index].icon) self.activeMedium = fieldGuide.items[index].icon
-        self.activeItemIndex = index
-      } else {
-        self.activeItemIndex = undefined
+    function setActiveItemIndex(index) {
+      const validFieldGuide = isValidReference(() => self.active)
+      if (validFieldGuide) {
+        const fieldGuide = self.active
+        if (fieldGuide && index + 1 <= fieldGuide.items.length && fieldGuide.items[index]) {
+          if (fieldGuide.items[index].icon) self.activeMedium = fieldGuide.items[index].icon
+          self.activeItemIndex = index
+        } else {
+          self.activeItemIndex = undefined
+        }
       }
     }
 

--- a/packages/lib-classifier/src/store/FieldGuideStore.spec.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.spec.js
@@ -47,7 +47,7 @@ function setupStores(clientStub) {
 }
 
 
-describe.only('Model > FieldGuideStore', function () {
+describe('Model > FieldGuideStore', function () {
   it('should exist', function () {
     expect(FieldGuideStore).to.be.an('object')
   })

--- a/packages/lib-classifier/src/store/FieldGuideStore.spec.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.spec.js
@@ -1,8 +1,9 @@
 import sinon from 'sinon'
 import asyncStates from '@zooniverse/async-states'
+import { applySnapshot } from 'mobx-state-tree'
 
-import RootStore from './RootStore'
 import FieldGuideStore from './FieldGuideStore'
+import ProjectStore from './ProjectStore'
 
 import {
   ProjectFactory,
@@ -12,17 +13,19 @@ import {
 
 const medium = FieldGuideMediumFactory.build()
 const fieldGuide = FieldGuideFactory.build()
-const fieldGuideWithItems = FieldGuideFactory.build({ items: [
-  {
-    content: 'All about cats',
-    icon: medium.id,
-    title: 'Cats'
-  },
-  {
-    content: 'All about dogs',
-    title: 'Dogs'
-  }
-] })
+const fieldGuideWithItems = FieldGuideFactory.build({
+  items: [
+    {
+      content: 'All about cats',
+      icon: medium.id,
+      title: 'Cats'
+    },
+    {
+      content: 'All about dogs',
+      title: 'Dogs'
+    }
+  ]
+})
 
 const fieldGuideWithoutIcon = FieldGuideFactory.build({
   items: [
@@ -35,62 +38,53 @@ const fieldGuideWithoutIcon = FieldGuideFactory.build({
 
 const project = ProjectFactory.build()
 
-describe('Model > FieldGuideStore', function () {
-  function fetchFieldGuide (rootStore) {
-    sinon.stub(rootStore.fieldGuide, 'fetchFieldGuide')
-    rootStore.projects.setResource(project)
-    return rootStore.projects.setActive(project.id)
-      .then(() => {
-        rootStore.fieldGuide.fetchFieldGuide.restore()
-        return rootStore.fieldGuide.fetchFieldGuide()
-      })
-  }
+function setupStores(clientStub) {
+  const store = FieldGuideStore.create()
+  store.projects = ProjectStore.create()
+  store.client = clientStub
 
-  function setupStores (clientStub) {
-    const store = RootStore.create({
-      classifications: {},
-      dataVisAnnotating: {},
-      drawing: {},
-      feedback: {},
-      subjects: {},
-      subjectViewer: {},
-      tutorials: {},
-      workflows: {},
-      workflowSteps: {},
-      userProjectPreferences: {}
-    }, { client: clientStub })
+  return store
+}
 
-    return store
-  }
 
+describe.only('Model > FieldGuideStore', function () {
   it('should exist', function () {
     expect(FieldGuideStore).to.be.an('object')
   })
 
-  it('should remain in an initialized state if there is no project', function () {
-    const panoptesClientStub = { panoptes: { get: sinon.stub().callsFake(() => Promise.resolve(null)) } }
-    const rootStore = setupStores(panoptesClientStub)
-    expect(rootStore.tutorials.loadingState).to.equal(asyncStates.initialized)
-    expect(rootStore.client.panoptes.get).to.have.not.been.called()
+  describe('when there isn\'t a project', function () {
+    it('should remain in an initialized state', function () {
+      const panoptesClientStub = { panoptes: { get: sinon.stub().callsFake(() => Promise.resolve({ body: null })) } }
+      const fieldGuideStore = setupStores(panoptesClientStub)
+      expect(fieldGuideStore.loadingState).to.equal(asyncStates.initialized)
+      expect(fieldGuideStore.client.panoptes.get).to.have.not.been.called()
+    })
   })
 
-  it('should set the field guide if there is a project', function (done) {
-    const panoptesClientStub = {
-      panoptes: {
-        get: sinon.stub().callsFake((url) => {
-          if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
-          if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
-          return Promise.resolve({ body: null })
-        })
+  describe('when there is a project', function () {
+    it('should set the field guide', function (done) {
+      const panoptesClientStub = {
+        panoptes: {
+          get: sinon.stub().callsFake((url) => {
+            if (url === '/field_guides') return Promise.resolve({ body: { field_guides: [fieldGuide] } })
+            if (url === `/field_guides/${fieldGuide.id}/attached_images`) return Promise.resolve({ body: { media: [] } })
+            return Promise.resolve({ body: null })
+          })
+        }
       }
-    }
-    const rootStore = setupStores(panoptesClientStub)
+      const fieldGuideStore = setupStores(panoptesClientStub)
+      applySnapshot(fieldGuideStore.projects, { active: project.id, resources: { [project.id]: project } })
 
-    fetchFieldGuide(rootStore)
-      .then(() => {
-        const fieldGuideInStore = rootStore.fieldGuide.active
-        expect(fieldGuideInStore.toJSON()).to.deep.equal(fieldGuide)
+      expect(fieldGuideStore.loadingState).to.equal(asyncStates.initialized)
+      expect(fieldGuideStore.active).to.be.undefined()
+
+      fieldGuideStore.fetchFieldGuide(project.id).then(() => {
+        const fieldGuideInStore = fieldGuideStore.active
+        expect(fieldGuideInStore.id).to.deep.equal(fieldGuide.id)
+        expect(fieldGuideStore.loadingState).to.equal(asyncStates.success)
+        expect(fieldGuideStore.client.panoptes.get).to.have.been.calledTwice()
       }).then(done, done)
+    })
   })
 
   describe('Actions > fetchFieldGuide', function () {
@@ -104,11 +98,10 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
-
-      fetchFieldGuide(rootStore)
+      const fieldGuideStore = setupStores(panoptesClientStub)
+      fieldGuideStore.fetchFieldGuide(project.id)
         .then(() => {
-          expect(rootStore.client.panoptes.get.withArgs('/field_guides', { project_id: project.id })).to.have.been.calledOnce()
+          expect(fieldGuideStore.client.panoptes.get.withArgs('/field_guides', { project_id: project.id })).to.have.been.calledOnce()
         }).then(done, done)
     })
 
@@ -122,14 +115,15 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
+      const fieldGuideStore = setupStores(panoptesClientStub)
 
-      const setResourceSpy = sinon.spy(rootStore.fieldGuide, 'setResource')
+      const setResourceSpy = sinon.spy(fieldGuideStore, 'setResource')
+      expect(fieldGuideStore.loadingState).to.equal(asyncStates.initialized)
 
-      fetchFieldGuide(rootStore)
+      fieldGuideStore.fetchFieldGuide(project.id)
         .then(() => {
           expect(setResourceSpy).to.have.not.been.called()
-          expect(rootStore.fieldGuide.loadingState).to.equal(asyncStates.success)
+          expect(fieldGuideStore.loadingState).to.equal(asyncStates.success)
         }).then(() => {
           setResourceSpy.restore()
         }).then(done, done)
@@ -145,19 +139,11 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
+      const fieldGuideStore = setupStores(panoptesClientStub)
 
-      sinon.stub(rootStore.fieldGuide, 'fetchFieldGuide')
-
-      rootStore.projects.setResource(project)
-      rootStore.projects.setActive(project.id)
-        .then(() => rootStore.client.panoptes.get.resetHistory())
+      fieldGuideStore.fetchFieldGuide(project.id)
         .then(() => {
-          rootStore.fieldGuide.fetchFieldGuide.restore()
-          return rootStore.fieldGuide.fetchFieldGuide()
-        })
-        .then(() => {
-          expect(rootStore.client.panoptes.get.withArgs(`/field_guides/${fieldGuide.id}/attached_images`)).to.have.been.calledOnce()
+          expect(fieldGuideStore.client.panoptes.get.withArgs(`/field_guides/${fieldGuide.id}/attached_images`)).to.have.been.calledOnce()
         }).then(done, done)
     })
 
@@ -171,12 +157,12 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
+      const fieldGuideStore = setupStores(panoptesClientStub)
 
-      const setResourceSpy = sinon.spy(rootStore.fieldGuide, 'setResource')
-      const setActiveSpy = sinon.spy(rootStore.fieldGuide, 'setActive')
+      const setResourceSpy = sinon.spy(fieldGuideStore, 'setResource')
+      const setActiveSpy = sinon.spy(fieldGuideStore, 'setActive')
 
-      fetchFieldGuide(rootStore)
+      fieldGuideStore.fetchFieldGuide(project.id)
         .then(() => {
           expect(setResourceSpy).to.have.been.calledOnceWith(fieldGuide)
           expect(setActiveSpy).to.have.been.calledOnceWith(fieldGuide.id)
@@ -194,11 +180,12 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
+      const fieldGuideStore = setupStores(panoptesClientStub)
+      expect(fieldGuideStore.loadingState).to.equal(asyncStates.initialized)
 
-      fetchFieldGuide(rootStore)
+      fieldGuideStore.fetchFieldGuide(project.id)
         .then(() => {
-          expect(rootStore.fieldGuide.loadingState).to.equal(asyncStates.error)
+          expect(fieldGuideStore.loadingState).to.equal(asyncStates.error)
         }).then(done, done)
     })
   })
@@ -214,11 +201,11 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
+      const fieldGuideStore = setupStores(panoptesClientStub)
 
-      const setMediaResourcesSpy = sinon.spy(rootStore.fieldGuide, 'setMediaResources')
+      const setMediaResourcesSpy = sinon.spy(fieldGuideStore, 'setMediaResources')
 
-      fetchFieldGuide(rootStore)
+      fieldGuideStore.fetchFieldGuide(project.id)
         .then(() => {
           expect(setMediaResourcesSpy).to.have.not.been.called()
         }).then(() => {
@@ -236,11 +223,11 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
+      const fieldGuideStore = setupStores(panoptesClientStub)
 
-      const setMediaResourcesSpy = sinon.spy(rootStore.fieldGuide, 'setMediaResources')
+      const setMediaResourcesSpy = sinon.spy(fieldGuideStore, 'setMediaResources')
 
-      fetchFieldGuide(rootStore)
+      fieldGuideStore.fetchFieldGuide(project.id)
         .then(() => {
           expect(setMediaResourcesSpy).to.have.been.calledOnceWith([medium])
         }).then(() => {
@@ -260,12 +247,13 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
 
-      rootStore.fieldGuide.setModalVisibility(true)
-      expect(rootStore.fieldGuide.showModal).to.be.true()
-      rootStore.fieldGuide.setModalVisibility(false)
-      expect(rootStore.fieldGuide.showModal).to.be.false()
+      const fieldGuideStore = setupStores(panoptesClientStub)
+      expect(fieldGuideStore.showModal).to.be.false()
+      fieldGuideStore.setModalVisibility(true)
+      expect(fieldGuideStore.showModal).to.be.true()
+      fieldGuideStore.setModalVisibility(false)
+      expect(fieldGuideStore.showModal).to.be.false()
     })
   })
 
@@ -280,12 +268,15 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
+      const fieldGuideStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide(rootStore).then(() => {
-        rootStore.fieldGuide.setActiveItemIndex(0)
-        expect(rootStore.fieldGuide.activeItemIndex).to.be.undefined()
-        expect(rootStore.fieldGuide.activeMedium).to.be.undefined()
+      expect(fieldGuideStore.activeItemIndex).to.be.undefined()
+      expect(fieldGuideStore.activeMedium).to.be.undefined()
+
+      fieldGuideStore.fetchFieldGuide(project.id).then(() => {
+        fieldGuideStore.setActiveItemIndex(0)
+        expect(fieldGuideStore.activeItemIndex).to.be.undefined()
+        expect(fieldGuideStore.activeMedium).to.be.undefined()
       }).then(done, done)
     })
 
@@ -299,12 +290,15 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
+      const fieldGuideStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide(rootStore).then(() => {
-        rootStore.fieldGuide.setActiveItemIndex()
-        expect(rootStore.fieldGuide.activeItemIndex).to.be.undefined()
-        expect(rootStore.fieldGuide.activeMedium).to.be.undefined()
+      expect(fieldGuideStore.activeItemIndex).to.be.undefined()
+      expect(fieldGuideStore.activeMedium).to.be.undefined()
+
+      fieldGuideStore.fetchFieldGuide(project.id).then(() => {
+        fieldGuideStore.setActiveItemIndex()
+        expect(fieldGuideStore.activeItemIndex).to.be.undefined()
+        expect(fieldGuideStore.activeMedium).to.be.undefined()
       }).then(done, done)
     })
 
@@ -318,12 +312,15 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
+      const fieldGuideStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide(rootStore).then(() => {
-        rootStore.fieldGuide.setActiveItemIndex(2)
-        expect(rootStore.fieldGuide.activeItemIndex).to.be.undefined()
-        expect(rootStore.fieldGuide.activeMedium).to.be.undefined()
+      expect(fieldGuideStore.activeItemIndex).to.be.undefined()
+      expect(fieldGuideStore.activeMedium).to.be.undefined()
+
+      fieldGuideStore.fetchFieldGuide(project.id).then(() => {
+        fieldGuideStore.setActiveItemIndex(2)
+        expect(fieldGuideStore.activeItemIndex).to.be.undefined()
+        expect(fieldGuideStore.activeMedium).to.be.undefined()
       }).then(done, done)
     })
 
@@ -337,13 +334,15 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
+      const fieldGuideStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide(rootStore)
+      expect(fieldGuideStore.activeItemIndex).to.be.undefined()
+
+      fieldGuideStore.fetchFieldGuide(project.id)
         .then(() => {
           fieldGuideWithItems.items.forEach((item, index) => {
-            rootStore.fieldGuide.setActiveItemIndex(index)
-            expect(rootStore.fieldGuide.activeItemIndex).to.equal(index)
+            fieldGuideStore.setActiveItemIndex(index)
+            expect(fieldGuideStore.activeItemIndex).to.equal(index)
           })
         }).then(done, done)
     })
@@ -358,12 +357,14 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
+      const fieldGuideStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide(rootStore)
+      expect(fieldGuideStore.activeMedium).to.be.undefined()
+
+      fieldGuideStore.fetchFieldGuide(project.id)
         .then(() => {
-          rootStore.fieldGuide.setActiveItemIndex(0)
-          expect(rootStore.fieldGuide.activeMedium.toJSON()).to.deep.equal(medium)
+          fieldGuideStore.setActiveItemIndex(0)
+          expect(fieldGuideStore.activeMedium.toJSON()).to.deep.equal(medium)
         }).then(done, done)
     })
 
@@ -377,12 +378,15 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
+      const fieldGuideStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide(rootStore).then(() => {
-        rootStore.fieldGuide.setActiveItemIndex(0)
-        expect(rootStore.fieldGuide.activeItemIndex).to.equal(0)
-        expect(rootStore.fieldGuide.activeMedium).to.be.undefined()
+      expect(fieldGuideStore.activeItemIndex).to.be.undefined()
+      expect(fieldGuideStore.activeMedium).to.be.undefined()
+
+      fieldGuideStore.fetchFieldGuide(project.id).then(() => {
+        fieldGuideStore.setActiveItemIndex(0)
+        expect(fieldGuideStore.activeItemIndex).to.equal(0)
+        expect(fieldGuideStore.activeMedium).to.be.undefined()
       }).then(done, done)
     })
   })
@@ -398,28 +402,28 @@ describe('Model > FieldGuideStore', function () {
           })
         }
       }
-      const rootStore = setupStores(panoptesClientStub)
+      const fieldGuideStore = setupStores(panoptesClientStub)
 
-      fetchFieldGuide(rootStore)
+      fieldGuideStore.fetchFieldGuide(project.id)
         .then(() => {
-          rootStore.fieldGuide.setActiveItemIndex(0)
-          rootStore.fieldGuide.setModalVisibility(true)
+          fieldGuideStore.setActiveItemIndex(0)
+          fieldGuideStore.setModalVisibility(true)
         })
         .then(() => {
-          expect(rootStore.fieldGuide.active).to.be.ok()
-          expect(rootStore.fieldGuide.resources).to.be.ok()
-          expect(rootStore.fieldGuide.attachedMedia).to.be.ok()
-          expect(rootStore.fieldGuide.activeMedium).to.be.ok()
-          expect(rootStore.fieldGuide.activeItemIndex).to.equal(0)
-          expect(rootStore.fieldGuide.showModal).to.be.true()
-          return rootStore.fieldGuide.reset()
+          expect(fieldGuideStore.active.id).to.equal(fieldGuideWithItems.id)
+          expect(fieldGuideStore.resources.size).to.equal(1)
+          expect(fieldGuideStore.attachedMedia.size).to.equal(1)
+          expect(fieldGuideStore.activeMedium.id).to.equal(medium.id)
+          expect(fieldGuideStore.activeItemIndex).to.equal(0)
+          expect(fieldGuideStore.showModal).to.be.true()
+          return fieldGuideStore.reset()
         }).then(() => {
-          expect(rootStore.fieldGuide.active).to.be.undefined()
-          expect(rootStore.fieldGuide.resources.size).to.equal(0)
-          expect(rootStore.fieldGuide.attachedMedia.size).to.equal(0)
-          expect(rootStore.fieldGuide.activeMedium).to.be.undefined()
-          expect(rootStore.fieldGuide.activeItemIndex).to.be.undefined()
-          expect(rootStore.fieldGuide.showModal).to.be.false()
+          expect(fieldGuideStore.active).to.be.undefined()
+          expect(fieldGuideStore.resources.size).to.equal(0)
+          expect(fieldGuideStore.attachedMedia.size).to.equal(0)
+          expect(fieldGuideStore.activeMedium).to.be.undefined()
+          expect(fieldGuideStore.activeItemIndex).to.be.undefined()
+          expect(fieldGuideStore.showModal).to.be.false()
         }).then(done, done)
     })
   })


### PR DESCRIPTION
Package: lib-classifier

This refactors the FieldGuideStore tests to get them passing again. This bypasses MST lifecycle `afterAttach` by scoping the mocked store to only the FieldGuideStore and not using the `RootStore` at all. I suspect there's still something wrong in how we're setting up the stores, but this setup is more the direction I'd like to go with the tests, and adding later a specific test for `afterAttach` that involves the `RootStore` rather than use it across the board.

I've also added a few `isValidReference` checks that were missing still. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
