### PR TITLE
Drawing: Add marks prop to InteractionLayer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -9,7 +9,7 @@ const StyledRect = styled('rect')`
   cursor: ${props => props.disabled ? 'not-allowed' : 'crosshair'};
 `
 
-function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, move, scale, width }) {
+function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, marks, move, scale, width }) {
   const [ activeMark, setActiveMark ] = useState(null)
   const [ creating, setCreating ] = useState(false)
   const { svg, getScreenCTM } = useContext(SVGContext)
@@ -76,19 +76,14 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, mo
         fill='transparent'
         onPointerDown={onPointerDown}
       />
-      {activeDrawingTask &&
-        activeDrawingTask.tools.map(tool => {
-          return (
-            <DrawingToolMarks
-              key={`${tool.type}-${tool.color}`}
-              activeMarkId={activeMark && activeMark.id}
-              marks={Array.from(tool.marks.values())}
-              onDelete={() => setActiveMark(null)}
-              onSelectMark={mark => setActiveMark(mark)}
-              scale={scale}
-            />
-          )
-        })
+      {marks &&
+        <DrawingToolMarks
+          activeMarkId={activeMark && activeMark.id}
+          marks={marks}
+          onDelete={() => setActiveMark(null)}
+          onSelectMark={mark => setActiveMark(mark)}
+          scale={scale}
+        />
       }
     </g>
   )
@@ -99,12 +94,14 @@ InteractionLayer.propTypes = {
   activeTool: PropTypes.object.isRequired,
   height: PropTypes.number.isRequired,
   disabled: PropTypes.bool,
+  marks: PropTypes.array,
   scale: PropTypes.number,
   width: PropTypes.number.isRequired
 }
 
 InteractionLayer.defaultProps = {
   disabled: false,
+  marks: [],
   scale: 1
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -22,7 +22,7 @@ function storeMapper (stores) {
   const disabled = activeTool ? activeTool.disabled : false
   const drawingAnnotations = Array.from(classification.annotations.values())
     .filter(annotation => getType(annotation).name === 'DrawingAnnotation')
-  const { marks } = activeDrawingTask
+  const { marks } = activeDrawingTask || {}
   return {
     activeDrawingTask,
     activeTool,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -22,11 +22,13 @@ function storeMapper (stores) {
   const disabled = activeTool ? activeTool.disabled : false
   const drawingAnnotations = Array.from(classification.annotations.values())
     .filter(annotation => getType(annotation).name === 'DrawingAnnotation')
+  const { marks } = activeDrawingTask
   return {
     activeDrawingTask,
     activeTool,
     disabled,
     drawingAnnotations,
+    marks,
     move
   }
 }
@@ -35,7 +37,17 @@ function storeMapper (stores) {
 @observer
 class InteractionLayerContainer extends Component {
   render () {
-    const { activeDrawingTask, activeTool, disabled, drawingAnnotations, height, move, scale, width } = this.props
+    const {
+      activeDrawingTask,
+      activeTool,
+      disabled,
+      drawingAnnotations,
+      height,
+      marks,
+      move,
+      scale,
+      width
+    } = this.props
     return (
       <>
         {drawingAnnotations.map(annotation =>
@@ -52,6 +64,7 @@ class InteractionLayerContainer extends Component {
             activeTool={activeTool}
             disabled={disabled}
             height={height}
+            marks={marks}
             move={move}
             scale={scale}
             width={width}


### PR DESCRIPTION
Add the current drawing task marks to the InteractionLayer as an observable array.

Package:
lib-classifier

Closes #1411.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
