### PR TITLE
docker-compose: mount local source files

### DIFF
--- a/packages/app-content-pages/docker-compose.yml
+++ b/packages/app-content-pages/docker-compose.yml
@@ -14,5 +14,5 @@ services:
       - "3000:3000"
       - "9001:9001"
     volumes:
-      - ../../:/usr/src
-      - /usr/src/node_modules
+      - ./pages:/usr/src/packages/app-content-pages/pages
+      - ./src:/usr/src/packages/app-content-pages/src

--- a/packages/app-project/README.md
+++ b/packages/app-project/README.md
@@ -33,7 +33,6 @@ The production server is started on port 3000 by default.
 
 #### Docker
 ```sh
-docker-compose run --rm dev build
 docker-compose run --rm --service-ports dev start
 ````
 

--- a/packages/app-project/docker-compose.yml
+++ b/packages/app-project/docker-compose.yml
@@ -13,8 +13,9 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ../../:/usr/src
-      - /usr/src/node_modules
+      - ./pages:/usr/src/packages/app-project/pages
+      - ./src:/usr/src/packages/app-project/src
+      - ./stores:/usr/src/packages/app-project/stores
   storybook:
     image: front-end-monorepo_dev:latest
     entrypoint:
@@ -25,5 +26,6 @@ services:
     ports:
       - "9001:9001"
     volumes:
-      - ../../:/usr/src
-      - /usr/src/node_modules
+      - ./pages:/usr/src/packages/app-project/pages
+      - ./src:/usr/src/packages/app-project/src
+      - ./stores:/usr/src/packages/app-project/stores

--- a/packages/lib-classifier/docker-compose.yml
+++ b/packages/lib-classifier/docker-compose.yml
@@ -15,8 +15,7 @@ services:
     environment:
       - HOST=0.0.0.0
     volumes:
-      - ../../:/usr/src
-      - /usr/src/node_modules
+      - ./src:/usr/src/packages/lib-classifier/src
   storybook:
     image: front-end-monorepo_dev:latest
     entrypoint:
@@ -27,5 +26,4 @@ services:
     ports:
       - "6006:6006"
     volumes:
-      - ../../:/usr/src
-      - /usr/src/node_modules
+      - ./src:/usr/src/packages/lib-classifier/src


### PR DESCRIPTION
Update docker-compose for the development environment to mount local source files to the running container, but not other files such as local node modules or config.

Should fix problems where `yarn install` has to be run locally in order to use docker for local development, because node modules installed in each package under `/usr/src/packages` are replaced by node modules from the mounted local volume.

Also fixes some errors in the `app-project` README.

Package:
app-content-pages
app-project
lib-classifier


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
