### PR TITLE
Remove useState from tasks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -48,7 +48,7 @@ class Tasks extends React.Component {
       return (
         <Box as='form' gap='small' justify='between' fill>
           {tasks.map((task) => {
-            const { TaskComponent } = taskRegistry.get(task.type)
+            const TaskComponent = observer(taskRegistry.get(task.type).TaskComponent)
             if (TaskComponent) {
               return (
                 <Box key={task.taskKey} basis='auto'>

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
@@ -2,7 +2,7 @@ import { Markdownz } from '@zooniverse/react-components'
 import { Box, Text } from 'grommet'
 import { observable } from 'mobx'
 import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
-import React, { useState } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import zooTheme from '@zooniverse/grommet-theme'
@@ -33,7 +33,7 @@ function MultipleChoiceTask (props) {
     task
   } = props
   const { annotation } = task
-  const [ value, setValue ] = useState(annotation.value)
+  const { value } = annotation
 
   function onChange (index, event) {
     const newValue = value ? value.slice(0) : []
@@ -43,7 +43,6 @@ function MultipleChoiceTask (props) {
       const indexInValue = newValue.indexOf(index)
       newValue.splice(indexInValue, 1)
     }
-    setValue(newValue)
     task.updateAnnotation(newValue)
   }
 

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.spec.js
@@ -13,7 +13,9 @@ const task = {
   required: false,
   taskKey: 'T1',
   type: 'multiple',
-  updateAnnotation: sinon.stub()
+  updateAnnotation: sinon.stub().callsFake(value => {
+    task.annotation.value = value
+  })
 }
 
 describe('MultipleChoiceTask', function () {
@@ -60,9 +62,10 @@ describe('MultipleChoiceTask', function () {
   describe('onChange', function () {
     let wrapper
     beforeEach(function () {
+      const annotation = { task: task.taskKey, value: [] }
       wrapper = shallow(
         <MultipleChoiceTask
-          task={task}
+          task={Object.assign({}, task, { annotation })}
         />
       )
     })
@@ -76,26 +79,31 @@ describe('MultipleChoiceTask', function () {
       task.answers.forEach((answer, index) => {
         const node = wrapper.find({ label: answer.label })
         node.simulate('change', { target: { checked: true } })
+        wrapper.setProps({ task })
         expectedValue.push(index)
-        expect(task.updateAnnotation.withArgs(expectedValue)).to.have.been.calledOnce()
+        expect(task.annotation.value).to.deep.equal(expectedValue)
       })
     })
 
     it('should add checked answers to the annotation value', function () {
       const firstNode = wrapper.find({ label: task.answers[0].label })
       firstNode.simulate('change', { target: { checked: true } })
+      wrapper.setProps({ task })
+      expect(task.annotation.value).to.deep.equal([0])
       const lastNode = wrapper.find({ label: task.answers[2].label })
       lastNode.simulate('change', { target: { checked: true } })
-      expect(task.updateAnnotation.withArgs([0])).to.have.been.calledOnce()
-      expect(task.updateAnnotation.withArgs([0, 2])).to.have.been.calledOnce()
+      wrapper.setProps({ task })
+      expect(task.annotation.value).to.deep.equal([0, 2])
     })
 
     it('should remove unchecked answers from the annotation value', function () {
       const firstNode = wrapper.find({ label: task.answers[0].label })
       firstNode.simulate('change', { target: { checked: true } })
-      expect(task.updateAnnotation.withArgs([0])).to.have.been.calledOnce()
+      wrapper.setProps({ task })
+      expect(task.annotation.value).to.deep.equal([0])
       firstNode.simulate('change', { target: { checked: false } })
-      expect(task.updateAnnotation.withArgs([])).to.have.been.calledOnce()
+      wrapper.setProps({ task })
+      expect(task.annotation.value).to.deep.equal([])
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.js
@@ -3,7 +3,7 @@ import { Box, Text } from 'grommet'
 import { observable } from 'mobx'
 import { inject, observer, PropTypes as MobXPropTypes } from 'mobx-react'
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import zooTheme from '@zooniverse/grommet-theme'
 import { pxToRem } from '@zooniverse/react-components'
@@ -34,9 +34,8 @@ function SingleChoiceTask (props) {
     task
   } = props
   const { annotation } = task
-  const [ value, setValue ] = useState(annotation.value)
+  const { value } = annotation
   function onChange (index, event) {
-    setValue(index)
     if (event.target.checked) task.updateAnnotation(index)
   }
 

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
@@ -8,8 +8,7 @@ counterpart.registerTranslations('en', en)
 
 function TextTask (props) {
   const { autoFocus, disabled, task } = props
-  const defaultValue = task.annotation.value
-  const [value, setValue] = React.useState(defaultValue)
+  const { value } = task.annotation
   const textArea = React.createRef()
 
   function onChange (event) {
@@ -18,7 +17,6 @@ function TextTask (props) {
   }
 
   function updateText (text) {
-    setValue(text)
     task.updateAnnotation(text)
   }
 

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.spec.js
@@ -8,7 +8,7 @@ import TextTask from './'
 
 describe('TextTask', function () {
   let wrapper
-  const mockTask = {
+  const task = {
     annotation: {
       task: 'T0',
       value: ''
@@ -16,35 +16,38 @@ describe('TextTask', function () {
     instruction: 'Type something here',
     taskKey: 'T0',
     text_tags: ['insertion', 'deletion'],
-    updateAnnotation: sinon.stub()
+    updateAnnotation: sinon.stub().callsFake(value => {
+      task.annotation.value = value
+    })
   }
 
   before(function () {
     wrapper = shallow(
       <TextTask
-        task={mockTask}
+        task={task}
       />
     )
   })
 
   it('should have a labelled textarea', function () {
     const label = wrapper.find('label')
-    expect(label.find(Text).prop('children')).to.equal(mockTask.instruction)
+    expect(label.find(Text).prop('children')).to.equal(task.instruction)
     const textarea = label.find(TextArea)
-    expect(textarea.prop('value')).to.equal(mockTask.annotation.value)
+    expect(textarea.prop('value')).to.equal(task.annotation.value)
   })
 
   describe('onChange', function () {
     beforeEach(function () {
+      const annotation = { task: 'T0', value: '' }
       wrapper = shallow(
         <TextTask
-          task={mockTask}
+          task={Object.assign({}, task, { annotation })}
         />
       )
     })
 
     afterEach(function () {
-      mockTask.updateAnnotation.resetHistory()
+      task.updateAnnotation.resetHistory()
     })
 
     it('should update the textarea', function () {
@@ -55,6 +58,7 @@ describe('TextTask', function () {
         }
       }
       textArea.simulate('change', fakeEvent)
+      wrapper.setProps({ task })
       expect(wrapper.find(TextArea).prop('value')).to.equal(fakeEvent.target.value)
     })
 
@@ -66,7 +70,8 @@ describe('TextTask', function () {
         }
       }
       textArea.simulate('change', fakeEvent)
-      expect(mockTask.updateAnnotation.withArgs(fakeEvent.target.value)).to.have.been.calledOnce()
+      wrapper.setProps({ task })
+      expect(task.annotation.value).to.deep.equal(fakeEvent.target.value)
     })
   })
 
@@ -78,20 +83,20 @@ describe('TextTask', function () {
       }
       wrapper = mount(
         <TextTask
-          task={Object.assign({}, mockTask, { annotation })}
+          task={Object.assign({}, task, { annotation })}
         />
       )
     })
 
     afterEach(function () {
-      mockTask.updateAnnotation.resetHistory()
+      task.updateAnnotation.resetHistory()
     })
 
     it('should render buttons for tagging text', function () {
       expect(wrapper.find('button')).to.have.lengthOf(2)
     })
 
-    mockTask.text_tags.forEach(function (tag) {
+    task.text_tags.forEach(function (tag) {
       it(`should render a ${tag} button`, function () {
         const button = wrapper.find('button').find({ value: tag })
         expect(button).to.have.lengthOf(1)
@@ -110,6 +115,7 @@ describe('TextTask', function () {
       textArea.selectionEnd = 11
       const expectedText = 'Hello, [insertion]this[/insertion] is some test text.'
       insertionButton.simulate('click', fakeEvent)
+      wrapper.setProps({ task })
       expect(textArea.value).to.equal(expectedText)
     })
   })


### PR DESCRIPTION
- Remove `useState` from tasks, so that the current task value is always passed in as a prop via the task annotation.
- Observe tasks for changes.
- Rewrite tests to directly test annotation values.

Package:
lib-classifier

Closes #1407.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
