### PR TITLE
Change default from null to types.model

### DIFF
--- a/packages/lib-classifier/src/store/tasks/DrawingTask.js
+++ b/packages/lib-classifier/src/store/tasks/DrawingTask.js
@@ -15,7 +15,7 @@ const Drawing = types.model('Drawing', {
         case 'point':
           return Point
         default:
-          return null
+          return types.model({})
       }
     }
   })),


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
Changes the switch default from `null` to `types.model({})` so that the classifier doesn't crash with Kitteh Zoo anymore. Its drawing task uses an ellipse which we don't have a model for yet. 

We might want to change line 16 in the workflow step store to do the same?

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
