### PR TITLE
Run the dev server in the background

### DIFF
--- a/packages/app-project/README.md
+++ b/packages/app-project/README.md
@@ -16,8 +16,8 @@ This package should be cloned as part of the [front-end-monorepo](https://github
 Starts a development server on port 3000 and a Storybook server on port 9001 by default.
 
 #### Docker
-- `docker-compose up` to run a dev server on http://localhost:3000 and the storybook on http://localhost:9001.
-- `docker-compose down` to stop the container.
+- `docker-compose up -d` to run a dev server, in the background, on http://localhost:3000 and the storybook on http://localhost:9001.
+- `docker-compose down` to stop the dev containers.
 - `docker-compose run --rm dev test` to run the tests.
 
 #### Node/yarn


### PR DESCRIPTION
Update the development instructions to run the dev server and storybook in the background.

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used by a screen reader and without a mouse?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
