### PR TITLE
Remove Docker production-apps build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,3 @@ RUN yarn install
 
 RUN yarn bootstrap
 
-FROM node:12 AS production-apps
-
-RUN mkdir -p /usr/src
-WORKDIR /usr/src/
-
-COPY --from=bootstrap /usr/src /usr/src
-
-RUN yarn workspace @zooniverse/fe-project build
-
-RUN yarn workspace @zooniverse/fe-content-pages build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
             script {
               def dockerRepoName = 'zooniverse/front-end-monorepo'
               def dockerImageName = "${dockerRepoName}:${BRANCH_NAME}"
-              def newImage = docker.build(dockerImageName, "--target bootstrap ./")
+              def newImage = docker.build(dockerImageName)
               newImage.push()
               newImage.push('latest')
             }

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -24,4 +24,12 @@ printf 'Building `lib-classifier`...\n'
 yarn workspace @zooniverse/classifier build
 printf '\n'
 
+printf 'Building `fe-project`...\n'
+yarn workspace @zooniverse/fe-project build
+printf '\n'
+
+printf 'Building `fe-content-pages`...\n'
+yarn workspace @zooniverse/fe-content-pages build
+printf '\n'
+
 echo 'Done!'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,15 +5,13 @@ services:
     image: front-end-monorepo_dev:latest
     build:
       context: ./
-      target: bootstrap
     entrypoint:
       - "yarn"
     command: ["test:ci"]
   fe-project:
-    image: front-end-monorepo_prod:latest
+    image: front-end-monorepo_dev:latest
     build:
       context: ./
-      target: production-apps
     entrypoint:
       - "yarn"
       - "workspace"
@@ -22,10 +20,9 @@ services:
     ports:
       - "3000:3000"
   fe-content:
-    image: front-end-monorepo_prod:latest
+    image: front-end-monorepo_dev:latest
     build:
       context: ./
-      target: production-apps
     entrypoint:
       - "yarn"
       - "workspace"

--- a/packages/app-content-pages/Dockerfile
+++ b/packages/app-content-pages/Dockerfile
@@ -13,8 +13,6 @@ ENV APP_ENV production
 
 WORKDIR /usr/src/packages/app-content-pages/
 
-RUN yarn build
-
 ENV PORT 3000
 EXPOSE 3000
 

--- a/packages/app-content-pages/docker-compose.yml
+++ b/packages/app-content-pages/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     image: front-end-monorepo_dev:latest
     build:
       context: ../../
-      target: bootstrap
     entrypoint:
       - "yarn"
       - "workspace"

--- a/packages/app-project/Dockerfile
+++ b/packages/app-project/Dockerfile
@@ -13,8 +13,6 @@ ENV APP_ENV production
 
 WORKDIR /usr/src/packages/app-project/
 
-RUN yarn build
-
 ENV PORT 3000
 EXPOSE 3000
 

--- a/packages/app-project/docker-compose.yml
+++ b/packages/app-project/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     image: front-end-monorepo_dev:latest
     build:
       context: ../../
-      target: bootstrap
     entrypoint:
       - "yarn"
       - "workspace"

--- a/packages/lib-classifier/docker-compose.yml
+++ b/packages/lib-classifier/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     image: front-end-monorepo_dev:latest
     build:
       context: ../../
-      target: bootstrap
     entrypoint:
       - "yarn"
       - "workspace"


### PR DESCRIPTION
Move the NextJS app builds back into the bootstrap script.
Remove the local production-apps build image.
Remove all references to named targets.
Build all docker images, dev and production, from the bootstrapped monorepo.

This PR reverts most of the changes from #1109 and moves back to the much simpler build process that we originally used, where bootstrapping the monorepo built all its packages.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
