### PR TITLE
Change the asset prefix for staging

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -35,7 +35,7 @@ spec:
             - containerPort: 3000
           env:
             - name: ASSET_PREFIX
-              value: https://fe-project.zooniverse.org
+              value: https://fe-project.preview.zooniverse.org
             - name: NEWRELIC_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
@@ -84,7 +84,7 @@ spec:
             - containerPort: 3000
           env:
             - name: ASSET_PREFIX
-              value: https://fe-content-pages.zooniverse.org
+              value: https://fe-content-pages.preview.zooniverse.org
             - name: CONTENTFUL_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Use .preview.zooniverse.org for staging assets.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
