### PR TITLE
Add LCV annotation filter conditional for width greater than zero

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -204,10 +204,10 @@ class LightCurveViewer extends Component {
     if (!this.isCurrentTaskValidForAnnotation()) return // Sanity check
 
     const annotations = this.annotationBrushes
-      .filter((raw) => (raw.minX !== undefined && raw.maxX !== undefined && (raw.maxX - raw.minX) > 0))
+      .filter((raw) => (raw.minX !== undefined && raw.maxX !== undefined && raw.minX !== null && raw.maxX !== null))
       .map((raw) => {
         const x = (raw.minX + raw.maxX) / 2
-        const width = (raw.maxX - raw.minX)
+        const width = Math.abs(raw.maxX - raw.minX)
         const toolType = props.currentTask.tools[props.toolIndex].type
         return { x, width, tool: props.toolIndex, zoomLevelOnCreation: raw.zoomLevelOnCreation, toolType }
       })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -204,7 +204,7 @@ class LightCurveViewer extends Component {
     if (!this.isCurrentTaskValidForAnnotation()) return // Sanity check
 
     const annotations = this.annotationBrushes
-      .filter((raw) => (raw.minX !== undefined && raw.maxX !== undefined))
+      .filter((raw) => (raw.minX !== undefined && raw.maxX !== undefined && (raw.maxX - raw.minX) > 0))
       .map((raw) => {
         const x = (raw.minX + raw.maxX) / 2
         const width = (raw.maxX - raw.minX)


### PR DESCRIPTION
Package:
- lib-classifier

Describe your changes:
- adds conditional for width > 0 to existing filter on brush annotations before saving brush annotations as classification annotations

Notes:
- I think this could be done in a few different ways, alternatively:
  - checking width on const declaration (line 210), if less than zero then handle then, would keep annotation (as opposed to adding in filter which eliminates entire related annotation)
  - separate filter, arguably easier to read, possible performance downside (and 2 filters on same thing (`raw`) would be strange)
  - I'm sure others
- I didn't see related tests, which I didn't think there were, but might be right in front of me, if so I'll add tests asap
- intentionally as `>` and not `>=`, as I can't think of instance where width would be 0, but of course open to suggestion

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
