### PR TITLE
Drawing: Add tasks to drawing tools

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
@@ -1,5 +1,8 @@
 import { types } from 'mobx-state-tree'
 import { Mark } from '../../marks'
+import SingleChoiceTask  from '@plugins/tasks/SingleChoiceTask'
+import MultipleChoiceTask from '@plugins/tasks/MultipleChoiceTask'
+import TextTask from '@plugins/tasks/TextTask'
 
 const Tool = types.model('Tool', {
   color: types.optional(types.string, ''),
@@ -7,10 +10,19 @@ const Tool = types.model('Tool', {
   marks: types.map(Mark),
   max: types.optional(types.union(types.string, types.number), Infinity),
   min: types.optional(types.union(types.string, types.number), 0),
+  tasks: types.array(types.union(
+    SingleChoiceTask.TaskModel,
+    MultipleChoiceTask.TaskModel,
+    TextTask.TaskModel
+  ))
 })
   .views(self => ({
     get disabled () {
       return self.marks.size >= self.max
+    },
+
+    get hasCompletedTasks () {
+      return self.tasks.reduce((isStepComplete, task) => isStepComplete && task.isComplete, true)
     },
 
     get isComplete () {


### PR DESCRIPTION
Add tool.tasks to the Tool model. 
- Allow question and text tasks as drawing tool tasks. 
- Add `tool.hasCompletedTasks` to check for complete annotations on subtasks.
- Copy task tests from the Step model.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
