### PR TITLE
Alias test/ to @test in dev

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/AlreadySeenBanner/AlreadySeenBannerContainer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/AlreadySeenBanner/AlreadySeenBannerContainer.stories.js
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import { AlreadySeenBannerContainer } from './AlreadySeenBannerContainer'
 import readme from '../../README.md'
 import backgrounds from '../../../../../../../.storybook/lib/backgrounds'
-import { SubjectFactory } from '../../../../../../../test/factories'
+import { SubjectFactory } from '@test/factories'
 
 const config = {
   notes: {

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/RetiredBanner/RetiredBannerContainer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/RetiredBanner/RetiredBannerContainer.stories.js
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import { RetiredBannerContainer } from './RetiredBannerContainer'
 import readme from '../../README.md'
 import backgrounds from '../../../../../../../.storybook/lib/backgrounds'
-import { SubjectFactory } from '../../../../../../../test/factories'
+import { SubjectFactory } from '@test/factories'
 
 const config = {
   notes: {

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/UserHasFinishedWorkflowBanner/UserHasFinishedWorkflowBannerContainer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/UserHasFinishedWorkflowBanner/UserHasFinishedWorkflowBannerContainer.stories.js
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import { UserHasFinishedWorkflowBannerContainer } from './UserHasFinishedWorkflowBannerContainer'
 import readme from '../../README.md'
 import backgrounds from '../../../../../../../.storybook/lib/backgrounds'
-import { SubjectFactory } from '../../../../../../../test/factories'
+import { SubjectFactory } from '@test/factories'
 
 const config = {
   notes: {

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/WorkflowIsFinishedBanner/WorkflowIsFinishedBannerContainer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/WorkflowIsFinishedBanner/WorkflowIsFinishedBannerContainer.stories.js
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import { WorkflowIsFinishedBannerContainer } from './WorkflowIsFinishedBannerContainer'
 import readme from '../../README.md'
 import backgrounds from '../../../../../../../.storybook/lib/backgrounds'
-import { SubjectFactory } from '../../../../../../../test/factories'
+import { SubjectFactory } from '@test/factories'
 
 const config = {
   notes: {

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/FieldGuide.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/FieldGuide.spec.js
@@ -3,7 +3,7 @@ import React from 'react'
 import FieldGuide from './FieldGuide'
 import FieldGuideItem from './components/FieldGuideItem'
 import FieldGuideItems from './components/FieldGuideItems'
-import { FieldGuideMediumFactory } from '../../../../../../../test/factories'
+import { FieldGuideMediumFactory } from '@test/factories'
 
 const medium = FieldGuideMediumFactory.build()
 const items = [

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.spec.js
@@ -7,7 +7,7 @@ import sinon from 'sinon'
 
 import { FieldGuideItem } from './FieldGuideItem'
 import FieldGuideItemIcon from '../FieldGuideItemIcon'
-import { FieldGuideMediumFactory } from '../../../../../../../../../test/factories'
+import { FieldGuideMediumFactory } from '@test/factories'
 
 const medium = FieldGuideMediumFactory.build()
 const attachedMedia = observable.map().set(medium.id, medium)

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItemIcon/FieldGuideItemIcon.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItemIcon/FieldGuideItemIcon.spec.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { observable } from 'mobx'
 import { Media } from '@zooniverse/react-components'
 import FieldGuideItemIcon from './FieldGuideItemIcon'
-import { FieldGuideMediumFactory } from '../../../../../../../../../test/factories'
+import { FieldGuideMediumFactory } from '@test/factories'
 
 const medium = FieldGuideMediumFactory.build()
 const attachedMedia = observable.map()

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItems/FieldGuideItemAnchor.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItems/FieldGuideItemAnchor.spec.js
@@ -5,7 +5,7 @@ import { observable } from 'mobx'
 import { Markdownz } from '@zooniverse/react-components'
 import FieldGuideItemAnchor, { AnchorLabel } from './FieldGuideItemAnchor'
 import FieldGuideItemIcon from '../FieldGuideItemIcon'
-import { FieldGuideMediumFactory } from '../../../../../../../../../test/factories'
+import { FieldGuideMediumFactory } from '@test/factories'
 
 const medium = FieldGuideMediumFactory.build()
 const attachedMedia = observable.map()

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItems/FieldGuideItems.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItems/FieldGuideItems.spec.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { Grid } from 'grommet'
 import FieldGuideItems from './FieldGuideItems'
 import FieldGuideItemAnchor from './FieldGuideItemAnchor'
-import { FieldGuideMediumFactory } from '../../../../../../../../../test/factories'
+import { FieldGuideMediumFactory } from '@test/factories'
 
 const medium = FieldGuideMediumFactory.build()
 const items = [

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuideButton/FieldGuideButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuideButton/FieldGuideButton.spec.js
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme'
 import sinon from 'sinon'
 import React from 'react'
 import FieldGuideButton, { ButtonLabel } from './FieldGuideButton'
-import { FieldGuideFactory, FieldGuideMediumFactory } from '../../../../../../../test/factories'
+import { FieldGuideFactory, FieldGuideMediumFactory } from '@test/factories'
 
 const medium = FieldGuideMediumFactory.build()
 const items = [

--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.spec.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import ModalTutorial from './ModalTutorial'
 import { Modal } from '@zooniverse/react-components'
 import asyncStates from '@zooniverse/async-states'
-import { TutorialFactory } from '../../../../../test/factories'
+import { TutorialFactory } from '@test/factories'
 
 const tutorial = TutorialFactory.build()
 

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
@@ -5,7 +5,7 @@ import { Box, Grommet } from 'grommet'
 import SlideTutorial from './SlideTutorial'
 // import readme from './README.md'
 import backgrounds from '../../../../../.storybook/lib/backgrounds'
-import { TutorialMediumFactory } from '../../../../../test/factories'
+import { TutorialMediumFactory } from '@test/factories'
 
 // TODO: add readme
 const config = {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.spec.js
@@ -7,7 +7,7 @@ import sinon from 'sinon'
 import { TaskArea } from './TaskArea'
 import Tasks from './components/Tasks'
 import SlideTutorial from '../SlideTutorial'
-import { TutorialFactory } from '../../../../../test/factories'
+import { TutorialFactory } from '@test/factories'
 
 const tutorial = TutorialFactory.build()
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.spec.js
@@ -8,7 +8,7 @@ import ClassificationStore from '../../../../../../../../store/ClassificationSto
 import SingleChoiceTask from '../../../../../../../../store/tasks/SingleChoiceTask'
 import MultipleChoiceTask from '../../../../../../../../store/tasks/MultipleChoiceTask'
 import Step from '../../../../../../../../store/Step'
-import { SubjectFactory, WorkflowFactory, ProjectFactory } from '../../../../../../../../../test/factories'
+import { SubjectFactory, WorkflowFactory, ProjectFactory } from '@test/factories'
 
 const steps = observable.map([
   Step.create({ stepKey: 'S0', taskKeys: ['T0'] }),

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.spec.js
@@ -4,7 +4,7 @@ import React from 'react'
 import sinon from 'sinon'
 
 import { DoneAndTalkButton } from './DoneAndTalkButton'
-import { ProjectFactory, SubjectFactory } from '../../../../../../../../../../../test/factories'
+import { ProjectFactory, SubjectFactory } from '@test/factories'
 
 const project = ProjectFactory.build()
 const subject = SubjectFactory.build()

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButtonContainer.spec.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { expect } from 'chai'
 import sinon from 'sinon'
-import { SubjectFactory } from '../../../../../../../../../../../test/factories'
+import { SubjectFactory } from '@test/factories'
 import DoneAndTalkButtonContainer from './DoneAndTalkButtonContainer'
 import DoneAndTalkButton from './DoneAndTalkButton'
 

--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -9,8 +9,8 @@ import {
   SingleChoiceAnnotationFactory,
   SingleChoiceTaskFactory,
   WorkflowFactory
-} from '../../test/factories'
-import stubPanoptesJs from '../../test/stubPanoptesJs'
+} from '@test/factories'
+import stubPanoptesJs from '@test/stubPanoptesJs'
 import helpers from './feedback/helpers'
 import { SingleChoiceAnnotation } from './annotations'
 

--- a/packages/lib-classifier/src/store/FeedbackStore.spec.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.spec.js
@@ -9,7 +9,7 @@ import {
   FeedbackFactory,
   ProjectFactory,
   WorkflowFactory
-} from '../../test/factories'
+} from '@test/factories'
 import { Factory } from 'rosie'
 
 const rulesStub = {

--- a/packages/lib-classifier/src/store/FieldGuideStore.spec.js
+++ b/packages/lib-classifier/src/store/FieldGuideStore.spec.js
@@ -9,7 +9,7 @@ import {
   ProjectFactory,
   FieldGuideFactory,
   FieldGuideMediumFactory
-} from '../../test/factories'
+} from '@test/factories'
 
 const medium = FieldGuideMediumFactory.build()
 const fieldGuide = FieldGuideFactory.build()

--- a/packages/lib-classifier/src/store/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject.spec.js
@@ -2,7 +2,7 @@ import sinon from 'sinon'
 import Subject from './Subject'
 import ProjectStore from './ProjectStore'
 import WorkflowStore from './WorkflowStore'
-import { ProjectFactory, SubjectFactory, WorkflowFactory } from '../../test/factories'
+import { ProjectFactory, SubjectFactory, WorkflowFactory } from '@test/factories'
 import subjectViewers from '../helpers/subjectViewers'
 
 const stub = SubjectFactory.build()

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -1,9 +1,9 @@
 import sinon from 'sinon'
 import RootStore from './RootStore'
 import { openTalkPage, MINIMUM_QUEUE_SIZE } from './SubjectStore'
-import { ProjectFactory, SubjectFactory, WorkflowFactory } from '../../test/factories'
+import { ProjectFactory, SubjectFactory, WorkflowFactory } from '@test/factories'
 import { Factory } from 'rosie'
-import stubPanoptesJs from '../../test/stubPanoptesJs'
+import stubPanoptesJs from '@test/stubPanoptesJs'
 
 describe('Model > SubjectStore', function () {
   const longListSubjects = Factory.buildList('subject', 10)

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -10,8 +10,8 @@ import {
   WorkflowFactory,
   UPPFactory,
   UserFactory
-} from '../../test/factories'
-import stubPanoptesJs from '../../test/stubPanoptesJs'
+} from '@test/factories'
+import stubPanoptesJs from '@test/stubPanoptesJs'
 
 const seenMock = new Date().toISOString()
 const token = '1235'

--- a/packages/lib-classifier/src/store/UserProjectPreferencesStore.spec.js
+++ b/packages/lib-classifier/src/store/UserProjectPreferencesStore.spec.js
@@ -9,8 +9,8 @@ import {
   TutorialFactory,
   UPPFactory,
   UserFactory
-} from '../../test/factories'
-import stubPanoptesJs from '../../test/stubPanoptesJs'
+} from '@test/factories'
+import stubPanoptesJs from '@test/stubPanoptesJs'
 
 const project = ProjectFactory.build()
 const upp = UPPFactory.build()

--- a/packages/lib-classifier/src/store/WorkflowStepStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.spec.js
@@ -6,9 +6,9 @@ import {
   ProjectFactory,
   SingleChoiceTaskFactory,
   WorkflowFactory
-} from '../../test/factories'
+} from '@test/factories'
 import { Factory } from 'rosie'
-import stubPanoptesJs from '../../test/stubPanoptesJs'
+import stubPanoptesJs from '@test/stubPanoptesJs'
 
 function setupStores (clientStub, project, workflow) {
   const store = RootStore.create({

--- a/packages/lib-classifier/src/store/WorkflowStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStore.spec.js
@@ -4,8 +4,8 @@ import {
   SingleChoiceTaskFactory,
   ProjectFactory,
   WorkflowFactory
-} from '../../test/factories'
-import stubPanoptesJs from '../../test/stubPanoptesJs'
+} from '@test/factories'
+import stubPanoptesJs from '@test/stubPanoptesJs'
 
 const workflow = WorkflowFactory.build({
   tasks: { T1: SingleChoiceTaskFactory.build() },

--- a/packages/lib-classifier/webpack.dev.js
+++ b/packages/lib-classifier/webpack.dev.js
@@ -30,7 +30,8 @@ module.exports = {
   resolve: {
     alias: {
       '@plugins': path.resolve(__dirname, 'src/plugins'),
-      '@store': path.resolve(__dirname, 'src/store')
+      '@store': path.resolve(__dirname, 'src/store'),
+      '@test': path.resolve(__dirname, 'test')
     }
   },
   module: {


### PR DESCRIPTION
Alias the classifier test utils directory to `@test` for more convenient module resolution.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
