### PR TITLE
Remove mobx-upgrade branch from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ node_js:
 branches:
   only:
     - master
-    - mobx-upgrade
 
 cache: yarn
 


### PR DESCRIPTION
I don't really like that we have to remember to add and remove branches from the travis config to get tests to run. Is there an advantage to doing this versus what we had configured before?

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
