### PR TITLE
Test feedback with invalid or undefined arguments

### DIFF
--- a/packages/lib-classifier/src/store/feedback/helpers/generate-rules.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/generate-rules.js
@@ -17,8 +17,8 @@ import getFeedbackFromTasks from './get-feedback-from-tasks'
 // that rule.
 
 function generateRules (subject, workflow) {
-  const subjectRules = metadataToRules(subject.metadata)
-  const workflowRules = getFeedbackFromTasks(workflow.tasks)
+  const subjectRules = subject ? metadataToRules(subject.metadata) : {}
+  const workflowRules = workflow ? getFeedbackFromTasks(workflow.tasks) : {}
   const canonicalRules = {}
 
   _.forEach(workflowRules, (rules, taskId) => {

--- a/packages/lib-classifier/src/store/feedback/helpers/generate-rules.spec.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/generate-rules.spec.js
@@ -51,6 +51,40 @@ describe('feedback: generateRules', function () {
     })
   })
 
+  describe('without a valid subject or workflow', function () {
+    const subject = mockSubjectWithRule('51')
+    const workflow = {
+      tasks: {
+        T0: mockTaskWithRule('51'),
+        T1: mockTaskWithRule('52')
+      }
+    }
+
+    it('should return an empty object for an invalid subject', function () {
+      expect(generateRules(false, workflow)).to.be.empty()
+    })
+
+    it('should return an empty object for an undefined subject', function () {
+      expect(generateRules(undefined, workflow)).to.be.empty()
+    })
+
+    it('should return an empty object for a null subject', function () {
+      expect(generateRules(null, workflow)).to.be.empty()
+    })
+
+    it('should return an empty object for an invalid workflow', function () {
+      expect(generateRules(subject, false)).to.be.empty()
+    })
+
+    it('should return an empty object for an undefined workflow', function () {
+      expect(generateRules(subject, undefined)).to.be.empty()
+    })
+
+    it('should return an empty object for a null workflow', function () {
+      expect(generateRules(subject, null)).to.be.empty()
+    })
+  })
+
   describe('with task feedback enabled', function () {
     const subject = mockSubjectWithRule('51')
     const workflow = {

--- a/packages/lib-classifier/src/store/feedback/helpers/is-feedback-active.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/is-feedback-active.js
@@ -13,7 +13,7 @@ function getSubjectFeedback (subject) {
 }
 
 function getWorkflowFeedback (workflow) {
-  const taskFeedback = getFeedbackFromTasks(workflow.tasks)
+  const taskFeedback = workflow ? getFeedbackFromTasks(workflow.tasks) : {}
   return Object.keys(taskFeedback).length > 0
 }
 

--- a/packages/lib-classifier/src/store/feedback/helpers/is-feedback-active.spec.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/is-feedback-active.spec.js
@@ -46,4 +46,32 @@ describe('Feedback: isFeedbackActive', function () {
       expect(isFeedbackActive(project, false, workflow)).to.be.false()
     })
   })
+  describe('with undefined arguments', function () {
+    it('should be false', function () {
+      expect(isFeedbackActive()).to.be.false()
+    })
+    it('should be false with an undefined project', function () {
+      expect(isFeedbackActive(undefined, subject, workflow)).to.be.false()
+    })
+    it('should be false with an undefined workflow', function () {
+      expect(isFeedbackActive(project, subject, undefined)).to.be.false()
+    })
+    it('should be false with an undefined subject', function () {
+      expect(isFeedbackActive(project, undefined, workflow)).to.be.false()
+    })
+  })
+  describe('with null arguments', function () {
+    it('should be false', function () {
+      expect(isFeedbackActive(null, null, null)).to.be.false()
+    })
+    it('should be false with a null project', function () {
+      expect(isFeedbackActive(null, subject, workflow)).to.be.false()
+    })
+    it('should be false with a null workflow', function () {
+      expect(isFeedbackActive(project, subject, null)).to.be.false()
+    })
+    it('should be false with a null subject', function () {
+      expect(isFeedbackActive(project, null, workflow)).to.be.false()
+    })
+  })
 })

--- a/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.spec.js
+++ b/packages/lib-classifier/src/store/feedback/helpers/metadata-to-rules.spec.js
@@ -67,4 +67,10 @@ describe('feedback: metadataToRules', function () {
       expect(logError).to.have.been.calledWith('Subject metadata feedback rule index [1] is improperly formatted. The feedback rule index should be an integer.')
     })
   })
+
+  describe('with undefined metadata', function () {
+    it('should generate an empty rules object', function () {
+      expect(metadataToRules()).to.be.empty()
+    })
+  })
 })


### PR DESCRIPTION
Package:
lib-classifier

Adds some tests to the feedback helper functions that call them with null, undefined or false (invalid) projects, workflows and subjects.

This is more for completeness than anything else, to rule out another potential cause of #1112.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
