### PR TITLE
Drawing: Replace svg props with SVGContext

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -1,21 +1,23 @@
 import cuid from 'cuid'
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
 import styled from 'styled-components'
+import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import DrawingToolMarks from './components/DrawingToolMarks'
 
 const StyledRect = styled('rect')`
   cursor: ${props => props.disabled ? 'not-allowed' : 'crosshair'};
 `
 
-function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, scale, svg, width }) {
+function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, scale, width }) {
   const [ activeMark, setActiveMark ] = useState(null)
   const [ creating, setCreating ] = useState(false)
+  const { svg, getScreenCTM } = useContext(SVGContext)
 
   function convertEvent (event) {
     const type = event.type
 
-    const svgEventOffset = getEventOffset(event.clientX, event.clientY)
+    const svgEventOffset = getEventOffset(event)
 
     const svgCoordinateEvent = {
       pointerId: event.pointerId,
@@ -27,11 +29,11 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, sc
     return svgCoordinateEvent
   }
 
-  function getEventOffset (x, y) {
-    const svgEvent = svg.createSVGPoint()
-    svgEvent.x = x
-    svgEvent.y = y
-    const svgEventOffset = svgEvent.matrixTransform(svg.getScreenCTM().inverse())
+  function getEventOffset (event) {
+    const svgPoint = svg.createSVGPoint()
+    svgPoint.x = event.clientX
+    svgPoint.y = event.clientY
+    const svgEventOffset = svgPoint.matrixTransform(svg.getScreenCTM().inverse())
     return svgEventOffset
   }
 
@@ -82,7 +84,6 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, sc
               onDelete={() => setActiveMark(null)}
               onSelectMark={mark => setActiveMark(mark)}
               scale={scale}
-              svg={svg}
               tool={tool}
             />
           )
@@ -98,7 +99,6 @@ InteractionLayer.propTypes = {
   height: PropTypes.number.isRequired,
   disabled: PropTypes.bool,
   scale: PropTypes.number,
-  svg: PropTypes.instanceOf(Element).isRequired,
   width: PropTypes.number.isRequired
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -33,7 +33,7 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, sc
     const svgPoint = svg.createSVGPoint()
     svgPoint.x = event.clientX
     svgPoint.y = event.clientY
-    const svgEventOffset = svgPoint.matrixTransform(svg.getScreenCTM().inverse())
+    const svgEventOffset = svgPoint.matrixTransform(getScreenCTM().inverse())
     return svgEventOffset
   }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -42,7 +42,7 @@ describe('Component > InteractionLayer', function () {
   }
   const svg = document.createElementNS("http://www.w3.org/2000/svg","svg")
   svg.createSVGPoint = () => mockSVGPoint
-  svg.getScreenCTM = () => mockScreenCTM
+  const getScreenCTM = () => mockScreenCTM
 
   describe('when enabled', function () {
     beforeEach(function () {
@@ -68,7 +68,7 @@ describe('Component > InteractionLayer', function () {
       activeTool = mockDrawingTask.activeTool
       sinon.stub(activeTool, 'createMark').callsFake(() => mockMark)
       wrapper = mount(
-        <SVGContext.Provider value={{ svg }}>
+        <SVGContext.Provider value={{ svg, getScreenCTM }}>
           <svg>
             <InteractionLayer
               activeDrawingTask={mockDrawingTask}
@@ -152,7 +152,7 @@ describe('Component > InteractionLayer', function () {
       sinon.stub(activeTool, 'createMark').callsFake(() => mockMark)
       activeTool.createMark.resetHistory()
       wrapper = mount(
-        <SVGContext.Provider value={{ svg }}>
+        <SVGContext.Provider value={{ svg, getScreenCTM }}>
           <svg>
             <InteractionLayer
               activeDrawingTask={mockDrawingTask}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
@@ -1,10 +1,12 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import { DeleteButton, DrawingToolRoot } from '@plugins/drawingTools/components'
+import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 
-function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMark, scale, svg, tool }) {
+function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMark, scale, tool }) {
   const marksArray = Array.from(tool.marks.values())
+  const { svg } = useContext(SVGContext)
 
   return marksArray.map((mark, index) => {
     const MarkingComponent = observer(mark.toolComponent)
@@ -54,21 +56,18 @@ function DrawingToolMarks ({ activeMarkId, onDelete, onDeselectMark, onSelectMar
         onDelete={deleteMark}
         onDeselect={onDeselectMark}
         onSelect={onSelectMark}
-        svg={svg}
         tool={tool}
       >
         <MarkingComponent
           active={isActive}
           mark={mark}
           scale={scale}
-          svg={svg}
           tool={tool}
         />
         {isActive && <ObservedDeleteButton
           label={`Delete ${tool.type}`}
           mark={mark}
           scale={scale}
-          svg={svg}
           onDelete={deleteMark}
         />}
       </DrawingToolRoot>
@@ -82,7 +81,6 @@ DrawingToolMarks.propTypes = {
   onDeselectMark: PropTypes.func,
   onSelectMark: PropTypes.func,
   scale: PropTypes.number,
-  svg: PropTypes.instanceOf(Element).isRequired,
   tool: PropTypes.object.isRequired
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
@@ -1,12 +1,14 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 import sinon from 'sinon'
 import { LineTool } from '@plugins/drawingTools/models/tools'
 import { Line } from '@plugins/drawingTools/models/marks'
 import { DrawingToolRoot } from '@plugins/drawingTools/components'
+import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import DrawingToolMarks from './DrawingToolMarks'
 
 describe('Components > DrawingToolMarks', function () {
+  let mockContext
   let svg
   let tool
 
@@ -22,28 +24,29 @@ describe('Components > DrawingToolMarks', function () {
     lineTool.createMark({ id: 'line1' }),
     lineTool.createMark({ id: 'line2' }),
     tool = lineTool
+    mockContext = { svg }
   })
 
   it('should render without crashing', function () {
-    const wrapper = shallow(<DrawingToolMarks tool={tool} svg={svg} />)
+    const wrapper = shallow(<DrawingToolMarks tool={tool} />)
     expect(wrapper).to.be.ok()
   })
   
   it('should render two lines', function () {
-    const wrapper = shallow(<DrawingToolMarks tool={tool} svg={svg} />)
+    const wrapper = shallow(<DrawingToolMarks tool={tool} />)
     const marks = wrapper.find('Line')
     expect(marks.length).to.equal(2)
   })
 
   describe('with an active mark', function () {
     it('should show that mark as active', function () {
-      const wrapper = shallow(<DrawingToolMarks activeMarkId='line1' tool={tool} svg={svg} />)
+      const wrapper = shallow(<DrawingToolMarks activeMarkId='line1' tool={tool} />)
       const mark = wrapper.find('Line').first()
       expect(mark.prop('active')).to.be.true()
     })
 
     it('should render a delete button', function () {
-      const wrapper = shallow(<DrawingToolMarks activeMarkId='line1' tool={tool} svg={svg} />)
+      const wrapper = shallow(<DrawingToolMarks activeMarkId='line1' tool={tool} />)
       const line = tool.marks.get('line1')
       const deleteButton = wrapper.find('DeleteButton')
       expect(deleteButton.prop('mark')).to.equal(line)
@@ -60,13 +63,16 @@ describe('Components > DrawingToolMarks', function () {
       deleteMark = sinon.spy(tool, 'deleteMark')
       onDeselectMark = sinon.stub()
       onDelete = sinon.stub()
-      const wrapper = shallow(
-        <DrawingToolMarks
-          onDelete={onDelete}
-          onDeselectMark={onDeselectMark}
-          tool={tool}
-          svg={svg}
-        />
+      const wrapper = mount(
+        <SVGContext.Provider value={mockContext}>
+          <svg>
+            <DrawingToolMarks
+              onDelete={onDelete}
+              onDeselectMark={onDeselectMark}
+              tool={tool}
+            />
+          </svg>
+        </SVGContext.Provider>
       )
       dragEnd = wrapper.find(DrawingToolRoot).first().prop('dragEnd')
     })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { createContext, forwardRef } from 'react'
+import React, { forwardRef } from 'react'
 import styled from 'styled-components'
 
 import InteractionLayer from '../InteractionLayer'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { forwardRef } from 'react'
+import React, { createContext, forwardRef } from 'react'
 import styled from 'styled-components'
 
 import InteractionLayer from '../InteractionLayer'
@@ -20,7 +20,6 @@ const SingleImageViewer = forwardRef(function SingleImageViewer ({ children, hei
       <InteractionLayer
         scale={scale}
         height={height}
-        svg={ref ? ref.current : null}
         width={width}
       />
     </SVG>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -88,7 +88,7 @@ class SingleImageViewerContainer extends React.Component {
     }
 
     const svg = this.imageViewer.current
-    const { getScreenCTM } = svg ? svg : {}
+    const getScreenCTM = () => svg.getScreenCTM()
     
     return (
       <SVGContext.Provider value={{ svg, getScreenCTM }}>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -2,6 +2,7 @@ import asyncStates from '@zooniverse/async-states'
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import SingleImageViewer from './SingleImageViewer'
 import locationValidator from '../../helpers/locationValidator'
 
@@ -86,20 +87,25 @@ class SingleImageViewerContainer extends React.Component {
       return null
     }
 
+    const svg = this.imageViewer.current
+    const { getScreenCTM } = svg ? svg : {}
+    
     return (
-      <SingleImageViewer
-        ref={this.imageViewer}
-        height={naturalHeight}
-        scale={scale}
-        width={naturalWidth}
-      >
-        <image
-          ref={this.subjectImage}
+      <SVGContext.Provider value={{ svg, getScreenCTM }}>
+        <SingleImageViewer
+          ref={this.imageViewer}
           height={naturalHeight}
+          scale={scale}
           width={naturalWidth}
-          xlinkHref={src}
-        />
-      </SingleImageViewer>
+        >
+          <image
+            ref={this.subjectImage}
+            height={naturalHeight}
+            width={naturalWidth}
+            xlinkHref={src}
+          />
+        </SingleImageViewer>
+      </SVGContext.Provider>
     )
   }
 }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.js
@@ -24,7 +24,6 @@ const DrawingToolRoot = forwardRef(function DrawingToolRoot({
   onDelete,
   onDeselect,
   onSelect,
-  svg,
   tool
 }, ref) {
   const mainStyle = {

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.js
@@ -4,7 +4,7 @@ import DragHandle from '../DragHandle'
 
 const GRAB_STROKE_WIDTH = 6
 
-function Line ({ active, children, mark, scale, svg, tool }) {
+function Line ({ active, children, mark, scale, tool }) {
   const { x1, y1, x2, y2 } = mark
 
   function onHandleDrag (coords) {
@@ -16,9 +16,9 @@ function Line ({ active, children, mark, scale, svg, tool }) {
       <line x1={x1} y1={y1} x2={x2} y2={y2} />
       <line x1={x1} y1={y1} x2={x2} y2={y2} strokeWidth={GRAB_STROKE_WIDTH / scale} strokeOpacity='0' />
       {active &&
-        <DragHandle scale={scale} svg={svg} x={x1} y={y1} dragMove={(e, d) => onHandleDrag({ x1: x1 + d.x, y1: y1 + d.y, x2, y2 })} />}
+        <DragHandle scale={scale} x={x1} y={y1} dragMove={(e, d) => onHandleDrag({ x1: x1 + d.x, y1: y1 + d.y, x2, y2 })} />}
       {active &&
-        <DragHandle scale={scale} svg={svg} x={x2} y={y2} dragMove={(e, d) => onHandleDrag({ x1, y1, x2: x2 + d.x, y2: y2 + d.y })} />}
+        <DragHandle scale={scale} x={x2} y={y2} dragMove={(e, d) => onHandleDrag({ x1, y1, x2: x2 + d.x, y2: y2 + d.y })} />}
       {children}
     </g>
   )

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.js
@@ -14,7 +14,7 @@ const SELECTED_RADIUS = {
 const CROSSHAIR_SPACE = 0.2
 const CROSSHAIR_WIDTH = 1
 
-function Point ({ active, children, mark, scale, svg, tool }) {
+function Point ({ active, children, mark, scale, tool }) {
   const { size } = tool
   const crosshairSpace = CROSSHAIR_SPACE / scale
   const crosshairWidth = CROSSHAIR_WIDTH / scale

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -22,7 +22,7 @@ function draggable (WrappedComponent) {
     convertEvent (event) {
       const type = event.type
 
-      const svgEventOffset = this.getEventOffset(event.clientX, event.clientY)
+      const svgEventOffset = this.getEventOffset(event)
 
       const svgCoordinateEvent = {
         pointerId: event.pointerId,
@@ -34,12 +34,13 @@ function draggable (WrappedComponent) {
       return svgCoordinateEvent
     }
 
-    getEventOffset (x, y) {
-      const { svg } = this.context
-      const svgEvent = svg.createSVGPoint()
-      svgEvent.x = x
-      svgEvent.y = y
-      const svgEventOffset = svgEvent.matrixTransform(svg.getScreenCTM().inverse())
+    getEventOffset (event) {
+      const { clientX, clientY } = event
+      const { svg, getScreenCTM } = this.context
+      const svgPoint = svg.createSVGPoint()
+      svgPoint.x = clientX
+      svgPoint.y = clientY
+      const svgEventOffset = svgPoint.matrixTransform(getScreenCTM().inverse())
       return svgEventOffset
     }
 

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react'
+import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 
 function draggable (WrappedComponent) {
   class Draggable extends PureComponent {
@@ -34,7 +35,7 @@ function draggable (WrappedComponent) {
     }
 
     getEventOffset (x, y) {
-      const { svg } = this.props
+      const { svg } = this.context
       const svgEvent = svg.createSVGPoint()
       svgEvent.x = x
       svgEvent.y = y
@@ -96,6 +97,8 @@ function draggable (WrappedComponent) {
       )
     }
   }
+
+  Draggable.contextType = SVGContext
 
   Draggable.defaultProps = {
     coords: {

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.spec.js
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react'
 import { mount } from 'enzyme'
 import { expect } from 'chai'
 import sinon from 'sinon'
+import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import draggable from './draggable'
 
 describe('draggable', function () {
@@ -28,13 +29,17 @@ describe('draggable', function () {
 
   before(function () {
     wrapper = mount(
-      <Draggable
-        dragStart={onStart}
-        dragMove={onMove}
-        dragEnd={onEnd}
-        svg={mockSVG}
-      />
+      <SVGContext.Provider value={{ svg: mockSVG }}>
+        <svg>
+          <Draggable
+            dragStart={onStart}
+            dragMove={onMove}
+            dragEnd={onEnd}
+          />
+        </svg>
+      </SVGContext.Provider>
     )
+    .find(Draggable)
   })
 
   describe('on pointer down', function () {

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.spec.js
@@ -25,11 +25,12 @@ describe('draggable', function () {
       inverse: sinon.stub()
     }))
   }
+  const getScreenCTM = sinon.stub().callsFake(() => ({ inverse: sinon.stub() }))
   let wrapper
 
   before(function () {
     wrapper = mount(
-      <SVGContext.Provider value={{ svg: mockSVG }}>
+      <SVGContext.Provider value={{ svg: mockSVG, getScreenCTM }}>
         <svg>
           <Draggable
             dragStart={onStart}

--- a/packages/lib-classifier/src/plugins/drawingTools/shared/SVGContext.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/shared/SVGContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react'
+
+export default createContext({})


### PR DESCRIPTION
https://github.com/zooniverse/front-end-monorepo/pull/1388#pullrequestreview-335473579 suggests moving away from transforming the SVG element directly when we transform drawings eg. by rotating the subject.

This PR removes the `svg` prop from drawing components and replaces it with `SVGContext`, which can be used to pass the transformation context to child components.

Enzyme's shallow rendering doesn't support `useContext` so a few components are now tested with a full DOM mount.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
