### PR TITLE
Remove source maps from production

### DIFF
--- a/packages/lib-classifier/webpack.dist.js
+++ b/packages/lib-classifier/webpack.dist.js
@@ -8,7 +8,6 @@ const EnvironmentWebpackPlugin = new webpack.EnvironmentPlugin({
 })
 
 module.exports = {
-  devtool: 'source-map',
   entry: './src/components/Classifier/index.js',
   externals: [
     '@zooniverse/grommet-theme',

--- a/packages/lib-react-components/webpack.dist.js
+++ b/packages/lib-react-components/webpack.dist.js
@@ -3,7 +3,6 @@ const path = require('path')
 const PeerDepsExternalsPlugin = require('peer-deps-externals-webpack-plugin')
 
 module.exports = {
-  devtool: 'source-map',
   entry: './src/index.js',
   mode: 'production',
   module: {


### PR DESCRIPTION
Remove source maps from the production config for lib-react-components and lib-classifier. This should speed up build times and may improve download times.

Package:
lib-classifier
lib-react-components

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
