### PR TITLE
Add frame scroll handler

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
@@ -49,15 +49,24 @@ export function NextLabel () {
   )
 }
 
-export const StyledInput = styled.input`
+export const StyledFrame = styled.label`
   ${props => props.theme && css`
-    &:checked + img {
-      outline: ${props.theme.global.colors['neutral-4']} solid;
+    input:checked + img {
+      border: ${props.theme.global.colors['neutral-4']} solid;
+    }
+    input:focus + img {
+      outline: 2px solid ${tint(0.5, props.theme.global.colors.brand)};
+    }
+
+    input:hover + img {
+      outline: 2px solid ${tint(0.5, props.theme.global.colors.brand)};
     }
   `}
-  clip: rect(0 0 0 0);
-  overflow: hidden;
-  position: absolute;
+  input {
+    opacity: 0.01;
+    position: absolute;
+  }
+
 `
 
 export const StyledImage = styled.img`
@@ -97,21 +106,20 @@ class FrameCarousel extends React.Component {
       const url = location[mimeType]
       const activeFrame = frame === index
       return (
-        <label
+        <StyledFrame
           key={`${url}-${index}`}
         >
-          <StyledInput
+          <input
             checked={activeFrame}
             name='frame'
             onChange={() => onFrameChange(index)}
-            src={url}
             type='radio'
           />
           <StyledImage
             alt={counterpart('MultiFrameViewer.FrameCarousel.thumbnailAltText')}
             src={url}
           />
-        </label>
+        </StyledFrame>
       )
     })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
