### PR TITLE
Drawing: check for out-of-bounds marks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -15,18 +15,33 @@ describe('Component > InteractionLayer', function () {
     initialPosition: sinon.stub(),
     setCoordinates: sinon.stub()
   }
-  const mockSVGEvent = {
+  const mockSVGPoint = {
+    x: 100,
+    y: 200,
     matrixTransform: sinon.stub().callsFake(() => ({
       x: 100,
       y: 200
     }))
   }
-  const mockSVG = {
-    createSVGPoint: sinon.stub().callsFake(() => mockSVGEvent),
-    getScreenCTM: sinon.stub().callsFake(() => ({
-      inverse: sinon.stub()
-    }))
+  const mockScreenCTM = {
+    a: 1,
+    b: 1,
+    c: 1,
+    d: 1,
+    e: 1,
+    f: 1,
+    inverse: () => ({
+      a: 1,
+      b: 1,
+      c: 1,
+      d: 1,
+      e: 1,
+      f: 1
+    })
   }
+  const svg = document.createElementNS("http://www.w3.org/2000/svg","svg")
+  svg.createSVGPoint = () => mockSVGPoint
+  svg.getScreenCTM = () => mockScreenCTM
 
   beforeEach(function () {
     const mockDrawingTask = DrawingTask.TaskModel.create({
@@ -55,7 +70,7 @@ describe('Component > InteractionLayer', function () {
         activeDrawingTask={mockDrawingTask}
         activeTool={activeTool}
         height={400}
-        svg={mockSVG}
+        svg={svg}
         width={600}
       />)
   })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
@@ -10,10 +10,9 @@ function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMar
     const MarkingComponent = observer(mark.toolComponent)
     const ObservedDeleteButton = observer(DeleteButton)
     const isActive = mark.id === activeMarkId
-    const markRef = React.createRef()
 
-    function isInBounds (markComponent) {
-      const object = markComponent.getBounds()
+    function isInBounds (markElement) {
+      const object = markElement.getBoundingClientRect()
       const bounds = svg.getBoundingClientRect()
       const notBeyondLeft = (object.left + object.width) > bounds.left
       const notBeyondRight = object.left < (bounds.left + bounds.width)
@@ -31,9 +30,9 @@ function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMar
       mark.move(difference)
     }
 
-    function deselectMark () {
+    function deselectMark (event) {
       onDeselectMark(mark)
-      if (!isInBounds(markRef.current)) {
+      if (!isInBounds(event.currentTarget)) {
         deleteMark()
       }
     }
@@ -44,7 +43,6 @@ function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMar
 
     return (
       <DrawingToolRoot
-        ref={markRef}
         key={mark.id}
         isActive={isActive}
         coords={mark.coords}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
@@ -10,6 +10,17 @@ function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMar
     const MarkingComponent = observer(mark.toolComponent)
     const ObservedDeleteButton = observer(DeleteButton)
     const isActive = mark.id === activeMarkId
+    const markRef = React.createRef()
+
+    function isInBounds (markComponent) {
+      const object = markComponent.getBounds()
+      const bounds = svg.getBoundingClientRect()
+      const notBeyondLeft = (object.left + object.width) > bounds.left
+      const notBeyondRight = object.left < (bounds.left + bounds.width)
+      const notBeyondTop = (object.top + object.height) > bounds.top
+      const notBeyondBottom = object.top < (bounds.top + bounds.height)
+      return notBeyondLeft && notBeyondRight && notBeyondTop && notBeyondBottom
+    }
 
     function deleteMark () {
       tool.deleteMark(mark)
@@ -22,6 +33,9 @@ function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMar
 
     function deselectMark () {
       onDeselectMark(mark)
+      if (!isInBounds(markRef.current)) {
+        deleteMark()
+      }
     }
 
     function selectMark () {
@@ -30,6 +44,7 @@ function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMar
 
     return (
       <DrawingToolRoot
+        ref={markRef}
         key={mark.id}
         isActive={isActive}
         coords={mark.coords}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
@@ -11,7 +11,7 @@ describe('Components > DrawingToolMarks', function () {
   let tool
 
   beforeEach(function () {
-    svg = document.createElement('svg')
+    svg = document.createElementNS("http://www.w3.org/2000/svg","svg");
     const svgBounds = { left: 0, top: 0, right: 2000, bottom: 1000, width: 2000, height: 1000 }
     sinon.stub(svg, 'getBoundingClientRect').callsFake(() => svgBounds )
     const lineTool = LineTool.create({

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import { shallow } from 'enzyme'
+import sinon from 'sinon'
 import { PointTool, LineTool } from '@plugins/drawingTools/models/tools'
 import { Point, Line } from '@plugins/drawingTools/models/marks'
+import { DrawingToolRoot } from '@plugins/drawingTools/components'
 import DrawingToolMarks from './DrawingToolMarks'
 
 describe('Components > DrawingToolMarks', function () {
@@ -10,6 +12,8 @@ describe('Components > DrawingToolMarks', function () {
 
   beforeEach(function () {
     svg = document.createElement('svg')
+    const svgBounds = { left: 0, top: 0, right: 2000, bottom: 1000, width: 2000, height: 1000 }
+    sinon.stub(svg, 'getBoundingClientRect').callsFake(() => svgBounds )
     const lineTool = LineTool.create({
       help: '',
       label: 'Draw a line',
@@ -43,6 +47,77 @@ describe('Components > DrawingToolMarks', function () {
       const line = tool.marks.get('line1')
       const deleteButton = wrapper.find('DeleteButton')
       expect(deleteButton.prop('mark')).to.equal(line)
+    })
+  })
+
+  describe('when a mark is moved to a new position', function () {
+    let dragEnd
+    let onDeselectMark
+    let onDelete
+    let deleteMark
+
+    before(function () {
+      deleteMark = sinon.spy(tool, 'deleteMark')
+      onDeselectMark = sinon.stub()
+      onDelete = sinon.stub()
+      const wrapper = shallow(
+        <DrawingToolMarks
+          onDelete={onDelete}
+          onDeselectMark={onDeselectMark}
+          tool={tool}
+          svg={svg}
+        />
+      )
+      dragEnd = wrapper.find(DrawingToolRoot).first().prop('dragEnd')
+    })
+
+    it('should deselect the mark', function () {
+      const mockBounds = { left: 0, top: 0, right: 100, bottom: 100, width: 100, height: 100 }
+      const currentTarget = {
+        getBoundingClientRect: () => mockBounds
+      }
+      const fakeEvent = { currentTarget }
+      dragEnd(fakeEvent)
+      expect(onDeselectMark).to.have.been.calledOnce()
+    })
+
+    describe('when the mark is inside the SVG element', function () {
+      it('should do nothing', function () {
+        const mockBounds = { left: 0, top: 0, right: 100, bottom: 100, width: 100, height: 100 }
+        const currentTarget = {
+          getBoundingClientRect: () => mockBounds
+        }
+        const fakeEvent = { currentTarget }
+        dragEnd(fakeEvent)
+        expect(tool.marks.size).to.equal(2)
+        expect(onDelete).to.not.have.been.called()
+      })
+    })
+
+    describe('when the mark overlaps the SVG element', function () {
+      it('should do nothing', function () {
+        const mockBounds = { left: 1990, top: 20, right: 2090, bottom: 120, width: 100, height: 100 }
+        const currentTarget = {
+          getBoundingClientRect: () => mockBounds
+        }
+        const fakeEvent = { currentTarget }
+        dragEnd(fakeEvent)
+        expect(tool.marks.size).to.equal(2)
+        expect(onDelete).to.not.have.been.called()
+      })
+    })
+
+    describe('when the mark is outside the SVG element', function () {
+      it('should delete the mark', function () {
+        const mockBounds = { left: 2090, top: 20, right: 2190, bottom: 120, width: 100, height: 100 }
+        const currentTarget = {
+          getBoundingClientRect: () => mockBounds
+        }
+        const fakeEvent = { currentTarget }
+        dragEnd(fakeEvent)
+        expect(onDelete).to.have.been.calledOnce()
+        expect(deleteMark).to.have.been.calledOnce()
+      })
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { PointTool, LineTool } from '@plugins/drawingTools/models/tools'
+import { Point, Line } from '@plugins/drawingTools/models/marks'
+import DrawingToolMarks from './DrawingToolMarks'
+
+describe('Components > DrawingToolMarks', function () {
+  let svg
+  let tool
+
+  beforeEach(function () {
+    svg = document.createElement('svg')
+    const lineTool = LineTool.create({
+      help: '',
+      label: 'Draw a line',
+      type: 'line'
+    })
+    lineTool.createMark({ id: 'line1' }),
+    lineTool.createMark({ id: 'line2' }),
+    tool = lineTool
+  })
+
+  it('should render without crashing', function () {
+    const wrapper = shallow(<DrawingToolMarks tool={tool} svg={svg} />)
+    expect(wrapper).to.be.ok()
+  })
+  
+  it('should render two lines', function () {
+    const wrapper = shallow(<DrawingToolMarks tool={tool} svg={svg} />)
+    const marks = wrapper.find('Line')
+    expect(marks.length).to.equal(2)
+  })
+
+  describe('with an active mark', function () {
+    it('should show that mark as active', function () {
+      const wrapper = shallow(<DrawingToolMarks activeMarkId='line1' tool={tool} svg={svg} />)
+      const mark = wrapper.find('Line').first()
+      expect(mark.prop('active')).to.be.true()
+    })
+
+    it('should render a delete button', function () {
+      const wrapper = shallow(<DrawingToolMarks activeMarkId='line1' tool={tool} svg={svg} />)
+      const line = tool.marks.get('line1')
+      const deleteButton = wrapper.find('DeleteButton')
+      expect(deleteButton.prop('mark')).to.equal(line)
+    })
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import sinon from 'sinon'
-import { PointTool, LineTool } from '@plugins/drawingTools/models/tools'
-import { Point, Line } from '@plugins/drawingTools/models/marks'
+import { LineTool } from '@plugins/drawingTools/models/tools'
+import { Line } from '@plugins/drawingTools/models/marks'
 import { DrawingToolRoot } from '@plugins/drawingTools/components'
 import DrawingToolMarks from './DrawingToolMarks'
 

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -18,6 +18,10 @@ function draggable (WrappedComponent) {
       }
     }
 
+    getBounds () {
+      return this.wrappedComponent.current.getBoundingClientRect()
+    }
+
     convertEvent (event) {
       const type = event.type
 

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -18,10 +18,6 @@ function draggable (WrappedComponent) {
       }
     }
 
-    getBounds () {
-      return this.wrappedComponent.current.getBoundingClientRect()
-    }
-
     convertEvent (event) {
       const type = event.type
 
@@ -72,8 +68,9 @@ function draggable (WrappedComponent) {
     dragEnd (event) {
       const { releasePointerCapture } = this.wrappedComponent.current
       const { x, y, pointerId } = this.convertEvent(event)
+      const { currentTarget } = event
       if (pointerId === this.state.pointerId) {
-        this.props.dragEnd({ x, y, pointerId })
+        this.props.dragEnd({ currentTarget, x, y, pointerId })
         releasePointerCapture && this.wrappedComponent.current.releasePointerCapture(pointerId)
       }
       this.setState({ coords: { x: null, y: null }, dragging: false, pointerId: -1 })

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.spec.js
@@ -76,6 +76,7 @@ describe('draggable', function () {
   describe('on pointer up', function () {
     before(function () {
       const fakeEvent = {
+        currentTarget: {},
         preventDefault () {
           return true
         },


### PR DESCRIPTION
Delete marks when they are completely outside the SVG drawing canvas by comparing the bounding client rectangles of the mark element and the parent SVG element. Based on PFE's [`isInBounds`](https://github.com/zooniverse/Panoptes-Front-End/blob/abab2b0115231dc34fd824f70f46a0c372b3043e/app/lib/is-in-bounds.coffee#L1-L8) function.

Package:
lib-classifier

Closes #1334.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
