### PR TITLE
Add a default annotation to tasks

### DIFF
--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -12,6 +12,7 @@ import {
 } from '../../test/factories'
 import stubPanoptesJs from '../../test/stubPanoptesJs'
 import helpers from './feedback/helpers'
+import { SingleChoiceAnnotation } from './annotations'
 
 const feedbackRulesStub = {
   T0: [{
@@ -120,7 +121,9 @@ describe('Model > ClassificationStore', function () {
       })
 
       beforeEach(function () {
-        classifications.addAnnotation(singleChoiceAnnotationStub.value, { type: 'single', taskKey: singleChoiceAnnotationStub.task })
+        const taskStub = Object.assign({}, singleChoiceTaskStub, { taskKey: singleChoiceAnnotationStub.task })
+        taskStub.createAnnotation = () => SingleChoiceAnnotation.create(singleChoiceAnnotationStub)
+        classifications.addAnnotation(singleChoiceAnnotationStub.value, taskStub)
         classifications.completeClassification({
           preventDefault: sinon.stub()
         })
@@ -182,7 +185,9 @@ describe('Model > ClassificationStore', function () {
         })
 
         subjectToBeClassified = rootStore.subjects.active
-        classifications.addAnnotation(singleChoiceAnnotationStub.value, { type: 'single', taskKey: singleChoiceAnnotationStub.task })
+        const taskStub = Object.assign({}, singleChoiceTaskStub, { taskKey: singleChoiceAnnotationStub.task })
+        taskStub.createAnnotation = () => SingleChoiceAnnotation.create(singleChoiceAnnotationStub)
+        classifications.addAnnotation(singleChoiceAnnotationStub.value, taskStub)
         classificationWithAnnotation = classifications.active
         classifications.completeClassification({
           preventDefault: sinon.stub()

--- a/packages/lib-classifier/src/store/tasks/DataVisAnnotationTask.js
+++ b/packages/lib-classifier/src/store/tasks/DataVisAnnotationTask.js
@@ -1,8 +1,9 @@
 import { types } from 'mobx-state-tree'
 import Task from './Task'
 import { Graph2dRangeXTool } from './dataVisTools'
+import { DataVisAnnotation } from '../annotations'
 
-const DataVisAnnotation = types.model('DataVisAnnotation', {
+const DataVisTask = types.model('DataVisTask', {
   help: types.optional(types.string, ''),
   instruction: types.maybe(types.string),
   tools: types.array(types.union({
@@ -13,7 +14,12 @@ const DataVisAnnotation = types.model('DataVisAnnotation', {
   }, Graph2dRangeXTool)),
   type: types.literal('dataVisAnnotation')
 })
+.views(self => ({
+  get defaultAnnotation () {
+    return DataVisAnnotation.create({ task: self.taskKey })
+  }
+}))
 
-const DataVisAnnotationTask = types.compose('DataVisAnnotationTask', Task, DataVisAnnotation)
+const DataVisAnnotationTask = types.compose('DataVisAnnotationTask', Task, DataVisTask)
 
 export default DataVisAnnotationTask

--- a/packages/lib-classifier/src/store/tasks/DataVisAnnotationTask.js
+++ b/packages/lib-classifier/src/store/tasks/DataVisAnnotationTask.js
@@ -3,7 +3,7 @@ import Task from './Task'
 import { Graph2dRangeXTool } from './dataVisTools'
 import { DataVisAnnotation } from '../annotations'
 
-const DataVisTask = types.model('DataVisTask', {
+const DataVisTaskModel = types.model('DataVisTaskModel', {
   help: types.optional(types.string, ''),
   instruction: types.maybe(types.string),
   tools: types.array(types.union({
@@ -20,6 +20,6 @@ const DataVisTask = types.model('DataVisTask', {
   }
 }))
 
-const DataVisAnnotationTask = types.compose('DataVisAnnotationTask', Task, DataVisTask)
+const DataVisAnnotationTask = types.compose('DataVisAnnotationTask', Task, DataVisTaskModel)
 
 export default DataVisAnnotationTask

--- a/packages/lib-classifier/src/store/tasks/DrawingTask.js
+++ b/packages/lib-classifier/src/store/tasks/DrawingTask.js
@@ -1,6 +1,7 @@
 import { types } from 'mobx-state-tree'
 import Task from './Task'
 import { Line, Point } from './drawingTools'
+import { DrawingAnnotation } from '../annotations'
 
 // TODO: Need to define tool models
 
@@ -21,6 +22,12 @@ const Drawing = types.model('Drawing', {
   })),
   type: types.literal('drawing')
 })
+.views(self => ({
+  get defaultAnnotation () {
+    return DrawingAnnotation.create({ task: self.taskKey })
+  }
+}))
+
 
 const DrawingTask = types.compose('DrawingTask', Task, Drawing)
 

--- a/packages/lib-classifier/src/store/tasks/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/store/tasks/MultipleChoiceTask.js
@@ -1,6 +1,6 @@
 import { types } from 'mobx-state-tree'
 import Task from './Task'
-import MultipleChoiceAnnotation from '../annotations/MultipleChoiceAnnotation'
+import { MultipleChoiceAnnotation } from '../annotations'
 
 // TODO: should we make question/instruction consistent between task types?
 // What should be it called? I think we should use 'instruction'

--- a/packages/lib-classifier/src/store/tasks/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/store/tasks/SingleChoiceTask.js
@@ -1,6 +1,6 @@
 import { types } from 'mobx-state-tree'
 import Task from './Task'
-import SingleChoiceAnnotation from '../annotations/SingleChoiceAnnotation'
+import { SingleChoiceAnnotation } from '../annotations'
 
 // TODO: should we make question/instruction consistent between task types?
 // What should be it called? I think we should use 'instruction'

--- a/packages/lib-classifier/src/store/tasks/SingleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/store/tasks/SingleChoiceTask.spec.js
@@ -22,7 +22,7 @@ describe('Model > SingleChoiceTask', function () {
   it('should error for invalid tasks', function () {
     let errorThrown = false
     try {
-      const task = TextTask.create({})
+      const task = SingleChoiceTask.create({})
     } catch (e) {
       errorThrown = true
     }

--- a/packages/lib-classifier/src/store/tasks/Task.js
+++ b/packages/lib-classifier/src/store/tasks/Task.js
@@ -22,6 +22,10 @@ const Task = types.model('Task', {
   updateAnnotation (value) {
     const { addAnnotation } = getRoot(self).classifications
     addAnnotation(value, self)
+  },
+  createAnnotation () {
+    const newAnnotation = self.defaultAnnotation
+    return newAnnotation
   }
 }))
 

--- a/packages/lib-classifier/src/store/tasks/Task.spec.js
+++ b/packages/lib-classifier/src/store/tasks/Task.spec.js
@@ -1,9 +1,56 @@
+import { getType } from 'mobx-state-tree'
+import ClassificationStore from '../ClassificationStore'
 import Task from './Task'
+import Annotation from '../annotations/Annotation'
 
 describe('Model > Task', function () {
+  const mockTask = {
+    taskKey: 'T0'
+  }
+
   it('should exist', function () {
     const taskInstance = Task.create({ taskKey: 'T3' })
     expect(taskInstance).to.be.ok()
     expect(taskInstance).to.be.an('object')
+  })
+
+  it('should error for invalid tasks', function () {
+    let errorThrown = false
+    try {
+      const task = Task.create({})
+    } catch (e) {
+      errorThrown = true
+    }
+    expect(errorThrown).to.be.true()
+  })
+
+  describe('with a classification', function () {
+    let task
+
+    before(function () {
+      task = Task.create(mockTask)
+      task.classifications = ClassificationStore.create()
+      const mockSubject = {
+        id: 'subject',
+        metadata: {}
+      }
+      const mockWorkflow = {
+        id: 'workflow',
+        version: '1.0'
+      }
+      const mockProject = {
+        id: 'project'
+      }
+      task.classifications.createClassification(mockSubject, mockWorkflow, mockProject)
+    })
+
+    it('should start up with an undefined value', function () {
+      expect(task.annotation.value).to.be.undefined()
+    })
+
+    it('should create new Annotation models', function () {
+      const annotation = task.createAnnotation()
+      expect(getType(annotation)).to.equal(Annotation)
+    })
   })
 })

--- a/packages/lib-classifier/src/store/tasks/Task.spec.js
+++ b/packages/lib-classifier/src/store/tasks/Task.spec.js
@@ -52,5 +52,9 @@ describe('Model > Task', function () {
       const annotation = task.createAnnotation()
       expect(getType(annotation)).to.equal(Annotation)
     })
+
+    it('should add its task key to annotations', function () {
+      expect(task.annotation.task).to.equal(task.taskKey)
+    })
   })
 })


### PR DESCRIPTION
This PR delegates responsibility for creating new annotations to individual tasks, with the aim of simplifying the classifications store and making it easier to add new tasks.

 - Add a default annotation to each task model.
 - Add a generic createAnnotation action to all tasks.
 - Remove getAnnotationType and createDefaultAnnotation from the classifications store.

Package:
lib-classifier


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
