### PR TITLE
Create Sentry releases on push to master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,8 @@ jobs:
    env:
      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-     SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+     SENTRY_PROJECT_APP: ${{ secrets.SENTRY_PROJECT_APP }}
+     SENTRY_CONTENT_APP: ${{ secrets.SENTRY_CONTENT_APP }}
 
    steps: 
     # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#using-the-checkout-action
@@ -39,7 +40,7 @@ jobs:
         # Create a new Sentry release with the commit SHA as the version.
         # Associate all commits since the last finalised release.
         export VERSION=$(sentry-cli releases propose-version)
-        sentry-cli releases new -p $SENTRY_PROJECT $VERSION
+        sentry-cli releases new -p $SENTRY_PROJECT_APP -p $SENTRY_CONTENT_APP $VERSION
         sentry-cli releases set-commits --auto $VERSION
         
         # Create new staging deploy for this Sentry release
@@ -57,7 +58,6 @@ jobs:
    env:
      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-     SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
    steps: 
     # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#using-the-checkout-action

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ADD_LABEL: "approved"
 
-name: New Sentry Release
+name: Create new Sentry Release
 
 on:
   push:
@@ -44,6 +44,8 @@ jobs:
         
         # Create new staging deploy for this Sentry release
         sentry-cli releases deploys $VERSION new -e 'staging'
+
+name: Finalise production Sentry Release
 
 on:
   release:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,3 +11,64 @@ jobs:
         APPROVALS: "1"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ADD_LABEL: "approved"
+
+name: New Sentry Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+   runs-on: ubuntu-latest
+   env:
+     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+     SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+     SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+
+   steps: 
+    # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#using-the-checkout-action
+    - uses: actions/checkout@v1.0.0
+
+    - name: Create new Sentry release
+      run: |
+        # Install Sentry CLI
+        curl -sL https://sentry.io/get-cli/ | bash
+        
+        # Create a new Sentry release with the commit SHA as the version.
+        # Associate all commits since the last finalised release.
+        export VERSION=$(sentry-cli releases propose-version)
+        sentry-cli releases new -p $SENTRY_PROJECT $VERSION
+        sentry-cli releases set-commits --auto $VERSION
+        
+        # Create new staging deploy for this Sentry release
+        sentry-cli releases deploys $VERSION new -e 'staging'
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+   runs-on: ubuntu-latest
+   env:
+     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+     SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+     SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+
+   steps: 
+    # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#using-the-checkout-action
+    - uses: actions/checkout@v1.0.0
+
+    - name: Finalise Sentry release
+      run: |
+        # Install Sentry CLI
+        curl -sL https://sentry.io/get-cli/ | bash
+        
+        # Finalise existing Sentry release
+        export VERSION=$GITHUB_SHA
+        sentry-cli releases finalize $VERSION
+        
+        # Create new production deploy for this Sentry release
+        sentry-cli releases deploys $VERSION new -e 'production'

--- a/packages/app-content-pages/src/helpers/logger/initializeSentry.js
+++ b/packages/app-content-pages/src/helpers/logger/initializeSentry.js
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/browser'
 
 export default function initializeSentry () {
   const dsn = process.env.SENTRY_DSN
-  const release = `@zooniverse/fe-project@${process.env.COMMIT_ID}`
+  const release = process.env.COMMIT_ID
   const environment = process.env.APP_ENV
 
   if (dsn) {

--- a/packages/app-project/src/helpers/logger/initializeSentry.js
+++ b/packages/app-project/src/helpers/logger/initializeSentry.js
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/browser'
 export default function initializeSentry () {
   const dsn = process.env.SENTRY_DSN
   const environment = process.env.APP_ENV
-  const release = `@zooniverse/fe-project@${process.env.COMMIT_ID}`
+  const release = process.env.COMMIT_ID
   console.log('Initialising Sentry:', dsn, environment, release)
 
   if (dsn) {


### PR DESCRIPTION
Add a couple of new GitHub actions.
- on merge to master, create a new Sentry release from the commit SHA, link to all commits since the last finalised release and deploy it as a staging release.
- on publishing a new release, which is always production-release for this repo, get the existing release for the commit SHA and finalise it, then deploy as a production release.

Update the Sentry client to use commit SHA for release versions.

Package:
app-project
app-content-pages

Closes #1583.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
