### PR TITLE
Add build environment to Docker image names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
           steps {
             dir ('packages/app-content-pages') {
               script {
-                def dockerRepoName = 'zooniverse/fe-content-pages'
+                def dockerRepoName = 'zooniverse/fe-content-pages-${APP_ENV}'
                 def dockerImageName = "${dockerRepoName}:${GIT_COMMIT}"
                 def buildArgs = "--build-arg APP_ENV --build-arg ASSET_PREFIX --build-arg COMMIT_ID --build-arg SENTRY_DSN ."
                 def newImage = docker.build(dockerImageName, buildArgs)
@@ -84,7 +84,7 @@ pipeline {
           steps {
             dir ('packages/app-project') {
               script {
-                def dockerRepoName = 'zooniverse/fe-project'
+                def dockerRepoName = 'zooniverse/fe-project-${APP_ENV}'
                 def dockerImageName = "${dockerRepoName}:${GIT_COMMIT}"
                 def buildArgs = "--build-arg APP_ENV --build-arg ASSET_PREFIX --build-arg COMMIT_ID --build-arg SENTRY_DSN ."
                 def newImage = docker.build(dockerImageName, buildArgs)

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: fe-project-production
-          image: zooniverse/fe-project:__IMAGE_TAG__
+          image: zooniverse/fe-project-production:__IMAGE_TAG__
           ports:
             - containerPort: 3000
           env:
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
         - name: fe-content-pages-production
-          image: zooniverse/fe-content-pages:__IMAGE_TAG__
+          image: zooniverse/fe-content-pages-production:__IMAGE_TAG__
           ports:
             - containerPort: 3000
           env:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: fe-project-staging
-          image: zooniverse/fe-project:__IMAGE_TAG__
+          image: zooniverse/fe-project-staging:__IMAGE_TAG__
           ports:
             - containerPort: 3000
           env:
@@ -83,7 +83,7 @@ spec:
     spec:
       containers:
         - name: fe-content-pages-staging
-          image: zooniverse/fe-content-pages:__IMAGE_TAG__
+          image: zooniverse/fe-content-pages-staging:__IMAGE_TAG__
           ports:
             - containerPort: 3000
           env:


### PR DESCRIPTION
Add the NextJS app build environment (staging or production) to their Docker image names, so that we can distinguish between staging and production versions of the apps when deploying.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
