### PR TITLE
Classifier: Consolidate store subject observers

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -19,8 +19,8 @@ function storeMapper (stores) {
   const [activeDrawingTask] = activeStepTasks.filter(task => task.type === 'drawing')
   const activeTool = activeDrawingTask ? activeDrawingTask.activeTool : null
   const disabled = activeTool ? activeTool.disabled : false
-  const drawingAnnotations = Array.from(classification.annotations.values())
-    .filter(annotation => getType(annotation).name === 'DrawingAnnotation')
+  const annotations = classification ? Array.from(classification.annotations.values()) : []
+  const drawingAnnotations = annotations.filter(annotation => getType(annotation).name === 'DrawingAnnotation')
   const { activeMark, marks, setActiveMark, setSubTaskVisibility } = activeDrawingTask || {}
   return {
     activeDrawingTask,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -129,6 +129,7 @@ class SingleImageViewerContainer extends React.Component {
     }
 
     const svg = this.imageViewer.current
+    const enableDrawing = (loadingState === asyncStates.success) && enableInteractionLayer
 
     return (
       <SVGContext.Provider value={{ svg }}>
@@ -142,7 +143,7 @@ class SingleImageViewerContainer extends React.Component {
           setOnZoom={setOnZoom}
         >
           <SingleImageViewer
-            enableInteractionLayer={enableInteractionLayer}
+            enableInteractionLayer={enableDrawing}
             height={naturalHeight}
             onKeyDown={onKeyDown}
             ref={this.imageViewer}

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -11,18 +11,16 @@ import TaskNavButtons from './components/TaskNavButtons'
 import taskRegistry from '@plugins/tasks'
 
 function storeMapper (stores) {
-  const { active: classification, addAnnotation } = stores.classifierStore.classifications
+  const { active: classification } = stores.classifierStore.classifications
   const { loadingState } = stores.classifierStore.workflows
-  const { active: step, activeStepTasks: tasks, isThereTaskHelp } = stores.classifierStore.workflowSteps
+  const { active: step, isThereTaskHelp } = stores.classifierStore.workflowSteps
   const { loadingState: subjectReadyState } = stores.classifierStore.subjectViewer
   return {
-    addAnnotation,
     classification,
     isThereTaskHelp,
     loadingState,
     step,
     subjectReadyState,
-    tasks
   }
 }
 
@@ -41,9 +39,9 @@ class Tasks extends React.Component {
   }
 
   [asyncStates.success] () {
-    const { addAnnotation, classification, isThereTaskHelp, subjectReadyState, step, tasks, theme } = this.props
+    const { classification, isThereTaskHelp, subjectReadyState, step, theme } = this.props
     const ready = subjectReadyState === asyncStates.success
-    if (classification && tasks.length > 0) {
+    if (classification && step.tasks.length > 0) {
       // setting the wrapping box of the task component to a basis of 246px feels hacky,
       // but gets the area to be the same 453px height (or very close) as the subject area
       // and keeps the task nav buttons at the the bottom area
@@ -51,11 +49,11 @@ class Tasks extends React.Component {
       // but works for now
       return (
         <Box as='form' gap='small' justify='between' fill>
-          {tasks.map((task) => {
+          {step.tasks.map((task) => {
             // classifications.addAnnotation(task, value) retrieves any existing task annotation from the store
             // or creates a new one if one doesn't exist.
             // The name is a bit confusing.
-            const annotation = addAnnotation(task)
+            const annotation = classification.addAnnotation(task)
             task.setAnnotation(annotation)
             const TaskComponent = observer(taskRegistry.get(task.type).TaskComponent)
             if (annotation && TaskComponent) {
@@ -74,7 +72,7 @@ class Tasks extends React.Component {
 
             return (<Paragraph>Task component could not be rendered.</Paragraph>)
           })}
-          {isThereTaskHelp && <TaskHelp tasks={tasks} />}
+          {isThereTaskHelp && <TaskHelp tasks={step.tasks} />}
           <TaskNavButtons disabled={!ready || !step.isComplete} />
         </Box>
       )
@@ -92,15 +90,13 @@ class Tasks extends React.Component {
 Tasks.propTypes = {
   isThereTaskHelp: PropTypes.bool,
   loadingState: PropTypes.oneOf(asyncStates.values),
-  ready: PropTypes.bool,
-  tasks: PropTypes.arrayOf(PropTypes.object)
+  ready: PropTypes.bool
 }
 
 Tasks.defaultProps = {
   isThereTaskHelp: false,
   loadingState: asyncStates.initialized,
-  ready: false,
-  tasks: []
+  ready: false
 }
 
 @inject(storeMapper)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
@@ -11,7 +11,6 @@ import { ProjectFactory, SubjectFactory, WorkflowFactory } from '@test/factories
 import stubPanoptesJs from '@test/stubPanoptesJs'
 
 describe('Tasks', function () {
-  let addAnnotation
   let classification
   let step
   let tasks
@@ -97,7 +96,6 @@ describe('Tasks', function () {
         client
       })
       classification = rootStore.classifications.active
-      addAnnotation = rootStore.classifications.addAnnotation
       step = rootStore.workflowSteps.active
     })
 
@@ -132,9 +130,8 @@ describe('Tasks', function () {
           <Tasks
             loadingState={asyncStates.success}
             ready
-            addAnnotation={addAnnotation}
             classification={classification}
-            tasks={step.tasks}
+            step={step}
           />
         )
         // Is there a better way to do this?
@@ -148,11 +145,10 @@ describe('Tasks', function () {
           before(function () {
             const wrapper = shallow(
               <Tasks
-                addAnnotation={addAnnotation}
                 classification={classification}
                 loadingState={asyncStates.success}
                 subjectReadyState={asyncStates.loading}
-                tasks={step.tasks}
+                step={step}
               />
             )
             taskWrapper = wrapper.find(TaskComponent.displayName)
@@ -167,12 +163,10 @@ describe('Tasks', function () {
           before(function () {
             const wrapper = shallow(
               <Tasks
-                addAnnotation={addAnnotation}
                 classification={classification}
                 loadingState={asyncStates.success}
                 subjectReadyState={asyncStates.success}
                 step={step}
-                tasks={step.tasks}
               />
             )
             taskWrapper = wrapper.find(TaskComponent.displayName)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
@@ -18,15 +18,6 @@ describe('Tasks', function () {
 
   const taskTypes = Object.keys(taskRegistry.register)
 
-  before(function () {
-    // Mute the onAction warnings for the duration of these tests.
-    sinon.stub(console, 'error')
-  })
-
-  after(function () {
-    console.error.restore()
-  })
-
   taskTypes.forEach(function (taskType) {
     before(function () {
       const task = taskRegistry.get(taskType)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
@@ -1,5 +1,6 @@
 import { observer } from 'mobx-react'
 import React from 'react'
+import { Factory } from 'rosie'
 import sinon from 'sinon'
 import { shallow } from 'enzyme'
 import { Tasks } from './Tasks'
@@ -46,7 +47,7 @@ describe('Tasks', function () {
       const { panoptes } = stubPanoptesJs({
         field_guides: [],
         projects: [projectSnapshot],
-        subjects: [subjectSnapshot],
+        subjects: Factory.buildList('subject', 10),
         tutorials: [],
         workflows: [workflowSnapshot]
       })
@@ -86,6 +87,11 @@ describe('Tasks', function () {
         },
         client
       })
+      rootStore.workflows.setResource(workflowSnapshot)
+      rootStore.workflows.setActive(workflowSnapshot.id)
+      rootStore.subjects.setResource(subjectSnapshot)
+      rootStore.subjects.setActive(subjectSnapshot.id)
+      rootStore.subjectViewer.onSubjectReady()
       classification = rootStore.classifications.active
       step = rootStore.workflowSteps.active
     })

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
@@ -73,6 +73,8 @@ const Drawing = types.model('Drawing', {
 
     function reset () {
       self.tools.forEach(tool => tool.reset())
+      self.activeToolIndex = 0
+      self.subTaskVisibility = false
     }
     
     function setSubTaskVisibility (visible, drawingMarkNode) {

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
@@ -230,9 +230,6 @@ describe('Model > DrawingTask', function () {
       expect(lineTool.marks.size).to.equal(0)
     })
 
-    it('should clear stale marks from the task', function () {
-      expect(marks.length).to.equal(0)
-    })
 
     it('should reset the active tool', function () {
       expect(task.activeToolIndex).to.equal(0)

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
@@ -199,8 +199,10 @@ describe('Model > DrawingTask', function () {
     let marks
     let pointTool
     let lineTool
+    let task
+
     before(function () {
-      const task = DrawingTask.TaskModel.create(drawingTaskSnapshot)
+      task = DrawingTask.TaskModel.create(drawingTaskSnapshot)
       const annotation = task.defaultAnnotation
       const store = types.model('MockStore', {
         annotation: DrawingTask.AnnotationModel,
@@ -213,6 +215,8 @@ describe('Model > DrawingTask', function () {
       task.setAnnotation(annotation)
       pointTool = task.tools[0]
       lineTool = task.tools[1]
+      task.setActiveTool(1)
+      task.setSubTaskVisibility(true)
       task.reset()
       marks = task.marks
     })
@@ -224,6 +228,18 @@ describe('Model > DrawingTask', function () {
     it('should clear stale marks from the drawing tools', function () {
       expect(pointTool.marks.size).to.equal(0)
       expect(lineTool.marks.size).to.equal(0)
+    })
+
+    it('should clear stale marks from the task', function () {
+      expect(marks.length).to.equal(0)
+    })
+
+    it('should reset the active tool', function () {
+      expect(task.activeToolIndex).to.equal(0)
+    })
+
+    it('should reset the subtask visibility', function () {
+      expect(task.subTaskVisibility).to.be.false()
     })
   })
 })

--- a/packages/lib-classifier/src/store/AnnotationsStore.js
+++ b/packages/lib-classifier/src/store/AnnotationsStore.js
@@ -1,5 +1,4 @@
-import { addDisposer, getParent, onAction, types } from 'mobx-state-tree'
-import { autorun } from 'mobx'
+import { types } from 'mobx-state-tree'
 import Annotation from '@plugins/tasks/models/Annotation'
 
 const AnnotationsStore = types
@@ -18,20 +17,8 @@ const AnnotationsStore = types
     }
   }))
   .actions(self => {
-    function afterAttach() {
-      createParentObserver()
-    }
-
-    function createParentObserver() {
-      const parentNodeDisposer = autorun(() => {
-        // grandparent can either be a Tool or the ClassificationStore
-        // immediate parent is the map
-        const parentNode = getParent(self, 2)
-        onAction(parentNode, (call) => {
-          if (call.name === 'reset') self.reset()
-        })
-      }, { name: 'AnnotationsStore parent node observer autorun' })
-      addDisposer(self, parentNodeDisposer)
+    function beforeDestroy() {
+      self.reset()
     }
 
     function addAnnotation (task, value) {
@@ -60,7 +47,7 @@ const AnnotationsStore = types
 
     return {
       addAnnotation,
-      afterAttach,
+      beforeDestroy,
       removeAnnotation,
       reset
     }

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -2,8 +2,8 @@ import asyncStates from '@zooniverse/async-states'
 import counterpart from 'counterpart'
 import cuid from 'cuid'
 import _ from 'lodash'
-import { autorun, toJS } from 'mobx'
-import { addDisposer, flow, getRoot, isValidReference, types } from 'mobx-state-tree'
+import { toJS } from 'mobx'
+import { flow, getRoot, isValidReference, types } from 'mobx-state-tree'
 import { Split } from 'seven-ten'
 
 import Classification, { ClassificationMetadata } from './Classification'
@@ -48,26 +48,6 @@ const ClassificationStore = types
     }
   })
   .actions(self => {
-    function afterAttach () {
-      createSubjectObserver()
-    }
-
-    function createSubjectObserver () {
-      const subjectDisposer = autorun(() => {
-        const { projects, subjects, workflows } = getRoot(self)
-        const validSubjectReference = isValidReference(() => subjects && subjects.active)
-        const validWorkflowReference = isValidReference(() => workflows && workflows.active)
-        const validProjectReference = isValidReference(() => projects && projects.active)
-        if (validSubjectReference && validWorkflowReference && validProjectReference) {
-          const subject = getRoot(self).subjects.active
-          const workflow = getRoot(self).workflows.active
-          const project = getRoot(self).projects.active
-          self.reset()
-          self.createClassification(subject, workflow, project)
-        }
-      }, { name: 'ClassificationStore Subject Observer autorun' })
-      addDisposer(self, subjectDisposer)
-    }
 
     function createClassification (subject, workflow, project) {
       if (!subject || !workflow || !project) {
@@ -221,7 +201,6 @@ const ClassificationStore = types
 
     return {
       addAnnotation,
-      afterAttach,
       completeClassification,
       createClassification,
       onClassificationSaved,

--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -246,8 +246,14 @@ describe('Model > ClassificationStore', function () {
         helpers.isFeedbackActive.restore()
       })
 
-      // Why is this test here?
-      // The observer is in the feedback store
+      /* 
+        Why is this test here?
+        The observer is in the root store.
+        I'm not sure why these are here either. (JOD)
+        The RootStore tests could be updated to test that feedback
+        is added to classifications on classificationComplete.
+        The tests for invalid feedback would have to be moved too.
+      */
       it('should update feedback', function () {
         expect(feedback.update.withArgs(singleChoiceAnnotationSnapshot)).to.have.been.calledOnce()
       })

--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -8,42 +8,46 @@ import {
   ProjectFactory,
   SingleChoiceAnnotationFactory,
   SingleChoiceTaskFactory,
+  SubjectFactory,
   WorkflowFactory
 } from '@test/factories'
 import stubPanoptesJs from '@test/stubPanoptesJs'
 import helpers from './feedback/helpers'
 import taskRegistry from '@plugins/tasks'
 
-const { AnnotationModel: SingleChoiceAnnotation } = taskRegistry.get('single')
-
-const feedbackRulesStub = {
-  T0: [{
-    id: 'testRule',
-    answer: '0',
-    strategy: 'singleAnswerQuestion',
-    successEnabled: true,
-    successMessage: 'Yay!',
-    failureEnabled: true,
-    failureMessage: 'No!'
-  }]
-}
-const subjectsStub = Factory.buildList('subject', 10)
-const singleChoiceTaskStub = SingleChoiceTaskFactory.build()
-const singleChoiceAnnotationStub = SingleChoiceAnnotationFactory.build()
-const workflowStub = WorkflowFactory.build({ tasks: { T0: singleChoiceTaskStub } })
-const projectStub = ProjectFactory.build({}, { activeWorkflowId: workflowStub.id })
-
 describe('Model > ClassificationStore', function () {
+  const { AnnotationModel: SingleChoiceAnnotation } = taskRegistry.get('single')
+
+  const feedbackRulesSnapshot = {
+    T0: [{
+      id: 'testRule',
+      answer: '0',
+      strategy: 'singleAnswerQuestion',
+      successEnabled: true,
+      successMessage: 'Yay!',
+      failureEnabled: true,
+      failureMessage: 'No!'
+    }]
+  }
+  const subjectsSnapshot = Factory.buildList('subject', 10)
+  const singleChoiceTaskSnapshot = SingleChoiceTaskFactory.build()
+  const singleChoiceAnnotationSnapshot = SingleChoiceAnnotationFactory.build()
+  const workflowSnapshot = WorkflowFactory.build({ tasks: { T0: singleChoiceTaskSnapshot } })
+  const projectSnapshot = ProjectFactory.build({}, { activeWorkflowId: workflowSnapshot.id })
+  const subjectSnapshot = SubjectFactory.build()
+
   function setupStores (stores) {
-    const clientStub = stubPanoptesJs({ classifications: [], subjects: subjectsStub })
+    const clientSnapshot = stubPanoptesJs({ classifications: [], subjects: subjectsSnapshot })
     const store = RootStore.create(stores, {
-      client: clientStub,
+      client: clientSnapshot,
       authClient: { checkBearerToken: () => Promise.resolve(), checkCurrent: () => Promise.resolve() }
     })
-    store.projects.setResource(projectStub)
-    store.projects.setActive(projectStub.id)
-    store.workflows.setResource(workflowStub)
-    store.workflows.setActive(workflowStub.id)
+    store.projects.setResource(projectSnapshot)
+    store.projects.setActive(projectSnapshot.id)
+    store.workflows.setResource(workflowSnapshot)
+    store.workflows.setActive(workflowSnapshot.id)
+    store.subjects.setResource(subjectSnapshot)
+    store.subjects.setActive(subjectSnapshot.id)
     return store
   }
 
@@ -66,8 +70,10 @@ describe('Model > ClassificationStore', function () {
         workflowSteps: {},
         userProjectPreferences: {}
       })
-      rootStore.subjects.setResource(subjectsStub[0])
-      rootStore.subjects.setActive(subjectsStub[0].id)
+      rootStore.subjectViewer.onSubjectReady()
+      rootStore.subjects.setResource(subjectsSnapshot[0])
+      rootStore.subjects.setActive(subjectsSnapshot[0].id)
+      rootStore.subjectViewer.onSubjectReady()
       classifications = rootStore.classifications
     })
 
@@ -78,16 +84,16 @@ describe('Model > ClassificationStore', function () {
 
     it('should create an empty Classification with links to the Project, Workflow, and Subject', function () {
       const classification = classifications.active.toJSON()
-      const subject = subjectsStub[0]
+      const subject = subjectsSnapshot[0]
       expect(classification).to.be.ok()
-      expect(classification.links.project).to.equal(projectStub.id)
-      expect(classification.links.workflow).to.equal(workflowStub.id)
+      expect(classification.links.project).to.equal(projectSnapshot.id)
+      expect(classification.links.workflow).to.equal(workflowSnapshot.id)
       expect(classification.links.subjects[0]).to.equal(subject.id)
     })
 
     it('should create an empty Classification with the correct Subject Selection metadata', function () {
       const classification = classifications.active.toJSON()
-      const subject = subjectsStub[0]
+      const subject = subjectsSnapshot[0]
       expect(classification.metadata.subjectSelectionState).to.be.ok()
       expect(classification.metadata.subjectSelectionState.already_seen).to.equal(subject.already_seen)
       expect(classification.metadata.subjectSelectionState.finished_workflow).to.equal(subject.finished_workflow)
@@ -111,8 +117,10 @@ describe('Model > ClassificationStore', function () {
         workflowSteps: {},
         userProjectPreferences: {}
       })
-      rootStore.subjects.setResource(subjectsStub[0])
-      rootStore.subjects.setActive(subjectsStub[0].id)
+      rootStore.subjectViewer.onSubjectReady()
+      rootStore.subjects.setResource(subjectsSnapshot[0])
+      rootStore.subjects.setActive(subjectsSnapshot[0].id)
+      rootStore.subjectViewer.onSubjectReady()
       classifications = rootStore.classifications
     })
 
@@ -124,8 +132,9 @@ describe('Model > ClassificationStore', function () {
     it('should reset and create a new classification', function () {
       const firstClassificationId = classifications.active.id
       expect(classifications.active.toJSON()).to.ok()
-      rootStore.subjects.setResource(subjectsStub[1])
-      rootStore.subjects.setActive(subjectsStub[1].id)
+      rootStore.subjects.setResource(subjectsSnapshot[1])
+      rootStore.subjects.setActive(subjectsSnapshot[1].id)
+      rootStore.subjectViewer.onSubjectReady()
       expect(classifications.active.id).to.not.equal(firstClassificationId)
     })
   })
@@ -136,29 +145,30 @@ describe('Model > ClassificationStore', function () {
       let rootStore
       before(function () {
         sinon.stub(helpers, 'isFeedbackActive').callsFake(() => true)
-        const invalidFeedbackStub = {
+        const invalidFeedbackSnapshot = {
           rules: {}
         }
 
         rootStore = setupStores({
           dataVisAnnotating: {},
           drawing: {},
-          feedback: invalidFeedbackStub,
+          feedback: invalidFeedbackSnapshot,
           fieldGuide: {},
           subjectViewer: {},
           tutorials: {},
           workflowSteps: {},
           userProjectPreferences: {}
         })
+        rootStore.subjectViewer.onSubjectReady()
 
         classifications = rootStore.classifications
         classifications.setOnComplete(sinon.stub())
       })
 
       beforeEach(function () {
-        const taskStub = Object.assign({}, singleChoiceTaskStub, { taskKey: singleChoiceAnnotationStub.task })
-        taskStub.createAnnotation = () => SingleChoiceAnnotation.create(singleChoiceAnnotationStub)
-        classifications.addAnnotation(taskStub, singleChoiceAnnotationStub.value)
+        const taskSnapshot = Object.assign({}, singleChoiceTaskSnapshot, { taskKey: singleChoiceAnnotationSnapshot.task })
+        taskSnapshot.createAnnotation = () => SingleChoiceAnnotation.create(singleChoiceAnnotationSnapshot)
+        classifications.addAnnotation(taskSnapshot, singleChoiceAnnotationSnapshot.value)
         classifications.completeClassification({
           preventDefault: sinon.stub()
         })
@@ -205,8 +215,8 @@ describe('Model > ClassificationStore', function () {
         subjectViewer = rootStore.subjectViewer
       })
 
-      beforeEach(function () {
-        const activeFeedback = FeedbackFactory.build({ rules: feedbackRulesStub })
+      before(function () {
+        const activeFeedback = FeedbackFactory.build({ rules: feedbackRulesSnapshot })
         // Classification completion adds feedback metadata if feedback is active and there are rules
         // So first we update the feedback store to have active feedback
         // Then call the classification complete event
@@ -220,16 +230,16 @@ describe('Model > ClassificationStore', function () {
         })
 
         subjectToBeClassified = rootStore.subjects.active
-        const taskStub = Object.assign({}, singleChoiceTaskStub, { taskKey: singleChoiceAnnotationStub.task })
-        taskStub.createAnnotation = () => SingleChoiceAnnotation.create(singleChoiceAnnotationStub)
-        classifications.addAnnotation(taskStub, singleChoiceAnnotationStub.value)
+        const taskSnapshot = Object.assign({}, singleChoiceTaskSnapshot, { taskKey: singleChoiceAnnotationSnapshot.task })
+        taskSnapshot.createAnnotation = () => SingleChoiceAnnotation.create(singleChoiceAnnotationSnapshot)
+        classifications.addAnnotation(taskSnapshot, singleChoiceAnnotationSnapshot.value)
         classificationWithAnnotation = classifications.active
         classifications.completeClassification({
           preventDefault: sinon.stub()
         })
       })
 
-      afterEach(function () {
+      after(function () {
         onComplete.resetHistory()
         feedback.update.resetHistory()
         subjectViewer.resetSubject()
@@ -245,7 +255,7 @@ describe('Model > ClassificationStore', function () {
       // Why is this test here?
       // The observer is in the feedback store
       it('should update feedback', function () {
-        expect(feedback.update.withArgs(singleChoiceAnnotationStub)).to.have.been.calledOnce()
+        expect(feedback.update.withArgs(singleChoiceAnnotationSnapshot)).to.have.been.calledOnce()
       })
 
       it('should call the onComplete callback with the classification and subject', function () {
@@ -260,7 +270,7 @@ describe('Model > ClassificationStore', function () {
         })
 
         it('should have a feedback key', function () {
-          expect(metadata.feedback).to.eql(feedbackRulesStub)
+          expect(metadata.feedback).to.eql(feedbackRulesSnapshot)
         })
 
         it('should record subject dimensions', function () {

--- a/packages/lib-classifier/src/store/FeedbackStore.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.js
@@ -1,5 +1,5 @@
 import { autorun } from 'mobx'
-import { addDisposer, addMiddleware, getRoot, isValidReference, onAction, types } from 'mobx-state-tree'
+import { addDisposer, addMiddleware, getRoot, isValidReference, types } from 'mobx-state-tree'
 import { flatten } from 'lodash'
 
 import helpers from './feedback/helpers'
@@ -45,21 +45,8 @@ const FeedbackStore = types
     }
 
     function afterAttach () {
-      createClassificationObserver()
       createSubjectMiddleware()
       createSubjectObserver()
-    }
-
-    function createClassificationObserver () {
-      const classificationDisposer = autorun(() => {
-        onAction(getRoot(self).classifications, (call) => {
-          if (call.name === 'completeClassification') {
-            const annotations = getRoot(self).classifications.currentAnnotations
-            annotations.forEach(annotation => self.update(annotation))
-          }
-        })
-      }, { name: 'FeedbackStore Classification Observer autorun' })
-      addDisposer(self, classificationDisposer)
     }
 
     function onNewSubject () {

--- a/packages/lib-classifier/src/store/FeedbackStore.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.js
@@ -46,7 +46,6 @@ const FeedbackStore = types
 
     function afterAttach () {
       createSubjectMiddleware()
-      createSubjectObserver()
     }
 
     function onNewSubject () {
@@ -82,11 +81,6 @@ const FeedbackStore = types
         })
       }, { name: 'FeedbackStore Subject Middleware autorun' })
       addDisposer(self, subjectMiddleware)
-    }
-
-    function createSubjectObserver () {
-      const subjectDisposer = autorun(onNewSubject, { name: 'FeedbackStore Subject Observer autorun' })
-      addDisposer(self, subjectDisposer)
     }
 
     function createRules (subject) {

--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -53,7 +53,7 @@ const RootStore = types
 
     function createSubjectObserver () {
       const subjectDisposer = autorun(() => {
-        const { classifications, projects, subjects, workflows, workflowSteps } = self
+        const { classifications, feedback, projects, subjects, workflows, workflowSteps } = self
         const subject = tryReference(() => subjects?.active)
         const workflow = tryReference(() => workflows?.active)
         const project = tryReference(() => projects?.active)
@@ -61,6 +61,7 @@ const RootStore = types
           workflowSteps.resetSteps()
           classifications.reset()
           classifications.createClassification(subject, workflow, project)
+          feedback.onNewSubject()
         }
       }, { name: 'Root Store Subject Observer autorun' })
       addDisposer(self, subjectDisposer)

--- a/packages/lib-classifier/src/store/RootStore.spec.js
+++ b/packages/lib-classifier/src/store/RootStore.spec.js
@@ -1,4 +1,7 @@
+import { Factory } from 'rosie'
 import sinon from 'sinon'
+import { ProjectFactory, SubjectFactory, WorkflowFactory } from '@test/factories'
+import stubPanoptesJs from '@test/stubPanoptesJs'
 import RootStore from './RootStore'
 
 describe('Model > RootStore', function () {
@@ -46,5 +49,93 @@ describe('Model > RootStore', function () {
     const addToCollection = sinon.stub()
     model.setOnAddToCollection(addToCollection)
     expect(model.onAddToCollection).to.equal(addToCollection)
+  })
+  
+  describe('when a subject loads', function () {
+    let model
+    let subjectSnapshot
+
+    before(function () {
+      const projectSnapshot = ProjectFactory.build({
+        id: 'testProject',
+        display_name: 'A test project',
+        links: {
+          default_workflow: 'testWorkflow' 
+        }
+      })
+      subjectSnapshot = SubjectFactory.build()
+      const workflowSnapshot = WorkflowFactory.build({
+        id: 'testWorkflow',
+        display_name: 'A test workflow',
+        tasks: {
+          T0: {
+            type: 'single',
+            question: 'Yes or no?',
+            answers: [ 'yes', 'no' ]
+          },
+          T1: {
+            type: 'multiple',
+            question: 'Pick some fruit',
+            answers: [ 'apples', 'oranges', 'pears' ]
+          }
+        }
+      })
+      const client = stubPanoptesJs({
+        subjects: Factory.buildList('subject', 10),
+        workflows: [workflowSnapshot]
+      })
+      client.tutorials = {
+        get: sinon.stub().callsFake(() => Promise.resolve({ body: { tutorials: [] } }))
+      }
+      model = RootStore.create({
+        projects: {
+          active: 'testProject',
+          resources: {
+            testProject: projectSnapshot
+          }
+        },
+        subjects: {
+          active: subjectSnapshot.id,
+          resources: {
+            [subjectSnapshot.id]: subjectSnapshot
+          }
+        },
+        workflows: {
+          active: 'testWorkflow',
+          resources: {
+            testWorkflow: workflowSnapshot
+          }
+        }
+      }, {
+        client,
+        authClient: { checkBearerToken: () => Promise.resolve(), checkCurrent: () => Promise.resolve() }
+      })
+      model.workflows.setResource(workflowSnapshot)
+      model.workflows.setActive(workflowSnapshot.id)
+      model.subjects.setResource(subjectSnapshot)
+      model.subjects.setActive(subjectSnapshot.id)
+      model.workflowSteps.selectStep('S2')
+      model.feedback.showFeedback()
+      model.subjectViewer.onSubjectReady({})
+    })
+    
+
+    it('should reset workflow steps', function () {
+      const activeStep = model.workflowSteps.active
+      expect(activeStep.stepKey).to.equal('S1')
+    })
+
+    it('should create a new classification', function () {
+      expect(model.classifications.active.links).to.deep.equal({
+        project: 'testProject',
+        subjects: [ subjectSnapshot.id ],
+        workflow: 'testWorkflow'
+      })
+    })
+
+    it('should reset subject feedback', function () {
+      expect(model.feedback.rules).to.be.empty()
+      expect(model.feedback.showModal).to.be.false()
+    })
   })
 })

--- a/packages/lib-classifier/src/store/RootStore.spec.js
+++ b/packages/lib-classifier/src/store/RootStore.spec.js
@@ -1,10 +1,10 @@
 import sinon from 'sinon'
 import RootStore from './RootStore'
 
-let model
-const client = { foo: 'bar' }
-
 describe('Model > RootStore', function () {
+  let model
+  const client = { foo: 'bar' }
+
   before(function () {
     model = RootStore.create({}, { client })
   })

--- a/packages/lib-classifier/src/store/TutorialStore.spec.js
+++ b/packages/lib-classifier/src/store/TutorialStore.spec.js
@@ -1,3 +1,4 @@
+import { Factory } from 'rosie'
 import sinon from 'sinon'
 import asyncStates from '@zooniverse/async-states'
 
@@ -13,72 +14,75 @@ import {
 } from '@test/factories'
 import stubPanoptesJs from '@test/stubPanoptesJs'
 
-const seenMock = new Date().toISOString()
-const token = '1235'
+describe('Model > TutorialStore', function () {
+  const seenMock = new Date().toISOString()
+  const token = '1235'
 
-const user = UserFactory.build()
-const project = ProjectFactory.build()
-const workflow = WorkflowFactory.build({ id: project.configuration.default_workflow })
-const medium = TutorialMediumFactory.build()
+  const user = UserFactory.build()
+  const project = ProjectFactory.build()
+  const workflow = WorkflowFactory.build({ id: project.configuration.default_workflow })
+  const medium = TutorialMediumFactory.build()
 
-const tutorial = TutorialFactory.build({ steps: [
-  { content: '# Hello', media: medium.id },
-  { content: '# Step 2' }
-] })
+  const tutorial = TutorialFactory.build({ steps: [
+    { content: '# Hello', media: medium.id },
+    { content: '# Step 2' }
+  ] })
 
-const tutorialNullKind = TutorialFactory.build(
-  {
-    steps: [
-      { content: '# Hello', media: medium.id },
-      { content: '# Step 2' }
-    ],
-    kind: null
-  }
-)
-
-const upp = UPPFactory.build()
-const uppWithTutorialTimeStamp = UPPFactory.build({
-  preferences: {
-    tutorials_completed_at: {
-      [tutorial.id]: seenMock
+  const tutorialNullKind = TutorialFactory.build(
+    {
+      steps: [
+        { content: '# Hello', media: medium.id },
+        { content: '# Step 2' }
+      ],
+      kind: null
     }
-  }
-})
+  )
 
-const panoptesClient = stubPanoptesJs({ workflows: workflow })
-
-const clientStub = (tutorialResource = tutorial) => {
-  return Object.assign({}, panoptesClient, {
-    tutorials: {
-      get: sinon.stub().callsFake(() => {
-        return Promise.resolve({
-          body: {
-            tutorials: [tutorialResource]
-          }
-        })
-      }),
-      getAttachedImages: sinon.stub().callsFake(() => {
-        return Promise.resolve({
-          body: {
-            media: [medium]
-          }
-        })
-      })
+  const upp = UPPFactory.build()
+  const uppWithTutorialTimeStamp = UPPFactory.build({
+    preferences: {
+      tutorials_completed_at: {
+        [tutorial.id]: seenMock
+      }
     }
   })
-}
 
-const authClientStubWithoutUser = {
-  checkCurrent: sinon.stub().callsFake(() => Promise.resolve(null)),
-  checkBearerToken: sinon.stub().callsFake(() => Promise.resolve(null))
-}
+  const panoptesClient = stubPanoptesJs({
+    subjects: Factory.buildList('subject', 10),
+    workflows: workflow
+  })
 
-const authClientStubWithUser = {
-  checkCurrent: sinon.stub().callsFake(() => Promise.resolve(user)),
-  checkBearerToken: sinon.stub().callsFake(() => Promise.resolve(token))
-}
+  const clientStub = (tutorialResource = tutorial) => {
+    return Object.assign({}, panoptesClient, {
+      tutorials: {
+        get: sinon.stub().callsFake(() => {
+          return Promise.resolve({
+            body: {
+              tutorials: [tutorialResource]
+            }
+          })
+        }),
+        getAttachedImages: sinon.stub().callsFake(() => {
+          return Promise.resolve({
+            body: {
+              media: [medium]
+            }
+          })
+        })
+      }
+    })
+  }
 
-describe('Model > TutorialStore', function () {
+  const authClientStubWithoutUser = {
+    checkCurrent: sinon.stub().callsFake(() => Promise.resolve(null)),
+    checkBearerToken: sinon.stub().callsFake(() => Promise.resolve(null))
+  }
+
+  const authClientStubWithUser = {
+    checkCurrent: sinon.stub().callsFake(() => Promise.resolve(user)),
+    checkBearerToken: sinon.stub().callsFake(() => Promise.resolve(token))
+  }
+
   function fetchTutorials (rootStore) {
     sinon.stub(rootStore.tutorials, 'fetchTutorials')
     return rootStore.workflows.setActive(workflow.id)
@@ -434,8 +438,16 @@ describe('Model > TutorialStore', function () {
     let tutorialsClient
 
     before(function () {
-      const panoptesClientWithUPP = stubPanoptesJs({ project_preferences: upp, workflows: workflow })
-      const panoptesClientWithUPPTimestamp = stubPanoptesJs({ project_preferences: uppWithTutorialTimeStamp, workflows: workflow })
+      const panoptesClientWithUPP = stubPanoptesJs({
+        project_preferences: upp,
+        subjects: Factory.buildList('subject', 10),
+        workflows: workflow
+      })
+      const panoptesClientWithUPPTimestamp = stubPanoptesJs({
+        project_preferences: uppWithTutorialTimeStamp,
+        subjects: Factory.buildList('subject', 10),
+        workflows: workflow
+      })
       tutorialsClient = {
         tutorials: {
           get: sinon.stub().callsFake(() => {

--- a/packages/lib-classifier/src/store/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.js
@@ -1,5 +1,5 @@
 import { autorun } from 'mobx'
-import { addDisposer, getRoot, isValidReference, onAction, types } from 'mobx-state-tree'
+import { addDisposer, getRoot, isValidReference, types } from 'mobx-state-tree'
 
 import Step from './Step'
 import taskRegistry, { taskModels } from '@plugins/tasks'
@@ -65,7 +65,6 @@ const WorkflowStepStore = types
   .actions(self => {
     function afterAttach () {
       createWorkflowObserver()
-      createSubjectObserver()
     }
 
     function createWorkflowObserver () {
@@ -86,15 +85,6 @@ const WorkflowStepStore = types
         }
       }, { name: 'WorkflowStepStore Workflow Observer autorun' })
       addDisposer(self, workflowDisposer)
-    }
-
-    function createSubjectObserver () {
-      const subjectDisposer = autorun(() => {
-        onAction(getRoot(self), (call) => {
-          if (call.name === 'onSubjectReady') self.resetSteps()
-        }, true)
-      }, { name: 'WorkflowStepStore Subject Observer autorun' })
-      addDisposer(self, subjectDisposer)
     }
 
     function getNextStepKey () {

--- a/packages/lib-classifier/src/store/WorkflowStepStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.spec.js
@@ -56,7 +56,11 @@ describe('Model > WorkflowStepStore', function () {
       })
 
       const project = ProjectFactory.build({}, { activeWorkflowId: workflow.id })
-      const panoptesClientStub = stubPanoptesJs({ projects: project, workflows: workflow })
+      const panoptesClientStub = stubPanoptesJs({
+        projects: project,
+        subjects: Factory.buildList('subject', 10),
+        workflows: workflow
+      })
       rootStore = setupStores(panoptesClientStub, project)
     })
 
@@ -127,7 +131,11 @@ describe('Model > WorkflowStepStore', function () {
         }
       })
       const project = ProjectFactory.build({}, { activeWorkflowId: workflow.id })
-      const panoptesClientStub = stubPanoptesJs({ projects: project, workflows: workflow })
+      const panoptesClientStub = stubPanoptesJs({
+        projects: project,
+        subjects: Factory.buildList('subject', 10),
+        workflows: workflow
+      })
       rootStore = setupStores(panoptesClientStub, project)
     })
 

--- a/packages/lib-classifier/src/store/WorkflowStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStore.spec.js
@@ -1,3 +1,4 @@
+import { Factory } from 'rosie'
 import RootStore from './RootStore'
 import WorkflowStore from './WorkflowStore'
 import {
@@ -7,33 +8,33 @@ import {
 } from '@test/factories'
 import stubPanoptesJs from '@test/stubPanoptesJs'
 
-const workflow = WorkflowFactory.build({
-  tasks: { T1: SingleChoiceTaskFactory.build() },
-  steps: [['S1', { taskKeys: ['T1'] }]]
-})
-const projectWithDefault = ProjectFactory.build({}, { activeWorkflowId: workflow.id })
-const projectWithoutDefault = ProjectFactory.build({ configuration: { default_workflow: undefined } }, { activeWorkflowId: workflow.id })
-
-function setupStores (clientStub, project) {
-  const store = RootStore.create({
-    classifications: {},
-    dataVisAnnotating: {},
-    drawing: {},
-    feedback: {},
-    fieldGuide: {},
-    subjects: {},
-    subjectViewer: {},
-    tutorials: {},
-    workflowSteps: {},
-    userProjectPreferences: {}
-  }, { client: clientStub, authClient: { checkBearerToken: () => Promise.resolve(), checkCurrent: () => Promise.resolve() } })
-
-  store.projects.setResource(project)
-  store.projects.setActive(project.id)
-  return store
-}
-
 describe('Model > WorkflowStore', function () {
+  const workflow = WorkflowFactory.build({
+    tasks: { T1: SingleChoiceTaskFactory.build() },
+    steps: [['S1', { taskKeys: ['T1'] }]]
+  })
+  const projectWithDefault = ProjectFactory.build({}, { activeWorkflowId: workflow.id })
+  const projectWithoutDefault = ProjectFactory.build({ configuration: { default_workflow: undefined } }, { activeWorkflowId: workflow.id })
+
+  function setupStores (clientStub, project) {
+    const store = RootStore.create({
+      classifications: {},
+      dataVisAnnotating: {},
+      drawing: {},
+      feedback: {},
+      fieldGuide: {},
+      subjects: {},
+      subjectViewer: {},
+      tutorials: {},
+      workflowSteps: {},
+      userProjectPreferences: {}
+    }, { client: clientStub, authClient: { checkBearerToken: () => Promise.resolve(), checkCurrent: () => Promise.resolve() } })
+
+    store.projects.setResource(project)
+    store.projects.setActive(project.id)
+    return store
+  }
+
   it('should exist', function () {
     expect(WorkflowStore).to.be.an('object')
   })
@@ -43,6 +44,7 @@ describe('Model > WorkflowStore', function () {
       before(function () {
         const panoptesClientStub = stubPanoptesJs({
           projects: projectWithoutDefault,
+          subjects: Factory.buildList('subject', 10),
           workflows: workflow
         })
 
@@ -64,6 +66,7 @@ describe('Model > WorkflowStore', function () {
       let rootStore
       before(function () {
         const panoptesClientStub = stubPanoptesJs({
+          subjects: Factory.buildList('subject', 10),
           workflows: workflow
         })
 
@@ -83,6 +86,7 @@ describe('Model > WorkflowStore', function () {
       let rootStore
       before(function () {
         const panoptesClientStub = stubPanoptesJs({
+          subjects: Factory.buildList('subject', 10),
           workflows: workflow
         })
 


### PR DESCRIPTION
Consolidate the subject observers from the feedback, workflow steps and classifications stores into one function in the root store. When the subject changes, reset the workflow steps, create a new classification, then reset subject feedback. I think this will fix #1521 by making sure the first task is selected before the classification is created.

This PR also fixes a couple of infinite loops that showed up in the Tutorial Store tests (infinitely requesting new subjects) and the UPP Store tests (infinitely requesting a new workflow.) 

I've also moved the Feedback `onAction` listener up to the root in order to mute warnings from that store. Classification and Mark `onAction` listeners are replaced with `beforeDestroy` actions to remove those warnings too. Otherwise, I was finding the console so noisy that failing tests were impossible to debug.

Package:
lib-classifier

Closes #1521.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
