### PR TITLE
Update SubjectPreview stories

### DIFF
--- a/packages/app-project/.storybook/lib/backgrounds.js
+++ b/packages/app-project/.storybook/lib/backgrounds.js
@@ -1,7 +1,8 @@
 import zooTheme from '@zooniverse/grommet-theme'
 
-const backgrounds = [
+const lightDefault = [
   {
+    default: true,
     name: 'light',
     value: zooTheme.global.colors['light-1']
   },
@@ -10,5 +11,22 @@ const backgrounds = [
     value: zooTheme.global.colors['dark-1']
   }
 ]
+
+const darkDefault = [
+  {
+    name: 'light',
+    value: zooTheme.global.colors['light-1']
+  },
+  {
+    default: true,
+    name: 'dark',
+    value: zooTheme.global.colors['dark-1']
+  }
+]
+
+const backgrounds = {
+  lightDefault,
+  darkDefault
+}
 
 export default backgrounds

--- a/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.stories.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.stories.js
@@ -90,7 +90,7 @@ storiesOf('Project App / Shared / Subject Preview', module)
   ))
   .add('video', () => (
     <Grommet theme={{ ...zooTheme, dark: boolean('Dark theme', false) }}>
-      <Box>
+      <Box background={{ dark: 'dark-3', light: 'light-3' }} height='medium' pad='medium' width='medium'>
         <SubjectPreview
           height={'200px'}
           isLoggedIn={boolean('User logged in', true)}

--- a/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.stories.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.stories.js
@@ -1,8 +1,11 @@
 import { storiesOf } from '@storybook/react'
 import { withKnobs, boolean } from '@storybook/addon-knobs';
 import zooTheme from '@zooniverse/grommet-theme'
-import { Grommet } from 'grommet'
+import { Box, Grommet } from 'grommet'
 import React from 'react'
+import { backgrounds } from '../../../../.storybook/lib'
+
+const darkThemeConfig = { backgrounds: backgrounds.darkDefault }
 
 import SubjectPreview from './'
 
@@ -46,34 +49,55 @@ storiesOf('Project App / Shared / Subject Preview', module)
   .addDecorator(withKnobs)
   .add('plain', () => (
     <Grommet theme={{ ...zooTheme, dark: boolean('Dark theme', false) }}>
-      <SubjectPreview
-        height={'200px'}
-        isLoggedIn={boolean('User logged in', true)}
-        subject={CAT}
-        slug='zooniverse/snapshot-serengeti'
-        width={'270px'}
-      />
+      <Box background={{ dark: 'dark-3', light: 'light-3'}} height='medium' pad='medium' width='medium'>
+        <SubjectPreview
+          height={'200px'}
+          isLoggedIn={boolean('User logged in', true)}
+          subject={CAT}
+          slug='zooniverse/snapshot-serengeti'
+          width={'270px'}
+        />
+      </Box>
     </Grommet>
   ))
+
+  .add('dark theme', () => (
+    <Grommet theme={{ ...zooTheme, dark: boolean('Dark theme', true) }}>
+      <Box background={{ dark: 'dark-3', light: 'light-3' }} height='medium' pad='medium' width='medium'>
+        <SubjectPreview
+          height={'200px'}
+          isLoggedIn={boolean('User logged in', true)}
+          subject={CAT}
+          slug='zooniverse/snapshot-serengeti'
+          width={'270px'}
+        />
+      </Box>
+    </Grommet>
+  ), darkThemeConfig)
+
   .add('transcription', () => (
     <Grommet theme={{ ...zooTheme, dark: boolean('Dark theme', false) }}>
-      <SubjectPreview
-        height={'200px'}
-        isLoggedIn={boolean('User logged in', true)}
-        subject={PORTRAIT_PAGE}
-        slug='zooniverse/snapshot-serengeti'
-        width={'270px'}
-      />
+      <Box background={{ dark: 'dark-3', light: 'light-3' }} height='medium' pad='medium' width='medium'>
+        <SubjectPreview
+          height={'200px'}
+          isLoggedIn={boolean('User logged in', true)}
+          subject={PORTRAIT_PAGE}
+          slug='zooniverse/snapshot-serengeti'
+          width={'270px'}
+        />
+      </Box>
     </Grommet>
   ))
   .add('video', () => (
     <Grommet theme={{ ...zooTheme, dark: boolean('Dark theme', false) }}>
-      <SubjectPreview
-        height={'200px'}
-        isLoggedIn={boolean('User logged in', true)}
-        subject={VIDEO}
-        slug='zooniverse/snapshot-serengeti'
-        width={'270px'}
-      />
+      <Box>
+        <SubjectPreview
+          height={'200px'}
+          isLoggedIn={boolean('User logged in', true)}
+          subject={VIDEO}
+          slug='zooniverse/snapshot-serengeti'
+          width={'270px'}
+        />
+      </Box>
     </Grommet>
   ))


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: app-project

Describe your changes:
Updates the backgrounds available to be usable as a configuration default for stories. Updates the `SubjectPreview` stories to have a `Box` background that can react to the dark theme toggling as well as add a 'dark theme' story that sets the story background to be like the project app by default. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
