### PR TITLE
Use the project's workflow description

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.js
@@ -17,8 +17,9 @@ const markdownzComponents = {
 }
 
 function WorkflowSelector (props) {
-  const { workflowDescription, workflows } = props
+  const { workflows } = props
   const loaderColor = props.theme.global.colors.brand
+  const workflowDescription = props.workflowDescription || counterpart('WorkflowSelector.message')
 
   return (
     <Box>
@@ -86,10 +87,6 @@ WorkflowSelector.propTypes = {
       id: string.isRequired
     }).isRequired).isRequired
   }).isRequired
-}
-
-WorkflowSelector.defaultProps = {
-  workflowDescription: counterpart('WorkflowSelector.message')
 }
 
 export default withTheme(WorkflowSelector)

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.js
@@ -1,7 +1,7 @@
 import asyncStates from '@zooniverse/async-states'
-import { SpacedText } from '@zooniverse/react-components'
+import { Markdownz, SpacedText } from '@zooniverse/react-components'
 import counterpart from 'counterpart'
-import { Box, Text } from 'grommet'
+import { Box, Paragraph, Text } from 'grommet'
 import { arrayOf, shape, string } from 'prop-types'
 import React from 'react'
 import { withTheme } from 'styled-components'
@@ -12,8 +12,12 @@ import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
 
