### PR TITLE
Classifier: fix zoom button key handlers

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
@@ -40,13 +40,14 @@ class ZoomInButtonContainer extends React.Component {
   }
 
   render () {
+    const { zoomIn } = this.props
     return (
       <span
         touch-action='none'
         onPointerDown={this.onPointerDown}
         onPointerUp={this.onPointerUp}
       >
-        <ZoomInButton onClick={() => true} />
+        <ZoomInButton onClick={zoomIn} />
       </span>
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
@@ -40,13 +40,14 @@ class ZoomOutButtonContainer extends React.Component {
   }
 
   render () {
+    const { zoomOut } = this.props
     return (
       <span
         touch-action='none'
         onPointerDown={this.onPointerDown}
         onPointerUp={this.onPointerUp}
       >
-        <ZoomOutButton onClick={() => true} />
+        <ZoomOutButton onClick={zoomOut} />
       </span>
     )
   }


### PR DESCRIPTION
Add zoomIn/zoomOut as a click handler for the Grommet zoom buttons. This allows the buttons to be operated with the Enter key or the spacebar.

Package:
lib-classifier

Closes #1581.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
