### PR TITLE
Drawing: Add delete button specs

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 const StyledGroup = styled('g')`
@@ -67,11 +68,17 @@ function DeleteButton ({ label, mark, scale, rotate, onDelete }) {
   )
 }
 
+DeleteButton.propTypes = {
+  label: PropTypes.string.isRequired,
+  mark: PropTypes.object.isRequired,
+  onDelete: PropTypes.func,
+  rotate: PropTypes.number,
+  scale: PropTypes.number
+}
 DeleteButton.defaultProps = {
-  x: 0,
-  y: 0,
+  onDelete: () => true,
   rotate: 0,
-  destroyTransitionDuration: 300
+  scale: 1
 }
 
 export default DeleteButton

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.spec.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { expect } from 'chai'
+import sinon from 'sinon'
+import { Point } from '@plugins/drawingTools/models/marks'
+import DeleteButton from './DeleteButton'
+
+describe('Drawing tools > Delete button', function () {
+  const mark = Point.create({ id: 'point1', x: 50, y: 50 })
+
+  it('should render without crashing', function () {
+    const wrapper = shallow(<DeleteButton label='Delete' mark={mark} />)
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should be positioned by its mark', function () {
+    const { x, y } = mark.deleteButtonPosition(1)
+    const wrapper = shallow(<DeleteButton label='Delete' mark={mark} />)
+    const transform = wrapper.root().prop('transform')
+    expect(transform).to.have.string(`translate(${x}, ${y})`)
+  })
+
+  describe('on pointer down', function () {
+    it('should call onDelete', function () {
+      const fakeEvent = new Event('pointerdown')
+      const onDelete = sinon.stub()
+      const wrapper = shallow(<DeleteButton label='Delete' mark={mark} onDelete={onDelete} />)
+      wrapper.simulate('pointerdown', fakeEvent)
+      expect(onDelete).to.have.been.calledOnce()
+    })
+  })
+
+  describe('on key down', function () {
+    it('should call onDelete for Enter', function () {
+      const fakeEvent = new Event('keydown')
+      fakeEvent.key = 'Enter'
+      const onDelete = sinon.stub()
+      const wrapper = shallow(<DeleteButton label='Delete' mark={mark} onDelete={onDelete} />)
+      wrapper.simulate('keydown', fakeEvent)
+      expect(onDelete).to.have.been.calledOnce()
+    })
+
+    it('should call onDelete for space', function () {
+      const fakeEvent = new Event('keydown')
+      fakeEvent.key = ' '
+      const onDelete = sinon.stub()
+      const wrapper = shallow(<DeleteButton label='Delete' mark={mark} onDelete={onDelete} />)
+      wrapper.simulate('keydown', fakeEvent)
+      expect(onDelete).to.have.been.calledOnce()
+    })
+
+    it('should ignore any other key', function () {
+      const fakeEvent = new Event('keydown')
+      fakeEvent.key = 'Tab'
+      const onDelete = sinon.stub()
+      const wrapper = shallow(<DeleteButton label='Delete' mark={mark} onDelete={onDelete} />)
+      wrapper.simulate('keydown', fakeEvent)
+      expect(onDelete).to.have.not.been.called()
+    })
+  })
+})


### PR DESCRIPTION
Define prop types and defaults for the drawing delete button.
Add specs for the delete button.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
