### PR TITLE
Drawing: add x_center, y_center to Point marks

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/README.md
+++ b/packages/lib-classifier/src/plugins/drawingTools/README.md
@@ -54,11 +54,15 @@ The [base Mark model](https://github.com/zooniverse/front-end-monorepo/tree/mast
 - _isValid (boolean)_ Read only. True if any required validations pass for this mark (eg. minimum length for a line.)
 - _tool (Tool)_ Read only. A reference to the tool that created this mark.
 - _addAnnotation(task, value)_ Add `value` to the annotation for `task`, which should be a valid task for this mark.
+- _x (number)_ Read only. X position of the mark's centre, in SVG coordinates relative to the subject image. Override this if `mark.x` should refer to a different position eg. the mark's top left corner for rectangles.
+- _y (number)_ Read only. Y position of the mark's centre, in SVG coordinates relative to the subject image. Override this if `mark.y` should refer to a different position eg. the mark's top left corner for rectangles.
 
 All marks should extend the Mark model by implementing the following views and actions:
 - _coords (Object { x, y })_ Read only. Returns the `{ x, y }` coords for this mark.
 - _deleteButtonPosition(scale) (Object { x, y })_ Given the image scale, return the `{ x, y }` position for this mark's delete button.
 - _toolComponent (React.Component)_ Read only. Returns the React component used to render this mark.
+- _x_center_ (number)_ x position of the mark's centre, in SVG coordinates relative to the subject image.
+- _y_center_ (number)_ y position of the mark's centre, in SVG coordinates relative to the subject image.
 - _initialDrag({ x, y })_ Called on drag when first creating the mark. `{ x, y }` are the new position of the dragged pointer in the frame of the subject image.
 - _initialPosition({ x, y })_ Called on initial click/tap when creating the mark. `{ x, y }` are the position of the pointer in the frame of the subject image.
 - _move(difference)_ Called on drag when moving the mark. `difference` is the change in position since the last move: `{ x, y }`.
@@ -67,5 +71,5 @@ All marks should extend the Mark model by implementing the following views and a
 In addition, mark models should extend the base Mark model with any properties specific to the new shape. These mark properties will be passed to Panoptes as the annotation for this mark. Marks may specify the following properties, which have a special meaning when rendering marks.
 
 - _angle (number)_ Rotation angle of the mark in degrees, measure clockwise from the positive x-axis.
-- _x (number)_ x position of the mark's centre of rotation, in SVG coordinates relative to the subject image.
-- _y (number)_ y position of the mark's centre of rotation, in SVG coordinates relative to the subject image.
+- _x_rotation_ (number)_ x position of the mark's centre of rotation, in SVG coordinates relative to the subject image.
+- _y_rotation_ (number)_ y position of the mark's centre of rotation, in SVG coordinates relative to the subject image.

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
@@ -22,6 +22,14 @@ const BaseMark = types.model('BaseMark', {
 
     get tool () {
       return getParentOfType(self, Tool)
+    },
+
+    get x () {
+      return self.x_center
+    },
+
+    get y () {
+      return self.y_center
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Point/Point.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Point/Point.js
@@ -7,8 +7,8 @@ import Mark from '../Mark'
 
 const PointModel = types
   .model('PointModel', {
-    x: types.optional(types.number, 0),
-    y: types.optional(types.number, 0)
+    x_center: types.optional(types.number, 0),
+    y_center: types.optional(types.number, 0)
   })
   .views(self => ({
     get coords () {
@@ -38,23 +38,23 @@ const PointModel = types
   }))
   .actions(self => {
     function initialDrag ({ x, y }) {
-      self.x = x
-      self.y = y
+      self.x_center = x
+      self.y_center = y
     }
 
     function initialPosition ({ x, y }) {
-      self.x = x
-      self.y = y
+      self.x_center = x
+      self.y_center = y
     }
 
     function move ({ x, y }) {
-      self.x += x
-      self.y += y
+      self.x_center += x
+      self.y_center += y
     }
 
     function setCoordinates ({ x, y }) {
-      self.x = x
-      self.y = y
+      self.x_center = x
+      self.y_center = y
     }
 
     return {


### PR DESCRIPTION
Add x_center, y_center to the Point model.
Make mark.x, mark.y read-only aliases for mark.x_center and mark.y_center for all marks.

See #1390 for the proposal to add `x_center` and `y_center`.

Package:
lib-classifier/plugins/drawingTools

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
