### PR TITLE
Fix transcription task when there are other steps

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -24,7 +24,7 @@ function storeMapper (stores) {
   const subject = stores.classifierStore.subjects.active
   const [activeInteractionTask] = activeStepTasks.filter(task => task.type === 'drawing' || task.type === 'transcription')
   const annotations = classification ? Array.from(classification.annotations.values()) : []
-  const interactionTaskAnnotations = annotations.filter(annotation => getType(annotation).name === ('DrawingAnnotation' || 'TranscriptionAnnotation'))
+  const interactionTaskAnnotations = annotations.filter(annotation => (getType(annotation).name === 'DrawingAnnotation' || getType(annotation).name === 'TranscriptionAnnotation'))
   const { consensusLines } = subject.transcriptionReductions || {}
 
   return {

--- a/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionAnnotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionAnnotation.js
@@ -4,7 +4,7 @@ import { TranscriptionLine } from '@plugins/drawingTools/models/marks'
 import Annotation from '../../../models/Annotation'
 
 const Transcription = types.model('Transcription', {
-  value: types.array(TranscriptionLine)
+  value: types.array(types.safeReference(TranscriptionLine))
 })
   .views(self => ({
     // This is a copy of DrawingAnnotation's toSnapshot with the exception of

--- a/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionAnnotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionAnnotation.js
@@ -1,4 +1,4 @@
-import { types } from 'mobx-state-tree'
+import { getRoot, getSnapshot, resolveIdentifier, types } from 'mobx-state-tree'
 import TranscriptionTask from './TranscriptionTask'
 import { TranscriptionLine } from '@plugins/drawingTools/models/marks'
 import Annotation from '../../../models/Annotation'

--- a/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionAnnotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionAnnotation.spec.js
@@ -1,0 +1,153 @@
+import { types } from 'mobx-state-tree'
+import TranscriptionTask from './TranscriptionTask'
+import TranscriptionAnnotation from './TranscriptionAnnotation'
+import { TranscriptionLine } from '@plugins/drawingTools/experimental/models/marks'
+
+describe('Model > TranscriptionAnnotation', function () {
+  const transcriptionLine = TranscriptionLine.create({
+    id: 'mockAnnotation',
+    frame: 0,
+    toolIndex: 0,
+    toolType: 'transcriptionLine',
+    x1: 10,
+    y1: 30,
+    x2: 20,
+    y2: 30
+  })
+
+
+  const transcriptionAnnotationSnapshot = {
+    id: 'transcription1',
+    task: 'T0',
+    taskType: 'transcription',
+    value: [transcriptionLine.id]
+  }
+
+  it('should exist', function () {
+    const transcriptionAnnotation = TranscriptionAnnotation.create(transcriptionAnnotationSnapshot)
+    expect(transcriptionAnnotation).to.exist()
+    expect(transcriptionAnnotation).to.be.an('object')
+  })
+
+  describe('annotation snapshot', function () {
+    function buildMockAnnotation({ taskSnapshot }) {
+      const transcriptionTask = TranscriptionTask.create(taskSnapshot)
+      const annotation = transcriptionTask.createAnnotation()
+      // TODO: build a more realistic model tree here.
+      types.model('MockStore', {
+        transcriptionTask: TranscriptionTask,
+        annotation: TranscriptionAnnotation
+      })
+        .create({
+          transcriptionTask,
+          annotation
+        })
+      return { annotation, transcriptionTask }
+    }
+
+    describe('with text subtask', function () {
+      let snapshot
+
+      before(function () {
+        const { annotation, transcriptionTask } = buildMockAnnotation({
+          taskSnapshot: {
+            instruction: 'transcribe the text',
+            taskKey: 'T0',
+            tools: [
+              {
+                type: 'transcriptionLine',
+                details: [{
+                  type: 'text',
+                  instruction: 'transcribe the text',
+                  answers: 'foo'
+                }]
+              }
+            ],
+            type: 'transcription'
+          }
+        })
+        const transcriptionLineTool = transcriptionTask.tools[0]
+        const transcriptionLine1 = transcriptionLineTool.createMark({
+          x1: 50,
+          x2: 100,
+          y1: 100,
+          y2: 200
+        })
+        const transcriptionLine2 = transcriptionLineTool.createMark({
+          x1: 150,
+          x2: 175,
+          y1: 200,
+          y2: 238
+        })
+        const textTask = transcriptionLineTool.tasks[0]
+        transcriptionLine1.addAnnotation(textTask, 'foo')
+        transcriptionLine2.addAnnotation(textTask, 'bar')
+        snapshot = annotation.toSnapshot()
+      })
+
+      it('should be an array', function () {
+        expect(snapshot).to.be.a('array')
+      })
+
+      it('should contain the task annotation plus one annotation for the text subtask', function () {
+        expect(snapshot).to.have.lengthOf(3)
+      })
+
+      it('should contain snapshots of the annotation plus text subtask answer', function () {
+        const [annotation] = snapshot
+        const transcriptionLine1Answer = {
+          task: 'T0.0.0',
+          taskType: 'text',
+          value: 'foo',
+          markIndex: 0
+        }
+
+        const transcriptionLine2Answer = {
+          task: 'T0.0.0',
+          taskType: 'text',
+          value: 'bar',
+          markIndex: 1
+        }
+
+        expect(snapshot).to.deep.equal([annotation, transcriptionLine1Answer, transcriptionLine2Answer])
+      })
+
+      describe('the annotation snapshot', function () {
+        it('should contain a task key', function () {
+          const [annotation] = snapshot
+          expect(annotation.task).to.equal('T0')
+        })
+
+        it('should contain a taskType', function () {
+          const [annotation] = snapshot
+          expect(annotation.taskType).to.equal('transcription')
+        })
+
+        it('should include snapshots of the drawn marks', function () {
+          const [annotation] = snapshot
+          const transcriptionLine1Snapshot = {
+            details: [{ task: 'T0.0.0' }],
+            frame: 0,
+            toolIndex: 0,
+            toolType: 'transcriptionLine',
+            x1: 50,
+            x2: 100,
+            y1: 100,
+            y2: 200
+          }
+          const transcriptionLine2Snapshot = {
+            details: [{ task: 'T0.0.0' }],
+            frame: 0,
+            toolIndex: 0,
+            toolType: 'transcriptionLine',
+            x1: 150,
+            x2: 175,
+            y1: 200,
+            y2: 238
+          }
+          expect(annotation.value).to.deep.equal([transcriptionLine1Snapshot, transcriptionLine2Snapshot])
+        })
+      })
+    })
+  })
+})

--- a/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionTask.spec.js
@@ -1,0 +1,187 @@
+import { types } from 'mobx-state-tree'
+import TranscriptionTask from '@plugins/tasks/experimental/TranscriptionTask'
+
+const details = [
+  {
+    type: 'text',
+    instruction: 'Transcribe something',
+    required: true
+  }
+]
+
+const transcriptionLineTool = {
+  help: '',
+  label: 'Underline the text',
+  type: 'transcriptionLine',
+  details
+}
+
+const transcriptionTaskSnapshot = {
+  instruction: "Transcribe the text",
+  taskKey: 'T3',
+  tools: [transcriptionLineTool],
+  type: 'transcription'
+}
+
+describe('Model > TranscriptionTask', function () {
+  it('should exist', function () {
+    const transcriptionTask = TranscriptionTask.TaskModel.create(transcriptionTaskSnapshot)
+    expect(transcriptionTask).to.be.ok()
+    expect(transcriptionTask).to.be.an('object')
+  })
+
+  it('should have a property `type` of `drawing`', function () {
+    const transcriptionTask = TranscriptionTask.TaskModel.create(transcriptionTaskSnapshot)
+    expect(transcriptionTask).to.include({ type: 'transcription' })
+  })
+
+  it('should throw an error with incorrect property `type`', function () {
+    expect(() => TranscriptionTask.TaskModel.create({ type: 'orange' })).to.throw()
+  })
+
+  it('should load a text subtask on creation.', function () {
+    const transcriptionTask = TranscriptionTask.TaskModel.create(transcriptionTaskSnapshot)
+    expect(transcriptionTask.tools[0].tasks).to.have.lengthOf(1)
+  })
+
+  it('should assign task keys to subtasks.', function () {
+    const transcriptionTask = TranscriptionTask.TaskModel.create(transcriptionTaskSnapshot)
+    const [textSubtask] = transcriptionTask.tools[0].tasks
+    expect(textSubtask.taskKey).to.equal('T3.0.0')
+  })
+
+  describe('drawn marks', function () {
+    let marks
+    before(function () {
+      const transcriptionTask = TranscriptionTask.TaskModel.create(transcriptionTaskSnapshot)
+      transcriptionTask.tools[0].createMark({ id: 'transcriptionLine1' })
+      marks = transcriptionTask.marks
+    })
+
+    it('should exist for each drawn mark', function () {
+      expect(marks).to.have.lengthOf(1)
+    })
+  })
+
+  describe('active mark', function () {
+    let transcriptionTask
+
+    before(function () {
+      transcriptionTask = TranscriptionTask.TaskModel.create(transcriptionTaskSnapshot)
+      transcriptionTask.tools[0].createMark({ id: 'transcriptionLine1' })
+    })
+
+    it('should be undefined by default', function () {
+      expect(transcriptionTask.activeMark).to.be.undefined()
+    })
+
+    it('should be set from stored marks', function () {
+      const transcriptionLineMark = transcriptionTask.marks[0]
+      transcriptionTask.setActiveMark(transcriptionLineMark)
+      expect(transcriptionTask.activeMark).to.equal(transcriptionLineMark)
+    })
+  })
+
+  describe('with subtask annotations', function () {
+    let transcriptionLine
+    let textSubTask
+    let task
+
+    before(function () {
+      task = TranscriptionTask.TaskModel.create(transcriptionTaskSnapshot)
+      textSubTask = task.tools[0].tasks[0]
+      const annotation = task.defaultAnnotation
+      types.model('MockStore', {
+        annotation: TranscriptionTask.AnnotationModel,
+        task: TranscriptionTask.TaskModel
+      })
+        .create({
+          annotation,
+          task
+        })
+
+      function updateMark(mark, value) {
+        const markAnnotation = mark.addAnnotation(textSubTask)
+        textSubTask.setAnnotation(markAnnotation)
+        markAnnotation.update(value)
+      }
+
+      task.setAnnotation(annotation)
+      transcriptionLine = task.tools[0].createMark({ id: 'transcriptionLine' })
+
+      updateMark(transcriptionLine, 'foo')
+    })
+
+    it('should store an annotation for transcriptionLine', function () {
+      expect(transcriptionLine.annotation(textSubTask).task).to.equal('T3.0.0')
+      expect(transcriptionLine.annotation(textSubTask).taskType).to.equal('text')
+      expect(transcriptionLine.annotation(textSubTask).value).to.equal('foo')
+    })
+  })
+
+  describe('on complete', function () {
+    let transcriptionLine
+    let task
+
+    before(function () {
+      task = TranscriptionTask.TaskModel.create(transcriptionTaskSnapshot)
+      const annotation = task.defaultAnnotation
+      const store = types.model('MockStore', {
+        annotation: TranscriptionTask.AnnotationModel,
+        task: TranscriptionTask.TaskModel
+      })
+        .create({
+          annotation,
+          task
+        })
+      task.setAnnotation(annotation)
+      transcriptionLine = task.tools[0].createMark({ id: 'transcriptionLine1' })
+      task.complete()
+    })
+
+    it('should copy marks to the task annotation', function () {
+      expect(task.annotation.value).to.deep.equal([transcriptionLine])
+    })
+  })
+
+  describe('on reset', function () {
+    let marks
+    let transcriptionLineTool
+    let task
+
+    before(function () {
+      task = TranscriptionTask.TaskModel.create(transcriptionTaskSnapshot)
+      const annotation = task.defaultAnnotation
+      types.model('MockStore', {
+        annotation: TranscriptionTask.AnnotationModel,
+        task: TranscriptionTask.TaskModel
+      })
+        .create({
+          annotation,
+          task
+        })
+      task.setAnnotation(annotation)
+      transcriptionLineTool = task.tools[0]
+      task.setSubTaskVisibility(true)
+      task.reset()
+      marks = task.marks
+    })
+
+    it('should clear stale marks from the task', function () {
+      expect(marks.length).to.equal(0)
+    })
+
+    it('should clear stale marks from the drawing tools', function () {
+      expect(transcriptionLineTool.marks.size).to.equal(0)
+    })
+
+
+    it('should reset the active tool', function () {
+      expect(task.activeToolIndex).to.equal(0)
+    })
+
+    it('should reset the subtask visibility', function () {
+      expect(task.subTaskVisibility).to.be.false()
+    })
+  })
+})


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

Describe your changes:
The test project and workflow http://local.zooniverse.org:8080/?project=1764&workflow=3392 using the transcription task was failing to go to the next step of tasks. This was because of a missing safe reference type in the models. The filter for the annotations to display previous task marks also had a syntax error. 

WIP because I'm going to look to see if there are any tests that can be updated or added. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
