### PR TITLE
Add focus and hover styles to workflow links

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.js
@@ -21,7 +21,7 @@ function WorkflowSelectButton (props) {
 
   return (
     <Link as={as} href={href} passHref>
-      <Button label={workflow.displayName} {...rest} />
+      <Button label={workflow.displayName} primary {...rest} />
     </Link>
   )
 }

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/theme.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/theme.js
@@ -1,20 +1,32 @@
+import { adjustHue } from 'polished'
+
 const theme = {
   button: {
     border: {
       width: '0'
     },
-    color: 'black',
-    extend: props => `
-      text-align: center;
-      background: ${props.theme.global.colors['neutral-4']};
-      &:hover {
-        box-shadow: none;
-      }
-      &:disabled {
-        cursor: not-allowed;
-      }
-    `
-  }
+    color: {
+      dark: 'neutral-4',
+      light: 'black'
+    },
+    extend: props => {
+      const { theme: { dark, global: { colors } } } = props
+      
+      return `
+        text-align: center;
+        background: ${colors['neutral-4']};
+        &:disabled {
+          cursor: not-allowed;
+        }
+        &:focus:not(:disabled),
+        &:hover:not(:disabled) {
+          background: ${adjustHue(-7, colors['neutral-4'])};
+          box-shadow: 1px 1px 2px rgba(0, 0, 0, .5);
+          color: white;
+        }
+    `}
+  },
+  
 }
 
 export default theme

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/theme.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/theme.js
@@ -3,7 +3,8 @@ import { adjustHue } from 'polished'
 const theme = {
   button: {
     border: {
-      width: '0'
+      color: 'neutral-4',
+      width: '1px'
     },
     color: {
       dark: 'neutral-4',
@@ -14,19 +15,18 @@ const theme = {
       
       return `
         text-align: center;
-        background: ${colors['neutral-4']};
+        background: ${dark ? colors['dark-3'] : colors['neutral-4']};
         &:disabled {
           cursor: not-allowed;
         }
         &:focus:not(:disabled),
         &:hover:not(:disabled) {
-          background: ${adjustHue(-7, colors['neutral-4'])};
+          background: ${dark ? colors['neutral-4'] : adjustHue(-7, colors['neutral-4'])};
           box-shadow: 1px 1px 2px rgba(0, 0, 0, .5);
-          color: white;
+          color: ${dark ? 'black' : 'white'};
         }
     `}
-  },
-  
+  }
 }
 
 export default theme

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/theme.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/theme.js
@@ -10,12 +10,17 @@ const theme = {
       dark: 'neutral-4',
       light: 'black'
     },
+    primary: {
+      color: {
+        dark: 'dark-3',
+        light: 'neutral-4'
+      }
+    },
     extend: props => {
       const { theme: { dark, global: { colors } } } = props
       
       return `
         text-align: center;
-        background: ${dark ? colors['dark-3'] : colors['neutral-4']};
         &:disabled {
           cursor: not-allowed;
         }
@@ -23,7 +28,7 @@ const theme = {
         &:hover:not(:disabled) {
           background: ${dark ? colors['neutral-4'] : adjustHue(-7, colors['neutral-4'])};
           box-shadow: 1px 1px 2px rgba(0, 0, 0, .5);
-          color: ${dark ? 'black' : 'white'};
+          color: ${dark ? 'white' : 'black'};
         }
     `}
   }


### PR DESCRIPTION
Add focus and hover styles to the workflow links on the project home page.

The colour is taken from the Next button styles here:
https://github.com/zooniverse/front-end-monorepo/blob/cacf750a015ce9758c6b044b6f888abffaf9cb92/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/NextButton/theme.js#L24-L29

NB. those workflow links don't have dark theme styles set at the moment, but the current colour seems to work with both light and dark backgrounds.

If we're using these styles in multiple places, then they should be inherited from the theme, rather than defined in a `theme.js` file buried in the classifier.

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
