### PR TITLE
fix content pages pages when API data is unavailable

### DIFF
--- a/packages/app-content-pages/src/screens/Publications/PublicationsContainer.js
+++ b/packages/app-content-pages/src/screens/Publications/PublicationsContainer.js
@@ -10,8 +10,7 @@ import Publications from './Publications'
 counterpart.registerTranslations('en', en)
 
 function PublicationsContainer(props) {
-  const error = props.error
-  const publicationsData = props.publicationsData || []
+  const { error, publicationsData } = props
   const [activeFilter, setActiveFilter] = useState(null)
 
   const filters = createFilters(publicationsData, activeFilter, setActiveFilter)
@@ -46,6 +45,10 @@ PublicationsContainer.getInitialProps = async ({ req }) => {
 PublicationsContainer.propTypes = {
   error: string,
   publicationsData: array,
+}
+
+PublicationsContainer.defaultProps = {
+  publicationsData: []
 }
 
 export default PublicationsContainer

--- a/packages/app-content-pages/src/screens/Publications/PublicationsContainer.js
+++ b/packages/app-content-pages/src/screens/Publications/PublicationsContainer.js
@@ -10,7 +10,8 @@ import Publications from './Publications'
 counterpart.registerTranslations('en', en)
 
 function PublicationsContainer(props) {
-  const { error, publicationsData } = props
+  const error = props.error
+  const publicationsData = props.publicationsData || []
   const [activeFilter, setActiveFilter] = useState(null)
 
   const filters = createFilters(publicationsData, activeFilter, setActiveFilter)
@@ -30,9 +31,12 @@ function PublicationsContainer(props) {
 PublicationsContainer.getInitialProps = async ({ req }) => {
   const host = getHost(req)
   let error
-  const publicationsData = await request.get(host + '/api/publications')
-    .then(res => res.body)
-    .catch(err => error = err.message)
+  let publicationsData = []
+  try {
+    publicationsData = (await request.get(host + '/api/publications')).body
+  } catch (err) {
+    error = err.message
+  }
   return {
     error,
     publicationsData

--- a/packages/app-content-pages/src/screens/Publications/PublicationsContainer.spec.js
+++ b/packages/app-content-pages/src/screens/Publications/PublicationsContainer.spec.js
@@ -1,5 +1,7 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
+import request from 'superagent'
 
 import PublicationsContainer from './PublicationsContainer'
 import mockData from './PublicationsContainer.mock'
@@ -17,6 +19,50 @@ describe('Component > PublicationsContainer', function () {
 
   it('should render without crashing', function () {
     expect(wrapper).to.be.ok()
+  })
+
+  describe('with no publications data', function () {
+    it('should render without crashing', function () {
+      const noDataWrapper = shallow(<PublicationsContainer publicationsData={undefined} />)
+      expect(noDataWrapper).to.be.ok()
+    })
+  })
+
+  describe('populates the "publicationsData" props from contentful API', function () {
+    let getpublicationsDataStub
+
+    afterEach(function () {
+      getpublicationsDataStub.restore()
+    })
+
+    it('should handle valid API data', async () => {
+      getpublicationsDataStub = sinon.stub(request, 'get').returns({ body: DATA })
+      const props = await PublicationsContainer.getInitialProps({})
+      expect(props).to.deep.equal({
+        error: undefined,
+        publicationsData: DATA
+      })
+    })
+
+    it('should handle empty API reponse', async () => {
+      getpublicationsDataStub = sinon.stub(request, 'get').returns({ body: [] })
+      const props = await PublicationsContainer.getInitialProps({})
+      expect(props).to.deep.equal({
+        error: undefined,
+        publicationsData: []
+      })
+    })
+
+    it('should handle API errors', async () => {
+      var errorMsg = 'failed to connect to API'
+      var errorPromise = Promise.reject(new Error(errorMsg))
+      getpublicationsDataStub = sinon.stub(request, 'get').returns(errorPromise)
+      const props = await PublicationsContainer.getInitialProps({})
+      expect(props).to.deep.equal({
+        error: errorMsg,
+        publicationsData: []
+      })
+    })
   })
 
   it('should render the `Publications` component', function () {

--- a/packages/app-content-pages/src/screens/Team/TeamContainer.js
+++ b/packages/app-content-pages/src/screens/Team/TeamContainer.js
@@ -10,8 +10,7 @@ import Team from './Team'
 counterpart.registerTranslations('en', en)
 
 function TeamContainer (props) {
-  const error = props.error
-  const teamData = props.teamData || [];
+  const { error, teamData } = props
   const [activeFilter, setActiveFilter] = useState(null)
 
   const filters = createFilters(teamData, activeFilter, setActiveFilter)
@@ -46,6 +45,10 @@ TeamContainer.getInitialProps = async ({ req }) => {
 TeamContainer.propTypes = {
   error: string,
   teamData: array,
+}
+
+TeamContainer.defaultProps = {
+  teamData: []
 }
 
 export default TeamContainer

--- a/packages/app-content-pages/src/screens/Team/TeamContainer.js
+++ b/packages/app-content-pages/src/screens/Team/TeamContainer.js
@@ -32,9 +32,11 @@ TeamContainer.getInitialProps = async ({ req }) => {
   const host = getHost(req)
   let error
   let teamData
-  await request.get(host + '/api/team')
-    .then(res => teamData = res.body)
-    .catch(err => error = err.message)
+  try {
+    teamData = (await request.get(host + '/api/team')).body
+  } catch (err) {
+    error = err.message
+  }
   return {
     error,
     teamData

--- a/packages/app-content-pages/src/screens/Team/TeamContainer.js
+++ b/packages/app-content-pages/src/screens/Team/TeamContainer.js
@@ -58,8 +58,6 @@ function createFilters (teamData, activeFilter, setActiveFilter) {
     setActive: () => setActiveFilter(null)
   }
 
-  console.log(teamData);
-
   const teamFilters = teamData.map(team => ({
     active: activeFilter === team.name,
     name: team.name,

--- a/packages/app-content-pages/src/screens/Team/TeamContainer.js
+++ b/packages/app-content-pages/src/screens/Team/TeamContainer.js
@@ -31,8 +31,9 @@ function TeamContainer (props) {
 TeamContainer.getInitialProps = async ({ req }) => {
   const host = getHost(req)
   let error
-  const teamData = await request.get(host + '/api/team')
-    .then(res => res.body)
+  let teamData
+  await request.get(host + '/api/team')
+    .then(res => teamData = res.body)
     .catch(err => error = err.message)
   return {
     error,

--- a/packages/app-content-pages/src/screens/Team/TeamContainer.js
+++ b/packages/app-content-pages/src/screens/Team/TeamContainer.js
@@ -10,7 +10,8 @@ import Team from './Team'
 counterpart.registerTranslations('en', en)
 
 function TeamContainer (props) {
-  const { error, teamData } = props
+  const error = props.error
+  const teamData = props.teamData || [];
   const [activeFilter, setActiveFilter] = useState(null)
 
   const filters = createFilters(teamData, activeFilter, setActiveFilter)
@@ -56,6 +57,8 @@ function createFilters (teamData, activeFilter, setActiveFilter) {
     name: counterpart('Team.showAll'),
     setActive: () => setActiveFilter(null)
   }
+
+  console.log(teamData);
 
   const teamFilters = teamData.map(team => ({
     active: activeFilter === team.name,

--- a/packages/app-content-pages/src/screens/Team/TeamContainer.js
+++ b/packages/app-content-pages/src/screens/Team/TeamContainer.js
@@ -31,7 +31,7 @@ function TeamContainer (props) {
 TeamContainer.getInitialProps = async ({ req }) => {
   const host = getHost(req)
   let error
-  let teamData
+  let teamData = []
   try {
     teamData = (await request.get(host + '/api/team')).body
   } catch (err) {

--- a/packages/app-content-pages/src/screens/Team/TeamContainer.spec.js
+++ b/packages/app-content-pages/src/screens/Team/TeamContainer.spec.js
@@ -23,8 +23,7 @@ describe('Component > TeamContainer', function () {
 
   describe('with no team data', function () {
     it('should render without crashing', function () {
-      let teamNoData;
-      let noDataWrapper = shallow(<TeamContainer teamData={teamNoData} />)
+      const noDataWrapper = shallow(<TeamContainer teamData={undefined} />)
       expect(noDataWrapper).to.be.ok()
     })
   })
@@ -37,8 +36,8 @@ describe('Component > TeamContainer', function () {
     })
 
     it('should handle valid API data', async () => {
-      getTeamDataStub = sinon.stub(request, 'get').returns({body: DATA});
-      const props = await TeamContainer.getInitialProps({});
+      getTeamDataStub = sinon.stub(request, 'get').returns({ body: DATA })
+      const props = await TeamContainer.getInitialProps({})
       expect(props).to.deep.equal({
         error: undefined,
         teamData: DATA
@@ -46,8 +45,8 @@ describe('Component > TeamContainer', function () {
     })
 
     it('should handle empty API reponse', async () => {
-      getTeamDataStub = sinon.stub(request, 'get').returns({body: []});
-      const props = await TeamContainer.getInitialProps({});
+      getTeamDataStub = sinon.stub(request, 'get').returns({ body: [] })
+      const props = await TeamContainer.getInitialProps({})
       expect(props).to.deep.equal({
         error: undefined,
         teamData: []
@@ -57,11 +56,11 @@ describe('Component > TeamContainer', function () {
     it('should handle API errors', async () => {
       var errorMsg = 'failed to connect to API'
       var errorPromise = Promise.reject(new Error(errorMsg))
-      getTeamDataStub = sinon.stub(request, 'get').returns(errorPromise);
-      const props = await TeamContainer.getInitialProps({});
+      getTeamDataStub = sinon.stub(request, 'get').returns(errorPromise)
+      const props = await TeamContainer.getInitialProps({})
       expect(props).to.deep.equal({
         error: errorMsg,
-        teamData: [],
+        teamData: []
       })
     })
   })

--- a/packages/app-content-pages/src/screens/Team/TeamContainer.spec.js
+++ b/packages/app-content-pages/src/screens/Team/TeamContainer.spec.js
@@ -1,5 +1,7 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
+import request from 'superagent'
 
 import TeamContainer from './TeamContainer'
 import mockData from './TeamContainer.mock'
@@ -24,6 +26,43 @@ describe('Component > TeamContainer', function () {
       let teamNoData;
       let noDataWrapper = shallow(<TeamContainer teamData={teamNoData} />)
       expect(noDataWrapper).to.be.ok()
+    })
+  })
+
+  describe('populates the "teamData" props from contentful API', function () {
+    let getTeamDataStub
+
+    afterEach(function () {
+      getTeamDataStub.restore()
+    })
+
+    it('should handle valid API data', async () => {
+      getTeamDataStub = sinon.stub(request, 'get').returns({body: DATA});
+      const props = await TeamContainer.getInitialProps({});
+      expect(props).to.deep.equal({
+        error: undefined,
+        teamData: DATA
+      })
+    })
+
+    it('should handle empty API reponse', async () => {
+      getTeamDataStub = sinon.stub(request, 'get').returns({body: []});
+      const props = await TeamContainer.getInitialProps({});
+      expect(props).to.deep.equal({
+        error: undefined,
+        teamData: []
+      })
+    })
+
+    it('should handle API errors', async () => {
+      var errorMsg = 'failed to connect to API'
+      var errorPromise = Promise.reject(new Error(errorMsg))
+      getTeamDataStub = sinon.stub(request, 'get').returns(errorPromise);
+      const props = await TeamContainer.getInitialProps({});
+      expect(props).to.deep.equal({
+        teamData: undefined,
+        error: errorMsg
+      })
     })
   })
 

--- a/packages/app-content-pages/src/screens/Team/TeamContainer.spec.js
+++ b/packages/app-content-pages/src/screens/Team/TeamContainer.spec.js
@@ -19,6 +19,14 @@ describe('Component > TeamContainer', function () {
     expect(wrapper).to.be.ok()
   })
 
+  describe('with no team data', function () {
+    it('should render without crashing', function () {
+      let teamNoData;
+      let noDataWrapper = shallow(<TeamContainer teamData={teamNoData} />)
+      expect(noDataWrapper).to.be.ok()
+    })
+  })
+
   it('should render the `Team` component', function () {
     expect(componentWrapper).to.have.lengthOf(1)
   })

--- a/packages/app-content-pages/src/screens/Team/TeamContainer.spec.js
+++ b/packages/app-content-pages/src/screens/Team/TeamContainer.spec.js
@@ -60,8 +60,8 @@ describe('Component > TeamContainer', function () {
       getTeamDataStub = sinon.stub(request, 'get').returns(errorPromise);
       const props = await TeamContainer.getInitialProps({});
       expect(props).to.deep.equal({
-        teamData: undefined,
-        error: errorMsg
+        error: errorMsg,
+        teamData: [],
       })
     })
   })


### PR DESCRIPTION
Package: app-content-pages

Closes #1499 

If the contentful API call errors (missing secret client setup) then the `teamData|publicationsData` are left undefined. This PR fixes this issue by adding a check for undefined values and replaces them with an empty array on props and adds default values to the API requests

For bonus points (and learnings), I added tests on the default props API calls to contentful API for team and publications data.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
