### PR TITLE
Ensure ProjectAnnouncement takes the width of its container

### DIFF
--- a/packages/app-project/src/components/ProjectAnnouncement/ProjectAnnouncement.js
+++ b/packages/app-project/src/components/ProjectAnnouncement/ProjectAnnouncement.js
@@ -20,7 +20,7 @@ const components = {
 function ProjectAnnouncement (props) {
   const { announcement } = props
   return (
-    <Box align='center' background='neutral-4' pad='small'>
+    <Box align='center' background='neutral-4' fill='horizontal' pad='small'>
       <Markdownz components={components}>
         {announcement}
       </Markdownz>

--- a/packages/app-project/src/components/ProjectAnnouncement/ProjectAnnouncement.spec.js
+++ b/packages/app-project/src/components/ProjectAnnouncement/ProjectAnnouncement.spec.js
@@ -1,4 +1,4 @@
-import { render } from 'enzyme'
+import { render, shallow } from 'enzyme'
 import React from 'react'
 
 import ProjectAnnouncement from './ProjectAnnouncement'
@@ -19,5 +19,10 @@ describe('Component > ProjectAnnouncement', function () {
   it('should render a paragraph with the announcement text', function () {
     const paragraphWrapper = wrapper.find('p')
     expect(paragraphWrapper.text()).to.equal(ANNOUNCEMENT)
+  })
+
+  it('should be the full width of its container', function () {
+    const shallowWrapper = shallow(<ProjectAnnouncement announcement={ANNOUNCEMENT} />)
+    expect(shallowWrapper.prop('fill')).to.equal('horizontal')
   })
 })


### PR DESCRIPTION
Closes #1197.

I've just tested this on https://frontend.preview.zooniverse.org/projects/srallen086/srallen-testing?env=staging, and it looks okay now (possibly because the component was moved in #1233). Just in case, I've added the `fill` prop to the banner `Box`.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
