### PR TITLE
Revert "Tmp revert for migration (#1515)"

### DIFF
--- a/packages/app-content-pages/src/screens/Publications/PublicationsContainer.js
+++ b/packages/app-content-pages/src/screens/Publications/PublicationsContainer.js
@@ -30,9 +30,12 @@ function PublicationsContainer(props) {
 PublicationsContainer.getInitialProps = async ({ req }) => {
   const host = getHost(req)
   let error
-  const publicationsData = await request.get(host + '/api/publications')
-    .then(res => res.body)
-    .catch(err => error = err.message)
+  let publicationsData = []
+  try {
+    publicationsData = (await request.get(host + '/api/publications')).body
+  } catch (err) {
+    error = err.message
+  }
   return {
     error,
     publicationsData
@@ -42,6 +45,10 @@ PublicationsContainer.getInitialProps = async ({ req }) => {
 PublicationsContainer.propTypes = {
   error: string,
   publicationsData: array,
+}
+
+PublicationsContainer.defaultProps = {
+  publicationsData: []
 }
 
 export default PublicationsContainer

--- a/packages/app-content-pages/src/screens/Publications/PublicationsContainer.spec.js
+++ b/packages/app-content-pages/src/screens/Publications/PublicationsContainer.spec.js
@@ -1,5 +1,7 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
+import request from 'superagent'
 
 import PublicationsContainer from './PublicationsContainer'
 import mockData from './PublicationsContainer.mock'
@@ -17,6 +19,50 @@ describe('Component > PublicationsContainer', function () {
 
   it('should render without crashing', function () {
     expect(wrapper).to.be.ok()
+  })
+
+  describe('with no publications data', function () {
+    it('should render without crashing', function () {
+      const noDataWrapper = shallow(<PublicationsContainer publicationsData={undefined} />)
+      expect(noDataWrapper).to.be.ok()
+    })
+  })
+
+  describe('populates the "publicationsData" props from contentful API', function () {
+    let getpublicationsDataStub
+
+    afterEach(function () {
+      getpublicationsDataStub.restore()
+    })
+
+    it('should handle valid API data', async () => {
+      getpublicationsDataStub = sinon.stub(request, 'get').returns({ body: DATA })
+      const props = await PublicationsContainer.getInitialProps({})
+      expect(props).to.deep.equal({
+        error: undefined,
+        publicationsData: DATA
+      })
+    })
+
+    it('should handle empty API reponse', async () => {
+      getpublicationsDataStub = sinon.stub(request, 'get').returns({ body: [] })
+      const props = await PublicationsContainer.getInitialProps({})
+      expect(props).to.deep.equal({
+        error: undefined,
+        publicationsData: []
+      })
+    })
+
+    it('should handle API errors', async () => {
+      var errorMsg = 'failed to connect to API'
+      var errorPromise = Promise.reject(new Error(errorMsg))
+      getpublicationsDataStub = sinon.stub(request, 'get').returns(errorPromise)
+      const props = await PublicationsContainer.getInitialProps({})
+      expect(props).to.deep.equal({
+        error: errorMsg,
+        publicationsData: []
+      })
+    })
   })
 
   it('should render the `Publications` component', function () {

--- a/packages/app-content-pages/src/screens/Team/TeamContainer.js
+++ b/packages/app-content-pages/src/screens/Team/TeamContainer.js
@@ -30,9 +30,12 @@ function TeamContainer (props) {
 TeamContainer.getInitialProps = async ({ req }) => {
   const host = getHost(req)
   let error
-  const teamData = await request.get(host + '/api/team')
-    .then(res => res.body)
-    .catch(err => error = err.message)
+  let teamData = []
+  try {
+    teamData = (await request.get(host + '/api/team')).body
+  } catch (err) {
+    error = err.message
+  }
   return {
     error,
     teamData
@@ -42,6 +45,10 @@ TeamContainer.getInitialProps = async ({ req }) => {
 TeamContainer.propTypes = {
   error: string,
   teamData: array,
+}
+
+TeamContainer.defaultProps = {
+  teamData: []
 }
 
 export default TeamContainer

--- a/packages/app-content-pages/src/screens/Team/TeamContainer.spec.js
+++ b/packages/app-content-pages/src/screens/Team/TeamContainer.spec.js
@@ -1,5 +1,7 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
+import request from 'superagent'
 
 import TeamContainer from './TeamContainer'
 import mockData from './TeamContainer.mock'
@@ -17,6 +19,50 @@ describe('Component > TeamContainer', function () {
 
   it('should render without crashing', function () {
     expect(wrapper).to.be.ok()
+  })
+
+  describe('with no team data', function () {
+    it('should render without crashing', function () {
+      const noDataWrapper = shallow(<TeamContainer teamData={undefined} />)
+      expect(noDataWrapper).to.be.ok()
+    })
+  })
+
+  describe('populates the "teamData" props from contentful API', function () {
+    let getTeamDataStub
+
+    afterEach(function () {
+      getTeamDataStub.restore()
+    })
+
+    it('should handle valid API data', async () => {
+      getTeamDataStub = sinon.stub(request, 'get').returns({ body: DATA })
+      const props = await TeamContainer.getInitialProps({})
+      expect(props).to.deep.equal({
+        error: undefined,
+        teamData: DATA
+      })
+    })
+
+    it('should handle empty API reponse', async () => {
+      getTeamDataStub = sinon.stub(request, 'get').returns({ body: [] })
+      const props = await TeamContainer.getInitialProps({})
+      expect(props).to.deep.equal({
+        error: undefined,
+        teamData: []
+      })
+    })
+
+    it('should handle API errors', async () => {
+      var errorMsg = 'failed to connect to API'
+      var errorPromise = Promise.reject(new Error(errorMsg))
+      getTeamDataStub = sinon.stub(request, 'get').returns(errorPromise)
+      const props = await TeamContainer.getInitialProps({})
+      expect(props).to.deep.equal({
+        error: errorMsg,
+        teamData: []
+      })
+    })
   })
 
   it('should render the `Team` component', function () {

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.spec.js
@@ -1,15 +1,56 @@
+import { getSnapshot } from 'mobx-state-tree'
 import Mark from './Mark'
 import { Tool } from '@plugins/drawingTools/models/tools'
 
 describe('Models > Drawing Task > Mark', function () {
   let mark
 
+  function mockMark (options) {
+    const defaultOptions = {
+      required: false
+    }
+    const { required } = options || defaultOptions
+    const toolData = {
+      color: '#ff0000',
+      label: 'Point',
+      max: '10',
+      min: 1,
+      type: 'default'
+    }
+    const details = [
+      {
+        type: 'multiple',
+        question: 'which fruit?',
+        answers: ['apples', 'oranges', 'pears'],
+        required
+      },
+      {
+        type: 'single',
+        question: 'how many?',
+        answers: ['one', 'two', 'three'],
+        required
+      }
+    ]
+    const drawingTool = Tool.create(Object.assign({}, toolData, { details }))
+    const multipleTaskSnapshot = Object.assign({}, drawingTool.details[0], { taskKey: 'multiple' })
+    const singleTaskSnapshot = Object.assign({}, drawingTool.details[1], { taskKey: 'single' })
+    const multipleTask = drawingTool.createTask(multipleTaskSnapshot)
+    const singleTask = drawingTool.createTask(singleTaskSnapshot)
+    const mark = drawingTool.createMark({ id: 'mockMark' })
+    return { drawingTool, mark, multipleTask, singleTask }
+  }
+
   before(function () {
-    mark = Mark.create({ id: 'test', toolType: 'default' })
+    mark = Mark.create({ toolType: 'default' })
   })
 
   it('should exist', function () {
     expect(mark).to.be.ok()
+  })
+
+  it('should have an id', function () {
+    expect(mark.id).to.exist()
+    expect(mark.id).to.be.a('string')
   })
 
   it('should have a toolIndex', function () {
@@ -25,7 +66,7 @@ describe('Models > Drawing Task > Mark', function () {
   })
 
   it('should be able to store annotations', function () {
-    expect(mark.annotations).to.be.ok()
+    expect(mark.annotations).to.be.a('map')
   })
 
   describe('getDistance', function () {
@@ -54,38 +95,12 @@ describe('Models > Drawing Task > Mark', function () {
 
   describe('with subtasks', function () {
     let mark
-    const toolData = {
-      color: '#ff0000',
-      label: 'Point',
-      max: '10',
-      min: 1,
-      type: 'default'
-    }
 
     describe('with incomplete, optional tasks', function () {
       let drawingTool
 
       before(function () {
-        const details = [
-          {
-            type: 'multiple',
-            question: 'which fruit?',
-            answers: ['apples', 'oranges', 'pears'],
-            required: false
-          },
-          {
-            type: 'single',
-            question: 'how many?',
-            answers: ['one', 'two', 'three'],
-            required: false
-          }
-        ]
-        drawingTool = Tool.create(Object.assign({}, toolData, { details }))
-        const multipleTaskSnapshot = Object.assign({}, drawingTool.details[0], { taskKey: 'multiple' })
-        const singleTaskSnapshot = Object.assign({}, drawingTool.details[1], { taskKey: 'single' })
-        drawingTool.createTask(multipleTaskSnapshot)
-        drawingTool.createTask(singleTaskSnapshot)
-        mark = drawingTool.createMark({ id: 'mockMark' })
+        ({ drawingTool, mark } = mockMark())
       })
 
       it('should be complete', function () {
@@ -101,26 +116,7 @@ describe('Models > Drawing Task > Mark', function () {
       let drawingTool
 
       before(function () {
-        const details = [
-          {
-            type: 'multiple',
-            question: 'which fruit?',
-            answers: ['apples', 'oranges', 'pears'],
-            required: false
-          },
-          {
-            type: 'single',
-            question: 'how many?',
-            answers: ['one', 'two', 'three'],
-            required: true
-          }
-        ]
-        drawingTool = Tool.create(Object.assign({}, toolData, { details }))
-        const multipleTaskSnapshot = Object.assign({}, drawingTool.details[0], { taskKey: 'multiple' })
-        const singleTaskSnapshot = Object.assign({}, drawingTool.details[1], { taskKey: 'single' })
-        drawingTool.createTask(multipleTaskSnapshot)
-        drawingTool.createTask(singleTaskSnapshot)
-        mark = drawingTool.createMark({ id: 'mockMark' })
+        ({ drawingTool, mark } = mockMark({ required: true }))
       })
 
       it('should be incomplete', function () {
@@ -139,26 +135,7 @@ describe('Models > Drawing Task > Mark', function () {
       let singleTask
 
       before(function () {
-        const details = [
-          {
-            type: 'multiple',
-            question: 'which fruit?',
-            answers: ['apples', 'oranges', 'pears'],
-            required: true
-          },
-          {
-            type: 'single',
-            question: 'how many?',
-            answers: ['one', 'two', 'three'],
-            required: true
-          }
-        ]
-        drawingTool = Tool.create(Object.assign({}, toolData, { details }))
-        const multipleTaskSnapshot = Object.assign({}, drawingTool.details[0], { taskKey: 'multiple' })
-        const singleTaskSnapshot = Object.assign({}, drawingTool.details[1], { taskKey: 'single' })
-        multipleTask = drawingTool.createTask(multipleTaskSnapshot)
-        singleTask = drawingTool.createTask(singleTaskSnapshot)
-        mark = drawingTool.createMark({ id: 'mockMark' })
+        ({ drawingTool, mark, multipleTask, singleTask } = mockMark({ required: true }))
       })
 
       it('should be incomplete', function () {
@@ -190,6 +167,30 @@ describe('Models > Drawing Task > Mark', function () {
           expect(drawingTool.isComplete).to.be.true()
         })
       })
+    })
+  })
+
+  describe('snapshots', function () {
+    let multipleChoiceAnnotation
+    let singleChoiceAnnotation
+    let snapshot
+
+    before(function () {
+      const { mark, multipleTask, singleTask } = mockMark()
+      singleChoiceAnnotation = mark.addAnnotation(singleTask, 1)
+      multipleChoiceAnnotation = mark.addAnnotation(multipleTask, [0, 2])
+      snapshot = getSnapshot(mark)
+    })
+
+    it('should not have an ID', function () {
+      expect(snapshot.id).to.be.undefined()
+    })
+
+    it('should have an annotations array', function () {
+      expect(snapshot.annotations).to.deep.equal([
+        singleChoiceAnnotation.toSnapshot(),
+        multipleChoiceAnnotation.toSnapshot()
+      ])
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.js
@@ -1,4 +1,5 @@
-import { types } from 'mobx-state-tree'
+import { getRoot, getSnapshot, resolveIdentifier, types } from 'mobx-state-tree'
+import DrawingTask from './DrawingTask'
 import Annotation from '../../models/Annotation'
 import * as markTypes from '@plugins/drawingTools/models/marks'
 
@@ -6,6 +7,34 @@ const markReferenceTypes = Object.values(markTypes).map(markType => types.refere
 const Drawing = types.model('Drawing', {
   value: types.array(types.union(...markReferenceTypes))
 })
+  .views(self => ({
+    toSnapshot () {
+      const snapshot = getSnapshot(self)
+      // resolve mark references (IDs) in the snapshot to mark snapshots
+      const actualTask = resolveIdentifier(DrawingTask, getRoot(self), self.task)
+      const value = actualTask.marks.map(mark => getSnapshot(mark))
+      const drawingSnapshot = Object.assign({}, snapshot, { value })
+      // flatten subtask annotations into a single annotations array
+      // then return the flattened array
+      const drawingAnnotations = [drawingSnapshot]
+      drawingSnapshot.value.forEach((markSnapshot, markIndex) => {
+        const mark = Object.assign({}, markSnapshot)
+        // map subtask keys to mark.details
+        mark.details = mark.annotations.map(annotation => ({ task: annotation.task }))
+        // push mark.annotations to the returned array
+        mark.annotations.forEach(markAnnotation => {
+          const finalAnnotation = Object.assign({}, markAnnotation, { markIndex })
+          // strip annotation IDs
+          const { id, ...rest } = finalAnnotation
+          drawingAnnotations.push(rest)
+        })
+        // remove annotations from individual marks
+        const { annotations, ...rest } = mark
+        drawingSnapshot.value[markIndex] = rest
+      })
+      return drawingAnnotations
+    }
+  }))
 
 const DrawingAnnotation = types.compose('DrawingAnnotation', Annotation, Drawing)
 

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingAnnotation.spec.js
@@ -1,19 +1,193 @@
+import { types } from 'mobx-state-tree'
+import DrawingTask from './DrawingTask'
 import DrawingAnnotation from './DrawingAnnotation'
 import { Point } from '@plugins/drawingTools/models/marks'
 
-const point = Point.create({ id: 'mockAnnotation', frame: 0, toolIndex: 0, toolType: 'point', x: 100, y: 150 })
-
-const drawingAnnotationSnapshot = {
-  id: 'drawing1',
-  task: 'T0',
-  taskType: 'drawing',
-  value: [ point.id ]
-}
-
 describe('Model > DrawingAnnotation', function () {
+  const point = Point.create({ id: 'mockAnnotation', frame: 0, toolIndex: 0, toolType: 'point', x: 100, y: 150 })
+
+
+  const drawingAnnotationSnapshot = {
+    id: 'drawing1',
+    task: 'T0',
+    taskType: 'drawing',
+    value: [ point.id ]
+  }
+
   it('should exist', function () {
     const drawingAnnotation = DrawingAnnotation.create(drawingAnnotationSnapshot)
     expect(drawingAnnotation).to.exist()
     expect(drawingAnnotation).to.be.an('object')
+  })
+
+  describe('annotation snapshots', function () {
+
+    function buildMockAnnotation ({ taskSnapshot }) {
+      const drawingTask = DrawingTask.create(taskSnapshot)
+      const annotation = drawingTask.createAnnotation()
+      // TODO: build a more realistic model tree here.
+      types.model('MockStore', {
+        drawingTask: DrawingTask,
+        annotation: DrawingAnnotation
+      })
+      .create({
+        drawingTask,
+        annotation
+      })
+      return { annotation, drawingTask }
+    }
+
+    describe('without subtasks', function () {
+      let snapshot
+
+      before(function () {
+        const { annotation, drawingTask } = buildMockAnnotation({
+          taskSnapshot: {
+            instruction: 'draw things!',
+            taskKey: 'T0',
+            tools: [
+              {
+                type: 'point'
+              }
+            ],
+            type: 'drawing'
+          }
+        })
+        const pointTool = drawingTask.tools[0]
+        pointTool.createMark({
+          x: 50,
+          y: 100
+        })
+        snapshot = annotation.toSnapshot()
+      })
+
+      it('should be an array', function () {
+        expect(snapshot).to.be.a('array')
+      })
+
+      it('should contain exactly one annotation', function () {
+        expect(snapshot).to.have.lengthOf(1)
+      })
+
+      describe('the annotation snapshot', function () {
+        it('should contain a task key', function () {
+          const [ annotation ] = snapshot
+          expect(annotation.task).to.equal('T0')
+        })
+
+        it('should contain a taskType', function () {
+          const [ annotation ] = snapshot
+          expect(annotation.taskType).to.equal('drawing')
+        })
+
+        it('should include snapshots of the drawn marks', function () {
+          const [ annotation ] = snapshot
+          const pointSnapshot = {
+            details: [],
+            frame: 0,
+            toolIndex: 0,
+            toolType: 'point',
+            x: 50,
+            y: 100
+          }
+          expect(annotation.value).to.deep.equal([ pointSnapshot ])
+        })
+      })
+    })
+
+    describe('with subtasks', function () {
+      let snapshot
+
+      before(function () {
+        const { annotation, drawingTask } = buildMockAnnotation({
+          taskSnapshot: {
+            instruction: 'draw things!',
+            taskKey: 'T0',
+            tools: [
+              {
+                type: 'point',
+                details: [{
+                  type: 'single',
+                  question: 'Yes or no?',
+                  answers: [ 'yes', 'no' ]
+                }]
+              }
+            ],
+            type: 'drawing'
+          }
+        })
+        const pointTool = drawingTask.tools[0]
+        const point1 = pointTool.createMark({
+          x: 50,
+          y: 100
+        })
+        const point2 = pointTool.createMark({
+          x: 150,
+          y: 200
+        })
+        const questionTask = pointTool.tasks[0]
+        point1.addAnnotation(questionTask, 0)
+        point2.addAnnotation(questionTask, 1)
+        snapshot = annotation.toSnapshot()
+      })
+
+      it('should be an array', function () {
+        expect(snapshot).to.be.a('array')
+      })
+
+      it('should contain the task annotation plus one annotation for each subtask', function () {
+        expect(snapshot).to.have.lengthOf(3)
+      })
+
+      it('should contain snapshots of the annotation plus subtask answers', function () {
+        const [ annotation ] = snapshot
+        const point1Answer = {
+          task: 'T0.0.0',
+          taskType: 'single',
+          value: 0,
+          markIndex: 0
+        }
+        const point2Answer = {
+          task: 'T0.0.0',
+          taskType: 'single',
+          value: 1,
+          markIndex: 1
+        }
+        expect(snapshot).to.deep.equal([ annotation, point1Answer, point2Answer ])
+      })
+
+      describe('the annotation snapshot', function () {
+        it('should contain a task key', function () {
+          const [ annotation ] = snapshot
+          expect(annotation.task).to.equal('T0')
+        })
+
+        it('should contain a taskType', function () {
+          const [ annotation ] = snapshot
+          expect(annotation.taskType).to.equal('drawing')
+        })
+
+        it('should include snapshots of the drawn marks', function () {
+          const [ annotation ] = snapshot
+          const point1Snapshot = {
+            details: [{ task: 'T0.0.0' }],
+            frame: 0,
+            toolIndex: 0,
+            toolType: 'point',
+            x: 50,
+            y: 100
+          }
+          const point2Snapshot = {
+            details: [{ task: 'T0.0.0' }],
+            frame: 0,
+            toolIndex: 0,
+            toolType: 'point',
+            x: 150,
+            y: 200
+          }
+          expect(annotation.value).to.deep.equal([ point1Snapshot, point2Snapshot ])
+        })
+      })
+    })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
@@ -1,13 +1,30 @@
-import { types } from 'mobx-state-tree'
+import cuid from 'cuid'
+import { getSnapshot, types } from 'mobx-state-tree'
 
 const Annotation = types.model('Annotation', {
   id: types.identifier,
   task: types.string,
   taskType: types.string
 })
+  .preProcessSnapshot(snapshot => {
+    const newSnapshot = Object.assign({}, snapshot)
+    // generate annotation IDs, if not present
+    newSnapshot.id = snapshot.id || cuid()
+    return newSnapshot
+  })
+  .postProcessSnapshot(snapshot => {
+    const newSnapshot = Object.assign({}, snapshot)
+    // remove annotation IDs
+    delete newSnapshot.id
+    return newSnapshot
+  })
   .views(self => ({
     get isComplete () {
       return true
+    },
+
+    toSnapshot () {
+      return getSnapshot(self)
     }
   }))
   .actions(self => ({

--- a/packages/lib-classifier/src/plugins/tasks/models/Annotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Annotation.spec.js
@@ -1,9 +1,32 @@
+import { getSnapshot } from 'mobx-state-tree'
 import Annotation from './Annotation'
 
 describe('Model > Annotation', function () {
+  let annotationInstance
+
+  before(function () {
+    annotationInstance = Annotation.create({ task: 'T4', taskType: 'default' })
+  })
+
   it('should exist', function () {
-    const annotationInstance = Annotation.create({ id: 'default1', task: 'T4', taskType: 'default' })
     expect(annotationInstance).to.be.ok()
     expect(annotationInstance).to.be.an('object')
+  })
+
+  it('should have an id', function () {
+    expect(annotationInstance.id).to.exist()
+    expect(annotationInstance.id).to.be.a('string')
+  })
+
+  describe('snapshots', function () {
+    let snapshot
+
+    before(function () {
+      snapshot = getSnapshot(annotationInstance)
+    })
+
+    it('should not have an ID', function () {
+      expect(snapshot.id).to.be.undefined()
+    })
   })
 })

--- a/packages/lib-classifier/src/store/Classification.spec.js
+++ b/packages/lib-classifier/src/store/Classification.spec.js
@@ -1,11 +1,24 @@
-import cuid from 'cuid'
+import { getSnapshot } from 'mobx-state-tree'
+import taskRegistry from '@plugins/tasks'
 import Classification, { ClassificationMetadata } from './Classification'
 
 describe('Model > Classification', function () {
   let model
+
   before(function () {
     model = Classification.create({
-      id: cuid(),
+      annotations: [
+        {
+          task: 'T1',
+          taskType: 'single',
+          value: 1
+        },
+        {
+          task: 'T0',
+          taskType: 'text',
+          value: 'Hello'
+        }
+      ],
       links: {
         project: '1234',
         subjects: ['4567'],
@@ -23,5 +36,68 @@ describe('Model > Classification', function () {
   it('should exist', function () {
     expect(model).to.be.ok()
     expect(model).to.be.an('object')
+  })
+
+  it('should have an ID', function () {
+    expect(model.id).to.exist()
+    expect(model.id).to.be.a('string')
+  })
+
+  describe('existing annotations', function () {
+    it('should exist', function () {
+      expect(model.annotations.size).to.equal(2)
+    })
+
+    it('should preserve the original array order', function () {
+      const annotations = model.annotations.values()
+      let annotation = annotations.next().value
+      expect(annotation.task).to.equal('T1')
+      expect(annotation.taskType).to.equal('single')
+      expect(annotation.value).to.equal(1)
+      annotation = annotations.next().value
+      expect(annotation.task).to.equal('T0')
+      expect(annotation.taskType).to.equal('text')
+      expect(annotation.value).to.equal('Hello')
+      annotation = annotations.next().value
+      expect(annotation).to.be.undefined()
+    })
+  })
+
+  describe('snapshots', function () {
+    let snapshot
+    let firstAnnotation
+    let secondAnnotation
+
+    before(function () {
+      const singleChoiceTask = taskRegistry.get('single')
+      const textTask = taskRegistry.get('text')
+      const singleChoice = singleChoiceTask.TaskModel.create({
+        question: 'yes or no?',
+        answers: [ 'yes', 'no'],
+        taskKey: 'T1',
+        type: 'single'
+      })
+      const text = textTask.TaskModel.create({
+        instruction: 'type something',
+        taskKey: 'T0',
+        type: 'text'
+      })
+      // lets update a couple of mock annotations
+      firstAnnotation = model.addAnnotation(singleChoice, 0)
+      secondAnnotation = model.addAnnotation(text, 'This is a text task')
+      snapshot = model.toSnapshot()
+    })
+
+    it('should not have an ID', function () {
+      expect(snapshot.id).to.be.undefined()
+    })
+
+    it('should have an annotations array', function () {
+      expect(snapshot.annotations).to.be.a('array')
+    })
+
+    it('should preserve annotation order', function () {
+      expect(snapshot.annotations).to.deep.equal([ firstAnnotation.toSnapshot(), secondAnnotation.toSnapshot() ])
+    })
   })
 })

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -10,7 +10,6 @@ import Classification, { ClassificationMetadata } from './Classification'
 import ResourceStore from './ResourceStore'
 import {
   ClassificationQueue,
-  convertMapToArray,
   sessionUtils
 } from './utils'
 
@@ -177,9 +176,7 @@ const ClassificationStore = types
 
         classification.completed = true
         // Convert from observables
-        const classificationToSubmit = toJS(classification, { exportMapsAsObjects: false })
-        delete classificationToSubmit.id // remove temp id
-        classificationToSubmit.annotations = convertMapToArray(classificationToSubmit.annotations)
+        let classificationToSubmit = classification.toSnapshot()
 
         const convertedMetadata = {}
         Object.entries(classificationToSubmit.metadata).forEach((entry) => {


### PR DESCRIPTION
This reverts commit 7aceaca920df06d831e2de8e653d8d3291b2e5a2.

Restore staged features from #1506 and #1475.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
