### PR TITLE
Add withSourceMaps to app-content-pages

### DIFF
--- a/packages/app-content-pages/next.config.js
+++ b/packages/app-content-pages/next.config.js
@@ -4,6 +4,7 @@ const { execSync } = require('child_process')
 const Dotenv = require('dotenv-webpack')
 const path = require('path')
 const { setAliases } = require('require-control')
+const withSourceMaps = require('@zeit/next-source-maps')()
 
 // Fixes the FOUC due to SC not collecting styles from symlinked packages
 // https://github.com/styled-components/styled-components/issues/2322
@@ -11,7 +12,7 @@ setAliases({
   'styled-components': resolveHoisted('styled-components')
 })
 
-module.exports = {
+const nextConfig = {
   env: {
     COMMIT_ID: execSync('git rev-parse HEAD').toString('utf8').trim(),
     PANOPTES_ENV: process.env.PANOPTES_ENV || 'staging'
@@ -34,3 +35,6 @@ module.exports = {
 function resolveHoisted (packageName) {
   return path.resolve(path.join(__dirname, '../../node_modules', packageName))
 }
+
+module.exports = withSourceMaps(nextConfig)
+

--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@babel/plugin-proposal-decorators": "~7.8.3",
     "@sentry/browser": "^5.4.3",
+    "@zeit/next-source-maps": "0.0.4-canary.1",
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/grommet-theme": "~2.2.0",
     "@zooniverse/panoptes-js": "~0.1.0",


### PR DESCRIPTION
Enable source maps for the content pages app. See also #1467.

Package:
app-content-pages

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
