### PR TITLE
Revert "Drawing: Add pointer capture to mark creation (#1420)"

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -41,8 +41,6 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, ma
     if (disabled || move) {
       return true
     }
-
-    const { target, pointerId } = event
     const activeMark = activeTool.createMark({
       id: cuid(),
       toolIndex: activeDrawingTask.activeToolIndex
@@ -50,7 +48,6 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, ma
     activeMark.initialPosition(convertEvent(event))
     setActiveMark(activeMark)
     setCreating(true)
-    target.setPointerCapture(pointerId)
     return false
   }
 
@@ -58,14 +55,13 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, ma
     creating && activeMark.initialDrag(convertEvent(event))
   }
 
-  function onFinish (event) {
-    const { target, pointerId } = event
+
+  function onFinish () {
     setCreating(false)
     if (activeMark && !activeMark.isValid) {
       activeTool.deleteMark(activeMark)
       setActiveMark(null)
     }
-    target.releasePointerCapture(pointerId)
   }
 
   return (

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -100,38 +100,15 @@ describe('Component > InteractionLayer', function () {
     describe('on pointer events', function () {
       it('should create a mark on pointer down', function () {
         const fakeEvent = {
-          pointerId: 'fakePointer',
-          type: 'pointer',
-          target: {
-            setPointerCapture: sinon.stub(),
-            releasePointerCapture: sinon.stub()
-          }
+          type: 'pointer'
         }
         wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
         expect(activeTool.createMark).to.have.been.calledOnce()
       })
 
-      it('should capture the pointer on pointer down', function () {
-        const fakeEvent = {
-          pointerId: 'fakePointer',
-          type: 'pointer',
-          target: {
-            setPointerCapture: sinon.stub(),
-            releasePointerCapture: sinon.stub()
-          }
-        }
-        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
-        expect(fakeEvent.target.setPointerCapture.withArgs('fakePointer')).to.have.been.calledOnce()
-      })
-
       it('should place a new mark on pointer down', function () {
         const fakeEvent = {
-          pointerId: 'fakePointer',
-          type: 'pointer',
-          target: {
-            setPointerCapture: sinon.stub(),
-            releasePointerCapture: sinon.stub()
-          }
+          type: 'pointer'
         }
         wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
         expect(mockMark.initialPosition).to.have.been.calledOnce()
@@ -139,12 +116,7 @@ describe('Component > InteractionLayer', function () {
 
       it('should drag the new mark on pointer down + move', function () {
         const fakeEvent = {
-          pointerId: 'fakePointer',
-          type: 'pointer',
-          target: {
-            setPointerCapture: sinon.stub(),
-            releasePointerCapture: sinon.stub()
-          }
+          type: 'pointer'
         }
         wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
         wrapper.find(InteractionLayer).simulate('pointermove', fakeEvent)
@@ -201,12 +173,7 @@ describe('Component > InteractionLayer', function () {
 
     it('should not create a mark on pointer down', function () {
       const fakeEvent = {
-        pointerId: 'fakePointer',
-        type: 'pointer',
-        target: {
-          setPointerCapture: sinon.stub(),
-          releasePointerCapture: sinon.stub()
-        }
+        type: 'pointer'
       }
       wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
       expect(activeTool.createMark).to.have.not.been.called()


### PR DESCRIPTION
Reverts pointer capture (#1420) to fix creating new marks (#1454).

Package:
lib-classifier

Closes #1454.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
