### PR TITLE
Add white to theme

### DIFF
--- a/packages/lib-grommet-theme/CHANGELOG.md
+++ b/packages/lib-grommet-theme/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unpublished] 2019-10-24
+## [Unpublished]
 ### Added
 - Added `#43BBFD` (blue) as `neutral-5`.
+- Added `#ffffff` (white) as `neutral-6`
 
 ### Changed
 - Lowered font weight for form input text.

--- a/packages/lib-grommet-theme/README.md
+++ b/packages/lib-grommet-theme/README.md
@@ -54,6 +54,7 @@ class MyComponent extends React.Component {
 | `neutral-3` | `#0C4881` | ![](https://via.placeholder.com/80x30.png/0C4881?text=+) |
 | `neutral-4` | `#f0b200` | ![](https://via.placeholder.com/80x30.png/f0b200?text=+) |
 | `neutral-5` | `#43BBFD` | ![](https://via.placeholder.com/80x30.png/43BBFD?text=+) |
+| `neutral-6` | `#ffffff` | ![](https://via.placeholder.com/80x30.png/ffffff?text=+)
 | `status-critical` | `#E45950` | ![](https://via.placeholder.com/80x30.png/E45950?text=+) |
 | `status-error` | `#FFB6AA` | ![](https://via.placeholder.com/80x30.png/FFB6AA?text=+) |
 | `status-warning` | `#CC9200` | ![](https://via.placeholder.com/80x30.png/CC9200?text=+) |

--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -36,6 +36,7 @@ const darkTeal = '#005D69'
 const navy = '#0C4881'
 const gold = '#f0b200'
 const blue = '#43BBFD'
+const white = '#ffffff'
 
 const accentColors = [
   mint, // accent-1
@@ -49,7 +50,8 @@ const neutralColors = [
   darkTeal, // neutral-2
   navy, // neutral-3
   gold, // neutral-4
-  blue // neutral-5
+  blue, // neutral-5
+  white // neutral-6
 ]
 
 const statusColors = {


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package:

Closes #1456

Describe your changes:
Adds white to theme since we're using it with a couple of the newer WIP subject viewers.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
