### PR TITLE
Only allow hero images to fill available space

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Background/Background.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Background/Background.js
@@ -9,7 +9,7 @@ const Img = styled.img`
     width: 100%;
 
   @media (min-width: ${props => props.breakpoint}px) {
-    height: 100%;
+    flex: 1 1 auto;
     object-position: 0 50%;
   }
 `


### PR DESCRIPTION
Hero images can currently expand beyond the available space in the Hero widget if they're taller than the height of the workflows box; this forces them to only flex to the available height.