### PR TITLE
Add a story for the recent subjects carousel

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjects.stories.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjects.stories.js
@@ -6,6 +6,7 @@ import React from 'react'
 import en from './locales/en'
 
 import RecentSubjects from './RecentSubjects'
+import RecentSubjectsCarousel from './RecentSubjectsCarousel'
 
 counterpart.registerTranslations('en', en)
 
@@ -89,6 +90,14 @@ storiesOf('Project App / Screens / Project Home / Recent Subjects', module)
       />
     </Grommet>
   ))
+  .add('carousel view', () => (
+    <Grommet theme={zooTheme}>
+      <RecentSubjectsCarousel
+        href='/projects/zooniverse/snapshot-serengeti/talk'
+        subjects={SUBJECTS}
+      />
+    </Grommet>
+  ), { viewport: { defaultViewport: 'iphone5' }})
   .add('transcription', () => (
     <Grommet theme={zooTheme}>
       <RecentSubjects

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjects.stories.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjects.stories.js
@@ -82,6 +82,7 @@ const VIDEO_SUBJECTS = [
   }
 ]
 storiesOf('Project App / Screens / Project Home / Recent Subjects', module)
+  .addParameters({ viewport: { defaultViewport: 'responsive' }})
   .add('plain', () => (
     <Grommet theme={zooTheme}>
       <RecentSubjects


### PR DESCRIPTION
Add a story for recent Talk subjects, on the project home page, on small screens.

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used by a screen reader and without a mouse?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
