### PR TITLE
Preload images for the single image viewer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -9,29 +9,20 @@ const SVG = styled.svg`
   width: 100%;
 `
 
-const SingleImageViewer = React.forwardRef(function SingleImageViewer ({ onError, onLoad, url }, ref) {
+const SingleImageViewer = React.forwardRef(function SingleImageViewer ({ url }, ref) {
   return (
     <SVG ref={ref}>
       <image
         height='100%'
         width='100%'
         xlinkHref={url}
-        onError={onError}
-        onLoad={onLoad}
       />
       <InteractionLayer />
     </SVG>
   )
 })
 
-SingleImageViewer.defaultProps = {
-  onError: () => true,
-  onLoad: () => true
-}
-
 SingleImageViewer.propTypes = {
-  onError: PropTypes.func,
-  onLoad: PropTypes.func,
   url: PropTypes.string.isRequired
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -9,9 +9,13 @@ const SVG = styled.svg`
   width: 100%;
 `
 
-const SingleImageViewer = React.forwardRef(function SingleImageViewer ({ url }, ref) {
+const SingleImageViewer = React.forwardRef(function SingleImageViewer ({ height, url, width }, ref) {
+  const viewBox = `0 0 ${width} ${height}`
   return (
-    <SVG ref={ref}>
+    <SVG
+      ref={ref}
+      viewBox={viewBox}
+    >
       <image
         height='100%'
         width='100%'
@@ -23,7 +27,9 @@ const SingleImageViewer = React.forwardRef(function SingleImageViewer ({ url }, 
 })
 
 SingleImageViewer.propTypes = {
-  url: PropTypes.string.isRequired
+  height: PropTypes.number.isRequired,
+  url: PropTypes.string.isRequired,
+  width: PropTypes.number.isRequired
 }
 
 export default SingleImageViewer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.stories.js
@@ -1,8 +1,11 @@
+import asyncStates from '@zooniverse/async-states'
 import React from 'react'
+import sinon from 'sinon'
 import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Grommet } from 'grommet'
-import SingleImageViewer from './SingleImageViewer'
+import { Provider } from 'mobx-react'
+import SingleImageViewer from './'
 // import readme from './README.md'
 import backgrounds from '../../../../../../../.storybook/lib/backgrounds'
 
@@ -13,30 +16,55 @@ const config = {
   }
 }
 
+const subject = {
+  locations: [
+    { 'image/jpeg': 'http://placekitten.com/500/300' }
+  ]
+}
+
+const mockStore = {
+  drawing: {
+    addToStream: sinon.stub()
+  },
+  workflowSteps: {
+    activeStepTasks: []
+  }
+}
+
+function ViewerContext (props) {
+  const { children, theme } = props
+  return (
+    <Provider classifierStore={mockStore}>
+      <Grommet theme={theme}>
+        {children}
+      </Grommet>
+    </Provider>
+  )
+}
+
 const darkThemeConfig = Object.assign({}, config, { backgrounds: backgrounds.darkDefault })
 
-// TODO: add store connection for drawing because of the interaction layer
-// storiesOf('SingleImageViewer', module)
-//   .add('light theme', () => {
-//     return (
-//       <Grommet theme={zooTheme}>
-//         <Box height='medium' width='large'>
-//           <SingleImageViewer
-//             url='http://placekitten.com/500/300'
-//           />
-//         </Box>
-//       </Grommet>
-//     )
-//   }, config)
-//   .add('dark theme', () => {
-//     const darkZooTheme = Object.assign({}, zooTheme, { dark: true })
-//     return (
-//       <Grommet theme={darkZooTheme}>
-//         <Box height='medium' width='large'>
-//           <SingleImageViewer
-//             url='http://placekitten.com/500/300'
-//           />
-//         </Box>
-//       </Grommet>
-//     )
-//   }, darkThemeConfig)
+storiesOf('SingleImageViewer', module)
+  .add('light theme', () => {
+    return (
+      <ViewerContext theme={zooTheme}>
+        <Box height='medium' width='large'>
+          <SingleImageViewer
+            subject={subject}
+          />
+        </Box>
+      </ViewerContext>
+    )
+  }, config)
+  .add('dark theme', () => {
+    const darkZooTheme = Object.assign({}, zooTheme, { dark: true })
+    return (
+      <ViewerContext theme={darkZooTheme}>
+        <Box height='medium' width='large'>
+          <SingleImageViewer
+            subject={subject}
+          />
+        </Box>
+      </ViewerContext>
+    )
+  }, darkThemeConfig)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -9,7 +9,13 @@ class SingleImageViewerContainer extends React.Component {
   constructor () {
     super()
     this.imageViewer = React.createRef()
-    this.onLoad = this.onLoad.bind(this)
+    this.state = {
+      img: {}
+    }
+  }
+
+  componentDidMount () {
+    this.onLoad()
   }
 
   fetchImage (url) {
@@ -19,15 +25,25 @@ class SingleImageViewerContainer extends React.Component {
       img.onload = () => resolve(img)
       img.onerror = reject
       img.src = url
+      return img
     })
   }
 
-  async getImageSize () {
+  async preload () {
     const { subject } = this.props
-    // TODO: Add polyfill for Object.values for IE
-    const imageUrl = Object.values(subject.locations[0])[0]
-    const img = await this.fetchImage(imageUrl)
-    const svg = this.imageViewer.current
+    if (subject && subject.locations) {
+      // TODO: Add polyfill for Object.values for IE
+      const imageUrl = Object.values(subject.locations[0])[0]
+      const img = await this.fetchImage(imageUrl)
+      this.setState({ img })
+      return img
+    }
+    return {}
+  }
+
+  async getImageSize () {
+    const img = await this.preload()
+    const svg = this.imageViewer.current || {}
     return {
       clientHeight: svg.clientHeight,
       clientWidth: svg.clientWidth,
@@ -43,30 +59,30 @@ class SingleImageViewerContainer extends React.Component {
       const target = { clientHeight, clientWidth, naturalHeight, naturalWidth }
       onReady({ target })
     } catch (error) {
+      console.error(error)
       onError(error)
     }
   }
 
   render () {
     const { loadingState, onError, subject } = this.props
+    const { img } = this.state
+    const url = img && img.src
+
     if (loadingState === asyncStates.error) {
       return (
         <div>Something went wrong.</div>
       )
     }
 
-    if (!subject) {
+    if (!url) {
       return null
     }
-
-    // TODO: Add polyfill for Object.values for IE
-    const imageUrl = Object.values(subject.locations[0])[0]
+    
     return (
       <SingleImageViewer
         ref={this.imageViewer}
-        onError={onError}
-        onLoad={this.onLoad}
-        url={imageUrl}
+        url={url}
       />
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -67,7 +67,7 @@ class SingleImageViewerContainer extends React.Component {
   render () {
     const { loadingState, onError, subject } = this.props
     const { img } = this.state
-    const url = img && img.src
+    const { naturalHeight, naturalWidth, src} = img
 
     if (loadingState === asyncStates.error) {
       return (
@@ -75,14 +75,16 @@ class SingleImageViewerContainer extends React.Component {
       )
     }
 
-    if (!url) {
+    if (!src) {
       return null
     }
     
     return (
       <SingleImageViewer
         ref={this.imageViewer}
-        url={url}
+        height={naturalHeight}
+        width={naturalWidth}
+        url={src}
       />
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -107,6 +107,30 @@ describe('Component > SingleImageViewerContainer', function () {
         done()
       })
     })
+
+    it('should pass the original image dimensions to the SVG image', function (done) {
+      const svg = wrapper.instance().imageViewer.current
+      const fakeEvent = {
+        target: {
+          clientHeight: 0,
+          clientWidth: 0
+        }
+      }
+      const expectedEvent = {
+        target: {
+          clientHeight: svg.clientHeight,
+          clientWidth: svg.clientWidth,
+          naturalHeight: height,
+          naturalWidth: width
+        }
+      }
+      onReady.callsFake(function () {
+        const { height, width } = wrapper.find(SingleImageViewer).props()
+        expect(height).to.equal(height)
+        expect(width).to.equal(width)
+        done()
+      })
+    })
   })
 
   describe('with an invalid subject', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -32,14 +32,6 @@ describe('Component > SingleImageViewerContainer', function () {
     }
   }
 
-  before(function () {
-    sinon.stub(console, 'error')
-  })
-
-  after(function () {
-    console.error.restore()
-  })
-
   describe('without a subject', function () {
     const onError = sinon.stub()
 
@@ -61,7 +53,7 @@ describe('Component > SingleImageViewerContainer', function () {
     const onReady = sinon.stub()
     const onError = sinon.stub()
 
-    before(function () {
+    beforeEach(function () {
       const subject = {
         id: 'test',
         locations: [
@@ -114,7 +106,6 @@ describe('Component > SingleImageViewerContainer', function () {
         expect(onError).to.not.have.been.called()
         done()
       })
-      imageWrapper.simulate('load', fakeEvent)
     })
   })
 
@@ -124,6 +115,10 @@ describe('Component > SingleImageViewerContainer', function () {
     const onError = sinon.stub()
 
     before(function () {
+      sinon.stub(console, 'error')
+    })
+
+    beforeEach(function () {
       const subject = {
         id: 'test',
         locations: [
@@ -147,27 +142,20 @@ describe('Component > SingleImageViewerContainer', function () {
       }
     })
 
-    after(function () {
+    afterEach(function () {
       onError.resetHistory()
       onReady.resetHistory()
+    })
+
+    after(function () {
+      console.error.restore()
     })
 
     it('should render without crashing', function () {
       expect(wrapper).to.be.ok()
     })
 
-    it('should log an error from an invalid SVG image', function (done) {
-      const fakeSVGError = {
-        message: 'the SVG image failed to load'
-      }
-      onError.callsFake(function () {
-        expect(onError.withArgs(fakeSVGError)).to.have.been.calledOnce()
-        done()
-      })
-      imageWrapper.simulate('error', fakeSVGError)
-    })
-
-    it('should log an error from an invalid HTML img', function (done) {
+    it('should log an error from an invalid image', function (done) {
       const fakeEvent = {
         target: {
           clientHeight: 0,
@@ -178,18 +166,13 @@ describe('Component > SingleImageViewerContainer', function () {
         expect(onError.withArgs(HTMLImgError)).to.have.been.calledOnce()
         done()
       })
-      imageWrapper.simulate('load', fakeEvent)
     })
 
     it('should not call onReady', function (done) {
-      const fakeSVGError = {
-        message: 'the SVG image failed to load'
-      }
       onError.callsFake(function () {
         expect(onReady).to.not.have.been.called()
         done()
       })
-      imageWrapper.simulate('error', fakeSVGError)
     })
   })
 })


### PR DESCRIPTION
Preload subject images with a HTML `<img>` element. Set subject dimensions and render the SVG image once the HTML image has loaded.
Add stories for the image viewer.

Package:
lib-classifier

For #1094.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [x] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
