### PR TITLE
Make lower footer responsive

### DIFF
--- a/packages/lib-react-components/src/ZooFooter/components/PolicyLinkSection/PolicyLinkSection.js
+++ b/packages/lib-react-components/src/ZooFooter/components/PolicyLinkSection/PolicyLinkSection.js
@@ -4,12 +4,14 @@ import React from 'react'
 
 import zipLabelsAndUrls from '../../helpers/zipLabelsAndUrls'
 import SpacedText from '../../../SpacedText'
+import withResponsiveContext from '../../../helpers/withResponsiveContext'
 
-export default function PolicyLinkSection ({ className, labels, urls }) {
+function PolicyLinkSection (props) {
+  const { labels, screenSize, urls } = props
   const links = zipLabelsAndUrls(labels, urls)
-
+  const direction = screenSize === 'small' ? 'column' : 'row'
   return (
-    <Box as='nav' className={className} direction='row' gap='medium' role='presentation'>
+    <Box as='nav' direction={direction} gap='medium' role='presentation'>
 
       {links.length > 0 && links.map(link => (
         <Anchor
@@ -31,3 +33,5 @@ PolicyLinkSection.propTypes = {
   labels: arrayOf(string).isRequired,
   urls: arrayOf(string).isRequired
 }
+
+export default withResponsiveContext(PolicyLinkSection)


### PR DESCRIPTION
The lower footer links (privacy policy, jobs etc.) are always displayed horizontally, which is too wide for smaller screens (e.g. iPhone SE). This makes them render vertically on `small` screen sizes.

Weirdly, I found that trying to do it with `styled-components` (by creating a `StyledBox`) broke the spacing between child items :(

Wide:

![FireShot Capture 028 - Storybook - localhost](https://user-images.githubusercontent.com/2725841/65963729-499daf00-e453-11e9-84ba-aa92510b80f8.png)

Narrow:

![FireShot Capture 030 - Storybook - localhost](https://user-images.githubusercontent.com/2725841/65963700-3be82980-e453-11e9-9d3f-daaa450bf495.png)