### PR TITLE
Create steps from combo tasks

### DIFF
--- a/packages/lib-classifier/src/store/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.js
@@ -177,7 +177,7 @@ const WorkflowStepStore = types
       const taskKeys = Object.keys(workflow.tasks)
       const { first_task } = workflow
 
-      function comboToStepTasks (task) {
+      function getStepTasksFromCombo (task) {
         task.tasks.forEach(function (taskKey) {
           taskKeys.splice(taskKeys.indexOf(taskKey), 1)
         })
@@ -192,7 +192,7 @@ const WorkflowStepStore = types
 
         if (workflow.tasks[first_task].type === 'combo') {
           const combo = workflow.tasks[first_task]
-          firstStep.taskKeys = comboToStepTasks(combo)
+          firstStep.taskKeys = getStepTasksFromCombo(combo)
         }
 
         taskKeys.splice(taskKeys.indexOf(first_task), 1)
@@ -204,7 +204,7 @@ const WorkflowStepStore = types
         if (task.type !== 'shortcut') {
           let stepTasks = [taskKey]
           if (task.type === 'combo') {
-            stepTasks = comboToStepTasks(task)
+            stepTasks = getStepTasksFromCombo(task)
           }
           self.steps.put({
             stepKey: `S${index + 1}`,

--- a/packages/lib-classifier/src/store/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.js
@@ -164,29 +164,51 @@ const WorkflowStepStore = types
         // put is a MST method, not native to ES Map
         // the key is inferred from the identifier type of the target model
         const taskToStore = Object.assign({}, workflow.tasks[taskKey], { taskKey })
-        self.tasks.put(taskToStore)
+        try {
+          self.tasks.put(taskToStore)
+        }
+        catch (e) {
+          console.log(`${taskKey} ${taskToStore.type} is not a supported task type`)
+        }
       })
     }
 
     function convertWorkflowToUseSteps (workflow) {
       const taskKeys = Object.keys(workflow.tasks)
+      const { first_task } = workflow
 
-      if (workflow.first_task) {
-        const firstStep = {
+      function comboToStepTasks (task) {
+        task.tasks.forEach(function (taskKey) {
+          taskKeys.splice(taskKeys.indexOf(taskKey), 1)
+        })
+        return task.tasks
+      }
+
+      if (first_task) {
+        let firstStep = {
           stepKey: 'S0',
-          taskKeys: [workflow.first_task]
+          taskKeys: [first_task]
         }
 
+        if (workflow.tasks[first_task].type === 'combo') {
+          const combo = workflow.tasks[first_task]
+          firstStep.taskKeys = comboToStepTasks(combo)
+        }
+
+        taskKeys.splice(taskKeys.indexOf(first_task), 1)
         self.steps.put(firstStep)
       }
 
       taskKeys.forEach((taskKey, index) => {
-        if (taskKey !== workflow.first_task &&
-            (workflow.tasks[taskKey].type !== 'combo' ||
-            workflow.tasks[taskKey].type !== 'shortcut')) {
+        const task = workflow.tasks[taskKey]
+        if (task.type !== 'shortcut') {
+          let stepTasks = [taskKey]
+          if (task.type === 'combo') {
+            stepTasks = comboToStepTasks(task)
+          }
           self.steps.put({
             stepKey: `S${index + 1}`,
-            taskKeys: [taskKey]
+            taskKeys: stepTasks
           })
         }
       })


### PR DESCRIPTION
Update `convertWorkflowToUseSteps` to create steps from `task.tasks` in combo tasks.
Update `setTasks` to log unsupported tasks and continue, rather than failing at the first unsupported task in a workflow.
Add a combo task to the tests when a workflow has no defined steps.

Package:
lib-classifier


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
