### PR TITLE
Classifier: Pass the theme prop to task components

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/FieldGuide.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/FieldGuide.js
@@ -15,8 +15,8 @@ function storeMapper (stores) {
   }
 }
 
-@withTheme
 @inject(storeMapper)
+@withTheme
 @observer
 class FieldGuide extends React.Component {
   render () {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -3,6 +3,7 @@ import { Box, Paragraph } from 'grommet'
 import { inject, observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { withTheme } from 'styled-components'
 
 import TaskHelp from './components/TaskHelp'
 import TaskNavButtons from './components/TaskNavButtons'
@@ -40,7 +41,7 @@ class Tasks extends React.Component {
   }
 
   [asyncStates.success] () {
-    const { addAnnotation, classification, isThereTaskHelp, subjectReadyState, step, tasks } = this.props
+    const { addAnnotation, classification, isThereTaskHelp, subjectReadyState, step, tasks, theme } = this.props
     const ready = subjectReadyState === asyncStates.success
     if (classification && tasks.length > 0) {
       // setting the wrapping box of the task component to a basis of 246px feels hacky,
@@ -61,10 +62,11 @@ class Tasks extends React.Component {
               return (
                 <Box key={annotation.id} basis='auto'>
                   <TaskComponent
+                    {...this.props}
                     disabled={!ready}
                     annotation={annotation}
                     task={task}
-                    {...this.props}
+                    theme={theme}
                   />
                 </Box>
               )
@@ -102,6 +104,7 @@ Tasks.defaultProps = {
 }
 
 @inject(storeMapper)
+@withTheme
 @observer
 class DecoratedTasks extends Tasks {}
 

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
@@ -5,12 +5,11 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import TaskInput from '../../components/TaskInput'
-import zooTheme from '@zooniverse/grommet-theme'
 
 const maxWidth = pxToRem(60)
 const StyledBox = styled(Box)`
   img:only-child, svg:only-child {
-    background: ${zooTheme.global.colors.brand};
+    ${props => props.theme && css`background: ${props.theme.global.colors.brand};`}
     max-width: ${maxWidth};
   }
 `
@@ -30,7 +29,8 @@ function MultipleChoiceTask (props) {
     annotation,
     className,
     disabled,
-    task
+    task,
+    theme
   } = props
   const { value } = annotation
 
@@ -50,6 +50,7 @@ function MultipleChoiceTask (props) {
       autoFocus={(value && value.length === 0)}
       className={className}
       disabled={disabled}
+      theme={theme}
     >
       <StyledText size='small' tag='legend'>
         <Markdownz>

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
@@ -80,7 +80,12 @@ function MultipleChoiceTask (props) {
 
 MultipleChoiceTask.defaultProps = {
   className: '',
-  disabled: false
+  disabled: false,
+  theme: {
+    global: {
+      colors: {}
+    }
+  }
 }
 
 MultipleChoiceTask.propTypes = {
@@ -97,7 +102,12 @@ MultipleChoiceTask.propTypes = {
     help: PropTypes.string,
     question: PropTypes.string,
     required: PropTypes.bool
-  }).isRequired
+  }).isRequired,
+  theme: PropTypes.shape({
+    global: PropTypes.shape({
+      colors: PropTypes.object
+   })
+ })
 }
 
 export default MultipleChoiceTask

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.js
@@ -2,7 +2,7 @@ import { Markdownz, pxToRem } from '@zooniverse/react-components'
 import { Box, Text } from 'grommet'
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import TaskInput from '../../components/TaskInput'
 

--- a/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.js
@@ -4,14 +4,11 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css, withTheme } from 'styled-components'
 import TaskInput from '../../components/TaskInput'
-import zooTheme from '@zooniverse/grommet-theme'
 
-// TODO this really should use the theme from context/props instead
-// But broke tests for the Task component
 const maxWidth = pxToRem(60)
 const StyledBox = styled(Box)`
   img:only-child, svg:only-child {
-    background: ${zooTheme.global.colors.brand};
+    ${props => props.theme && css`background: ${props.theme.global.colors.brand};`}
     max-width: ${maxWidth};
   }
 `
@@ -101,4 +98,3 @@ SingleChoiceTask.propTypes = {
 }
 
 export default SingleChoiceTask
-// export { SingleChoiceTask }

--- a/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.js
@@ -2,7 +2,7 @@ import { Markdownz, pxToRem } from '@zooniverse/react-components'
 import { Box, Text } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, { css, withTheme } from 'styled-components'
+import styled, { css } from 'styled-components'
 import TaskInput from '../../components/TaskInput'
 
 const maxWidth = pxToRem(60)


### PR DESCRIPTION
Add the `withTheme` decorator to the task area, then pass the theme down to individual tasks as a prop.

See #1507 and #1511 for context. `observer` can't be applied to a component that's been decorated with `withTheme`, so we have to be careful how the theme is passed down to observed tasks.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
