### PR TITLE
Allow feedback rules with falsy values 

### DIFF
--- a/packages/lib-classifier/src/store/feedback/helpers/generate-rules.spec.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/generate-rules.spec.js
@@ -81,4 +81,42 @@ describe('feedback: generateRules', function () {
     }
     testSubjectAndWorkflow(subject, workflow)
   })
+
+  describe('with no matching rules', function () {
+    describe('when the workflow rule ID is truthy', function () {
+      const workflow = {
+        tasks: {
+          T0: mockTaskWithRule('1')
+        }
+      }
+
+      it('should return an empty object for a falsy subject rule ID', function () {
+        const subject = mockSubjectWithRule(0)
+        expect(generateRules(subject, workflow)).to.be.empty()
+      })
+
+      it('should return an empty object for a truthy subject rule ID', function () {
+        const subject = mockSubjectWithRule('0')
+        expect(generateRules(subject, workflow)).to.be.empty()
+      })
+    })
+
+    describe('when the workflow rule ID is falsy', function () {
+      const workflow = {
+        tasks: {
+          T0: mockTaskWithRule(0)
+        }
+      }
+
+      it('should return an empty object for a numeric subject rule ID', function () {
+        const subject = mockSubjectWithRule(1)
+        expect(generateRules(subject, workflow)).to.be.empty()
+      })
+
+      it('should return an empty object for a string subject rule ID', function () {
+        const subject = mockSubjectWithRule('1')
+        expect(generateRules(subject, workflow)).to.be.empty()
+      })
+    })
+  })
 })

--- a/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.js
@@ -1,17 +1,21 @@
-import _ from 'lodash'
-
 // Converts a subject metadata object into an array of feedback objects
-function metadataToRules (metadata) {
-  const rulesObject = _.reduce(metadata, (result, value, key) => {
-    const [prefix, ruleKey, propKey] = key.split('_')
+function metadataToRules (metadata = {}) {
+  const metadataKeys = Object.keys(metadata)
+  const rules = metadataKeys.reduce(function (result, key) {
+    const [prefix, ruleIndex, propKey] = key.split('_')
+    const value = metadata[key]
+    const stringValue = value.toString()
 
-    if (prefix === '#feedback' && value) {
-      _.set(result, `${ruleKey}.${propKey}`, value)
+    if (prefix === '#feedback' && stringValue) {
+      const rule = result[ruleIndex] || {}
+      rule[propKey] = value
+      result[ruleIndex] = rule
     }
 
     return result
-  }, {})
-  return _.toArray(rulesObject)
+  }, [])
+
+  return rules.filter(Boolean)
 }
 
 export default metadataToRules

--- a/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.js
@@ -7,6 +7,9 @@ function metadataToRules (metadata = {}) {
     const stringValue = value.toString()
 
     if (prefix === '#feedback' && stringValue) {
+      if (isNaN(ruleIndex)) {
+        console.error(`Subject metadata feedback rule index ${ruleIndex} is improperly formatted. The feedback rule index should be an integer.`)
+      }
       const rule = result[ruleIndex] || {}
       rule[propKey] = value
       result[ruleIndex] = rule

--- a/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.spec.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.spec.js
@@ -1,0 +1,36 @@
+import { expect } from 'chai'
+import metadataToRules from './metadata-to-rules'
+
+describe('feedback: metadataToRules', function () {
+  function mockSubjectWithRule (ruleID) {
+    return {
+      metadata: {
+        '#feedback_1_id': ruleID,
+        '#feedback_1_answer': '0',
+        '#feedback_1_failureMessage': 'Actually, this sound is from noise (background)',
+        '#feedback_1_successMessage': 'Correct!'
+      }
+    }
+  }
+
+  function expectedRules (ruleID) {
+    return [{
+      id: ruleID,
+      answer: '0',
+      failureMessage: 'Actually, this sound is from noise (background)',
+      successMessage: 'Correct!'
+    }]
+  }
+
+  it('should generate a rules object for string IDs', function () {
+    const subject = mockSubjectWithRule('0')
+    const rules = metadataToRules(subject.metadata)
+    expect(rules).to.deep.equal(expectedRules('0'))
+  })
+
+  it('should generate a rules object for numerical IDs', function () {
+    const subject = mockSubjectWithRule(0)
+    const rules = metadataToRules(subject.metadata)
+    expect(rules).to.deep.equal(expectedRules(0))
+  })
+})

--- a/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.spec.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai'
+import sinon from 'sinon'
 import metadataToRules from './metadata-to-rules'
 
 describe('feedback: metadataToRules', function () {
@@ -9,6 +10,16 @@ describe('feedback: metadataToRules', function () {
         '#feedback_1_answer': '0',
         '#feedback_1_failureMessage': 'Actually, this sound is from noise (background)',
         '#feedback_1_successMessage': 'Correct!'
+      }
+    }
+  }
+
+  function mockSubjectWithRuleNonIntegerN (ruleID) {
+    return {
+      metadata: {
+        '#feedback_[1]_id': ruleID,
+        '#feedback_a_answer': '0',
+        '#feedback_1a2b_failureMessage': 'Actually, this sound is from noise (background)'
       }
     }
   }
@@ -32,5 +43,24 @@ describe('feedback: metadataToRules', function () {
     const subject = mockSubjectWithRule(0)
     const rules = metadataToRules(subject.metadata)
     expect(rules).to.deep.equal(expectedRules(0))
+  })
+
+  describe('with subject metadata feedback ruleIndex not an integer', function () {
+    let logError
+    before(function () {
+      logError = sinon.stub(console, 'error')
+    })
+
+    after(function () {
+      console.error.restore()
+    })
+
+    it('should console error with message', function () {
+      const improperMetadataSubject = mockSubjectWithRuleNonIntegerN(0)
+      metadataToRules(improperMetadataSubject.metadata)
+
+      expect(logError).to.have.been.calledThrice()
+      expect(logError).to.have.been.calledWith('Subject metadata feedback rule index [1] is improperly formatted. The feedback rule index should be an integer.')
+    })
   })
 })


### PR DESCRIPTION
Package:
lib-classifier

Closes #1061.

Copies over the changes to feedback from zooniverse/Panoptes-Front-End#5445
Allows feedback with a rule ID of 0 (or other rule keys with falsy values) by converting rule values to strings before checking that they exist.

Also adds a spec and a check for subject feedback where the rule index is not a number.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
