### PR TITLE
Add subject image rotation

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -36,7 +36,7 @@ class ImageToolbar extends Component {
           <MoveButton />
           <ZoomInButton />
           <ZoomOutButton />
-          <RotateButton disabled />
+          <RotateButton />
           <FullscreenButton disabled />
           <ResetButton />
         </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButtonContainer.js
@@ -6,10 +6,13 @@ import RotateButton from './RotateButton'
 
 function storeMapper (stores) {
   const {
-    rotate
+    rotate,
+    rotationEnabled
   } = stores.classifierStore.subjectViewer
 
+  const disabled = !rotationEnabled
   return {
+    disabled,
     rotate
   }
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.spec.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme'
 import React from 'react'
 
 import SubjectViewer from './SubjectViewer'
+import SingleImageViewer from './components/SingleImageViewer'
 
 describe('Component > SubjectViewer', function () {
   it('should render without crashing', function () {
@@ -27,6 +28,6 @@ describe('Component > SubjectViewer', function () {
 
   it('should render a subject viewer if the subject store successfully loads', function () {
     const wrapper = shallow(<SubjectViewer.wrappedComponent subjectQueueState={asyncStates.success} subject={{ viewer: 'singleImage' }} />)
-    expect(wrapper.find('SingleImageViewerContainer')).to.have.lengthOf(1)
+    expect(wrapper.find(SingleImageViewer)).to.have.lengthOf(1)
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -9,12 +9,14 @@ const SVG = styled.svg`
   width: 100%;
 `
 
-const SingleImageViewer = forwardRef(function SingleImageViewer ({ children, height, scale, width }, ref) {
+const SingleImageViewer = forwardRef(function SingleImageViewer ({ children, height, rotate, scale, width }, ref) {
   const viewBox = `0 0 ${width} ${height}`
+  const transform = `rotate(${rotate})`
   return (
     <SVG
       ref={ref}
       viewBox={viewBox}
+      transform={transform}
     >
       {children}
       <InteractionLayer
@@ -28,11 +30,13 @@ const SingleImageViewer = forwardRef(function SingleImageViewer ({ children, hei
 
 SingleImageViewer.propTypes = {
   height: PropTypes.number.isRequired,
+  rotate: PropTypes.number,
   scale: PropTypes.number,
   width: PropTypes.number.isRequired
 }
 
 SingleImageViewer.defaultProps = {
+  rotate: 0,
   scale: 1
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -4,27 +4,30 @@ import styled from 'styled-components'
 
 import InteractionLayer from '../InteractionLayer'
 
-const SVG = styled.svg`
-  height: 100%;
-  width: 100%;
+const Container = styled.div`
+height: 100%;
+overflow: hidden;
+width: 100%;
 `
 
 const SingleImageViewer = forwardRef(function SingleImageViewer ({ children, height, rotate, scale, width }, ref) {
   const viewBox = `0 0 ${width} ${height}`
   const transform = `rotate(${rotate})`
   return (
-    <SVG
-      ref={ref}
-      viewBox={viewBox}
-      transform={transform}
-    >
-      {children}
-      <InteractionLayer
-        scale={scale}
-        height={height}
-        width={width}
-      />
-    </SVG>
+    <Container>
+      <svg
+        ref={ref}
+        transform={transform}
+        viewBox={viewBox}
+      >
+        {children}
+        <InteractionLayer
+          scale={scale}
+          height={height}
+          width={width}
+        />
+      </svg>
+    </Container>
   )
 })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -12,7 +12,7 @@ width: 100%;
 
 const SingleImageViewer = forwardRef(function SingleImageViewer ({ children, height, rotate, scale, width }, ref) {
   const viewBox = `0 0 ${width} ${height}`
-  const transform = `rotate(${rotate})`
+  const transform = `rotate(${rotate} 0 0)`
   return (
     <Container>
       <svg

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.spec.js
@@ -16,7 +16,7 @@ describe('Component > SingleImageViewer', function () {
   
   it('should be upright', function () {
     const transform = wrapper.find('svg').prop('transform')
-    expect(transform).to.have.string('rotate(0)')
+    expect(transform).to.have.string('rotate(0 0 0)')
   })
 
   describe('with a rotation angle', function () {
@@ -26,7 +26,7 @@ describe('Component > SingleImageViewer', function () {
 
     it('should be rotated', function () {
     const transform = wrapper.find('svg').prop('transform')
-    expect(transform).to.have.string('rotate(-90)')
+    expect(transform).to.have.string('rotate(-90 0 0)')
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.spec.js
@@ -7,7 +7,7 @@ let wrapper
 
 describe('Component > SingleImageViewer', function () {
   beforeEach(function () {
-    wrapper = shallow(<SingleImageViewer />)
+    wrapper = shallow(<SingleImageViewer width={100} height={200} />)
   })
 
   it('should render without crashing', function () {
@@ -15,7 +15,7 @@ describe('Component > SingleImageViewer', function () {
   })
   
   it('should be upright', function () {
-    const transform = wrapper.root().prop('transform')
+    const transform = wrapper.find('svg').prop('transform')
     expect(transform).to.have.string('rotate(0)')
   })
 
@@ -25,7 +25,7 @@ describe('Component > SingleImageViewer', function () {
     })
 
     it('should be rotated', function () {
-    const transform = wrapper.root().prop('transform')
+    const transform = wrapper.find('svg').prop('transform')
     expect(transform).to.have.string('rotate(-90)')
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.spec.js
@@ -13,4 +13,20 @@ describe('Component > SingleImageViewer', function () {
   it('should render without crashing', function () {
     expect(wrapper).to.be.ok()
   })
+  
+  it('should be upright', function () {
+    const transform = wrapper.root().prop('transform')
+    expect(transform).to.have.string('rotate(0)')
+  })
+
+  describe('with a rotation angle', function () {
+    beforeEach(function () {
+      wrapper.setProps({ rotate: -90 })
+    })
+
+    it('should be rotated', function () {
+    const transform = wrapper.root().prop('transform')
+    expect(transform).to.have.string('rotate(-90)')
+    })
+  })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -1,4 +1,5 @@
 import asyncStates from '@zooniverse/async-states'
+import { inject, observer } from 'mobx-react'
 import React from 'react'
 import PropTypes from 'prop-types'
 
@@ -6,6 +7,18 @@ import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import SingleImageViewer from './SingleImageViewer'
 import locationValidator from '../../helpers/locationValidator'
 
+function storeMapper (stores) {
+  const {
+    rotation
+  } = stores.classifierStore.subjectViewer
+
+  return {
+    rotation
+  }
+}
+
+@inject(storeMapper)
+@observer
 class SingleImageViewerContainer extends React.Component {
   constructor () {
     super()
@@ -67,7 +80,7 @@ class SingleImageViewerContainer extends React.Component {
   }
 
   render () {
-    const { loadingState, onError, subject } = this.props
+    const { loadingState, onError, rotation, subject } = this.props
     const { img } = this.state
     const { naturalHeight, naturalWidth, src } = img
     const subjectImageElement = this.subjectImage.current
@@ -95,6 +108,7 @@ class SingleImageViewerContainer extends React.Component {
         <SingleImageViewer
           ref={this.imageViewer}
           height={naturalHeight}
+          rotate={rotation}
           scale={scale}
           width={naturalWidth}
         >
@@ -110,7 +124,7 @@ class SingleImageViewerContainer extends React.Component {
   }
 }
 
-SingleImageViewerContainer.propTypes = {
+SingleImageViewerContainer.wrappedComponent.propTypes = {
   loadingState: PropTypes.string,
   onError: PropTypes.func,
   onReady: PropTypes.func,
@@ -119,7 +133,7 @@ SingleImageViewerContainer.propTypes = {
   })
 }
 
-SingleImageViewerContainer.defaultProps = {
+SingleImageViewerContainer.wrappedComponent.defaultProps = {
   ImageObject: window.Image,
   loadingState: asyncStates.initialized,
   onError: () => true,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -9,10 +9,12 @@ import locationValidator from '../../helpers/locationValidator'
 
 function storeMapper (stores) {
   const {
+    enableRotation,
     rotation
   } = stores.classifierStore.subjectViewer
 
   return {
+    enableRotation,
     rotation
   }
 }
@@ -30,6 +32,7 @@ class SingleImageViewerContainer extends React.Component {
   }
 
   componentDidMount () {
+    this.props.enableRotation()
     this.onLoad()
   }
 
@@ -125,6 +128,7 @@ class SingleImageViewerContainer extends React.Component {
 }
 
 SingleImageViewerContainer.wrappedComponent.propTypes = {
+  enableRotation: PropTypes.func,
   loadingState: PropTypes.string,
   onError: PropTypes.func,
   onReady: PropTypes.func,
@@ -134,6 +138,7 @@ SingleImageViewerContainer.wrappedComponent.propTypes = {
 }
 
 SingleImageViewerContainer.wrappedComponent.defaultProps = {
+  enableRotation: () => null,
   ImageObject: window.Image,
   loadingState: asyncStates.initialized,
   onError: () => true,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -36,7 +36,7 @@ describe('Component > SingleImageViewerContainer', function () {
     const onError = sinon.stub()
 
     before(function () {
-      wrapper = shallow(<SingleImageViewerContainer onError={onError} />)
+      wrapper = shallow(<SingleImageViewerContainer.wrappedComponent onError={onError} />)
     })
 
     it('should render without crashing', function () {
@@ -61,7 +61,7 @@ describe('Component > SingleImageViewerContainer', function () {
         ]
       }
       wrapper = shallow(
-        <SingleImageViewerContainer
+        <SingleImageViewerContainer.wrappedComponent
           ImageObject={ValidImage}
           subject={subject}
           onError={onError}
@@ -174,7 +174,7 @@ describe('Component > SingleImageViewerContainer', function () {
         ]
       }
       wrapper = shallow(
-        <SingleImageViewerContainer
+        <SingleImageViewerContainer.wrappedComponent
           ImageObject={InvalidImage}
           subject={subject}
           onError={onError}

--- a/packages/lib-classifier/src/store/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.js
@@ -15,7 +15,8 @@ const SubjectViewer = types
     fullscreen: types.optional(types.boolean, false),
     layout: types.optional(types.enumeration('layout', layouts.values), layouts.default),
     loadingState: types.optional(types.enumeration('loadingState', asyncStates.values), asyncStates.initialized),
-    move: types.optional(types.boolean, false)
+    move: types.optional(types.boolean, false),
+    rotation: types.optional(types.number, 0)
   })
 
   .volatile(self => ({
@@ -94,10 +95,12 @@ const SubjectViewer = types
       resetView () {
         console.log('resetting view')
         self.onZoom && self.onZoom('zoomto', 1.0)
+        self.rotation = 0
       },
 
       rotate () {
         console.log('rotating subject')
+        self.rotation -= 90
       },
 
       setLayout (layout = layouts.DefaultLayout) {

--- a/packages/lib-classifier/src/store/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.js
@@ -95,6 +95,7 @@ const SubjectViewer = types
       resetSubject () {
         self.loadingState = asyncStates.loading
         self.dimensions = []
+        self.rotation = 0
       },
 
       resetView () {

--- a/packages/lib-classifier/src/store/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.js
@@ -16,6 +16,7 @@ const SubjectViewer = types
     layout: types.optional(types.enumeration('layout', layouts.values), layouts.default),
     loadingState: types.optional(types.enumeration('loadingState', asyncStates.values), asyncStates.initialized),
     move: types.optional(types.boolean, false),
+    rotationEnabled: types.optional(types.boolean, false),
     rotation: types.optional(types.number, 0)
   })
 
@@ -64,6 +65,10 @@ const SubjectViewer = types
       enableMove () {
         self.annotate = false
         self.move = true
+      },
+
+      enableRotation () {
+        self.rotationEnabled = true
       },
 
       disableFullscreen () {

--- a/packages/lib-classifier/src/store/SubjectViewerStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.spec.js
@@ -73,6 +73,12 @@ describe('Model > SubjectViewerStore', function () {
       expect(subjectViewerStore.loadingState).to.equal(asyncStates.loading)
       expect(subjectViewerStore.dimensions).to.have.lengthOf(0)
     })
+
+    it('should reset the rotation angle when there is a new active subject', function () {
+      subjectViewerStore.rotate()
+      subjectViewerStore.resetSubject()
+      expect(subjectViewerStore.rotation).to.equal(0)
+    })
   })
 
   describe('Actions > resetView', function () {

--- a/packages/lib-classifier/src/store/SubjectViewerStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.spec.js
@@ -24,6 +24,20 @@ describe('Model > SubjectViewerStore', function () {
     })
   })
 
+  describe('Actions > enableRotation', function () {
+    let subjectViewerStore
+
+    before(function () {
+      subjectViewerStore = SubjectViewerStore.create()
+    })
+
+    it('should enable subject rotation', function () {
+      expect(subjectViewerStore.rotationEnabled).to.be.false()
+      subjectViewerStore.enableRotation()
+      expect(subjectViewerStore.rotationEnabled).to.be.true()
+    })
+  })
+
   describe('Actions > rotate', function () {
     let subjectViewerStore
 

--- a/packages/lib-classifier/src/store/SubjectViewerStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.spec.js
@@ -24,6 +24,21 @@ describe('Model > SubjectViewerStore', function () {
     })
   })
 
+  describe('Actions > rotate', function () {
+    let subjectViewerStore
+
+    before(function () {
+      subjectViewerStore = SubjectViewerStore.create()
+    })
+
+    it('should rotate the subject by -90 degrees', function () {
+      expect(subjectViewerStore.rotation).to.equal(0)
+      subjectViewerStore.rotate()
+      expect(subjectViewerStore.rotation).to.equal(-90)
+      subjectViewerStore.resetView()
+    })
+  })
+
   describe('Actions > resetSubject', function () {
     let subjectViewerStub
     let subjectViewerStore
@@ -43,6 +58,20 @@ describe('Model > SubjectViewerStore', function () {
       subjectViewerStore.resetSubject()
       expect(subjectViewerStore.loadingState).to.equal(asyncStates.loading)
       expect(subjectViewerStore.dimensions).to.have.lengthOf(0)
+    })
+  })
+
+  describe('Actions > resetView', function () {
+    let subjectViewerStore
+
+    before(function () {
+      subjectViewerStore = SubjectViewerStore.create()
+    })
+
+    it('should reset subject rotation', function () {
+      subjectViewerStore.rotate()
+      subjectViewerStore.resetView()
+      expect(subjectViewerStore.rotation).to.equal(0)
     })
   })
 })


### PR DESCRIPTION
Add a `rotate()` transform to SVG subject images.
Add a `rotation` angle and `rotate()` action to the SubjectViewer store.
Enable the rotation button in the image toolbar.

TODO:
- [x] conditionally disable rotation for subject viewers that don't use it.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
