### PR TITLE
Fix 1536 - allow Classifier to submit Classifications without Crashing

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -23,19 +23,23 @@ function SVGPanZoom ({
 
   const [ zoom, setZoom ] = useState(1)
   const [ viewBox, setViewBox ] = useState(defaultViewBox)
+  
+  function preventDefault (e) {
+    e.preventDefault()
+  }
 
   function onMount () {
     setOnDrag(onDrag)
     setOnPan(onPan)
     setOnZoom(onZoom)
-    scrollContainer.current.addEventListener('wheel', e => e.preventDefault())
+    scrollContainer.current.addEventListener('wheel', preventDefault)
   }
 
   function onUnmount () {
     setOnDrag(() => true)
     setOnPan(() => true)
     setOnZoom(() => true)
-    scrollContainer.current.removeEventListener('wheel', e => e.preventDefault())
+    scrollContainer.current.removeEventListener('wheel', preventDefault)
   }
 
   useEffect(() => {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { cloneElement, createRef, useEffect, useState } from 'react'
+import React, { cloneElement, useRef, useEffect, useState } from 'react'
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 
 function SVGPanZoom ({
@@ -13,7 +13,7 @@ function SVGPanZoom ({
   setOnPan,
   setOnZoom
 }) {
-  const scrollContainer = createRef()
+  const scrollContainer = useRef()
   const defaultViewBox = {
     x: 0,
     y: 0,


### PR DESCRIPTION
## PR Overview

Fixes #1536 
Package: `lib-classifier`

This PR fixes issue 1536, where the Classifier would crash every time a Classification is submitted. This problem seems to stem from the `SVGPanZoom` component attempting to remove an event listener for an `undefined` DOM element on unmount, which in turn was caused by the use of `createRef()` instead of `useRef()`

### Dev Notes

Here are the tech deets:

- when _mounting the component,_ `scrollContainer.current` is correctly defined as a HTML node.
- when _unmounting_ however, `scrollContainer.current` is `undefined`
- Turns out, this is because `createRef()` doesn't play well with _functional components..._ because it apparently supposed to be called only once (i.e. `constructor () { this.myRef = createRef() }` ), and with functional components the initial value of `createRef()` is lost between renders/updates?
- Anyway, `useRef()` keeps a consistent ref across all the lifecycle stages of a _functional component._

Here's a better explanation: https://stackoverflow.com/questions/54620698/whats-the-difference-between-useref-and-createref

> The difference is that createRef will always create a new ref. In a class-based component, you would typically put the ref in an instance property during construction (e.g. this.input = createRef()). You don't have this option in a function component. useRef takes care of returning the same ref each time as on the initial rendering.

### Status

Ready for review

EDIT: WAIT, no, not ready for review. I think I spotted another small problem. Give me one sec to document...