### PR TITLE
Replace "Classify" with "Get started" as the call to action

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.js
@@ -19,7 +19,7 @@ function WorkflowSelector (props) {
   return (
     <Box>
       <SpacedText weight='bold' margin={{ bottom: 'xsmall' }}>
-        {counterpart('WorkflowSelector.classify')}
+        {counterpart('WorkflowSelector.getStarted')}
       </SpacedText>
       <Text>
         {counterpart('WorkflowSelector.message')}

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/locales/en.json
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/locales/en.json
@@ -1,6 +1,6 @@
 {
   "WorkflowSelector": {
-    "classify": "Classify",
+    "getStarted": "Get Started!",
     "error": "There was an error fetching the workflows :(",
     "message": "Anyone can do real research!",
     "noWorkflows": "Nothing to classify"

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/locales/en.json
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/locales/en.json
@@ -2,7 +2,7 @@
   "WorkflowSelector": {
     "getStarted": "Get Started!",
     "error": "There was an error fetching the workflows :(",
-    "message": "Anyone can do real research!",
+    "message": "You can do real research by clicking to get started here!",
     "noWorkflows": "Nothing to classify"
   }
 }


### PR DESCRIPTION
Following on from our Slack conversation, this changes the call to action to "Get Started!"

<img width="1324" alt="Screenshot 2019-11-04 16 03 40" src="https://user-images.githubusercontent.com/2725841/68136133-aee63380-ff1c-11e9-9e40-6c7017fbc4d0.png">

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
