### PR TITLE
Classifier: delete annotations by task key

### DIFF
--- a/packages/lib-classifier/src/store/AnnotationsStore.js
+++ b/packages/lib-classifier/src/store/AnnotationsStore.js
@@ -27,8 +27,19 @@ const AnnotationsStore = types
       return annotation
     }
 
+    function removeAnnotation (taskKey) {
+      let taskAnnotation
+      self.annotations.forEach(annotation => {
+        if (annotation.task === taskKey) {
+          taskAnnotation = annotation
+        }
+      })
+      taskAnnotation && self.annotations.delete(taskAnnotation.id)
+    }
+
     return {
-      addAnnotation
+      addAnnotation,
+      removeAnnotation
     }
   })
 

--- a/packages/lib-classifier/src/store/AnnotationsStore.spec.js
+++ b/packages/lib-classifier/src/store/AnnotationsStore.spec.js
@@ -19,6 +19,10 @@ describe('Model > AnnotationsStore', function () {
   describe(`updating an annotation`, function () {
     const task = Task.create({ taskKey: 'T0', type: 'default', question: 'How many cats?' })
 
+    before(function () {
+      model = AnnotationsStore.create({})
+    })
+
     describe('for a new task', function () {
       it('should create a new annotation', function () {
         model.addAnnotation(task)
@@ -41,6 +45,31 @@ describe('Model > AnnotationsStore', function () {
         const annotation = model.addAnnotation(task, 2)
         expect(model.annotations.size).to.equal(1)
         expect(annotation.value).to.equal(2)
+      })
+    })
+  })
+
+  describe(`removing an annotation`, function () {
+    const task = Task.create({ taskKey: 'T0', type: 'default', question: 'How many cats?' })
+
+    before(function () {
+      model = AnnotationsStore.create({})
+    })
+
+    describe('for a new task', function () {
+      it('should do nothing', function () {
+        expect(model.annotations.size).to.equal(0)
+        model.removeAnnotation('T0')
+        expect(model.annotations.size).to.equal(0)
+      })
+    })
+
+    describe('for an existing task', function () {
+      it('should remove the existing annotation', function () {
+        const annotation = model.addAnnotation(task, 2)
+        expect(model.annotations.size).to.equal(1)
+        model.removeAnnotation('T0')
+        expect(model.annotations.size).to.equal(0)
       })
     })
   })

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -141,7 +141,7 @@ const ClassificationStore = types
         const classification = self.active
         const workflow = getRoot(self).workflows.active
         const isPersistAnnotationsSet = workflow.configuration.persist_annotations
-        if (!isPersistAnnotationsSet) classification.annotations.delete(taskKey)
+        if (!isPersistAnnotationsSet) classification.removeAnnotation(taskKey)
       } else {
         if (process.browser) {
           console.error('No active classification or no active workflow. Cannot remove annotation.')


### PR DESCRIPTION
Add `annotationsStore.removeAnnotation(taskKey)`, which finds the last annotation matching the supplied task key and removes it from the store.

Package:
lib-classifier

Closes #1498.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
