### PR TITLE
Drawing: fix InteractionLayer's crash from 'undefined' activeDrawingTask/activeTool

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -9,8 +9,8 @@ function storeMapper (stores) {
     activeStepTasks
   } = stores.classifierStore.workflowSteps
   const [activeDrawingTask] = activeStepTasks.filter(task => task.type === 'drawing')
-  const { activeTool } = activeDrawingTask
-  const { disabled } = activeTool
+  const activeTool = activeDrawingTask ? activeDrawingTask.activeTool : null
+  const disabled = activeTool ? activeTool.disabled : false
   return {
     activeDrawingTask,
     activeTool,
@@ -23,7 +23,7 @@ function storeMapper (stores) {
 class InteractionLayerContainer extends Component {
   render () {
     const { activeDrawingTask, activeTool, disabled, svg } = this.props
-    return activeDrawingTask ? 
+    return activeDrawingTask && activeTool ? 
     <InteractionLayer
       activeDrawingTask={activeDrawingTask}
       activeTool={activeTool}


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`
Target: `drawing-remove-rxjs` (#1266)

This PR fixes the issue in `drawing-remove-rxjs` where the classifier app crashes when encountering a Task that's not a Drawing Task.

 - `InteractionLayerContainer` now performs existential checks for the `activeDrawingTask` and `activeTool` variables.
- The `InteractionLayer` is only used for drawing interactions, so is displayed ONLY when there's an active Drawing Task in the Workflow, AND an Active Drawing Tool is selected for that task.

### Status

Ready for review.