### PR TITLE
Update is-feedback-active tests to use false instead of empty object

### DIFF
--- a/packages/lib-classifier/src/store/feedback/helpers/is-feedback-active.spec.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/is-feedback-active.spec.js
@@ -37,13 +37,13 @@ describe('Feedback: isFeedbackActive', function () {
   })
   describe('with an invalid project, workflow or subject', function () {
     it('should be false with an invalid project', function () {
-      expect(isFeedbackActive({}, subject, workflow)).to.be.false()
+      expect(isFeedbackActive(false, subject, workflow)).to.be.false()
     })
     it('should be false with an invalid workflow', function () {
-      expect(isFeedbackActive(project, subject, {})).to.be.false()
+      expect(isFeedbackActive(project, subject, false)).to.be.false()
     })
     it('should be false with an invalid subject', function () {
-      expect(isFeedbackActive(project, {}, workflow)).to.be.false()
+      expect(isFeedbackActive(project, false, workflow)).to.be.false()
     })
   })
 })


### PR DESCRIPTION
Package: lib-classifier

Related to #1121. Updates tests to use `false` as the argument when the resource is invalid. The Feedback store is using `isValidReference` which returns true or false depending on if the active reference is valid. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
