### PR TITLE
Drawing: add active mark to the drawing task

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -123,7 +123,7 @@ InteractionLayer.propTypes = {
 }
 
 InteractionLayer.defaultProps = {
-  activeMark: null,
+  activeMark: undefined,
   disabled: false,
   marks: [],
   scale: 1,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -12,8 +12,18 @@ const StyledRect = styled('rect')`
   }
 `
 
-function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, marks, move, scale, width }) {
-  const [ activeMark, setActiveMark ] = useState(null)
+function InteractionLayer ({
+  activeDrawingTask,
+  activeMark,
+  activeTool,
+  disabled,
+  height,
+  marks,
+  move,
+  scale,
+  setActiveMark,
+  width
+}) {
   const [ creating, setCreating ] = useState(false)
   const { svg, getScreenCTM } = useContext(SVGContext)
 
@@ -102,18 +112,22 @@ function InteractionLayer ({ activeDrawingTask, activeTool, disabled, height, ma
 
 InteractionLayer.propTypes = {
   activeDrawingTask: PropTypes.object.isRequired,
+  activeMark: PropTypes.object,
   activeTool: PropTypes.object.isRequired,
   height: PropTypes.number.isRequired,
   disabled: PropTypes.bool,
   marks: PropTypes.array,
   scale: PropTypes.number,
+  setActiveMark: PropTypes.func,
   width: PropTypes.number.isRequired
 }
 
 InteractionLayer.defaultProps = {
+  activeMark: null,
   disabled: false,
   marks: [],
-  scale: 1
+  scale: 1,
+  setActiveMark: () => null
 }
 
 export default InteractionLayer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -78,7 +78,7 @@ function InteractionLayer ({
     setCreating(false)
     if (activeMark && !activeMark.isValid) {
       activeTool.deleteMark(activeMark)
-      setActiveMark(null)
+      setActiveMark(undefined)
     }
     target.releasePointerCapture(pointerId)
   }
@@ -100,7 +100,7 @@ function InteractionLayer ({
         <DrawingToolMarks
           activeMarkId={activeMark && activeMark.id}
           marks={marks}
-          onDelete={() => setActiveMark(null)}
+          onDelete={() => setActiveMark(undefined)}
           onFinish={onFinish}
           onSelectMark={mark => setActiveMark(mark)}
           scale={scale}
@@ -127,7 +127,7 @@ InteractionLayer.defaultProps = {
   disabled: false,
   marks: [],
   scale: 1,
-  setActiveMark: () => null
+  setActiveMark: () => undefined
 }
 
 export default InteractionLayer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme'
-import React from 'react'
+import React, { useState } from 'react'
 import sinon from 'sinon'
 
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
@@ -64,17 +64,25 @@ describe('Component > InteractionLayer', function () {
         ],
         type: 'drawing'
       })
+      function InteractionLayerContainer () {
+        const [ activeMark, setActiveMark ] = useState(null)
+        return (
+          <InteractionLayer
+            activeDrawingTask={mockDrawingTask}
+            activeMark={activeMark}
+            activeTool={activeTool}
+            setActiveMark={setActiveMark}
+            height={400}
+            width={600}
+          />
+        )
+      }
       activeTool = mockDrawingTask.activeTool
       sinon.stub(activeTool, 'createMark').callsFake(() => mockMark)
       wrapper = mount(
         <SVGContext.Provider value={{ svg, getScreenCTM }}>
           <svg>
-            <InteractionLayer
-              activeDrawingTask={mockDrawingTask}
-              activeTool={activeTool}
-              height={400}
-              width={600}
-            />
+            <InteractionLayerContainer />
           </svg>
         </SVGContext.Provider>
       )

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -21,14 +21,16 @@ function storeMapper (stores) {
   const disabled = activeTool ? activeTool.disabled : false
   const drawingAnnotations = Array.from(classification.annotations.values())
     .filter(annotation => getType(annotation).name === 'DrawingAnnotation')
-  const { marks } = activeDrawingTask || {}
+  const { activeMark, marks, setActiveMark } = activeDrawingTask || {}
   return {
     activeDrawingTask,
+    activeMark,
     activeTool,
     disabled,
     drawingAnnotations,
     marks,
-    move
+    move,
+    setActiveMark
   }
 }
 
@@ -38,12 +40,14 @@ class InteractionLayerContainer extends Component {
   render () {
     const {
       activeDrawingTask,
+      activeMark,
       activeTool,
       disabled,
       drawingAnnotations,
       height,
       marks,
       move,
+      setActiveMark,
       scale,
       width
     } = this.props
@@ -60,11 +64,13 @@ class InteractionLayerContainer extends Component {
           <InteractionLayer
             key={activeDrawingTask.taskKey}
             activeDrawingTask={activeDrawingTask}
+            activeMark={activeMark}
             activeTool={activeTool}
             disabled={disabled}
             height={height}
             marks={marks}
             move={move}
+            setActiveMark={setActiveMark}
             scale={scale}
             width={width}
           />

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
@@ -2,11 +2,15 @@ import cuid from 'cuid'
 import { types } from 'mobx-state-tree'
 import Task from '../../models/Task'
 import * as tools from '@plugins/drawingTools/models/tools'
+import * as markTypes from '@plugins/drawingTools/models/marks'
 import DrawingAnnotation from './DrawingAnnotation'
 
+const markModels = Object.values(markTypes)
+const markReferenceTypes = markModels.map(markType => types.safeReference(markType))
 const toolModels = Object.values(tools)
 
 const Drawing = types.model('Drawing', {
+  activeMark: types.union(...markReferenceTypes),
   activeToolIndex: types.optional(types.number, 0),
   annotation: types.safeReference(DrawingAnnotation),
   help: types.optional(types.string, ''),
@@ -54,6 +58,10 @@ const Drawing = types.model('Drawing', {
       })
     }
 
+    function setActiveMark (mark) {
+      self.activeMark = mark
+    }
+
     function setActiveTool (toolIndex) {
       self.activeToolIndex = toolIndex
     }
@@ -70,6 +78,7 @@ const Drawing = types.model('Drawing', {
       afterCreate,
       complete,
       reset,
+      setActiveMark,
       setActiveTool
     }
   })

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
@@ -86,6 +86,29 @@ describe('Model > DrawingTask', function () {
     })
   })
 
+  describe('active mark', function () {
+    let drawingTask
+    let marks
+
+    before(function () {
+      drawingTask = DrawingTask.TaskModel.create(drawingTaskSnapshot)
+      drawingTask.tools[0].createMark({ id: 'point1' })
+      drawingTask.tools[0].createMark({ id: 'point2' })
+      drawingTask.tools[1].createMark({ id: 'line1' })
+      marks = drawingTask.marks
+    })
+
+    it('should be undefined by default', function () {
+      expect(drawingTask.activeMark).to.be.undefined()
+    })
+
+    it('should be set from stored marks', function () {
+      const point1 = drawingTask.marks[0]
+      drawingTask.setActiveMark(point1)
+      expect(drawingTask.activeMark).to.equal(point1)
+    })
+  })
+
   describe('with subtask annotations', function () {
     let line1
     let point1


### PR DESCRIPTION
Move `activeMark` and `setActiveMark` to the drawing task model, so that the active mark can be accessed from the subtask popup box.

Package:
lib-classifier

Towards #1315.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