+const markdownzComponents = {
+  p: nodeProps => <Paragraph {...nodeProps} margin='none' />
+}
+
 function WorkflowSelector (props) {
-  const { workflows } = props
+  const { workflowDescription, workflows } = props
   const loaderColor = props.theme.global.colors.brand
 
   return (
@@ -21,9 +25,9 @@ function WorkflowSelector (props) {
       <SpacedText weight='bold' margin={{ bottom: 'xsmall' }}>
         {counterpart('WorkflowSelector.getStarted')}
       </SpacedText>
-      <Text>
-        {counterpart('WorkflowSelector.message')}
-      </Text>
+      <Markdownz components={markdownzComponents}>
+        {workflowDescription}
+      </Markdownz>
 
       {(workflows.loading === asyncStates.error) && (
         <Box
@@ -76,11 +80,16 @@ function WorkflowSelector (props) {
 }
 
 WorkflowSelector.propTypes = {
+  workflowDescription: string,
   workflows: shape({
     data: arrayOf(shape({
       id: string.isRequired
     }).isRequired).isRequired
   }).isRequired
+}
+
+WorkflowSelector.defaultProps = {
+  workflowDescription: counterpart('WorkflowSelector.message')
 }
 
 export default withTheme(WorkflowSelector)

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.spec.js
@@ -18,7 +18,7 @@ const WORKFLOWS = {
 
 const WORKFLOW_DESCRIPTION = 'Sit nulla mi metus tellus aenean lobortis litora'
 
-describe.only('Component > Hero > WorkflowSelector > WorkflowSelector', function () {
+describe('Component > Hero > WorkflowSelector > WorkflowSelector', function () {
 
   it('should render without crashing', function () {
     const wrapper = shallow(

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.spec.js
@@ -1,16 +1,55 @@
-import { shallow } from 'enzyme'
+import { shallow, render } from 'enzyme'
 import React from 'react'
 
 import WorkflowSelector from './WorkflowSelector'
 
-let wrapper
+const THEME = {
+  global: {
+    colors: {
+      brand: '#000'
+    }
+  }
+}
 
-describe('Component > Hero > WorkflowSelector > WorkflowSelector', function () {
-  before(function () {
-    wrapper = shallow(<WorkflowSelector />)
-  })
+const WORKFLOWS = {
+  data: [],
+  loading: false
+}
+
+const WORKFLOW_DESCRIPTION = 'Sit nulla mi metus tellus aenean lobortis litora'
+
+describe.only('Component > Hero > WorkflowSelector > WorkflowSelector', function () {
 
   it('should render without crashing', function () {
+    const wrapper = shallow(
+      <WorkflowSelector
+        theme={THEME}
+        workflows={WORKFLOWS}
+        workflowDescription={WORKFLOW_DESCRIPTION}
+      />)
     expect(wrapper).to.be.ok()
   })
+
+  describe('workflow description', function () {
+    it('should use the `workflowDescription` prop if available', function () {
+      const wrapper = render(
+        <WorkflowSelector
+          theme={THEME}
+          workflows={WORKFLOWS}
+          workflowDescription={WORKFLOW_DESCRIPTION}
+        />)
+      expect(wrapper.text()).to.include(WORKFLOW_DESCRIPTION)
+    })
+
+    it('should use the default message if the `workflowDescription` prop is unset', function () {
+      const wrapper = render(
+        <WorkflowSelector
+          theme={THEME}
+          workflows={WORKFLOWS}
+        />)
+      const DEFAULT_WORKFLOW_DESCRIPTION = 'You can do real research by clicking to get started here!'
+      expect(wrapper.text()).to.include(DEFAULT_WORKFLOW_DESCRIPTION)
+    })
+  })
+
 })

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.spec.js
@@ -17,6 +17,7 @@ const WORKFLOWS = {
 }
 
 const WORKFLOW_DESCRIPTION = 'Sit nulla mi metus tellus aenean lobortis litora'
+const DEFAULT_WORKFLOW_DESCRIPTION = 'You can do real research by clicking to get started here!'
 
 describe('Component > Hero > WorkflowSelector > WorkflowSelector', function () {
 
@@ -47,7 +48,16 @@ describe('Component > Hero > WorkflowSelector > WorkflowSelector', function () {
           theme={THEME}
           workflows={WORKFLOWS}
         />)
-      const DEFAULT_WORKFLOW_DESCRIPTION = 'You can do real research by clicking to get started here!'
+      expect(wrapper.text()).to.include(DEFAULT_WORKFLOW_DESCRIPTION)
+    })
+
+    it('should use the default message if the `workflowDescription` prop is an empty string', function () {
+      const wrapper = render(
+        <WorkflowSelector
+          theme={THEME}
+          workflows={WORKFLOWS}
+          workflowDescription=''
+        />)
       expect(wrapper.text()).to.include(DEFAULT_WORKFLOW_DESCRIPTION)
     })
   })

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.spec.js
@@ -5,7 +5,7 @@ import WorkflowSelector from './WorkflowSelector'
 
 let wrapper
 
-describe('Component > Hero > WorkflowSelector', function () {
+describe('Component > Hero > WorkflowSelector > WorkflowSelector', function () {
   before(function () {
     wrapper = shallow(<WorkflowSelector />)
   })

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelectorContainer.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelectorContainer.js
@@ -1,0 +1,32 @@
+import { inject, observer } from 'mobx-react'
+import { string } from 'prop-types'
+import React, { Component } from 'react'
+
+import WorkflowSelector from './WorkflowSelector'
+
+function storeMapper (stores) {
+  return {
+    workflowDescription: stores.store.project.workflow_description || undefined
+  }
+}
+
+class WorkflowSelectorContainer extends Component {
+  render () {
+    return (
+      <WorkflowSelector {...this.props} />
+    )
+  }
+}
+
+WorkflowSelectorContainer.propTypes = {
+  workflowDescription: string
+}
+
+@inject(storeMapper)
+@observer
+class DecoratedWorkflowSelectorContainer extends WorkflowSelectorContainer { }
+
+export {
+  DecoratedWorkflowSelectorContainer as default,
+  WorkflowSelectorContainer
+}

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelectorContainer.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelectorContainer.js
@@ -6,7 +6,7 @@ import WorkflowSelector from './WorkflowSelector'
 
 function storeMapper (stores) {
   return {
-    workflowDescription: stores.store.project.workflow_description || undefined
+    workflowDescription: stores.store.project.workflow_description
   }
 }
 

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelectorContainer.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelectorContainer.spec.js
@@ -4,8 +4,6 @@ import React from 'react'
 import { WorkflowSelectorContainer } from './WorkflowSelectorContainer'
 import WorkflowSelector from './WorkflowSelector'
 
-const WORKFLOW_DESCRIPTION = 'Sit nulla mi metus tellus aenean lobortis litora'
-
 describe('Component > Hero > WorkflowSelector > WorkflowSelectorContainer', function () {
   let wrapper
   let componentWrapper

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelectorContainer.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelectorContainer.spec.js
@@ -1,0 +1,29 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import { WorkflowSelectorContainer } from './WorkflowSelectorContainer'
+import WorkflowSelector from './WorkflowSelector'
+
+const WORKFLOW_DESCRIPTION = 'Sit nulla mi metus tellus aenean lobortis litora'
+
+describe('Component > Hero > WorkflowSelector > WorkflowSelectorContainer', function () {
+  let wrapper
+  let componentWrapper
+
+  before(function () {
+    wrapper = shallow(<WorkflowSelectorContainer workflowDescription={WORKFLOW_DESCRIPTION} />)
+    componentWrapper = wrapper.find(WorkflowSelector)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render the `WorkflowSelector` component', function () {
+    expect(componentWrapper).to.have.lengthOf(1)
+  })
+
+  it('should pass down the `workflowDescription` prop', function () {
+    expect(componentWrapper.prop('workflowDescription')).to.equal(WORKFLOW_DESCRIPTION)
+  })
+})

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelectorContainer.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelectorContainer.spec.js
@@ -4,6 +4,8 @@ import React from 'react'
 import { WorkflowSelectorContainer } from './WorkflowSelectorContainer'
 import WorkflowSelector from './WorkflowSelector'
 
+const WORKFLOW_DESCRIPTION = 'Sit nulla mi metus tellus aenean lobortis litora'
+
 describe('Component > Hero > WorkflowSelector > WorkflowSelectorContainer', function () {
   let wrapper
   let componentWrapper

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/index.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/index.js
@@ -1,1 +1,1 @@
-export { default } from './WorkflowSelector'
+export { default } from './WorkflowSelectorContainer'

--- a/packages/app-project/stores/Project.js
+++ b/packages/app-project/stores/Project.js
@@ -26,7 +26,8 @@ const Project = types
     retired_subjects_count: types.optional(types.number, 0),
     slug: types.optional(types.string, ''),
     urls: types.frozen([]),
-    subjects_count: types.optional(types.number, 0)
+    subjects_count: types.optional(types.number, 0),
+    workflow_description: types.optional(types.string, '')
   })
 
   .views(self => ({
@@ -73,7 +74,8 @@ const Project = types
             'retired_subjects_count',
             'slug',
             'subjects_count',
-            'urls'
+            'urls',
+            'workflow_description'
           ]
           properties.forEach(property => { self[property] = project[property] })
 

--- a/packages/app-project/stores/Project.spec.js
+++ b/packages/app-project/stores/Project.spec.js
@@ -63,6 +63,10 @@ describe('Stores > Project', function () {
       expect(projectStore.loadingState).to.equal(asyncStates.initialized)
     })
 
+    it('should have a `workflow_description` property', function () {
+      expect(projectStore.workflow_description).to.equal('')
+    })
+
     after(function () {
       rootStore = null
       projectStore = null


### PR DESCRIPTION
This allows the project home page to use the project's workflow description if available, and falls back to a default message if there isn't one specified.

As @eatyourgreens pointed out, this is a localised string; next thing to do is setup a language store, and enhance the resource models to support translations.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
