### PR TITLE
Prevent classification feedback metadata being added incorrectly

### DIFF
--- a/packages/lib-classifier/src/store/FeedbackStore.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.js
@@ -105,7 +105,7 @@ const FeedbackStore = types
     }
 
     function update (annotation) {
-      if (self.isActive) {
+      if (self.isActive && self.rules.size > 0) {
         const { task, value } = annotation
         const taskRules = self.rules.get(task) || []
         const updatedTaskRules = taskRules.map(rule => {


### PR DESCRIPTION
Package: lib-classifier

For #1112 

Describe your changes:
This checks that there are rules in addition to feedback being active when calling `update` when an annotation is added. This prevents inaccurate feedback metadata being added to the classification. 

This should have tests updated to cover this scenario, but I'm holding to do that to prevent a massive merge conflict with the mobx-upgrade branch.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
