### PR TITLE
Add a `min-height` to the Hero component

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.js
@@ -12,6 +12,7 @@ import { Media } from '../../../../shared/components/Media'
 const StyledContentBox = styled(ContentBox)`
   ${props => (props.screenSize !== 'small') && `
     border-color: transparent;
+    min-height: 545px;
     max-height: 763px;
   `}
 `


### PR DESCRIPTION
Adds a `min-height` of `545px` to the Hero component, as per the design review in #1152.

![FireShot Capture 018 - Planet Hunters TESS - Zooniverse - People-powered research - localhost](https://user-images.githubusercontent.com/2725841/65685043-f7c2e680-e058-11e9-9f53-b51f89abf751.jpg)

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
