### PR TITLE
Add no workflows fallback to Hero

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.js
@@ -37,18 +37,25 @@ function WorkflowSelector (props) {
 
       {(workflows.loading === asyncStates.success) && (
         <Box margin={{ top: 'small' }}>
-          {workflows.data.map(workflow =>
+          {(workflows.data.length > 0) && workflows.data.map(workflow =>
             <WorkflowSelectButton key={workflow.id} workflow={workflow} />
+          )}
+          {(workflows.data.length === 0) && (
+            <Box background='accent-4' pad='xsmall'>
+              <Text size='small' textAlign='center'>
+                {counterpart('WorkflowSelector.noWorkflows')}
+              </Text>
+            </Box>
           )}
         </Box>
       )}
 
-      {(!asyncStates.values.includes(workflows.loading)) && (
+      {(![asyncStates.success, asyncStates.error].includes(workflows.loading)) && (
         <Box align='center' justify='center' margin={{ top: 'small' }}>
           <Box height='xxsmall' width='xxsmall'>
             <Bars
               fill={loaderColor}
-              height='100%'
+              height='80%'
               viewBox='0 0 135 140'
               width='100%'
             />

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.js
@@ -8,17 +8,16 @@ import React from 'react'
 import theme from './theme'
 
 function WorkflowSelectButton (props) {
-  const { router, workflow } = props
+  const { router, workflow, ...rest } = props
 
   const as = workflow.default
     ? `${router.asPath}/classify`
     : `${router.asPath}/classify/workflow/${workflow.id}`
-
   const href = '/Classify'
 
   return (
     <Link as={as} href={href} passHref>
-      <Button label={workflow.displayName} />
+      <Button label={workflow.displayName} {...rest} />
     </Link>
   )
 }
@@ -28,9 +27,9 @@ WorkflowSelectButton.propTypes = {
     asPath: string.isRequired
   }),
   workflow: shape({
-    default: bool.isRequired,
+    default: bool,
     displayName: string.isRequired,
-    id: string.isRequired
+    id: string
   }).isRequired
 }
 

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.spec.js
@@ -18,7 +18,6 @@ describe('Component > WorkflowSelectButton', function () {
 
   before(function () {
     wrapper = render(<WorkflowSelectButton router={ROUTER} workflow={WORKFLOW} />)
-    console.info(wrapper.html())
   })
 
   it('should render without crashing', function () {

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/locales/en.json
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/locales/en.json
@@ -1,4 +1,0 @@
-{
-  "WorkflowSelectButton": {
-  }
-}

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/theme.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/theme.js
@@ -10,6 +10,9 @@ const theme = {
       &:hover {
         box-shadow: none;
       }
+      &:disabled {
+        cursor: not-allowed;
+      }
     `
   }
 }

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/locales/en.json
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/locales/en.json
@@ -2,6 +2,7 @@
   "WorkflowSelector": {
     "classify": "Classify",
     "error": "There was an error fetching the workflows :(",
-    "message": "Anyone can do real research!"
+    "message": "Anyone can do real research!",
+    "noWorkflows": "Nothing to classify"
   }
 }


### PR DESCRIPTION
Adds a disabled button with a `nothing to classify` message to the Hero component when there are no active workflows. 

<img width="536" alt="Screenshot 2019-09-24 12 09 48" src="https://user-images.githubusercontent.com/2725841/65506762-383d2b80-dec4-11e9-8be1-fe8e50006b3d.png">

cc #1152
Closes #1150