### PR TITLE
Add Line and Point stories

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.js
@@ -25,11 +25,15 @@ function Line ({ active, children, mark, scale }) {
 }
 
 Line.propTypes = {
-  active: PropTypes.bool
+  active: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  mark: PropTypes.object.isRequired,
+  scale: PropTypes.number
 }
 
 Line.defaultProps = {
-  active: false
+  active: false,
+  scale: 1
 }
 
 export default Line

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.stories.js
@@ -1,0 +1,70 @@
+import { withKnobs } from '@storybook/addon-knobs'
+import { storiesOf } from '@storybook/react'
+import zooTheme from '@zooniverse/grommet-theme'
+import React, { Component, createRef, forwardRef } from 'react'
+import sinon from 'sinon'
+import { LineTool } from '@plugins/drawingTools/models/tools'
+import { DrawingToolRoot }from '@plugins/drawingTools/components'
+import Line from './Line'
+
+class DrawingStory extends Component {
+  render () {
+    const { children, mark } = this.props
+
+    return (
+      <svg viewBox='0 0 300 400' height={300} width={400}>
+        <DrawingToolRoot
+          label='Line'
+          mark={mark}
+        >
+          {children}
+        </DrawingToolRoot>
+      </svg>
+    )
+  }
+}
+storiesOf('Drawing tools | Line', module)
+  .addDecorator(withKnobs)
+  .addParameters({
+    viewport: {
+      defaultViewport: 'responsive'
+    }
+  })
+  .add('complete', function () {
+    const tool = LineTool.create({
+      color: 'red',
+      type: 'line'
+    })
+    const mark = tool.createMark({
+      id: 'line1',
+      toolType: 'line',
+      x1: 10,
+      y1: 120,
+      x2: 205,
+      y2: 15
+    })
+    return (
+      <DrawingStory mark={mark}>
+        <Line mark={mark} />
+      </DrawingStory>
+    )
+  })
+  .add('active', function () {
+    const tool = LineTool.create({
+      color: 'red',
+      type: 'line'
+    })
+    const mark = tool.createMark({
+      id: 'line1',
+      toolType: 'line',      
+      x1: 10,
+      y1: 120,
+      x2: 205,
+      y2: 15
+    })
+    return (
+      <DrawingStory mark={mark}>
+        <Line active mark={mark} />
+      </DrawingStory>
+    )
+  })

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.stories.js
@@ -1,0 +1,66 @@
+import { withKnobs } from '@storybook/addon-knobs'
+import { storiesOf } from '@storybook/react'
+import zooTheme from '@zooniverse/grommet-theme'
+import React, { Component, createRef, forwardRef } from 'react'
+import sinon from 'sinon'
+import { PointTool } from '@plugins/drawingTools/models/tools'
+import { DrawingToolRoot }from '@plugins/drawingTools/components'
+import Point from './Point'
+
+class DrawingStory extends Component {
+  render () {
+    const { children, mark } = this.props
+
+    return (
+      <svg viewBox='0 0 300 400' height={300} width={400}>
+        <DrawingToolRoot
+          label='Point'
+          mark={mark}
+        >
+          {children}
+        </DrawingToolRoot>
+      </svg>
+    )
+  }
+}
+storiesOf('Drawing tools | Point', module)
+  .addDecorator(withKnobs)
+  .addParameters({
+    viewport: {
+      defaultViewport: 'responsive'
+    }
+  })
+  .add('complete', function () {
+    const tool = PointTool.create({
+      color: 'red',
+      type: 'point'
+    })
+    const mark = tool.createMark({
+      id: 'point1',
+      toolType: 'point',
+      x: 100,
+      y: 120
+    })
+    return (
+      <DrawingStory mark={mark}>
+        <Point mark={mark} />
+      </DrawingStory>
+    )
+  })
+  .add('active', function () {
+    const tool = PointTool.create({
+      color: 'red',
+      type: 'point'
+    })
+    const mark = tool.createMark({
+      id: 'point1',
+      toolType: 'point',      
+      x: 100,
+      y: 120
+    })
+    return (
+      <DrawingStory mark={mark}>
+        <Point active mark={mark} />
+      </DrawingStory>
+    )
+  })


### PR DESCRIPTION
Add stories for the Line and Point drawing marks. Each mark has an active and complete (deselected) state.

Package:
lib-classifier

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [x] Has a storybook story been created or updated?
- [x] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [x] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
