### PR TITLE
Drawing: Add x, y, angle to drawing tool root

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.js
@@ -105,4 +105,7 @@ DrawingToolRoot.defaultProps = {
   }
 }
 
+
 export default draggable(observer(DrawingToolRoot))
+export { DrawingToolRoot }
+

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.js
@@ -1,3 +1,4 @@
+import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React, { forwardRef, useState } from 'react'
 import styled from 'styled-components'
@@ -55,6 +56,10 @@ const DrawingToolRoot = forwardRef(function DrawingToolRoot ({
     onDeselect(mark)
   }
 
+  let transform = ''
+  transform = (mark.x && mark.y) ? `${transform} translate(${mark.x}, ${mark.y})` : transform
+  transform = mark.angle ? `${transform} rotate(${mark.angle})` : transform
+
   return (
     <StyledGroup
       {...mainStyle}
@@ -64,6 +69,7 @@ const DrawingToolRoot = forwardRef(function DrawingToolRoot ({
       strokeWidth={isActive ? SELECTED_STROKE_WIDTH / scale : STROKE_WIDTH / scale}
       focusable
       tabIndex={0}
+      transform={transform}
       onBlur={deselect}
       onFocus={select}
       onKeyDown={onKeyDown}
@@ -99,4 +105,4 @@ DrawingToolRoot.defaultProps = {
   }
 }
 
-export default draggable(DrawingToolRoot)
+export default draggable(observer(DrawingToolRoot))

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.spec.js
@@ -1,17 +1,120 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { expect } from 'chai'
-import DrawingToolRoot from './DrawingToolRoot'
+import sinon from 'sinon'
+import { EllipseTool, PointTool } from '@plugins/drawingTools/models/tools'
+import { DrawingToolRoot } from './DrawingToolRoot'
 import Point from '../Point'
 
-describe('Root tool', function () {
+describe('Drawing tools > drawing tool root', function () {
+  const pointTool = PointTool.create({
+    type: 'point'
+  })
+  const point = pointTool.createMark({
+    id: 'point1'
+  })
+  const onDelete = sinon.stub()
+  const onDeselect = sinon.stub()
+  const onSelect = sinon.stub()
+  let wrapper
+
+  beforeEach(function () {
+    wrapper = shallow(
+      <DrawingToolRoot
+        label='Point 1'
+        mark={point}
+        onDelete={onDelete}
+        onDeselect={onDeselect}
+        onSelect={onSelect}
+      >
+        <Point mark={point} />
+      </DrawingToolRoot>
+    )
+  })
+
+  after(function () {
+    onDeselect.resetHistory()
+    onSelect.resetHistory()
+  })
+
   it('should render without crashing', function () {
-    const wrapper = shallow(<DrawingToolRoot><Point coordinates={{ x: 100, y: 200 }} /></DrawingToolRoot>)
     expect(wrapper).to.be.ok()
   })
 
   it('should render a child drawing tool', function () {
-    const wrapper = shallow(<DrawingToolRoot><Point coordinates={{ x: 100, y: 200 }} /></DrawingToolRoot>)
     expect(wrapper.find(Point)).to.have.lengthOf(1)
+  })
+
+  describe('on focus', function () {
+    before(function () {
+      wrapper.root().simulate('focus')
+    })
+
+    it('should be selected', function () {
+      expect(onSelect).to.have.been.calledOnce()
+    })
+  })
+
+  describe('on blur', function () {
+    before(function () {
+      wrapper.simulate('blur')
+    })
+
+    it('should be deselected', function () {
+      expect(onDeselect).to.have.been.calledOnce()
+    })
+  })
+
+  describe('on keydown', function () {
+    describe('with backspace', function () {
+      const fakeEvent = {
+        key: 'Backspace',
+        preventDefault: sinon.stub(),
+        stopPropagation: sinon.stub()
+      }
+
+      before(function () {
+        wrapper.simulate('keydown', fakeEvent)
+      })
+
+      after(function () {
+        onDelete.resetHistory()
+      })
+
+      it('should cancel event bubbling', function () {
+        expect(fakeEvent.stopPropagation).to.have.been.calledOnce()
+      })
+
+      it('should cancel the default backspace handler', function () {
+        expect(fakeEvent.preventDefault).to.have.been.calledOnce()
+      })
+
+      it('should be deleted', function () {
+        expect(onDelete).to.have.been.calledOnce()
+      })
+    })
+
+    describe('with other keys', function () {
+      const fakeEvent = {
+        key: 'Tab',
+        preventDefault: sinon.stub(),
+        stopPropagation: sinon.stub()
+      }
+      before(function () {
+        wrapper.simulate('keydown', fakeEvent)
+      })
+
+      it('should not cancel event bubbling', function () {
+        expect(fakeEvent.stopPropagation).to.not.have.been.called()
+      })
+
+      it('should not cancel the default key handler', function () {
+        expect(fakeEvent.preventDefault).to.not.have.been.called()
+      })
+
+      it('should not be deleted', function () {
+        expect(onDelete).to.not.have.been.called()
+      })
+    })
   })
 })

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.spec.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { expect } from 'chai'
 import sinon from 'sinon'
-import { EllipseTool, PointTool } from '@plugins/drawingTools/models/tools'
+import { PointTool, Tool } from '@plugins/drawingTools/models/tools'
 import { DrawingToolRoot } from './DrawingToolRoot'
 import Point from '../Point'
 
@@ -114,6 +114,34 @@ describe('Drawing tools > drawing tool root', function () {
 
       it('should not be deleted', function () {
         expect(onDelete).to.not.have.been.called()
+      })
+    })
+  })
+
+  describe('mark position', function () {
+    it('should be positioned at {mark.x, mark.y}', function () {
+      point.initialPosition({ x: 50, y: 120 })
+      wrapper.setProps({ mark: point })
+      const transform = wrapper.root().prop('transform')
+      expect(transform).to.have.string('translate(50, 120)')
+    })
+
+    describe( 'when rotated', function () {
+      beforeEach(function () {
+        const tool = Tool.create({
+          type: 'tool'
+        })
+        const mark = tool.createMark({
+          id: 'tool1',
+          x: 50,
+          y: 120
+        })
+        mark.angle = -45
+        wrapper.setProps({ mark: mark })
+      })
+      it('should be rotated by mark.angle', function () {
+        const transform = wrapper.root().prop('transform')
+        expect(transform).to.have.string('rotate(-45)')
       })
     })
   })

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.js
@@ -22,7 +22,7 @@ function Point ({ active, children, mark, scale }) {
   const radius = RADIUS[size] / scale
 
   return (
-    <g transform={`translate(${mark.x}, ${mark.y})`}>
+    <g>
       <line x1='0' y1={-1 * crosshairSpace * selectedRadius} x2='0' y2={-1 * selectedRadius} strokeWidth={crosshairWidth} />
       <line x1={-1 * crosshairSpace * selectedRadius} y1='0' x2={-1 * selectedRadius} y2='0' strokeWidth={crosshairWidth} />
       <line x1='0' y1={crosshairSpace * selectedRadius} x2='0' y2={selectedRadius} strokeWidth={crosshairWidth} />

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Point/Point.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Point/Point.js
@@ -23,8 +23,8 @@ const PointModel = types
       const theta = (DELETE_BUTTON_ANGLE) * (Math.PI / 180)
       const dx = (20 / scale) * Math.cos(theta)
       const dy = -1 * (20 / scale) * Math.sin(theta)
-      const x = self.x + dx
-      const y = self.y + dy
+      const x = dx
+      const y = dy
       return { x, y }
     },
 


### PR DESCRIPTION
Make (x, y, angle) common, optional properties for all marks, defining the position of the mark and rotation about that position.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
