### PR TITLE
Add a multi-stage Docker build for production apps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 **/dist
 **/node_modules
 **/.DS_Store
+Dockerfile
 docs
 plop
 plopfile.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:10
+FROM node:10 AS bootstrap
 
 RUN mkdir -p /usr/src
 WORKDIR /usr/src/
 
-COPY ./ .
+COPY ./ /usr/src
 RUN chown -R node:node .
 
 USER node
@@ -11,3 +11,14 @@ USER node
 RUN yarn install
 
 RUN yarn bootstrap
+
+FROM node:10 AS production-apps
+
+RUN mkdir -p /usr/src
+WORKDIR /usr/src/
+
+COPY --from=bootstrap /usr/src /usr/src
+
+RUN yarn workspace @zooniverse/fe-project build
+
+RUN yarn workspace @zooniverse/fe-content-pages build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
             script {
               def dockerRepoName = 'zooniverse/front-end-monorepo'
               def dockerImageName = "${dockerRepoName}:${BRANCH_NAME}"
-              def newImage = docker.build(dockerImageName)
+              def newImage = docker.build(dockerImageName, "--target bootstrap")
               newImage.push()
               newImage.push('latest')
             }

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ docker-compose build
 
 `docker-compose down` stops the running container.
 
-`docker-compose run --rm test` runs the tests.
+`docker-compose run --rm yarn` runs the CI tests by default.
 
 Development environments for individual packages can be run from the package directories. For example:
 ```sh

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -24,12 +24,4 @@ printf 'Building `lib-classifier`...\n'
 yarn workspace @zooniverse/classifier build
 printf '\n'
 
-printf 'Building `fe-project`...\n'
-yarn workspace @zooniverse/fe-project build
-printf '\n'
-
-printf 'Building `fe-content-pages`...\n'
-yarn workspace @zooniverse/fe-content-pages build
-printf '\n'
-
 echo 'Done!'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,19 @@
 version: '3.4'
 
 services:
-  test:
+  yarn:
     image: front-end-monorepo_dev:latest
     build:
       context: ./
+      target: bootstrap
     entrypoint:
       - "yarn"
-    command: ["test"]
-    volumes:
-      - ${PWD}:/usr/src
-      - /usr/src/node_modules
+    command: ["test:ci"]
   fe-project:
-    image: front-end-monorepo_dev:latest
+    image: front-end-monorepo_prod:latest
     build:
       context: ./
+      target: production-apps
     entrypoint:
       - "yarn"
       - "workspace"
@@ -23,9 +22,10 @@ services:
     ports:
       - "3000:3000"
   fe-content:
-    image: front-end-monorepo_dev:latest
+    image: front-end-monorepo_prod:latest
     build:
       context: ./
+      target: production-apps
     entrypoint:
       - "yarn"
       - "workspace"

--- a/packages/app-content-pages/Dockerfile
+++ b/packages/app-content-pages/Dockerfile
@@ -2,6 +2,8 @@ FROM zooniverse/front-end-monorepo:latest
 
 WORKDIR /usr/src/packages/app-content-pages/
 
+RUN yarn build
+
 ENV PORT 3000
 EXPOSE 3000
 CMD [ "yarn", "start" ]

--- a/packages/app-content-pages/README.md
+++ b/packages/app-content-pages/README.md
@@ -21,12 +21,12 @@ To get the credentials, go to https://app.contentful.com/spaces/jt90kyhvp0qv/api
 
 ### Running in development
 
-####Docker
+#### Docker
 - `docker-compose up` to run a server on http://localhost:3000.
 - `docker-compose down` to stop the dev server.
 - `docker-compose run --rm dev test` to run the tests.
 
-####Node/yarn
+#### Node/yarn
 ```sh
 yarn dev
 ```
@@ -45,8 +45,8 @@ Starts a Storybook server on port 9001 by default.
 ### Running in production
 
 ```sh
-npm run build
-npm run start
+yarn build
+yarn start
 ```
 
 Next.js [treats the build and serve tasks as separate steps](https://github.com/zeit/next.js/#production-deployment) when running in production.

--- a/packages/app-content-pages/docker-compose.yml
+++ b/packages/app-content-pages/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: front-end-monorepo_dev:latest
     build:
       context: ../../
+      target: bootstrap
     entrypoint:
       - "yarn"
       - "workspace"

--- a/packages/app-project/Dockerfile
+++ b/packages/app-project/Dockerfile
@@ -2,6 +2,9 @@ FROM zooniverse/front-end-monorepo:latest
 
 WORKDIR /usr/src/packages/app-project/
 
+RUN yarn build
+
 ENV PORT 3000
 EXPOSE 3000
+
 CMD [ "yarn", "start" ]

--- a/packages/app-project/docker-compose.yml
+++ b/packages/app-project/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: front-end-monorepo_dev:latest
     build:
       context: ../../
+      target: bootstrap
     entrypoint:
       - "yarn"
       - "workspace"

--- a/packages/lib-classifier/docker-compose.yml
+++ b/packages/lib-classifier/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: front-end-monorepo_dev:latest
     build:
       context: ../../
+      target: bootstrap
     entrypoint:
       - "yarn"
       - "workspace"


### PR DESCRIPTION
Package:
lib-classifier
app-project
app-content-pages

- Split the docker build into `bootstrap`, which installs the monorepo and builds dependencies, and `production-apps`, which builds the NextJS apps.
- Remove the NextJS builds from the bootstrap script.
- update the docker-compose setup to use the appropriate named target for each local docker image. `front-end-monorepo_dev` builds from the `bootstrap` stage. `front-end-monorepo_prod` builds from the `production-apps` stage.
- rename the test service to yarn, since it runs yarn commands, and remove local mounted volumes when testing the production set-up. If local files change, you'll need to run `docker-compose build` to test the changes in a new production image.
- Update the Jenkins build to build `zooniverse/front-end-monorepo` with the bootstrapped monorepo, then build and start the NextJS apps in their respective images.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
