### PR TITLE
[VSLCV] Series focus control

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
@@ -24,6 +24,7 @@ function ScatterPlot (props) {
     children,
     data,
     dataPointSize,
+    focusedSeries,
     invertAxes,
     margin,
     padding,
@@ -112,7 +113,8 @@ function ScatterPlot (props) {
         {dataPoints.map((series, seriesIndex) => {
           const glyphColor = getDataSeriesColor({
             defaultColors: Object.values(colors.drawingTools),
-            seriesOptions: series.seriesOptions,
+            focusedSeries,
+            seriesOptions: series?.seriesOptions,
             seriesIndex,
             themeColors: colors
           })
@@ -197,6 +199,7 @@ ScatterPlot.defaultProps = {
   axisColor: '',
   backgroundColor: '',
   dataPointSize: 20,
+  focusedSeries: [],
   invertAxes: {
     x: false,
     y: false
@@ -261,6 +264,7 @@ ScatterPlot.propTypes = {
     }))
   ]).isRequired,
   dataPointSize: PropTypes.number,
+  focusedSeries: PropTypes.arrayOf(PropTypes.object),
   invertAxes: PropTypes.shape({
     x: PropTypes.bool,
     y: PropTypes.bool

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.js
@@ -21,6 +21,7 @@ const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, r
       amplitude,
       period
     },
+    focusedSeries,
     imgSrc,
     invertYAxis,
     periodMultiple,
@@ -28,7 +29,8 @@ const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, r
     rawJSON,
     setPeriodMultiple,
     setSeriesFocus,
-    setYAxisInversion
+    setYAxisInversion,
+    theme
   } = props
 
   return (
@@ -47,17 +49,21 @@ const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, r
       ]}
     >
       <Controls
+        data={rawJSON.data}
+        focusedSeries={focusedSeries}
         gridArea='controls'
         periodMultiple={periodMultiple}
         setPeriodMultiple={setPeriodMultiple}
         setSeriesFocus={setSeriesFocus}
         setYAxisInversion={setYAxisInversion}
+        theme={theme}
       />
       <Box
         gridArea='phasedJSON'
       >
         <ScatterPlotViewer
           data={phasedJSON.data}
+          focusedSeries={focusedSeries}
           invertAxes={{ x: false, y: invertYAxis }}
           xAxisLabel={counterpart('VariableStarViewer.phase')}
           yAxisLabel={phasedJSON.chartOptions.yAxisLabel}
@@ -68,6 +74,7 @@ const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, r
       >
         <ScatterPlotViewer
           data={rawJSON.data}
+          focusedSeries={focusedSeries}
           invertAxes={{ x: false, y: invertYAxis }}
           xAxisLabel={rawJSON.chartOptions.xAxisLabel}
           yAxisLabel={rawJSON.chartOptions.yAxisLabel}
@@ -83,11 +90,13 @@ const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, r
       >
         <BarChartViewer
           data={period.data}
+          focusedSeries={focusedSeries}
           xAxisLabel={period.options.xAxisLabel}
           yAxisLabel={period.options.yAxisLabel}
         />
         <BarChartViewer
           data={amplitude.data}
+          focusedSeries={focusedSeries}
           xAxisLabel={amplitude.options.xAxisLabel}
           yAxisLabel={amplitude.options.yAxisLabel}
         />
@@ -123,6 +132,7 @@ VariableStarViewer.defaultProps = {
       options: {}
     }
   },
+  focusedSeries: [],
   imgSrc: '',
   invertYAxis: false,
   periodMultiple: 1,
@@ -157,6 +167,7 @@ VariableStarViewer.propTypes = {
       options: PropTypes.object
     })
   }),
+  focusedSeries: PropTypes.arrayOf(PropTypes.object),
   imgSrc: PropTypes.string,
   invertYAxis: PropTypes.bool,
   periodMultiple: PropTypes.number,
