### PR TITLE
Remove shared environment from Jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
               environment {
                 ASSET_PREFIX = 'https://fe-project.zooniverse.org'
                 COMMIT_ID = "${GIT_COMMIT}"
-                SENTRY_DSN = 'https://1f0126a750244108be76957b989081e8@sentry.io/1492498'
+                SENTRY_DSN = 'https://2a50683835694829b4bc3cccc9adcc1b@sentry.io/1492691'
               }
 
               steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,10 +42,6 @@ pipeline {
         }
 
         stage('Build app Docker images') {
-          environment {
-            COMMIT_ID = "${GIT_COMMIT}"
-            SENTRY_DSN = 'https://1f0126a750244108be76957b989081e8@sentry.io/1492498'
-          }
 
           parallel {
             stage('Build @zooniverse/fe-content-pages') {
@@ -53,6 +49,8 @@ pipeline {
 
               environment {
                 ASSET_PREFIX = 'https://fe-content-pages.zooniverse.org'
+                COMMIT_ID = "${GIT_COMMIT}"
+                SENTRY_DSN = 'https://1f0126a750244108be76957b989081e8@sentry.io/1492498'
               }
 
               steps {
@@ -73,6 +71,8 @@ pipeline {
 
               environment {
                 ASSET_PREFIX = 'https://fe-project.zooniverse.org'
+                COMMIT_ID = "${GIT_COMMIT}"
+                SENTRY_DSN = 'https://1f0126a750244108be76957b989081e8@sentry.io/1492498'
               }
 
               steps {

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -36,6 +36,8 @@ spec:
           env:
             - name: ASSET_PREFIX
               value: https://fe-project.zooniverse.org
+            - name: COMMIT_ID
+              value: __IMAGE_TAG__
             - name: NEWRELIC_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
@@ -85,6 +87,8 @@ spec:
           env:
             - name: ASSET_PREFIX
               value: https://fe-content-pages.zooniverse.org
+            - name: COMMIT_ID
+              value: __IMAGE_TAG__
             - name: CONTENTFUL_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -36,6 +36,8 @@ spec:
           env:
             - name: ASSET_PREFIX
               value: https://fe-project.preview.zooniverse.org
+            - name: COMMIT_ID
+              value: __IMAGE_TAG__
             - name: NEWRELIC_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
@@ -87,6 +89,8 @@ spec:
           env:
             - name: ASSET_PREFIX
               value: https://fe-content-pages.preview.zooniverse.org
+            - name: COMMIT_ID
+              value: __IMAGE_TAG__
             - name: CONTENTFUL_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/packages/app-project/src/helpers/logger/initializeSentry.js
+++ b/packages/app-project/src/helpers/logger/initializeSentry.js
@@ -2,13 +2,14 @@ import * as Sentry from '@sentry/browser'
 
 export default function initializeSentry () {
   const dsn = process.env.SENTRY_DSN
-  const appEnv = process.env.APP_ENV
+  const environment = process.env.APP_ENV
   const release = `@zooniverse/fe-project@${process.env.COMMIT_ID}`
+  console.log('Initialising Sentry:', dsn, environment, release)
 
   if (dsn) {
     Sentry.init({
       dsn,
-      environment: appEnv,
+      environment,
       release
     })
   }


### PR DESCRIPTION
Remove the shared environment from Jenkins builds. Instead, declare the Git commit and Sentry DSN separately for each NextJS app build.

Also fix that I set the wrong DSN for the project app in #1590.

Package:
app-project
app-content-pages

Closes #1592.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
