### PR TITLE
Add the theme toggle to the project home page

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.js
+++ b/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.js
@@ -1,16 +1,23 @@
 import { Grid } from 'grommet'
 import React from 'react'
+import { withResponsiveContext } from '@zooniverse/react-components'
 
 import MessageFromResearcher from './components/MessageFromResearcher'
 import AboutProject from '../../shared/components/AboutProject'
 import ConnectWithProject from '../../shared/components/ConnectWithProject'
 import ProjectStatistics from '../../shared/components/ProjectStatistics'
 import ZooniverseTalk from './components/ZooniverseTalk'
+import ThemeModeToggle from '../../components/ThemeModeToggle'
 
-function ProjectHomePage () {
+function ProjectHomePage (props) {
+  const { screenSize } = props
+  const responsiveColumns = (screenSize === 'small') ? ['auto'] : ['auto', '1em']
   return (
     <Grid gap='medium' margin='medium'>
-      <ZooniverseTalk />
+      <Grid columns={responsiveColumns} gap='small'>
+        <ZooniverseTalk />
+        <ThemeModeToggle />
+      </Grid>
       <ProjectStatistics />
       <Grid
         fill='horizontal'
@@ -25,4 +32,5 @@ function ProjectHomePage () {
   )
 }
 
-export default ProjectHomePage
+export default withResponsiveContext(ProjectHomePage)
+export { ProjectHomePage }


### PR DESCRIPTION
Adds the dark/light theme toggle and responsive context to the project home page.

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
