### PR TITLE
Drawing: Add classification snapshot processors

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
@@ -17,7 +17,6 @@ const BaseMark = types.model('BaseMark', {
   toolType: types.string
 })
   .preProcessSnapshot(snapshot => {
-    console.log('Mark preprocessor', snapshot)
     const newSnapshot = Object.assign({}, snapshot)
     // generate mark IDs, if not present
     newSnapshot.id = snapshot.id || cuid()
@@ -27,17 +26,14 @@ const BaseMark = types.model('BaseMark', {
       snapshot.annotations.forEach(annotation => annotationsMap[annotation.task] = annotation)
       newSnapshot.annotations = annotationsMap
     }
-    console.log(newSnapshot)
     return newSnapshot
   })
   .postProcessSnapshot(snapshot => {
-    console.log('Mark postprocessor')
     const newSnapshot = Object.assign({}, snapshot)
     // remove mark IDs
     delete newSnapshot.id
     // convert subtask annotations to an array
     newSnapshot.annotations = Object.values(snapshot.annotations)
-    console.log(newSnapshot)
     return newSnapshot
   })
   .views(self => ({

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
@@ -21,10 +21,13 @@ const BaseMark = types.model('BaseMark', {
     // generate mark IDs, if not present
     newSnapshot.id = snapshot.id || cuid()
     // convert any subtask annotations arrays to a map
-    const annotationsMap = {}
     if (snapshot.annotations && Array.isArray(snapshot.annotations)) {
-      snapshot.annotations.forEach(annotation => annotationsMap[annotation.task] = annotation)
-      newSnapshot.annotations = annotationsMap
+      const annotations = {}
+      snapshot.annotations.forEach(annotation => {
+        annotation.id = annotation.id || cuid()
+        annotations[annotation.id] = annotation
+      })
+      newSnapshot = Object.assign({}, newSnapshot, { annotations })
     }
     return newSnapshot
   })

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.spec.js
@@ -1,3 +1,4 @@
+import { getSnapshot } from 'mobx-state-tree'
 import Mark from './Mark'
 import { Tool } from '@plugins/drawingTools/models/tools'
 
@@ -5,11 +6,16 @@ describe('Models > Drawing Task > Mark', function () {
   let mark
 
   before(function () {
-    mark = Mark.create({ id: 'test', toolType: 'default' })
+    mark = Mark.create({ toolType: 'default' })
   })
 
   it('should exist', function () {
     expect(mark).to.be.ok()
+  })
+
+  it('should have an id', function () {
+    expect(mark.id).to.exist()
+    expect(mark.id).to.be.a('string')
   })
 
   it('should have a toolIndex', function () {
@@ -190,6 +196,22 @@ describe('Models > Drawing Task > Mark', function () {
           expect(drawingTool.isComplete).to.be.true()
         })
       })
+    })
+  })
+
+  describe('snapshots', function () {
+    let snapshot
+
+    before(function () {
+      snapshot = getSnapshot(mark)
+    })
+
+    it('should not have an ID', function () {
+      expect(snapshot.id).to.be.undefined()
+    })
+
+    it('should have an annotations array', function () {
+      expect(snapshot.annotations).to.be.a('array')
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.spec.js
@@ -66,7 +66,7 @@ describe('Models > Drawing Task > Mark', function () {
   })
 
   it('should be able to store annotations', function () {
-    expect(mark.annotations).to.be.ok()
+    expect(mark.annotations).to.be.a('map')
   })
 
   describe('getDistance', function () {

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.js
@@ -32,7 +32,6 @@ const Drawing = types.model('Drawing', {
         const { annotations, ...rest } = mark
         drawingSnapshot.value[markIndex] = rest
       })
-      console.log('drawing annotation', drawingAnnotations)
       return drawingAnnotations
     }
   }))

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.js
@@ -8,7 +8,7 @@ const Drawing = types.model('Drawing', {
   value: types.array(types.union(...markReferenceTypes))
 })
   .views(self => ({
-    get toSnapshot () {
+    toSnapshot () {
       const snapshot = getSnapshot(self)
       // resolve mark references (IDs) in the snapshot to mark snapshots
       const actualTask = resolveIdentifier(DrawingTask, getRoot(self), self.task)

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.js
@@ -1,4 +1,5 @@
-import { types } from 'mobx-state-tree'
+import { getRoot, getSnapshot, resolveIdentifier, types } from 'mobx-state-tree'
+import DrawingTask from './DrawingTask'
 import Annotation from '../../models/Annotation'
 import * as markTypes from '@plugins/drawingTools/models/marks'
 
@@ -6,6 +7,35 @@ const markReferenceTypes = Object.values(markTypes).map(markType => types.refere
 const Drawing = types.model('Drawing', {
   value: types.array(types.union(...markReferenceTypes))
 })
+  .views(self => ({
+    get toSnapshot () {
+      const snapshot = getSnapshot(self)
+      // resolve mark references (IDs) in the snapshot to mark snapshots
+      const actualTask = resolveIdentifier(DrawingTask, getRoot(self), self.task)
+      const value = actualTask.marks.map(mark => getSnapshot(mark))
+      const drawingSnapshot = Object.assign({}, snapshot, { value })
+      // flatten subtask annotations into a single annotations array
+      // then return the flattened array
+      const drawingAnnotations = [drawingSnapshot]
+      drawingSnapshot.value.forEach((markSnapshot, markIndex) => {
+        const mark = Object.assign({}, markSnapshot)
+        // map subtask keys to mark.details
+        mark.details = mark.annotations.map(annotation => ({ task: annotation.task }))
+        // push mark.annotations to the returned array
+        mark.annotations.forEach(markAnnotation => {
+          const finalAnnotation = Object.assign({}, markAnnotation, { markIndex })
+          // strip annotation IDs
+          const { id, ...rest } = finalAnnotation
+          drawingAnnotations.push(rest)
+        })
+        // remove annotations from individual marks
+        const { annotations, ...rest } = mark
+        drawingSnapshot.value[markIndex] = rest
+      })
+      console.log('drawing annotation', drawingAnnotations)
+      return drawingAnnotations
+    }
+  }))
 
 const DrawingAnnotation = types.compose('DrawingAnnotation', Annotation, Drawing)
 

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.spec.js
@@ -21,38 +21,42 @@ describe('Model > DrawingAnnotation', function () {
   })
 
   describe('annotation snapshots', function () {
+
+    function buildMockAnnotation ({ taskSnapshot }) {
+      const drawingTask = DrawingTask.create(taskSnapshot)
+      const annotation = drawingTask.createAnnotation()
+      // TODO: build a more realistic model tree here.
+      types.model('MockStore', {
+        drawingTask: DrawingTask,
+        annotation: DrawingAnnotation
+      })
+      .create({
+        drawingTask,
+        annotation
+      })
+      return { annotation, drawingTask }
+    }
+
     describe('without subtasks', function () {
       let snapshot
 
       before(function () {
-        const drawingTask = DrawingTask.create({
-          instruction: 'draw things!',
-          taskKey: 'T0',
-          tools: [
-            {
-              type: 'point'
-            }
-          ],
-          type: 'drawing'
+        const { annotation, drawingTask } = buildMockAnnotation({
+          taskSnapshot: {
+            instruction: 'draw things!',
+            taskKey: 'T0',
+            tools: [
+              {
+                type: 'point'
+              }
+            ],
+            type: 'drawing'
+          }
         })
         const pointTool = drawingTask.tools[0]
-        const point = pointTool.createMark({
+        pointTool.createMark({
           x: 50,
           y: 100
-        })
-        const annotation = DrawingAnnotation.create({
-          id: 'drawing1',
-          task: 'T0',
-          taskType: 'drawing',
-          value: [ point ]
-        })
-        const mockStore = types.model('MockStore', {
-          drawingTask: DrawingTask,
-          annotation: DrawingAnnotation
-        })
-        .create({
-          drawingTask,
-          annotation
         })
         snapshot = annotation.toSnapshot()
       })
@@ -95,29 +99,22 @@ describe('Model > DrawingAnnotation', function () {
       let snapshot
 
       before(function () {
-        const drawingTask = DrawingTask.create({
-          instruction: 'draw things!',
-          taskKey: 'T0',
-          tools: [
-            {
-              type: 'point',
-              details: [{
-                type: 'single',
-                answers: ['yes', 'no'],
-                question: 'yes or no?'
-              }]
-            }
-          ],
-          type: 'drawing'
-        })
-        const annotation = DrawingAnnotation.create(drawingAnnotationSnapshot)
-        const mockStore = types.model('MockStore', {
-          drawingTask: DrawingTask,
-          annotation: DrawingAnnotation
-        })
-        .create({
-          drawingTask,
-          annotation
+        const { annotation, drawingTask } = buildMockAnnotation({
+          taskSnapshot: {
+            instruction: 'draw things!',
+            taskKey: 'T0',
+            tools: [
+              {
+                type: 'point',
+                details: [{
+                  type: 'single',
+                  question: 'Yes or no?',
+                  answers: [ 'yes', 'no' ]
+                }]
+              }
+            ],
+            type: 'drawing'
+          }
         })
         const pointTool = drawingTask.tools[0]
         const point1 = pointTool.createMark({

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.spec.js
@@ -54,7 +54,7 @@ describe('Model > DrawingAnnotation', function () {
           drawingTask,
           annotation
         })
-        snapshot = annotation.toSnapshot
+        snapshot = annotation.toSnapshot()
       })
 
       it('should contain exactly one annotation', function () {
@@ -127,7 +127,7 @@ describe('Model > DrawingAnnotation', function () {
         const questionTask = pointTool.tasks[0]
         point1.addAnnotation(questionTask, 0)
         point2.addAnnotation(questionTask, 1)
-        snapshot = annotation.toSnapshot
+        snapshot = annotation.toSnapshot()
       })
 
       it('should contain the task annotation plus one annotation for each subtask', function () {

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.spec.js
@@ -1,19 +1,187 @@
+import { types } from 'mobx-state-tree'
+import DrawingTask from './DrawingTask'
 import DrawingAnnotation from './DrawingAnnotation'
 import { Point } from '@plugins/drawingTools/models/marks'
 
-const point = Point.create({ id: 'mockAnnotation', frame: 0, toolIndex: 0, toolType: 'point', x: 100, y: 150 })
-
-const drawingAnnotationSnapshot = {
-  id: 'drawing1',
-  task: 'T0',
-  taskType: 'drawing',
-  value: [ point.id ]
-}
-
 describe('Model > DrawingAnnotation', function () {
+  const point = Point.create({ id: 'mockAnnotation', frame: 0, toolIndex: 0, toolType: 'point', x: 100, y: 150 })
+
+
+  const drawingAnnotationSnapshot = {
+    id: 'drawing1',
+    task: 'T0',
+    taskType: 'drawing',
+    value: [ point.id ]
+  }
+
   it('should exist', function () {
     const drawingAnnotation = DrawingAnnotation.create(drawingAnnotationSnapshot)
     expect(drawingAnnotation).to.exist()
     expect(drawingAnnotation).to.be.an('object')
+  })
+
+  describe('annotation snapshots', function () {
+    describe('without subtasks', function () {
+      let snapshot
+
+      before(function () {
+        const drawingTask = DrawingTask.create({
+          instruction: 'draw things!',
+          taskKey: 'T0',
+          tools: [
+            {
+              type: 'point'
+            }
+          ],
+          type: 'drawing'
+        })
+        const pointTool = drawingTask.tools[0]
+        const point = pointTool.createMark({
+          x: 50,
+          y: 100
+        })
+        const annotation = DrawingAnnotation.create({
+          id: 'drawing1',
+          task: 'T0',
+          taskType: 'drawing',
+          value: [ point ]
+        })
+        const mockStore = types.model('MockStore', {
+          drawingTask: DrawingTask,
+          annotation: DrawingAnnotation
+        })
+        .create({
+          drawingTask,
+          annotation
+        })
+        snapshot = annotation.toSnapshot
+      })
+
+      it('should contain exactly one annotation', function () {
+        expect(snapshot).to.have.lengthOf(1)
+      })
+
+      describe('the annotation snapshot', function () {
+        it('should contain a task key', function () {
+          const [ annotation ] = snapshot
+          expect(annotation.task).to.equal('T0')
+        })
+
+        it('should contain a taskType', function () {
+          const [ annotation ] = snapshot
+          expect(annotation.taskType).to.equal('drawing')
+        })
+
+        it('should include snapshots of the drawn marks', function () {
+          const [ annotation ] = snapshot
+          const pointSnapshot = {
+            details: [],
+            frame: 0,
+            toolIndex: 0,
+            toolType: 'point',
+            x: 50,
+            y: 100
+          }
+          expect(annotation.value).to.deep.equal([ pointSnapshot ])
+        })
+      })
+    })
+
+    describe('with subtasks', function () {
+      let snapshot
+
+      before(function () {
+        const drawingTask = DrawingTask.create({
+          instruction: 'draw things!',
+          taskKey: 'T0',
+          tools: [
+            {
+              type: 'point',
+              details: [{
+                type: 'single',
+                answers: ['yes', 'no'],
+                question: 'yes or no?'
+              }]
+            }
+          ],
+          type: 'drawing'
+        })
+        const annotation = DrawingAnnotation.create(drawingAnnotationSnapshot)
+        const mockStore = types.model('MockStore', {
+          drawingTask: DrawingTask,
+          annotation: DrawingAnnotation
+        })
+        .create({
+          drawingTask,
+          annotation
+        })
+        const pointTool = drawingTask.tools[0]
+        const point1 = pointTool.createMark({
+          x: 50,
+          y: 100
+        })
+        const point2 = pointTool.createMark({
+          x: 150,
+          y: 200
+        })
+        const questionTask = pointTool.tasks[0]
+        point1.addAnnotation(questionTask, 0)
+        point2.addAnnotation(questionTask, 1)
+        snapshot = annotation.toSnapshot
+      })
+
+      it('should contain the task annotation plus one annotation for each subtask', function () {
+        expect(snapshot).to.have.lengthOf(3)
+      })
+      it('should contain snapshots of the annotation plus subtask answers', function () {
+        const [ annotation ] = snapshot
+        const point1Answer = {
+          task: 'T0.0.0',
+          taskType: 'single',
+          value: 0,
+          markIndex: 0
+        }
+        const point2Answer = {
+          task: 'T0.0.0',
+          taskType: 'single',
+          value: 1,
+          markIndex: 1
+        }
+        expect(snapshot).to.deep.equal([ annotation, point1Answer, point2Answer ])
+      })
+
+      describe('the annotation snapshot', function () {
+        it('should contain a task key', function () {
+          const [ annotation ] = snapshot
+          expect(annotation.task).to.equal('T0')
+        })
+
+        it('should contain a taskType', function () {
+          const [ annotation ] = snapshot
+          expect(annotation.taskType).to.equal('drawing')
+        })
+
+        it('should include snapshots of the drawn marks', function () {
+          const [ annotation ] = snapshot
+          const point1Snapshot = {
+            details: [{ task: 'T0.0.0' }],
+            frame: 0,
+            toolIndex: 0,
+            toolType: 'point',
+            x: 50,
+            y: 100
+          }
+          const point2Snapshot = {
+            details: [{ task: 'T0.0.0' }],
+            frame: 0,
+            toolIndex: 0,
+            toolType: 'point',
+            x: 150,
+            y: 200
+          }
+          expect(annotation.value).to.deep.equal([ point1Snapshot, point2Snapshot ])
+        })
+      })
+    })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.spec.js
@@ -57,6 +57,10 @@ describe('Model > DrawingAnnotation', function () {
         snapshot = annotation.toSnapshot()
       })
 
+      it('should be an array', function () {
+        expect(snapshot).to.be.a('array')
+      })
+
       it('should contain exactly one annotation', function () {
         expect(snapshot).to.have.lengthOf(1)
       })
@@ -130,9 +134,14 @@ describe('Model > DrawingAnnotation', function () {
         snapshot = annotation.toSnapshot()
       })
 
+      it('should be an array', function () {
+        expect(snapshot).to.be.a('array')
+      })
+
       it('should contain the task annotation plus one annotation for each subtask', function () {
         expect(snapshot).to.have.lengthOf(3)
       })
+
       it('should contain snapshots of the annotation plus subtask answers', function () {
         const [ annotation ] = snapshot
         const point1Answer = {

--- a/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
@@ -1,4 +1,4 @@
-import { types } from 'mobx-state-tree'
+import { getSnapshot, types } from 'mobx-state-tree'
 
 const Annotation = types.model('Annotation', {
   id: types.identifier,
@@ -8,6 +8,12 @@ const Annotation = types.model('Annotation', {
   .views(self => ({
     get isComplete () {
       return true
+    },
+
+    get toSnapshot () {
+      const snapshot = getSnapshot(self)
+      const { id, ...filteredSnapshot } = snapshot
+      return filteredSnapshot
     }
   }))
   .actions(self => ({

--- a/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
@@ -23,7 +23,7 @@ const Annotation = types.model('Annotation', {
       return true
     },
 
-    get toSnapshot () {
+    toSnapshot () {
       return getSnapshot(self)
     }
   }))

--- a/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
@@ -1,3 +1,4 @@
+import cuid from 'cuid'
 import { getSnapshot, types } from 'mobx-state-tree'
 
 const Annotation = types.model('Annotation', {
@@ -5,15 +6,25 @@ const Annotation = types.model('Annotation', {
   task: types.string,
   taskType: types.string
 })
+  .preProcessSnapshot(snapshot => {
+    const newSnapshot = Object.assign({}, snapshot)
+    // generate annotation IDs, if not present
+    newSnapshot.id = snapshot.id || cuid()
+    return newSnapshot
+  })
+  .postProcessSnapshot(snapshot => {
+    const newSnapshot = Object.assign({}, snapshot)
+    // remove annotation IDs
+    delete newSnapshot.id
+    return newSnapshot
+  })
   .views(self => ({
     get isComplete () {
       return true
     },
 
     get toSnapshot () {
-      const snapshot = getSnapshot(self)
-      const { id, ...filteredSnapshot } = snapshot
-      return filteredSnapshot
+      return getSnapshot(self)
     }
   }))
   .actions(self => ({

--- a/packages/lib-classifier/src/plugins/tasks/models/Annotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Annotation.spec.js
@@ -1,9 +1,32 @@
+import { getSnapshot } from 'mobx-state-tree'
 import Annotation from './Annotation'
 
 describe('Model > Annotation', function () {
+  let annotationInstance
+
+  before(function () {
+    annotationInstance = Annotation.create({ task: 'T4', taskType: 'default' })
+  })
+
   it('should exist', function () {
-    const annotationInstance = Annotation.create({ id: 'default1', task: 'T4', taskType: 'default' })
     expect(annotationInstance).to.be.ok()
     expect(annotationInstance).to.be.an('object')
+  })
+
+  it('should have an id', function () {
+    expect(annotationInstance.id).to.exist()
+    expect(annotationInstance.id).to.be.a('string')
+  })
+
+  describe('snapshots', function () {
+    let snapshot
+
+    before(function () {
+      snapshot = getSnapshot(annotationInstance)
+    })
+
+    it('should not have an ID', function () {
+      expect(snapshot.id).to.be.undefined()
+    })
   })
 })

--- a/packages/lib-classifier/src/store/Classification.js
+++ b/packages/lib-classifier/src/store/Classification.js
@@ -55,12 +55,10 @@ const Classification = types
         annotations = annotations.concat(annotation.toSnapshot)
       })
       snapshot = Object.assign({}, snapshot, { annotations })
-      console.log('Panoptes classification', snapshot)
       return snapshot
     }
   }))
   .preProcessSnapshot(snapshot => {
-    console.log('Classification preprocessor', snapshot)
     const newSnapshot = Object.assign({}, snapshot)
     // generate classification IDs, if not present
     newSnapshot.id = snapshot.id || cuid()
@@ -70,18 +68,15 @@ const Classification = types
       snapshot.annotations.forEach(annotation => annotationsMap[annotation.task] = annotation)
       newSnapshot.annotations = annotationsMap
     }
-    console.log(newSnapshot)
     return newSnapshot
   })
   .postProcessSnapshot(snapshot => {
-    console.log('Classification postprocessor')
     const newSnapshot = Object.assign({}, snapshot)
     // remove temporary classification IDs
     // TODO: leave the ID if it came from Panoptes
     delete newSnapshot.id
     // convert annotations to an array
     newSnapshot.annotations = Object.values(snapshot.annotations)
-    console.log(newSnapshot)
     return newSnapshot
   })
 

--- a/packages/lib-classifier/src/store/Classification.js
+++ b/packages/lib-classifier/src/store/Classification.js
@@ -48,11 +48,11 @@ const Classification = types
     metadata: types.maybe(ClassificationMetadata)
   })
   .views(self => ({
-    get toSnapshot () {
+    toSnapshot () {
       let snapshot = getSnapshot(self)
       let annotations = []
       self.annotations.forEach(annotation => {
-        annotations = annotations.concat(annotation.toSnapshot)
+        annotations = annotations.concat(annotation.toSnapshot())
       })
       snapshot = Object.assign({}, snapshot, { annotations })
       return snapshot

--- a/packages/lib-classifier/src/store/Classification.js
+++ b/packages/lib-classifier/src/store/Classification.js
@@ -59,14 +59,17 @@ const Classification = types
     }
   }))
   .preProcessSnapshot(snapshot => {
-    const newSnapshot = Object.assign({}, snapshot)
+    let newSnapshot = Object.assign({}, snapshot)
     // generate classification IDs, if not present
     newSnapshot.id = snapshot.id || cuid()
     // convert any annotations arrays to a map
-    const annotationsMap = {}
     if (snapshot.annotations && Array.isArray(snapshot.annotations)) {
-      snapshot.annotations.forEach(annotation => annotationsMap[annotation.task] = annotation)
-      newSnapshot.annotations = annotationsMap
+      const annotations = {}
+      snapshot.annotations.forEach(annotation => {
+        annotation.id = annotation.id || cuid()
+        annotations[annotation.id] = annotation
+      })
+      newSnapshot = Object.assign({}, newSnapshot, { annotations })
     }
     return newSnapshot
   })

--- a/packages/lib-classifier/src/store/Classification.spec.js
+++ b/packages/lib-classifier/src/store/Classification.spec.js
@@ -1,9 +1,15 @@
 import { getSnapshot } from 'mobx-state-tree'
+import taskRegistry from '@plugins/tasks'
 import Classification, { ClassificationMetadata } from './Classification'
 
 describe('Model > Classification', function () {
   let model
+  let firstAnnotation
+  let secondAnnotation
+
   before(function () {
+    const singleChoiceTask = taskRegistry.get('single')
+    const textTask = taskRegistry.get('text')
     model = Classification.create({
       links: {
         project: '1234',
@@ -17,6 +23,19 @@ describe('Model > Classification', function () {
         workflowVersion: '1.0'
       })
     })
+    const singleChoice = singleChoiceTask.TaskModel.create({
+      question: 'yes or no?',
+      answers: [ 'yes', 'no'],
+      taskKey: 'T1',
+      type: 'single'
+    })
+    const text = textTask.TaskModel.create({
+      instruction: 'type something',
+      taskKey: 'T0',
+      type: 'text'
+    })
+    firstAnnotation = model.addAnnotation(singleChoice, 0)
+    secondAnnotation = model.addAnnotation(text, 'This is a text task')
   })
 
   it('should exist', function () {
@@ -33,7 +52,7 @@ describe('Model > Classification', function () {
     let snapshot
 
     before(function () {
-      snapshot = getSnapshot(model)
+      snapshot = model.toSnapshot
     })
 
     it('should not have an ID', function () {
@@ -42,6 +61,10 @@ describe('Model > Classification', function () {
 
     it('should have an annotations array', function () {
       expect(snapshot.annotations).to.be.a('array')
+    })
+
+    it('should preserve annotation order', function () {
+      expect(snapshot.annotations).to.deep.equal([ firstAnnotation.toSnapshot, secondAnnotation.toSnapshot ])
     })
   })
 })

--- a/packages/lib-classifier/src/store/Classification.spec.js
+++ b/packages/lib-classifier/src/store/Classification.spec.js
@@ -1,11 +1,10 @@
-import cuid from 'cuid'
+import { getSnapshot } from 'mobx-state-tree'
 import Classification, { ClassificationMetadata } from './Classification'
 
 describe('Model > Classification', function () {
   let model
   before(function () {
     model = Classification.create({
-      id: cuid(),
       links: {
         project: '1234',
         subjects: ['4567'],
@@ -23,5 +22,26 @@ describe('Model > Classification', function () {
   it('should exist', function () {
     expect(model).to.be.ok()
     expect(model).to.be.an('object')
+  })
+
+  it('should have an ID', function () {
+    expect(model.id).to.exist()
+    expect(model.id).to.be.a('string')
+  })
+
+  describe('snapshots', function () {
+    let snapshot
+
+    before(function () {
+      snapshot = getSnapshot(model)
+    })
+
+    it('should not have an ID', function () {
+      expect(snapshot.id).to.be.undefined()
+    })
+
+    it('should have an annotations array', function () {
+      expect(snapshot.annotations).to.be.a('array')
+    })
   })
 })

--- a/packages/lib-classifier/src/store/Classification.spec.js
+++ b/packages/lib-classifier/src/store/Classification.spec.js
@@ -52,7 +52,7 @@ describe('Model > Classification', function () {
     let snapshot
 
     before(function () {
-      snapshot = model.toSnapshot
+      snapshot = model.toSnapshot()
     })
 
     it('should not have an ID', function () {
@@ -64,7 +64,7 @@ describe('Model > Classification', function () {
     })
 
     it('should preserve annotation order', function () {
-      expect(snapshot.annotations).to.deep.equal([ firstAnnotation.toSnapshot, secondAnnotation.toSnapshot ])
+      expect(snapshot.annotations).to.deep.equal([ firstAnnotation.toSnapshot(), secondAnnotation.toSnapshot() ])
     })
   })
 })

--- a/packages/lib-classifier/src/store/Classification.spec.js
+++ b/packages/lib-classifier/src/store/Classification.spec.js
@@ -4,13 +4,21 @@ import Classification, { ClassificationMetadata } from './Classification'
 
 describe('Model > Classification', function () {
   let model
-  let firstAnnotation
-  let secondAnnotation
 
   before(function () {
-    const singleChoiceTask = taskRegistry.get('single')
-    const textTask = taskRegistry.get('text')
     model = Classification.create({
+      annotations: [
+        {
+          task: 'T1',
+          taskType: 'single',
+          value: 1
+        },
+        {
+          task: 'T0',
+          taskType: 'text',
+          value: 'Hello'
+        }
+      ],
       links: {
         project: '1234',
         subjects: ['4567'],
@@ -23,19 +31,6 @@ describe('Model > Classification', function () {
         workflowVersion: '1.0'
       })
     })
-    const singleChoice = singleChoiceTask.TaskModel.create({
-      question: 'yes or no?',
-      answers: [ 'yes', 'no'],
-      taskKey: 'T1',
-      type: 'single'
-    })
-    const text = textTask.TaskModel.create({
-      instruction: 'type something',
-      taskKey: 'T0',
-      type: 'text'
-    })
-    firstAnnotation = model.addAnnotation(singleChoice, 0)
-    secondAnnotation = model.addAnnotation(text, 'This is a text task')
   })
 
   it('should exist', function () {
@@ -48,10 +43,48 @@ describe('Model > Classification', function () {
     expect(model.id).to.be.a('string')
   })
 
+  describe('existing annotations', function () {
+    it('should exist', function () {
+      expect(model.annotations.size).to.equal(2)
+    })
+
+    it('should preserve the original array order', function () {
+      const annotations = model.annotations.values()
+      let annotation = annotations.next().value
+      expect(annotation.task).to.equal('T1')
+      expect(annotation.taskType).to.equal('single')
+      expect(annotation.value).to.equal(1)
+      annotation = annotations.next().value
+      expect(annotation.task).to.equal('T0')
+      expect(annotation.taskType).to.equal('text')
+      expect(annotation.value).to.equal('Hello')
+      annotation = annotations.next().value
+      expect(annotation).to.be.undefined()
+    })
+  })
+
   describe('snapshots', function () {
     let snapshot
+    let firstAnnotation
+    let secondAnnotation
 
     before(function () {
+      const singleChoiceTask = taskRegistry.get('single')
+      const textTask = taskRegistry.get('text')
+      const singleChoice = singleChoiceTask.TaskModel.create({
+        question: 'yes or no?',
+        answers: [ 'yes', 'no'],
+        taskKey: 'T1',
+        type: 'single'
+      })
+      const text = textTask.TaskModel.create({
+        instruction: 'type something',
+        taskKey: 'T0',
+        type: 'text'
+      })
+      // lets update a couple of mock annotations
+      firstAnnotation = model.addAnnotation(singleChoice, 0)
+      secondAnnotation = model.addAnnotation(text, 'This is a text task')
       snapshot = model.toSnapshot()
     })
 

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -176,7 +176,7 @@ const ClassificationStore = types
 
         classification.completed = true
         // Convert from observables
-        let classificationToSubmit = classification.toSnapshot
+        let classificationToSubmit = classification.toSnapshot()
 
         const convertedMetadata = {}
         Object.entries(classificationToSubmit.metadata).forEach((entry) => {

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -10,7 +10,6 @@ import Classification, { ClassificationMetadata } from './Classification'
 import ResourceStore from './ResourceStore'
 import {
   ClassificationQueue,
-  convertMapToArray,
   sessionUtils
 } from './utils'
 
@@ -177,9 +176,7 @@ const ClassificationStore = types
 
         classification.completed = true
         // Convert from observables
-        const classificationToSubmit = toJS(classification, { exportMapsAsObjects: false })
-        delete classificationToSubmit.id // remove temp id
-        classificationToSubmit.annotations = convertMapToArray(classificationToSubmit.annotations)
+        let classificationToSubmit = classification.toSnapshot
 
         const convertedMetadata = {}
         Object.entries(classificationToSubmit.metadata).forEach((entry) => {


### PR DESCRIPTION
Package:
lib-classifier

Towards #1443.

Use snapshot processors to serialise classifications as per [ADR 25](https://github.com/zooniverse/front-end-monorepo/blob/master/docs/arch/adr-25.md#annotation-json-structure-1).

Add a new `toSnapshot` view to annotations and classifications, which returns a snapshot where all references have been resolved to full snapshots.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
