### PR TITLE
Add subjects.append(newSubjects)

### DIFF
--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -111,6 +111,17 @@ const SubjectStore = types
       }
     }
 
+    function append (newSubjects) {
+      newSubjects.forEach(subject => {
+        self.resources.put(subject)
+      })
+
+      const validSubjectReference = isValidReference(() => self.active)
+      if (!validSubjectReference) {
+        self.advance()
+      }
+    }
+
     function * populateQueue () {
       const root = getRoot(self)
       const client = root.client.panoptes
@@ -125,14 +136,7 @@ const SubjectStore = types
           const response = yield client.get(`/subjects/queued`, { workflow_id: workflowId }, { authorization })
 
           if (response.body.subjects && response.body.subjects.length > 0) {
-            response.body.subjects.forEach(subject => {
-              self.resources.put(subject)
-            })
-
-            const validSubjectReference = isValidReference(() => self.active)
-            if (!validSubjectReference) {
-              self.advance()
-            }
+            self.append(response.body.subjects)
           }
 
           self.loadingState = asyncStates.success
@@ -150,6 +154,7 @@ const SubjectStore = types
     return {
       advance,
       afterAttach,
+      append,
       populateQueue: flow(populateQueue),
       reset
     }

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -121,6 +121,26 @@ describe('Model > SubjectStore', function () {
     })
   })
 
+  describe('Actions > append', function () {
+    const subjects = mockSubjectStore([])
+
+    before(function () {
+      subjects.append(shortListSubjects)
+      subjects.append(longListSubjects)
+    })
+
+    it('should increase the size of the queue', function () {
+      expect(subjects.resources.size).to.equal(shortListSubjects.length + longListSubjects.length)
+    })
+
+    it('should add new subjects to the end of the queue', function () {
+      const initialSubjectIDs = shortListSubjects.map(subject => subject.id)
+      const newSubjectIDs = longListSubjects.map(subject => subject.id)
+      const queue = Array.from(subjects.resources.keys())
+      expect(queue).to.deep.equal([...initialSubjectIDs, ...newSubjectIDs])
+    })
+  })
+
   describe('Views > isThereMetadata', function () {
     it('should return false when there is not an active queue subject', function (done) {
       const subjects = mockSubjectStore([])

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -126,18 +126,41 @@ describe('Model > SubjectStore', function () {
 
     before(function () {
       subjects.append(shortListSubjects)
-      subjects.append(longListSubjects)
     })
 
     it('should increase the size of the queue', function () {
-      expect(subjects.resources.size).to.equal(shortListSubjects.length + longListSubjects.length)
+      expect(subjects.resources.size).to.equal(shortListSubjects.length)
     })
 
     it('should add new subjects to the end of the queue', function () {
       const initialSubjectIDs = shortListSubjects.map(subject => subject.id)
-      const newSubjectIDs = longListSubjects.map(subject => subject.id)
       const queue = Array.from(subjects.resources.keys())
-      expect(queue).to.deep.equal([...initialSubjectIDs, ...newSubjectIDs])
+      expect(queue).to.deep.equal(initialSubjectIDs)
+    })
+
+    it('should set the active subject', function () {
+      expect(subjects.active.id).to.equal(shortListSubjects[0].id)
+    })
+
+    describe('with an existing queue', function () {
+      before(function () {
+        subjects.append(longListSubjects)
+      })
+
+      it('should increase the size of the queue', function () {
+        expect(subjects.resources.size).to.equal(shortListSubjects.length + longListSubjects.length)
+      })
+
+      it('should add new subjects to the end of the queue', function () {
+        const initialSubjectIDs = shortListSubjects.map(subject => subject.id)
+        const newSubjectIDs = longListSubjects.map(subject => subject.id)
+        const queue = Array.from(subjects.resources.keys())
+        expect(queue).to.deep.equal([...initialSubjectIDs, ...newSubjectIDs])
+      })
+
+      it('should not change the active subject', function () {
+        expect(subjects.active.id).to.equal(shortListSubjects[0].id)
+      })
     })
   })
 


### PR DESCRIPTION
Package:
lib-classifier

Adds an `append` action to the subject store, plus a couple of specs.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
