### PR TITLE
Classifier: Validate locations before creating subjects

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.js
@@ -39,7 +39,7 @@ class SubjectViewer extends React.Component {
 
   [asyncStates.success] () {
     const { onError, onSubjectReady, subject, subjectReadyState } = this.props
-    const Viewer = getViewer(subject.viewer)
+    const Viewer = getViewer(subject?.viewer)
 
     if (Viewer) {
       return (

--- a/packages/lib-classifier/src/helpers/createLocationCounts/createLocationCounts.spec.js
+++ b/packages/lib-classifier/src/helpers/createLocationCounts/createLocationCounts.spec.js
@@ -59,9 +59,10 @@ describe('Helpers > createLocationCounts', function () {
   })
 
   describe('when the mime types are invalid', function () {
-    it('should return an empty object', function () {
+    it('should return 0 locations', function () {
       const return5 = createLocationCounts(mockSubject(mockLocations5))
-      expect(return5).to.be.empty()
+      expect(return5.images).to.equal(0)
+      expect(return5.json).to.equal(0)
     })
   })
 })

--- a/packages/lib-classifier/src/helpers/index.js
+++ b/packages/lib-classifier/src/helpers/index.js
@@ -1,0 +1,6 @@
+export { default as createLocationCounts } from './createLocationCounts'
+export { default as featureDetection } from './featureDetection'
+export { default as layouts } from './layouts'
+export { default as subjectViewers } from './subjectViewers'
+export { default as validateMimeType } from './validateMimeType'
+export { default as validateSubjectLocations } from './validateSubjectLocations'

--- a/packages/lib-classifier/src/helpers/validateMimeType/validateMimeType.js
+++ b/packages/lib-classifier/src/helpers/validateMimeType/validateMimeType.js
@@ -10,7 +10,7 @@ export default function validateMimeType (mimeType) {
   const [type, format] = mimeType.split('/')
   const isMimeTypeValid = mimeTypesRegexes[type].test(format)
   if (!isMimeTypeValid) {
-    throw new Error(`${mimeType} is not valid for use in the classifier.`)
+     console.error(`${mimeType} is not valid for use in the classifier.`)
   }
 
   return isMimeTypeValid

--- a/packages/lib-classifier/src/helpers/validateMimeType/validateMimeType.spec.js
+++ b/packages/lib-classifier/src/helpers/validateMimeType/validateMimeType.spec.js
@@ -42,23 +42,21 @@ describe('Helpers > validateMimeType', function () {
   })
 
   describe('invalid mime types', function () {
-    it('should return an error', function () {
+    it('should return false', function () {
       invalidMimeTypes.forEach((mimeType) => {
-        expect(function () { 
-          validateMimeType(mimeType)
-        }).to.throw(Error, `${mimeType} is not valid for use in the classifier.`)
+        expect(validateMimeType(mimeType)).to.be.false()
       })
     })
 
-    it('should return errors only for the invalid types', function () {
+    it('should return false only for the invalid types', function () {
       let successCount = 0
       let errorCount = 0
       const allMimeTypes = validMimeTypes.concat(invalidMimeTypes)
       allMimeTypes.forEach((mimeType) => {
-        try { 
-          const result = validateMimeType(mimeType)
-          if (result) successCount += 1
-        } catch (error) {
+        const result = validateMimeType(mimeType)
+        if (result) {
+          successCount += 1
+        } else {
           errorCount += 1
         }
       })

--- a/packages/lib-classifier/src/helpers/validateMimeType/validateMimeType.spec.js
+++ b/packages/lib-classifier/src/helpers/validateMimeType/validateMimeType.spec.js
@@ -49,19 +49,19 @@ describe('Helpers > validateMimeType', function () {
     })
 
     it('should return false only for the invalid types', function () {
-      let successCount = 0
-      let errorCount = 0
+      let validCount = 0
+      let invalidCount = 0
       const allMimeTypes = validMimeTypes.concat(invalidMimeTypes)
       allMimeTypes.forEach((mimeType) => {
         const result = validateMimeType(mimeType)
         if (result) {
-          successCount += 1
+          validCount += 1
         } else {
-          errorCount += 1
+          invalidCount += 1
         }
       })
-      expect(successCount).to.equal(validMimeTypes.length)
-      expect(errorCount).to.equal(invalidMimeTypes.length)
+      expect(validCount).to.equal(validMimeTypes.length)
+      expect(invalidCount).to.equal(invalidMimeTypes.length)
     })
   })
 })

--- a/packages/lib-classifier/src/helpers/validateSubjectLocations/index.js
+++ b/packages/lib-classifier/src/helpers/validateSubjectLocations/index.js
@@ -1,0 +1,1 @@
+export { default } from './validateSubjectLocations'

--- a/packages/lib-classifier/src/helpers/validateSubjectLocations/validateSubjectLocations.js
+++ b/packages/lib-classifier/src/helpers/validateSubjectLocations/validateSubjectLocations.js
@@ -24,14 +24,10 @@ export default function validateSubjectLocations (locations) {
         return url.endsWith(extension)
       })
     } else {
-      console.error(`${location} is invalid`)
+      console.error(`${mimeType}, ${url} is invalid`)
       return false
     }
   })
-
-  if (!areLocationsValid) {
-    throw new Error(`One of the subject locations is invalid: ${locations}.`)
-  }
 
   return areLocationsValid
 }

--- a/packages/lib-classifier/src/helpers/validateSubjectLocations/validateSubjectLocations.spec.js
+++ b/packages/lib-classifier/src/helpers/validateSubjectLocations/validateSubjectLocations.spec.js
@@ -45,23 +45,17 @@ describe('Helpers > validateSubjectLocations', function () {
   })
 
   describe('invalid subject locations', function () {
-    it('should return an error', function () {
-      expect(function () {
-        validateSubjectLocations(invalidSubjectLocations)
-      }).to.throw(Error)
+    it('should return false', function () {
+      expect(validateSubjectLocations(invalidSubjectLocations)).to.be.false()
     })
 
-    it('should return an error if any one of the locations is invalid', function () {
+    it('should return false if any one of the locations is invalid', function () {
       const allLocations = validSubjectLocations.concat(invalidSubjectLocations)
-      expect(function () {
-        validateSubjectLocations(allLocations)
-      }).to.throw(Error)
+      expect(validateSubjectLocations(allLocations)).to.be.false()
     })
 
-    it('should return an error if the location mismatched mimetype and file extension', function () {
-      expect(function () {
-        validateSubjectLocations(misMatchedLocation)
-      }).to.throw(Error)
+    it('should return false if the location mismatched mimetype and file extension', function () {
+      expect(validateSubjectLocations(misMatchedLocation)).to.be.false()
     })
   })
 })

--- a/packages/lib-classifier/src/store/Subject/Subject.js
+++ b/packages/lib-classifier/src/store/Subject/Subject.js
@@ -3,6 +3,7 @@ import { addDisposer, destroy, getRoot, tryReference, types } from 'mobx-state-t
 import Resource from '../Resource'
 import createLocationCounts from '@helpers/createLocationCounts'
 import subjectViewers from '@helpers/subjectViewers'
+import validateSubjectLocations from '@helpers/validateSubjectLocations'
 import TranscriptionReductions from '../TranscriptionReductions'
 
 const Subject = types
@@ -10,7 +11,7 @@ const Subject = types
     already_seen: types.optional(types.boolean, false),
     favorite: types.optional(types.boolean, false),
     finished_workflow: types.optional(types.boolean, false),
-    locations: types.frozen([]),
+    locations: types.refinement('SubjectLocations', types.frozen([]), validateSubjectLocations),
     metadata: types.frozen({}),
     retired: types.optional(types.boolean, false),
     selected_at: types.maybe(types.string),

--- a/packages/lib-classifier/src/store/Subject/Subject.js
+++ b/packages/lib-classifier/src/store/Subject/Subject.js
@@ -1,9 +1,7 @@
 import { autorun } from 'mobx'
 import { addDisposer, destroy, getRoot, tryReference, types } from 'mobx-state-tree'
 import Resource from '../Resource'
-import createLocationCounts from '@helpers/createLocationCounts'
-import subjectViewers from '@helpers/subjectViewers'
-import validateSubjectLocations from '@helpers/validateSubjectLocations'
+import { createLocationCounts, subjectViewers, validateSubjectLocations } from '@helpers'
 import TranscriptionReductions from '../TranscriptionReductions'
 
 const Subject = types

--- a/packages/lib-classifier/src/store/Subject/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject/Subject.spec.js
@@ -188,20 +188,19 @@ describe('Model > Subject', function () {
       })
     })
 
-    describe('when the subject location is invalid', function () {
+    describe('when any subject locations are invalid', function () {
       describe('single image', function () {
-        it('should return a null viewer', function () {
+        it('should throw an error', function () {
           const singleImageSubject = SubjectFactory.build({ locations: [{ 'image/tiff': 'https://foo.bar/example.tiff' }] })
-          const subjectStore = Subject.create(singleImageSubject)
-          subjectStore.workflows = WorkflowStore.create({})
-          subjectStore.workflows.setResource(workflow)
-          subjectStore.workflows.setActive(workflow.id)
-          expect(subjectStore.viewer).to.be.null()
+          function subjectStore () {
+            return Subject.create(singleImageSubject)
+          }
+          expect(subjectStore).to.throw(Error)
         })
       })
 
       describe('multi-frame', function () {
-        it('should return a null viewer', function () {
+        it('should throw an error', function () {
           const multiMediaSubject = SubjectFactory.build({
             locations: [
               { 'image/tiff': 'https://foo.bar/example.tiff' },
@@ -209,11 +208,10 @@ describe('Model > Subject', function () {
               { 'image/png': 'https://foo.bar/example.png' }
             ]
           })
-          const subjectStore = Subject.create(multiMediaSubject)
-          subjectStore.workflows = WorkflowStore.create({})
-          subjectStore.workflows.setResource(workflow)
-          subjectStore.workflows.setActive(workflow.id)
-          expect(subjectStore.viewer).to.be.null()
+          function subjectStore () {
+            return Subject.create(multiMediaSubject)
+          }
+          expect(subjectStore).to.throw(Error)
         })
       })
     })

--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -130,12 +130,17 @@ const SubjectStore = types
 
     function append (newSubjects) {
       newSubjects.forEach(subject => {
-        const existsInQueue = self.resources.get(subject.id)
-        if (!existsInQueue) self.resources.put(subject)
+        try {
+          const existsInQueue = self.resources.get(subject.id)
+          if (!existsInQueue) self.resources.put(subject)
+        } catch (error) {
+          console.error(`Subject ${subject.id} is not a valid subject.`)
+          console.error(error)
+        }
       })
 
       const validSubjectReference = isValidReference(() => self.active)
-      if (!validSubjectReference) {
+      if (!validSubjectReference && self.resources.size > 0) {
         self.advance()
       }
     }


### PR DESCRIPTION
- Add `validateSubjectLocations` to the Subject model as a refinement for locations.
- Change the MIME type and file extension validators to return false, rather than throwing, for invalid MIME types and file extensions.
- Expect `Subject.create(snapshot)` to throw an error if the provided snapshot  contains invalid file locations.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
