### PR TITLE
Fix invalid ARIA role

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChart.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChart.js
@@ -53,6 +53,7 @@ function DailyClassificationsChart ({ stats, projectName, theme }) {
 
   function tickLabelProps () {
     return {
+      'aria-hidden': 'true',
       dx: '-0.25em',
       dy: '0.2em',
       fill: axisColour,

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChart.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChart.js
@@ -95,7 +95,7 @@ function DailyClassificationsChart ({ stats, projectName, theme }) {
               >
                 <Bar
                   aria-label={stat.alt}
-                  role="image"
+                  role="img"
                   fill={theme.global.colors['accent-2']}
                   height={barHeight}
                   width={barWidth}

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChart.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChart.spec.js
@@ -104,7 +104,7 @@ describe('Component > DailyClassificationsChart', function () {
         })
 
         it('should be an image', function () {
-          expect(bar.prop('role')).to.equal('image')
+          expect(bar.prop('role')).to.equal('img')
         })
 
         it('should have an accessible description', function () {


### PR DESCRIPTION
Fix the img role for the stats chart bars.
Hide the axis tick text, which makes no sense when read out of context.

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
- [ ] Is the changelog updated?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && yarn bootstrap` and app works as expected?
- [ ] Can you run a [production build](https://github.com/zooniverse/front-end-monorepo#getting-started) of the app?
