### PR TITLE
Transcription line updates

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.js
@@ -2,10 +2,18 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { DragHandle } from '@plugins/drawingTools/components'
 
-const FINISHER_RADIUS = 8
+const FINISHER_RADIUS = 6
 const GRAB_STROKE_WIDTH = 6
+const COLOURS = {
+  active: '#5cb85c',
+  default: '#00ced1',
+  transcribed: '#c33',
+  complete: '#979797'
+}
 
-function TranscriptionLine ({ active, mark, onFinish, scale }) {
+function TranscriptionLine ({ active, mark, onFinish, scale, state }) {
+  state = active ? 'active' : state
+  const colour = COLOURS[state]
   const { x1, y1, x2, y2, finished } = mark
   const finisherRadius = FINISHER_RADIUS / scale
 
@@ -19,10 +27,16 @@ function TranscriptionLine ({ active, mark, onFinish, scale }) {
   }
 
   return (
-    <g>
+    <g
+      color={colour}
+      fill={colour}
+      stroke={colour}
+      strokeWidth={1}
+    >
       <line x1={x1} y1={y1} x2={x2} y2={y2} />
+      <line x1={x1} y1={y1} x2={x2} y2={y2} strokeWidth={GRAB_STROKE_WIDTH / scale} strokeOpacity='0' />
 
-      {active &&
+      {active ?
         <DragHandle
           fill='transparent'
           radius={6}
@@ -30,19 +44,35 @@ function TranscriptionLine ({ active, mark, onFinish, scale }) {
           x={x1}
           y={y1}
           dragMove={(e, d) => onHandleDrag({ x1: x1 + d.x, y1: y1 + d.y, x2, y2 })}
-        />}
-      {active &&
+        /> :
+        <circle
+          cx={x1}
+          cy={y1}
+          fill='transparent'
+          r={finisherRadius}
+          stroke='currentColor'
+        />
+      }
+      {active ?
         <DragHandle
           radius={6}
           scale={scale}
           x={x2}
           y={y2}
           dragMove={(e, d) => onHandleDrag({ x1, y1, x2: x2 + d.x, y2: y2 + d.y })}
-        />}
+        /> :
+        <circle
+          cx={x2}
+          cy={y2}
+          fill='currentColor'
+          r={finisherRadius}
+          stroke='currentColor'
+        />
+      }
 
       {active && !finished &&
         <g>
-          <circle r={finisherRadius} cx={x1} cy={y1} stroke="transparent" onPointerDown={handleFinishClick} />
+          <circle r={finisherRadius} cx={x1} cy={y1} fill="transparent" onPointerDown={handleFinishClick} />
           <circle r={finisherRadius} cx={x2} cy={y2} onPointerDown={handleFinishClick} />
         </g>
       }
@@ -54,13 +84,15 @@ TranscriptionLine.propTypes = {
   active: PropTypes.bool,
   mark: PropTypes.object.isRequired,
   onFinish: PropTypes.func,
-  scale: PropTypes.number
+  scale: PropTypes.number,
+  state: PropTypes.string
 }
 
 TranscriptionLine.defaultProps = {
   active: false,
   onFinish: () => true,
-  scale: 1
+  scale: 1,
+  state: 'default'
 }
 
 export default TranscriptionLine

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
@@ -87,3 +87,39 @@ storiesOf('Drawing tools | Transcription Line', module)
       </DrawingStory>
     )
   })
+  .add('transcribed', function () {
+    const tool = TranscriptionLineTool.create({
+      color: 'red',
+      type: 'transcriptionLine'
+    })
+    const mark = tool.createMark({
+      id: 'transcriptionLine1',
+      x1: 10,
+      y1: 20,
+      x2: 205,
+      y2: 15
+    })
+    return (
+      <DrawingStory mark={mark} tool={tool}>
+        <TranscriptionLine state='transcribed' mark={mark} />
+      </DrawingStory>
+    )
+  })
+  .add('complete', function () {
+    const tool = TranscriptionLineTool.create({
+      color: 'red',
+      type: 'transcriptionLine'
+    })
+    const mark = tool.createMark({
+      id: 'transcriptionLine1',
+      x1: 10,
+      y1: 20,
+      x2: 205,
+      y2: 15
+    })
+    return (
+      <DrawingStory mark={mark} tool={tool}>
+        <TranscriptionLine state='complete' mark={mark} />
+      </DrawingStory>
+    )
+  })


### PR DESCRIPTION
Set colours for line state: active, transcribed, completed or default.
Add start and end circles.

Package:
lib-classifier


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
