### PR TITLE
Check id existence before calling toString

### DIFF
--- a/packages/lib-classifier/src/store/feedback/helpers/generate-rules.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/generate-rules.js
@@ -24,11 +24,15 @@ function generateRules (subject, workflow) {
   _.forEach(workflowRules, (rules, taskId) => {
     const taskRules = _.reduce(rules, (result, workflowRule) => {
       const matchingSubjectRule = _.find(subjectRules, (subjectRule) => {
-        if (subjectRule.id && workflowRule.id) {
+        if ((subjectRule.id !== null && subjectRule.id !== undefined) &&
+          (workflowRule.id !== null && workflowRule.id !== undefined)) {
           return subjectRule.id.toString() === workflowRule.id.toString()
+        } else {
+          if (process.browser) {
+            console.warn('Feedback: Subject rule id or workflow rule id is null or undefined')
+          }
+          return false
         }
-
-        return null
       })
 
       if (matchingSubjectRule) {

--- a/packages/lib-classifier/src/store/feedback/helpers/generate-rules.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/generate-rules.js
@@ -23,8 +23,13 @@ function generateRules (subject, workflow) {
 
   _.forEach(workflowRules, (rules, taskId) => {
     const taskRules = _.reduce(rules, (result, workflowRule) => {
-      const matchingSubjectRule = _.find(subjectRules, subjectRule =>
-        subjectRule.id.toString() === workflowRule.id.toString())
+      const matchingSubjectRule = _.find(subjectRules, (subjectRule) => {
+        if (subjectRule.id && workflowRule.id) {
+          return subjectRule.id.toString() === workflowRule.id.toString()
+        }
+
+        return null
+      })
 
       if (matchingSubjectRule) {
         const ruleStrategy = workflowRule.strategy

--- a/packages/lib-classifier/src/store/feedback/helpers/generate-rules.spec.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/generate-rules.spec.js
@@ -31,9 +31,11 @@ describe('feedback: generateRules', function () {
     it('should generate rules for tasks with feedback enabled', function () {
       expect(generateRules(subject, workflow)).to.have.property('T0')
     })
+
     it('should not generate rules for tasks with feedback disabled', function () {
       expect(generateRules(subject, workflow)).not.to.have.property('T1')
     })
+
     it('should copy subject rules', function () {
       const taskFeedbackRule = generateRules(subject, workflow).T0[0]
       expect(taskFeedbackRule).to.have.property('failureMessage')
@@ -82,6 +84,41 @@ describe('feedback: generateRules', function () {
     testSubjectAndWorkflow(subject, workflow)
   })
 
+  describe('when the rule id is 0', function () {
+    const subject = mockSubjectWithRule(0)
+    const workflow = {
+      tasks: {
+        T0: mockTaskWithRule(0),
+        T1: mockTaskWithRule('52')
+      }
+    }
+    testSubjectAndWorkflow(subject, workflow)
+  })
+
+  describe('with a null or undefined rule id', function () {
+    it('should return an empty object when null', function () {
+      const subject = mockSubjectWithRule(null)
+      const workflow = {
+        tasks: {
+          T0: mockTaskWithRule(null)
+        }
+      }
+
+      expect(generateRules(subject, workflow)).to.be.empty()
+    })
+
+    it('should return an empty object when undefined', function () {
+      const subject = mockSubjectWithRule(undefined)
+      const workflow = {
+        tasks: {
+          T0: mockTaskWithRule(undefined)
+        }
+      }
+
+      expect(generateRules(subject, workflow)).to.be.empty()
+    })
+  })
+
   describe('with no matching rules', function () {
     describe('when the workflow rule ID is truthy', function () {
       const workflow = {
@@ -91,7 +128,7 @@ describe('feedback: generateRules', function () {
       }
 
       it('should return an empty object for a falsy subject rule ID', function () {
-        const subject = mockSubjectWithRule(0)
+        const subject = mockSubjectWithRule(null)
         expect(generateRules(subject, workflow)).to.be.empty()
       })
 
@@ -101,10 +138,10 @@ describe('feedback: generateRules', function () {
       })
     })
 
-    describe('when the workflow rule ID is falsy', function () {
+    describe('when the workflow rule ID is null or undefined', function () {
       const workflow = {
         tasks: {
-          T0: mockTaskWithRule(0)
+          T0: mockTaskWithRule(null)
         }
       }
 


### PR DESCRIPTION
Package: lib-classifier

Related to #1112. Checks for the existence of the subject rule id and workflow rule id before calling `toString` on them. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
