### PR TITLE
Make generateHostUrl server-agnostic

### DIFF
--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -122,7 +122,11 @@ function getSlugFromUrl (relativeUrl) {
 }
 
 function generateHostUrl (context) {
-  const { connection, headers } = context.req
-  const protocol = connection.encrypted ? 'https' : 'http'
-  return `${protocol}://${headers.host}`
+  if (context.req) {
+    const { connection, headers } = context.req
+    const protocol = connection.encrypted ? 'https' : 'http'
+    return `${protocol}://${headers.host}`
+  } else {
+    return location.origin
+  }
 }


### PR DESCRIPTION
The function generating the host URL (used in OG tags etc) is breaking when run on the client. This makes it server/client agnostic by checking for the `req` object, and falling back to `location` when `req` is unavailable.
