### PR TITLE
Handle null subject metadata values to display in table

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.js
@@ -36,6 +36,8 @@ export function formatValue (value) {
     return stringValue
   }
 
+  if (value === null) return 'null'
+
   return ''
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.spec.js
@@ -9,7 +9,8 @@ const metadata = {
   id: '1',
   href: 'https://zooniverse.org',
   '#hidden': true,
-  '!onlyTalk': false
+  '!onlyTalk': false,
+  'foo': null
 }
 
 describe('MetadataModal', function () {


### PR DESCRIPTION
Package: lib-classifier

Related to #1112 

Describe your changes:
Checks if metadata value is null and displays `"null"` for it.

Before:
![Screen Shot 2019-09-09 at 11 09 38 AM](https://user-images.githubusercontent.com/5016731/64645393-6efe4680-d3da-11e9-9978-0ae4ecb89444.png)

After:
<img width="341" alt="Screen Shot 2019-09-10 at 2 46 25 PM" src="https://user-images.githubusercontent.com/5016731/64645405-73c2fa80-d3da-11e9-8a63-a922655f75c0.png">

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
