### PR TITLE
Drawing: fix evergreen subtask tests

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
@@ -58,36 +58,59 @@ describe('Model > DrawingTools > Tool', function () {
       console.error.restore()
     })
 
-    it('should create a new task for valid subtasks', function () {
-      const details = [
-        {
-          type: 'multiple',
-          question: 'which fruit?',
-          answers: ['apples', 'oranges', 'pears'],
-          required: false
-        },
-        {
-          type: 'single',
-          question: 'how many?',
-          answers: ['one', 'two', 'three'],
-          required: false
-        },
-        {
-          type: 'text',
-          instruction: 'Transcribe something',
-          required: false
-        }
-      ]
-      const tool = Tool.create(Object.assign({}, toolData, { details }))
-      const multipleTaskSnapshot = Object.assign({}, tool.details[0], {taskKey: 'multiple'})
-      const singleTaskSnapshot = Object.assign({}, tool.details[1], {taskKey: 'single'})
-      const textTaskSnapshot = Object.assign({}, tool.details[2], {taskKey: 'text'})
-      const multipleTask = tool.createTask(multipleTaskSnapshot)
-      const singleTask = tool.createTask(singleTaskSnapshot)
-      const textTask = tool.createTask(singleTaskSnapshot)
-      expect(tool.tasks[0]).to.equal(multipleTask)
-      expect(tool.tasks[1]).to.equal(singleTask)
-      expect(tool.tasks[2]).to.equal(textTask)
+    describe('with valid subtasks', function () {
+      let multipleTaskSnapshot
+      let singleTaskSnapshot
+      let textTaskSnapshot
+      let tool
+
+      before(function () {
+        const details = [
+          {
+            type: 'multiple',
+            question: 'which fruit?',
+            answers: ['apples', 'oranges', 'pears'],
+            help: '',
+            required: false
+          },
+          {
+            type: 'single',
+            question: 'how many?',
+            answers: ['one', 'two', 'three'],
+            help: '',
+            required: false
+          },
+          {
+            type: 'text',
+            instruction: 'Transcribe something',
+            help: '',
+            required: false,
+            text_tags: []
+          }
+        ]
+        tool = Tool.create(Object.assign({}, toolData, { details }))
+        multipleTaskSnapshot = Object.assign({}, tool.details[0], {taskKey: 'multiple'})
+        singleTaskSnapshot = Object.assign({}, tool.details[1], {taskKey: 'single'})
+        textTaskSnapshot = Object.assign({}, tool.details[2], {taskKey: 'text'})
+        tool.createTask(multipleTaskSnapshot)
+        tool.createTask(singleTaskSnapshot)
+        tool.createTask(textTaskSnapshot)
+      })
+
+      it('should create multiple choice tasks', function () {
+        const {annotation, ...snapshot} = tool.tasks[0]
+        expect(snapshot).to.deep.equal(multipleTaskSnapshot)
+      })
+
+      it('should create single choice tasks', function () {
+        const {annotation, ...snapshot} = tool.tasks[1]
+        expect(snapshot).to.deep.equal(singleTaskSnapshot)
+      })
+
+      it('should create text tasks', function () {
+        const {annotation, ...snapshot} = tool.tasks[2]
+        expect(snapshot).to.deep.equal(textTaskSnapshot)
+      })
     })
 
     it('should error for invalid subtasks', function () {


### PR DESCRIPTION
Test drawing tool subtasks by checking the task model against an expected snapshot for each type of valid subtask.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
