### PR TITLE
Drawing tools: draggable updates

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -62,11 +62,12 @@ function draggable (WrappedComponent) {
       const { coords, dragging, pointerId } = this.state
       if (dragging && event.pointerId === pointerId) {
         const { x, y } = this.convertEvent(event)
+        const { currentTarget } = event
         const difference = {
           x: x - coords.x,
           y: y - coords.y
         }
-        this.props.dragMove(event, difference)
+        this.props.dragMove({ currentTarget, x, y, pointerId }, difference)
         this.setState({ coords: { x, y } })
       }
     }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -84,7 +84,6 @@ function draggable (WrappedComponent) {
 
     render () {
       const { children, dragStart, dragMove, dragEnd, ...rest } = this.props
-      const { dragging } = this.state
       return (
         <g
           onPointerDown={this.dragStart}
@@ -93,7 +92,6 @@ function draggable (WrappedComponent) {
         >
           <WrappedComponent
             ref={this.wrappedComponent}
-            dragging={dragging}
             {...rest}
           >
             {children}

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -84,7 +84,7 @@ function draggable (WrappedComponent) {
     }
 
     render () {
-      const { children, dragStart, dragMove, dragEnd, ...rest } = this.props
+      const { children, coords, dragStart, dragMove, dragEnd, ...rest } = this.props
       return (
         <g
           onPointerDown={this.dragStart}


### PR DESCRIPTION
Package:
lib-classifier

A couple of small changes to the `draggable` decorator, which makes SVG components draggable.

- remove the `dragging` prop from child components/elements. It wasn't being used for anything except debugging.
- remove the `coords` prop from children.
- pass back the `{ x, y }` coordinates of the pointer on `dragMove`. This isn't being used at the moment, but will be needed for shapes that use rotation transforms (eg. the ellipse) and for freehand drawing.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
