### PR TITLE
Switch to production environment in k8 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,23 +115,9 @@ Apps should have their directory names prefixed with `app-`, e.g. `/project` bec
 
 ## Production deployment
 
-Deploys are handled by [Jenkins](https://jenkins.zooniverse.org/job/Zooniverse%20GitHub/job/front-end-monorepo/). Firstly, a base Docker image is created which installs and builds the `lib-` packages, and that's used as a base image for creating `app-` images, which are then deployed to Kubernetes.
+Deploys to production are handled by [Jenkins](https://jenkins.zooniverse.org/job/Zooniverse%20GitHub/job/front-end-monorepo/). Firstly, a base Docker image is created which installs and builds the `lib-` packages, and that's used as a base image for creating `app-` images, which are then deployed to Kubernetes.
 
 More information is available in [ADR 12](docs/arch/adr-12.md).
-
-Merges to master deploy to a staging instance that uses Panoptes production. This is used for manual end to end behavior testing for new code and design reviews. Deployments to a production are triggered by setting a `production-release` git tag. This can either be done using the git CLI or using lita on slack. 
-
-More information is available in [ADR 17](docs/arch/adr-17.md)
-
-### Environment variables
-
-We use an environment variable, `PANOPTES_ENV`, to set which Panoptes API endpoint to use. Setting to `production` will use `https://www.zooniverse.org/api` and `staging` to `https://panoptes-staging.zooniverse.org/api`. The build scripts for the apps and libraries default to production. 
-
-### Docker images
-
-- `zooniverse/front-end-monorepo`
-- `zooniverse/fe-content-pages`
-- `zooniverse/fe-project`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,23 @@ Apps should have their directory names prefixed with `app-`, e.g. `/project` bec
 
 ## Production deployment
 
-Deploys to production are handled by [Jenkins](https://jenkins.zooniverse.org/job/Zooniverse%20GitHub/job/front-end-monorepo/). Firstly, a base Docker image is created which installs and builds the `lib-` packages, and that's used as a base image for creating `app-` images, which are then deployed to Kubernetes.
+Deploys are handled by [Jenkins](https://jenkins.zooniverse.org/job/Zooniverse%20GitHub/job/front-end-monorepo/). Firstly, a base Docker image is created which installs and builds the `lib-` packages, and that's used as a base image for creating `app-` images, which are then deployed to Kubernetes.
 
 More information is available in [ADR 12](docs/arch/adr-12.md).
+
+Merges to master deploy to a staging instance that uses Panoptes production. This is used for manual end to end behavior testing for new code and design reviews. Deployments to a production are triggered by setting a `production-release` git tag. This can either be done using the git CLI or using lita on slack. 
+
+More information is available in [ADR 17](docs/arch/adr-17.md)
+
+### Environment variables
+
+We use an environment variable, `PANOPTES_ENV`, to set which Panoptes API endpoint to use. Setting to `production` will use `https://www.zooniverse.org/api` and `staging` to `https://panoptes-staging.zooniverse.org/api`. The build scripts for the apps and libraries default to production. 
+
+### Docker images
+
+- `zooniverse/front-end-monorepo`
+- `zooniverse/fe-content-pages`
+- `zooniverse/fe-project`
 
 ---
 

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -42,9 +42,9 @@ spec:
                   name: newrelic-license-key
                   key: key
             - name: NODE_ENV
-              value: staging
+              value: production
             - name: PANOPTES_ENV
-              value: staging
+              value: production
             - name: SENTRY_DSN
               value: https://2a50683835694829b4bc3cccc9adcc1b@sentry.io/1492691
 ---
@@ -101,8 +101,8 @@ spec:
                   name: newrelic-license-key
                   key: key
             - name: NODE_ENV
-              value: staging
+              value: production
             - name: PANOPTES_ENV
-              value: staging
+              value: production
             - name: SENTRY_DSN
               value: https://1f0126a750244108be76957b989081e8@sentry.io/1492498


### PR DESCRIPTION
Package: all

Describe your changes:
As discussed, this switches the k8 config setting to use production environment. I've started on updating the readme to describe this in more detail. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
