### PR TITLE
Add mobx-upgrade to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ node_js:
 
 branches:
   only:
-  - master
+    - master
+    - mobx-upgrade
+    - update-store-instantiation
 
 cache: yarn
 


### PR DESCRIPTION
Run CI tests on the mobx-upgrade and update-store-instantiation feature branches.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
