### PR TITLE
Name anonymous forwardRef functions

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/DragHandle/DragHandle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DragHandle/DragHandle.js
@@ -10,7 +10,7 @@ const StyledCircle = styled('circle')`
 const RADIUS = screen.width > 900 ? 4 : 10
 const OVERSHOOT = screen.width > 900 ? 4 : 10
 
-const DragHandle = forwardRef(({ scale, x, y }, ref) => {
+const DragHandle = forwardRef(function DragHandle({ scale, x, y }, ref) {
 
   const styleProps = {
     fill: 'currentColor',

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.js
@@ -15,7 +15,7 @@ const StyledGroup = styled('g')`
   }
 `
 
-const DrawingToolRoot = forwardRef(({
+const DrawingToolRoot = forwardRef(function DrawingToolRoot({
   children,
   dragging,
   isActive,
@@ -26,7 +26,7 @@ const DrawingToolRoot = forwardRef(({
   onSelect,
   svg,
   tool
-}, ref) => {
+}, ref) {
   const mainStyle = {
     color: tool && tool.color ? tool.color : 'green',
     fill: 'transparent',

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -106,7 +106,7 @@ function draggable (WrappedComponent) {
     dragMove: () => true,
     dragEnd: () => true
   }
-  const name = WrappedComponent.displayName || WrappedComponent.name
+  const name = WrappedComponent.displayName || WrappedComponent.name || WrappedComponent.render.name
   Draggable.displayName = `draggable(${name})`
   Draggable.wrappedComponent = WrappedComponent
 


### PR DESCRIPTION
Add names for the forwardrefs in the DragHandle and DrawingToolRoot components.
Add Component.render.name as a third option when trying to figure out a component's name.

Package:
lib-classifier

Closes #1386.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
