### PR TITLE
Classifier: fix Tasks storybook errors

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -13,11 +13,6 @@ import SubjectStore from '@store/SubjectStore'
 import WorkflowStore from '@store/WorkflowStore'
 import WorkflowStepStore from '@store/WorkflowStepStore'
 import Step from '@store/Step'
-import taskRegistry from '@plugins/tasks'
-
-const SingleChoiceTask = taskRegistry.get('single').TaskModel
-const MultipleChoiceTask = taskRegistry.get('multiple').TaskModel
-const TextTask = taskRegistry.get('text').TaskModel
 
 function createStore() {
   const classifications = ClassificationStore.create()

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -202,10 +202,10 @@ storiesOf('Tasks', module)
   })
   .add('drawing', function () {
     const tasks = {
-      T0: {
+      T2: {
         help: 'Draw on the image.',
         instruction: 'Draw something',
-        taskKey: 'T0',
+        taskKey: 'T2',
         tools: [
           {
             color: zooTheme.global.colors['drawing-red'],
@@ -236,7 +236,7 @@ storiesOf('Tasks', module)
     }
     const step = {
       stepKey: 'S1',
-      taskKeys: ['T0']
+      taskKeys: ['T2']
     }
     addStepToStore(step, tasks)
     const dark = boolean('Dark theme', false)
@@ -258,10 +258,10 @@ storiesOf('Tasks', module)
   })
   .add('transcription', function () {
     const tasks = {
-      T0: {
+      T3: {
         help: 'Underline the line to transcribe with two clicks, then enter in the text transcription.',
         instruction: 'Underline and transcribe',
-        taskKey: 'T0',
+        taskKey: 'T3',
         tools: [
           {
             help: '',
@@ -274,7 +274,7 @@ storiesOf('Tasks', module)
     }
     const step = {
       stepKey: 'S1',
-      taskKeys: ['T0']
+      taskKeys: ['T3']
     }
     addStepToStore(step, tasks)
     const dark = boolean('Dark theme', false)

--- a/packages/lib-classifier/src/store/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.js
@@ -126,9 +126,8 @@ const WorkflowStepStore = types
     }
 
     function setSteps (workflow) {
-      workflow.steps.forEach((entry) => {
-        const newStep = { stepKey: entry[0], taskKeys: entry[1].taskKeys, next: entry[1].next }
-        self.steps.put(newStep)
+      workflow.steps.forEach(([ stepKey, step ]) => {
+        self.steps.put(Object.assign({}, step, { stepKey }))
       })
     }
 

--- a/packages/lib-classifier/src/store/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.js
@@ -1,5 +1,5 @@
 import { autorun } from 'mobx'
-import { addDisposer, getRoot, isValidReference, types } from 'mobx-state-tree'
+import { addDisposer, getRoot, isValidReference, tryReference, types } from 'mobx-state-tree'
 
 import Step from './Step'
 
@@ -41,19 +41,15 @@ const WorkflowStepStore = types
 
     get shouldWeShowDoneAndTalkButton () {
       const isThereANextStep = self.isThereANextStep()
-      const validWorkflowReference = isValidReference(() => getRoot(self).workflows.active)
-      const validClassificationReference = isValidReference(() => getRoot(self).classifications.active)
-      if (validWorkflowReference && validClassificationReference) {
-        const workflow = getRoot(self).workflows.active
-        const classification = getRoot(self).classifications.active
+      const workflow = tryReference(() => getRoot(self).workflows?.active)
+      const classification = tryReference(() => getRoot(self).classifications?.active)
 
-        if (workflow && classification) {
-          const disableTalk = classification.metadata.subject_flagged
-          return !isThereANextStep &&
-          workflow.configuration.hide_classification_summaries && // TODO: we actually want to reverse this logic
-          !disableTalk // &&
-          // !completed TODO: implement classification completed validations per task?
-        }
+      if (workflow && classification) {
+        const disableTalk = classification.metadata.subject_flagged
+        return !isThereANextStep &&
+        workflow.configuration.hide_classification_summaries && // TODO: we actually want to reverse this logic
+        !disableTalk // &&
+        // !completed TODO: implement classification completed validations per task?
       }
 
       return false
@@ -66,9 +62,8 @@ const WorkflowStepStore = types
 
     function createWorkflowObserver () {
       const workflowDisposer = autorun(() => {
-        const validWorkflowReference = isValidReference(() => getRoot(self).workflows.active)
-        if (validWorkflowReference) {
-          const workflow = getRoot(self).workflows.active
+        const workflow = tryReference(() => getRoot(self).workflows?.active)
+        if (workflow) {
           self.reset()
           if (workflow.steps &&
             workflow.steps.length > 0 &&
@@ -132,7 +127,7 @@ const WorkflowStepStore = types
 
     function setSteps (workflow) {
       workflow.steps.forEach((entry) => {
-        const newStep = Step.create({ stepKey: entry[0], taskKeys: entry[1].taskKeys, next: entry[1].next })
+        const newStep = { stepKey: entry[0], taskKeys: entry[1].taskKeys, next: entry[1].next }
         self.steps.put(newStep)
       })
     }

--- a/packages/lib-classifier/src/store/WorkflowStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStore.js
@@ -19,7 +19,7 @@ const WorkflowStore = types
 
     function createProjectObserver () {
       const projectDisposer = autorun(() => {
-        const validProjectReference = isValidReference(() => getRoot(self).projects.active)
+        const validProjectReference = isValidReference(() => getRoot(self).projects?.active)
         if (validProjectReference) {
           self.reset()
           const queryParamId = getQueryParamId()
@@ -31,7 +31,7 @@ const WorkflowStore = types
 
     function createUPPObserver () {
       const uppDisposer = autorun(() => {
-        const validUPPReference = isValidReference(() => getRoot(self).userProjectPreferences.active)
+        const validUPPReference = isValidReference(() => getRoot(self).userProjectPreferences?.active)
         const validWorkflowReference = isValidReference(() => self.active)
         if (validUPPReference && !validWorkflowReference) {
           self.reset()


### PR DESCRIPTION
Tasks stories created a new store each time the story function ran (eg. when a knob setting changes), which throws errors in the MobX Provider. The store is redefined here to be a single, constant variable and individual stories change it by calling actions on the WorkflowSteps model.
Some undefined reference errors in individual stores are also caught and fixed here.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
