### PR TITLE
Check for null or undefined metadata value

### DIFF
--- a/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.js
@@ -4,7 +4,7 @@ function metadataToRules (metadata = {}) {
   const rules = metadataKeys.reduce(function (result, key) {
     const [prefix, ruleIndex, propKey] = key.split('_')
     const value = metadata[key]
-    const stringValue = value.toString()
+    const stringValue = (value !== null && value !== undefined) ? value.toString() : ''
 
     if (prefix === '#feedback' && stringValue) {
       if (isNaN(ruleIndex)) {

--- a/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.spec.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.spec.js
@@ -9,7 +9,9 @@ describe('feedback: metadataToRules', function () {
         '#feedback_1_id': ruleID,
         '#feedback_1_answer': '0',
         '#feedback_1_failureMessage': 'Actually, this sound is from noise (background)',
-        '#feedback_1_successMessage': 'Correct!'
+        '#feedback_1_successMessage': 'Correct!',
+        'foo': null,
+        'bar': undefined
       }
     }
   }
@@ -19,7 +21,9 @@ describe('feedback: metadataToRules', function () {
       metadata: {
         '#feedback_[1]_id': ruleID,
         '#feedback_a_answer': '0',
-        '#feedback_1a2b_failureMessage': 'Actually, this sound is from noise (background)'
+        '#feedback_1a2b_failureMessage': 'Actually, this sound is from noise (background)',
+        'foo': null,
+        'bar': undefined
       }
     }
   }


### PR DESCRIPTION
Package: lib-classifier

For #1112. Not marking as closed because there are a couple more specs and improvements I want to make and I'm not confident this is 100% fixing the bugs I've seen.

Describe your changes:
Some TESS subjects have metadata with null values:

![Screen Shot 2019-09-09 at 11 09 32 AM](https://user-images.githubusercontent.com/5016731/64566216-1025c800-d31b-11e9-8458-4494ed05f3a9.png)

`metadata-to-rules` helper function attempt to convert this to a string, but `null.toString()` will throw. 

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
