### PR TITLE
Add a text input task

### DIFF
--- a/packages/lib-classifier/.babelrc
+++ b/packages/lib-classifier/.babelrc
@@ -20,6 +20,9 @@
   ],
   "env": {
     "test": {
+      "plugins": [
+        ["babel-plugin-webpack-alias", { "config": "./webpack.dev.js" }]
+      ],
       "presets": [
         "@babel/preset-env",
         "@babel/preset-react"

--- a/packages/lib-classifier/.storybook/webpack.config.js
+++ b/packages/lib-classifier/.storybook/webpack.config.js
@@ -1,0 +1,10 @@
+const path = require('path')
+const webpackConfig = require('../webpack.dev')
+
+module.exports = async ({ config }) => {
+
+  const newAliases = webpackConfig.resolve.alias
+  const alias = Object.assign({}, config.resolve.alias, newAliases)
+  config.resolve = Object.assign({}, config.resolve, { alias } )
+  return config
+}

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -70,6 +70,7 @@
     "@zooniverse/react-components": "~0.7.1",
     "@zooniverse/standard": "~1.0.0",
     "babel-loader": "~8.0.6",
+    "babel-plugin-webpack-alias": "~2.1.2",
     "chai": "~4.2.0",
     "dirty-chai": "~2.0.1",
     "enzyme": "~3.10.0",

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -45,7 +45,7 @@ class Tasks extends React.Component {
       // there has to be a better way
       // but works for now
       return (
-        <Box as='form' justify='between' fill>
+        <Box as='form' gap="small" justify='between' fill>
           {tasks.map((task) => {
             const TaskComponent = getTaskComponent(task.type)
             if (TaskComponent) {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -3,7 +3,6 @@ import { Box, Paragraph } from 'grommet'
 import { inject, observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { ThemeProvider } from 'styled-components'
 
 import getTaskComponent from './helpers/getTaskComponent'
 import TaskHelp from './components/TaskHelp'
@@ -46,24 +45,22 @@ class Tasks extends React.Component {
       // there has to be a better way
       // but works for now
       return (
-        <ThemeProvider theme={{ mode: this.props.theme }}>
-          <Box as='form' justify='between' fill>
-            {tasks.map((task) => {
-              const TaskComponent = getTaskComponent(task.type)
-              if (TaskComponent) {
-                return (
-                  <Box key={task.taskKey} basis='auto'>
-                    <TaskComponent disabled={!ready} task={task} {...this.props} />
-                  </Box>
-                )
-              }
+        <Box as='form' justify='between' fill>
+          {tasks.map((task) => {
+            const TaskComponent = getTaskComponent(task.type)
+            if (TaskComponent) {
+              return (
+                <Box key={task.taskKey} basis='auto'>
+                  <TaskComponent disabled={!ready} task={task} {...this.props} />
+                </Box>
+              )
+            }
 
-              return (<Paragraph>Task component could not be rendered.</Paragraph>)
-            })}
-            {isThereTaskHelp && <TaskHelp tasks={tasks} />}
-            <TaskNavButtons disabled={!ready} />
-          </Box>
-        </ThemeProvider>
+            return (<Paragraph>Task component could not be rendered.</Paragraph>)
+          })}
+          {isThereTaskHelp && <TaskHelp tasks={tasks} />}
+          <TaskNavButtons disabled={!ready} />
+        </Box>
       )
     }
 
@@ -80,16 +77,14 @@ Tasks.propTypes = {
   isThereTaskHelp: PropTypes.bool,
   loadingState: PropTypes.oneOf(asyncStates.values),
   ready: PropTypes.bool,
-  tasks: PropTypes.arrayOf(PropTypes.object),
-  theme: PropTypes.string
+  tasks: PropTypes.arrayOf(PropTypes.object)
 }
 
 Tasks.defaultProps = {
   isThereTaskHelp: false,
   loadingState: asyncStates.initialized,
   ready: false,
-  tasks: [],
-  theme: 'light'
+  tasks: []
 }
 
 @inject(storeMapper)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import React from 'react'
 import sinon from 'sinon'
-import { Grommet } from 'grommet'
+import { Box, Grommet } from 'grommet'
 import { Provider } from "mobx-react"
 
 import { Tasks } from './Tasks'
@@ -24,8 +24,38 @@ const mockStore = {
   }
 }
 
+function MockTask({ dark, isThereTaskHelp, subjectReadyState, step, store, tasks, zooTheme}) {
+  const background = dark ?
+    zooTheme.global.colors['dark-1'] :
+    zooTheme.global.colors['light-1']
+  return (
+    <Provider classifierStore={store}>
+      <Grommet theme={Object.assign({}, zooTheme, { dark })}>
+        <Box
+          background={background}
+          pad='1em'
+          width='380px'
+        >
+          <Tasks
+            isThereTaskHelp={isThereTaskHelp}
+            loadingState={asyncStates.success}
+            step={step}
+            subjectReadyState={subjectReadyState}
+            tasks={tasks}
+          />
+        </Box>
+      </Grommet>
+    </Provider>
+  )
+}
+
 storiesOf('Tasks', module)
 .addDecorator(withKnobs)
+.addParameters({
+  viewport: {
+    defaultViewport: 'responsive'
+  }
+})
 .add('loading', function () {
   return (
     <Provider classifierStore={mockStore}>
@@ -51,6 +81,7 @@ storiesOf('Tasks', module)
   }]
   const dark = boolean('Dark theme', false)
   const subjectReadyState = select('Subject loading', asyncStates, asyncStates.success)
+  const isThereTaskHelp = boolean('Enable task help', true)
   const store = Object.assign({}, mockStore, {
     workflows: {
       loadingState: asyncStates.success
@@ -63,17 +94,16 @@ storiesOf('Tasks', module)
     }
   })
   return (
-    <Provider classifierStore={store}>
-      <Grommet theme={Object.assign({}, zooTheme, { dark })}>
-        <Tasks
-          isThereTaskHelp={true}
-          loadingState={asyncStates.success}
-          step={step}
-          subjectReadyState={subjectReadyState}
-          tasks={tasks}
-        />
-      </Grommet>
-    </Provider>
+    <MockTask
+      dark={dark}
+      isThereTaskHelp={isThereTaskHelp}
+      loadingState={asyncStates.success}
+      step={step}
+      store={store}
+      subjectReadyState={subjectReadyState}
+      tasks={tasks}
+      zooTheme={zooTheme}
+    />
   )
 })
 .add('multiple tasks', function () {
@@ -102,6 +132,7 @@ storiesOf('Tasks', module)
   ]
   const dark = boolean('Dark theme', false)
   const subjectReadyState = select('Subject loading', asyncStates, asyncStates.success)
+  const isThereTaskHelp = boolean('Enable task help', true)
   const store = Object.assign({}, mockStore, {
     workflows: {
       loadingState: asyncStates.success
@@ -114,17 +145,16 @@ storiesOf('Tasks', module)
     }
   })
   return (
-    <Provider classifierStore={store}>
-      <Grommet theme={Object.assign({}, zooTheme, { dark })}>
-        <Tasks
-          isThereTaskHelp={true}
-          loadingState={asyncStates.success}
-          step={step}
-          subjectReadyState={subjectReadyState}
-          tasks={tasks}
-        />
-      </Grommet>
-    </Provider>
+    <MockTask
+      dark={dark}
+      isThereTaskHelp={isThereTaskHelp}
+      loadingState={asyncStates.success}
+      step={step}
+      store={store}
+      subjectReadyState={subjectReadyState}
+      tasks={tasks}
+      zooTheme={zooTheme}
+    />
   )
 })
 .add('text', function () {
@@ -143,6 +173,7 @@ storiesOf('Tasks', module)
   const dark = boolean('Dark theme', false)
   const loadingState = select('Subject loading', asyncStates, asyncStates.success)
   const subjectReadyState = select('Subject loading', asyncStates, asyncStates.success)
+  const isThereTaskHelp = boolean('Enable task help', true)
   const store = Object.assign({}, mockStore, {
     subjectViewer: {
       loadingState
@@ -158,16 +189,15 @@ storiesOf('Tasks', module)
     }
   })
   return (
-    <Provider classifierStore={store}>
-      <Grommet theme={Object.assign({}, zooTheme, { dark })}>
-        <Tasks
-          isThereTaskHelp={true}
-          loadingState={asyncStates.success}
-          step={step}
-          subjectReadyState={subjectReadyState}
-          tasks={tasks}
-        />
-      </Grommet>
-    </Provider>
+    <MockTask
+      dark={dark}
+      isThereTaskHelp={isThereTaskHelp}
+      loadingState={asyncStates.success}
+      step={step}
+      store={store}
+      subjectReadyState={subjectReadyState}
+      tasks={tasks}
+      zooTheme={zooTheme}
+    />
   )
 })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -71,7 +71,6 @@ storiesOf('Tasks', module)
           step={step}
           subjectReadyState={subjectReadyState}
           tasks={tasks}
-          theme={dark ? 'dark' : 'light'}
         />
       </Grommet>
     </Provider>
@@ -123,7 +122,6 @@ storiesOf('Tasks', module)
           step={step}
           subjectReadyState={subjectReadyState}
           tasks={tasks}
-          theme={dark ? 'dark' : 'light'}
         />
       </Grommet>
     </Provider>
@@ -166,7 +164,6 @@ storiesOf('Tasks', module)
           step={step}
           subjectReadyState={subjectReadyState}
           tasks={tasks}
-          theme={dark ? 'dark' : 'light'}
         />
       </Grommet>
     </Provider>

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -131,11 +131,13 @@ storiesOf('Tasks', module)
   const step = null
   const tasks = [
     {
+      annotation: { task: 'T0', value: '' },
       help: 'Type something into the text box.',
       instruction: 'Type something here',
       taskKey: 'T0',
       text_tags: ['insertion', 'deletion'],
-      type: 'text'
+      type: 'text',
+      updateAnnotation: sinon.stub()
     }
   ]
   const dark = boolean('Dark theme', false)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -129,3 +129,46 @@ storiesOf('Tasks', module)
     </Provider>
   )
 })
+.add('text', function () {
+  const step = null
+  const tasks = [
+    {
+      help: 'Type something into the text box.',
+      instruction: 'Type something here',
+      taskKey: 'T0',
+      text_tags: ['insertion', 'deletion'],
+      type: 'text'
+    }
+  ]
+  const dark = boolean('Dark theme', false)
+  const loadingState = select('Subject loading', asyncStates, asyncStates.success)
+  const subjectReadyState = select('Subject loading', asyncStates, asyncStates.success)
+  const store = Object.assign({}, mockStore, {
+    subjectViewer: {
+      loadingState
+    },
+    workflows: {
+      loadingState: asyncStates.success
+    },
+    workflowSteps: {
+      activeStepTasks: tasks,
+      isThereANextStep: () => false,
+      isThereAPreviousStep: () => false,
+      isThereTaskHelp: true
+    }
+  })
+  return (
+    <Provider classifierStore={store}>
+      <Grommet theme={Object.assign({}, zooTheme, { dark })}>
+        <Tasks
+          isThereTaskHelp={true}
+          loadingState={asyncStates.success}
+          step={step}
+          subjectReadyState={subjectReadyState}
+          tasks={tasks}
+          theme={dark ? 'dark' : 'light'}
+        />
+      </Grommet>
+    </Provider>
+  )
+})

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/helpers/getTaskComponent.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/helpers/getTaskComponent.js
@@ -2,12 +2,14 @@ import DrawingTask from '../components/DrawingTask'
 import DataVisAnnotationTask from '../components/DataVisAnnotationTask'
 import SingleChoiceTask from '../components/SingleChoiceTask'
 import MultipleChoiceTask from '../components/MultipleChoiceTask'
+import { TextTask } from '@plugins/tasks/TextTask'
 
 const taskTypes = {
   drawing: DrawingTask,
   dataVisAnnotation: DataVisAnnotationTask,
   single: SingleChoiceTask,
-  multiple: MultipleChoiceTask
+  multiple: MultipleChoiceTask,
+  text: TextTask
 }
 
 export default function getTaskComponent (taskType) {

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
@@ -1,5 +1,5 @@
 import { PlainButton } from '@zooniverse/react-components'
-import { Box, FormField, TextArea } from 'grommet'
+import { Box, Text, TextArea } from 'grommet'
 import React from 'react'
 
 function TextTask (props) {
@@ -44,11 +44,13 @@ function TextTask (props) {
   }
 
   return (
-    <Box>
-      <FormField
+    <Box
+      direction="column"
+    >
+      <label
         htmlFor={`${task.taskKey}-${task.type}`}
-        label={task.instruction}
       >
+        <Text>{task.instruction}</Text>
         <TextArea
           ref={textArea}
           autoFocus={autoFocus}
@@ -57,7 +59,7 @@ function TextTask (props) {
           value={value}
           onChange={onChange}
         />
-      </FormField>
+      </label>
       <Box
         gap='small'
         justify='center'

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
@@ -4,7 +4,7 @@ import React from 'react'
 
 function TextTask (props) {
   const { autoFocus, disabled, task } = props
-  const defaultValue = task.annotation ? task.annotation.value : ''
+  const defaultValue = task.annotation.value
   const [value, setValue] = React.useState(defaultValue)
   const textArea = React.createRef()
 

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
@@ -1,6 +1,10 @@
 import { PlainButton } from '@zooniverse/react-components'
+import counterpart from 'counterpart'
 import { Box, Text, TextArea } from 'grommet'
 import React from 'react'
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
 
 function TextTask (props) {
   const { autoFocus, disabled, task } = props
@@ -60,6 +64,14 @@ function TextTask (props) {
           onChange={onChange}
         />
       </label>
+      {(task.text_tags.length > 0) &&
+        <Text
+          id={`textModifiers-${task.taskKey}`}
+          weight='bold'
+        >
+          {counterpart('TextTask.modifiers')}
+        </Text>
+      }
       <Box
         gap='small'
         justify='start'
@@ -67,6 +79,8 @@ function TextTask (props) {
       >
         {task.text_tags.map(tag => (
           <PlainButton
+            aria-labelledby={`textModifiers-${task.taskKey} ${task.taskKey}-${tag}`}
+            id={`${task.taskKey}-${tag}`}
             key={tag}
             disabled={disabled}
             justify='start'

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
@@ -58,16 +58,22 @@ function TextTask (props) {
           onChange={onChange}
         />
       </FormField>
-      {task.text_tags.map(tag => (
-        <PlainButton
-          key={tag}
-          disabled={disabled}
-          justify='start'
-          onClick={setTagSelection}
-          text={tag}
-          value={tag}
-        />
-      ))}
+      <Box
+        gap='small'
+        justify='center'
+        direction='row'
+      >
+        {task.text_tags.map(tag => (
+          <PlainButton
+            key={tag}
+            disabled={disabled}
+            justify='start'
+            onClick={setTagSelection}
+            text={tag}
+            value={tag}
+          />
+        ))}
+      </Box>
     </Box>
   )
 }

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
@@ -62,7 +62,7 @@ function TextTask (props) {
       </label>
       <Box
         gap='small'
-        justify='center'
+        justify='start'
         direction='row'
       >
         {task.text_tags.map(tag => (

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
@@ -1,0 +1,75 @@
+import { PlainButton } from '@zooniverse/react-components'
+import { Box, FormField, TextArea } from 'grommet'
+import React from 'react'
+
+function TextTask (props) {
+  const { autoFocus, disabled, task } = props
+  const defaultValue = task.annotation ? task.annotation.value : ''
+  const [value, setValue] = React.useState(defaultValue)
+  const textArea = React.createRef()
+
+  function onChange (event) {
+    const { target } = event
+    updateText(target.value)
+  }
+
+  function updateText (text) {
+    setValue(text)
+    task.updateAnnotation(text)
+  }
+
+  function setTagSelection (e) {
+    const textTag = e.currentTarget.value
+    const startTag = `[${textTag}]`
+    const endTag = `[/${textTag}]`
+    const selectionStart = textArea.current.selectionStart
+    const selectionEnd = textArea.current.selectionEnd
+    const textBefore = value.substring(0, selectionStart)
+    let textAfter
+    let newValue
+
+    if (selectionStart === selectionEnd) {
+      textAfter = value.substring(selectionStart, value.length)
+      newValue = textBefore + startTag + endTag + textAfter
+    } else {
+      const textInBetween = value.substring(selectionStart, selectionEnd)
+      textAfter = value.substring(selectionEnd, value.length)
+      newValue = textBefore + startTag + textInBetween + endTag + textAfter
+    }
+    updateText(newValue)
+    if (textArea.current.focus) {
+      textArea.current.setSelectionRange((newValue.length - textAfter.length), (newValue.length - textAfter.length))
+      textArea.current.focus()
+    }
+  }
+
+  return (
+    <Box>
+      <FormField
+        htmlFor={`${task.taskKey}-${task.type}`}
+        label={task.instruction}
+      >
+        <TextArea
+          ref={textArea}
+          autoFocus={autoFocus}
+          disabled={disabled}
+          id={`${task.taskKey}-${task.type}`}
+          value={value}
+          onChange={onChange}
+        />
+      </FormField>
+      {task.text_tags.map(tag => (
+        <PlainButton
+          key={tag}
+          disabled={disabled}
+          justify='start'
+          onClick={setTagSelection}
+          text={tag}
+          value={tag}
+        />
+      ))}
+    </Box>
+  )
+}
+
+export default TextTask

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { mount, shallow } from 'enzyme'
-import { FormField, TextArea } from 'grommet'
+import { Text, TextArea } from 'grommet'
 import { expect } from 'chai'
 import sinon from 'sinon'
 
@@ -28,8 +28,8 @@ describe('TextTask', function () {
   })
 
   it('should have a labelled textarea', function () {
-    const label = wrapper.find(FormField)
-    expect(label.prop('label')).to.equal(mockTask.instruction)
+    const label = wrapper.find('label')
+    expect(label.find(Text).prop('children')).to.equal(mockTask.instruction)
     const textarea = label.find(TextArea)
     expect(textarea.prop('value')).to.equal(mockTask.annotation.value)
   })

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.spec.js
@@ -1,0 +1,116 @@
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import { FormField, TextArea } from 'grommet'
+import { expect } from 'chai'
+import sinon from 'sinon'
+
+import TextTask from './'
+
+describe('TextTask', function () {
+  let wrapper
+  const mockTask = {
+    annotation: {
+      task: 'T0',
+      value: ''
+    },
+    instruction: 'Type something here',
+    taskKey: 'T0',
+    text_tags: ['insertion', 'deletion'],
+    updateAnnotation: sinon.stub()
+  }
+
+  before(function () {
+    wrapper = shallow(
+      <TextTask
+        task={mockTask}
+      />
+    )
+  })
+
+  it('should have a labelled textarea', function () {
+    const label = wrapper.find(FormField)
+    expect(label.prop('label')).to.equal(mockTask.instruction)
+    const textarea = label.find(TextArea)
+    expect(textarea.prop('value')).to.equal(mockTask.annotation.value)
+  })
+
+  describe('onChange', function () {
+    beforeEach(function () {
+      wrapper = shallow(
+        <TextTask
+          task={mockTask}
+        />
+      )
+    })
+
+    afterEach(function () {
+      mockTask.updateAnnotation.resetHistory()
+    })
+
+    it('should update the textarea', function () {
+      const textArea = wrapper.find(TextArea)
+      const fakeEvent = {
+        target: {
+          value: 'Hello there!'
+        }
+      }
+      textArea.simulate('change', fakeEvent)
+      expect(wrapper.find(TextArea).prop('value')).to.equal(fakeEvent.target.value)
+    })
+
+    it('should update the task annotation', function () {
+      const textArea = wrapper.find(TextArea)
+      const fakeEvent = {
+        target: {
+          value: 'Hello there!'
+        }
+      }
+      textArea.simulate('change', fakeEvent)
+      expect(mockTask.updateAnnotation.withArgs(fakeEvent.target.value)).to.have.been.calledOnce()
+    })
+  })
+
+  describe('text tagging', function () {
+    beforeEach(function () {
+      const annotation = {
+        task: 'T0',
+        value: 'Hello, this is some test text.'
+      }
+      wrapper = mount(
+        <TextTask
+          task={Object.assign({}, mockTask, { annotation })}
+        />
+      )
+    })
+
+    afterEach(function () {
+      mockTask.updateAnnotation.resetHistory()
+    })
+
+    it('should render buttons for tagging text', function () {
+      expect(wrapper.find('button')).to.have.lengthOf(2)
+    })
+
+    mockTask.text_tags.forEach(function (tag) {
+      it(`should render a ${tag} button`, function () {
+        const button = wrapper.find('button').find({ value: tag })
+        expect(button).to.have.lengthOf(1)
+      })
+    })
+
+    it('should tag text', function () {
+      const insertionButton = wrapper.find('button').find({ value: 'insertion' })
+      const fakeEvent = {
+        currentTarget: {
+          value: 'insertion'
+        }
+      }
+      const textArea = wrapper.find(TextArea).getDOMNode()
+      textArea.selectionStart = 7
+      textArea.selectionEnd = 11
+      const expectedText = 'Hello, [insertion]this[/insertion] is some test text.'
+      insertionButton.simulate('click', fakeEvent)
+      expect(textArea.value).to.equal(expectedText)
+    })
+  })
+})

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/index.js
@@ -1,0 +1,1 @@
+export { default } from './TextTask'

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/locales/en.json
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/locales/en.json
@@ -1,0 +1,5 @@
+{
+  "TextTask": {
+    "modifiers": "Text modifiers"
+  }
+}

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/index.js
@@ -1,0 +1,4 @@
+export { default as TextTask } from './components/TextTask'
+export { default as TextModel } from './models/TextTask'
+export { default as TextAnnotation } from './models/TextAnnotation'
+

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextAnnotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextAnnotation.js
@@ -1,8 +1,9 @@
 import { types } from 'mobx-state-tree'
+import { Annotation } from '@store/annotations'
 
-const TextAnnotation = types.model('TextAnnotation', {
-  task: types.identifier,
+const Text = types.model('Text', {
   value: types.optional(types.string, '')
 })
 
+const TextAnnotation = types.compose('TextAnnotation', Annotation, Text)
 export default TextAnnotation

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextAnnotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextAnnotation.js
@@ -1,0 +1,8 @@
+import { types } from 'mobx-state-tree'
+
+const TextAnnotation = types.model('TextAnnotation', {
+  task: types.identifier,
+  value: types.optional(types.string, '')
+})
+
+export default TextAnnotation

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextAnnotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextAnnotation.spec.js
@@ -1,0 +1,24 @@
+import TextAnnotation from './TextAnnotation'
+
+describe('Model > TextAnnotation', function () {
+  it('should exist', function () {
+    const annotation = TextAnnotation.create({ task: 'T4' })
+    expect(annotation).to.be.ok()
+    expect(annotation).to.be.an('object')
+  })
+
+  it('should have a default value', function () {
+    const annotation = TextAnnotation.create({ task: 'T4' })
+    expect(annotation.value).to.equal('')
+  })
+
+  it('should error for invalid annotations', function () {
+    let errorThrown = false
+    try {
+      const annotation = TextAnnotation.create({ task: 'T4', value: 5 })
+    } catch (e) {
+      errorThrown = true
+    }
+    expect(errorThrown).to.be.true()
+  })
+})

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.js
@@ -10,12 +10,16 @@ const TextTask = types.model('TextTask', {
   type: types.literal('text')
 })
   .views(self => ({
+    get defaultAnnotation () {
+      return TextAnnotation.create({ task: self.taskKey })
+    },
     get annotation () {
       const { currentAnnotations } = getRoot(self).classifications
+      let currentAnnotation
       if (currentAnnotations && currentAnnotations.size > 0) {
-        return currentAnnotations.get(self.taskKey)
+        currentAnnotation = currentAnnotations.get(self.taskKey)
       }
-      return TextAnnotation.create({ task: self.taskKey })
+      return currentAnnotation || self.defaultAnnotation
     }
   }))
   .actions(self => ({

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.js
@@ -1,6 +1,6 @@
 import { getRoot, types } from 'mobx-state-tree'
+import { Task } from '@store/tasks'
 import TextAnnotation from './TextAnnotation'
-import { Task } from '../../../../store/tasks'
 
 const Text = types.model('Text', {
   help: types.optional(types.string, ''),

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.js
@@ -12,14 +12,6 @@ const Text = types.model('Text', {
   .views(self => ({
     get defaultAnnotation () {
       return TextAnnotation.create({ task: self.taskKey })
-    },
-    get annotation () {
-      const { currentAnnotations } = getRoot(self).classifications
-      let currentAnnotation
-      if (currentAnnotations && currentAnnotations.size > 0) {
-        currentAnnotation = currentAnnotations.get(self.taskKey)
-      }
-      return currentAnnotation || self.defaultAnnotation
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.js
@@ -1,0 +1,28 @@
+import { getRoot, types } from 'mobx-state-tree'
+import TextAnnotation from './TextAnnotation'
+
+const TextTask = types.model('TextTask', {
+  help: types.optional(types.string, ''),
+  instruction: types.string,
+  required: types.optional(types.boolean, false),
+  taskKey: types.identifier,
+  text_tags: types.array(types.string),
+  type: types.literal('text')
+})
+  .views(self => ({
+    get annotation () {
+      const { currentAnnotations } = getRoot(self).classifications
+      if (currentAnnotations && currentAnnotations.size > 0) {
+        return currentAnnotations.get(self.taskKey)
+      }
+      return TextAnnotation.create({ task: self.taskKey })
+    }
+  }))
+  .actions(self => ({
+    updateAnnotation (value) {
+      const { addAnnotation } = getRoot(self).classifications
+      addAnnotation(value, self)
+    }
+  }))
+
+export default TextTask

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.js
@@ -1,11 +1,11 @@
 import { getRoot, types } from 'mobx-state-tree'
 import TextAnnotation from './TextAnnotation'
+import { Task } from '../../../../store/tasks'
 
-const TextTask = types.model('TextTask', {
+const Text = types.model('Text', {
   help: types.optional(types.string, ''),
   instruction: types.string,
   required: types.optional(types.boolean, false),
-  taskKey: types.identifier,
   text_tags: types.array(types.string),
   type: types.literal('text')
 })
@@ -22,11 +22,7 @@ const TextTask = types.model('TextTask', {
       return currentAnnotation || self.defaultAnnotation
     }
   }))
-  .actions(self => ({
-    updateAnnotation (value) {
-      const { addAnnotation } = getRoot(self).classifications
-      addAnnotation(value, self)
-    }
-  }))
+
+const TextTask = types.compose('TextTask', Task, Text)
 
 export default TextTask

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.spec.js
@@ -1,0 +1,68 @@
+import ClassificationStore from '@store/ClassificationStore'
+import TextTask from './TextTask'
+
+describe('Model > TextTask', function () {
+  const textTask = {
+    instruction: 'Type something here',
+    taskKey: 'T0',
+    text_tags: ['insertion', 'deletion'],
+    type: 'text'
+  }
+
+  const singleChoiceTask = {
+    answers: [
+      { label: 'yes', next: 'S2' },
+      { label: 'no', next: 'S3' }
+    ],
+    question: 'Do you exist?',
+    required: false,
+    taskKey: 'T1',
+    type: 'single'
+  }
+
+  it('should exist', function () {
+    const task = TextTask.create(textTask)
+    expect(task).to.be.ok()
+    expect(task).to.be.an('object')
+  })
+
+  it('should error for invalid tasks', function () {
+    let errorThrown = false
+    try {
+      const task = TextTask.create(singleChoiceTask)
+    } catch (e) {
+      errorThrown = true
+    }
+    expect(errorThrown).to.be.true()
+  })
+
+  describe('with a classification', function () {
+    let task
+
+    before(function () {
+      task = TextTask.create(textTask)
+      task.classifications = ClassificationStore.create()
+      const mockSubject = {
+        id: 'subject',
+        metadata: {}
+      }
+      const mockWorkflow = {
+        id: 'workflow',
+        version: '1.0'
+      }
+      const mockProject = {
+        id: 'project'
+      }
+      task.classifications.createClassification(mockSubject, mockWorkflow, mockProject)
+    })
+
+    it('should start up with an empty string', function () {
+      expect(task.annotation.value).to.equal('')
+    })
+
+    it('should update annotations', function () {
+      task.updateAnnotation('Hello there!')
+      expect(task.annotation.value).to.equal('Hello there!')
+    })
+  })
+})

--- a/packages/lib-classifier/src/store/Classification.js
+++ b/packages/lib-classifier/src/store/Classification.js
@@ -1,6 +1,7 @@
 import { types, getType } from 'mobx-state-tree'
 import Resource from './Resource'
 import { SingleChoiceAnnotation, MultipleChoiceAnnotation, DataVisAnnotation } from './annotations'
+import { TextAnnotation } from '@plugins/tasks/TextTask'
 
 const ClassificationMetadata = types.model('ClassificationMetadata', {
   classifier_version: types.literal('2.0'),
@@ -36,15 +37,12 @@ const ClassificationMetadata = types.model('ClassificationMetadata', {
 
 const Classification = types
   .model('Classification', {
-    annotations: types.map(types.union({
-      dispatcher: (snapshot) => {
-        const snapshotType = getType(snapshot)
-        if (snapshotType.name === 'SingleChoiceAnnotation') return SingleChoiceAnnotation
-        if (snapshotType.name === 'MultipleChoiceAnnotation') return MultipleChoiceAnnotation
-        if (snapshotType.name === 'DataVisAnnotation') return DataVisAnnotation
-        return undefined
-      }
-    }, SingleChoiceAnnotation, MultipleChoiceAnnotation, DataVisAnnotation)),
+    annotations: types.map(types.union(
+        SingleChoiceAnnotation,
+        MultipleChoiceAnnotation,
+        DataVisAnnotation,
+        TextAnnotation
+      )),
     completed: types.optional(types.boolean, false),
     links: types.frozen({
       project: types.string,

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -13,6 +13,7 @@ import {
   convertMapToArray,
   sessionUtils
 } from './utils'
+import { TextAnnotation } from '@plugins/tasks/TextTask'
 
 const ClassificationStore = types
   .model('ClassificationStore', {

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -13,7 +13,6 @@ import {
   convertMapToArray,
   sessionUtils
 } from './utils'
-import { TextAnnotation } from '@plugins/tasks/TextTask'
 
 const ClassificationStore = types
   .model('ClassificationStore', {

--- a/packages/lib-classifier/src/store/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.js
@@ -3,18 +3,31 @@ import { addDisposer, getRoot, isValidReference, onAction, types } from 'mobx-st
 
 import Step from './Step'
 import { DrawingTask, DataVisAnnotationTask, MultipleChoiceTask, SingleChoiceTask } from './tasks'
+import { TextModel } from '@plugins/tasks/TextTask'
+
+function taskDispatcher (snapshot) {
+  if (snapshot.type === 'drawing') return DrawingTask
+  if (snapshot.type === 'multiple') return MultipleChoiceTask
+  if (snapshot.type === 'single') return SingleChoiceTask
+  if (snapshot.type === 'dataVisAnnotation') return DataVisAnnotationTask
+  if (snapshot.type === 'text') return TextModel
+  return undefined
+}
+
+const taskTypes = types.union(
+  { dispatcher: taskDispatcher },
+  DrawingTask,
+  DataVisAnnotationTask,
+  MultipleChoiceTask,
+  SingleChoiceTask,
+  TextModel
+)
 
 const WorkflowStepStore = types
   .model('WorkflowStepStore', {
     active: types.safeReference(Step),
     steps: types.map(Step),
-    tasks: types.map(types.union({ dispatcher: (snapshot) => {
-      if (snapshot.type === 'drawing') return DrawingTask
-      if (snapshot.type === 'multiple') return MultipleChoiceTask
-      if (snapshot.type === 'single') return SingleChoiceTask
-      if (snapshot.type === 'dataVisAnnotation') return DataVisAnnotationTask
-      return undefined
-    } }, DrawingTask, DataVisAnnotationTask, MultipleChoiceTask, SingleChoiceTask))
+    tasks: types.map(taskTypes)
   })
   .views(self => ({
     get activeStepTasks () {
@@ -22,7 +35,7 @@ const WorkflowStepStore = types
       if (validStepReference) {
         return self.active.taskKeys.map((taskKey) => {
           return self.tasks.get(taskKey)
-        })
+        }).filter(Boolean)
       }
 
       return []
@@ -166,8 +179,7 @@ const WorkflowStepStore = types
         const taskToStore = Object.assign({}, workflow.tasks[taskKey], { taskKey })
         try {
           self.tasks.put(taskToStore)
-        }
-        catch (e) {
+        } catch (e) {
           console.log(`${taskKey} ${taskToStore.type} is not a supported task type`)
         }
       })

--- a/packages/lib-classifier/webpack.dev.js
+++ b/packages/lib-classifier/webpack.dev.js
@@ -27,6 +27,12 @@ module.exports = {
     './dev/index.js'
   ],
   mode: 'development',
+  resolve: {
+    alias: {
+      '@plugins': path.resolve(__dirname, 'src/plugins'),
+      '@store': path.resolve(__dirname, 'src/store')
+    }
+  },
   module: {
     rules: [
       {

--- a/packages/lib-classifier/webpack.dist.js
+++ b/packages/lib-classifier/webpack.dist.js
@@ -22,6 +22,12 @@ module.exports = {
     'styled-components'
   ],
   mode: 'production',
+  resolve: {
+    alias: {
+      '@plugins': path.resolve(__dirname, 'src/plugins'),
+      '@store': path.resolve(__dirname, 'src/store')
+    }
+  },
   module: {
     rules: [
       {

--- a/packages/lib-grommet-theme/CHANGELOG.md
+++ b/packages/lib-grommet-theme/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unpublished] 2019-10-24
+
+### Changed
+- Lowered font weight for form input text.
+
 ## [2.2.0] 2019-09-23
 ### Added
 - Negative edge sizes

--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -186,7 +186,10 @@ const theme = deepFreeze({
           unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
         }
       `
-    }
+    },
+    input: {
+      weight: 'inherit'
+    },
   },
   anchor: {
     color: {


### PR DESCRIPTION
Adds the text task from #1212 without any of the changes to component loading. The new task code is manually added to each component or store that depends upon it.

I've kept the file structure from #1212 for convenience, but that can be changed.

EDIT: functionally, this works but it needs styling. 

Package:
lib-classifier

Closes #1141.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
