### PR TITLE
Drawing: Add toolType to marks

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.spec.js
@@ -6,7 +6,7 @@ import { Point } from '@plugins/drawingTools/models/marks'
 import DeleteButton from './DeleteButton'
 
 describe('Drawing tools > Delete button', function () {
-  const mark = Point.create({ id: 'point1', x: 50, y: 50 })
+  const mark = Point.create({ id: 'point1', x: 50, y: 50, toolType: 'point' })
 
   it('should render without crashing', function () {
     const wrapper = shallow(<DeleteButton label='Delete' mark={mark} />)

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DrawingToolRoot/DrawingToolRoot.spec.js
@@ -129,7 +129,7 @@ describe('Drawing tools > drawing tool root', function () {
     describe( 'when rotated', function () {
       beforeEach(function () {
         const tool = Tool.create({
-          type: 'tool'
+          type: 'default'
         })
         const mark = tool.createMark({
           id: 'tool1',

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
@@ -12,7 +12,8 @@ const BaseMark = types.model('BaseMark', {
     TextTask.AnnotationModel
   )),
   frame: types.optional(types.number, 0),
-  toolIndex: types.optional(types.number, 0)
+  toolIndex: types.optional(types.number, 0),
+  toolType: types.string
 })
   .views(self => ({
     getAngle (x1, y1, x2, y2) {

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.spec.js
@@ -4,7 +4,7 @@ describe('Models > Drawing Task > Mark', function () {
   let mark
 
   before(function () {
-    mark = Mark.create({ id: 'test' })
+    mark = Mark.create({ id: 'test', toolType: 'default' })
   })
 
   it('should exist', function () {

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/LineTool/LineTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/LineTool/LineTool.js
@@ -8,7 +8,7 @@ const LineTool = types.model('Line', {
 })
   .actions(self => {
     function createMark (mark) {
-      const newMark = Line.create(mark)
+      const newMark = Line.create(Object.assign({}, mark, { toolType: self.type }))
       self.marks.put(newMark)
       return newMark
     }

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/PointTool/PointTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/PointTool/PointTool.js
@@ -9,7 +9,7 @@ const PointTool = types.model('Point', {
 })
   .actions(self => {
     function createMark (mark) {
-      const newMark = Point.create(mark)
+      const newMark = Point.create(Object.assign({}, mark, { toolType: self.type }))
       self.marks.put(newMark)
       return newMark
     }

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
@@ -6,7 +6,8 @@ const Tool = types.model('Tool', {
   label: types.optional(types.string, ''),
   marks: types.map(Mark),
   max: types.optional(types.union(types.string, types.number), Infinity),
-  min: types.optional(types.union(types.string, types.number), 0)
+  min: types.optional(types.union(types.string, types.number), 0),
+  type: types.literal('default')
 })
   .views(self => ({
     get disabled () {
@@ -19,7 +20,7 @@ const Tool = types.model('Tool', {
   }))
   .actions(self => {
     function createMark (mark) {
-      const newMark = Mark.create(mark)
+      const newMark = Mark.create(Object.assign({}, mark, { toolType: self.type }))
       self.marks.put(newMark)
       return newMark
     }

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
@@ -4,7 +4,8 @@ const toolData = {
   color: '#ff0000',
   label: 'Point',
   max: '10',
-  min: 1
+  min: 1,
+  type: 'default'
 }
 
 describe('Model > DrawingTools > Tool', function () {

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.spec.js
@@ -1,7 +1,7 @@
 import DrawingAnnotation from './DrawingAnnotation'
 import { Point } from '@plugins/drawingTools/models/marks'
 
-const point = Point.create({ id: 'mockAnnotation', frame: 0, toolIndex: 0, x: 100, y: 150 })
+const point = Point.create({ id: 'mockAnnotation', frame: 0, toolIndex: 0, toolType: 'point', x: 100, y: 150 })
 
 const drawingAnnotationSnapshot = {
   task: 'T0',


### PR DESCRIPTION
Add toolType to all marks.
Add toolType to createMark for all tools.
Add a type to the Tool model.
Update tests.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
