### PR TITLE
Make feedback.isActive a computed value

### DIFF
--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -187,7 +187,7 @@ const ClassificationStore = types
         }
 
         const feedback = getRoot(self).feedback
-        if (feedback.isActive && feedback.rules.size > 0) {
+        if (feedback.isValid) {
           metadata.feedback = toJS(feedback.rules)
         }
 

--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -11,6 +11,7 @@ import {
   WorkflowFactory
 } from '../../test/factories'
 import stubPanoptesJs from '../../test/stubPanoptesJs'
+import helpers from './feedback/helpers'
 
 const feedbackRulesStub = {
   T0: [{
@@ -98,8 +99,8 @@ describe('Model > ClassificationStore', function () {
       let classifications
       let rootStore
       before(function () {
+        sinon.stub(helpers, 'isFeedbackActive').callsFake(() => true)
         const invalidFeedbackStub = {
-          isActive: true,
           rules: {}
         }
 
@@ -123,6 +124,10 @@ describe('Model > ClassificationStore', function () {
         classifications.completeClassification({
           preventDefault: sinon.stub()
         })
+      })
+
+      after(function () {
+        helpers.isFeedbackActive.restore()
       })
 
       it('should not add feedback to classification metadata', function () {
@@ -154,6 +159,7 @@ describe('Model > ClassificationStore', function () {
         sinon.stub(rootStore.feedback, 'createRules')
         sinon.stub(rootStore.feedback, 'update')
         sinon.stub(rootStore.feedback, 'reset')
+        sinon.stub(helpers, 'isFeedbackActive').callsFake(() => true)
         classifications = rootStore.classifications
         feedback = rootStore.feedback
         onComplete = sinon.stub()
@@ -162,7 +168,7 @@ describe('Model > ClassificationStore', function () {
       })
 
       beforeEach(function () {
-        const activeFeedback = FeedbackFactory.build({ isActive: true, rules: feedbackRulesStub })
+        const activeFeedback = FeedbackFactory.build({ rules: feedbackRulesStub })
         // Classification completion adds feedback metadata if feedback is active and there are rules
         // So first we update the feedback store to have active feedback
         // Then call the classification complete event
@@ -193,6 +199,7 @@ describe('Model > ClassificationStore', function () {
         feedback.createRules.restore()
         feedback.update.restore()
         feedback.reset.restore()
+        helpers.isFeedbackActive.restore()
       })
 
       // Why is this test here?

--- a/packages/lib-classifier/src/store/FeedbackStore.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.js
@@ -24,7 +24,10 @@ const FeedbackStore = types
     },
     get isActive () {
       const { projects = {}, subjects = {}, workflows = {} } = getRoot(self)
-      return helpers.isFeedbackActive(projects.active, subjects.active, workflows.active)
+      const validProject = isValidReference(() => projects.active) && projects.active
+      const validWorkflow = isValidReference(() => workflows.active) && workflows.active
+      const validSubject = isValidReference(() => subjects.active) && subjects.active
+      return helpers.isFeedbackActive(validProject, validSubject, validWorkflow)
     },
     // This is a workaround for https://github.com/zooniverse/front-end-monorepo/issues/1112
     // (feedback incorrectly being active when there are no rules)
@@ -100,10 +103,9 @@ const FeedbackStore = types
     }
 
     function createRules (subject) {
-      const validProjectReference = isValidReference(() => getRoot(self).projects.active)
       const validWorkflowReference = isValidReference(() => getRoot(self).workflows.active)
 
-      if (validProjectReference && validWorkflowReference && subject) {
+      if (validWorkflowReference && subject) {
         const workflow = getRoot(self).workflows.active
 
         if (self.isActive) {

--- a/packages/lib-classifier/src/store/FeedbackStore.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.js
@@ -26,6 +26,9 @@ const FeedbackStore = types
       const { projects = {}, subjects = {}, workflows = {} } = getRoot(self)
       return helpers.isFeedbackActive(projects.active, subjects.active, workflows.active)
     },
+    get isValid () {
+      return self.isActive && self.rules && self.rules.size > 0
+    },
     get messages () {
       return self.applicableRules
         .map(rule => rule.success ? rule.successMessage : rule.failureMessage)
@@ -121,7 +124,7 @@ const FeedbackStore = types
     }
 
     function update (annotation) {
-      if (self.isActive && self.rules.size > 0) {
+      if (self.isValid) {
         const { task, value } = annotation
         const taskRules = self.rules.get(task) || []
         const updatedTaskRules = taskRules.map(rule => {

--- a/packages/lib-classifier/src/store/FeedbackStore.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.js
@@ -26,6 +26,8 @@ const FeedbackStore = types
       const { projects = {}, subjects = {}, workflows = {} } = getRoot(self)
       return helpers.isFeedbackActive(projects.active, subjects.active, workflows.active)
     },
+    // This is a workaround for https://github.com/zooniverse/front-end-monorepo/issues/1112
+    // (feedback incorrectly being active when there are no rules)
     get isValid () {
       return self.isActive && self.rules && self.rules.size > 0
     },

--- a/packages/lib-classifier/src/store/FeedbackStore.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.js
@@ -7,7 +7,6 @@ import strategies from './feedback/strategies'
 
 const FeedbackStore = types
   .model('FeedbackStore', {
-    isActive: types.optional(types.boolean, false),
     rules: types.map(types.frozen({})),
     showModal: types.optional(types.boolean, false)
   })
@@ -22,6 +21,10 @@ const FeedbackStore = types
     get hideSubjectViewer () {
       return flatten(Array.from(self.rules.values()))
         .some(rule => rule.hideSubjectViewer)
+    },
+    get isActive () {
+      const { projects = {}, subjects = {}, workflows = {} } = getRoot(self)
+      return helpers.isFeedbackActive(projects.active, subjects.active, workflows.active)
     },
     get messages () {
       return self.applicableRules
@@ -96,9 +99,7 @@ const FeedbackStore = types
       const validWorkflowReference = isValidReference(() => getRoot(self).workflows.active)
 
       if (validProjectReference && validWorkflowReference && subject) {
-        const project = getRoot(self).projects.active
         const workflow = getRoot(self).workflows.active
-        self.isActive = helpers.isFeedbackActive(project, subject, workflow)
 
         if (self.isActive) {
           self.rules = helpers.generateRules(subject, workflow)
@@ -132,7 +133,6 @@ const FeedbackStore = types
     }
 
     function reset () {
-      self.isActive = false
       self.rules.clear()
       self.showModal = false
       const onHide = getRoot(self).subjects.advance

--- a/packages/lib-classifier/src/store/FeedbackStore.spec.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.spec.js
@@ -83,7 +83,6 @@ describe('Model > FeedbackStore', function () {
 
   describe('Actions', function () {
     before(function () {
-      sinon.stub(helpers, 'isFeedbackActive').callsFake(() => true)
       sinon.stub(helpers, 'generateRules').callsFake(() => rulesStub)
       strategies.testStrategy = {
         reducer: sinon.stub().callsFake(rule => rule)
@@ -91,13 +90,13 @@ describe('Model > FeedbackStore', function () {
     })
 
     after(function () {
-      helpers.isFeedbackActive.restore()
       helpers.generateRules.restore()
     })
 
     describe('createRules', function () {
       let feedback, feedbackStub
       before(function () {
+        sinon.stub(helpers, 'isFeedbackActive').callsFake(() => true)
         feedbackStub = FeedbackFactory.build()
         feedback = FeedbackStore.create(feedbackStub)
         feedback.projects = ProjectStore.create()
@@ -118,6 +117,10 @@ describe('Model > FeedbackStore', function () {
         helpers.generateRules.resetHistory()
       })
 
+      after(function () {
+        helpers.isFeedbackActive.restore()
+      })
+
       it('should generate rules', function () {
         expect(feedback.rules.toJSON()).to.be.empty()
         feedback.createRules(subject)
@@ -130,7 +133,8 @@ describe('Model > FeedbackStore', function () {
       let feedback, feedbackStub
       describe('when feedback is active', function () {
         before(function () {
-          feedbackStub = FeedbackFactory.build({ isActive: true, rules: rulesStub })
+          sinon.stub(helpers, 'isFeedbackActive').callsFake(() => true)
+          feedbackStub = FeedbackFactory.build({ rules: rulesStub })
           feedback = FeedbackStore.create(feedbackStub)
           feedback.projects = ProjectStore.create()
           feedback.workflows = WorkflowStore.create()
@@ -148,6 +152,7 @@ describe('Model > FeedbackStore', function () {
 
         after(function () {
           strategies.testStrategy.reducer.resetHistory()
+          helpers.isFeedbackActive.restore()
         })
 
         it('should reduce the rule and value', function () {
@@ -158,11 +163,16 @@ describe('Model > FeedbackStore', function () {
 
       describe('when feedback is not active', function () {
         before(function () {
-          feedbackStub = FeedbackFactory.build({ isActive: false, rules: {} })
+          sinon.stub(helpers, 'isFeedbackActive').callsFake(() => false)
+          feedbackStub = FeedbackFactory.build({ rules: {} })
           feedback = FeedbackStore.create(feedbackStub)
           feedback.projects = ProjectStore.create()
           feedback.workflows = WorkflowStore.create()
           feedback.subjects = SubjectStore.create()
+        })
+
+        after(function () {
+          helpers.isFeedbackActive.restore()
         })
 
         beforeEach(function () {
@@ -186,11 +196,19 @@ describe('Model > FeedbackStore', function () {
 
     describe('reset', function () {
       let feedback, feedbackStub
+      before(function () {
+        sinon.stub(helpers, 'isFeedbackActive').callsFake(() => true)
+      })
+
       beforeEach(function () {
-        feedbackStub = FeedbackFactory.build({ isActive: true, rules: rulesStub, showModal: true })
+        feedbackStub = FeedbackFactory.build({ rules: rulesStub, showModal: true })
         feedback = FeedbackStore.create(feedbackStub)
         feedback.subjects = SubjectStore.create()
         sinon.stub(feedback.subjects, 'advance').callsFake(() => { })
+      })
+
+      after(function () {
+        helpers.isFeedbackActive.restore()
       })
 
       it('should reset feedback rules', function () {
@@ -216,8 +234,13 @@ describe('Model > FeedbackStore', function () {
     describe('showFeedback', function () {
       let feedback
       before(function () {
-        const feedbackStub = FeedbackFactory.build({ isActive: true, rules: rulesStub })
+        sinon.stub(helpers, 'isFeedbackActive').callsFake(() => true)
+        const feedbackStub = FeedbackFactory.build({ rules: rulesStub })
         feedback = FeedbackStore.create(feedbackStub)
+      })
+
+      after(function () {
+        helpers.isFeedbackActive.restore()
       })
 
       it('should set showModal state to true', function () {
@@ -230,13 +253,18 @@ describe('Model > FeedbackStore', function () {
     describe('hideFeedback', function () {
       let feedback
       before(function () {
-        const feedbackStub = FeedbackFactory.build({ isActive: true, rules: rulesStub, showModal: true })
+        sinon.stub(helpers, 'isFeedbackActive').callsFake(() => true)
+        const feedbackStub = FeedbackFactory.build({ rules: rulesStub, showModal: true })
         feedback = FeedbackStore.create(feedbackStub)
       })
 
       beforeEach(function () {
         feedback.setOnHide(sinon.stub())
         feedback.hideFeedback()
+      })
+
+      after(function () {
+        helpers.isFeedbackActive.restore()
       })
 
       it('should set showModal state to false', function () {
@@ -293,8 +321,13 @@ describe('Model > FeedbackStore', function () {
   describe('Views > messages', function () {
     let feedback, feedbackStub
     before(function () {
-      feedbackStub = FeedbackFactory.build({ isActive: true, rules: rulesStub, showModal: true })
+      sinon.stub(helpers, 'isFeedbackActive').callsFake(() => true)
+      feedbackStub = FeedbackFactory.build({ rules: rulesStub, showModal: true })
       feedback = FeedbackStore.create(feedbackStub)
+    })
+
+    after(function () {
+      helpers.isFeedbackActive.restore()
     })
 
     it('should return an array of feedback messages', function () {


### PR DESCRIPTION
Make `feedback.isActive` a view that wraps the `isFeedbackActive` helper. Update tests to stub `isFeedbackActive` when they mock active or inactive feedback.

Adds a `feedback.isValid` view, rather than validating feedback in component code.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
