### PR TITLE
Feedback bug fixes

### DIFF
--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -148,7 +148,7 @@ const ClassificationStore = types
       }
 
       const feedback = getRoot(self).feedback
-      if (feedback.isActive && feedback.rules) {
+      if (feedback.isActive && feedback.rules.size > 0) {
         metadata.feedback = toJS(feedback.rules)
       }
 

--- a/packages/lib-classifier/src/store/FeedbackStore.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.js
@@ -90,7 +90,6 @@ const FeedbackStore = types
       const workflow = getRoot(self).workflows.active
 
       self.isActive = helpers.isFeedbackActive(project, subject, workflow)
-
       if (self.isActive) {
         self.rules = helpers.generateRules(subject, workflow)
       }
@@ -106,13 +105,15 @@ const FeedbackStore = types
     }
 
     function update (annotation) {
-      const { task, value } = annotation
-      const taskRules = self.rules.get(task) || []
-      const updatedTaskRules = taskRules.map(rule => {
-        const ruleReducer = strategies[rule.strategy].reducer
-        return ruleReducer(rule, value)
-      })
-      self.rules.set(task, updatedTaskRules)
+      if (self.isActive) {
+        const { task, value } = annotation
+        const taskRules = self.rules.get(task) || []
+        const updatedTaskRules = taskRules.map(rule => {
+          const ruleReducer = strategies[rule.strategy].reducer
+          return ruleReducer(rule, value)
+        })
+        self.rules.set(task, updatedTaskRules)
+      }
     }
 
     function reset () {


### PR DESCRIPTION
Package: lib-classifier

For #874 (maybe closes?)

Describe your changes:
- Updates the conditional to check that the feedback rules sizes is greater than 0 before updating the classification metadata with feedback information. 
- Updates the feedback store `update` action to only update the feedback rules if feedback is active
- Adds specs for both

The feedback store tests could use refactoring, however, I'm trying to minimize the merge conflict that this will cause with the MST updates (and subsequent test updates that caused). So this is really only scoped to test for these bug fixes.

There may still be a scenario where `isActive` is true, but there are no feedback rules because the subject is a real subject and has no feedback rule subject metadata, so `isActive` shouldn't be true, but is. I've seen this on first load of a real subject on TESS, so it isn't a bug with the reset action. It is likely a bug with one of the helpers that determine whether or not to set `isActive` to true in the store. However, we haven't reliably and consistently replicated this yet although it has been observed. See slack discussion on it.

This PR, though, will at least prevent adding a `T1: []` feedback metadata to the classification metadata when the subject is real and `isActive` is false. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
