### PR TITLE
Drawing: Add drawn marks to the tab order

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingMarks/DrawingMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingMarks/DrawingMarks.js
@@ -7,7 +7,7 @@ import DeleteButton from '@plugins/tasks/DrawingTask/components/tools/DeleteButt
 function DrawingMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMark, svg, tool }) {
   const marksArray = Array.from(tool.marks.values())
 
-  return marksArray.map(mark => {
+  return marksArray.map((mark, index) => {
 
     const MarkingComponent = observer(mark.toolComponent)
     const ObservedDeleteButton = observer(DeleteButton)
@@ -38,6 +38,7 @@ function DrawingMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMark, s
         dragStart={selectMark}
         dragMove={moveMark}
         dragEnd={deselectMark}
+        label={`Mark ${index}`}
         mark={mark}
         onDelete={deleteMark}
         onDeselect={onDeselectMark}
@@ -52,6 +53,7 @@ function DrawingMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMark, s
           tool={tool}
         />
         {isActive && <ObservedDeleteButton
+          label={`Delete ${tool.type}`}
           mark={mark}
           svg={svg}
           onDelete={deleteMark}

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/components/tools/DeleteButton.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/components/tools/DeleteButton.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-function DeleteButton ({ mark, svg, rotate, onDelete }) {
+function DeleteButton ({ label, mark, svg, rotate, onDelete }) {
   const RADIUS = (screen.width < 900) ? 11 : 8
   const STROKE_COLOR = 'white'
   const FILL_COLOR = 'black'
@@ -41,6 +41,7 @@ function DeleteButton ({ mark, svg, rotate, onDelete }) {
     <g
       focusable
       tabIndex={0}
+      aria-label={label}
       role='button'
       transform={transform}
       stroke={STROKE_COLOR}

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/components/tools/DrawingToolRoot.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/components/tools/DrawingToolRoot.js
@@ -1,13 +1,21 @@
 import PropTypes from 'prop-types'
 import React, { forwardRef, useState } from 'react'
+import styled from 'styled-components'
 import draggable from '../components/draggable'
 
 const STROKE_WIDTH = 2
 const SELECTED_STROKE_WIDTH = 3
 
+const StyledGroup = styled('g')`
+  :focus {
+    outline: none;
+  }
+`
+
 const DrawingToolRoot = forwardRef(({
     children,
     isActive,
+    label,
     mark,
     onDelete,
     onDeselect,
@@ -44,24 +52,26 @@ const DrawingToolRoot = forwardRef(({
   }
 
   return (
-    <g
+    <StyledGroup
       {...mainStyle}
       ref={ref}
+      aria-label={label}
       strokeWidth ={isActive ? SELECTED_STROKE_WIDTH : STROKE_WIDTH}
       focusable
-      tabIndex='-1'
-      onFocus={select}
+      tabIndex={0}
       onBlur={deselect}
+      onFocus={select}
       onKeyDown={onKeyDown}
     >
       {children}
-    </g>
+    </StyledGroup>
   )
 })
 
 DrawingToolRoot.propTypes = {
   active: PropTypes.bool,
   children: PropTypes.node.isRequired,
+  label: PropTypes.string.isRequired,
   onDelete: PropTypes.func,
   onDeselect: PropTypes.func,
   onSelect: PropTypes.func,


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package:
lib-classifier

Add the drawing tool root to the tab order so that we can tab through drawn marks.
Select and deselect marks on focus and blur.
Add labels to marks so we can announce focus changes.
Add a label to the delete button.

Testing this in the dev classifier: Draw a few marks, click the theme toggle to focus it, then Tab/Shift-Tab forward and backward through the page. All drawn marks should be in the page tab order.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
