### PR TITLE
Classifier: Grouped subject models

### DIFF
--- a/packages/lib-classifier/src/store/SingleImageSubject/SingleImageSubject.js
+++ b/packages/lib-classifier/src/store/SingleImageSubject/SingleImageSubject.js
@@ -1,0 +1,13 @@
+import { types } from 'mobx-state-tree'
+import createLocationCounts from '../../helpers/createLocationCounts'
+import Subject from '../Subject'
+
+const SingleImageSubject = types
+  .refinement('SingleImageSubject', Subject, subject => {
+    const counts = createLocationCounts(subject)
+    return counts.images === 1
+  })
+
+  
+
+export default SingleImageSubject

--- a/packages/lib-classifier/src/store/SingleImageSubject/SingleImageSubject.js
+++ b/packages/lib-classifier/src/store/SingleImageSubject/SingleImageSubject.js
@@ -5,7 +5,7 @@ import Subject from '../Subject'
 const SingleImageSubject = types
   .refinement('SingleImageSubject', Subject, subject => {
     const counts = createLocationCounts(subject)
-    return counts.images === 1
+    return subject.locations.length === 1 && counts.images === 1
   })
 
   

--- a/packages/lib-classifier/src/store/SingleImageSubject/SingleImageSubject.spec.js
+++ b/packages/lib-classifier/src/store/SingleImageSubject/SingleImageSubject.spec.js
@@ -30,6 +30,19 @@ describe('Model > SingleImageSubject', function () {
     expect(subject.locations).to.have.lengthOf(1)
   })
 
