### PR TITLE
Classifier: add `subject_viewer_config` to `workflow.configuration`

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md
@@ -44,15 +44,17 @@ Optionally, the SGV can be further configured to specify a certain grid size. Th
 ```
 workflow.configuration = {
   subject_viewer: 'subjectGroup',
-  cell_width: 1200,
-  cell_height: 1000,
-  cell_style: {
-    stroke: '#fff',
-    strokeWidth: '4',
-    fill: '#000'
-  },
-  grid_columns: 4,
-  grid_rows: 3
+  subject_viewer_config: {
+    cell_width: 1200,
+    cell_height: 1000,
+    cell_style: {
+      stroke: '#fff',
+      strokeWidth: '4',
+      fill: '#000'
+    },
+    grid_columns: 4,
+    grid_rows: 3
+  }
 }
 ```
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/SubjectGroupViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/SubjectGroupViewerContainer.js
@@ -32,13 +32,13 @@ function storeMapper (stores) {
     active: activeWorkflow
   } = stores.classifierStore.workflows
   
-  const workflowConfig = activeWorkflow && activeWorkflow.configuration || {}
+  const viewerConfig = activeWorkflow?.configuration?.subject_viewer_config || {}
   
-  const cellWidth = workflowConfig.cell_width || DEFAULT_CELL_WIDTH
-  const cellHeight = workflowConfig.cell_height || DEFAULT_CELL_HEIGHT
-  const cellStyle = workflowConfig.cell_style || DEFAULT_CELL_STYLE
-  const gridColumns = workflowConfig.grid_columns || DEFAULT_GRID_COLUMNS
-  const gridRows = workflowConfig.grid_rows || DEFAULT_GRID_ROWS
+  const cellWidth = viewerConfig.cell_width || DEFAULT_CELL_WIDTH
+  const cellHeight = viewerConfig.cell_height || DEFAULT_CELL_HEIGHT
+  const cellStyle = viewerConfig.cell_style || DEFAULT_CELL_STYLE
+  const gridColumns = viewerConfig.grid_columns || DEFAULT_GRID_COLUMNS
+  const gridRows = viewerConfig.grid_rows || DEFAULT_GRID_ROWS
 
   return {
     cellWidth,

--- a/packages/lib-classifier/src/store/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
+++ b/packages/lib-classifier/src/store/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
@@ -5,7 +5,8 @@ const WorkflowConfiguration = types.model({
   enable_switching_flipbook_and_separate: types.optional(types.boolean, false),
   hide_classification_summaries: types.optional(types.boolean, false),
   multi_image_mode: types.optional(types.enumeration('multiImageMode', ['flipbook', 'separate']), 'flipbook'),
-  subject_viewer: types.maybe(types.enumeration('subjectViewer', ['lightcurve', 'multiFrame', 'subjectGroup']))
+  subject_viewer: types.maybe(types.enumeration('subjectViewer', ['lightcurve', 'multiFrame', 'subjectGroup'])),
+  subject_viewer_config: types.frozen()
 })
   .views(self => ({
     get viewerType () {

--- a/packages/lib-classifier/src/store/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
+++ b/packages/lib-classifier/src/store/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
@@ -6,7 +6,7 @@ const WorkflowConfiguration = types.model({
   hide_classification_summaries: types.optional(types.boolean, false),
   multi_image_mode: types.optional(types.enumeration('multiImageMode', ['flipbook', 'separate']), 'flipbook'),
   subject_viewer: types.maybe(types.enumeration('subjectViewer', ['lightcurve', 'multiFrame', 'subjectGroup'])),
-  subject_viewer_config: types.frozen()
+  subject_viewer_config: types.frozen({})
 })
   .views(self => ({
     get viewerType () {


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`

This PR allows custom Subject Viewers to have their own configuration objects, in their respective Workflow's configuration object.

- For example, this workflow configuration states that we want to use the "Subject Group" viewer (which displays images in a grid) in this workflow, and that SubjectGroupViewer should be using a 5x5 grid:
  ```
  workflow.configuration = {
    subject_viewer: 'subjectGroup',
    subject_viewer_config: {
      grid_columns: 5,
      grid_rows: 5
    }
  }
  ```
- The definition of a custom Subject Viewer's configuration object is specific to that Subject Viewer (effectively arbitrary at this point of development) so I used `type.frozen`
- Additionally, the SubjectGroupViewer component - the primary viewer that will be affected by/that requires this update - has been updated to reflect the intended changes.

### Additional Information / Context

The Classifier allows certain workflows to use "custom" Subject Viewers. For example, the TESS project's LightCurveViewer and the SURVOS project's SubjectGroupViewer.

I call these "custom" viewers because you need to explicitly tell the Classifier that you want to use these viewers, via `workflow.configuration.subject_viewer`. In contrast, "standard" viewers (e.g. Single Image Viewers) automatically get used based on the shape of the Subject being served. (See `src/store/Subject/Subject.js`'s `get viewer ()`)

`workflow.configuration.subject_viewer` was first introduced by the TESS project.

`workflow.configuration.subject_viewer_configuration` is being introduced in light of the SURVOS project, where we now realise that a grid-based viewer (the SubjectGroupViewer) should be flexible enough to accommodate any kind of grid configuration, be it 3x3 grids of 100x100 pixel cells or 8x5 grids of 80x40 pixel cells.

### Status

Ready for review!
