### PR TITLE
Move assetPrefix to runtime config

### DIFF
--- a/packages/app-project/next.config.js
+++ b/packages/app-project/next.config.js
@@ -20,10 +20,13 @@ module.exports = {
   assetPrefix,
 
   env: {
-    ASSET_PREFIX: assetPrefix,
     COMMIT_ID: execSync('git rev-parse HEAD').toString('utf8').trim(),
     PANOPTES_ENV,
     TALK_HOST: talkHosts[PANOPTES_ENV]
+  },
+
+  publicRuntimeConfig: {
+    assetPrefix
   },
 
   webpack: (config) => {

--- a/packages/app-project/src/screens/ClassifyPage/components/RecentSubjects/RecentSubjects.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/RecentSubjects/RecentSubjects.js
@@ -1,10 +1,10 @@
 import counterpart from 'counterpart'
 import { Box, Grid, Paragraph } from 'grommet'
+import getConfig from 'next/config'
 import { array, bool, number, string } from 'prop-types'
 import React from 'react'
 
 import en from './locales/en'
-
 import ContentBox from '@shared/components/ContentBox'
 import SubjectPreview from '@shared/components/SubjectPreview'
 
@@ -13,9 +13,8 @@ counterpart.registerTranslations('en', en)
 function RecentSubjects (props) {
   const { isLoggedIn, recents, projectName, size, slug } = props
   const height = (size === 1) ? '40vw' : '200px'
-  const placeholderUrl = process.env.ASSET_PREFIX
-    ? `${process.env.ASSET_PREFIX}/subject-placeholder.png`
-    : '/subject-placeholder.png'
+  const { publicRuntimeConfig: { assetPrefix } } = getConfig()
+  const placeholderUrl = `${assetPrefix || ''}/subject-placeholder.png`
 
   return (
     <ContentBox title={counterpart('RecentSubjects.title', { projectName })}>

--- a/packages/app-project/src/screens/ClassifyPage/components/RecentSubjects/RecentSubjects.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/RecentSubjects/RecentSubjects.js
@@ -13,8 +13,9 @@ counterpart.registerTranslations('en', en)
 function RecentSubjects (props) {
   const { isLoggedIn, recents, projectName, size, slug } = props
   const height = (size === 1) ? '40vw' : '200px'
-  const { publicRuntimeConfig: { assetPrefix } } = getConfig()
-  const placeholderUrl = `${assetPrefix || ''}/subject-placeholder.png`
+  const { publicRuntimeConfig = {} } = getConfig() || {}
+  const assetPrefix = publicRuntimeConfig.assetPrefix || ''
+  const placeholderUrl = `${assetPrefix}/subject-placeholder.png`
 
   return (
     <ContentBox title={counterpart('RecentSubjects.title', { projectName })}>


### PR DESCRIPTION
Closes #1214

Makes `assetPrefix` available as a run-time config property, so that it gets correctly set by the local env var and generates the correct urls. Removes it from the build-time config block, as it would have to be dynamically set by Jenkins and we'd then have to build separate images depending on the environment

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
