### PR TITLE
Fix 1543 - inactive drawing marks must not be draggable

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -103,6 +103,7 @@ function InteractionLayer ({
           onDelete={() => setActiveMark(undefined)}
           onFinish={onFinish}
           onSelectMark={mark => setActiveMark(mark)}
+          onMove={(mark, difference) => mark.move(difference)}
           scale={scale}
         />
       }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
@@ -48,9 +48,9 @@ function DrawingToolMarks ({ activeMarkId, marks, onDelete, onDeselectMark, onFi
         key={mark.id}
         isActive={isActive}
         coords={mark.coords}
-        dragStart={selectMark}
-        dragMove={moveMark}
-        dragEnd={deselectMark}
+        dragStart={isActive && selectMark}
+        dragMove={isActive && moveMark}
+        dragEnd={isActive && deselectMark}
         label={`Mark ${index}`}
         mark={mark}
         onDelete={deleteMark}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
@@ -29,10 +29,12 @@ function DrawingToolMarks ({ activeMarkId, marks, onDelete, onDeselectMark, onFi
     }
 
     function moveMark (event, difference) {
+      if (!isActive) return;
       mark.move(difference)
     }
 
     function deselectMark (event) {
+      if (!isActive) return;
       onDeselectMark(mark)
       if (!isInBounds(event.currentTarget)) {
         deleteMark()
@@ -40,6 +42,7 @@ function DrawingToolMarks ({ activeMarkId, marks, onDelete, onDeselectMark, onFi
     }
 
     function selectMark () {
+      if (!isActive) return;
       onSelectMark(mark)
     }
 
@@ -48,9 +51,9 @@ function DrawingToolMarks ({ activeMarkId, marks, onDelete, onDeselectMark, onFi
         key={mark.id}
         isActive={isActive}
         coords={mark.coords}
-        dragStart={isActive && selectMark}
-        dragMove={isActive && moveMark}
-        dragEnd={isActive && deselectMark}
+        dragStart={selectMark}
+        dragMove={moveMark}
+        dragEnd={deselectMark}
         label={`Mark ${index}`}
         mark={mark}
         onDelete={deleteMark}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { DeleteButton, Mark } from '@plugins/drawingTools/components'
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 
-function DrawingToolMarks ({ activeMarkId, marks, onDelete, onDeselectMark, onFinish, onSelectMark, scale }) {
+function DrawingToolMarks ({ activeMarkId, marks, onDelete, onDeselectMark, onFinish, onMove, onSelectMark, scale }) {
   const { svg } = useContext(SVGContext)
 
   return marks.map((mark, index) => {
@@ -29,8 +29,7 @@ function DrawingToolMarks ({ activeMarkId, marks, onDelete, onDeselectMark, onFi
     }
 
     function moveMark (event, difference) {
-      if (!isActive) return;
-      mark.move(difference)
+      onMove(mark, difference)
     }
 
     function deselectMark (event) {
@@ -81,6 +80,7 @@ DrawingToolMarks.propTypes = {
   marks: PropTypes.array.isRequired,
   onDelete: PropTypes.func,
   onDeselectMark: PropTypes.func,
+  onMove: PropTypes.func,
   onSelectMark: PropTypes.func,
   scale: PropTypes.number
 }
@@ -89,6 +89,7 @@ DrawingToolMarks.defaultProps = {
   activeMarkId: '',
   onDelete: () => true,
   onDeselectMark: () => true,
+  onMove: () => true,
   onSelectMark: () => true,
   scale: 1
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
@@ -34,7 +34,6 @@ function DrawingToolMarks ({ activeMarkId, marks, onDelete, onDeselectMark, onFi
     }
 
     function deselectMark (event) {
-      if (!isActive) return;
       onDeselectMark(mark)
       if (!isInBounds(event.currentTarget)) {
         deleteMark()
@@ -42,7 +41,6 @@ function DrawingToolMarks ({ activeMarkId, marks, onDelete, onDeselectMark, onFi
     }
 
     function selectMark () {
-      if (!isActive) return;
       onSelectMark(mark)
     }
 


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`
Fixes #1543 

This PR ensures that when a drawing mark isn't active (i.e. it was made in a previous workflow step), it can't be moved.

### Status

Ready for review

EDIT: Just saw @eatyourgreens's comment in https://github.com/zooniverse/front-end-monorepo/issues/1543#issuecomment-591973928