### PR TITLE
Add docker testing notes

### DIFF
--- a/packages/app-project/README.md
+++ b/packages/app-project/README.md
@@ -47,7 +47,22 @@ yarn start
 See [Testing](#testing) for more details.
 
 #### Docker
-`docker-compose run --rm dev test`.
+Run the whole test suite in the container and exit
+```
+# run the tests in the docker container
+docker-compose run --rm dev test
+```
+Interactively run the test suite from a bash shell in the container
+```
+# launch an interactive bash shell in the dev app
+docker-compose run --rm --entrypoint="/bin/bash" dev
+
+# change directory to the desired app (app-project)
+cd packages/app-project/
+
+# run the tests for this app
+yarn test
+```
 
 #### Node/yarn
 ```sh


### PR DESCRIPTION
Package: `app-project`

Add some notes on how to use docker containers to interactively test apps, i.e. from a bash console in the container with all the required test infrastructure installed.

I found this flow useful:
1.  dip into the code
0. make some changes
0. test my changes using `.only` mocha syntax
0. re-run the tests with `yarn test`
0. iterate until happy

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
