### PR TITLE
Drawing: Add angle and distance helpers to marks

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
@@ -16,6 +16,18 @@ const BaseMark = types.model('BaseMark', {
   toolIndex: types.optional(types.number, 0)
 })
   .views(self => ({
+    getAngle (x1, y1, x2, y2) {
+      const deltaX = x2 - x1
+      const deltaY = y2 - y1
+      return Math.atan2(deltaY, deltaX) * (180 / Math.PI)
+    },
+
+    getDistance (x1, y1, x2, y2) {
+      const aSquared = Math.pow(x2 - x1, 2)
+      const bSquared = Math.pow(y2 - y1, 2)
+      return Math.sqrt(aSquared + bSquared)
+    },
+
     get isValid () {
       return true
     },

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.spec.js
@@ -26,4 +26,28 @@ describe('Models > Drawing Task > Mark', function () {
   it('should be able to store annotations', function () {
     expect(mark.annotations).to.be.ok()
   })
+
+  describe('getDistance', function () {
+    it('should return the distance between two points', function () {
+      expect(mark.getDistance(-20, -20, 20, 10)).to.equal(50)
+    })
+  })
+
+  describe('getAngle', function () {
+    it('should work at -90 degrees', function () {
+      expect(mark.getAngle(-20, -20, -20, -40)).to.equal(-90)
+    })
+
+    it('should work at 0 degrees', function () {
+      expect(mark.getAngle(-20, -20, 20, -20)).to.equal(0)
+    })
+
+    it('should work at 90 degrees', function () {
+      expect(mark.getAngle(-20, -20, -20, 20)).to.equal(90)
+    })
+
+    it('should work at 180 degrees', function () {
+      expect(mark.getAngle(-20, -20, -40, -20)).to.equal(180)
+    })
+  })
 })


### PR DESCRIPTION
Add getAngle and getDistance to all marks.
Add tests.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
