### PR TITLE
Drawing: Add mouse event handlers

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -8,7 +8,7 @@ const StyledRect = styled('rect')`
   cursor: ${props => props.disabled ? 'not-allowed' : 'crosshair'};
 `
 
-function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, scale, svg, width }) {
+function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, scale, svg, usePointer, width }) {
   const [ activeMark, setActiveMark ] = useState(null)
   const [ creating, setCreating ] = useState(false)
 
@@ -60,17 +60,30 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, sc
     }
   }
 
+  const pointerHandlers = {
+    onPointerMove,
+    onPointerUp
+  }
+
+  const mouseHandlers = {
+    onMouseMove: onPointerMove,
+    onMouseUp: onPointerUp
+  }
+
+  const rootProps = usePointer ? pointerHandlers : mouseHandlers
+
+  const rectProps = usePointer ? { onPointerDown } : { onMouseDown: onPointerDown }
+
   return (
     <g
-      onPointerMove={onPointerMove}
-      onPointerUp={onPointerUp}
+      {...rootProps}
     >
       <StyledRect
         disabled={disabled}
         width={width}
         height={height}
         fill='transparent'
-        onPointerDown={onPointerDown}
+        {...rectProps}
       />
       {activeDrawingTask &&
         activeDrawingTask.tools.map(tool => {
@@ -98,12 +111,14 @@ InteractionLayer.propTypes = {
   disabled: PropTypes.bool,
   scale: PropTypes.number,
   svg: PropTypes.instanceOf(Element).isRequired,
+  usePointer: PropTypes.bool,
   width: PropTypes.number.isRequired
 }
 
 InteractionLayer.defaultProps = {
   disabled: false,
-  scale: 1
+  scale: 1,
+  usePointer: !!window.PointerEvent
 }
 
 export default InteractionLayer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -56,6 +56,7 @@ describe('Component > InteractionLayer', function () {
         activeTool={activeTool}
         height={400}
         svg={mockSVG}
+        usePointer
         width={600}
       />)
   })

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.js
@@ -7,7 +7,7 @@ const StyledGroup = styled('g')`
   }
 `
 
-function DeleteButton ({ label, mark, scale, svg, rotate, onDelete }) {
+function DeleteButton ({ label, mark, scale, svg, rotate, onDelete, usePointer }) {
   const RADIUS = (screen.width < 900) ? 11 : 8
   const STROKE_COLOR = 'white'
   const FILL_COLOR = 'black'
@@ -44,6 +44,8 @@ function DeleteButton ({ label, mark, scale, svg, rotate, onDelete }) {
     return false
   }
 
+  const eventHandlers = usePointer ? { onKeyDown, onPointerDown } : { onKeyDown, onMouseDown: onPointerDown }
+
   return (
     <StyledGroup
       focusable
@@ -53,8 +55,7 @@ function DeleteButton ({ label, mark, scale, svg, rotate, onDelete }) {
       transform={transform}
       stroke={STROKE_COLOR}
       strokeWidth={STROKE_WIDTH}
-      onKeyDown={onKeyDown}
-      onPointerDown={onPointerDown}
+      {...eventHandlers}
     >
       <circle
         r={RADIUS}
@@ -72,7 +73,8 @@ DeleteButton.defaultProps = {
   x: 0,
   y: 0,
   rotate: 0,
-  destroyTransitionDuration: 300
+  destroyTransitionDuration: 300,
+  usePointer: !!window.PointerEvent
 }
 
 export default DeleteButton

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -76,13 +76,26 @@ function draggable (WrappedComponent) {
     }
 
     render () {
-      const { children, dragStart, dragMove, dragEnd, ...rest } = this.props
+      const { children, dragStart, dragMove, dragEnd, usePointer, ...rest } = this.props
       const { dragging } = this.state
+
+      const pointerHandlers = {
+        onPointerDown: this.dragStart,
+        onPointerMove: this.dragMove,
+        onPointerUp: this.dragEnd
+      }
+
+      const mouseHandlers = {
+        onMouseDown: this.dragStart,
+        onMouseMove: this.dragMove,
+        onMouseUp: this.dragEnd
+      }
+
+      const eventHandlers = usePointer ? pointerHandlers : mouseHandlers
+
       return (
         <g
-          onPointerDown={this.dragStart}
-          onPointerMove={this.dragMove}
-          onPointerUp={this.dragEnd}
+          {...eventHandlers}
         >
           <WrappedComponent
             ref={this.wrappedComponent}
@@ -103,7 +116,8 @@ function draggable (WrappedComponent) {
     },
     dragStart: () => true,
     dragMove: () => true,
-    dragEnd: () => true
+    dragEnd: () => true,
+    usePointer: !!window.PointerEvent
   }
   const name = WrappedComponent.displayName || WrappedComponent.name
   Draggable.displayName = `draggable(${name})`

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.spec.js
@@ -33,6 +33,7 @@ describe('draggable', function () {
         dragMove={onMove}
         dragEnd={onEnd}
         svg={mockSVG}
+        usePointer
       />
     )
   })


### PR DESCRIPTION
Add mouse handlers as fallbacks when pointer events aren't supported. Map each mouse event handler to the equivalent pointer event.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
