### PR TITLE
WIP Add new auth client to app-project

### DIFF
--- a/packages/app-project/next.config.js
+++ b/packages/app-project/next.config.js
@@ -22,7 +22,7 @@ module.exports = {
   env: {
     COMMIT_ID: execSync('git rev-parse HEAD').toString('utf8').trim(),
     PANOPTES_ENV,
-    TALK_HOST: talkHosts[PANOPTES_ENV]
+    TALK_HOST: talkHosts[PANOPTES_ENV],
   },
 
   publicRuntimeConfig: {

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -23,6 +23,7 @@
     "@sindresorhus/string-hash": "~1.2.0",
     "@vx/vx": "~0.0.191",
     "@zooniverse/async-states": "~0.0.1",
+    "@zooniverse/auth": "1.0.0",
     "@zooniverse/classifier": "^0.0.1",
     "@zooniverse/grommet-theme": "~2.2.0",
     "@zooniverse/panoptes-js": "~0.1.0",

--- a/packages/app-project/pages/Index.js
+++ b/packages/app-project/pages/Index.js
@@ -1,9 +1,12 @@
 import React from 'react'
 import { Heading } from 'grommet'
+import StandardLayout from '@shared/components/StandardLayout'
 
 export default () => (
-  <div>
-    <Heading><code>project</code> app</Heading>
-    <p>This app handles all project-specific routes, i.e. all routes under <code>/projects/[owner]/[project-name]</code>.</p>
-  </div>
+  <StandardLayout>
+    <div>
+      <Heading><code>project</code> app</Heading>
+      <p>This app handles all project-specific routes, i.e. all routes under <code>/projects/[owner]/[project-name]</code>.</p>
+    </div>
+  </StandardLayout>
 )

--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -39,20 +39,30 @@ export default class MyApp extends App {
       // cookie is in the next.js context req object
       const mode = getCookie(context, 'mode') || undefined
       const dismissedAnnouncementBanner = getCookie(context, 'dismissedAnnouncementBanner') || undefined
-      const store = initStore(pageProps.isServer, {
+      const snapshot = {
+        config: {
+          apiHostUrl: process.env.API_HOST_URL,
+          clientAppID: process.env.CLIENT_APP_ID
+        },
         ui: {
           dismissedAnnouncementBanner,
           mode
         }
-      })
+      }
+      const store = initStore(pageProps.isServer, snapshot)
+      // console.info(getSnapshot(store))
+      // store.auth.createClient()
+      // const f = await store.auth.client.resumeSession()
+      // console.info(f)
 
       const { owner, project } = context.query
       if (owner && project) {
         const projectSlug = `${owner}/${project}`
         const query = (context.query.env) ? { env: context.query.env } : {}
         await store.project.fetch(projectSlug, query)
-        pageProps.initialState = getSnapshot(store)
       }
+
+      pageProps.initialState = getSnapshot(store)
     }
 
     return { pageProps }
@@ -61,13 +71,17 @@ export default class MyApp extends App {
   constructor (props) {
     super()
     const { isServer, initialState } = props.pageProps
+    console.info(initialState)
     this.store = initStore(isServer, initialState, props.client)
     makeInspectable(this.store)
   }
 
   componentDidMount () {
     console.info(`Deployed commit is ${process.env.COMMIT_ID}`)
-    this.store.user.checkCurrent()
+    // this.store.user.checkCurrent()
+    this.store.auth.createClient()
+    // console.info(getSnapshot(this.store))
+
   }
 
   componentDidCatch (error, errorInfo) {

--- a/packages/app-project/src/components/AuthModal/components/LoginForm/LoginFormContainer.spec.js
+++ b/packages/app-project/src/components/AuthModal/components/LoginForm/LoginFormContainer.spec.js
@@ -43,7 +43,7 @@ describe('Component > LoginFormContainer', function () {
     before(function () {
       CLOSE_MODAL = sinon.spy()
       MOCK_STORE = {
-        user: { set: sinon.spy() }
+        set: sinon.spy()
       }
       VALID_SIGN_IN = sinon.stub().resolves(MOCK_USER_RESOURCE)
 
@@ -58,7 +58,7 @@ describe('Component > LoginFormContainer', function () {
 
     afterEach(function () {
       CLOSE_MODAL.resetHistory()
-      MOCK_STORE.user.set.resetHistory()
+      MOCK_STORE.set.resetHistory()
       VALID_SIGN_IN.resetHistory()
       INVALID_SIGN_IN.resetHistory()
       API_ERROR_STUB.resetHistory()
@@ -74,14 +74,14 @@ describe('Component > LoginFormContainer', function () {
       const validWrapper = shallow(<LoginFormContainer
         authClient={{ signIn: VALID_SIGN_IN }}
         closeModal={CLOSE_MODAL}
-        store={MOCK_STORE}
+        userStore={MOCK_STORE}
       />)
 
       try {
         await validWrapper.instance().onSubmit(MOCK_FORM_VALUES, MOCK_FORMIK)
         expect(VALID_SIGN_IN).to.have.been.calledWith(MOCK_FORM_VALUES)
         expect(MOCK_FORMIK.setSubmitting).to.have.been.calledWith(false)
-        expect(MOCK_STORE.user.set).to.have.been.calledWith(MOCK_USER_RESOURCE)
+        expect(MOCK_STORE.set).to.have.been.calledWith(MOCK_USER_RESOURCE)
         expect(CLOSE_MODAL).to.have.been.called()
       } catch (error) {
         expect.fail(error)

--- a/packages/app-project/stores/Auth.js
+++ b/packages/app-project/stores/Auth.js
@@ -1,0 +1,22 @@
+import { getRoot, types } from 'mobx-state-tree'
+import createClient from '@zooniverse/auth'
+
+const Auth = types
+  .model('Auth')
+
+  .volatile(() => ({
+    client: null
+  }))
+
+  .actions(self => ({
+    createClient () {
+      const apiHostUrl = getRoot(self).config.apiHostUrl
+      const clientAppID = getRoot(self).config.clientAppID
+      self.client = createClient({
+        hostUrl: apiHostUrl,
+        clientAppID,
+      })
+    }
+  }))
+
+export default Auth

--- a/packages/app-project/stores/Config.js
+++ b/packages/app-project/stores/Config.js
@@ -1,0 +1,9 @@
+import { types } from 'mobx-state-tree'
+
+const Config = types
+  .model('Config', {
+    apiHostUrl: types.optional(types.string, ''),
+    clientAppID: types.optional(types.string, ''),
+  })
+
+export default Config

--- a/packages/app-project/stores/Store.js
+++ b/packages/app-project/stores/Store.js
@@ -1,7 +1,9 @@
 import { addMiddleware, getEnv, types } from 'mobx-state-tree'
 import { logNodeError } from '../src/helpers/logger'
 
+import Auth from './Auth'
 import Collections from './Collections'
+import Config from './Config'
 import Project from './Project'
 import Recents from './Recents'
 import UI from './UI'
@@ -10,7 +12,9 @@ import YourStats from './YourStats'
 
 const Store = types
   .model('Store', {
+    auth: types.optional(Auth, {}),
     collections: types.optional(Collections, {}),
+    config: types.optional(Config, {}),
     project: types.optional(Project, {}),
     recents: types.optional(Recents, {}),
     ui: types.optional(UI, {}),

--- a/packages/lib-auth/src/client.js
+++ b/packages/lib-auth/src/client.js
@@ -110,7 +110,9 @@ class Client {
    * @param {Array|string} response.headers.set-cookie - The `set-cookie` header
    */
   _getJWTFromResponse (response) {
-    const setCookie = response.headers['set-cookie']
+    const { headers } = response
+    const setCookie = headers['set-cookie'] || []
+    console.info('_getJWTFromResponse', 'response', response)
     const cookies = (setCookie instanceof Array) ? setCookie : [setCookie]
     return cookies.reduce((jwt, cookieString) => {
       if (jwt) {
@@ -268,7 +270,7 @@ class Client {
    * @param {Object} credentials - The credentials for the user logging in.
    * @param {string} credentials.login - The user's username or email address.
    * @param {string} credentials.password - The user's password.
-   * @returns {Promise} Resolves to the new access token.
+   * @returns {Promise} Resolves to the user resource.
    */
   async signIn (credentials) {
     if (this.isSignedIn()) {
@@ -285,8 +287,11 @@ class Client {
       }
     }
     const response = await this._httpClient.post('/users/sign_in', data)
-    const jwt = this._getJWTFromResponse(response)
-    return this.resumeSession(jwt)
+    const jwt = this._getJWTFromBrowser() || this._getJWTFromResponse(response)
+    await this.resumeSession(jwt)
+    const user = response.data.users[0]
+    console.info(user)
+    return user
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -357,9 +357,9 @@
   integrity sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==
 
 "@babel/parser@^7.4.4":
-  version "7.8.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.0.tgz#54682775f1fb25dd29a93a02315aab29a6a292bb"
-  integrity sha512-VVtsnUYbd1+2A2vOVhm4P2qNXQE8L/W859GpUHfUcdhX8d3pEKThZuIr6fztocWx9HbK+00/CR0tXnhAggJ4CA==
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.3.tgz#790874091d2001c9be6ec426c2eed47bc7679081"
+  integrity sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==
 
 "@babel/parser@^7.7.7":
   version "7.7.7"
@@ -4558,9 +4558,9 @@ axios@^0.19.0, axios@^0.19.0-beta.1:
     is-buffer "^2.0.2"
 
 axios@~0.19.0:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.1.tgz#8a6a04eed23dfe72747e1dd43c604b8f1677b5aa"
-  integrity sha512-Yl+7nfreYKaLRvAvjNPkvfjnQHJM1yLBY3zhqAwcJSwR/6ETkanUgylgtIvkvz0xJ+p/vZuNw8X7Hnb7Whsbpw==
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   dependencies:
     follow-redirects "1.5.10"
 


### PR DESCRIPTION
**Experimental for now!**

Related to #1380, this adds the new auth client to the projects app.

- [ ] Be able to server-side render as authenticated user
- [x] Be able to sign in on the client
- [ ] Make authenticated requests on the server
# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
