### PR TITLE
Drawing: scale marks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -9,9 +9,11 @@ const StyledRect = styled('rect')`
   pointer-events: ${props => props.disabled ? 'none' : 'all'};
 `
 
-function InteractionLayer ({ activeDrawingTask, activeTool, disabled, svg }) {
+function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, svg, width }) {
   const [ activeMark, setActiveMark ] = useState(null)
   const [ creating, setCreating ] = useState(false)
+  const [ scale, setScale ] = useState(1)
+  const interactionLayer = React.createRef()
 
   function convertEvent (event) {
     const type = event.type
@@ -41,6 +43,9 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, svg }) {
       id: cuid(),
       toolIndex: activeDrawingTask.activeToolIndex
     })
+    const { width: clientWidth, height: clientHeight } = interactionLayer.current.getBoundingClientRect()
+    const scale = clientWidth / width
+    setScale(scale)
     activeMark.initialPosition(convertEvent(event))
     setActiveMark(activeMark)
     setCreating(true)
@@ -64,10 +69,10 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, svg }) {
       onPointerUp={onPointerUp}
     >
       <StyledRect
-        id='InteractionLayer'
+        ref={interactionLayer}
         disabled={disabled}
-        width='100%'
-        height='100%'
+        width={width}
+        height={height}
         fill='transparent'
         onPointerDown={onPointerDown}
       />
@@ -79,6 +84,7 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, svg }) {
               activeMarkId={activeMark && activeMark.id}
               onDelete={() => setActiveMark(null)}
               onSelectMark={mark => setActiveMark(mark)}
+              scale={scale}
               svg={svg}
               tool={tool}
             />
@@ -92,8 +98,10 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, svg }) {
 InteractionLayer.propTypes = {
   activeDrawingTask: PropTypes.object.isRequired,
   activeTool: PropTypes.object.isRequired,
+  height: PropTypes.number.isRequired,
   disabled: PropTypes.bool,
-  svg: PropTypes.instanceOf(Element).isRequired
+  svg: PropTypes.instanceOf(Element).isRequired,
+  width: PropTypes.number.isRequired
 }
 
 InteractionLayer.defaultProps = {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -9,11 +9,9 @@ const StyledRect = styled('rect')`
   pointer-events: ${props => props.disabled ? 'none' : 'all'};
 `
 
-function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, svg, width }) {
+function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, scale, svg, width }) {
   const [ activeMark, setActiveMark ] = useState(null)
   const [ creating, setCreating ] = useState(false)
-  const [ scale, setScale ] = useState(1)
-  const interactionLayer = React.createRef()
 
   function convertEvent (event) {
     const type = event.type
@@ -43,9 +41,6 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, sv
       id: cuid(),
       toolIndex: activeDrawingTask.activeToolIndex
     })
-    const { width: clientWidth, height: clientHeight } = interactionLayer.current.getBoundingClientRect()
-    const scale = clientWidth / width
-    setScale(scale)
     activeMark.initialPosition(convertEvent(event))
     setActiveMark(activeMark)
     setCreating(true)
@@ -69,7 +64,6 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, sv
       onPointerUp={onPointerUp}
     >
       <StyledRect
-        ref={interactionLayer}
         disabled={disabled}
         width={width}
         height={height}
