### PR TITLE
Update to panoptes.js 0.1.0

### DIFF
--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -20,7 +20,7 @@
     "@sentry/browser": "^5.4.3",
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/grommet-theme": "~2.2.0",
-    "@zooniverse/panoptes-js": "~0.0.1",
+    "@zooniverse/panoptes-js": "~0.1.0",
     "@zooniverse/react-components": "~0.7.1",
     "async": "~2.6.2",
     "babel-plugin-dynamic-import-node": "~2.2.0",

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -22,7 +22,7 @@
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/classifier": "^0.0.1",
     "@zooniverse/grommet-theme": "~2.2.0",
-    "@zooniverse/panoptes-js": "~0.0.1",
+    "@zooniverse/panoptes-js": "~0.1.0",
     "@zooniverse/react-components": "~0.7.1",
     "babel-plugin-dynamic-import-node": "~2.3.0",
     "babel-plugin-styled-components": "~1.10.6",

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "@zooniverse/grommet-theme": "~2.2.0",
-    "@zooniverse/panoptes-js": "~0.0.1",
+    "@zooniverse/panoptes-js": "~0.1.0",
     "@zooniverse/react-components": "~0.7.1",
     "grommet": "~2.7.x",
     "grommet-icons": "~4.3.x",
@@ -59,7 +59,7 @@
     "@storybook/addons": "^5.1.9",
     "@storybook/react": "^5.1.9",
     "@zooniverse/grommet-theme": "~2.2.0",
-    "@zooniverse/panoptes-js": "~0.0.1",
+    "@zooniverse/panoptes-js": "~0.1.0",
     "@zooniverse/react-components": "~0.7.1",
     "@zooniverse/standard": "~1.0.0",
     "babel-loader": "~8.0.6",

--- a/packages/lib-panoptes-js/docs/CHANGELOG.md
+++ b/packages/lib-panoptes-js/docs/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.1.0] Unreleased
+## [0.1.0] 2019-09-23
 ### Added
 - Base helpers for HTTP requests GET, PUT, POST, and DELETE
 - Client configuration file for which API host to use depending on environment

--- a/packages/lib-panoptes-js/package.json
+++ b/packages/lib-panoptes-js/package.json
@@ -8,24 +8,25 @@
   "main": "src/index.js",
   "scripts": {
     "lint": "zoo-standard --fix | snazzy",
+    "postversion": "npm publish",
     "test": "NODE_ENV=test mocha",
     "test:ci": "NODE_ENV=test mocha --reporter=min"
   },
   "dependencies": {
-    "@zooniverse/standard": "^1.0.0",
-    "snazzy": "^8.0.0",
+    "@zooniverse/standard": "~1.0.0",
+    "snazzy": "~8.0.0",
     "superagent": "~5.1.0",
     "url-parse": "~1.4.7"
   },
   "devDependencies": {
     "chai": "~4.2.0",
-    "dirty-chai": "^2.0.1",
+    "dirty-chai": "~2.0.1",
     "jsdom": "~15.1.1",
     "mocha": "~6.1.4",
     "mock-local-storage": "~1.1.8",
     "nock": "~10.0.6",
     "sinon": "~7.3.2",
-    "sinon-chai": "^3.3.0"
+    "sinon-chai": "~3.3.0"
   },
   "engines": {
     "node": ">=10"

--- a/packages/lib-panoptes-js/package.json
+++ b/packages/lib-panoptes-js/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
   "repository": "github:zooniverse/front-end-monorepo",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "main": "src/index.js",
   "scripts": {
     "lint": "zoo-standard --fix | snazzy",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7159,7 +7159,7 @@ dir-glob@^2.0.0, dir-glob@^2.2.2:
   dependencies:
     path-type "^3.0.0"
 
-dirty-chai@^2.0.1, dirty-chai@~2.0.1:
+dirty-chai@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/dirty-chai/-/dirty-chai-2.0.1.tgz#6b2162ef17f7943589da840abc96e75bda01aff3"
   integrity sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w==
@@ -15153,7 +15153,7 @@ simplebar@^4.1.0:
     lodash.throttle "^4.1.1"
     resize-observer-polyfill "^1.5.1"
 
-sinon-chai@^3.3.0, sinon-chai@~3.3.0:
+sinon-chai@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.3.0.tgz#8084ff99451064910fbe2c2cb8ab540c00b740ea"
   integrity sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==


### PR DESCRIPTION
Package: lib-panoptes-js, lib-classifier, apps

Describe your changes:
Published panoptes.js to 0.1.0. This updates the changelog and the libraries and apps that use it.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
