### PR TITLE
Drawing: Use the state tree to get a mark's tool

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -82,10 +82,10 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, mo
             <DrawingToolMarks
               key={`${tool.type}-${tool.color}`}
               activeMarkId={activeMark && activeMark.id}
+              marks={Array.from(tool.marks.values())}
               onDelete={() => setActiveMark(null)}
               onSelectMark={mark => setActiveMark(mark)}
               scale={scale}
-              tool={tool}
             />
           )
         })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -5,6 +5,7 @@ import React, { Component } from 'react'
 import { DrawingToolRoot } from '@plugins/drawingTools/components'
 
 import InteractionLayer from './InteractionLayer'
+import DrawingToolMarks from './components/DrawingToolMarks'
 
 function storeMapper (stores) {
   const {
@@ -38,22 +39,11 @@ class InteractionLayerContainer extends Component {
     return (
       <>
         {drawingAnnotations.map(annotation =>
-          annotation.value.map((mark, index) => {
-            const MarkingComponent = mark.toolComponent
-            return (
-              <DrawingToolRoot
-                key={mark.id}
-                label={`${mark.tool.type} ${index}`}
-                isActive={false}
-                mark={mark}
-              >
-                <MarkingComponent
-                  mark={mark}
-                  scale={scale}
-                />
-              </DrawingToolRoot>
-            )
-          })
+          <DrawingToolMarks
+            key={annotation.task}
+            marks={annotation.value}
+            scale={scale}
+          />
         )}
         {activeDrawingTask && activeTool &&
           <InteractionLayer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -8,8 +8,7 @@ import InteractionLayer from './InteractionLayer'
 
 function storeMapper (stores) {
   const {
-    activeStepTasks,
-    tasks
+    activeStepTasks
   } = stores.classifierStore.workflowSteps
   const {
     move
@@ -27,8 +26,7 @@ function storeMapper (stores) {
     activeTool,
     disabled,
     drawingAnnotations,
-    move,
-    tasks
+    move
   }
 }
 
@@ -36,27 +34,22 @@ function storeMapper (stores) {
 @observer
 class InteractionLayerContainer extends Component {
   render () {
-    const { activeDrawingTask, activeTool, disabled, drawingAnnotations, height, move, scale, svg, tasks, width } = this.props
+    const { activeDrawingTask, activeTool, disabled, drawingAnnotations, height, move, scale, width } = this.props
     return (
       <>
         {drawingAnnotations.map(annotation =>
-          annotation.value.map(mark => {
+          annotation.value.map((mark, index) => {
             const MarkingComponent = mark.toolComponent
-            const [ task ] = tasks.filter(task => task.taskKey === annotation.task)
-            const tool = task.tools[mark.toolIndex]
             return (
               <DrawingToolRoot
                 key={mark.id}
+                label={`${mark.tool.type} ${index}`}
                 isActive={false}
                 mark={mark}
-                svg={svg}
-                tool={tool}
               >
                 <MarkingComponent
                   mark={mark}
                   scale={scale}
-                  svg={svg}
-                  tool={tool}
                 />
               </DrawingToolRoot>
             )
@@ -71,7 +64,6 @@ class InteractionLayerContainer extends Component {
             height={height}
             move={move}
             scale={scale}
-            svg={svg}
             width={width}
           />
         }
@@ -86,7 +78,6 @@ InteractionLayerContainer.wrappedComponent.propTypes = {
   height: PropTypes.number.isRequired,
   isDrawingInActiveWorkflowStep: PropTypes.bool,
   scale: PropTypes.number,
-  svg: PropTypes.object,
   width: PropTypes.number.isRequired
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.spec.js
@@ -1,6 +1,8 @@
 import { shallow } from 'enzyme'
 import React from 'react'
 import InteractionLayerContainer from './InteractionLayerContainer'
+import InteractionLayer from './InteractionLayer'
+import DrawingToolMarks from './components/DrawingToolMarks'
 
 describe('Component > InteractionLayerContainer', function () {
   it('should render without crashing', function () {
@@ -10,7 +12,25 @@ describe('Component > InteractionLayerContainer', function () {
   describe('with an active drawing task and drawing tool', function () {
     it('should render an InteractionLayer', function () {
       const wrapper = shallow(<InteractionLayerContainer.wrappedComponent activeDrawingTask activeTool />)
-      expect(wrapper.find('InteractionLayer')).to.have.lengthOf(1)
+      expect(wrapper.find(InteractionLayer)).to.have.lengthOf(1)
+    })
+  })
+
+  describe('with annotations from previous drawing tasks', function () {
+    it('should render DrawingToolMarks', function () {
+      const drawingAnnotations = [{
+        task: 'T2',
+        value: [
+          { id: 'point1', frame: 0, toolIndex: 0, x: 100, y: 200 }
+        ]
+      }, {
+        task: 'T3',
+        value: [
+          { id: 'line1', frame: 0, toolIndex: 0, x1: 100, y1: 200, x2: 150, y2: 200 }
+        ]
+      }]
+      const wrapper = shallow(<InteractionLayerContainer.wrappedComponent drawingAnnotations={drawingAnnotations} />)
+      expect(wrapper.find(DrawingToolMarks)).to.have.lengthOf(2)
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
@@ -57,13 +57,11 @@ function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMar
         onDeselect={onDeselectMark}
         onSelect={onSelectMark}
         scale={scale}
-        tool={tool}
       >
         <MarkingComponent
           active={isActive}
           mark={mark}
           scale={scale}
-          tool={tool}
         />
         {isActive && <ObservedDeleteButton
           label={`Delete ${tool.type}`}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types'
 import { DeleteButton, DrawingToolRoot } from '@plugins/drawingTools/components'
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 
-function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMark, scale, tool }) {
-  const marksArray = Array.from(tool.marks.values())
+function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMark, scale, marks }) {
   const { svg } = useContext(SVGContext)
 
-  return marksArray.map((mark, index) => {
+  return marks.map((mark, index) => {
+    const { tool } = mark
     const MarkingComponent = observer(mark.toolComponent)
     const ObservedDeleteButton = observer(DeleteButton)
     const isActive = mark.id === activeMarkId
@@ -76,11 +76,11 @@ function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMar
 
 DrawingToolMarks.propTypes = {
   activeMarkId: PropTypes.string,
+  marks: PropTypes.array.isRequired,
   onDelete: PropTypes.func,
   onDeselectMark: PropTypes.func,
   onSelectMark: PropTypes.func,
-  scale: PropTypes.number,
-  tool: PropTypes.object.isRequired
+  scale: PropTypes.number
 }
 
 DrawingToolMarks.defaultProps = {

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.js
@@ -24,9 +24,9 @@ const DrawingToolRoot = forwardRef(function DrawingToolRoot({
   onDelete,
   onDeselect,
   onSelect,
-  scale,
-  tool
+  scale
 }, ref) {
+  const { tool } = mark
   const mainStyle = {
     color: tool && tool.color ? tool.color : 'green',
     fill: 'transparent',

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.js
@@ -4,7 +4,7 @@ import DragHandle from '../DragHandle'
 
 const GRAB_STROKE_WIDTH = 6
 
-function Line ({ active, children, mark, scale, tool }) {
+function Line ({ active, children, mark, scale }) {
   const { x1, y1, x2, y2 } = mark
 
   function onHandleDrag (coords) {
@@ -25,8 +25,7 @@ function Line ({ active, children, mark, scale, tool }) {
 }
 
 Line.propTypes = {
-  active: PropTypes.bool,
-  tool: PropTypes.object
+  active: PropTypes.bool
 }
 
 Line.defaultProps = {

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.js
@@ -14,8 +14,8 @@ const SELECTED_RADIUS = {
 const CROSSHAIR_SPACE = 0.2
 const CROSSHAIR_WIDTH = 1
 
-function Point ({ active, children, mark, scale, tool }) {
-  const { size } = tool
+function Point ({ active, children, mark, scale }) {
+  const { size } = mark.tool
   const crosshairSpace = CROSSHAIR_SPACE / scale
   const crosshairWidth = CROSSHAIR_WIDTH / scale
   const selectedRadius = SELECTED_RADIUS[size] / scale
@@ -35,16 +35,18 @@ function Point ({ active, children, mark, scale, tool }) {
 
 Point.propTypes = {
   active: PropTypes.bool,
-  scale: PropTypes.number,
-  tool: PropTypes.object
+  mark: PropTypes.object,
+  scale: PropTypes.number
 }
 
 Point.defaultProps = {
   active: false,
-  scale: 1,
-  tool: {
-    size: 'large'
-  }
+  mark: {
+    tool: {
+      size: 'large'
+    }
+  },
+  scale: 1
 }
 
 export default Point

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.spec.js
@@ -4,9 +4,16 @@ import { expect } from 'chai'
 import Point from './Point'
 
 describe('Point tool', function () {
+  const mark = {
+    x: 100,
+    y: 200,
+    tool: {
+      size: 'large'
+    }
+  }
   it('should render without crashing', function () {
     const wrapper = shallow(<Point
-      mark={{ x: 100, y: 200 }}
+      mark={mark}
     />)
     expect(wrapper).to.be.ok()
   })
@@ -32,7 +39,7 @@ describe('Point tool', function () {
   it('should render with radius', function () {
     const wrapper = shallow(
       <Point
-        mark={{ x: 100, y: 200 }}
+        mark={mark}
       />)
     expect(wrapper.containsMatchingElement(<circle r={10} />)).to.be.true()
   })
@@ -41,7 +48,7 @@ describe('Point tool', function () {
     const wrapper = shallow(
       <Point
         active
-        mark={{ x: 100, y: 200 }}
+        mark={mark}
       />)
     expect(wrapper.containsMatchingElement(<circle r={20} />)).to.be.true()
   })

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Line/Line.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Line/Line.js
@@ -1,6 +1,7 @@
-import { addDisposer, getRoot, isValidReference, types } from 'mobx-state-tree'
+import { addDisposer, getRoot, getParentOfType, isValidReference, types } from 'mobx-state-tree'
 import { autorun } from 'mobx'
 import { Line as LineComponent } from '../../../components/'
+import { LineTool } from '@plugins/drawingTools/models/tools'
 
 import Mark from '../Mark'
 
@@ -36,6 +37,10 @@ const LineModel = types
 
     get isValid () {
       return self.length - MINIMUM_LENGTH > 0
+    },
+
+    get tool () {
+      return getParentOfType(self, LineTool)
     },
 
     get toolComponent () {

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
@@ -1,7 +1,8 @@
-import { types } from 'mobx-state-tree'
+import { getParentOfType, types } from 'mobx-state-tree'
 import SingleChoiceTask  from '@plugins/tasks/SingleChoiceTask'
 import MultipleChoiceTask from '@plugins/tasks/MultipleChoiceTask'
 import TextTask from '@plugins/tasks/TextTask'
+import { Tool } from '@plugins/drawingTools/models/tools'
 import AnnotationsStore from '@store/AnnotationsStore'
 
 const BaseMark = types.model('BaseMark', {
@@ -17,6 +18,10 @@ const BaseMark = types.model('BaseMark', {
   .views(self => ({
     get isValid () {
       return true
+    },
+
+    get tool () {
+      return getParentOfType(self, Tool)
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Point/Point.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Point/Point.js
@@ -1,6 +1,7 @@
-import { addDisposer, getRoot, isValidReference, types } from 'mobx-state-tree'
+import { addDisposer, getRoot, getParentOfType, isValidReference, types } from 'mobx-state-tree'
 import { autorun } from 'mobx'
 import { Point as PointComponent } from '../../../components'
+import { PointTool } from '@plugins/drawingTools/models/tools'
 
 import Mark from '../Mark'
 
@@ -25,6 +26,10 @@ const PointModel = types
       const x = self.x + dx
       const y = self.y + dy
       return { x, y }
+    },
+
+    get tool () {
+      return getParentOfType(self, PointTool)
     },
 
     get toolComponent () {

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/index.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/index.js
@@ -1,2 +1,3 @@
 export { default as LineTool } from './LineTool'
 export { default as PointTool } from './PointTool'
+export { default as Tool } from './Tool'

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.js
@@ -2,10 +2,9 @@ import { types } from 'mobx-state-tree'
 import Annotation from '../../models/Annotation'
 import * as markTypes from '@plugins/drawingTools/models/marks'
 
+const markReferenceTypes = Object.values(markTypes).map(markType => types.reference(markType))
 const Drawing = types.model('Drawing', {
-  value: types.array(
-    types.union(...Object.values(markTypes))
-  )
+  value: types.array(types.union(...markReferenceTypes))
 })
 
 const DrawingAnnotation = types.compose('DrawingAnnotation', Annotation, Drawing)

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.spec.js
@@ -1,14 +1,17 @@
 import DrawingAnnotation from './DrawingAnnotation'
+import { Point } from '@plugins/drawingTools/models/marks'
 
-const drawingAnnotation = {
+const point = Point.create({ id: 'mockAnnotation', frame: 0, toolIndex: 0, x: 100, y: 150 })
+
+const drawingAnnotationSnapshot = {
   task: 'T0',
-  value: [{ id: 'mockAnnotation', frame: 0, toolIndex: 0, x: 100, y: 150 }]
+  value: [ point.id ]
 }
 
 describe('Model > DrawingAnnotation', function () {
   it('should exist', function () {
-    const drawingAnnotationInstance = DrawingAnnotation.create(drawingAnnotation)
-    expect(drawingAnnotationInstance).to.exist()
-    expect(drawingAnnotationInstance).to.be.an('object')
+    const drawingAnnotation = DrawingAnnotation.create(drawingAnnotationSnapshot)
+    expect(drawingAnnotation).to.exist()
+    expect(drawingAnnotation).to.be.an('object')
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
@@ -38,18 +38,15 @@ const Drawing = types.model('Drawing', {
     }
 
     function complete () {
-      const newValue = self.marks.map(mark => detach(mark))
-      self.updateAnnotation(newValue)
+      self.updateAnnotation(self.marks)
     }
 
     function start () {
       const activeMarks = self.annotation.value
-      activeMarks.forEach(function addMarksToTools (mark) {
-        const newMark = clone(mark)
-        const tool = tryReference(() => self.tools[newMark.toolIndex])
-        tool && tool.marks.put(newMark)
-      })
-      self.updateAnnotation([])
+      // if the current annotation is empty, clear any leftover marks.
+      if (activeMarks.length === 0) {
+        self.tools.forEach(tool => tool.marks.clear())
+      }
     }
 
     return {

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
@@ -70,10 +70,6 @@ describe('Model > DrawingTask', function () {
       marks = drawingTask.marks
     })
 
-    it('should remove marks from the task', function () {
-      expect(marks).to.be.empty()
-    })
-
     it('should copy marks to the task annotation', function () {
       expect(addAnnotation).to.have.been.calledOnce()
     })
@@ -83,18 +79,16 @@ describe('Model > DrawingTask', function () {
     let marks
     let pointTool
     let lineTool
-    let addAnnotation
     before(function () {
       const drawingTask = DrawingTask.create(drawingTaskSnapshot)
       pointTool = drawingTask.tools[0]
       lineTool = drawingTask.tools[1]
+      const point1 = pointTool.createMark({ id: 'point1' })
+      const point2 = pointTool.createMark({ id: 'point2' })
+      const line1 = lineTool.createMark({ id: 'line1' })
       const taskAnnotation = DrawingAnnotation.create({
         task: 'T3',
-        value: [
-          Point.create({ id: 'point1', toolIndex: 0 }),
-          Point.create({ id: 'point2', toolIndex: 0 }),
-          Line.create({ id: 'line1', toolIndex: 1 })
-        ]
+        value: []
       })
       drawingTask.classifications = {
         addAnnotation: sinon.stub(),
@@ -102,20 +96,15 @@ describe('Model > DrawingTask', function () {
       }
       drawingTask.start()
       marks = drawingTask.marks
-      addAnnotation = drawingTask.classifications.addAnnotation.withArgs(drawingTask, [])
     })
 
-    it('should add existing annotation marks to the task', function () {
-      expect(marks.length).to.equal(3)
+    it('should clear stale marks from the task', function () {
+      expect(marks.length).to.equal(0)
     })
 
-    it('should clear marks from the current annotation', function () {
-      expect(addAnnotation).to.have.been.calledOnce()
-    })
-
-    it('should copy marks to the correct tools', function () {
-      expect(pointTool.marks.size).to.equal(2)
-      expect(lineTool.marks.size).to.equal(1)
+    it('should clear stale marks from the drawing tools', function () {
+      expect(pointTool.marks.size).to.equal(0)
+      expect(lineTool.marks.size).to.equal(0)
     })
   })
 })

--- a/packages/lib-classifier/src/store/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.js
@@ -60,10 +60,6 @@ const WorkflowStepStore = types
       }
 
       return false
-    },
-
-    get tasks () {
-      return Array.from(self.steps.values()).reduce((allTasks, step) => allTasks.concat(step.tasks), [])
     }
   }))
   .actions(self => {


### PR DESCRIPTION
Use `getParentOfType` to get the tool that created a mark.
Remove redundant tool props from mark components.
Pass marks to annotations by reference.
Clear stale marks from a tool if the current annotation is empty.
Remove `workflowSteps.tasks`, which was only being used to look up the tool for a given mark.
Add tests for rendered marks in the subject viewer.

Package:
lib-classifier

Closes #1363.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
