### PR TITLE
Set up Task stories

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -11,10 +11,10 @@ import TaskNavButtons from './components/TaskNavButtons'
 
 function storeMapper (stores) {
   const { loadingState } = stores.classifierStore.workflows
-  const { active: step } = stores.classifierStore.workflowSteps
-  const tasks = stores.classifierStore.workflowSteps.activeStepTasks
+  const { active: step, activeStepTasks: tasks, isThereTaskHelp } = stores.classifierStore.workflowSteps
   const { loadingState: subjectReadyState } = stores.classifierStore.subjectViewer
   return {
+    isThereTaskHelp,
     loadingState,
     step,
     subjectReadyState,
@@ -39,7 +39,7 @@ class Tasks extends React.Component {
   }
 
   [asyncStates.success] () {
-    const { subjectReadyState, tasks } = this.props
+    const { isThereTaskHelp, subjectReadyState, tasks } = this.props
     const ready = subjectReadyState === asyncStates.success
     if (tasks.length > 0) {
       // setting the wrapping box of the task component to a basis of 246px feels hacky,
@@ -62,7 +62,7 @@ class Tasks extends React.Component {
 
               return (<Paragraph>Task component could not be rendered.</Paragraph>)
             })}
-            <TaskHelp />
+            {isThereTaskHelp && <TaskHelp tasks={tasks} />}
             <TaskNavButtons disabled={!ready} />
           </Box>
         </ThemeProvider>
@@ -79,6 +79,7 @@ class Tasks extends React.Component {
 }
 
 Tasks.wrappedComponent.propTypes = {
+  isThereTaskHelp: PropTypes.bool,
   loadingState: PropTypes.oneOf(asyncStates.values),
   ready: PropTypes.bool,
   tasks: PropTypes.arrayOf(PropTypes.object),
@@ -86,6 +87,7 @@ Tasks.wrappedComponent.propTypes = {
 }
 
 Tasks.wrappedComponent.defaultProps = {
+  isThereTaskHelp: false,
   loadingState: asyncStates.initialized,
   ready: false,
   tasks: [],

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -22,8 +22,6 @@ function storeMapper (stores) {
   }
 }
 
-@inject(storeMapper)
-@observer
 class Tasks extends React.Component {
   [asyncStates.initialized] () {
     return null
@@ -78,7 +76,7 @@ class Tasks extends React.Component {
   }
 }
 
-Tasks.wrappedComponent.propTypes = {
+Tasks.propTypes = {
   isThereTaskHelp: PropTypes.bool,
   loadingState: PropTypes.oneOf(asyncStates.values),
   ready: PropTypes.bool,
@@ -86,7 +84,7 @@ Tasks.wrappedComponent.propTypes = {
   theme: PropTypes.string
 }
 
-Tasks.wrappedComponent.defaultProps = {
+Tasks.defaultProps = {
   isThereTaskHelp: false,
   loadingState: asyncStates.initialized,
   ready: false,
@@ -94,4 +92,9 @@ Tasks.wrappedComponent.defaultProps = {
   theme: 'light'
 }
 
-export default Tasks
+@inject(storeMapper)
+@observer
+class DecoratedTasks extends Tasks {}
+
+export default DecoratedTasks
+export { Tasks }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { expect } from 'chai'
-import Tasks from './Tasks'
+import { Tasks } from './Tasks'
 import asyncStates from '@zooniverse/async-states'
 
 describe('Tasks', function () {
@@ -14,34 +14,34 @@ describe('Tasks', function () {
   }]
 
   it('should render without crashing', function () {
-    const wrapper = shallow(<Tasks.wrappedComponent />)
+    const wrapper = shallow(<Tasks />)
     expect(wrapper).to.be.ok()
   })
 
   it('should render null on initialization', function () {
-    const wrapper = shallow(<Tasks.wrappedComponent />)
+    const wrapper = shallow(<Tasks />)
     expect(wrapper.type()).to.be.null()
   })
 
   it('should render a loading UI when the workflow loading', function () {
-    const wrapper = shallow(<Tasks.wrappedComponent loadingState={asyncStates.loading} />)
+    const wrapper = shallow(<Tasks loadingState={asyncStates.loading} />)
     expect(wrapper.contains('Loading')).to.be.true()
   })
 
   it('should render an error message when there is a loading error', function () {
-    const wrapper = shallow(<Tasks.wrappedComponent loadingState={asyncStates.error} />)
+    const wrapper = shallow(<Tasks loadingState={asyncStates.error} />)
     expect(wrapper.contains('Something went wrong')).to.be.true()
   })
 
   it('should render null if the workflow is load but has no tasks', function () {
-    const wrapper = shallow(<Tasks.wrappedComponent loadingState={asyncStates.success} ready />)
+    const wrapper = shallow(<Tasks loadingState={asyncStates.success} ready />)
     expect(wrapper.type()).to.be.null()
   })
 
   it('should render the correct task component if the workflow is loaded', function () {
-    const wrapper = shallow(<Tasks.wrappedComponent loadingState={asyncStates.success} ready tasks={tasks} />)
+    const wrapper = shallow(<Tasks loadingState={asyncStates.success} ready tasks={tasks} />)
     // Is there a better way to do this?
-    expect(wrapper.find('inject-SingleChoiceTask')).to.have.lengthOf(1)
+    expect(wrapper.find('SingleChoiceTask')).to.have.lengthOf(1)
   })
 
   describe('task components', function () {
@@ -50,13 +50,13 @@ describe('Tasks', function () {
     describe('while the subject is loading', function () {
       before(function () {
         const wrapper = shallow(
-          <Tasks.wrappedComponent
+          <Tasks
             loadingState={asyncStates.success}
             subjectReadyState={asyncStates.loading}
             tasks={tasks}
           />
         )
-        taskWrapper = wrapper.find('inject-SingleChoiceTask')
+        taskWrapper = wrapper.find('SingleChoiceTask')
       })
 
       it('should be disabled', function () {
@@ -67,13 +67,13 @@ describe('Tasks', function () {
     describe('when the subject viewer is ready', function () {
       before(function () {
         const wrapper = shallow(
-          <Tasks.wrappedComponent
+          <Tasks
             loadingState={asyncStates.success}
             subjectReadyState={asyncStates.success}
             tasks={tasks}
           />
         )
-        taskWrapper = wrapper.find('inject-SingleChoiceTask')
+        taskWrapper = wrapper.find('SingleChoiceTask')
       })
 
       it('should be enabled', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -42,6 +42,7 @@ storiesOf('Tasks', module)
   const tasks = [{
     annotation: { task: 'init' },
     answers: [{ label: 'yes' }, { label: 'no' }],
+    help: 'Choose an answer from the choices given, then press Done.',
     question: 'Is there a cat?',
     required: true,
     taskKey: 'init',
@@ -82,6 +83,7 @@ storiesOf('Tasks', module)
     {
       annotation: { task: 'T0' },
       answers: [{ label: 'yes' }, { label: 'no' }],
+      help: 'Choose an answer from the choices given, then press Done.',
       question: 'Is there a cat?',
       required: true,
       taskKey: 'T0',
@@ -91,8 +93,8 @@ storiesOf('Tasks', module)
     {
       annotation: { task: 'T1', value: [] },
       answers: [{ label: 'sleeping' }, { label: 'playing' }, { label: 'looking indifferent' }],
+      help: 'Pick as many answers as apply, then press Done.',
       question: 'What is it doing?',
-      help: 'Choose an answer from the choices given, then press Done.',
       required: true,
       taskKey: 'T1',
       type: 'multiple',

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -3,6 +3,7 @@ import asyncStates from '@zooniverse/async-states'
 import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import React from 'react'
+import sinon from 'sinon'
 import { Grommet } from 'grommet'
 import { Provider } from "mobx-react"
 
@@ -39,12 +40,13 @@ storiesOf('Tasks', module)
 .add('single answer question', function () {
   const step = null
   const tasks = [{
+    annotation: { task: 'init' },
     answers: [{ label: 'yes' }, { label: 'no' }],
     question: 'Is there a cat?',
-    help: 'Choose an answer from the choices given, then press Done.',
     required: true,
     taskKey: 'init',
-    type: 'single'
+    type: 'single',
+    updateAnnotation: sinon.stub()
   }]
   const dark = boolean('Dark theme', false)
   const subjectReadyState = select('Subject loading', asyncStates, asyncStates.success)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -1,0 +1,70 @@
+import { withKnobs, boolean, select } from '@storybook/addon-knobs'
+import asyncStates from '@zooniverse/async-states'
+import { storiesOf } from '@storybook/react'
+import zooTheme from '@zooniverse/grommet-theme'
+import React from 'react'
+import { Grommet } from 'grommet'
+import { Provider } from "mobx-react"
+
+import Tasks from './Tasks'
+
+const mockStore = {
+  classifications: {},
+  subjects: {},
+  subjectViewer: {
+    loadingState: asyncStates.loading
+  },
+  workflows: {
+    loadingState: asyncStates.loading
+  },
+  workflowSteps: {
+    isThereANextStep: () => false,
+    isThereAPreviousStep: () => false
+  }
+}
+
+storiesOf('Tasks', module)
+.addDecorator(withKnobs)
+.add('loading', function () {
+  return (
+    <Provider classifierStore={mockStore}>
+      <Grommet theme={zooTheme}>
+        <Tasks/>
+      </Grommet>
+    </Provider>
+  )
+})
+.add('single answer question', function () {
+  const step = null
+  const tasks = [{
+    answers: [{ label: 'yes' }, { label: 'no' }],
+    question: 'Is there a cat?',
+    help: 'Choose an answer from the choices given, then press Done.',
+    required: true,
+    taskKey: 'init',
+    type: 'single'
+  }]
+  const dark = boolean('Dark theme', false)
+  const loadingState = select('Subject loading', asyncStates, asyncStates.success)
+  const store = Object.assign({}, mockStore, {
+    subjectViewer: {
+      loadingState
+    },
+    workflows: {
+      loadingState: asyncStates.success
+    },
+    workflowSteps: {
+      activeStepTasks: tasks,
+      isThereANextStep: () => false,
+      isThereAPreviousStep: () => false,
+      isThereTaskHelp: true
+    }
+  })
+  return (
+    <Provider classifierStore={store}>
+      <Grommet theme={Object.assign({}, zooTheme, { dark })}>
+        <Tasks/>
+      </Grommet>
+    </Provider>
+  )
+})

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -6,7 +6,7 @@ import React from 'react'
 import { Grommet } from 'grommet'
 import { Provider } from "mobx-react"
 
-import Tasks from './Tasks'
+import { Tasks } from './Tasks'
 
 const mockStore = {
   classifications: {},
@@ -29,7 +29,9 @@ storiesOf('Tasks', module)
   return (
     <Provider classifierStore={mockStore}>
       <Grommet theme={zooTheme}>
-        <Tasks/>
+        <Tasks
+          loadingState={asyncStates.loading}
+        />
       </Grommet>
     </Provider>
   )
@@ -45,11 +47,8 @@ storiesOf('Tasks', module)
     type: 'single'
   }]
   const dark = boolean('Dark theme', false)
-  const loadingState = select('Subject loading', asyncStates, asyncStates.success)
+  const subjectReadyState = select('Subject loading', asyncStates, asyncStates.success)
   const store = Object.assign({}, mockStore, {
-    subjectViewer: {
-      loadingState
-    },
     workflows: {
       loadingState: asyncStates.success
     },
@@ -63,7 +62,14 @@ storiesOf('Tasks', module)
   return (
     <Provider classifierStore={store}>
       <Grommet theme={Object.assign({}, zooTheme, { dark })}>
-        <Tasks/>
+        <Tasks
+          isThereTaskHelp={true}
+          loadingState={asyncStates.success}
+          step={step}
+          subjectReadyState={subjectReadyState}
+          tasks={tasks}
+          theme={dark ? 'dark' : 'light'}
+        />
       </Grommet>
     </Provider>
   )

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -37,7 +37,7 @@ storiesOf('Tasks', module)
     </Provider>
   )
 })
-.add('single answer question', function () {
+.add('single task', function () {
   const step = null
   const tasks = [{
     annotation: { task: 'init' },
@@ -48,6 +48,57 @@ storiesOf('Tasks', module)
     type: 'single',
     updateAnnotation: sinon.stub()
   }]
+  const dark = boolean('Dark theme', false)
+  const subjectReadyState = select('Subject loading', asyncStates, asyncStates.success)
+  const store = Object.assign({}, mockStore, {
+    workflows: {
+      loadingState: asyncStates.success
+    },
+    workflowSteps: {
+      activeStepTasks: tasks,
+      isThereANextStep: () => false,
+      isThereAPreviousStep: () => false,
+      isThereTaskHelp: true
+    }
+  })
+  return (
+    <Provider classifierStore={store}>
+      <Grommet theme={Object.assign({}, zooTheme, { dark })}>
+        <Tasks
+          isThereTaskHelp={true}
+          loadingState={asyncStates.success}
+          step={step}
+          subjectReadyState={subjectReadyState}
+          tasks={tasks}
+          theme={dark ? 'dark' : 'light'}
+        />
+      </Grommet>
+    </Provider>
+  )
+})
+.add('multiple tasks', function () {
+  const step = null
+  const tasks = [
+    {
+      annotation: { task: 'T0' },
+      answers: [{ label: 'yes' }, { label: 'no' }],
+      question: 'Is there a cat?',
+      required: true,
+      taskKey: 'T0',
+      type: 'single',
+      updateAnnotation: sinon.stub()
+    },
+    {
+      annotation: { task: 'T1', value: [] },
+      answers: [{ label: 'sleeping' }, { label: 'playing' }, { label: 'looking indifferent' }],
+      question: 'What is it doing?',
+      help: 'Choose an answer from the choices given, then press Done.',
+      required: true,
+      taskKey: 'T1',
+      type: 'multiple',
+      updateAnnotation: sinon.stub()
+    }
+  ]
   const dark = boolean('Dark theme', false)
   const subjectReadyState = select('Subject loading', asyncStates, asyncStates.success)
   const store = Object.assign({}, mockStore, {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/SingleChoiceTask/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/SingleChoiceTask/SingleChoiceTask.js
@@ -3,7 +3,7 @@ import { Box, Text } from 'grommet'
 import { observable } from 'mobx'
 import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import zooTheme from '@zooniverse/grommet-theme'
 import { pxToRem } from '@zooniverse/react-components'
@@ -26,80 +26,58 @@ const StyledText = styled(Text)`
   }
 `
 
-function storeMapper (stores) {
+function SingleChoiceTask (props) {
   const {
-    addAnnotation
-  } = stores.classifierStore.classifications
-  const annotations = stores.classifierStore.classifications.currentAnnotations
-  return {
-    addAnnotation,
-    annotations
+    annotations,
+    className,
+    disabled,
+    task
+  } = props
+  const { annotation } = task
+  const [ value, setValue ] = useState(annotation.value)
+  function onChange (index, event) {
+    setValue(index)
+    if (event.target.checked) task.updateAnnotation(index)
   }
+
+  return (
+    <StyledBox
+      className={className}
+      disabled={disabled}
+    >
+      <StyledText size='small' tag='legend'>
+        <Markdownz>
+          {task.question}
+        </Markdownz>
+      </StyledText>
+
+      {task.answers.map((answer, index) => {
+        const checked = (value + 1) ? index === value : false
+        return (
+          <TaskInput
+            autoFocus={checked}
+            checked={checked}
+            disabled={disabled}
+            index={index}
+            key={`${task.taskKey}_${index}`}
+            label={answer.label}
+            name={task.taskKey}
+            onChange={onChange.bind(this, index)}
+            required={task.required}
+            type='radio'
+          />
+        )
+      })}
+    </StyledBox>
+  )
 }
 
-@inject(storeMapper)
-@observer
-class SingleChoiceTask extends React.Component {
-  onChange (index, event) {
-    const { addAnnotation, task } = this.props
-    if (event.target.checked) addAnnotation(index, task)
-  }
-
-  render () {
-    const {
-      annotations,
-      className,
-      disabled,
-      task
-    } = this.props
-    let annotation
-    if (annotations && annotations.size > 0) {
-      annotation = annotations.get(task.taskKey)
-    }
-
-    return (
-      <StyledBox
-        className={className}
-        disabled={disabled}
-      >
-        <StyledText size='small' tag='legend'>
-          <Markdownz>
-            {task.question}
-          </Markdownz>
-        </StyledText>
-
-        {task.answers.map((answer, index) => {
-          const checked = (annotation && annotation.value + 1) ? index === annotation.value : false
-          return (
-            <TaskInput
-              autoFocus={checked}
-              checked={checked}
-              disabled={disabled}
-              index={index}
-              key={`${task.taskKey}_${index}`}
-              label={answer.label}
-              name={task.taskKey}
-              onChange={this.onChange.bind(this, index)}
-              required={task.required}
-              type='radio'
-            />
-          )
-        })}
-      </StyledBox>
-    )
-  }
-}
-
-SingleChoiceTask.wrappedComponent.defaultProps = {
-  addAnnotation: () => {},
-  annotations: observable.map(),
+SingleChoiceTask.defaultProps = {
   disabled: false,
   task: {}
 }
 
-SingleChoiceTask.wrappedComponent.propTypes = {
-  addAnnotation: PropTypes.func,
-  annotations: MobXPropTypes.observableMap,
+SingleChoiceTask.propTypes = {
   disabled: PropTypes.bool,
   task: PropTypes.shape({
     answers: PropTypes.arrayOf(PropTypes.shape({

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskHelp/TaskHelp.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskHelp/TaskHelp.js
@@ -42,10 +42,12 @@ function TaskHelp (props) {
             {tasks.map((task) => {
               if (tasks.length > 1) {
                 return (
-                  <Markdownz key={task.taskKey}>
-                    {task.help}
+                  <>
+                    <Markdownz key={task.taskKey}>
+                      {task.help}
+                    </Markdownz>
                     <hr />
-                  </Markdownz>
+                  </>
                 )
               }
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskHelp/TaskHelp.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskHelp/TaskHelp.js
@@ -3,7 +3,7 @@ import counterpart from 'counterpart'
 import { Button, Box } from 'grommet'
 import { inject, observer } from 'mobx-react'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 
 import en from './locales/en'
@@ -14,81 +14,58 @@ export const StyledPlainButton = styled(PlainButton)`
   text-align: center;
 `
 
-function storeMapper (stores) {
-  const tasks = stores.classifierStore.workflowSteps.activeStepTasks
-  const { isThereTaskHelp } = stores.classifierStore.workflowSteps
-  return {
-    isThereTaskHelp,
-    tasks
-  }
-}
+function TaskHelp (props) {
+  const [ showModal, setShowModal ] = useState(false)
 
-@inject(storeMapper)
-@observer
-class TaskHelp extends React.Component {
-  constructor () {
-    super()
+  const label = counterpart('TaskHelp.label')
+  const { tasks } = props
 
-    this.state = {
-      showModal: false
-    }
-  }
-
-  render () {
-    const label = counterpart('TaskHelp.label')
-    const { isThereTaskHelp, tasks } = this.props
-
-    if (isThereTaskHelp) {
-      return (
+  return (
+    <>
+      <Box>
+        <StyledPlainButton
+          onClick={() => setShowModal(true)}
+          margin={{ bottom: 'small' }}
+          text={label}
+        />
+      </Box>
+      <Modal
+        active={showModal}
+        closeFn={() => setShowModal(false)}
+        title={label}
+      >
         <>
-          <Box>
-            <StyledPlainButton
-              onClick={() => this.setState({ showModal: true })}
-              margin={{ bottom: 'small' }}
-              text={label}
+          <Box
+            height='medium'
+            overflow='auto'
+          >
+            {tasks.map((task) => {
+              if (tasks.length > 1) {
+                return (
+                  <Markdownz key={task.taskKey}>
+                    {task.help}
+                    <hr />
+                  </Markdownz>
+                )
+              }
+
+              return <Markdownz key={task.taskKey}>{task.help}</Markdownz>
+            })}
+          </Box>
+          <Box pad={{ top: 'small' }}>
+            <Button
+              onClick={() => setShowModal(false)}
+              label={counterpart('TaskHelp.close')}
+              primary
             />
           </Box>
-          <Modal
-            active={this.state.showModal}
-            closeFn={() => this.setState({ showModal: false })}
-            title={label}
-          >
-            <>
-              <Box
-                height='medium'
-                overflow='auto'
-              >
-                {tasks.map((task) => {
-                  if (tasks.length > 1) {
-                    return (
-                      <Markdownz key={task.taskKey}>
-                        {task.help}
-                        <hr />
-                      </Markdownz>
-                    )
-                  }
-
-                  return <Markdownz key={task.taskKey}>{task.help}</Markdownz>
-                })}
-              </Box>
-              <Box pad={{ top: 'small' }}>
-                <Button
-                  onClick={() => this.setState({ showModal: false })}
-                  label={counterpart('TaskHelp.close')}
-                  primary
-                />
-              </Box>
-            </>
-          </Modal>
         </>
-      )
-    }
-
-    return null
-  }
+      </Modal>
+    </>
+  )
 }
 
-TaskHelp.wrappedComponent.propTypes = {
+TaskHelp.propTypes = {
   tasks: PropTypes.arrayOf(PropTypes.object).isRequired
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskHelp/TaskHelp.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskHelp/TaskHelp.spec.js
@@ -1,3 +1,4 @@
+import { Modal } from '@zooniverse/react-components'
 import { Button } from 'grommet'
 import { shallow } from 'enzyme'
 import React from 'react'
@@ -11,25 +12,21 @@ const tasks = [{
 
 describe('TaskHelp', function () {
   it('should render without crashing', function () {
-    const wrapper = shallow(<TaskHelp.wrappedComponent tasks={tasks} />)
+    const wrapper = shallow(<TaskHelp tasks={tasks} />)
     expect(wrapper).to.be.ok()
   })
 
-  it('should render null if there is no task help', function () {
-    const wrapper = shallow(<TaskHelp.wrappedComponent isThereTaskHelp={false} tasks={[{ taskKey: 'init' }]} />)
-    expect(wrapper.html()).to.be.null()
-  })
-
   it('should render the modal when the need help button is clicked', function () {
-    const wrapper = shallow(<TaskHelp.wrappedComponent isThereTaskHelp tasks={tasks} />)
+    const wrapper = shallow(<TaskHelp tasks={tasks} />)
     wrapper.find(NeedHelpButton).simulate('click')
-    expect(wrapper.state('showModal')).to.be.true()
+    expect(wrapper.find(Modal).prop('active')).to.be.true()
   })
 
   it('should no longer render the modal when the close button is clicked', function () {
-    const wrapper = shallow(<TaskHelp.wrappedComponent isThereTaskHelp tasks={tasks} />)
-    wrapper.setState({ showModal: true })
+    const wrapper = shallow(<TaskHelp tasks={tasks} />)
+    wrapper.find(NeedHelpButton).simulate('click')
+    expect(wrapper.find(Modal).prop('active')).to.be.true()
     wrapper.find(Button).simulate('click')
-    expect(wrapper.state('showModal')).to.be.false()
+    expect(wrapper.find(Modal).prop('active')).to.be.false()
   })
 })

--- a/packages/lib-classifier/src/store/tasks/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/store/tasks/MultipleChoiceTask.js
@@ -1,5 +1,6 @@
 import { types } from 'mobx-state-tree'
 import Task from './Task'
+import MultipleChoiceAnnotation from '../annotations/MultipleChoiceAnnotation'
 
 // TODO: should we make question/instruction consistent between task types?
 // What should be it called? I think we should use 'instruction'
@@ -14,6 +15,25 @@ const MultipleChoice = types.model('MultipleChoice', {
   required: types.maybe(types.boolean),
   type: types.literal('multiple')
 })
+.views(self => ({
+  get annotation () {
+    const { currentAnnotations } = getRoot(self).classifications
+    let currentAnnotation
+    if (currentAnnotations && currentAnnotations.size > 0) {
+      currentAnnotation = currentAnnotations.get(self.taskKey)
+    }
+    return currentAnnotation || self.defaultAnnotation
+  },
+  get defaultAnnotation () {
+    return MultipleChoiceAnnotation.create({ task: self.taskKey })
+  }
+}))
+.actions(self => ({
+  updateAnnotation (value) {
+    const { addAnnotation } = getRoot(self).classifications
+    addAnnotation(value, self)
+  }
+}))
 
 const MultipleChoiceTask = types.compose('MultipleChoiceTask', Task, MultipleChoice)
 

--- a/packages/lib-classifier/src/store/tasks/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/store/tasks/MultipleChoiceTask.js
@@ -16,22 +16,8 @@ const MultipleChoice = types.model('MultipleChoice', {
   type: types.literal('multiple')
 })
 .views(self => ({
-  get annotation () {
-    const { currentAnnotations } = getRoot(self).classifications
-    let currentAnnotation
-    if (currentAnnotations && currentAnnotations.size > 0) {
-      currentAnnotation = currentAnnotations.get(self.taskKey)
-    }
-    return currentAnnotation || self.defaultAnnotation
-  },
   get defaultAnnotation () {
     return MultipleChoiceAnnotation.create({ task: self.taskKey })
-  }
-}))
-.actions(self => ({
-  updateAnnotation (value) {
-    const { addAnnotation } = getRoot(self).classifications
-    addAnnotation(value, self)
   }
 }))
 

--- a/packages/lib-classifier/src/store/tasks/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/store/tasks/SingleChoiceTask.js
@@ -1,4 +1,4 @@
-import { getRoot, types } from 'mobx-state-tree'
+import { types } from 'mobx-state-tree'
 import Task from './Task'
 import SingleChoiceAnnotation from '../annotations/SingleChoiceAnnotation'
 
@@ -16,22 +16,8 @@ const SingleChoice = types.model('SingleChoice', {
   type: types.literal('single')
 })
 .views(self => ({
-  get annotation () {
-    const { currentAnnotations } = getRoot(self).classifications
-    let currentAnnotation
-    if (currentAnnotations && currentAnnotations.size > 0) {
-      currentAnnotation = currentAnnotations.get(self.taskKey)
-    }
-    return currentAnnotation || self.defaultAnnotation
-  },
   get defaultAnnotation () {
     return SingleChoiceAnnotation.create({ task: self.taskKey })
-  }
-}))
-.actions(self => ({
-  updateAnnotation (value) {
-    const { addAnnotation } = getRoot(self).classifications
-    addAnnotation(value, self)
   }
 }))
 

--- a/packages/lib-classifier/src/store/tasks/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/store/tasks/SingleChoiceTask.js
@@ -1,5 +1,6 @@
-import { types } from 'mobx-state-tree'
+import { getRoot, types } from 'mobx-state-tree'
 import Task from './Task'
+import SingleChoiceAnnotation from '../annotations/SingleChoiceAnnotation'
 
 // TODO: should we make question/instruction consistent between task types?
 // What should be it called? I think we should use 'instruction'
@@ -14,6 +15,25 @@ const SingleChoice = types.model('SingleChoice', {
   required: types.maybe(types.boolean), // Should this be an optional type with the default to true?
   type: types.literal('single')
 })
+.views(self => ({
+  get annotation () {
+    const { currentAnnotations } = getRoot(self).classifications
+    let currentAnnotation
+    if (currentAnnotations && currentAnnotations.size > 0) {
+      currentAnnotation = currentAnnotations.get(self.taskKey)
+    }
+    return currentAnnotation || self.defaultAnnotation
+  },
+  get defaultAnnotation () {
+    return SingleChoiceAnnotation.create({ task: self.taskKey })
+  }
+}))
+.actions(self => ({
+  updateAnnotation (value) {
+    const { addAnnotation } = getRoot(self).classifications
+    addAnnotation(value, self)
+  }
+}))
 
 const SingleChoiceTask = types.compose('SingleChoiceTask', Task, SingleChoice)
 

--- a/packages/lib-classifier/src/store/tasks/SingleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/store/tasks/SingleChoiceTask.spec.js
@@ -1,3 +1,4 @@
+import ClassificationStore from '../ClassificationStore'
 import SingleChoiceTask from './SingleChoiceTask'
 
 const singleChoiceTask = {
@@ -16,5 +17,45 @@ describe('Model > SingleChoiceTask', function () {
     const singleChoiceTaskInstance = SingleChoiceTask.create(singleChoiceTask)
     expect(singleChoiceTaskInstance).to.be.ok()
     expect(singleChoiceTaskInstance).to.be.an('object')
+  })
+
+  it('should error for invalid tasks', function () {
+    let errorThrown = false
+    try {
+      const task = TextTask.create({})
+    } catch (e) {
+      errorThrown = true
+    }
+    expect(errorThrown).to.be.true()
+  })
+
+  describe('with a classification', function () {
+    let task
+
+    before(function () {
+      task = SingleChoiceTask.create(singleChoiceTask)
+      task.classifications = ClassificationStore.create()
+      const mockSubject = {
+        id: 'subject',
+        metadata: {}
+      }
+      const mockWorkflow = {
+        id: 'workflow',
+        version: '1.0'
+      }
+      const mockProject = {
+        id: 'project'
+      }
+      task.classifications.createClassification(mockSubject, mockWorkflow, mockProject)
+    })
+
+    it('should start up with a null value', function () {
+      expect(task.annotation.value).to.be.null()
+    })
+
+    it('should update annotations', function () {
+      task.updateAnnotation(1)
+      expect(task.annotation.value).to.equal(1)
+    })
   })
 })

--- a/packages/lib-classifier/src/store/tasks/Task.js
+++ b/packages/lib-classifier/src/store/tasks/Task.js
@@ -1,7 +1,28 @@
-import { types } from 'mobx-state-tree'
+import { getRoot, types } from 'mobx-state-tree'
+import Annotation from '../annotations/Annotation'
 
 const Task = types.model('Task', {
   taskKey: types.identifier
 })
+.views(self => ({
+  get annotation () {
+    const { currentAnnotations } = getRoot(self).classifications
+    let currentAnnotation
+    if (currentAnnotations && currentAnnotations.size > 0) {
+      currentAnnotation = currentAnnotations.get(self.taskKey)
+    }
+    return currentAnnotation || self.defaultAnnotation
+  },
+  get defaultAnnotation () {
+    // Override this in a real task
+    return Annotation.create({ task: self.taskKey })
+  }
+}))
+.actions(self => ({
+  updateAnnotation (value) {
+    const { addAnnotation } = getRoot(self).classifications
+    addAnnotation(value, self)
+  }
+}))
 
 export default Task


### PR DESCRIPTION
I started adding stories for the text task in #1212 then realised that setting up the Tasks component to work with mocks deserved its own PR.

This PR:
 - sets up stories for the Tasks component, using basic mocked stores and the question tasks as an example. 
 - converts TaskHelp to a functional component that is conditionally rendered by the Tasks component.
- rewrites the SingleChoiceTask and MultipleChoiceTask components and models so that they can be tested in isolation, following the pattern for the text task in #1212

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