@@ -100,12 +94,14 @@ InteractionLayer.propTypes = {
   activeTool: PropTypes.object.isRequired,
   height: PropTypes.number.isRequired,
   disabled: PropTypes.bool,
+  scale: PropTypes.number,
   svg: PropTypes.instanceOf(Element).isRequired,
   width: PropTypes.number.isRequired
 }
 
 InteractionLayer.defaultProps = {
-  disabled: false
+  disabled: false,
+  scale: 1
 }
 
 export default InteractionLayer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -32,7 +32,7 @@ function storeMapper (stores) {
 @observer
 class InteractionLayerContainer extends Component {
   render () {
-    const { activeDrawingTask, activeTool, disabled, drawingAnnotations, height, svg, tasks, width } = this.props
+    const { activeDrawingTask, activeTool, disabled, drawingAnnotations, height, scale, svg, tasks, width } = this.props
     return (
       <>
         {drawingAnnotations.map(annotation =>
@@ -50,6 +50,7 @@ class InteractionLayerContainer extends Component {
               >
                 <MarkingComponent
                   mark={mark}
+                  scale={scale}
                   svg={svg}
                   tool={tool}
                 />
@@ -64,6 +65,7 @@ class InteractionLayerContainer extends Component {
             activeTool={activeTool}
             disabled={disabled}
             height={height}
+            scale={scale}
             svg={svg}
             width={width}
           />
@@ -78,13 +80,15 @@ InteractionLayerContainer.wrappedComponent.propTypes = {
   drawingAnnotations: PropTypes.array,
   height: PropTypes.number.isRequired,
   isDrawingInActiveWorkflowStep: PropTypes.bool,
+  scale: PropTypes.number,
   svg: PropTypes.object,
   width: PropTypes.number.isRequired
 }
 
 InteractionLayerContainer.wrappedComponent.defaultProps = {
   drawingAnnotations: [],
-  isDrawingInActiveWorkflowStep: false
+  isDrawingInActiveWorkflowStep: false,
+  scale: 1
 }
 
 export default InteractionLayerContainer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -32,7 +32,7 @@ function storeMapper (stores) {
 @observer
 class InteractionLayerContainer extends Component {
   render () {
-    const { activeDrawingTask, activeTool, disabled, drawingAnnotations, svg, tasks } = this.props
+    const { activeDrawingTask, activeTool, disabled, drawingAnnotations, height, svg, tasks, width } = this.props
     return (
       <>
         {drawingAnnotations.map(annotation =>
@@ -63,7 +63,9 @@ class InteractionLayerContainer extends Component {
             activeDrawingTask={activeDrawingTask}
             activeTool={activeTool}
             disabled={disabled}
+            height={height}
             svg={svg}
+            width={width}
           />
         }
       </>
@@ -71,10 +73,13 @@ class InteractionLayerContainer extends Component {
   }
 }
 
+
 InteractionLayerContainer.wrappedComponent.propTypes = {
   drawingAnnotations: PropTypes.array,
+  height: PropTypes.number.isRequired,
   isDrawingInActiveWorkflowStep: PropTypes.bool,
-  svg: PropTypes.object
+  svg: PropTypes.object,
+  width: PropTypes.number.isRequired
 }
 
 InteractionLayerContainer.wrappedComponent.defaultProps = {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import { DeleteButton, DrawingToolRoot } from '@plugins/drawingTools/components'
 
-function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMark, svg, tool }) {
+function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMark, scale, svg, tool }) {
   const marksArray = Array.from(tool.marks.values())
 
   return marksArray.map((mark, index) => {
@@ -47,12 +47,14 @@ function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMar
         <MarkingComponent
           active={isActive}
           mark={mark}
+          scale={scale}
           svg={svg}
           tool={tool}
         />
         {isActive && <ObservedDeleteButton
           label={`Delete ${tool.type}`}
           mark={mark}
+          scale={scale}
           svg={svg}
           onDelete={deleteMark}
         />}
@@ -66,6 +68,7 @@ DrawingToolMarks.propTypes = {
   onDelete: PropTypes.func,
   onDeselectMark: PropTypes.func,
   onSelectMark: PropTypes.func,
+  scale: PropTypes.number,
   svg: PropTypes.instanceOf(Element).isRequired,
   tool: PropTypes.object.isRequired
 }
@@ -74,7 +77,8 @@ DrawingToolMarks.defaultProps = {
   activeMarkId: '',
   onDelete: () => true,
   onDeselectMark: () => true,
-  onSelectMark: () => true
+  onSelectMark: () => true,
+  scale: 1
 }
 
 export default DrawingToolMarks

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -9,19 +9,16 @@ const SVG = styled.svg`
   width: 100%;
 `
 
-const SingleImageViewer = forwardRef(function SingleImageViewer ({ height, url, width }, ref) {
+const SingleImageViewer = forwardRef(function SingleImageViewer ({ children, height, scale, width }, ref) {
   const viewBox = `0 0 ${width} ${height}`
   return (
     <SVG
       ref={ref}
       viewBox={viewBox}
     >
-      <image
-        height='100%'
-        width='100%'
-        xlinkHref={url}
-      />
+      {children}
       <InteractionLayer
+        scale={scale}
         height={height}
         svg={ref ? ref.current : null}
         width={width}
@@ -32,8 +29,12 @@ const SingleImageViewer = forwardRef(function SingleImageViewer ({ height, url, 
 
 SingleImageViewer.propTypes = {
   height: PropTypes.number.isRequired,
-  url: PropTypes.string.isRequired,
+  scale: PropTypes.number,
   width: PropTypes.number.isRequired
+}
+
+SingleImageViewer.defaultProps = {
+  scale: 1
 }
 
 export default SingleImageViewer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -21,7 +21,11 @@ const SingleImageViewer = forwardRef(function SingleImageViewer ({ height, url, 
         width='100%'
         xlinkHref={url}
       />
-      <InteractionLayer svg={ref ? ref.current : null} />
+      <InteractionLayer
+        height={height}
+        svg={ref ? ref.current : null}
+        width={width}
+      />
     </SVG>
   )
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.spec.js
@@ -3,21 +3,14 @@ import React from 'react'
 
 import SingleImageViewer from './SingleImageViewer'
 
-const IMAGE_URL = 'http://placekitten.com/200/300'
 let wrapper
 
 describe('Component > SingleImageViewer', function () {
   beforeEach(function () {
-    wrapper = shallow(<SingleImageViewer url={IMAGE_URL} />)
+    wrapper = shallow(<SingleImageViewer />)
   })
 
   it('should render without crashing', function () {
     expect(wrapper).to.be.ok()
-  })
-
-  it('should render an svg image based on the subject prop', function () {
-    const image = wrapper.find('image')
-    expect(image).to.have.lengthOf(1)
-    expect(image.prop('xlinkHref')).to.equal(IMAGE_URL)
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -9,6 +9,7 @@ class SingleImageViewerContainer extends React.Component {
   constructor () {
     super()
     this.imageViewer = React.createRef()
+    this.subjectImage = React.createRef()
     this.state = {
       img: {}
     }
@@ -68,6 +69,12 @@ class SingleImageViewerContainer extends React.Component {
     const { loadingState, onError, subject } = this.props
     const { img } = this.state
     const { naturalHeight, naturalWidth, src } = img
+    const subjectImageElement = this.subjectImage.current
+    let scale = 1
+    if (subjectImageElement) {
+      const { width: clientWidth, height: clientHeight } = subjectImageElement.getBoundingClientRect()
+      scale = clientWidth / naturalWidth
+    }
 
     if (loadingState === asyncStates.error) {
       return (
@@ -83,9 +90,16 @@ class SingleImageViewerContainer extends React.Component {
       <SingleImageViewer
         ref={this.imageViewer}
         height={naturalHeight}
+        scale={scale}
         width={naturalWidth}
-        url={src}
-      />
+      >
+        <image
+          ref={this.subjectImage}
+          height={naturalHeight}
+          width={naturalWidth}
+          xlinkHref={src}
+        />
+      </SingleImageViewer>
     )
   }
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -131,6 +131,30 @@ describe('Component > SingleImageViewerContainer', function () {
         done()
       })
     })
+
+    it('should render an svg image', function () {
+      const svg = wrapper.instance().imageViewer.current
+      const fakeEvent = {
+        target: {
+          clientHeight: 0,
+          clientWidth: 0
+        }
+      }
+      const expectedEvent = {
+        target: {
+          clientHeight: svg.clientHeight,
+          clientWidth: svg.clientWidth,
+          naturalHeight: height,
+          naturalWidth: width
+        }
+      }
+      onReady.callsFake(function () {
+        const image = wrapper.find('image')
+        expect(image).to.have.lengthOf(1)
+        expect(image.prop('xlinkHref')).to.equal('https://some.domain/image.jpg')
+        done()
+      })
+    })
   })
 
   describe('with an invalid subject', function () {

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton.js
@@ -7,7 +7,7 @@ const StyledGroup = styled('g')`
   }
 `
 
-function DeleteButton ({ label, mark, svg, rotate, onDelete }) {
+function DeleteButton ({ label, mark, scale, svg, rotate, onDelete }) {
   const RADIUS = (screen.width < 900) ? 11 : 8
   const STROKE_COLOR = 'white'
   const FILL_COLOR = 'black'
@@ -18,7 +18,7 @@ function DeleteButton ({ label, mark, svg, rotate, onDelete }) {
     M 0 ${-1 * RADIUS * 0.7}
     L 0 ${RADIUS * 0.7}
   `
-  const { x, y } = mark.deleteButtonPosition
+  const { x, y } = mark.deleteButtonPosition(scale)
   const matrix = svg.getScreenCTM()
   const transform = `
     translate(${x}, ${y})

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DragHandle/DragHandle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DragHandle/DragHandle.js
@@ -10,7 +10,7 @@ const StyledCircle = styled('circle')`
 const RADIUS = screen.width > 900 ? 4 : 10
 const OVERSHOOT = screen.width > 900 ? 4 : 10
 
-const DragHandle = forwardRef(({ svg, x, y }, ref) => {
+const DragHandle = forwardRef(({ scale, svg, x, y }, ref) => {
   const matrix = svg.getScreenCTM()
 
   const styleProps = {

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Line.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Line.js
@@ -4,7 +4,7 @@ import DragHandle from '../components/DragHandle'
 
 const GRAB_STROKE_WIDTH = 6
 
-function Line ({ active, children, mark, svg, tool }) {
+function Line ({ active, children, mark, scale, svg, tool }) {
   const { x1, y1, x2, y2 } = mark
 
   function onHandleDrag (coords) {
@@ -14,11 +14,11 @@ function Line ({ active, children, mark, svg, tool }) {
   return (
     <g>
       <line x1={x1} y1={y1} x2={x2} y2={y2} />
-      <line x1={x1} y1={y1} x2={x2} y2={y2} strokeWidth={GRAB_STROKE_WIDTH} strokeOpacity='0' />
+      <line x1={x1} y1={y1} x2={x2} y2={y2} strokeWidth={GRAB_STROKE_WIDTH / scale} strokeOpacity='0' />
       {active &&
-        <DragHandle svg={svg} x={x1} y={y1} dragMove={(e, d) => onHandleDrag({ x1: x1 + d.x, y1: y1 + d.y, x2, y2 })} />}
+        <DragHandle scale={scale} svg={svg} x={x1} y={y1} dragMove={(e, d) => onHandleDrag({ x1: x1 + d.x, y1: y1 + d.y, x2, y2 })} />}
       {active &&
-        <DragHandle svg={svg} x={x2} y={y2} dragMove={(e, d) => onHandleDrag({ x1, y1, x2: x2 + d.x, y2: y2 + d.y })} />}
+        <DragHandle scale={scale} svg={svg} x={x2} y={y2} dragMove={(e, d) => onHandleDrag({ x1, y1, x2: x2 + d.x, y2: y2 + d.y })} />}
       {children}
     </g>
   )

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Point.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Point.js
@@ -16,11 +16,10 @@ const CROSSHAIR_WIDTH = 1
 
 function Point ({ active, children, mark, scale, svg, tool }) {
   const { size } = tool
-  const averageScale = (scale.horizontal + scale.vertical) / 2
-  const crosshairSpace = CROSSHAIR_SPACE / averageScale
-  const crosshairWidth = CROSSHAIR_WIDTH / averageScale
-  const selectedRadius = SELECTED_RADIUS[size] / averageScale
-  const radius = RADIUS[size] / averageScale
+  const crosshairSpace = CROSSHAIR_SPACE / scale
+  const crosshairWidth = CROSSHAIR_WIDTH / scale
+  const selectedRadius = SELECTED_RADIUS[size] / scale
+  const radius = RADIUS[size] / scale
 
   return (
     <g transform={`translate(${mark.x}, ${mark.y})`}>
@@ -36,19 +35,13 @@ function Point ({ active, children, mark, scale, svg, tool }) {
 
 Point.propTypes = {
   active: PropTypes.bool,
-  scale: PropTypes.shape({
-    horizontal: PropTypes.number,
-    vertical: PropTypes.number
-  }),
+  scale: PropTypes.number,
   tool: PropTypes.object
 }
 
 Point.defaultProps = {
   active: false,
-  scale: {
-    horizontal: 1,
-    vertical: 1
-  },
+  scale: 1,
   tool: {
     size: 'large'
   }

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Line.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Line.js
@@ -20,21 +20,24 @@ const LineModel = types
         y: self.y1
       }
     },
-    get deleteButtonPosition () {
-      const scale = 1
+
+    deleteButtonPosition (scale) {
       const BUFFER = 16
       const x = self.x1 > self.x2 ? self.x1 + (BUFFER / scale) : self.x1 - (BUFFER / scale)
       const y = self.y1
       // TODO: check for out of bounds coordinates
       return { x, y }
     },
+
     get length () {
       const { x1, y1, x2, y2 } = self
       return Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2))
     },
+
     get isValid () {
       return self.length - MINIMUM_LENGTH > 0
     },
+
     get toolComponent () {
       return LineComponent
     }

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Point.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Point.js
@@ -17,11 +17,11 @@ const PointModel = types
       }
     },
 
-    get deleteButtonPosition () {
+    deleteButtonPosition (scale) {
       const DELETE_BUTTON_ANGLE = 45
       const theta = (DELETE_BUTTON_ANGLE) * (Math.PI / 180)
-      const dx = 20 * Math.cos(theta)
-      const dy = -1 * 20 * Math.sin(theta)
+      const dx = (20 / scale) * Math.cos(theta)
+      const dy = -1 * (20 / scale) * Math.sin(theta)
       const x = self.x + dx
       const y = self.y + dy
       return { x, y }


### PR DESCRIPTION
Calculate the subject image scale when the subject image loads. Pass the scale down as a prop to marks. Scale rendered mark sizes and delete button position.

Package:
lib-classifier


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
