### PR TITLE
Bump theme version across packages

### DIFF
--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -20,7 +20,7 @@
     "@sentry/browser": "^5.4.3",
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/classifier": "^0.0.1",
-    "@zooniverse/grommet-theme": "~2.0.0",
+    "@zooniverse/grommet-theme": "~2.1.0",
     "@zooniverse/panoptes-js": "~0.0.1",
     "@zooniverse/react-components": "~0.7.1",
     "babel-plugin-dynamic-import-node": "~2.3.0",

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -31,7 +31,7 @@
     "valid-url": "~1.0.9"
   },
   "peerDependencies": {
-    "@zooniverse/grommet-theme": "~2.0.0",
+    "@zooniverse/grommet-theme": "~2.1.0",
     "@zooniverse/panoptes-js": "~0.0.1",
     "@zooniverse/react-components": "~0.7.1",
     "grommet": "~2.7.x",
@@ -58,7 +58,7 @@
     "@storybook/addon-viewport": "~5.1.9",
     "@storybook/addons": "^5.1.9",
     "@storybook/react": "^5.1.9",
-    "@zooniverse/grommet-theme": "~2.0.0",
+    "@zooniverse/grommet-theme": "~2.1.0",
     "@zooniverse/panoptes-js": "~0.0.1",
     "@zooniverse/react-components": "~0.7.1",
     "@zooniverse/standard": "~1.0.0",

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -35,7 +35,7 @@
     "unist-util-visit": "~1.4.0"
   },
   "peerDependencies": {
-    "@zooniverse/grommet-theme": "2.0.x",
+    "@zooniverse/grommet-theme": "2.1.x",
     "grommet": "2.7.x",
     "grommet-icons": "4.2.x",
     "react": "16.8.x",
@@ -57,7 +57,7 @@
     "@storybook/addon-viewport": "~5.1.9",
     "@storybook/addons": "~5.1.9",
     "@storybook/react": "~5.1.9",
-    "@zooniverse/grommet-theme": "~2.0.0",
+    "@zooniverse/grommet-theme": "~2.1.0",
     "@zooniverse/standard": "~1.0.0",
     "babel-loader": "~8.0.6",
     "babel-plugin-styled-components": "~1.10.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3580,6 +3580,13 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@zooniverse/grommet-theme@~2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@zooniverse/grommet-theme/-/grommet-theme-2.0.0.tgz#9cc997c7e7f81738ee7f7d08fed596e53c3ebfa8"
+  integrity sha512-vXfWwu0IhhkaT88rJdDsL87n74mXjECOHCZNdxl7snb5jVF7WBZm/BZQHFaQ3e/KLV28+xZJe6OF5ReiEoadRQ==
+  dependencies:
+    deep-freeze "~0.0.1"
+
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"


### PR DESCRIPTION
Package: almost all of em

Bumps zoo grommet theme version to 2.1.0 across packages. Fixes broken theme on site.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
