### PR TITLE
add prod compose file for production dockerfile testing

### DIFF
--- a/packages/app-content-pages/README.md
+++ b/packages/app-content-pages/README.md
@@ -22,9 +22,14 @@ To get the credentials, go to https://app.contentful.com/spaces/jt90kyhvp0qv/api
 ### Running in development
 
 #### Docker
+
 - `docker-compose up` to run a server on http://localhost:3000.
 - `docker-compose down` to stop the dev server.
-- `docker-compose run --rm app-content-pages test` to run the tests.
+- `docker-compose run --rm dev test` to run the tests.
+
+##### Preview the production Dockerfile image build
+
+- `docker-compose -f docker-compose-prod.yml up` to run a production Dockerfile image server on http://localhost:3000.
 
 #### Node/yarn
 ```sh

--- a/packages/app-content-pages/docker-compose-prod.yml
+++ b/packages/app-content-pages/docker-compose-prod.yml
@@ -1,0 +1,24 @@
+version: '3.2'
+
+services:
+  app-content-pages:
+    image: front-end-monorepo_project-content-pages:local
+    build:
+      context: .
+    command: [yarn, "start"]
+    environment:
+      - PORT=3000
+      - ASSET_PREFIX=http://localhost:3000
+      - NODE_ENV=development
+      - PANOPTES_ENV=staging
+      - NEXT_TELEMETRY_DISABLED=1
+      - APP_ENV=development
+    ports:
+      - "3000:3000"
+    volumes:
+      - app_content_pages_node_modules_cache:/usr/src/node_modules
+      - ./pages:/usr/src/packages/app-content-pages/pages
+      - ./src:/usr/src/packages/app-content-pages/src
+
+volumes:
+  app_content_pages_node_modules_cache:

--- a/packages/app-content-pages/docker-compose.yml
+++ b/packages/app-content-pages/docker-compose.yml
@@ -1,25 +1,19 @@
-version: '3.2'
+version: '3.4'
 
 services:
-  app-content-pages:
-    image: front-end-monorepo_project-content-pages:local
+  dev:
+    image: front-end-monorepo_dev:latest
     build:
-      context: .
-    command: [yarn, "dev"]
-    environment:
-      - PORT=3000
-      - ASSET_PREFIX=http://localhost:3000
-      - NODE_ENV=development
-      - PANOPTES_ENV=staging
-      - NEXT_TELEMETRY_DISABLED=1
-      - APP_ENV=development
+      context: ../../
+      target: bootstrap
+    entrypoint:
+      - "yarn"
+      - "workspace"
+      - "@zooniverse/fe-content-pages"
+    command: ["dev"]
     ports:
       - "3000:3000"
       - "9001:9001"
     volumes:
-      - app_content_pages_node_modules_cache:/usr/src/node_modules
       - ./pages:/usr/src/packages/app-content-pages/pages
       - ./src:/usr/src/packages/app-content-pages/src
-
-volumes:
-  app_content_pages_node_modules_cache:

--- a/packages/app-project/README.md
+++ b/packages/app-project/README.md
@@ -16,10 +16,15 @@ This package should be cloned as part of the [front-end-monorepo](https://github
 Starts a development server on port 3000 and a Storybook server on port 9001 by default.
 
 #### Docker
-- `docker-compose build project-app` to build the local image for reuse in project-app and storybook.
+
 - `docker-compose up -d` to run a dev server, in the background, on http://localhost:3000 and the storybook on http://localhost:9001.
 - `docker-compose down` to stop the dev containers.
-- `docker-compose run --rm project-app test` to run the tests.
+- `docker-compose run --rm dev test` to run the tests.
+
+##### Preview the production Dockerfile image build
+
+- `docker-compose -f docker-compose-prod.yml up` to run a production Dockerfile image server on http://localhost:3000.
+
 
 #### Node/yarn
 ```sh

