### PR TITLE
Project hero stories

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.stories.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.stories.js
@@ -20,7 +20,13 @@ const mockStore = {
       src: 'https://panoptes-uploads.zooniverse.org/production/project_background/260e68fd-d3ec-4a94-bb32-43ff91d5579a.jpeg'
     },
     description: 'Learn about and help document the wonders of nesting Western Bluebirds.',
-    display_name: 'Nest Quest Go: Western Bluebirds'
+    display_name: 'Nest Quest Go: Western Bluebirds',
+    slug: 'brbcornell/nest-quest-go-western-bluebirds',
+    workflow_description: `Choose your own adventure! There are many ways to engage with this project:  
+      1) "Nest Site": Smartphone-friendly, helps us understand where Western Bluebirds build their nests.  
+      2) "Location": Smartphone-friendly, series of questions on the geographic location of the nest.  
+      3) "Nest Attempt: Smartphone-friendly, for data-entry lovers to record nest attempt data on cards.  
+      4) "Comments": For transcription lovers, we ask you to transcribe all the written comments on the cards.`
   }
 }
 

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/IntroductionContainer.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/IntroductionContainer.js
@@ -17,7 +17,7 @@ function storeMapper (stores) {
 class IntroductionContainer extends Component {
   getLinkProps () {
     const { router } = this.props
-    const { owner, project } = router.query
+    const { owner, project } = router?.query || {}
     return {
       href: addQueryParams(`/projects/${owner}/${project}/about`, router)
     }

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.stories.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.stories.js
@@ -5,6 +5,7 @@ import zooTheme from '@zooniverse/grommet-theme'
 import counterpart from 'counterpart'
 import { Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
+import * as nextRouter from 'next/router'
 import PropTypes from 'prop-types'
 import React from 'react'
 import sinon from 'sinon'
@@ -39,7 +40,7 @@ const mockedRouter = {
     project: 'snapshot-serengeti'
   }
 }
-
+sinon.stub(nextRouter, 'useRouter').callsFake(() => mockedRouter)
 
 const WORKFLOWS = {
   loading: asyncStates.success,

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.stories.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/WorkflowSelector.stories.js
@@ -4,13 +4,28 @@ import asyncStates from '@zooniverse/async-states'
 import zooTheme from '@zooniverse/grommet-theme'
 import counterpart from 'counterpart'
 import { Grommet } from 'grommet'
-import Router from 'next/router'
+import { Provider } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
 import sinon from 'sinon'
 
 import WorkflowSelector from './'
 
+const store = {
+  project: {
+    background: {
+      src: 'https://panoptes-uploads.zooniverse.org/production/project_background/260e68fd-d3ec-4a94-bb32-43ff91d5579a.jpeg'
+    },
+    description: 'Learn about and help document the wonders of nesting Western Bluebirds.',
+    display_name: 'Nest Quest Go: Western Bluebirds',
+    slug: 'brbcornell/nest-quest-go-western-bluebirds',
+    workflow_description: `Choose your own adventure! There are many ways to engage with this project:  
+      1) "Nest Site": Smartphone-friendly, helps us understand where Western Bluebirds build their nests.  
+      2) "Location": Smartphone-friendly, series of questions on the geographic location of the nest.  
+      3) "Nest Attempt: Smartphone-friendly, for data-entry lovers to record nest attempt data on cards.  
+      4) "Comments": For transcription lovers, we ask you to transcribe all the written comments on the cards.`
+  }
+}
 /*
 Mock NextJS router adapted from
 https://github.com/zeit/next.js/issues/1827#issuecomment-470155709
@@ -25,29 +40,6 @@ const mockedRouter = {
   }
 }
 
-const withMockRouterContext = mockRouter => {
-  class MockRouterContext extends React.Component {
-    getChildContext () {
-      return {
-        router: { ...mockedRouter, ...mockRouter }
-      }
-    }
-    render () {
-      return this.props.children
-    }
-  }
-
-  // @ts-ignore
-  MockRouterContext.childContextTypes = {
-    router: PropTypes.object
-  }
-
-  return MockRouterContext
-}
-
-Router.router = mockedRouter
-
-const StorybookRouterFix = withMockRouterContext(mockedRouter)
 
 const WORKFLOWS = {
   loading: asyncStates.success,
@@ -84,24 +76,28 @@ storiesOf('Project App / Screens / Project Home / Workflow Selector', module)
   .addDecorator(withKnobs)
   .add('plain', () => (
     <Grommet theme={{ ...zooTheme, dark: boolean('Dark theme', false) }}>
-      <StorybookRouterFix>
+      <Provider store={store}>
         <WorkflowSelector
           workflows={WORKFLOWS}
         />
-      </StorybookRouterFix>
+      </Provider>
     </Grommet>
   ))
   .add('loading', () => (
     <Grommet theme={{ ...zooTheme, dark: boolean('Dark theme', false) }}>
-      <WorkflowSelector
-        workflows={WORKFLOWS_LOADING}
-      />
+      <Provider store={store}>
+        <WorkflowSelector
+          workflows={WORKFLOWS_LOADING}
+        />
+      </Provider>
     </Grommet>
   ))
   .add('error', () => (
     <Grommet theme={{ ...zooTheme, dark: boolean('Dark theme', false) }}>
-      <WorkflowSelector
-        workflows={WORKFLOWS_ERROR}
-      />
+      <Provider store={store}>
+        <WorkflowSelector
+          workflows={WORKFLOWS_ERROR}
+        />
+      </Provider>
     </Grommet>
   ))

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.js
@@ -3,7 +3,7 @@ import counterpart from 'counterpart'
 import { Button } from 'grommet'
 import { Next } from 'grommet-icons'
 import Link from 'next/link'
-import { withRouter } from 'next/router'
+import { useRouter } from 'next/router'
 import { bool, number, shape, string } from 'prop-types'
 import React from 'react'
 
@@ -15,8 +15,9 @@ import en from './locales/en'
 counterpart.registerTranslations('en', en)
 
 function WorkflowSelectButton (props) {
-  const { router, workflow, ...rest } = props
-  const { owner, project } = router.query
+  const { workflow, ...rest } = props
+  const router = useRouter()
+  const { owner, project } = router?.query || {}
 
   const url = (workflow.default)
     ? `/projects/${owner}/${project}/classify`
@@ -49,13 +50,6 @@ function WorkflowSelectButton (props) {
 }
 
 WorkflowSelectButton.propTypes = {
-  router: shape({
-    asPath: string.isRequired,
-    query: {
-      owner: string.isRequired,
-      project: string.isRequired
-    }
-  }).isRequired,
   workflow: shape({
     completeness: number,
     default: bool,
@@ -64,7 +58,7 @@ WorkflowSelectButton.propTypes = {
   }).isRequired
 }
 
-const DecoratedWorkflowSelectButton = withRouter(withThemeContext(WorkflowSelectButton, theme))
+const DecoratedWorkflowSelectButton = withThemeContext(WorkflowSelectButton, theme)
 
 export {
   DecoratedWorkflowSelectButton as default,

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.spec.js
@@ -1,5 +1,7 @@
 import { render, shallow } from 'enzyme'
+import * as nextRouter from 'next/router'
 import React from 'react'
+import sinon from 'sinon'
 
 import { WorkflowSelectButton } from './WorkflowSelectButton'
 
@@ -9,7 +11,7 @@ const WORKFLOW = {
   id: '1'
 }
 
-const ROUTER = {
+const router = {
   asPath: '/projects/foo/bar',
   query: {
     owner: 'foo',
@@ -18,27 +20,37 @@ const ROUTER = {
 }
 
 describe('Component > WorkflowSelectButton', function () {
+  before(function () {
+    sinon.stub(nextRouter, 'useRouter').callsFake(() => router)
+  })
+
+  after(function () {
+    nextRouter.useRouter.restore()
+  })
+
   it('should render without crashing', function () {
-    const wrapper = shallow(<WorkflowSelectButton router={ROUTER} workflow={WORKFLOW} />)
+    const wrapper = shallow(<WorkflowSelectButton workflow={WORKFLOW} />)
     expect(wrapper).to.be.ok()
   })
 
   describe('when used with a default workflow', function () {
     it('should be a link pointing to `/classify`', function () {
-      const wrapper = shallow(<WorkflowSelectButton router={ROUTER} workflow={{
-        ...WORKFLOW,
-        default: true
-      }} />)
+      const wrapper = shallow(
+          <WorkflowSelectButton workflow={{
+          ...WORKFLOW,
+          default: true
+        }} />
+      )
       expect(wrapper.name()).to.equal('Link')
-      expect(wrapper.prop('as')).to.equal(`${ROUTER.asPath}/classify`)
+      expect(wrapper.prop('as')).to.equal(`${router.asPath}/classify`)
     })
   })
 
   describe('when used with a non-default workflow', function () {
     it('should be a link pointing to `/classify/workflow/:workflow_id`', function () {
-      const wrapper = shallow(<WorkflowSelectButton router={ROUTER} workflow={WORKFLOW} />)
+      const wrapper = shallow(<WorkflowSelectButton workflow={WORKFLOW} />)
       expect(wrapper.name()).to.equal('Link')
-      expect(wrapper.prop('as')).to.equal(`${ROUTER.asPath}/classify/workflow/${WORKFLOW.id}`)
+      expect(wrapper.prop('as')).to.equal(`${router.asPath}/classify/workflow/${WORKFLOW.id}`)
     })
   })
 })


### PR DESCRIPTION
Fixes errors that are preventing the project hero and workflow selector stories from working in the storybook.
 - removes the broken mock router context from the stories.
 - adds a mock store and provider.
 - adds existence checks before using the Next router.
 - defaults project and owner in the URL to `undefined`.

Package:
app-project

Closes #1446.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
