### PR TITLE
[WIP] Fix content apps content api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,26 @@
 version: '3.7'
 
 services:
-  yarn:
-    image: front-end-monorepo_dev:latest
-    build:
-      context: ./
-      target: bootstrap
-    entrypoint:
-      - "yarn"
-    command: ["test:ci"]
-  fe-project:
-    image: front-end-monorepo_prod:latest
-    build:
-      context: ./
-      target: production-apps
-    entrypoint:
-      - "yarn"
-      - "workspace"
-      - "@zooniverse/fe-project"
-    command: ["start"]
-    ports:
-      - "3000:3000"
+  # yarn:
+  #   image: front-end-monorepo_dev:latest
+  #   build:
+  #     context: ./
+  #     target: bootstrap
+  #   entrypoint:
+  #     - "yarn"
+  #   command: ["test:ci"]
+  # fe-project:
+  #   image: front-end-monorepo_prod:latest
+  #   build:
+  #     context: ./
+  #     target: production-apps
+  #   entrypoint:
+  #     - "yarn"
+  #     - "workspace"
+  #     - "@zooniverse/fe-project"
+  #   command: ["start"]
+  #   ports:
+  #     - "3000:3000"
   fe-content:
     image: front-end-monorepo_prod:latest
     build:
@@ -31,6 +31,8 @@ services:
       - "workspace"
       - "@zooniverse/fe-content-pages"
     command: ["start"]
+    environment:
+      - ASSET_PREFIX=http://localhost:3000
     ports:
       - "3001:3000"
 

--- a/packages/app-content-pages/src/screens/Team/TeamContainer.js
+++ b/packages/app-content-pages/src/screens/Team/TeamContainer.js
@@ -32,8 +32,12 @@ TeamContainer.getInitialProps = async ({ req }) => {
   let error
   let teamData = []
   try {
+    console.log('FETCHING THE TEAM API DATA')
+    console.log(host + '/api/team')
     teamData = (await request.get(host + '/api/team')).body
   } catch (err) {
+    console.log('ERROR')
+    console.log(err)
     error = err.message
   }
   return {


### PR DESCRIPTION
Package: `app-content-pages`

Closes #1499

The Content API has app proxies at `/api/team` in the nextjs app. The way these are set are from the `ASSET_PREFIX` env var or from the hosted domain. In the root docker-compose setup our app is running on a different host port from the next JS app so we need to ensure the `ASSET_PREFIX` env var points to the correct content proxy API host, i.e. the running nextjs app host:port.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
