### PR TITLE
Project app: catch errors in initial page render

### DIFF
--- a/packages/app-project/next.config.js
+++ b/packages/app-project/next.config.js
@@ -13,6 +13,7 @@ const talkHosts = require('./config/talkHosts')
 const PANOPTES_ENV = process.env.PANOPTES_ENV || 'staging'
 const webpackConfig = require('./webpack.config')
 const assetPrefix = process.env.ASSET_PREFIX || ''
+const SENTRY_DSN = process.env.SENTRY_DSN
 
 console.info(PANOPTES_ENV, talkHosts[PANOPTES_ENV])
 
@@ -22,6 +23,7 @@ module.exports = {
   env: {
     COMMIT_ID: execSync('git rev-parse HEAD').toString('utf8').trim(),
     PANOPTES_ENV,
+    SENTRY_DSN,
     TALK_HOST: talkHosts[PANOPTES_ENV]
   },
 

--- a/packages/app-project/pages/_document.js
+++ b/packages/app-project/pages/_document.js
@@ -32,6 +32,11 @@ export default class MyDocument extends Document {
         ...initialProps,
         styles: <>{initialProps.styles}{sheet.getStyleElement()}</>
       }
+    } catch (error) {
+      logNodeError(error)
+      return {
+        html: error.message
+      }
     } finally {
       sheet.seal()
     }


### PR DESCRIPTION
Catch errors during `Document.getInitialProps(ctx)` and log them to Sentry. Render the error message to the page.

Pass SENTRY_DSN to the browser when webpack bundles the client code.

Package:
app-project

Closes #1451 (I think.)

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
