### PR TITLE
Test feedback on subject change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
 branches:
   only:
     - master
+    - mobx-upgrade
 
 cache: yarn
 

--- a/packages/lib-classifier/src/store/FeedbackStore.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.js
@@ -51,6 +51,15 @@ const FeedbackStore = types
       addDisposer(self, classificationDisposer)
     }
 
+    function onNewSubject () {
+      const validSubjectReference = isValidReference(() => getRoot(self).subjects.active)
+      if (validSubjectReference) {
+        const subject = getRoot(self).subjects.active
+        self.reset()
+        self.createRules(subject)
+      }
+    }
+
     function onSubjectAdvance (call, next, abort) {
       const shouldShowFeedback = self.isActive && self.messages.length && !self.showModal
       if (shouldShowFeedback) {
@@ -78,14 +87,7 @@ const FeedbackStore = types
     }
 
     function createSubjectObserver () {
-      const subjectDisposer = autorun(() => {
-        const validSubjectReference = isValidReference(() => getRoot(self).subjects.active)
-        if (validSubjectReference) {
-          const subject = getRoot(self).subjects.active
-          self.reset()
-          self.createRules(subject)
-        }
-      }, { name: 'FeedbackStore Subject Observer autorun' })
+      const subjectDisposer = autorun(onNewSubject, { name: 'FeedbackStore Subject Observer autorun' })
       addDisposer(self, subjectDisposer)
     }
 
@@ -143,6 +145,7 @@ const FeedbackStore = types
       setOnHide,
       showFeedback,
       hideFeedback,
+      onNewSubject,
       onSubjectAdvance,
       update,
       reset

--- a/packages/lib-classifier/src/store/FeedbackStore.spec.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.spec.js
@@ -405,6 +405,10 @@ describe('Model > FeedbackStore', function () {
       it('should not set isActive', function () {
         expect(feedback.isActive).to.be.false()
       })
+
+      it('should not generate rules', function () {
+        expect(feedback.rules).to.be.empty()
+      })
     })
 
     describe('when the subject has feedback', function () {
@@ -429,6 +433,10 @@ describe('Model > FeedbackStore', function () {
 
       it('should set isActive', function () {
         expect(feedback.isActive).to.be.true()
+      })
+
+      it('should generate new rules', function () {
+        expect(feedback.rules.toJSON()).to.deep.equal(rulesStub)
       })
     })
   })


### PR DESCRIPTION
Add an onNewSubject action to the feedback store and add tests when feedback is and isn't active. Rearrange the feedback store tests so that global stubs are only set for the action tests.

Package:
lib-classifier


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
