### PR TITLE
Drawing: Fix broken tests

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -95,3 +95,4 @@ InteractionLayer.propTypes = {
 }
 
 export default InteractionLayer
+export { StyledRect }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -1,8 +1,9 @@
 import { shallow } from 'enzyme'
 import React from 'react'
 import sinon from 'sinon'
+import styled from 'styled-components'
 
-import InteractionLayer from './InteractionLayer'
+import InteractionLayer, { StyledRect } from './InteractionLayer'
 import DrawingTask from '@plugins/tasks/DrawingTask'
 import { Line, Point } from '@plugins/tasks/DrawingTask/components/tools'
 
@@ -51,8 +52,8 @@ describe('Component > InteractionLayer', function () {
     expect(wrapper).to.be.ok()
   })
 
-  it('should return a transparent rect', function () {
-    const rect = wrapper.find('rect')
+  it('should render a transparent rect', function () {
+    const rect = wrapper.find(StyledRect)
     expect(rect.exists()).to.be.true()
     expect(rect.prop('id')).to.equal('InteractionLayer')
     expect(rect.prop('fill')).to.equal('transparent')
@@ -71,7 +72,7 @@ describe('Component > InteractionLayer', function () {
       const fakeEvent = {
         type: 'pointer'
       }
-      wrapper.find('rect').simulate('pointerdown', fakeEvent)
+      wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
       expect(mockDrawingTask.activeTool.createMark).to.have.been.calledOnce()
     })
 
@@ -83,8 +84,8 @@ describe('Component > InteractionLayer', function () {
       const fakeEvent = {
         type: 'pointer'
       }
-      wrapper.find('rect').simulate('pointerdown', fakeEvent)
-      wrapper.find('rect').simulate('pointermove', fakeEvent)
+      wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+      wrapper.simulate('pointermove', fakeEvent)
       expect(mockMark.initialDrag).to.have.been.calledOnce()
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.spec.js
@@ -1,7 +1,6 @@
 import { shallow } from 'enzyme'
 import React from 'react'
 import InteractionLayerContainer from './InteractionLayerContainer'
-import DrawingContainer from '../Drawing/DrawingContainer'
 
 describe('Component > InteractionLayerContainer', function () {
   it('should render without crashing', function () {
@@ -12,20 +11,6 @@ describe('Component > InteractionLayerContainer', function () {
     it('should render an InteractionLayer', function () {
       const wrapper = shallow(<InteractionLayerContainer.wrappedComponent activeDrawingTask />)
       expect(wrapper.find('InteractionLayer')).to.have.lengthOf(1)
-    })
-  })
-
-  describe('with active workflow step including a drawing task', function () {
-    it('should render a DrawingContainer', function () {
-      const wrapper = shallow(<InteractionLayerContainer.wrappedComponent activeStepTasks={activeStepTasksWithDrawing} />)
-      expect(wrapper.find(DrawingContainer)).to.have.lengthOf(1)
-    })
-  })
-
-  describe('with active workflow step excluding a drawing task', function () {
-    it('should not render a DrawingContainer', function () {
-      const wrapper = shallow(<InteractionLayerContainer.wrappedComponent activeStepTasks={activeStepTasksWithSingleChoice} />)
-      expect(wrapper.find(DrawingContainer)).to.have.lengthOf(0)
     })
   })
 })


### PR DESCRIPTION
Fix tests that broke in #1308.
Remove the DrawingContainer from tests, as it's no longer used anywhere.
Replace rect with a styled rect in InteractionLayer tests.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
