### PR TITLE
Drawing: generate subtasks from tool details

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.spec.js
@@ -17,23 +17,25 @@ describe('Models > Drawing Task > Mark', function () {
       min: 1,
       type: 'default'
     }
-    const details = [
+    const tasks = [
       {
+        taskKey: 'multiple',
         type: 'multiple',
         question: 'which fruit?',
         answers: ['apples', 'oranges', 'pears'],
         required
       },
       {
+        taskKey: 'single',
         type: 'single',
         question: 'how many?',
         answers: ['one', 'two', 'three'],
         required
       }
     ]
-    const drawingTool = Tool.create(Object.assign({}, toolData, { details }))
-    const multipleTaskSnapshot = Object.assign({}, drawingTool.details[0], { taskKey: 'multiple' })
-    const singleTaskSnapshot = Object.assign({}, drawingTool.details[1], { taskKey: 'single' })
+    const drawingTool = Tool.create(toolData)
+    const multipleTaskSnapshot = tasks[0]
+    const singleTaskSnapshot = tasks[1]
     const multipleTask = drawingTool.createTask(multipleTaskSnapshot)
     const singleTask = drawingTool.createTask(singleTaskSnapshot)
     const mark = drawingTool.createMark({ id: 'mockMark' })

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
@@ -18,6 +18,22 @@ const Tool = types.model('Tool', {
   )),
   type: types.literal('default')
 })
+  .preProcessSnapshot(snapshot => {
+    const newSnapshot = Object.assign({}, snapshot)
+    /*
+    Create tasks from details if we have details but no tasks.
+    */
+    if (snapshot.details && !snapshot.tasks) {
+      newSnapshot.tasks = []
+      snapshot.details.forEach((detail, detailIndex) => {
+        const toolKey = snapshot.key || 'subtask'
+        const taskKey = `${toolKey}.${detailIndex}`
+        const taskSnapshot = Object.assign({}, detail, { taskKey })
+        newSnapshot.tasks.push(taskSnapshot)
+      })
+    }
+    return newSnapshot
+  })
   .views(self => ({
     get disabled () {
       return self.marks.size >= self.max

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
@@ -65,8 +65,9 @@ describe('Model > DrawingTools > Tool', function () {
       let tool
 
       before(function () {
-        const details = [
+        const tasks = [
           {
+            taskKey: 'multiple',
             type: 'multiple',
             question: 'which fruit?',
             answers: ['apples', 'oranges', 'pears'],
@@ -74,6 +75,7 @@ describe('Model > DrawingTools > Tool', function () {
             required: false
           },
           {
+            taskKey: 'single',
             type: 'single',
             question: 'how many?',
             answers: ['one', 'two', 'three'],
@@ -81,6 +83,7 @@ describe('Model > DrawingTools > Tool', function () {
             required: false
           },
           {
+            taskKey: 'text',
             type: 'text',
             instruction: 'Transcribe something',
             help: '',
@@ -88,10 +91,10 @@ describe('Model > DrawingTools > Tool', function () {
             text_tags: []
           }
         ]
-        tool = Tool.create(Object.assign({}, toolData, { details }))
-        multipleTaskSnapshot = Object.assign({}, tool.details[0], {taskKey: 'multiple'})
-        singleTaskSnapshot = Object.assign({}, tool.details[1], {taskKey: 'single'})
-        textTaskSnapshot = Object.assign({}, tool.details[2], {taskKey: 'text'})
+        tool = Tool.create(toolData)
+        multipleTaskSnapshot = tasks[0]
+        singleTaskSnapshot = tasks[1]
+        textTaskSnapshot = tasks[2]
         tool.createTask(multipleTaskSnapshot)
         tool.createTask(singleTaskSnapshot)
         tool.createTask(textTaskSnapshot)
@@ -114,16 +117,17 @@ describe('Model > DrawingTools > Tool', function () {
     })
 
     it('should error for invalid subtasks', function () {
-      const details = [
+      const tasks = [
         {
+          taskKey: 'drawing',
           type: 'drawing',
           question: 'which fruit?',
           tools: [],
           required: false
         }
       ]
-      const tool = Tool.create(Object.assign({}, toolData, { details }))
-      const drawingTaskSnapshot = Object.assign({}, tool.details[0], {taskKey: 'drawing'})
+      const tool = Tool.create(toolData)
+      const drawingTaskSnapshot = tasks[0]
       const drawingTask = tool.createTask(drawingTaskSnapshot)
       expect(console.error.withArgs('drawing is not a valid drawing subtask')).to.have.been.calledOnce()
     })


### PR DESCRIPTION
Remove `DrawingTask.afterCreate()`.
Add preprocessors to both the drawing task and tool models, which will generate valid task snapshots from tool details if none are already present in the provided snapshot. This allows us to load in tools created by the project builder while also writing new code that can generate tools directly from snapshots eg. when creating tools for tests.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