+  describe('with an invalid subject', function () {
+    const subjectSnapshot = SubjectFactory.build({ 
+      locations: [
+        { 'image/png': 'https://foo.bar/example.png' },
+        { 'audio/mpeg': 'https://foo.bar/example.mp3' }
+      ]
+    })
+
+    it('should throw an error', function () {
+      expect(() => SingleImageSubject.create(subjectSnapshot)).to.throw()
+    })
+  })
+
   describe('Views > viewer', function () {
     before(function () {
       const { panoptes } = stubPanoptesJS({

--- a/packages/lib-classifier/src/store/SingleImageSubject/SingleImageSubject.spec.js
+++ b/packages/lib-classifier/src/store/SingleImageSubject/SingleImageSubject.spec.js
@@ -3,7 +3,7 @@ import SingleImageSubject from './SingleImageSubject'
 import RootStore from '../'
 import WorkflowStore from '../WorkflowStore'
 import { SubjectFactory, WorkflowFactory } from '@test/factories'
-import stubPanoptesJS from '@test/stubPanoptesJS'
+import stubPanoptesJs from '@test/stubPanoptesJs'
 import subjectViewers from '../../helpers/subjectViewers'
 
 describe('Model > SingleImageSubject', function () {
@@ -45,7 +45,7 @@ describe('Model > SingleImageSubject', function () {
 
   describe('Views > viewer', function () {
     before(function () {
-      const { panoptes } = stubPanoptesJS({
+      const { panoptes } = stubPanoptesJs({
         subjects: [ subject ],
         workflows: [ workflowSnapshot ]
       })

--- a/packages/lib-classifier/src/store/SingleImageSubject/index.js
+++ b/packages/lib-classifier/src/store/SingleImageSubject/index.js
@@ -1,0 +1,1 @@
+export { default } from './SingleImageSubject'

--- a/packages/lib-classifier/src/store/Subject/Subject.js
+++ b/packages/lib-classifier/src/store/Subject/Subject.js
@@ -1,9 +1,9 @@
 import { autorun } from 'mobx'
 import { addDisposer, destroy, getRoot, isValidReference, tryReference, types } from 'mobx-state-tree'
-import Resource from './Resource'
-import createLocationCounts from '../helpers/createLocationCounts'
-import subjectViewers from '../helpers/subjectViewers'
-import TranscriptionReductions from './TranscriptionReductions'
+import Resource from '../Resource'
+import createLocationCounts from '../../helpers/createLocationCounts'
+import subjectViewers from '../../helpers/subjectViewers'
+import TranscriptionReductions from '../TranscriptionReductions'
 
 const Subject = types
   .model('Subject', {

--- a/packages/lib-classifier/src/store/Subject/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject/Subject.spec.js
@@ -1,12 +1,12 @@
 import { Factory } from 'rosie'
 import sinon from 'sinon'
 import Subject from './Subject'
-import ProjectStore from './ProjectStore'
-import WorkflowStore from './WorkflowStore'
+import ProjectStore from '../ProjectStore'
+import WorkflowStore from '../WorkflowStore'
 import { ProjectFactory, SubjectFactory, WorkflowFactory } from '@test/factories'
-import stubPanoptesJs from '@test/stubPanoptesJs'
-import RootStore from './'
-import subjectViewers from '../helpers/subjectViewers'
+import stubPanoptesJs from '@test/stubPanoptesJS'
+import RootStore from '../'
+import subjectViewers from '../../helpers/subjectViewers'
 
 describe('Model > Subject', function () {
   const stub = SubjectFactory.build()

--- a/packages/lib-classifier/src/store/Subject/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject/Subject.spec.js
@@ -4,7 +4,7 @@ import Subject from './Subject'
 import ProjectStore from '../ProjectStore'
 import WorkflowStore from '../WorkflowStore'
 import { ProjectFactory, SubjectFactory, WorkflowFactory } from '@test/factories'
-import stubPanoptesJs from '@test/stubPanoptesJS'
+import stubPanoptesJs from '@test/stubPanoptesJs'
 import RootStore from '../'
 import subjectViewers from '../../helpers/subjectViewers'
 

--- a/packages/lib-classifier/src/store/Subject/index.js
+++ b/packages/lib-classifier/src/store/Subject/index.js
@@ -1,0 +1,1 @@
+export { default } from './Subject'

--- a/packages/lib-classifier/src/store/SubjectGroup/SubjectGroup.js
+++ b/packages/lib-classifier/src/store/SubjectGroup/SubjectGroup.js
@@ -3,6 +3,10 @@ import Resource from '../Resource'
 import subjectViewers from '../../helpers/subjectViewers'
 import SingleImageSubject from '../SingleImageSubject'
 
+function validateSubjects (subjects) {
+  return subjects.length > 1
+}
+
 const SubjectGroup = types
   .model('SubjectGroup', {
     already_seen: types.optional(types.boolean, false),
@@ -13,7 +17,7 @@ const SubjectGroup = types
     selected_at: types.maybe(types.string),
     selection_state: types.maybe(types.string),
     shouldDiscuss: types.maybe(types.frozen()),
-    subjects: types.array(SingleImageSubject),
+    subjects: types.refinement(types.array(SingleImageSubject), validateSubjects),
     user_has_finished_workflow: types.optional(types.boolean, false),
   })
 

--- a/packages/lib-classifier/src/store/SubjectGroup/SubjectGroup.js
+++ b/packages/lib-classifier/src/store/SubjectGroup/SubjectGroup.js
@@ -1,0 +1,12 @@
+import { types } from 'mobx-state-tree'
+import Resource from '../Resource'
+import SingleImageSubject from '../SingleImageSubject'
+
+const SubjectGroup = types
+  .model('SubjectGroup', {
+    subjects: types.array(SingleImageSubject)
+  })
+
+  
+
+export default types.compose('SubjectGroup', Resource, SubjectGroup)

--- a/packages/lib-classifier/src/store/SubjectGroup/SubjectGroup.js
+++ b/packages/lib-classifier/src/store/SubjectGroup/SubjectGroup.js
@@ -21,6 +21,30 @@ const SubjectGroup = types
     user_has_finished_workflow: types.optional(types.boolean, false),
   })
 
+  .views(self => ({
+    get locations () {
+      return self.subjects.map(subject => subject.locations[0])
+    },
+
+    get talkURL () {
+      const project = tryReference(() => getRoot(self).projects?.active)
+      if (project) {
+        const { origin } = window.location
+        return `${origin}/projects/${project.slug}/talk/subjects/${self.id}`
+      }
+
+      return ''
+    },
+
+    get viewer () {
+      return subjectViewers.subjectGroup
+    },
+
+    get workflow () {
+      return tryReference(() => getRoot(self).workflows?.active)
+    }
+  }))
+
   .actions(self => {
 
     function addToCollection () {
@@ -47,26 +71,6 @@ const SubjectGroup = types
       toggleFavorite
     }
   })
-
-  .views(self => ({
-    get talkURL () {
-      const project = tryReference(() => getRoot(self).projects?.active)
-      if (project) {
-        const { origin } = window.location
-        return `${origin}/projects/${project.slug}/talk/subjects/${self.id}`
-      }
-
-      return ''
-    },
-
-    get viewer () {
-      return subjectViewers.subjectGroup
-    },
-
-    get workflow () {
-      return tryReference(() => getRoot(self).workflows?.active)
-    }
-  }))
 
   
 

--- a/packages/lib-classifier/src/store/SubjectGroup/SubjectGroup.js
+++ b/packages/lib-classifier/src/store/SubjectGroup/SubjectGroup.js
@@ -1,11 +1,68 @@
-import { types } from 'mobx-state-tree'
+import { getRoot, tryReference, types } from 'mobx-state-tree'
 import Resource from '../Resource'
+import subjectViewers from '../../helpers/subjectViewers'
 import SingleImageSubject from '../SingleImageSubject'
 
 const SubjectGroup = types
   .model('SubjectGroup', {
-    subjects: types.array(SingleImageSubject)
+    already_seen: types.optional(types.boolean, false),
+    favorite: types.optional(types.boolean, false),
+    finished_workflow: types.optional(types.boolean, false),
+    metadata: types.frozen({}),
+    retired: types.optional(types.boolean, false),
+    selected_at: types.maybe(types.string),
+    selection_state: types.maybe(types.string),
+    shouldDiscuss: types.maybe(types.frozen()),
+    subjects: types.array(SingleImageSubject),
+    user_has_finished_workflow: types.optional(types.boolean, false),
   })
+
+  .actions(self => {
+
+    function addToCollection () {
+      const rootStore = getRoot(self)
+      rootStore.onAddToCollection(self.id)
+    }
+
+    function openInTalk (newTab = false) {
+      self.shouldDiscuss = {
+        newTab,
+        url: self.talkURL
+      }
+    }
+
+    function toggleFavorite () {
+      const rootStore = getRoot(self)
+      self.favorite = !self.favorite
+      rootStore.onToggleFavourite(self.id, self.favorite)
+    }
+
+    return {
+      addToCollection,
+      openInTalk,
+      toggleFavorite
+    }
+  })
+
+  .views(self => ({
+    get talkURL () {
+      const project = tryReference(() => getRoot(self).projects?.active)
+      if (project) {
+        const { origin } = window.location
+        return `${origin}/projects/${project.slug}/talk/subjects/${self.id}`
+      }
+
+      return ''
+    },
+
+    get viewer () {
+      return subjectViewers.subjectGroup
+    },
+
+    get workflow () {
+      return tryReference(() => getRoot(self).workflows?.active)
+    }
+  }))
 
   
 

--- a/packages/lib-classifier/src/store/SubjectGroup/SubjectGroup.spec.js
+++ b/packages/lib-classifier/src/store/SubjectGroup/SubjectGroup.spec.js
@@ -19,4 +19,10 @@ describe('Model > SubjectGroup', function () {
   it('should contain subjects', function () {
     expect(subjectGroup.subjects).to.have.lengthOf(25)
   })
+
+  it('should have subject locations', function () {
+    subjectGroup.locations.forEach(location => {
+      expect(location).to.deep.equal({ 'image/png': 'https://foo.bar/example.png' })
+    })
+  })
 })

--- a/packages/lib-classifier/src/store/SubjectGroup/SubjectGroup.spec.js
+++ b/packages/lib-classifier/src/store/SubjectGroup/SubjectGroup.spec.js
@@ -1,0 +1,22 @@
+import { Factory } from 'rosie'
+import SubjectGroup from './SubjectGroup'
+
+describe('Model > SubjectGroup', function () {
+  const subjects = Factory.buildList('subject', 25, { locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+  let subjectGroup
+
+  before(function () {
+    subjectGroup = SubjectGroup.create({
+      id: 'testGroup',
+      subjects
+    })
+  })
+
+  it('should exist', function () {
+    expect(subjectGroup).to.be.ok()
+  })
+
+  it('should contain subjects', function () {
+    expect(subjectGroup.subjects).to.have.lengthOf(25)
+  })
+})

--- a/packages/lib-classifier/src/store/SubjectGroup/index.js
+++ b/packages/lib-classifier/src/store/SubjectGroup/index.js
@@ -1,0 +1,1 @@
+export { default } from './SubjectGroup'

--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -10,8 +10,19 @@ import SubjectGroup from './SubjectGroup'
 
 const MINIMUM_QUEUE_SIZE = 3
 
-const subjectModels = [ SingleImageSubject, Subject, SubjectGroup ]
-const subjectReferences = subjectModels.map(model => types.safeReference(model))
+/*
+  see https://github.com/mobxjs/mobx-state-tree/issues/514
+  for advice about using references with types.union.
+*/
+const SingleSubject = types.union(SingleImageSubject, Subject)
+function subjectDispatcher (snapshot) {
+  if (snapshot.subjects) {
+    return SubjectGroup
+  }
+  return SingleSubject
+}
+const subjectModels = [ { dispatcher: subjectDispatcher }, SingleSubject, SubjectGroup ]
+const SubjectType = types.union(...subjectModels)
 
 
 function openTalkPage (talkURL, newTab = false) {
@@ -28,8 +39,8 @@ function openTalkPage (talkURL, newTab = false) {
 
 const SubjectStore = types
   .model('SubjectStore', {
-    active: types.union(...subjectReferences),
-    resources: types.map(types.union(...subjectModels)),
+    active: types.safeReference(SubjectType),
+    resources: types.map(SubjectType),
     type: types.optional(types.string, 'subjects')
   })
 

--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -5,8 +5,14 @@ import { getBearerToken } from './utils'
 import { filterByLabel, filters } from '../components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal'
 import ResourceStore from './ResourceStore'
 import Subject from './Subject'
+import SingleImageSubject from './SingleImageSubject'
+import SubjectGroup from './SubjectGroup'
 
 const MINIMUM_QUEUE_SIZE = 3
+
+const subjectModels = [ SingleImageSubject, Subject, SubjectGroup ]
+const subjectReferences = subjectModels.map(model => types.safeReference(model))
+
 
 function openTalkPage (talkURL, newTab = false) {
   if (newTab) {
@@ -22,8 +28,8 @@ function openTalkPage (talkURL, newTab = false) {
 
 const SubjectStore = types
   .model('SubjectStore', {
-    active: types.safeReference(Subject),
-    resources: types.map(Subject),
+    active: types.union(...subjectReferences),
+    resources: types.map(types.union(...subjectModels)),
     type: types.optional(types.string, 'subjects')
   })
 

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -1,5 +1,7 @@
 import sinon from 'sinon'
 import RootStore from './RootStore'
+import SubjectGroup from './SubjectGroup'
+import SingleImageSubject from './SingleImageSubject'
 import { openTalkPage, MINIMUM_QUEUE_SIZE } from './SubjectStore'
 import { ProjectFactory, SubjectFactory, WorkflowFactory } from '@test/factories'
 import { Factory } from 'rosie'
@@ -118,6 +120,38 @@ describe('Model > SubjectStore', function () {
         expect(subjects.resources.size).to.equal(0)
         expect(subjects.active).to.be.undefined()
       })
+    })
+  })
+
+  describe('single image subjects', function () {
+    let subjects
+    let imageSubjects = Factory.buildList('subject', 10, { locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+
+    before(function () {
+      subjects = mockSubjectStore([ ...imageSubjects ])
+    })
+
+    it('should be valid subjects', function () {
+      const expectedSubject = SingleImageSubject.create(imageSubjects[0])
+      expect(subjects.active).to.deep.equal(expectedSubject)
+    })
+  })
+
+  describe('subject groups', function () {
+    let subjects
+    let imageSubjects = Factory.buildList('subject', 25, { locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+
+    before(function () {
+      const subjectGroup = SubjectGroup.create({
+        id: '12345',
+        subjects: imageSubjects
+      })
+      subjects = mockSubjectStore([ subjectGroup, ...longListSubjects ])
+    })
+
+    it('should be valid subjects', function () {
+      expect(subjects.active.id).to.equal('12345')
+      expect(subjects.active.subjects).to.deep.equal(imageSubjects)
     })
   })
 

--- a/packages/lib-classifier/src/store/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore.spec.js
@@ -128,7 +128,7 @@ describe('Model > SubjectStore', function () {
     let imageSubjects = Factory.buildList('subject', 10, { locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
 
     before(function () {
-      subjects = mockSubjectStore([ ...imageSubjects ])
+      subjects = mockSubjectStore(imageSubjects)
     })
 
     it('should be valid subjects', function () {
@@ -142,16 +142,21 @@ describe('Model > SubjectStore', function () {
     let imageSubjects = Factory.buildList('subject', 25, { locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
 
     before(function () {
-      const subjectGroup = SubjectGroup.create({
-        id: '12345',
-        subjects: imageSubjects
-      })
-      subjects = mockSubjectStore([ subjectGroup, ...longListSubjects ])
+      const subjectGroups = []
+      for (let i = 0; i < 6; i++) {
+        const subjectGroup = {
+          id: `${i}`,
+          subjects: imageSubjects
+        }
+        subjectGroups.push(subjectGroup)
+      }
+      subjects = mockSubjectStore(subjectGroups)
     })
 
     it('should be valid subjects', function () {
-      expect(subjects.active.id).to.equal('12345')
-      expect(subjects.active.subjects).to.deep.equal(imageSubjects)
+      expect(subjects.active).to.exist()
+      expect(subjects.active.id).to.equal('0')
+      expect(subjects.active.subjects).to.have.lengthOf(25)
     })
   })
 


### PR DESCRIPTION
Adds a basic model for grouped subjects, which are composed of single image subjects. A `SingleImageSubject` is a refinement of `Subject` which has exactly one image. Not 0. Not 2. Three is right out.

Package:
lib-classifier

Towards #1484.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
