### PR TITLE
Classifier: Add the move cursor to draggable subjects

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/index.js
@@ -1,0 +1,7 @@
+export { default as AnnotateButton } from './AnnotateButton'
+export { default as FullscreenButton } from './FullscreenButton'
+export { default as MoveButton } from './MoveButton'
+export { default as ResetButton } from './ResetButton'
+export { default as RotateButton } from './RotateButton'
+export { default as ZoomInButton } from './ZoomInButton'
+export { default as ZoomOutButton } from './ZoomOutButton'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.stories.js
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
+import SubjectViewerStore from '@store/SubjectViewerStore'
 import SingleImageViewer, { SingleImageViewerContainer } from './SingleImageViewerContainer'
 import ZoomInButton from '../../../ImageToolbar/components/ZoomInButton/ZoomInButton'
 import ZoomOutButton from '../../../ImageToolbar/components/ZoomOutButton/ZoomOutButton'
@@ -23,16 +24,6 @@ const subject = {
   ]
 }
 
-let zoomCallback
-
-function onZoom(type) {
-  zoomCallback(type)
-}
-
-function setZoomCallback(callback) {
-  zoomCallback = callback
-}
-
 const mockStore = {
   classifications: {
     active: {
@@ -42,10 +33,9 @@ const mockStore = {
   drawing: {
     addToStream: sinon.stub()
   },
-  subjectViewer: {
-    enableRotation: () => null,
-    setOnZoom: setZoomCallback
-  },
+  subjectViewer: SubjectViewerStore.create({
+    move: true,
+  }),
   workflowSteps: {
     activeStepTasks: []
   }
@@ -68,27 +58,25 @@ const darkThemeConfig = Object.assign({}, config, { backgrounds: backgrounds.dar
 storiesOf('Subject Viewers | SingleImageViewer', module)
   .add('light theme', () => {
     return (
-      <Grommet theme={zooTheme}>
+      <ViewerContext theme={zooTheme}>
         <Box height='medium' width='large'>
-          <SingleImageViewerContainer
-            enableInteractionLayer={false}
+          <SingleImageViewer
             subject={subject}
           />
         </Box>
-      </Grommet>
+      </ViewerContext>
     )
   }, config)
   .add('dark theme', () => {
     const darkZooTheme = Object.assign({}, zooTheme, { dark: true })
     return (
-      <Grommet theme={darkZooTheme}>
+      <ViewerContext theme={darkZooTheme}>
         <Box height='medium' width='large'>
-          <SingleImageViewerContainer
-            enableInteractionLayer={false}
+          <SingleImageViewer
             subject={subject}
           />
         </Box>
-      </Grommet>
+      </ViewerContext>
     )
   }, darkThemeConfig)
   .add('pan and zoom', () => {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.stories.js
@@ -6,9 +6,10 @@ import { Box, Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
 import SubjectViewerStore from '@store/SubjectViewerStore'
 import SingleImageViewer, { SingleImageViewerContainer } from './SingleImageViewerContainer'
-import ZoomInButton from '../../../ImageToolbar/components/ZoomInButton/ZoomInButton'
-import ZoomOutButton from '../../../ImageToolbar/components/ZoomOutButton/ZoomOutButton'
-import ResetButton from '../../../ImageToolbar/components/ResetButton/ResetButton'
+import ZoomInButton from '../../../ImageToolbar/components/ZoomInButton/'
+import ZoomOutButton from '../../../ImageToolbar/components/ZoomOutButton/'
+import ResetButton from '../../../ImageToolbar/components/ResetButton/'
+import withKeyZoom from '../../../withKeyZoom'
 import readme from './README.md'
 import backgrounds from '../../../../../../../.storybook/lib/backgrounds'
 
@@ -79,18 +80,19 @@ storiesOf('Subject Viewers | SingleImageViewer', module)
       </ViewerContext>
     )
   }, darkThemeConfig)
-  .add('pan and zoom', () => {
+  .add('with zoom controls', () => {
+    const Toolbar = withKeyZoom(Box)
     return (
       <ViewerContext theme={zooTheme}>
+        <Toolbar direction='row'>
+          <ZoomInButton />
+          <ZoomOutButton />
+          <ResetButton />
+        </Toolbar>
         <Box height='medium' width='large'>
           <SingleImageViewer
             subject={subject}
           />
-        </Box>
-        <Box direction='row'>
-          <ZoomInButton onClick={() => onZoom('zoomin')} />
-          <ZoomOutButton onClick={() => onZoom('zoomout')} />
-          <ResetButton onClick={() => onZoom('zoomto')} />
         </Box>
       </ViewerContext>
     )

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.stories.js
@@ -6,9 +6,7 @@ import { Box, Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
 import SubjectViewerStore from '@store/SubjectViewerStore'
 import SingleImageViewer, { SingleImageViewerContainer } from './SingleImageViewerContainer'
-import ZoomInButton from '../../../ImageToolbar/components/ZoomInButton/'
-import ZoomOutButton from '../../../ImageToolbar/components/ZoomOutButton/'
-import ResetButton from '../../../ImageToolbar/components/ResetButton/'
+import { AnnotateButton, MoveButton, ResetButton, RotateButton, ZoomInButton, ZoomOutButton } from '../../../ImageToolbar/components/'
 import withKeyZoom from '../../../withKeyZoom'
 import readme from './README.md'
 import backgrounds from '../../../../../../../.storybook/lib/backgrounds'
@@ -34,9 +32,7 @@ const mockStore = {
   drawing: {
     addToStream: sinon.stub()
   },
-  subjectViewer: SubjectViewerStore.create({
-    move: true,
-  }),
+  subjectViewer: SubjectViewerStore.create({}),
   workflowSteps: {
     activeStepTasks: []
   }
@@ -85,8 +81,11 @@ storiesOf('Subject Viewers | SingleImageViewer', module)
     return (
       <ViewerContext theme={zooTheme}>
         <Toolbar direction='row'>
+          <AnnotateButton />
+          <MoveButton />
           <ZoomInButton />
           <ZoomOutButton />
+          <RotateButton />
           <ResetButton />
         </Toolbar>
         <Box height='medium' width='large'>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -15,6 +15,7 @@ import SubTaskPopup from '../../../SubTaskPopup'
 function storeMapper (stores) {
   const {
     enableRotation,
+    move,
     rotation,
     setOnZoom,
     setOnPan
@@ -22,6 +23,7 @@ function storeMapper (stores) {
 
   return {
     enableRotation,
+    move,
     rotation,
     setOnZoom,
     setOnPan
@@ -108,6 +110,7 @@ class SingleImageViewerContainer extends React.Component {
     const {
       enableInteractionLayer,
       loadingState,
+      move,
       onKeyDown,
       rotation,
       setOnPan,
@@ -132,6 +135,7 @@ class SingleImageViewerContainer extends React.Component {
 
     const svg = this.imageViewer.current
     const enableDrawing = (loadingState === asyncStates.success) && enableInteractionLayer
+    const SubjectImage = move ? DraggableImage : 'image'
 
     return (
       <SVGContext.Provider value={{ svg }}>
@@ -152,13 +156,14 @@ class SingleImageViewerContainer extends React.Component {
             rotate={rotation}
             width={naturalWidth}
           >
-            <DraggableImage
-              ref={this.subjectImage}
-              dragMove={this.dragMove}
-              height={naturalHeight}
-              width={naturalWidth}
-              xlinkHref={src}
-            />
+            <g ref={this.subjectImage}>
+              <SubjectImage
+                dragMove={this.dragMove}
+                height={naturalHeight}
+                width={naturalWidth}
+                xlinkHref={src}
+              />
+            </g>
           </SingleImageViewer>
         </SVGPanZoom>
         <SubTaskPopup />
@@ -171,6 +176,7 @@ SingleImageViewerContainer.propTypes = {
   enableInteractionLayer: PropTypes.bool,
   enableRotation: PropTypes.func,
   loadingState: PropTypes.string,
+  move: PropTypes.bool,
   onError: PropTypes.func,
   onReady: PropTypes.func,
   setOnPan: PropTypes.func,
@@ -185,6 +191,7 @@ SingleImageViewerContainer.defaultProps = {
   enableRotation: () => null,
   ImageObject: window.Image,
   loadingState: asyncStates.initialized,
+  move: false,
   onError: () => true,
   onReady: () => true,
   setOnPan: () => true,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -4,6 +4,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { draggable } from '@plugins/drawingTools/components'
 
+import styled from 'styled-components'
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import SVGPanZoom from '../SVGComponents/SVGPanZoom'
 import SingleImageViewer from './SingleImageViewer'
@@ -27,7 +28,9 @@ function storeMapper (stores) {
   }
 }
 
-const DraggableImage = draggable('image')
+const DraggableImage = styled(draggable('image'))`
+  cursor: move;
+`
 
 class SingleImageViewerContainer extends React.Component {
   constructor () {
@@ -194,4 +197,4 @@ SingleImageViewerContainer.defaultProps = {
 class DecoratedSingleImageViewerContainer extends SingleImageViewerContainer { }
 
 export default DecoratedSingleImageViewerContainer
-export { SingleImageViewerContainer }
+export { DraggableImage, SingleImageViewerContainer }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -53,7 +53,9 @@ describe('Component > SingleImageViewerContainer', function () {
     const onReady = sinon.stub()
     const onError = sinon.stub()
 
-    beforeEach(function () {
+    beforeEach(function (done) {
+      onReady.callsFake(() => done())
+      onError.callsFake(() => done())
       const subject = {
         id: 'test',
         locations: [
@@ -91,7 +93,7 @@ describe('Component > SingleImageViewerContainer', function () {
       expect(wrapper).to.be.ok()
     })
 
-    it('should record the original image dimensions on load', function (done) {
+    it('should record the original image dimensions on load', function () {
       const svg = wrapper.instance().imageViewer.current
       const fakeEvent = {
         target: {
@@ -107,58 +109,28 @@ describe('Component > SingleImageViewerContainer', function () {
           naturalWidth: width
         }
       }
-      onReady.callsFake(function () {
-        expect(onReady).to.have.been.calledOnceWith(expectedEvent)
-        expect(onError).to.not.have.been.called()
-        done()
-      })
+      expect(onReady).to.have.been.calledOnceWith(expectedEvent)
+      expect(onError).to.not.have.been.called()
     })
 
-    it('should pass the original image dimensions to the SVG image', function (done) {
-      const svg = wrapper.instance().imageViewer.current
-      const fakeEvent = {
-        target: {
-          clientHeight: 0,
-          clientWidth: 0
-        }
-      }
-      const expectedEvent = {
-        target: {
-          clientHeight: svg.clientHeight,
-          clientWidth: svg.clientWidth,
-          naturalHeight: height,
-          naturalWidth: width
-        }
-      }
-      onReady.callsFake(function () {
-        const { height, width } = wrapper.find(SingleImageViewer).props()
-        expect(height).to.equal(height)
-        expect(width).to.equal(width)
-        done()
-      })
+    it('should pass the original image dimensions to the SVG image', function () {
+      const { height, width } = wrapper.find(SingleImageViewer).props()
+      expect(height).to.equal(height)
+      expect(width).to.equal(width)
     })
 
-    it('should render an svg image', function (done) {
-      const svg = wrapper.instance().imageViewer.current
-      const fakeEvent = {
-        target: {
-          clientHeight: 0,
-          clientWidth: 0
-        }
-      }
-      const expectedEvent = {
-        target: {
-          clientHeight: svg.clientHeight,
-          clientWidth: svg.clientWidth,
-          naturalHeight: height,
-          naturalWidth: width
-        }
-      }
-      onReady.callsFake(function () {
+    it('should render an svg image', function () {
+      const image = wrapper.find('image')
+      expect(image).to.have.lengthOf(1)
+      expect(image.prop('xlinkHref')).to.equal('https://some.domain/image.jpg')
+    })
+
+    describe('with dragging enabled', function () {
+      it('should render a draggable image', function () {
+        wrapper.setProps({ move: true })
         const image = wrapper.find(DraggableImage)
         expect(image).to.have.lengthOf(1)
         expect(image.prop('xlinkHref')).to.equal('https://some.domain/image.jpg')
-        done()
       })
     })
   })
@@ -172,7 +144,9 @@ describe('Component > SingleImageViewerContainer', function () {
       sinon.stub(console, 'error')
     })
 
-    beforeEach(function () {
+    beforeEach(function (done) {
+      onReady.callsFake(() => done())
+      onError.callsFake(() => done())
       const subject = {
         id: 'test',
         locations: [
@@ -212,24 +186,18 @@ describe('Component > SingleImageViewerContainer', function () {
       expect(wrapper).to.be.ok()
     })
 
-    it('should log an error from an invalid image', function (done) {
+    it('should log an error from an invalid image', function () {
       const fakeEvent = {
         target: {
           clientHeight: 0,
           clientWidth: 0
         }
       }
-      onError.callsFake(function () {
-        expect(onError.withArgs(HTMLImgError)).to.have.been.calledOnce()
-        done()
-      })
+      expect(onError.withArgs(HTMLImgError)).to.have.been.calledOnce()
     })
 
-    it('should not call onReady', function (done) {
-      onError.callsFake(function () {
-        expect(onReady).to.not.have.been.called()
-        done()
-      })
+    it('should not call onReady', function () {
+      expect(onReady).to.not.have.been.called()
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme'
 import sinon from 'sinon'
 import React from 'react'
 
-import { SingleImageViewerContainer } from './SingleImageViewerContainer'
+import { DraggableImage, SingleImageViewerContainer } from './SingleImageViewerContainer'
 import SingleImageViewer from './SingleImageViewer'
 
 describe('Component > SingleImageViewerContainer', function () {
@@ -155,7 +155,7 @@ describe('Component > SingleImageViewerContainer', function () {
         }
       }
       onReady.callsFake(function () {
-        const image = wrapper.find('draggable(image)')
+        const image = wrapper.find(DraggableImage)
         expect(image).to.have.lengthOf(1)
         expect(image.prop('xlinkHref')).to.equal('https://some.domain/image.jpg')
         done()


### PR DESCRIPTION
Show the move cursor when subject images can be panned by dragging.

Package:
lib-classifier

Closes #1489.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
