### PR TITLE
Fix 1507 - allow MultipleChoiceTask component to observe changes again

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
@@ -2,7 +2,7 @@ import { Markdownz, pxToRem } from '@zooniverse/react-components'
 import { Box, Text } from 'grommet'
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled, { css, withTheme } from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import TaskInput from '../../components/TaskInput'
 
@@ -105,5 +105,5 @@ MultipleChoiceTask.propTypes = {
   theme: PropTypes.object
 }
 
-export default withTheme(MultipleChoiceTask)
+export default MultipleChoiceTask
 export { MultipleChoiceTask }

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
@@ -9,7 +9,7 @@ import zooTheme from '@zooniverse/grommet-theme'
 
 const StyledBox = styled(Box)`
   img:only-child, svg:only-child {
-    background: ${zootheme.global.colors.brand};
+    background: ${zooTheme.global.colors.brand};
     max-width: ${pxToRem(60)};
   }
 `

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
@@ -2,15 +2,16 @@ import { Markdownz, pxToRem } from '@zooniverse/react-components'
 import { Box, Text } from 'grommet'
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import TaskInput from '../../components/TaskInput'
 import zooTheme from '@zooniverse/grommet-theme'
 
+const maxWidth = pxToRem(60)
 const StyledBox = styled(Box)`
   img:only-child, svg:only-child {
     background: ${zooTheme.global.colors.brand};
-    max-width: ${pxToRem(60)};
+    max-width: ${maxWidth};
   }
 `
 

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
@@ -80,12 +80,7 @@ function MultipleChoiceTask (props) {
 
 MultipleChoiceTask.defaultProps = {
   className: '',
-  disabled: false,
-  theme: {
-    global: {
-      colors: {}
-    }
-  }
+  disabled: false
 }
 
 MultipleChoiceTask.propTypes = {
@@ -102,8 +97,7 @@ MultipleChoiceTask.propTypes = {
     help: PropTypes.string,
     question: PropTypes.string,
     required: PropTypes.bool
-  }).isRequired,
-  theme: PropTypes.object
+  }).isRequired
 }
 
 export default MultipleChoiceTask

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 
 import TaskInput from '../../components/TaskInput'
+import zooTheme from '@zooniverse/grommet-theme'
 
 const StyledBox = styled(Box)`
   img:only-child, svg:only-child {

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
@@ -29,8 +29,7 @@ function MultipleChoiceTask (props) {
     annotation,
     className,
     disabled,
-    task,
-    theme
+    task
   } = props
   const { value } = annotation
 
@@ -50,7 +49,6 @@ function MultipleChoiceTask (props) {
       autoFocus={(value && value.length === 0)}
       className={className}
       disabled={disabled}
-      theme={theme}
     >
       <StyledText size='small' tag='legend'>
         <Markdownz>

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
@@ -9,7 +9,7 @@ import zooTheme from '@zooniverse/grommet-theme'
 
 const StyledBox = styled(Box)`
   img:only-child, svg:only-child {
-    ${props => props.theme && css`background: ${props.theme.global.colors.brand};`}
+    background: ${zootheme.global.colors.brand};
     max-width: ${pxToRem(60)};
   }
 `


### PR DESCRIPTION
## PR Overview

package: `lib-classifier`
Fixes #1507 

This PR fixes an issue where, when a user clicks on an Answer label, the label isn't highlighted (marking it as selected/active) BUT the answers are correctly recorded in the Classifications.

Can be tested on any workflow with a single multiple-choice-answer task, e.g. http://localhost:8080/?env=staging&project=1895

### Details

The issue stems from (what appears to be) a conflict with the _store observers_ applied to the MultiChoiceTask component. Specifically, when the MultiChoiceTask component is exported with the `withTheme` decorator, the component stops listening for changes in the annotations store.

This means that when a user clicks on an Answer (i.e. action on a component), the annotations store will _correctly_ update (i.e. the selected answer is added to the classification to be submitted), BUT the component in turn does _not_ register that any changes were made, hence does _not_ re-render the component with the answer label highlighted.

### Status

This is a quick UI fix _only for the MultipleChoiceTask,_ and it's ready for review. 👌 

A deeper look into the decorators/observer problem should be done as a follow up.