### PR TITLE
Adjust preview thumbnail size

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjects.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjects.js
@@ -7,8 +7,8 @@ import SubjectThumbnail from './components/SubjectThumbnail'
 // TODO: Use the subject viewers from the classifier
 function RecentSubjects (props) {
   const { className, href, subjects } = props
-  const height = 350
-  const width = 400
+  const height = 200
+  const width = 270
   return (
     <Grid
       className={className}

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/components/SubjectThumbnail/SubjectThumbnail.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/components/SubjectThumbnail/SubjectThumbnail.js
@@ -39,9 +39,9 @@ function SubjectThumbnail ({ height, href, width, subject }) {
       >
         <Media
           alt={`subject ${subject.id}`}
-          height={400}
+          height={700}
           src={subjectURL}
-          width={400}
+          width={700}
         />
         <StyledSpacedText color='white' weight='bold'>
           {counterpart('RecentSubjects.subjectLabel', { id: subject.id })}

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/components/SubjectThumbnail/SubjectThumbnail.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/components/SubjectThumbnail/SubjectThumbnail.js
@@ -10,6 +10,9 @@ import en from './locales/en'
 counterpart.registerTranslations('en', en)
 
 const StyledBox = styled(Box)`
+  max-height: ${props => props.maxHeight}px;
+  max-width: ${props => props.maxWidth}px;
+  overflow: hidden;
   position: relative;
 `
 const StyledSpacedText = styled(SpacedText)`
@@ -29,14 +32,16 @@ function SubjectThumbnail ({ height, href, width, subject }) {
       <StyledBox
         elevation='small'
         fill
-        justify='end'
+        maxHeight={height}
+        justify='center'
         pad='none'
+        maxWidth={width}
       >
         <Media
           alt={`subject ${subject.id}`}
-          height={height}
+          height={400}
           src={subjectURL}
-          width={width}
+          width={400}
         />
         <StyledSpacedText color='white' weight='bold'>
           {counterpart('RecentSubjects.subjectLabel', { id: subject.id })}

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/components/SubjectThumbnail/SubjectThumbnail.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/components/SubjectThumbnail/SubjectThumbnail.spec.js
@@ -19,7 +19,7 @@ describe('Component > SubjectThumbnail', function () {
   }
 
   before(function () {
-    wrapper = shallow(<SubjectThumbnail height={100} href={href} width={100} subject={mockSubject('1')} />)
+    wrapper = shallow(<SubjectThumbnail height={200} href={href} width={270} subject={mockSubject('1')} />)
   })
 
   it('should render without crashing', function () {
@@ -33,5 +33,15 @@ describe('Component > SubjectThumbnail', function () {
     const media = link.find(Media)
     expect(link.prop('href')).to.equal(href)
     expect(media.prop('src')).to.equal(src)
+  })
+
+  it('should have a max height', function () {
+    const container = wrapper.find(Anchor).children().first()
+    expect(container.prop('maxHeight')).to.equal(200)
+  })
+
+  it('should have a max width', function () {
+    const container = wrapper.find(Anchor).children().first()
+    expect(container.prop('maxWidth')).to.equal(270)
   })
 })


### PR DESCRIPTION
Set the maximum subject thumbnail size to 270px width, 200px height.

See #1152.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
