### PR TITLE
Make Connect widget responsive

### DIFF
--- a/packages/app-project/src/shared/components/ConnectWithProject/ConnectWithProject.js
+++ b/packages/app-project/src/shared/components/ConnectWithProject/ConnectWithProject.js
@@ -3,19 +3,19 @@ import { Grid } from 'grommet'
 import { arrayOf, shape, string } from 'prop-types'
 import React from 'react'
 
-import ContentBox from '../ContentBox'
 import ProjectLink from './components/ProjectLink'
 import en from './locales/en'
+import ContentBox from '../ContentBox'
 
 counterpart.registerTranslations('en', en)
 
-function ConnectWithProject ({ className, projectName, urls }) {
+function ConnectWithProject (props) {
+  const { projectName, urls } = props
   return (
     <ContentBox
-      className={className}
       title={counterpart('ConnectWithProject.title', { projectName })}
     >
-      <Grid columns={['1fr', '1fr']} gap='medium' rows={['1fr']}>
+      <Grid columns={['repeat(auto-fill, minmax(280px, 1fr))']} gap='medium'>
         {urls.map(urlObject =>
           <ProjectLink
             key={urlObject.url}


### PR DESCRIPTION
Changes the Grid definition in the Connect to Project widget to make it responsive.

Before:

<img width="332" alt="Screenshot 2019-09-20 11 18 35" src="https://user-images.githubusercontent.com/2725841/65320613-2c86f780-db9a-11e9-8f9d-0d8b718d473b.png">

<img width="720" alt="Screenshot 2019-09-20 11 18 22" src="https://user-images.githubusercontent.com/2725841/65320614-2c86f780-db9a-11e9-9e4d-71f18e45ce35.png">

<img width="1336" alt="Screenshot 2019-09-20 11 18 11" src="https://user-images.githubusercontent.com/2725841/65320615-2c86f780-db9a-11e9-9edb-88cdd55c7a0e.png">


After:

<img width="364" alt="Screenshot 2019-09-20 11 19 22" src="https://user-images.githubusercontent.com/2725841/65320625-33156f00-db9a-11e9-9e2f-18cb3af16889.png">

<img width="701" alt="Screenshot 2019-09-20 11 19 43" src="https://user-images.githubusercontent.com/2725841/65320623-33156f00-db9a-11e9-89a4-fcb858c35bb1.png">

<img width="1059" alt="Screenshot 2019-09-20 11 19 52" src="https://user-images.githubusercontent.com/2725841/65320622-327cd880-db9a-11e9-9214-c96e60875060.png">


