### PR TITLE
Add focus and labels to the bars

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/BarChartViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/BarChartViewer.js
@@ -45,7 +45,11 @@ const BarChartViewer = React.forwardRef(function BarChartViewer (props, ref) {
   return (
     <Chart height={parentHeight} ref={ref} width={parentWidth}>
       <Background fill={backgroundColor} />
-      <Group left={xAxisMargin}>
+      <Group
+        focusable
+        left={xAxisMargin}
+        tabIndex={0}
+      >
         {data.map((datum, index) => {
           const { color, label, value } = datum
           const fill = color || colors.brand
@@ -54,12 +58,17 @@ const BarChartViewer = React.forwardRef(function BarChartViewer (props, ref) {
           const barWidth = xScale.bandwidth()
           const x = xScale(label)
           const y = yMax - barHeight
+          const alt = `${xAxisLabel} ${label}: ${yAxisLabel} ${value}`
           return (
             <Bar
+              aria-label={alt}
+              data-label={label}
+              data-value={value}
               fill={fill}
               height={barHeight}
               index={index}
               key={key}
+              role='img'
               width={barWidth}
               x={x}
               y={y}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/BarChartViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/BarChartViewer.spec.js
@@ -150,6 +150,10 @@ describe('Component > BarChartViewer', function () {
       expect(wrapper.find(Bar)).to.have.lengthOf(data.length)
     })
 
+    it('should have a focusable Group container', function () {
+      expect(wrapper.find(Group).first().props().focusable).be.true()
+    })
+
     it('should default to use the theme brand color for the fill', function () {
       const bars = wrapper.find(Bar)
       const { theme } = wrapper.props()
@@ -185,6 +189,14 @@ describe('Component > BarChartViewer', function () {
       const bars = wrapper.find(Bar)
       bars.forEach((bar) => {
         expect(bar.props().fill).to.equal(zooTheme.global.colors['accent-3'])
+      })
+    })
+
+    it('should have an aria-label', function () {
+      const bars = wrapper.find(Bar)
+      bars.forEach((bar) => {
+        const barProps = bar.props()
+        expect(barProps['aria-label']).to.equal(`${xAxisLabel} ${barProps['data-label']}: ${yAxisLabel} ${barProps['data-value']}`)
       })
     })
   })


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

For #1144

Describe your changes:
This adds focus, aria labels and role so the bars are read allowed with context. 

@eatyourgreens this blog post suggests using list and list item roles for bars: https://www.a11ywithlindsey.com/blog/accessibility-d3-bar-charts

I went with how you did it for the stats chart. Do you know if there are any pros vs cons in the different approaches?

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
