### PR TITLE
Drawing: disable mark creation

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -6,7 +6,6 @@ import DrawingToolMarks from './components/DrawingToolMarks'
 
 const StyledRect = styled('rect')`
   cursor: ${props => props.disabled ? 'not-allowed' : 'crosshair'};
-  pointer-events: ${props => props.disabled ? 'none' : 'all'};
 `
 
 function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, scale, svg, width }) {
@@ -37,6 +36,9 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, sc
   }
 
   function onPointerDown (event) {
+    if (disabled) {
+      return false
+    }
     const activeMark = activeTool.createMark({
       id: cuid(),
       toolIndex: activeDrawingTask.activeToolIndex

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -61,6 +61,9 @@ describe('Component > InteractionLayer', function () {
   })
 
   afterEach(function () {
+    mockMark.initialDrag.resetHistory()
+    mockMark.initialPosition.resetHistory()
+    mockMark.setCoordinates.resetHistory()
     activeTool.createMark.restore()
   })
 
@@ -84,6 +87,10 @@ describe('Component > InteractionLayer', function () {
     })
 
     it('should place a new mark on pointer down', function () {
+      const fakeEvent = {
+        type: 'pointer'
+      }
+      wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
       expect(mockMark.initialPosition).to.have.been.calledOnce()
     })
 
@@ -92,6 +99,27 @@ describe('Component > InteractionLayer', function () {
         type: 'pointer'
       }
       wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+      wrapper.simulate('pointermove', fakeEvent)
+      expect(mockMark.initialDrag).to.have.been.calledOnce()
+    })
+  })
+
+  describe('when disabled', function () {
+    it('should not create a mark on pointer down', function () {
+      const fakeEvent = {
+        type: 'pointer'
+      }
+      wrapper.setProps({ disabled: true })
+      wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+      expect(activeTool.createMark).to.have.not.been.called()
+    })
+
+    it('should drag a new mark on pointer down + move', function () {
+      const fakeEvent = {
+        type: 'pointer'
+      }
+      wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+      wrapper.setProps({ disabled: true })
       wrapper.simulate('pointermove', fakeEvent)
       expect(mockMark.initialDrag).to.have.been.calledOnce()
     })


### PR DESCRIPTION
Disable pointerDown events when the interaction layer is disabled, but allow other pointer events to be handled.

Package:
lib-classifier

Closes #1355.

TODO:
- [x] Add tests.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