@@ -71,20 +71,18 @@ export const StyledFrame = styled.label`
 `
 
 export const StyledImage = styled.img`
-  float: center;
-  height: 3em;
-  margin: 0.5em;
+  height: 40px;
   object-fit: cover;
   padding: 0;
-  width: 3em;
+  width: 40px;
 `
 
 class FrameCarousel extends React.Component {
   constructor () {
     super()
+    this.handleScroll = this.handleScroll.bind(this)
     this.handlePrevious = this.handlePrevious.bind(this)
     this.handleNext = this.handleNext.bind(this)
-    this.handleScroll = this.handleScroll.bind(this)
     this.activeLabel = React.createRef()
     this.frameList = React.createRef()
   }
@@ -93,35 +91,37 @@ class FrameCarousel extends React.Component {
     this.handleScroll()
   }
 
-  componentDidUpdate (prevProps) {
-    const { frame } = this.props
-    if (prevProps.frame !== frame) {
-      this.handleScroll()
+  handleScroll () {
+    const labelIsAboveContainerTop = this.activeLabel.current?.offsetTop <= this.frameList.current?.scrollTop
+    const labelIsBelowContainerBottom = this.activeLabel.current?.offsetTop >= (this.frameList.current?.scrollTop + this.frameList.current?.clientHeight)
+
+    if (labelIsAboveContainerTop || labelIsBelowContainerBottom) {
+      const newContainerTopPosition = this.activeLabel.current.offsetTop - this.activeLabel.current.offsetHeight
+      this.frameList.current.scrollTop = newContainerTopPosition
     }
   }
 
+  handleFrameChange (frameIndex) {
+    const { onFrameChange } = this.props
+    onFrameChange(frameIndex)
+  }
+
   handlePrevious () {
-    const { frame, onFrameChange } = this.props
+    const { frame } = this.props
     if (frame > 0) {
-      onFrameChange(frame - 1)
+      this.handleFrameChange(frame - 1)
     }
   }
 
   handleNext () {
-    const { frame, onFrameChange, locations } = this.props
+    const { frame, locations } = this.props
     if (frame < locations.length) {
-      onFrameChange(frame + 1)
-    }
-  }
-
-  handleScroll (event) {
-    if (this.activeLabel.current?.offsetTop <= this.frameList.current?.scrollTop || this.activeLabel.current?.offsetTop >= (this.frameList.current?.scrollTop + this.frameList.current?.clientHeight)) {
-      this.frameList.current.scrollTop = this.activeLabel.current.offsetTop - this.activeLabel.current.offsetHeight
+      this.handleFrameChange(frame + 1)
     }
   }
 
   render () {
-    const { frame, onFrameChange, locations } = this.props
+    const { frame, locations } = this.props
     const locationElements = locations.map((location, index) => {
       const mimeType = Object.keys(location)[0]
       const url = location[mimeType]
@@ -134,7 +134,7 @@ class FrameCarousel extends React.Component {
           <input
             checked={activeFrame}
             name='frame'
-            onChange={() => onFrameChange(index)}
+            onChange={() => this.handleFrameChange(index)}
             type='radio'
           />
           <StyledImage
@@ -165,6 +165,7 @@ class FrameCarousel extends React.Component {
           fill
           overflow='auto'
           ref={this.frameList}
+          style={{ position: 'relative', scrollBehavior: 'smooth' }}
         >
           {locationElements}
         </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
@@ -91,6 +91,13 @@ class FrameCarousel extends React.Component {
     this.handleScroll()
   }
 
+  componentDidUpdate (prevProps) {
+    const { frame } = this.props
+    if (prevProps.frame !== frame) {
+      this.handleScroll()
+    }
+  }
+
   handleScroll () {
     const labelIsAboveContainerTop = this.activeLabel.current?.offsetTop <= this.frameList.current?.scrollTop
     const labelIsBelowContainerBottom = this.activeLabel.current?.offsetTop >= (this.frameList.current?.scrollTop + this.frameList.current?.clientHeight)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
@@ -54,6 +54,7 @@ export const StyledFrame = styled.label`
     input:checked + img {
       border: ${props.theme.global.colors['neutral-4']} solid;
     }
+    
     input:focus + img {
       outline: 2px solid ${tint(0.5, props.theme.global.colors.brand)};
     }
@@ -83,6 +84,20 @@ class FrameCarousel extends React.Component {
     super()
     this.handlePrevious = this.handlePrevious.bind(this)
     this.handleNext = this.handleNext.bind(this)
+    this.handleScroll = this.handleScroll.bind(this)
+    this.activeLabel = React.createRef()
+    this.frameList = React.createRef()
+  }
+
+  componentDidMount () {
+    this.handleScroll()
+  }
+
+  componentDidUpdate (prevProps) {
+    const { frame } = this.props
+    if (prevProps.frame !== frame) {
+      this.handleScroll()
+    }
   }
 
   handlePrevious () {
@@ -99,6 +114,12 @@ class FrameCarousel extends React.Component {
     }
   }
 
+  handleScroll (event) {
+    if (this.activeLabel.current?.offsetTop <= this.frameList.current?.scrollTop || this.activeLabel.current?.offsetTop >= (this.frameList.current?.scrollTop + this.frameList.current?.clientHeight)) {
+      this.frameList.current.scrollTop = this.activeLabel.current.offsetTop - this.activeLabel.current.offsetHeight
+    }
+  }
+
   render () {
     const { frame, onFrameChange, locations } = this.props
     const locationElements = locations.map((location, index) => {
@@ -108,6 +129,7 @@ class FrameCarousel extends React.Component {
       return (
         <StyledFrame
           key={`${url}-${index}`}
+          ref={activeFrame ? this.activeLabel : null}
         >
           <input
             checked={activeFrame}
@@ -142,6 +164,7 @@ class FrameCarousel extends React.Component {
           direction='column'
           fill
           overflow='auto'
+          ref={this.frameList}
         >
           {locationElements}
         </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
@@ -16,7 +16,7 @@ export const StyledControlButton = styled(Button)`
     color: ${props.theme.global.colors['neutral-6']};
     background: ${props.theme.global.colors.brand};
 
-    &:hover, &:focus {
+    &:hover, &:focus, not(:disabled) {
       background: ${tint(0.5, props.theme.global.colors.brand)};
       box-shadow: none;
     }
@@ -61,12 +61,12 @@ export const StyledInput = styled.input`
 `
 
 export const StyledImage = styled.img`
-  height: 3em;
-  width: 3em;
-  margin: 0.5em;
   float: center;
+  height: 3em;
+  margin: 0.5em;
   object-fit: cover;
   padding: 0;
+  width: 3em;
 `
 
 class FrameCarousel extends React.Component {
@@ -97,7 +97,9 @@ class FrameCarousel extends React.Component {
       const url = location[mimeType]
       const activeFrame = frame === index
       return (
-        <label key={`${url}-${index}`}>
+        <label
+          key={`${url}-${index}`}
+        >
           <StyledInput
             checked={activeFrame}
             name='frame'
@@ -105,17 +107,20 @@ class FrameCarousel extends React.Component {
             src={url}
             type='radio'
           />
-          <StyledImage src={url} alt={counterpart('MultiFrameViewer.FrameCarousel.thumbnailAltText')} />
+          <StyledImage
+            alt={counterpart('MultiFrameViewer.FrameCarousel.thumbnailAltText')}
+            src={url}
+          />
         </label>
       )
     })
 
     return (
       <Box
-        background='neutral-6'
+        background={{ dark: 'dark-3', light: 'neutral-6' }}
         direction='column'
-        fill='vertical'
-        width={{ 'min': '2em' }}
+        height='450px'
+        width='7em'
       >
         <StyledControlButton
           disabled={frame === 0}
@@ -124,11 +129,11 @@ class FrameCarousel extends React.Component {
           onClick={() => this.handlePrevious()}
         />
         <Box
+          align='center'
           as='ul'
           direction='column'
           fill
-          align='center'
-          overflow='scroll'
+          overflow='auto'
         >
           {locationElements}
         </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.spec.js
@@ -5,11 +5,11 @@ import sinon from 'sinon'
 import {
   FrameCarousel,
   StyledControlButton,
-  StyledInput,
+  StyledFrame,
   StyledImage
 } from './FrameCarousel'
 
-describe('Component > FrameCarousel', function () {
+describe.only('Component > FrameCarousel', function () {
   let wrapper
   let onFrameChangeSpy
   const multiFrameSubjectLocations = [
@@ -45,36 +45,38 @@ describe('Component > FrameCarousel', function () {
     expect(wrapper.instance().props.locations).to.have.lengthOf(numberOfFrames)
   })
 
-  it('should render an input and an img for each location', function () {
-    const inputs = wrapper.find(StyledInput)
+  it('should render a label, input and an img for each location', function () {
+    const labels = wrapper.find(StyledFrame)
+    const inputs = wrapper.find('input')
     const images = wrapper.find(StyledImage)
-    expect(images).to.have.lengthOf(numberOfFrames)
+    expect(labels).to.have.lengthOf(numberOfFrames)
     expect(inputs).to.have.lengthOf(numberOfFrames)
+    expect(images).to.have.lengthOf(numberOfFrames)
   })
 
   it('should show the active location as checked', function () {
-    const inputs = wrapper.find(StyledInput)
+    const inputs = wrapper.find('input')
     expect(inputs.at(2).props().checked).to.be.true()
   })
 
   it('should show inactive locations as unchecked', function () {
-    const inputs = wrapper.find(StyledInput)
+    const inputs = wrapper.find('input')
     expect(inputs.at(0).props().checked).to.be.false()
     expect(inputs.at(1).props().checked).to.be.false()
     expect(inputs.at(3).props().checked).to.be.false()
   })
 
   it('should call onFrameChange with location index on input change', function () {
-    expect(wrapper.find(StyledInput).at(2).props().checked).to.be.true()
-    const lastInput = wrapper.find(StyledInput).last()
+    expect(wrapper.find('input').at(2).props().checked).to.be.true()
+    const lastInput = wrapper.find('input').last()
     lastInput.simulate('change')
     expect(onFrameChangeSpy.calledOnceWith(3)).to.be.true()
-    expect(wrapper.find(StyledInput).at(2).props().checked).to.be.false()
-    expect(wrapper.find(StyledInput).last().props().checked).to.be.true()
+    expect(wrapper.find('input').at(2).props().checked).to.be.false()
+    expect(wrapper.find('input').last().props().checked).to.be.true()
   })
 
   it('should call onFrameChange with appropriate index on previous button click', function () {
-    const inputs = wrapper.find(StyledInput)
+    const inputs = wrapper.find('input')
     expect(inputs.at(2).props().checked).to.be.true()
     const previousButton = wrapper.find(StyledControlButton).first()
     previousButton.simulate('click')
@@ -82,7 +84,7 @@ describe('Component > FrameCarousel', function () {
   })
 
   it('should call onFrameChange with appropriate index on next button click', function () {
-    const inputs = wrapper.find(StyledInput)
+    const inputs = wrapper.find('input')
     expect(inputs.at(2).props().checked).to.be.true()
     const nextButton = wrapper.find(StyledControlButton).last()
     nextButton.simulate('click')

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.spec.js
@@ -9,7 +9,7 @@ import {
   StyledImage
 } from './FrameCarousel'
 
-describe.only('Component > FrameCarousel', function () {
+describe('Component > FrameCarousel', function () {
   let wrapper
   let onFrameChangeSpy
   const multiFrameSubjectLocations = [

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewer.stories.js
@@ -30,7 +30,7 @@ const subject = {
     { 'image/jpeg': 'http://placekitten.com/300/500' }
   ],
   metadata: {
-    default_frame: 1
+    default_frame: 7
   }
 }
 


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
- adds refs, scroll handlers so active frame is visible if list of frames has overflow
- misc. styling cleanup

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