--- a/packages/app-project/docker-compose-prod.yml
+++ b/packages/app-project/docker-compose-prod.yml
@@ -1,0 +1,36 @@
+version: '3.4'
+
+services:
+  project-app:
+    image: front-end-monorepo_project-app:local
+    build:
+      context: .
+    command: [yarn, "dev"]
+    environment:
+      - PORT=3000
+      - ASSET_PREFIX= http://localhost:3000
+      - NODE_ENV=development
+      - PANOPTES_ENV=staging
+      - NEXT_TELEMETRY_DISABLED=1
+      - APP_ENV=development
+    ports:
+      - "3000:3000"
+    volumes:
+      - project_app_node_modules_cache:/usr/src/node_modules
+      - ./pages:/usr/src/packages/app-project/pages
+      - ./src:/usr/src/packages/app-project/src
+      - ./stores:/usr/src/packages/app-project/stores
+  storybook:
+    image: front-end-monorepo_project-app:local
+    command: [yarn, "storybook"]
+    environment:
+      - NODE_ENV=development
+    ports:
+      - "9001:9001"
+    volumes:
+      - ./pages:/usr/src/packages/app-project/pages
+      - ./src:/usr/src/packages/app-project/src
+      - ./stores:/usr/src/packages/app-project/stores
+
+volumes:
+  project_app_node_modules_cache:

--- a/packages/app-project/docker-compose-prod.yml
+++ b/packages/app-project/docker-compose-prod.yml
@@ -5,7 +5,7 @@ services:
     image: front-end-monorepo_project-app:local
     build:
       context: .
-    command: [yarn, "dev"]
+    command: [yarn, "start"]
     environment:
       - PORT=3000
       - ASSET_PREFIX= http://localhost:3000

--- a/packages/app-project/docker-compose-prod.yml
+++ b/packages/app-project/docker-compose-prod.yml
@@ -20,17 +20,5 @@ services:
       - ./pages:/usr/src/packages/app-project/pages
       - ./src:/usr/src/packages/app-project/src
       - ./stores:/usr/src/packages/app-project/stores
-  storybook:
-    image: front-end-monorepo_project-app:local
-    command: [yarn, "storybook"]
-    environment:
-      - NODE_ENV=development
-    ports:
-      - "9001:9001"
-    volumes:
-      - ./pages:/usr/src/packages/app-project/pages
-      - ./src:/usr/src/packages/app-project/src
-      - ./stores:/usr/src/packages/app-project/stores
-
 volumes:
   project_app_node_modules_cache:

--- a/packages/app-project/docker-compose.yml
+++ b/packages/app-project/docker-compose.yml
@@ -1,36 +1,32 @@
 version: '3.4'
 
 services:
-  project-app:
-    image: front-end-monorepo_project-app:local
+  dev:
+    image: front-end-monorepo_dev:latest
     build:
-      context: .
-    command: [yarn, "dev"]
-    environment:
-      - PORT=3000
-      - ASSET_PREFIX= http://localhost:3000
-      - NODE_ENV=development
-      - PANOPTES_ENV=staging
-      - NEXT_TELEMETRY_DISABLED=1
-      - APP_ENV=development
+      context: ../../
+      target: bootstrap
+    entrypoint:
+      - "yarn"
+      - "workspace"
+      - "@zooniverse/fe-project"
+    command: ["dev"]
     ports:
       - "3000:3000"
     volumes:
-      - project_app_node_modules_cache:/usr/src/node_modules
       - ./pages:/usr/src/packages/app-project/pages
       - ./src:/usr/src/packages/app-project/src
       - ./stores:/usr/src/packages/app-project/stores
   storybook:
-    image: front-end-monorepo_project-app:local
-    command: [yarn, "storybook"]
-    environment:
-      - NODE_ENV=development
+    image: front-end-monorepo_dev:latest
+    entrypoint:
+      - "yarn"
+      - "workspace"
+      - "@zooniverse/fe-project"
+    command: ["storybook"]
     ports:
       - "9001:9001"
     volumes:
       - ./pages:/usr/src/packages/app-project/pages
       - ./src:/usr/src/packages/app-project/src
       - ./stores:/usr/src/packages/app-project/stores
-
-volumes:
-  project_app_node_modules_cache:


### PR DESCRIPTION
use existing docker-compose for dev workflows and testing. Add a prod compose file for testing the project app dockerfile manually

Linked to #1494 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
