### PR TITLE
Add an ADR for task plugins

### DIFF
--- a/docs/arch/README.md
+++ b/docs/arch/README.md
@@ -22,3 +22,4 @@
 - [ADR 20: Transcription Task](adr-20.md)
 - [ADR 21: Auth Client](adr-21.md)
 - [ADR 22: Drawing tools](adr-22.md)
+- [ADR 23: Task plugins](adr-23.md)

--- a/docs/arch/adr-23.md
+++ b/docs/arch/adr-23.md
@@ -1,0 +1,40 @@
+# ADR-23 Tasks as classifier plugins
+
+## Context
+We'd like the new classifier to be easily extensible. However, adding new tasks to the classifier involved updating the code in several places:
+- add new code in three places:
+  - [task views](https://github.com/zooniverse/front-end-monorepo/blob/2e2ac27a442afc8cfaea6f7735b97ebb511367a8/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks).
+  - [task models](https://github.com/zooniverse/front-end-monorepo/blob/2e2ac27a442afc8cfaea6f7735b97ebb511367a8/packages/lib-classifier/src/store/tasks).
+  - [annotation models](https://github.com/zooniverse/front-end-monorepo/blob/2e2ac27a442afc8cfaea6f7735b97ebb511367a8/packages/lib-classifier/src/store/annotations).
+- import the new modules by name in several places, and register them:
+  - [registered views](https://github.com/zooniverse/front-end-monorepo/blob/2e2ac27a442afc8cfaea6f7735b97ebb511367a8/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/helpers/getTaskComponent.js).
+  - [import tasks models for workflow steps](https://github.com/zooniverse/front-end-monorepo/blob/2e2ac27a442afc8cfaea6f7735b97ebb511367a8/packages/lib-classifier/src/store/WorkflowStepStore.js#L5-L18).
+  - [import all annotations to the classification model](https://github.com/zooniverse/front-end-monorepo/blob/2e2ac27a442afc8cfaea6f7735b97ebb511367a8/packages/lib-classifier/src/store/Classification.js#L3).
+  - [register annotations with the classifications store](https://github.com/zooniverse/front-end-monorepo/blob/2e2ac27a442afc8cfaea6f7735b97ebb511367a8/packages/lib-classifier/src/store/ClassificationStore.js#L111-L120).
+
+It was easy to forget one of these steps and a lot of this could be automated in code.
+
+## Proposed solution
+
+- Keep all the code together. Store task views and models next to each other in the filesystem. (#1212)
+- Import named modules to a registry object (or similar) then load them in to other code from that register. (#1212)
+- Delegate responsibility from the classification to individual tasks. (#1228)
+
+## Implementation
+
+- Task code was moved to `lib-classifier/src/plugins/tasks`. Each task has its own directory, with these subdirectories:
+  - _components_: React components to render the task.
+  - _models_: MobX State Tree models for the task. One Task model and one Annotation model.
+- a _taskRegistry_ object was added, which is described in the [tasks README](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/plugins/tasks/readme.md).
+- Responsibility for creating new annotations was removed from the classifications store, removing the need for the classifications store to know about different types of tasks and how to create an annotation for each. New methods were added to the task models to delegate responsibility and make tasks more flexible:
+  - _task.createAnnotation()_ creates a new annotation of the correct type for a specific task.
+  - _task.defaultAnnotation_ (read-only) returns the default annotation for a specific task.
+
+## Suggestions
+
+- A similar architecture could be used to register subject viewers with the classifier.
+- Tasks could be removed completely from the classifier. When a workflow loads, its tasks could be instantiated outside the classifier and only the tasks needed for the workflow could be passed in as props.
+- The classifier could make better use of the MobX State Tree. A classification could store the tasks used to generate that classification, each task holding a reference to its own annotation. This opens up the possibility of more flexible code for tracking workflow history and handling recursive workflows. We could also take advantage of the tree (via _getParent()_ or _getParentOfType()_) to easily reference the task that generated a specific annotation, or the classification that a task is currently doing work for.
+- the registry model has no equivalent for `import { SingleChoiceAnnotation, MultipleChoiceAnnotation, TextAnnotation } from '@plugins/tasks/models/annotations'`. It would be helpful, but not necessary, to be able to do this when setting up classifier stores.
+- the task registry is only available after the task models have been set up and initialised, limiting its usefulness when accessing models in order to set up other models, such as drawing tools.
+

--- a/docs/arch/adr-23.md
+++ b/docs/arch/adr-23.md
@@ -14,13 +14,13 @@ We'd like the new classifier to be easily extensible. However, adding new tasks 
 
 It was easy to forget one of these steps and a lot of this could be automated in code.
 
-## Proposed solution
+## Decision
 
 - Keep all the code together. Store task views and models next to each other in the filesystem. (#1212)
 - Import named modules to a registry object (or similar) then load them in to other code from that register. (#1212)
 - Delegate responsibility from the classification to individual tasks. (#1228)
 
-## Implementation
+### Implementation
 
 - Task code was moved to `lib-classifier/src/plugins/tasks`. Each task has its own directory, with these subdirectories:
   - _components_: React components to render the task.
@@ -30,11 +30,14 @@ It was easy to forget one of these steps and a lot of this could be automated in
   - _task.createAnnotation()_ creates a new annotation of the correct type for a specific task.
   - _task.defaultAnnotation_ (read-only) returns the default annotation for a specific task.
 
-## Suggestions
+## Status
+
+Accepted
+
+## Consequences
 
 - A similar architecture could be used to register subject viewers with the classifier.
 - Tasks could be removed completely from the classifier. When a workflow loads, its tasks could be instantiated outside the classifier and only the tasks needed for the workflow could be passed in as props.
 - The classifier could make better use of the MobX State Tree. A classification could store the tasks used to generate that classification, each task holding a reference to its own annotation. This opens up the possibility of more flexible code for tracking workflow history and handling recursive workflows. We could also take advantage of the tree (via _getParent()_ or _getParentOfType()_) to easily reference the task that generated a specific annotation, or the classification that a task is currently doing work for.
 - the registry model has no equivalent for `import { SingleChoiceAnnotation, MultipleChoiceAnnotation, TextAnnotation } from '@plugins/tasks/models/annotations'`. It would be helpful, but not necessary, to be able to do this when setting up classifier stores.
 - the task registry is only available after the task models have been set up and initialised, limiting its usefulness when accessing models in order to set up other models, such as drawing tools.
-


### PR DESCRIPTION
An ADR describing why `plugins/tasks` was added to the classifier, with some questions about how it might be changed or improved.

Package:
lib-classifier

Closes #1351.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
