### PR TITLE
Drawing: Remove transformation matrices

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.js
@@ -7,7 +7,7 @@ const StyledGroup = styled('g')`
   }
 `
 
-function DeleteButton ({ label, mark, scale, svg, rotate, onDelete }) {
+function DeleteButton ({ label, mark, scale, rotate, onDelete }) {
   const RADIUS = (screen.width < 900) ? 11 : 8
   const STROKE_COLOR = 'white'
   const FILL_COLOR = 'black'
@@ -19,11 +19,10 @@ function DeleteButton ({ label, mark, scale, svg, rotate, onDelete }) {
     L 0 ${RADIUS * 0.7}
   `
   const { x, y } = mark.deleteButtonPosition(scale)
-  const matrix = svg.getScreenCTM()
   const transform = `
     translate(${x}, ${y})
     rotate(${rotate})
-    matrix( ${1 / matrix.a} 0 0 ${1 / matrix.d} 0 0)
+    scale(${1 / scale})
   `
   function onKeyDown (event) {
     switch (event.key) {

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DragHandle/DragHandle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DragHandle/DragHandle.js
@@ -10,8 +10,7 @@ const StyledCircle = styled('circle')`
 const RADIUS = screen.width > 900 ? 4 : 10
 const OVERSHOOT = screen.width > 900 ? 4 : 10
 
-const DragHandle = forwardRef(({ scale, svg, x, y }, ref) => {
-  const matrix = svg.getScreenCTM()
+const DragHandle = forwardRef(({ scale, x, y }, ref) => {
 
   const styleProps = {
     fill: 'currentColor',
@@ -19,7 +18,7 @@ const DragHandle = forwardRef(({ scale, svg, x, y }, ref) => {
     strokeWidth: OVERSHOOT,
     transform: `\
 translate(${x}, ${y})
-matrix( ${1 / matrix.a} 0 0 ${1 / matrix.d} 0 0)\
+scale(${1 / scale})\
 `
   }
   return <StyledCircle ref={ref} r={RADIUS} {...styleProps} />


### PR DESCRIPTION
Replace transformation matrices with scale transforms where they are being used for linear scaling.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
