### PR TITLE
Decouple Task components from classifications

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -48,11 +48,17 @@ class Tasks extends React.Component {
       return (
         <Box as='form' gap='small' justify='between' fill>
           {tasks.map((task) => {
+            const { annotation } = task
             const TaskComponent = observer(taskRegistry.get(task.type).TaskComponent)
             if (TaskComponent) {
               return (
                 <Box key={task.taskKey} basis='auto'>
-                  <TaskComponent disabled={!ready} task={task} {...this.props} />
+                  <TaskComponent
+                    disabled={!ready}
+                    annotation={annotation}
+                    task={task}
+                    {...this.props}
+                  />
                 </Box>
               )
             }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -10,10 +10,13 @@ import TaskNavButtons from './components/TaskNavButtons'
 import taskRegistry from '@plugins/tasks'
 
 function storeMapper (stores) {
+  const { active: classification, addAnnotation } = stores.classifierStore.classifications
   const { loadingState } = stores.classifierStore.workflows
   const { active: step, activeStepTasks: tasks, isThereTaskHelp } = stores.classifierStore.workflowSteps
   const { loadingState: subjectReadyState } = stores.classifierStore.subjectViewer
   return {
+    addAnnotation,
+    classification,
     isThereTaskHelp,
     loadingState,
     step,
@@ -37,9 +40,9 @@ class Tasks extends React.Component {
   }
 
   [asyncStates.success] () {
-    const { isThereTaskHelp, subjectReadyState, step, tasks } = this.props
+    const { addAnnotation, classification, isThereTaskHelp, subjectReadyState, step, tasks } = this.props
     const ready = subjectReadyState === asyncStates.success
-    if (tasks.length > 0) {
+    if (classification && tasks.length > 0) {
       // setting the wrapping box of the task component to a basis of 246px feels hacky,
       // but gets the area to be the same 453px height (or very close) as the subject area
       // and keeps the task nav buttons at the the bottom area
@@ -48,9 +51,10 @@ class Tasks extends React.Component {
       return (
         <Box as='form' gap='small' justify='between' fill>
           {tasks.map((task) => {
-            const { annotation } = task
+            addAnnotation(task)
+            const annotation = classification.annotation(task)
             const TaskComponent = observer(taskRegistry.get(task.type).TaskComponent)
-            if (TaskComponent) {
+            if (annotation && TaskComponent) {
               return (
                 <Box key={task.taskKey} basis='auto'>
                   <TaskComponent

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
@@ -1,17 +1,19 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { expect } from 'chai'
+import sinon from 'sinon'
 import { Tasks } from './Tasks'
 import asyncStates from '@zooniverse/async-states'
+import SingleChoiceTask from '@plugins/tasks/SingleChoiceTask'
 
 describe('Tasks', function () {
-  const tasks = [{
+  const tasks = [SingleChoiceTask.TaskModel.create({
     answers: [{ label: 'yes' }, { label: 'no' }],
     question: 'Is there a cat?',
     required: true,
     taskKey: 'init',
     type: 'single'
-  }]
+  })]
   const step = {
     isComplete: true,
     stepKey: 'S1',
@@ -20,6 +22,10 @@ describe('Tasks', function () {
       init: tasks[0]
     }
   }
+  const classification = {
+    annotation: task => ({ task: task.taskKey, value: 0 })
+  }
+  const addAnnotation = sinon.stub()
 
   it('should render without crashing', function () {
     const wrapper = shallow(<Tasks />)
@@ -47,7 +53,15 @@ describe('Tasks', function () {
   })
 
   it('should render the correct task component if the workflow is loaded', function () {
-    const wrapper = shallow(<Tasks loadingState={asyncStates.success} ready tasks={tasks} />)
+    const wrapper = shallow(
+      <Tasks
+        loadingState={asyncStates.success}
+        ready
+        addAnnotation={addAnnotation}
+        classification={classification}
+        tasks={tasks}
+      />
+    )
     // Is there a better way to do this?
     expect(wrapper.find('SingleChoiceTask')).to.have.lengthOf(1)
   })
@@ -59,6 +73,8 @@ describe('Tasks', function () {
       before(function () {
         const wrapper = shallow(
           <Tasks
+            addAnnotation={addAnnotation}
+            classification={classification}
             loadingState={asyncStates.success}
             subjectReadyState={asyncStates.loading}
             tasks={tasks}
@@ -76,6 +92,8 @@ describe('Tasks', function () {
       before(function () {
         const wrapper = shallow(
           <Tasks
+            addAnnotation={addAnnotation}
+            classification={classification}
             loadingState={asyncStates.success}
             subjectReadyState={asyncStates.success}
             step={step}

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/components/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/components/DrawingTask.js
@@ -1,7 +1,6 @@
 import { Box, Text } from 'grommet'
 import { Blank } from 'grommet-icons'
-import { observable } from 'mobx'
-import { observer, PropTypes as MobXPropTypes } from 'mobx-react'
+import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
@@ -73,12 +72,10 @@ class DrawingTask extends React.Component {
 }
 
 DrawingTask.defaultProps = {
-  annotations: observable.map(),
   task: {}
 }
 
 DrawingTask.propTypes = {
-  annotations: MobXPropTypes.observableMap,
   task: PropTypes.shape({
     help: PropTypes.string,
     instruction: PropTypes.string,

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
@@ -75,11 +75,14 @@ function MultipleChoiceTask (props) {
 }
 
 MultipleChoiceTask.defaultProps = {
-  disabled: false,
-  task: {}
+  disabled: false
 }
 
 MultipleChoiceTask.propTypes = {
+  annotation: PropTypes.shape({
+    update: PropTypes.func,
+    value: PropTypes.array
+  }).isRequired,
   disabled: PropTypes.bool,
   task: PropTypes.shape({
     answers: PropTypes.arrayOf(PropTypes.shape({
@@ -88,7 +91,7 @@ MultipleChoiceTask.propTypes = {
     help: PropTypes.string,
     question: PropTypes.string,
     required: PropTypes.bool
-  })
+  }).isRequired
 }
 
 export default MultipleChoiceTask

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
@@ -26,10 +26,10 @@ const StyledText = styled(Text)`
 
 function MultipleChoiceTask (props) {
   const {
+    annotation,
     disabled,
     task
   } = props
-  const { annotation } = task
   const { value } = annotation
 
   function onChange (index, event) {
@@ -40,7 +40,7 @@ function MultipleChoiceTask (props) {
       const indexInValue = newValue.indexOf(index)
       newValue.splice(indexInValue, 1)
     }
-    task.updateAnnotation(newValue)
+    annotation.update(newValue)
   }
 
   return (

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.spec.js
@@ -1,27 +1,24 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { expect } from 'chai'
-import sinon from 'sinon'
 import MultipleChoiceTask from './MultipleChoiceTask'
-
-// TODO: move this into a factory
-const task = {
-  annotation: { task: 'T1', value: [] },
-  answers: [{ label: 'napping' }, { label: 'standing' }, { label: 'playing' }],
-  question: 'What is/are the cat(s) doing?',
-  required: false,
-  taskKey: 'T1',
-  type: 'multiple',
-  updateAnnotation: sinon.stub().callsFake(value => {
-    task.annotation.value = value
-  })
-}
+import { default as Task } from '@plugins/tasks/MultipleChoiceTask'
 
 describe('MultipleChoiceTask', function () {
+  const task = Task.TaskModel.create({
+    answers: [{ label: 'napping' }, { label: 'standing' }, { label: 'playing' }],
+    question: 'What is/are the cat(s) doing?',
+    required: false,
+    taskKey: 'T1',
+    type: 'multiple'
+  })
+
+  const { annotation } = task
+
   describe('when it renders', function () {
     let wrapper
     before(function () {
-      wrapper = shallow(<MultipleChoiceTask task={task} />)
+      wrapper = shallow(<MultipleChoiceTask annotation={annotation} task={task} />)
     })
 
     it('should render without crashing', function () {
@@ -43,10 +40,11 @@ describe('MultipleChoiceTask', function () {
     let wrapper
 
     before(function () {
-      const annotation = { task: task.taskKey, value: [0] }
+      annotation.update([0])
       wrapper = shallow(
         <MultipleChoiceTask
-          task={Object.assign({}, task, { annotation })}
+          annotation={annotation}
+          task={task}
         />
       )
     })
@@ -61,16 +59,13 @@ describe('MultipleChoiceTask', function () {
   describe('onChange', function () {
     let wrapper
     beforeEach(function () {
-      const annotation = { task: task.taskKey, value: [] }
+      annotation.update([])
       wrapper = shallow(
         <MultipleChoiceTask
-          task={Object.assign({}, task, { annotation })}
+          annotation={annotation}
+          task={task}
         />
       )
-    })
-
-    afterEach(function () {
-      task.updateAnnotation.resetHistory()
     })
 
     it('should update the annotation', function () {
@@ -78,31 +73,26 @@ describe('MultipleChoiceTask', function () {
       task.answers.forEach((answer, index) => {
         const node = wrapper.find({ label: answer.label })
         node.simulate('change', { target: { checked: true } })
-        wrapper.setProps({ task })
         expectedValue.push(index)
-        expect(task.annotation.value).to.deep.equal(expectedValue)
+        expect(annotation.value).to.deep.equal(expectedValue)
       })
     })
 
     it('should add checked answers to the annotation value', function () {
       const firstNode = wrapper.find({ label: task.answers[0].label })
       firstNode.simulate('change', { target: { checked: true } })
-      wrapper.setProps({ task })
-      expect(task.annotation.value).to.deep.equal([0])
+      expect(annotation.value).to.deep.equal([0])
       const lastNode = wrapper.find({ label: task.answers[2].label })
       lastNode.simulate('change', { target: { checked: true } })
-      wrapper.setProps({ task })
-      expect(task.annotation.value).to.deep.equal([0, 2])
+      expect(annotation.value).to.deep.equal([0, 2])
     })
 
     it('should remove unchecked answers from the annotation value', function () {
       const firstNode = wrapper.find({ label: task.answers[0].label })
       firstNode.simulate('change', { target: { checked: true } })
-      wrapper.setProps({ task })
-      expect(task.annotation.value).to.deep.equal([0])
+      expect(annotation.value).to.deep.equal([0])
       firstNode.simulate('change', { target: { checked: false } })
-      wrapper.setProps({ task })
-      expect(task.annotation.value).to.deep.equal([])
+      expect(annotation.value).to.deep.equal([])
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.js
@@ -25,14 +25,14 @@ const StyledText = styled(Text)`
 
 function SingleChoiceTask (props) {
   const {
+    annotation,
     className,
     disabled,
     task
   } = props
-  const { annotation } = task
   const { value } = annotation
   function onChange (index, event) {
-    if (event.target.checked) task.updateAnnotation(index)
+    if (event.target.checked) annotation.update(index)
   }
 
   return (

--- a/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.js
@@ -68,11 +68,16 @@ function SingleChoiceTask (props) {
 }
 
 SingleChoiceTask.defaultProps = {
-  disabled: false,
-  task: {}
+  className: '',
+  disabled: false
 }
 
 SingleChoiceTask.propTypes = {
+  annotation: PropTypes.shape({
+    update: PropTypes.func,
+    value: PropTypes.number
+  }).isRequired,
+  className: PropTypes.string,
   disabled: PropTypes.bool,
   task: PropTypes.shape({
     answers: PropTypes.arrayOf(PropTypes.shape({
@@ -81,7 +86,7 @@ SingleChoiceTask.propTypes = {
     help: PropTypes.string,
     question: PropTypes.string,
     required: PropTypes.bool
-  })
+  }).isRequired
 }
 
 export default SingleChoiceTask

--- a/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.spec.js
@@ -1,25 +1,23 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { expect } from 'chai'
-import sinon from 'sinon'
 import SingleChoiceTask from './SingleChoiceTask'
-
-// TODO: move this into a factory
-const task = {
-  annotation: { task: 'init' },
-  answers: [{ label: 'yes' }, { label: 'no' }],
-  question: 'Is there a cat?',
-  required: true,
-  taskKey: 'init',
-  type: 'single',
-  updateAnnotation: sinon.stub()
-}
+import { default as Task } from '@plugins/tasks/SingleChoiceTask'
 
 describe('SingleChoiceTask', function () {
+  const task = Task.TaskModel.create({
+    answers: [{ label: 'yes' }, { label: 'no' }],
+    question: 'Is there a cat?',
+    required: true,
+    taskKey: 'init',
+    type: 'single'
+  })
+  const { annotation } = task
+
   describe('when it renders', function () {
     let wrapper
     before(function () {
-      wrapper = shallow(<SingleChoiceTask addAnnotation={() => {}} task={task} />)
+      wrapper = shallow(<SingleChoiceTask annotation={annotation} task={task} />)
     })
 
     it('should render without crashing', function () {
@@ -41,10 +39,11 @@ describe('SingleChoiceTask', function () {
     let wrapper
 
     before(function () {
-      const annotation = { task: task.taskKey, value: 0 }
+      annotation.update(0)
       wrapper = shallow(
         <SingleChoiceTask
-          task={Object.assign({}, task, { annotation })}
+          annotation={annotation}
+          task={task}
         />
       )
     })
@@ -58,26 +57,23 @@ describe('SingleChoiceTask', function () {
 
   describe('onChange event handler', function () {
     let wrapper
-    before(function () {
-      wrapper = shallow(<SingleChoiceTask task={task} />)
-    })
-
-    afterEach(function () {
-      task.updateAnnotation.resetHistory()
+    beforeEach(function () {
+      annotation.update(null)
+      wrapper = shallow(<SingleChoiceTask annotation={annotation} task={task} />)
     })
 
     it('should update the annotation', function () {
       task.answers.forEach((answer, index) => {
         const node = wrapper.find({ label: answer.label })
         node.simulate('change', { target: { checked: true } })
-        expect(task.updateAnnotation.withArgs(index)).to.have.been.calledOnce()
+        expect(annotation.value).to.equal(index)
       })
     })
 
     it('should not update the annotation if the answer is not checked', function () {
-      const node = wrapper.find({ label: task.answers[0].label })
+      const node = wrapper.find({ label: task.answers[1].label })
       node.simulate('change', { target: { checked: false } })
-      expect(task.updateAnnotation.withArgs(0)).to.not.have.been.called()
+      expect(annotation.value).to.be.null()
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
@@ -1,6 +1,7 @@
 import { PlainButton } from '@zooniverse/react-components'
 import counterpart from 'counterpart'
 import { Box, Text, TextArea } from 'grommet'
+import PropTypes from 'prop-types'
 import React from 'react'
 import en from './locales/en'
 
@@ -90,6 +91,28 @@ function TextTask (props) {
       </Box>
     </Box>
   )
+}
+
+TextTask.defaultProps = {
+  autoFocus: false,
+  className: '',
+  disabled: false
+}
+
+TextTask.propTypes = {
+  annotation: PropTypes.shape({
+    update: PropTypes.func,
+    value: PropTypes.string
+  }).isRequired,
+  autoFocus: PropTypes.bool,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  task: PropTypes.shape({
+    help: PropTypes.string,
+    instruction: PropTypes.string,
+    required: PropTypes.bool,
+    text_tags: PropTypes.arrayOf(PropTypes.string)
+  }).isRequired
 }
 
 export default TextTask

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.js
@@ -7,8 +7,8 @@ import en from './locales/en'
 counterpart.registerTranslations('en', en)
 
 function TextTask (props) {
-  const { autoFocus, disabled, task } = props
-  const { value } = task.annotation
+  const { annotation, autoFocus, disabled, task } = props
+  const { value } = annotation
   const textArea = React.createRef()
 
   function onChange (event) {
@@ -17,7 +17,7 @@ function TextTask (props) {
   }
 
   function updateText (text) {
-    task.updateAnnotation(text)
+    annotation.update(text)
   }
 
   function setTagSelection (e) {

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.spec.js
@@ -2,28 +2,23 @@ import React from 'react'
 import { mount, shallow } from 'enzyme'
 import { Text, TextArea } from 'grommet'
 import { expect } from 'chai'
-import sinon from 'sinon'
-
 import TextTask from './'
+import { default as Task } from '@plugins/tasks/TextTask'
 
 describe('TextTask', function () {
   let wrapper
-  const task = {
-    annotation: {
-      task: 'T0',
-      value: ''
-    },
+  const task = Task.TaskModel.create({
     instruction: 'Type something here',
     taskKey: 'T0',
     text_tags: ['insertion', 'deletion'],
-    updateAnnotation: sinon.stub().callsFake(value => {
-      task.annotation.value = value
-    })
-  }
+    type: 'text'
+  })
+  const { annotation } = task
 
   before(function () {
     wrapper = shallow(
       <TextTask
+        annotation={annotation}
         task={task}
       />
     )
@@ -33,32 +28,28 @@ describe('TextTask', function () {
     const label = wrapper.find('label')
     expect(label.find(Text).prop('children')).to.equal(task.instruction)
     const textarea = label.find(TextArea)
-    expect(textarea.prop('value')).to.equal(task.annotation.value)
+    expect(textarea.prop('value')).to.equal(annotation.value)
   })
 
   describe('onChange', function () {
     beforeEach(function () {
-      const annotation = { task: 'T0', value: '' }
+      annotation.update('')
       wrapper = shallow(
         <TextTask
-          task={Object.assign({}, task, { annotation })}
+          annotation={annotation}
+          task={task}
         />
       )
     })
 
-    afterEach(function () {
-      task.updateAnnotation.resetHistory()
-    })
-
     it('should update the textarea', function () {
-      const textArea = wrapper.find(TextArea)
       const fakeEvent = {
         target: {
           value: 'Hello there!'
         }
       }
-      textArea.simulate('change', fakeEvent)
-      wrapper.setProps({ task })
+      wrapper.find(TextArea).simulate('change', fakeEvent)
+      wrapper.setProps({ annotation })
       expect(wrapper.find(TextArea).prop('value')).to.equal(fakeEvent.target.value)
     })
 
@@ -70,26 +61,19 @@ describe('TextTask', function () {
         }
       }
       textArea.simulate('change', fakeEvent)
-      wrapper.setProps({ task })
-      expect(task.annotation.value).to.deep.equal(fakeEvent.target.value)
+      expect(annotation.value).to.deep.equal(fakeEvent.target.value)
     })
   })
 
   describe('text tagging', function () {
     beforeEach(function () {
-      const annotation = {
-        task: 'T0',
-        value: 'Hello, this is some test text.'
-      }
+      annotation.update('Hello, this is some test text.')
       wrapper = mount(
         <TextTask
-          task={Object.assign({}, task, { annotation })}
+          annotation={annotation}
+          task={task}
         />
       )
-    })
-
-    afterEach(function () {
-      task.updateAnnotation.resetHistory()
     })
 
     it('should render buttons for tagging text', function () {
@@ -115,8 +99,8 @@ describe('TextTask', function () {
       textArea.selectionEnd = 11
       const expectedText = 'Hello, [insertion]this[/insertion] is some test text.'
       insertionButton.simulate('click', fakeEvent)
-      wrapper.setProps({ task })
-      expect(textArea.value).to.equal(expectedText)
+      wrapper.setProps({ annotation })
+      expect(wrapper.find(TextArea).prop('value')).to.equal(expectedText)
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
@@ -9,5 +9,10 @@ const Annotation = types.model('Annotation', {
       return true
     }
   }))
+  .actions(self => ({
+    update (value) {
+      self.value = value
+    }
+  }))
 
 export default Annotation

--- a/packages/lib-classifier/src/plugins/tasks/models/Task.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Task.js
@@ -9,7 +9,7 @@ const Task = types.model('Task', {
   .views(self => ({
     get annotation () {
       const { classifications } = getRoot(self)
-      const { annotation } = classifications
+      const { annotation } = classifications || {}
       const currentAnnotation = annotation ? annotation(self) : self.defaultAnnotation
       return currentAnnotation
     },

--- a/packages/lib-classifier/src/plugins/tasks/models/Task.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Task.js
@@ -8,8 +8,10 @@ const Task = types.model('Task', {
 })
   .views(self => ({
     get annotation () {
-      const currentAnnotation = getRoot(self).classifications.annotation(self)
-      return currentAnnotation || self.defaultAnnotation
+      const { classifications } = getRoot(self)
+      const { annotation } = classifications
+      const currentAnnotation = annotation ? annotation(self) : self.defaultAnnotation
+      return currentAnnotation
     },
 
     get defaultAnnotation () {

--- a/packages/lib-classifier/src/store/Step.spec.js
+++ b/packages/lib-classifier/src/store/Step.spec.js
@@ -32,7 +32,6 @@ describe('Model > Step', function () {
     it('should be complete', function () {
       const step = Step.create({ stepKey: 'S1', taskKeys: ['T1', 'T2'], tasks })
       step.classifications = ClassificationStore.create()
-      step.classifications = ClassificationStore.create()
       const mockSubject = {
         id: 'subject',
         metadata: {}
@@ -60,7 +59,6 @@ describe('Model > Step', function () {
 
     it('should be incomplete', function () {
       const step = Step.create({ stepKey: 'S1', taskKeys: ['T1', 'T2'], tasks })
-      step.classifications = ClassificationStore.create()
       step.classifications = ClassificationStore.create()
       const mockSubject = {
         id: 'subject',

--- a/packages/lib-classifier/src/store/Step.spec.js
+++ b/packages/lib-classifier/src/store/Step.spec.js
@@ -32,6 +32,19 @@ describe('Model > Step', function () {
     it('should be complete', function () {
       const step = Step.create({ stepKey: 'S1', taskKeys: ['T1', 'T2'], tasks })
       step.classifications = ClassificationStore.create()
+      step.classifications = ClassificationStore.create()
+      const mockSubject = {
+        id: 'subject',
+        metadata: {}
+      }
+      const mockWorkflow = {
+        id: 'workflow',
+        version: '1.0'
+      }
+      const mockProject = {
+        id: 'project'
+      }
+      step.classifications.createClassification(mockSubject, mockWorkflow, mockProject)
       expect(step.isComplete).to.be.true()
     })
   })
@@ -48,6 +61,19 @@ describe('Model > Step', function () {
     it('should be incomplete', function () {
       const step = Step.create({ stepKey: 'S1', taskKeys: ['T1', 'T2'], tasks })
       step.classifications = ClassificationStore.create()
+      step.classifications = ClassificationStore.create()
+      const mockSubject = {
+        id: 'subject',
+        metadata: {}
+      }
+      const mockWorkflow = {
+        id: 'workflow',
+        version: '1.0'
+      }
+      const mockProject = {
+        id: 'project'
+      }
+      step.classifications.createClassification(mockSubject, mockWorkflow, mockProject)
       expect(step.isComplete).to.be.false()
     })
   })


### PR DESCRIPTION
Towards #1239. In order to render a form for the drawing subtasks linked to a particular transcription line, we want to be able to pass an annotation into a Task component independent of whether that annotation comes from the classification or a mark.

- connect `Tasks` to the classifications store.
- get the current annotation for each task from `classification.annotations`.
- Pass annotations into `TaskComponent` as an `annotation` prop.
- Add `annotation.update(value)` to update an annotation independent of where it is stored in the state tree.
- Update tests.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
