### PR TITLE
Drawing: limit marks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -79,7 +79,7 @@ function InteractionLayer ({ activeDrawingTask, svg }) {
         activeDrawingTask.tools.map(tool => {
           return (
             <DrawingToolMarks
-              key={`${tool.type}-${tool.toolIndex}`}
+              key={`${tool.type}-${tool.color}`}
               activeMarkId={activeMark && activeMark.id}
               onDelete={() => setActiveMark(null)}
               onSelectMark={mark => setActiveMark(mark)}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -1,5 +1,5 @@
 import cuid from 'cuid'
-import { func } from 'prop-types'
+import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import styled from 'styled-components'
 import DrawingToolMarks from './components/DrawingToolMarks'
@@ -9,7 +9,7 @@ const StyledRect = styled('rect')`
   pointer-events: ${props => props.disabled ? 'none' : 'all'};
 `
 
-function InteractionLayer ({ activeDrawingTask, svg }) {
+function InteractionLayer ({ activeDrawingTask, activeTool, disabled, svg }) {
   const [ activeMark, setActiveMark ] = useState(null)
   const [ creating, setCreating ] = useState(false)
 
@@ -37,7 +37,6 @@ function InteractionLayer ({ activeDrawingTask, svg }) {
   }
 
   function onPointerDown (event) {
-    const { activeTool } = activeDrawingTask
     const activeMark = activeTool.createMark({
       id: cuid(),
       toolIndex: activeDrawingTask.activeToolIndex
@@ -54,14 +53,11 @@ function InteractionLayer ({ activeDrawingTask, svg }) {
   function onPointerUp () {
     setCreating(false)
     if (activeMark && !activeMark.isValid) {
-      const { activeTool } = activeDrawingTask
       activeTool.deleteMark(activeMark)
       setActiveMark(null)
     }
   }
 
-  const { activeTool } = activeDrawingTask
-  const { disabled } = activeTool
   return (
     <g
       onPointerMove={onPointerMove}
@@ -94,6 +90,14 @@ function InteractionLayer ({ activeDrawingTask, svg }) {
 }
 
 InteractionLayer.propTypes = {
+  activeDrawingTask: PropTypes.object.isRequired,
+  activeTool: PropTypes.object.isRequired,
+  disabled: PropTypes.bool,
+  svg: PropTypes.instanceOf(Element).isRequired
+}
+
+InteractionLayer.defaultProps = {
+  disabled: false
 }
 
 export default InteractionLayer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -5,9 +5,8 @@ import styled from 'styled-components'
 import DrawingToolMarks from './components/DrawingToolMarks'
 
 const StyledRect = styled('rect')`
-  :hover {
-    cursor: crosshair;
-  }
+  cursor: ${props => props.disabled ? 'not-allowed' : 'crosshair'};
+  pointer-events: ${props => props.disabled ? 'none' : 'all'};
 `
 
 function InteractionLayer ({ activeDrawingTask, svg }) {
@@ -61,6 +60,8 @@ function InteractionLayer ({ activeDrawingTask, svg }) {
     }
   }
 
+  const { activeTool } = activeDrawingTask
+  const { disabled } = activeTool
   return (
     <g
       onPointerMove={onPointerMove}
@@ -68,6 +69,7 @@ function InteractionLayer ({ activeDrawingTask, svg }) {
     >
       <StyledRect
         id='InteractionLayer'
+        disabled={disabled}
         width='100%'
         height='100%'
         fill='transparent'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -9,8 +9,12 @@ function storeMapper (stores) {
     activeStepTasks
   } = stores.classifierStore.workflowSteps
   const [activeDrawingTask] = activeStepTasks.filter(task => task.type === 'drawing')
+  const { activeTool } = activeDrawingTask
+  const { disabled } = activeTool
   return {
-    activeDrawingTask
+    activeDrawingTask,
+    activeTool,
+    disabled
   }
 }
 
@@ -18,8 +22,15 @@ function storeMapper (stores) {
 @observer
 class InteractionLayerContainer extends Component {
   render () {
-    const { activeDrawingTask, svg } = this.props
-    return activeDrawingTask ? <InteractionLayer activeDrawingTask={activeDrawingTask} svg={svg} /> : null
+    const { activeDrawingTask, activeTool, disabled, svg } = this.props
+    return activeDrawingTask ? 
+    <InteractionLayer
+      activeDrawingTask={activeDrawingTask}
+      activeTool={activeTool}
+      disabled={disabled}
+      svg={svg}
+    /> : 
+    null
   }
 }
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/index.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/index.js
@@ -1,2 +1,3 @@
 export { default as Line } from './Line'
+export { default as Mark } from './Mark'
 export { default as Point } from './Point'

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/LineTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/LineTool.js
@@ -1,23 +1,11 @@
 import { types } from 'mobx-state-tree'
+import Tool from './Tool'
 import { Line } from '../marks'
 
 const LineTool = types.model('Line', {
-  color: types.optional(types.string, ''),
-  label: types.optional(types.string, ''),
   marks: types.map(Line),
-  max: types.optional(types.union(types.string, types.number), Infinity),
-  min: types.optional(types.union(types.string, types.number), 0),
   type: types.literal('line')
 })
-  .views(self => ({
-    get disabled () {
-      return self.marks.size >= self.max
-    },
-
-    get isComplete () {
-      return (self.marks.size >= self.min)
-    }
-  }))
   .actions(self => {
     function createMark (mark) {
       const newMark = Line.create(mark)
@@ -25,14 +13,9 @@ const LineTool = types.model('Line', {
       return newMark
     }
 
-    function deleteMark (mark) {
-      self.marks.delete(mark.id)
-    }
-
     return {
-      createMark,
-      deleteMark
+      createMark
     }
   })
 
-export default LineTool
+export default types.compose('LineTool', Tool, LineTool)

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/LineTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/LineTool.js
@@ -5,13 +5,17 @@ const LineTool = types.model('Line', {
   color: types.optional(types.string, ''),
   label: types.optional(types.string, ''),
   marks: types.map(Line),
-  max: types.maybe(types.union(types.string, types.number), ''),
-  min: types.maybe(types.union(types.string, types.number), ''),
+  max: types.optional(types.union(types.string, types.number), Infinity),
+  min: types.optional(types.union(types.string, types.number), 0),
   type: types.literal('line')
 })
   .views(self => ({
+    get disabled () {
+      return self.marks.size >= self.max
+    },
+
     get isComplete () {
-      return (self.marks.size >= self.min && self.marks.size <= self.max)
+      return (self.marks.size >= self.min)
     }
   }))
   .actions(self => {

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/PointTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/PointTool.js
@@ -1,24 +1,12 @@
 import { types } from 'mobx-state-tree'
+import Tool from './Tool'
 import { Point } from '../marks'
 
 const PointTool = types.model('Point', {
-  color: types.optional(types.string, ''),
-  label: types.optional(types.string, ''),
   marks: types.map(Point),
-  max: types.optional(types.union(types.string, types.number), Infinity),
-  min: types.optional(types.union(types.string, types.number), 0),
   size: types.optional(types.enumeration(['large', 'small']), 'large'),
   type: types.literal('point')
 })
-  .views(self => ({
-    get disabled () {
-      return self.marks.size >= self.max
-    },
-
-    get isComplete () {
-      return (self.marks.size >= self.min)
-    }
-  }))
   .actions(self => {
     function createMark (mark) {
       const newMark = Point.create(mark)
@@ -26,14 +14,9 @@ const PointTool = types.model('Point', {
       return newMark
     }
 
-    function deleteMark (mark) {
-      self.marks.delete(mark.id)
-    }
-
     return {
-      createMark,
-      deleteMark
+      createMark
     }
   })
 
-export default PointTool
+export default types.compose('PointTool', Tool, PointTool)

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/PointTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/PointTool.js
@@ -5,14 +5,18 @@ const PointTool = types.model('Point', {
   color: types.optional(types.string, ''),
   label: types.optional(types.string, ''),
   marks: types.map(Point),
-  max: types.maybe(types.union(types.string, types.number), ''),
-  min: types.maybe(types.union(types.string, types.number), ''),
+  max: types.optional(types.union(types.string, types.number), Infinity),
+  min: types.optional(types.union(types.string, types.number), 0),
   size: types.optional(types.enumeration(['large', 'small']), 'large'),
   type: types.literal('point')
 })
   .views(self => ({
+    get disabled () {
+      return self.marks.size >= self.max
+    },
+
     get isComplete () {
-      return (self.marks.size >= self.min && self.marks.size <= self.max)
+      return (self.marks.size >= self.min)
     }
   }))
   .actions(self => {

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool.js
@@ -1,0 +1,37 @@
+import { types } from 'mobx-state-tree'
+import { Mark } from '../marks'
+
+const Tool = types.model('Tool', {
+  color: types.optional(types.string, ''),
+  label: types.optional(types.string, ''),
+  marks: types.map(Mark),
+  max: types.optional(types.union(types.string, types.number), Infinity),
+  min: types.optional(types.union(types.string, types.number), 0),
+})
+  .views(self => ({
+    get disabled () {
+      return self.marks.size >= self.max
+    },
+
+    get isComplete () {
+      return (self.marks.size >= self.min)
+    }
+  }))
+  .actions(self => {
+    function createMark (mark) {
+      const newMark = Mark.create(mark)
+      self.marks.put(newMark)
+      return newMark
+    }
+
+    function deleteMark (mark) {
+      self.marks.delete(mark.id)
+    }
+
+    return {
+      createMark,
+      deleteMark
+    }
+  })
+
+export default Tool

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool.spec.js
@@ -1,0 +1,78 @@
+import Tool from './Tool'
+
+const toolData = {
+  color: '#ff0000',
+  label: 'Point',
+  max: '10',
+  min: 1
+}
+
+describe('Model > DrawingTools > Tool', function () {
+  it('should exist', function () {
+    const tool = Tool.create(toolData)
+    expect(tool).to.exist()
+    expect(tool).to.be.an('object')
+  })
+  
+  describe('tool.createMark', function () {
+    it('should add a new mark', function () {
+      const mark = { id: '1' }
+      const tool = Tool.create(toolData)
+      tool.createMark(mark)
+      expect(tool.marks.size).to.equal(1)
+    })
+  })
+
+  describe('tool.deleteMark', function () {
+    it('should remove a mark', function () {
+      const mark = { id: '1' }
+      const tool = Tool.create(toolData)
+      tool.createMark(mark)
+      tool.deleteMark(mark)
+      expect(tool.marks).to.be.empty()
+    })
+  })
+
+  describe('with fewer than the minimum marks', function () {
+    let tool
+
+    before(function () {
+      tool = Tool.create(toolData)
+    })
+
+    it('should be incomplete', function () {
+      expect(tool.isComplete).to.be.false()
+    })
+
+    it('should not be disabled', function () {
+      expect(tool.disabled).to.be.false()
+    })
+  })
+  
+  describe('with the minimum marks but fewer than the maximum marks', function () {
+    let tool
+
+    before(function () {
+      tool = Tool.create(toolData)
+      const ids = ['1', '2']
+      ids.forEach(id => tool.createMark({ id }))
+    })
+
+    it('should be complete', function () {
+      expect(tool.isComplete).to.be.true()
+    })
+
+    it('should not be disabled', function () {
+      expect(tool.disabled).to.be.false()
+    })
+  })
+  
+  describe('with the maximum marks', function () {
+    it('should be disabled', function () {
+      const tool = Tool.create(toolData)
+      const ids = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
+      ids.forEach(id => tool.createMark({ id }))
+      expect(tool.disabled).to.be.true()
+    })
+  })
+})

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/components/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/components/DrawingTask.js
@@ -54,7 +54,7 @@ class DrawingTask extends React.Component {
           return (
             <TaskInput
               checked={checked}
-              disabled={tool.isComplete}
+              disabled={tool.disabled}
               index={index}
               key={`${task.taskKey}_${index}`}
               label={tool.label}

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
@@ -16,14 +16,20 @@ const Drawing = types.model('Drawing', {
     get activeTool () {
       return self.tools[self.activeToolIndex]
     },
+
     get defaultAnnotation () {
       return DrawingAnnotation.create({ task: self.taskKey })
+    },
+
+    get isComplete () {
+      return self.tools.reduce((isTaskComplete, tool) => isTaskComplete && tool.isComplete, true)
     }
   }))
   .actions(self => {
     function setActiveTool (toolIndex) {
       self.activeToolIndex = toolIndex
     }
+
     return {
       setActiveTool
     }

--- a/packages/lib-classifier/src/plugins/tasks/components/InputStatus/InputStatus.js
+++ b/packages/lib-classifier/src/plugins/tasks/components/InputStatus/InputStatus.js
@@ -14,11 +14,13 @@ export const StyledInputStatus = styled(Text)`
 
 export default function InputStatus ({ count, tool }) {
   let status = counterpart('InputStatus.drawn', { count })
-  if (!!tool.min && !!tool.max) {
+  const hasMin = tool.min && tool.min > 0
+  const hasMax = tool.max && tool.max < Infinity
+  if (hasMin && hasMax) {
     status = counterpart('InputStatus.maxAndMin', { count, max: tool.max, min: tool.min })
-  } else if (!!tool.max && !tool.min) {
+  } else if (hasMax) {
     status = counterpart('InputStatus.max', { count, max: tool.max })
-  } else if (!tool.max && !!tool.min) {
+  } else if (hasMin) {
     status = counterpart('InputStatus.min', { count, min: tool.min })
   }
 


### PR DESCRIPTION
Add a generic `Tool` model.
Add `tool.disabled` to all tools.
Disable tools when `tool.marks` reaches its max size.
Disable the drawing surface when the active tool is disabled.
Disable a tool choice in the task area when that tool is disabled.
Add `task.isComplete` to drawing tasks (see #1307.)

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
