### PR TITLE
TranscriptionLine tool clean up

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.js
@@ -5,7 +5,7 @@ import { DragHandle } from '@plugins/drawingTools/components'
 const FINISHER_RADIUS = 8
 const GRAB_STROKE_WIDTH = 6
 
-function TranscriptionLine ({ active, mark, onFinish, scale, svg }) {
+function TranscriptionLine ({ active, mark, onFinish, scale }) {
   const { x1, y1, x2, y2, finished } = mark
   const finisherRadius = FINISHER_RADIUS / scale
 
@@ -27,7 +27,6 @@ function TranscriptionLine ({ active, mark, onFinish, scale, svg }) {
           fill='transparent'
           radius={6}
           scale={scale}
-          svg={svg}
           x={x1}
           y={y1}
           dragMove={(e, d) => onHandleDrag({ x1: x1 + d.x, y1: y1 + d.y, x2, y2 })}
@@ -36,7 +35,6 @@ function TranscriptionLine ({ active, mark, onFinish, scale, svg }) {
         <DragHandle
           radius={6}
           scale={scale}
-          svg={svg}
           x={x2}
           y={y2}
           dragMove={(e, d) => onHandleDrag({ x1, y1, x2: x2 + d.x, y2: y2 + d.y })}
@@ -57,7 +55,6 @@ TranscriptionLine.propTypes = {
   mark: PropTypes.object.isRequired,
   onFinish: PropTypes.func,
   scale: PropTypes.number,
-  svg: PropTypes.instanceOf(Element).isRequired
 }
 
 TranscriptionLine.defaultProps = {

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.spec.js
@@ -9,6 +9,7 @@ describe('Components > Drawing marks > Transcription line', function () {
   beforeEach(function () {
     mark = TranscriptionLineMark.create({
       id: 'line1',
+      toolType: 'transcriptionLine',
       x1: 100,
       y1: 200,
       x2: 300,

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
@@ -7,25 +7,18 @@ import { TranscriptionLineTool } from '@plugins/drawingTools/models/tools'
 import { DrawingToolRoot } from '@plugins/drawingTools/components'
 import TranscriptionLine from './TranscriptionLine'
 
-
 class DrawingStory extends Component {
-  constructor () {
-    super()
-    this.svg = React.createRef()
-  }
-
   render () {
     const { children, mark, tool } = this.props
-    const { svg } = this
+
     return (
-      <svg viewBox='0 0 300 400' height={300} width={400} ref={this.svg}>
+      <svg viewBox='0 0 300 400' height={300} width={400}>
         <DrawingToolRoot
           label='Transcription line'
           mark={mark}
-          svg={svg}
           tool={tool}
         >
-          {React.cloneElement(children, { svg: svg.current })}
+          {React.cloneElement(children)}
         </DrawingToolRoot>
       </svg>
     )
@@ -41,10 +34,11 @@ storiesOf('Drawing tools | Transcription Line', module)
   .add('complete', function () {
     const tool = TranscriptionLineTool.create({
       color: 'red',
-      type: 'polygon'
+      type: 'transcriptionLine'
     })
     const mark = tool.createMark({
       id: 'transcriptionLine1',
+      toolType: 'transcriptionLine',
       x1: 10,
       y1: 20,
       x2: 205,
@@ -60,10 +54,11 @@ storiesOf('Drawing tools | Transcription Line', module)
   .add('active', function () {
     const tool = TranscriptionLineTool.create({
       color: 'red',
-      type: 'polygon'
+      type: 'transcriptionLine'
     })
     const mark = tool.createMark({
       id: 'transcriptionLine1',
+      toolType: 'transcriptionLine',      
       x1: 10,
       y1: 20,
       x2: 205,
@@ -79,10 +74,11 @@ storiesOf('Drawing tools | Transcription Line', module)
   .add('unfinished', function () {
     const tool = TranscriptionLineTool.create({
       color: 'red',
-      type: 'polygon'
+      type: 'transcriptionLine'
     })
     const mark = tool.createMark({
       id: 'transcriptionLine1',
+      toolType: 'transcriptionLine',      
       x1: 10,
       y1: 20,
       x2: 205,

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/TranscriptionLine/TranscriptionLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/TranscriptionLine/TranscriptionLine.js
@@ -5,6 +5,7 @@ import { Mark } from '@plugins/drawingTools/models/marks'
 
 const TranscriptionLineModel = types
   .model('TranscriptionLineModel', {
+    toolType: types.literal('transcriptionLine'),
     x1: types.maybe(types.number),
     y1: types.maybe(types.number),
     x2: types.maybe(types.number),

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool.js
@@ -4,7 +4,7 @@ import { TranscriptionLine } from '../../marks'
 
 const TranscriptionLineTool = types.model('TranscriptionLine', {
   marks: types.map(TranscriptionLine),
-  type: types.literal('polygon')
+  type: types.literal('transcriptionLine')
 })
   .actions(self => {
     function createMark (mark) {

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
@@ -21,7 +21,11 @@ const BaseMark = types.model('BaseMark', {
     },
 
     get tool () {
-      return getParentOfType(self, Tool)
+      try {
+        return getParentOfType(self, Tool)
+      } catch (e) {
+        console.log(`no parent of ${Tool.type} available`)
+      }
     }
   }))
 


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

This is just a bit of clean up removing cruft and fixing some of the naming. I've added `toolType` to the mark to make this consistent with the decisions in ADR 24.

I added a try/catch around `getParentOfType` which gets the stories working again.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
