### PR TITLE
Add check for subtasks before setSubTaskVisibility

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -80,7 +80,9 @@ function InteractionLayer ({
     const { target, pointerId } = event
     
     setCreating(false)
-    setSubTaskVisibility(true, node)
+    if (activeMark && activeMark.tasks?.length > 0) {
+      setSubTaskVisibility(true, node)
+    }
     if (activeMark && !activeMark.isValid) {
       activeTool.deleteMark(activeMark)
       setActiveMark(undefined)
@@ -112,7 +114,9 @@ function InteractionLayer ({
           }}
           onFinish={onFinish}
           onSelectMark={(mark, node) => {
-            setSubTaskVisibility(true, node)  // Show sub-task again on select, in case it was closed 
+            if (mark.tasks?.length > 0) {
+              setSubTaskVisibility(true, node) // Show sub-task again on select, in case it was closed
+            }
             setActiveMark(mark)
           }}
           onMove={(mark, difference) => mark.move(difference)}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -80,9 +80,7 @@ function InteractionLayer ({
     const { target, pointerId } = event
     
     setCreating(false)
-    if (activeMark && activeMark.tasks?.length > 0) {
-      setSubTaskVisibility(true, node)
-    }
+    setSubTaskVisibility(true, node)
     if (activeMark && !activeMark.isValid) {
       activeTool.deleteMark(activeMark)
       setActiveMark(undefined)
@@ -114,9 +112,7 @@ function InteractionLayer ({
           }}
           onFinish={onFinish}
           onSelectMark={(mark, node) => {
-            if (mark.tasks?.length > 0) {
-              setSubTaskVisibility(true, node) // Show sub-task again on select, in case it was closed
-            }
+            setSubTaskVisibility(true, node) // Show sub-task again on select, in case it was closed
             setActiveMark(mark)
           }}
           onMove={(mark, difference) => mark.move(difference)}

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
@@ -81,10 +81,12 @@ export const Drawing = types.model('Drawing', {
     }
 
     function setSubTaskVisibility (visible, drawingMarkNode) {
-      self.subTaskVisibility = visible
-      self.subTaskMarkBounds = (drawingMarkNode)
-        ? drawingMarkNode.getBoundingClientRect()
-        : undefined
+      if (self.activeTool.tasks?.length > 0) {
+        self.subTaskVisibility = visible
+        self.subTaskMarkBounds = (drawingMarkNode)
+          ? drawingMarkNode.getBoundingClientRect()
+          : undefined
+      }
     }
 
     function togglePreviousMarks () {

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
@@ -81,7 +81,7 @@ export const Drawing = types.model('Drawing', {
     }
 
     function setSubTaskVisibility (visible, drawingMarkNode) {
-      if (self.activeTool.tasks?.length > 0) {
+      if (self.activeTool?.tasks?.length > 0) {
         self.subTaskVisibility = visible
         self.subTaskMarkBounds = (drawingMarkNode)
           ? drawingMarkNode.getBoundingClientRect()

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
@@ -1,7 +1,5 @@
 import { types } from 'mobx-state-tree'
-import sinon from 'sinon'
 import DrawingTask from '@plugins/tasks/DrawingTask'
-import SingleChoiceTask from '@plugins/tasks/SingleChoiceTask'
 
 const details = [
   {
@@ -71,6 +69,20 @@ describe('Model > DrawingTask', function () {
     subtasks.forEach((task, i) => expect(task.taskKey).to.equal(`T3.0.${i}`))
   })
 
+  it('should keep subTaskVisibility false if there is no tool subtask', function () {
+    const drawingTask = DrawingTask.TaskModel.create(drawingTaskSnapshot)
+    drawingTask.setActiveTool(1)
+    drawingTask.setSubTaskVisibility(true)
+    expect(drawingTask.subTaskVisibility).to.be.false()
+  })
+
+  it('should set subTaskVisibility to true if there is any tool subtask', function () {
+    const drawingTask = DrawingTask.TaskModel.create(drawingTaskSnapshot)
+    drawingTask.setActiveTool(0)
+    drawingTask.setSubTaskVisibility(true)
+    expect(drawingTask.subTaskVisibility).to.be.true()
+  })
+
   describe('drawn marks', function () {
     let marks
     before(function () {
@@ -117,7 +129,6 @@ describe('Model > DrawingTask', function () {
   })
 
   describe('with subtask annotations', function () {
-    let line1
     let point1
     let point2
     let point3
@@ -132,12 +143,12 @@ describe('Model > DrawingTask', function () {
         annotation: DrawingTask.AnnotationModel,
         task: DrawingTask.TaskModel
       })
-      .create({
-        annotation,
-        task
-      })
+        .create({
+          annotation,
+          task
+        })
 
-      function updateMark(mark, value) {
+      function updateMark (mark, value) {
         const markAnnotation = mark.addAnnotation(pointSubTask)
         pointSubTask.setAnnotation(markAnnotation)
         markAnnotation.update(value)
@@ -147,7 +158,6 @@ describe('Model > DrawingTask', function () {
       point1 = task.tools[0].createMark({ id: 'point1' })
       point2 = task.tools[0].createMark({ id: 'point2' })
       point3 = task.tools[0].createMark({ id: 'point3' })
-      line1 = task.tools[1].createMark({ id: 'line1' })
 
       updateMark(point1, 1)
       updateMark(point2, 1)
@@ -186,10 +196,10 @@ describe('Model > DrawingTask', function () {
         annotation: DrawingTask.AnnotationModel,
         task: DrawingTask.TaskModel
       })
-      .create({
-        annotation,
-        task
-      })
+        .create({
+          annotation,
+          task
+        })
       task.setAnnotation(annotation)
       point1 = task.tools[0].createMark({ id: 'point1' })
       point2 = task.tools[0].createMark({ id: 'point2' })
@@ -215,14 +225,14 @@ describe('Model > DrawingTask', function () {
         annotation: DrawingTask.AnnotationModel,
         task: DrawingTask.TaskModel
       })
-      .create({
-        annotation,
-        task
-      })
+        .create({
+          annotation,
+          task
+        })
       task.setAnnotation(annotation)
       pointTool = task.tools[0]
       lineTool = task.tools[1]
-      task.setActiveTool(1)
+      task.setActiveTool(0)
       task.setSubTaskVisibility(true)
       task.reset()
       marks = task.marks
@@ -236,7 +246,6 @@ describe('Model > DrawingTask', function () {
       expect(pointTool.marks.size).to.equal(0)
       expect(lineTool.marks.size).to.equal(0)
     })
-
 
     it('should reset the active tool', function () {
       expect(task.activeToolIndex).to.equal(0)


### PR DESCRIPTION
Package: lib-classifier

Fixes subtask showing after all drawing tools, even if no subtasks.

Describe your changes:
- adds conditional check for subtasks (`mark.tasks`) before setting subtask visibility (`setSubTaskVisibility`)

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
