### PR TITLE
Package up the collections button

### DIFF
--- a/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { Anchor, Box } from 'grommet'
 import { Media } from '@zooniverse/react-components'
 import { CollectionsButton, FavouritesButton, TalkLink } from './components'
-import CollectionsModal from '../CollectionsModal'
+
 
 import en from './locales/en'
 
@@ -16,17 +16,10 @@ function SubjectPreview ({ height, isLoggedIn, placeholder, subject, slug, width
   const collectionsModal = React.createRef()
   const href = `/projects/${slug}/talk/subjects/${subject.id}`
 
-  function addToCollections () {
-    collectionsModal.current.wrappedInstance.open(subject.id)
-  }
-
   return (
     <Box
       fill
     >
-      <CollectionsModal
-        ref={collectionsModal}
-      />
       <Anchor
         href={href}
       >
@@ -55,7 +48,7 @@ function SubjectPreview ({ height, isLoggedIn, placeholder, subject, slug, width
       />
       <CollectionsButton
         disabled={!isLoggedIn}
-        onClick={addToCollections}
+        subject={subject}
       />
     </Box>
   )

--- a/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.js
@@ -1,6 +1,7 @@
 import counterpart from 'counterpart'
-import PropTypes from 'prop-types'
+import { array, bool, func, shape, string } from 'prop-types'
 import React from 'react'
+import CollectionsModal from '@shared/components/CollectionsModal'
 import MetaToolsButton from '../MetaToolsButton'
 import CollectionsIcon from './CollectionsIcon'
 
@@ -9,23 +10,47 @@ import en from './locales/en'
 counterpart.registerTranslations('en', en)
 
 export default function CollectionsButton (props) {
-  const { disabled, onClick } = props
+  const { disabled, onClick, subject } = props
+  const collectionsModal = React.createRef()
+
+  function addToCollections () {
+    collectionsModal.current.wrappedInstance.open(subject.id)
+    onClick()
+  }
+
   return (
-    <MetaToolsButton
-      disabled={disabled}
-      icon={<CollectionsIcon color='dark-5' size='1em' />}
-      text={counterpart('CollectionsButton.add')}
-      onClick={onClick}
-    />
+    <>
+      <CollectionsModal
+        ref={collectionsModal}
+      />
+      <MetaToolsButton
+        disabled={disabled}
+        icon={<CollectionsIcon color='dark-5' size='1em' />}
+        text={counterpart('CollectionsButton.add')}
+        onClick={addToCollections}
+      />
+    </>
   )
 }
 
 CollectionsButton.propTypes = {
-  disabled: PropTypes.bool,
-  onClick: PropTypes.func
+  disabled: bool,
+  onClick: func,
+  subject: shape({
+    favorite: bool,
+    id: string,
+    toggleFavourite: func,
+    locations: array
+  })
 }
 
 CollectionsButton.defaultProps = {
   disabled: false,
-  onClick: () => false
+  onClick: () => false,
+  subject: {
+    favorite: false,
+    id: '',
+    toggleFavorite: () => false,
+    locations: []
+  }
 }

--- a/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.spec.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.spec.js
@@ -1,16 +1,24 @@
-import { shallow } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 import React from 'react'
 import sinon from 'sinon'
+import CollectionsModal from '@shared/components/CollectionsModal'
 import MetaToolsButton from '../MetaToolsButton'
-
 import CollectionsButton from './CollectionsButton'
 import CollectionsIcon from './CollectionsIcon'
 
-let wrapper
-
 describe('Component > CollectionsButton', function () {
+  let wrapper
+  const subject = {
+    favorite: false,
+    id: '12345',
+    locations: [
+      { 'image/jpeg': 'https://somedomain/photo.jpg' }
+    ],
+    toggleFavourite: () => false
+  }
+
   before(function () {
-    wrapper = shallow(<CollectionsButton />)
+    wrapper = shallow(<CollectionsButton subject={subject} />)
   })
 
   it('should render without crashing', function () {
@@ -23,26 +31,69 @@ describe('Component > CollectionsButton', function () {
     expect(icon).to.deep.equal(<CollectionsIcon color='dark-5' size='1em' />)
   })
 
-  it('should call props.onClick on click', function () {
-    const onClick = sinon.stub()
-    wrapper = shallow(
-      <CollectionsButton
-        onClick={onClick}
-      />
-    )
+  describe('on click', function () {
+    let onClick
+    let collectionsModal
 
-    wrapper.find(MetaToolsButton).simulate('click')
-    expect(onClick).to.have.been.calledOnce()
+    before(function () {
+      onClick = sinon.stub()
+      wrapper = mount(
+        <CollectionsButton
+          onClick={onClick}
+          subject={subject}
+        />
+      )
+      collectionsModal = wrapper.find(CollectionsModal).instance().wrappedInstance
+      sinon.stub(collectionsModal, 'open')
+      sinon.stub(console, 'error')
+    })
+
+    afterEach(function () {
+      collectionsModal.open.resetHistory()
+      onClick.resetHistory()
+    })
+
+    after(function () {
+      console.error.restore()
+    })
+
+    it('should open a collections modal', function () {
+      wrapper.find(MetaToolsButton).simulate('click')
+      expect(collectionsModal.open.withArgs(subject.id)).to.have.been.calledOnce()
+    })
+
+    it('should call props.onClick', function () {
+      wrapper.find(MetaToolsButton).simulate('click')
+      expect(onClick).to.have.been.calledOnce()
+    })
   })
 
   describe('when disabled', function () {
-    const onClick = sinon.stub()
-    wrapper = shallow(
-      <CollectionsButton
-        disabled
-        onClick={onClick}
-      />
-    )
+    let onClick
+    let collectionsModal
+
+    before(function () {
+      onClick = sinon.stub()
+      wrapper = mount(
+        <CollectionsButton
+          disabled
+          onClick={onClick}
+          subject={subject}
+        />
+      )
+      collectionsModal = wrapper.find(CollectionsModal).instance().wrappedInstance
+      sinon.spy(collectionsModal, 'open')
+    })
+
+    afterEach(function () {
+      collectionsModal.open.resetHistory()
+      onClick.resetHistory()
+    })
+
+    it('should not open a collections modal', function () {
+      wrapper.find(MetaToolsButton).simulate('click')
+      expect(collectionsModal.open).to.not.have.been.called()
+    })
 
     it('should not be clickable', function () {
       wrapper.find(MetaToolsButton).simulate('click')

--- a/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.stories.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.stories.js
@@ -1,0 +1,34 @@
+import { storiesOf } from '@storybook/react'
+import { withKnobs, boolean } from '@storybook/addon-knobs';
+import zooTheme from '@zooniverse/grommet-theme'
+import { Grommet } from 'grommet'
+import React from 'react'
+import readme from './README.md'
+
+import CollectionsButton from './'
+
+const config = {
+  notes: {
+    markdown: readme
+  }
+}
+
+const CAT = {
+  favorite: false,
+  id: '123',
+  locations: [
+    { 'image/jpeg': 'https://panoptes-uploads.zooniverse.org/335/0/2d63944e-f0bc-4fc5-8531-f603886513a1.jpeg' }
+  ]
+}
+
+storiesOf('Project App / Shared / Collections Button', module)
+  .addDecorator(withKnobs)
+  .add('plain', () => (
+    <Grommet theme={{ ...zooTheme, dark: boolean('Dark theme', false) }}>
+      <CollectionsButton
+        disabled={boolean('disabled', false)}
+        subject={CAT}
+      />
+    </Grommet>
+  ), config)
+

--- a/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/README.md
+++ b/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/README.md
@@ -1,0 +1,8 @@
+Renders a button which opens a modal to add the specified subject to a collection
+
+## props
+
+- disabled: _(bool)_ whether or not the rendered button is disabled. Default `false`
+- onClick: _(func)_ callback function that is called, without arguments, when the button is clicked.
+- subject: _(object)_ a subject. Can be a full subject model or any object with an `id` property.
+


### PR DESCRIPTION
Make the collections button self-contained by adding a collections modal to it. Open the modal when the button is clicked (the modal is responsible for closing itself.) Add tests to check that the modal is opened when the button is enabled and clicked.

_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package:
app-project

Towards #1193.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
