### PR TITLE
Fix background, Grommet props for Task stories

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -4,7 +4,6 @@ import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { types } from 'mobx-state-tree'
 import React from 'react'
-import sinon from 'sinon'
 import { Box, Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
 import { Tasks } from './Tasks'
@@ -12,7 +11,6 @@ import ClassificationStore from '@store/ClassificationStore'
 import SubjectStore from '@store/SubjectStore'
 import WorkflowStore from '@store/WorkflowStore'
 import WorkflowStepStore from '@store/WorkflowStepStore'
-import Step from '@store/Step'
 
 function createStore() {
   const classifications = ClassificationStore.create()
@@ -52,14 +50,22 @@ function addStepToStore (step, tasks) {
 }
 
 function MockTask (props) {
-  const { dark, zooTheme, ...taskProps } = props
-  const background = dark
-    ? zooTheme.global.colors['dark-1']
-    : zooTheme.global.colors['light-1']
+  const { dark, ...taskProps } = props
+
   return (
-    <Grommet theme={Object.assign({}, zooTheme, { dark })}>
+    <Grommet
+      background={{
+        dark: 'dark-1',
+        light: 'light-1'
+      }}
+      theme={Object.assign({}, zooTheme, { dark })}
+      themeMode={(dark) ? 'dark' : 'light'}
+    >
       <Box
-        background={background}
+        background={{
+          dark: 'dark-3',
+          light: 'neutral-6'
+        }}
         pad='1em'
         width='380px'
       >
@@ -81,11 +87,18 @@ storiesOf('Tasks', module)
   .add('loading', function () {
     return (
       <Provider classifierStore={{}}>
-        <Grommet theme={zooTheme}>
-          <Tasks
-            loadingState={asyncStates.loading}
-          />
-        </Grommet>
+        <MockTask
+          loadingState={asyncStates.loading}
+        />
+      </Provider>
+    )
+  })
+  .add('error', function () {
+    return (
+      <Provider classifierStore={{}}>
+        <MockTask
+          loadingState={asyncStates.error}
+        />
       </Provider>
     )
   })
@@ -117,7 +130,6 @@ storiesOf('Tasks', module)
           loadingState={asyncStates.success}
           step={store.workflowSteps.active}
           subjectReadyState={subjectReadyState}
-          zooTheme={zooTheme}
         />
       </Provider>
     )
@@ -158,7 +170,6 @@ storiesOf('Tasks', module)
           loadingState={asyncStates.success}
           step={store.workflowSteps.active}
           subjectReadyState={subjectReadyState}
-          zooTheme={zooTheme}
         />
       </Provider>
     )
@@ -190,7 +201,6 @@ storiesOf('Tasks', module)
           loadingState={asyncStates.success}
           step={store.workflowSteps.active}
           subjectReadyState={subjectReadyState}
-          zooTheme={zooTheme}
         />
       </Provider>
     )
@@ -224,6 +234,11 @@ storiesOf('Tasks', module)
             help: '',
             label: 'Draw a rectangle',
             type: 'rectangle',
+          }, {
+            color: zooTheme.global.colors['drawing-yellow'],
+            help: '',
+            label: 'Draw an ellipse',
+            type: 'ellipse',
           }
         ],
         type: 'drawing'
@@ -246,7 +261,6 @@ storiesOf('Tasks', module)
           loadingState={asyncStates.success}
           step={store.workflowSteps.active}
           subjectReadyState={subjectReadyState}
-          zooTheme={zooTheme}
         />
       </Provider>
     )
@@ -284,7 +298,6 @@ storiesOf('Tasks', module)
           loadingState={asyncStates.success}
           step={store.workflowSteps.active}
           subjectReadyState={subjectReadyState}
-          zooTheme={zooTheme}
         />
       </Provider>
     )

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskHelp/TaskHelp.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskHelp/TaskHelp.js
@@ -41,12 +41,12 @@ function TaskHelp (props) {
             {tasks.map((task) => {
               if (tasks.length > 1) {
                 return (
-                  <>
-                    <Markdownz key={task.taskKey}>
+                  <React.Fragment key={task.taskKey}>
+                    <Markdownz>
                       {task.help}
                     </Markdownz>
                     <hr />
-                  </>
+                  </React.Fragment>
                 )
               }
 


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

Describe your changes:
Pulls out relevant fixes from #1576 for the task stories. I've included one tiny bug fix for the TaskHelp for the key prop as well.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