@@ -175,4 +186,5 @@ VariableStarViewer.propTypes = {
   zooming: PropTypes.bool
 }
 
-export default VariableStarViewer
+export default withTheme(VariableStarViewer)
+export { VariableStarViewer }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.stories.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Grommet } from 'grommet'
 import { withKnobs, boolean, text, object } from '@storybook/addon-knobs'
+import { Factory } from 'rosie'
 import { VariableStarViewerContainer } from './VariableStarViewerContainer'
 import ZoomInButton from '../../../ImageToolbar/components/ZoomInButton/ZoomInButton'
 import ZoomOutButton from '../../../ImageToolbar/components/ZoomOutButton/ZoomOutButton'
@@ -44,16 +45,19 @@ const barJSON = {
   period: variableStarPeriodMockData
 }
 
+const subject = Factory.build('subject', {
+  locations: [
+    { 'application/json': 'https://raw.githubusercontent.com/zooniverse/front-end-monorepo/master/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/mockLightCurves/variableStar.json' }
+  ]
+})
+
 stories
   .add('light theme', () => {
     return (
       <Grommet theme={zooTheme}>
         <Box height='500px' width='700px'>
-          <VariableStarViewer
-            barJSON={barJSON}
-            imgSrc={image}
-            phasedJSON={variableStar}
-            rawJSON={object('data', variableStar)}
+          <VariableStarViewerContainer
+            subject={subject}
           />
         </Box>
       </Grommet>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.stories.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { Provider } from 'mobx-react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Grommet } from 'grommet'
 import { withKnobs, boolean, text, object } from '@storybook/addon-knobs'
-import { Factory } from 'rosie'
 import { VariableStarViewerContainer } from './VariableStarViewerContainer'
 import ZoomInButton from '../../../ImageToolbar/components/ZoomInButton/ZoomInButton'
 import ZoomOutButton from '../../../ImageToolbar/components/ZoomOutButton/ZoomOutButton'
@@ -16,6 +16,7 @@ import variableStar from '../../helpers/mockLightCurves/variableStar'
 import readme from './README.md'
 import backgrounds from '../../../../../../../.storybook/lib/backgrounds'
 import image from './mocks/temperature.png'
+import { Factory } from 'rosie'
 
 const config = {
   notes: {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.stories.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Provider } from 'mobx-react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Grommet } from 'grommet'
 import { withKnobs, boolean, text, object } from '@storybook/addon-knobs'
@@ -16,7 +15,6 @@ import variableStar from '../../helpers/mockLightCurves/variableStar'
 import readme from './README.md'
 import backgrounds from '../../../../../../../.storybook/lib/backgrounds'
 import image from './mocks/temperature.png'
-import { Factory } from 'rosie'
 
 const config = {
   notes: {
@@ -46,19 +44,16 @@ const barJSON = {
   period: variableStarPeriodMockData
 }
 
-const subject = Factory.build('subject', {
-  locations: [
-    { 'application/json': 'https://raw.githubusercontent.com/zooniverse/front-end-monorepo/master/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/mockLightCurves/variableStar.json' }
-  ]
-})
-
 stories
   .add('light theme', () => {
     return (
       <Grommet theme={zooTheme}>
         <Box height='500px' width='700px'>
-          <VariableStarViewerContainer
-            subject={subject}
+          <VariableStarViewer
+            barJSON={barJSON}
+            imgSrc={image}
+            phasedJSON={variableStar}
+            rawJSON={object('data', variableStar)}
           />
         </Box>
       </Grommet>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.js
@@ -160,7 +160,7 @@ class VariableStarViewerContainer extends Component {
     this.setState({ periodMultiple }, () => this.calculateJSON())
   }
 
-  setSeriesFocus(seriesToFocus) {
+  setSeriesFocus(event) {
     const newFocusedSeriesState = this.state.focusedSeries.map((series) => {
       const [[label, checked]] = Object.entries(series)
       if (label === event.target.value) {
@@ -216,6 +216,7 @@ VariableStarViewerContainer.defaultProps = {
 VariableStarViewerContainer.propTypes = {
   loadingState: PropTypes.string,
   onError: PropTypes.func,
+  onReady: PropTypes.func,
   subject: PropTypes.shape({
     id: PropTypes.string,
     locations: PropTypes.arrayOf(locationValidator)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.js
@@ -42,6 +42,7 @@ class VariableStarViewerContainer extends Component {
     }
 
     this.setYAxisInversion = this.setYAxisInversion.bind(this)
+    this.setSeriesFocus = this.setSeriesFocus.bind(this)
   }
 
   async componentDidMount() {
@@ -102,8 +103,10 @@ class VariableStarViewerContainer extends Component {
     const target = this.viewer.current
     const phasedJSON = this.calculatePhase(rawJSON)
     const barJSON = this.calculateBarJSON(rawJSON)
+    const focusedSeries = this.setupSeriesFocus(rawJSON)
     this.setState({
       barJSON,
+      focusedSeries,
       phasedJSON,
       rawJSON
     },
@@ -144,13 +147,30 @@ class VariableStarViewerContainer extends Component {
     })
   }
 
+  setupSeriesFocus (rawJSON) {
+    return rawJSON.data.map((series) => {
+      if (series?.seriesData.length > 0) {
+        return { [series.seriesOptions.label]: true }
+      }
+    })
+  }
+
   setPeriodMultiple(multiple) {
     const periodMultiple = parseFloat(multiple)
     this.setState({ periodMultiple }, () => this.calculateJSON())
   }
 
   setSeriesFocus(seriesToFocus) {
-    // TODO add handling
+    const newFocusedSeriesState = this.state.focusedSeries.map((series) => {
+      const [[label, checked]] = Object.entries(series)
+      if (label === event.target.value) {
+        return { [event.target.value]: event.target.checked }
+      } else {
+        return series
+      }
+    })
+
+    this.setState({ focusedSeries: newFocusedSeriesState })
   }
 
   setYAxisInversion () {
@@ -169,6 +189,7 @@ class VariableStarViewerContainer extends Component {
     return (
       <VariableStarViewer
         barJSON={this.state.barJSON}
+        focusedSeries={this.state.focusedSeries}
         imageSrc={this.state.imageSrc}
         invertYAxis={this.state.invertYAxis}
         periodMultiple={this.state.periodMultiple}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.spec.js
@@ -235,4 +235,70 @@ describe('Component > VariableStarViewerContainer', function () {
       }).then(done, done)
     })
   })
+
+  describe.only('with series focus', function () {
+    let cdmSpy
+    let nockScope
+    const subject = Factory.build('subject', {
+      locations: [
+        { 'application/json': 'http://localhost:8080/variableStar.json' }
+      ]
+    })
+    const focusedStateMock = [
+      { [variableStar.data[0].seriesOptions.label]: true },
+      { [variableStar.data[1].seriesOptions.label]: true }
+    ]
+
+    before(function () {
+      cdmSpy = sinon.spy(VariableStarViewerContainer.prototype, 'componentDidMount')
+      nockScope = nock('http://localhost:8080')
+        .persist(true)
+        .get('/variableStar.json')
+        .reply(200, variableStar)
+    })
+
+    afterEach(function () {
+      cdmSpy.resetHistory()
+    })
+
+    after(function () {
+      cdmSpy.restore()
+      nock.cleanAll()
+      nockScope.persist(false)
+    })
+
+    it('should default to focused states of true for each series', function (done) {
+      const wrapper = shallow(
+        <VariableStarViewerContainer
+          subject={subject}
+        />
+      )
+
+      expect(wrapper.state().focusedSeries).to.be.empty()
+      cdmSpy.returnValues[0].then(() => {
+        expect(wrapper.state().focusedSeries).to.deep.equal(focusedStateMock)
+      }).then(done, done)
+    })
+
+    it('should be able to toggle the focused state', function () {
+      const eventMock = {
+        target: {
+          checked: false,
+          value: Object.keys(focusedStateMock[0])[0]
+        }
+      }
+      const wrapper = shallow(
+        <VariableStarViewerContainer
+          subject={subject}
+        />
+      )
+      wrapper.setState({ rawJSON: variableStar, focusedSeries: focusedStateMock })
+      expect(wrapper.state().focusedSeries).to.deep.equal(focusedStateMock)
+      wrapper.instance().setSeriesFocus(eventMock)
+      expect(wrapper.state().focusedSeries).to.deep.equal([
+        { [variableStar.data[0].seriesOptions.label]: false },
+        { [variableStar.data[1].seriesOptions.label]: true }
+      ])
+    })
+  })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.spec.js
@@ -236,7 +236,7 @@ describe('Component > VariableStarViewerContainer', function () {
     })
   })
 
-  describe.only('with series focus', function () {
+  describe('with series focus', function () {
     let cdmSpy
     let nockScope
     const subject = Factory.build('subject', {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/Controls.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/Controls.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {
   Box,
-  CheckBox,
   FormField,
   RadioButtonGroup
 } from 'grommet'
@@ -12,6 +11,7 @@ import counterpart from 'counterpart'
 import FlipIcon from '../FlipIcon'
 import en from '../../locales/en'
 import theme from './theme'
+import FocusSeriesCheckBoxes from './components/FocusSeriesCheckBoxes'
 
 counterpart.registerTranslations('en', en)
 
@@ -31,6 +31,8 @@ export const FlipButton = styled(PlainButton)`
 
 function Controls(props) {
   const {
+    data,
+    focusedSeries,
     gridArea,
     periodMultiple,
     setSeriesFocus,
@@ -74,18 +76,13 @@ function Controls(props) {
           value={periodMultiple.toString()}
         />
       </FormField>
-      <Box>
-        <fieldset style={{ border: 'none', padding: 0 }}>
-          <label>
-            <input type='checkbox' />
-            <SpacedText style={{ fontSize: '0.5em' }}>red light</SpacedText>
-          </label>
-          <label>
-            <input type='checkbox' />
-            <SpacedText style={{ fontSize: '0.5em' }}>blue light</SpacedText>
-          </label>
-        </fieldset>
-        <SpacedText size='xsmall'>
+      <Box justify='between'>
+        <FocusSeriesCheckBoxes
+          data={data}
+          focusedSeries={focusedSeries}
+          setSeriesFocus={setSeriesFocus}
+        />
+        <SpacedText color='black' size='10px' weight='bold'>
           {counterpart('VariableStarViewer.focus')}
         </SpacedText>
       </Box>
@@ -94,6 +91,8 @@ function Controls(props) {
 }
 
 Controls.defaultProps = {
+  data: [],
+  focusedSeries: [],
   gridArea: '',
   periodMultiple: 1,
   setSeriesFocus: () => {},
@@ -102,6 +101,8 @@ Controls.defaultProps = {
 }
 
 Controls.propTypes = {
+  data: PropTypes.array,
+  focusedSeries: PropTypes.arrayOf(PropTypes.object),
   gridArea: PropTypes.string,
   periodMultiple: PropTypes.number,
   setSeriesFocus: PropTypes.func,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/Controls.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/Controls.spec.js
@@ -2,8 +2,15 @@ import { mount, shallow } from 'enzyme'
 import React from 'react'
 import sinon from 'sinon'
 import { Grommet } from 'grommet'
-import Controls, { FlipButton } from './Controls'
 import zooTheme from '@zooniverse/grommet-theme'
+import Controls, { FlipButton } from './Controls'
+import FocusSeriesCheckBoxes from './components/FocusSeriesCheckBoxes'
+import variableStar from '../../../../helpers/mockLightCurves/variableStar'
+
+const focusedSeriesMock = [
+  { foo: true },
+  { bar: true }
+]
 
 describe('VariableStarViewer > Component > Controls', function () {
   it('should render without crashing', function () {
@@ -21,6 +28,30 @@ describe('VariableStarViewer > Component > Controls', function () {
       )
       wrapper.find(FlipButton).simulate('click')
       expect(setYAxisInversionSpy).to.have.been.calledOnce()
+    })
+  })
+
+  describe('focus series checkbox controls', function () {
+    it('should render FocusSeriesCheckBoxes', function () {
+      const wrapper = mount(
+        <Grommet theme={zooTheme}>
+          <Controls data={variableStar.data} focusedSeries={focusedSeriesMock} setSeriesFocus={sinon.spy()} />
+        </Grommet>
+      )
+      expect(wrapper.find(FocusSeriesCheckBoxes)).to.have.lengthOf(1)
+    })
+
+    it('should pass the data, focusedSeries, and setSeriesFocus props', function () {
+      const wrapper = mount(
+        <Grommet theme={zooTheme}>
+          <Controls data={variableStar.data} focusedSeries={focusedSeriesMock} setSeriesFocus={sinon.spy()} />
+        </Grommet>
+      )
+      const controls = wrapper.find(Controls)
+      const focusControls = wrapper.find(FocusSeriesCheckBoxes)
+      expect(focusControls.props().data).to.deep.equal(controls.props().data)
+      expect(focusControls.props().focusedSeries).to.deep.equal(controls.props().focusedSeries)
+      expect(focusControls.props().setSeriesFocus).to.deep.equal(controls.props().setSeriesFocus)
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/FocusSeriesCheckBoxes/FocusSeriesCheckBoxes.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/FocusSeriesCheckBoxes/FocusSeriesCheckBoxes.js
@@ -23,7 +23,7 @@ export const StyledLabel = styled.label`
     position: absolute;
   }
 
-  &:hover, &:focus {
+  &:hover, &:focus-within {
     background-color: rgba(216,216,216,0.4);
   }
 `

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/FocusSeriesCheckBoxes/FocusSeriesCheckBoxes.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/FocusSeriesCheckBoxes/FocusSeriesCheckBoxes.js
@@ -8,6 +8,7 @@ import getDataSeriesColor from '../../../../../../helpers/getDataSeriesColor'
 import getDataSeriesSymbol from '../../../../../../helpers/getDataSeriesSymbol'
 
 export const StyledLabel = styled.label`
+  align-items: center;
   ${props => css`
     border: solid thin ${props.borderColor};
   `}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/FocusSeriesCheckBoxes/FocusSeriesCheckBoxes.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/FocusSeriesCheckBoxes/FocusSeriesCheckBoxes.js
@@ -1,0 +1,108 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Box } from 'grommet'
+import styled, { css, withTheme } from 'styled-components'
+import { transparentize } from 'polished'
+import { SpacedText } from '@zooniverse/react-components'
+import getDataSeriesColor from '../../../../../../helpers/getDataSeriesColor'
+import getDataSeriesSymbol from '../../../../../../helpers/getDataSeriesSymbol'
+
+export const StyledLabel = styled.label`
+  ${props => css`
+    border: solid thin ${props.borderColor};
+  `}
+  border-radius: 10px;
+  cursor: pointer;
+  display: inline-flex;
+  flex-direction: row;
+  padding: 2.5px 5px;
+
+  input {
+    opacity: 0.01;
+    position: absolute;
+  }
+
+  &:hover, &:focus {
+    background-color: rgba(216,216,216,0.4);
+  }
+`
+
+function FocusSeriesCheckBoxes (props) {
+  const {
+    data,
+    focusedSeries,
+    setSeriesFocus,
+    theme: {
+      global: {
+        colors
+      }
+    }
+  } = props
+
+  return (
+    <Box direction='row' gap='xsmall' pad='none'>
+      {focusedSeries.map((series, seriesIndex) => {
+        const [[label, checked]] = Object.entries(series)
+        const seriesCustomColor = data[seriesIndex]?.seriesOptions.color
+        const color = getDataSeriesColor({
+          defaultColors: Object.values(colors.drawingTools),
+          focusedSeries,
+          seriesOptions: seriesCustomColor,
+          seriesIndex,
+          themeColors: colors
+        })
+        const Glyph = getDataSeriesSymbol(seriesIndex)
+        return (
+          <StyledLabel
+            borderColor={(checked) ? colors['light-6'] : transparentize(0.5, colors['light-6'])}
+            htmlFor={label}
+            key={`${label}-${seriesIndex}`}
+          >
+            <input
+              checked={checked}
+              id={label}
+              name='series-focus'
+              onChange={event => { setSeriesFocus(event) }}
+              type='checkbox'
+              value={label}
+            />
+            <svg viewBox='0 0 10 10' width='15px' style={{ paddingRight: '0.5ch' }}>
+              <Glyph left={5} fill={color} size={20} top={5} />
+            </svg>
+            <SpacedText
+              color={(checked) ? 'black' : 'rbga(0,0,0,0.5)'}
+              style={{ fontSize: '0.5em', whiteSpace: 'nowrap' }} // TODO: update theme for smaller size of span text
+              weight='bold'
+            >
+              {label}
+            </SpacedText>
+          </StyledLabel>
+        )
+      })}
+    </Box>
+  )
+}
+
+FocusSeriesCheckBoxes.defaultProps = {
+  setSeriesFocus: () => {},
+  theme: {
+    global: {
+      colors: {
+        drawingTools: {}
+      }
+    }
+  }
+}
+
+FocusSeriesCheckBoxes.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.shape({
+    seriesData: PropTypes.array,
+    seriesOptions: PropTypes.object
+  })).isRequired,
+  focusedSeries: PropTypes.arrayOf(PropTypes.object).isRequired,
+  setSeriesFocus: PropTypes.func,
+  theme: PropTypes.object
+}
+
+export default withTheme(FocusSeriesCheckBoxes)
+export { FocusSeriesCheckBoxes }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/FocusSeriesCheckBoxes/FocusSeriesCheckBoxes.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/FocusSeriesCheckBoxes/FocusSeriesCheckBoxes.js
@@ -43,11 +43,11 @@ function FocusSeriesCheckBoxes (props) {
     <Box direction='row' gap='xsmall' pad='none'>
       {focusedSeries.map((series, seriesIndex) => {
         const [[label, checked]] = Object.entries(series)
-        const seriesCustomColor = data[seriesIndex]?.seriesOptions.color
+        const seriesOptions = data[seriesIndex]?.seriesOptions
         const color = getDataSeriesColor({
           defaultColors: Object.values(colors.drawingTools),
           focusedSeries,
-          seriesOptions: seriesCustomColor,
+          seriesOptions: seriesOptions,
           seriesIndex,
           themeColors: colors
         })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/FocusSeriesCheckBoxes/FocusSeriesCheckBoxes.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/FocusSeriesCheckBoxes/FocusSeriesCheckBoxes.spec.js
@@ -3,8 +3,9 @@ import React from 'react'
 import sinon from 'sinon'
 import zooTheme from '@zooniverse/grommet-theme'
 import { SpacedText } from '@zooniverse/react-components'
-import { FocusSeriesCheckBoxes, StyledLabel } from './FocusSeriesCheckBoxes'
+import { FocusSeriesCheckBoxes } from './FocusSeriesCheckBoxes'
 import variableStar from '../../../../../../helpers/mockLightCurves/variableStar'
+import getDataSeriesSymbol from '../../../../../../helpers/getDataSeriesSymbol'
 
 const seriesOneLabel = variableStar.data[0].seriesOptions.label
 const seriesTwoLabel = variableStar.data[1].seriesOptions.label
@@ -81,6 +82,26 @@ describe('Component > FocusSeriesCheckBoxes', function () {
       const [focusedStateLabel] = Object.keys(defaultStateFocusedSeries[index])
       expect(label.html()).to.contain(focusedStateLabel)
     })
+  })
+
+  it('should render different glyphs and colors in each checkbox', function () {
+    const wrapper = shallow(
+      <FocusSeriesCheckBoxes
+        data={data}
+        focusedSeries={defaultStateFocusedSeries}
+        theme={zooTheme}
+      />
+    )
+    const seriesOneGlyph = getDataSeriesSymbol(0)
+    const seriesTwoGlyph = getDataSeriesSymbol(1)
+    const firstGlyph = wrapper.find(seriesOneGlyph)
+    const secondGlyph = wrapper.find(seriesTwoGlyph)
+    expect(firstGlyph).to.have.lengthOf(1)
+    expect(secondGlyph).to.have.lengthOf(1)
+    expect(firstGlyph).to.not.equal(secondGlyph)
+    expect(firstGlyph.props().fill).to.not.be.empty()
+    expect(secondGlyph.props().fill).to.not.be.empty()
+    expect(firstGlyph.props().fill).to.not.equal(secondGlyph.props().fill)
   })
 
   it('should call setSeriesFocus for the onChange event', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/FocusSeriesCheckBoxes/FocusSeriesCheckBoxes.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/FocusSeriesCheckBoxes/FocusSeriesCheckBoxes.spec.js
@@ -1,0 +1,103 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import sinon from 'sinon'
+import zooTheme from '@zooniverse/grommet-theme'
+import { SpacedText } from '@zooniverse/react-components'
+import { FocusSeriesCheckBoxes, StyledLabel } from './FocusSeriesCheckBoxes'
+import variableStar from '../../../../../../helpers/mockLightCurves/variableStar'
+
+const seriesOneLabel = variableStar.data[0].seriesOptions.label
+const seriesTwoLabel = variableStar.data[1].seriesOptions.label
+const { data } = variableStar
+
+const defaultStateFocusedSeries = [
+  { [seriesOneLabel]: true },
+  { [seriesTwoLabel]: true }
+]
+
+const toggledStateFocusedSeries = [
+  { [seriesOneLabel]: true },
+  { [seriesTwoLabel]: false }
+]
+
+describe('Component > FocusSeriesCheckBoxes', function () {
+  it('should render without crashing', function () {
+    const wrapper = shallow(
+      <FocusSeriesCheckBoxes
+        data={data}
+        focusedSeries={defaultStateFocusedSeries}
+        theme={zooTheme}
+      />
+    )
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render checkbox inputs for the number of objects in the focused series state', function () {
+    const wrapper = shallow(
+      <FocusSeriesCheckBoxes
+        data={data}
+        focusedSeries={defaultStateFocusedSeries}
+        theme={zooTheme}
+      />
+    )
+    expect(wrapper.find("input[type='checkbox']")).to.have.lengthOf(defaultStateFocusedSeries.length)
+  })
+
+  it('should render the checked state based on the focused state', function () {
+    let inputs
+    const wrapper = shallow(
+      <FocusSeriesCheckBoxes
+        data={data}
+        focusedSeries={defaultStateFocusedSeries}
+        theme={zooTheme}
+      />
+    )
+
+    inputs = wrapper.find("input[type='checkbox']")
+    inputs.forEach((input, index) => {
+      const [focusedStateValue] = Object.values(defaultStateFocusedSeries[index])
+      expect(input.props().checked).to.equal(focusedStateValue)
+    })
+
+    wrapper.setProps({ focusedSeries: toggledStateFocusedSeries })
+
+    inputs = wrapper.find("input[type='checkbox']")
+    inputs.forEach((input, index) => {
+      const [focusedStateValue] = Object.values(toggledStateFocusedSeries[index])
+      expect(input.props().checked).to.equal(focusedStateValue)
+    })
+  })
+
+  it('should render the labels state based on the focused state', function () {
+    const wrapper = shallow(
+      <FocusSeriesCheckBoxes
+        data={data}
+        focusedSeries={defaultStateFocusedSeries}
+        theme={zooTheme}
+      />
+    )
+    const labels = wrapper.find(SpacedText)
+    labels.forEach((label, index) => {
+      const [focusedStateLabel] = Object.keys(defaultStateFocusedSeries[index])
+      expect(label.html()).to.contain(focusedStateLabel)
+    })
+  })
+
+  it('should call setSeriesFocus for the onChange event', function () {
+    const setSeriesFocusSpy = sinon.spy()
+    const wrapper = shallow(
+      <FocusSeriesCheckBoxes
+        data={data}
+        focusedSeries={defaultStateFocusedSeries}
+        setSeriesFocus={setSeriesFocusSpy}
+        theme={zooTheme}
+      />
+    )
+    const inputs = wrapper.find("input[type='checkbox']")
+    inputs.forEach((input) => {
+      input.simulate('change', { target: {} })
+      expect(setSeriesFocusSpy).to.have.been.calledOnceWith({ target: {} })
+      setSeriesFocusSpy.resetHistory()
+    })
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/FocusSeriesCheckBoxes/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/FocusSeriesCheckBoxes/index.js
@@ -1,0 +1,1 @@
+export { default } from './FocusSeriesCheckBoxes'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getDataSeriesColor/getDataSeriesColor.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getDataSeriesColor/getDataSeriesColor.js
@@ -30,6 +30,7 @@ export default function getDataSeriesColor({
     focusedSeries: focusedSeries = []
 } = {}) {
   const { color } = seriesOptions
+
   if (focusedSeries && focusedSeries[seriesIndex]) {
     const [focused] = Object.values(focusedSeries[seriesIndex]) || []
     if (focused) {


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package:

Closes #1429

Describe your changes:
**PRs #1526 and #1527 need to be merged first**. This adds the functionality for toggling UI focus on data series in the variable star viewer. WIP because this still needs some specs for the changes in `Controls`, but there's some setup for nock in #1527 that I'd like to use, so that comes first.

This should be manually testable in the storybook, but here's also a gif demonstrating it:

![Feb-19-2020 14-46-34](https://user-images.githubusercontent.com/5016731/74874705-c0661680-5326-11ea-9f2a-b4daba61e0e7.gif)

And a close up screenshot of the hover/focus state because the gif doesn't show it well:

<img width="227" alt="Screen Shot 2020-02-19 at 2 49 50 PM" src="https://user-images.githubusercontent.com/5016731/74874954-2488da80-5327-11ea-8e80-7a695544062f.png">

Indesign links for comparison:

Design for checked/unchecked style state: https://projects.invisionapp.com/d/main#/console/17294981/403043950/preview

Design for hover/focus state: 
https://projects.invisionapp.com/d/main#/console/17294981/405498288/preview
https://projects.invisionapp.com/d/main#/console/17294981/405498289/preview

A couple things to note here:
- ~The original storybook I setup wasn't connected to the container, but now it is so we can manually test the functions there. This includes some math that isn't added yet to calculate the JSON for the bar charts and the scatter plot for the phased view, so that's why there's no data displaying there now.~ Moved to #1527 so I can reuse this storybook setup for implementing other features.
- ~The red and and orange are from the fallback colors picked from the theme drawing tool colors. In reality, the variable star data will be setting this to a red and blue that has meaning for the data. For demonstration purposes here, though, the red and orange should be fine.~ Blue is being used with the example variable star data since #1526 merged.
- Other functions will be styled work as I implement the interactivity, so please just check the focus function and style for this

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
