### PR TITLE
Talk widget: Add an image carousel

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/ZooniverseTalk.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/ZooniverseTalk.js
@@ -40,7 +40,7 @@ function ZooniverseTalk (props) {
           <JoinInButton />
         </Box>
         <Box fill='horizontal'>
-          <RecentSubjects show={true} />
+          <RecentSubjects carousel={props.screenSize === 'small'} />
         </Box>
       </Grid>
     </ContentBox>

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsCarousel.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsCarousel.js
@@ -11,6 +11,7 @@ function RecentSubjectsCarousel (props) {
   const width = 700
   return (
     <Carousel
+      className={className}
       controls='arrows'
       fill
     >

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsCarousel.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsCarousel.js
@@ -1,0 +1,39 @@
+import counterpart from 'counterpart'
+import { arrayOf, shape, string } from 'prop-types'
+import React from 'react'
+import { Carousel } from 'grommet'
+import SubjectThumbnail from './components/SubjectThumbnail'
+
+// TODO: Use the subject viewers from the classifier
+function RecentSubjectsCarousel (props) {
+  const { className, href, subjects } = props
+  const height = 500
+  const width = 700
+  return (
+    <Carousel
+      controls='arrows'
+      fill
+    >
+      {subjects.map( subject => (
+        <SubjectThumbnail
+          key={subject.id}
+          height={height}
+          href={href}
+          subject={subject}
+          width={width}
+        />
+      ))}
+    </Carousel>
+  )
+}
+
+RecentSubjectsCarousel.propTypes = {
+  subjects: arrayOf(shape({
+    id: string
+  }))
+}
+
+RecentSubjectsCarousel.defaultProps = {
+}
+
+export default RecentSubjectsCarousel

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsCarousel.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsCarousel.js
@@ -29,12 +29,15 @@ function RecentSubjectsCarousel (props) {
 }
 
 RecentSubjectsCarousel.propTypes = {
+  className: string,
+  href: string.isRequired,
   subjects: arrayOf(shape({
     id: string
-  }))
+  })).isRequired
 }
 
 RecentSubjectsCarousel.defaultProps = {
+  className: undefined
 }
 
 export default RecentSubjectsCarousel

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsCarousel.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsCarousel.spec.js
@@ -1,0 +1,40 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import RecentSubjectsCarousel from './RecentSubjectsCarousel'
+import SubjectThumbnail from './components/SubjectThumbnail'
+
+describe('Component > RecentSubjectsCarousel', function () {
+  let wrapper
+  const subjects = [
+    mockSubject('2'),
+    mockSubject('1'),
+    mockSubject('3')
+  ]
+  function mockSubject(id) {
+    return {
+      id,
+      locations: [
+        {'image/jpeg': `https://www.zooniverse.org/mock-subjects/file-${id}.jpg`}
+      ]
+    }
+  }
+
+  before(function () {
+    wrapper = shallow(
+      <RecentSubjectsCarousel
+        href="/projects/test/project/talk"
+        subjects={subjects}
+      />
+    )
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render a thumbnail for each subject', function () {
+    const thumbnails = wrapper.find(SubjectThumbnail)
+    expect(thumbnails.length).to.equal(3)
+  })
+})

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsContainer.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsContainer.js
@@ -5,6 +5,7 @@ import { bool } from 'prop-types'
 import React, { Component } from 'react'
 
 import RecentSubjects from './RecentSubjects'
+import RecentSubjectsCarousel from './RecentSubjectsCarousel'
 import MessageBox from './components/MessageBox'
 import Placeholder from './components/Placeholder'
 import fetchRecentSubjects from './helpers/fetchRecentSubjects'
@@ -46,21 +47,20 @@ class RecentSubjectsContainer extends Component {
   }
 
   render () {
-    const { show } = this.props
+    const { carousel } = this.props
     const { loading, subjects } = this.state
     const href=`/projects/${this.props.slug}/talk`
     let result = null
+    const ThumbnailComponent = carousel ? RecentSubjectsCarousel : RecentSubjects
 
-    if (show) {
-      if (loading === asyncStates.success) {
-        result = (subjects.length < 1)
-          ? (<MessageBox children={counterpart('RecentSubjects.noSubjects')} />)
-          : (<RecentSubjects href={href} subjects={subjects} />)
-      } else if (loading === asyncStates.error) {
-        result = (<MessageBox children={counterpart('RecentSubjects.error')} />)
-      } else {
-        result = (<Placeholder />)
-      }
+    if (loading === asyncStates.success) {
+      result = (subjects.length < 1)
+        ? (<MessageBox children={counterpart('RecentSubjects.noSubjects')} />)
+        : (<ThumbnailComponent href={href} subjects={subjects} />)
+    } else if (loading === asyncStates.error) {
+      result = (<MessageBox children={counterpart('RecentSubjects.error')} />)
+    } else {
+      result = (<Placeholder />)
     }
 
     return result
@@ -68,11 +68,11 @@ class RecentSubjectsContainer extends Component {
 }
 
 RecentSubjectsContainer.propTypes = {
-  show: bool
+  carousel: bool
 }
 
 RecentSubjectsContainer.defaultProps = {
-  show: false
+  carousel: false
 }
 
 export default RecentSubjectsContainer


### PR DESCRIPTION
Add a carousel view for recent Talk subjects at small screen sizes, plus spec.

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
