### PR TITLE
Extract annotations out of classification model

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/models/Task.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Task.js
@@ -6,11 +6,7 @@ const Task = types.model('Task', {
 })
   .views(self => ({
     get annotation () {
-      const { currentAnnotations } = getRoot(self).classifications
-      let currentAnnotation
-      if (currentAnnotations && currentAnnotations.size > 0) {
-        currentAnnotation = currentAnnotations.get(self.taskKey)
-      }
+      const currentAnnotation = getRoot(self).classifications.annotation(self)
       return currentAnnotation || self.defaultAnnotation
     },
     get defaultAnnotation () {

--- a/packages/lib-classifier/src/store/AnnotationsStore.js
+++ b/packages/lib-classifier/src/store/AnnotationsStore.js
@@ -5,9 +5,14 @@ const AnnotationsStore = types
   .model('AnnotationsStore', {
     annotations: types.map(types.union(...annotationModels))
   })
+  .views(self =>({
+    annotation (task) {
+      return self.annotations.get(task.taskKey) || task.createAnnotation()
+    }
+  }))
   .actions(self => {
     function addAnnotation (task, annotationValue) {
-      const annotation = self.annotations.get(task.taskKey) || task.createAnnotation()
+      const annotation = self.annotation(task)
       // new annotations must be added to this store before we can modify them
       self.annotations.put(annotation)
       if (annotationValue) {

--- a/packages/lib-classifier/src/store/AnnotationsStore.js
+++ b/packages/lib-classifier/src/store/AnnotationsStore.js
@@ -1,0 +1,23 @@
+import { types, getType } from 'mobx-state-tree'
+import { annotationModels } from '@plugins/tasks'
+
+const AnnotationsStore = types
+  .model('AnnotationsStore', {
+    annotations: types.map(types.union(...annotationModels))
+  })
+  .actions(self => {
+    function addAnnotation (task, annotationValue) {
+      const annotation = self.annotations.get(task.taskKey) || task.createAnnotation()
+      // new annotations must be added to this store before we can modify them
+      self.annotations.put(annotation)
+      if (annotationValue) {
+        annotation.value = annotationValue
+      }
+    }
+
+    return {
+      addAnnotation
+    }
+  })
+
+export default AnnotationsStore

--- a/packages/lib-classifier/src/store/AnnotationsStore.spec.js
+++ b/packages/lib-classifier/src/store/AnnotationsStore.spec.js
@@ -1,0 +1,37 @@
+import AnnotationsStore from './AnnotationsStore'
+import taskRegistry from '@plugins/tasks'
+
+describe('Model > AnnotationsStore', function () {
+  let model
+  before(function () {
+    model = AnnotationsStore.create({})
+  })
+
+  it('should exist', function () {
+    expect(model).to.be.ok()
+    expect(model).to.be.an('object')
+  })
+
+  it('should have no annotations', function () {
+    expect(model.annotations.size).to.equal(0)
+  })
+
+  describe(`updating an annotation`, function () {
+    const SingleChoiceTask = taskRegistry.get('single').TaskModel
+    const task = SingleChoiceTask.create({ taskKey: 'T0', type: 'single', question: 'How many cats?' })
+
+    describe('for a new task', function () {
+      it('should create a new annotation', function () {
+        model.addAnnotation(task)
+        expect(model.annotations.size).to.equal(1)
+      })
+    })
+
+    describe('for an existing task', function () {
+      it('should not create a new annotation', function () {
+        model.addAnnotation(task, 2)
+        expect(model.annotations.size).to.equal(1)
+      })
+    })
+  })
+})

--- a/packages/lib-classifier/src/store/Classification.js
+++ b/packages/lib-classifier/src/store/Classification.js
@@ -1,4 +1,5 @@
 import { types, getType } from 'mobx-state-tree'
+import AnnotationsStore from './AnnotationsStore'
 import Resource from './Resource'
 import { annotationModels } from '@plugins/tasks'
 
@@ -36,9 +37,6 @@ const ClassificationMetadata = types.model('ClassificationMetadata', {
 
 const Classification = types
   .model('Classification', {
-    annotations: types.map(types.union(
-      ...annotationModels
-    )),
     completed: types.optional(types.boolean, false),
     links: types.frozen({
       project: types.string,
@@ -49,4 +47,4 @@ const Classification = types
   })
 
 export { ClassificationMetadata }
-export default types.compose('ClassificationResource', Resource, Classification)
+export default types.compose('ClassificationResource', Resource, AnnotationsStore, Classification)

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -113,12 +113,7 @@ const ClassificationStore = types
       if (validClassificationReference) {
         const classification = self.active
         if (classification) {
-          const annotation = classification.annotations.get(task.taskKey) || task.createAnnotation()
-          // new annotations must be added to this store before we can modify them
-          classification.annotations.put(annotation)
-          if (annotationValue !== undefined) {
-            annotation.value = annotationValue
-          }
+          classification.addAnnotation(task, annotationValue)
         }
       } else {
         if (process.browser) {

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -21,6 +21,14 @@ const ClassificationStore = types
     type: types.optional(types.string, 'classifications')
   })
   .views(self => ({
+    annotation (task) {
+      const validClassificationReference = isValidReference(() => self.active)
+      if (validClassificationReference) {
+        return self.active.annotation(task)
+      }
+      return null
+    },
+
     get currentAnnotations () {
       const validClassificationReference = isValidReference(() => self.active)
       if (validClassificationReference) {


### PR DESCRIPTION
Generalise annotations, in preparation for drawing subtasks.
- Move annotations to an AnnotationsStore model, so that they can be also be used by drawing marks.
- Make Classification an AnnotationsStore.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
