### PR TITLE
Refactor to reset pan, zoom, or rotate on new frame

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
@@ -177,13 +177,14 @@ class MultiFrameViewerContainer extends React.Component {
         />
         <SVGContext.Provider value={{ svg }}>
           <SVGPanZoom
-            img={img}
+            img={this.subjectImage.current}
             maxZoom={5}
             naturalHeight={naturalHeight}
             naturalWidth={naturalWidth}
             setOnDrag={this.setOnDrag}
             setOnPan={setOnPan}
             setOnZoom={setOnZoom}
+            src={src}
           >
             <SingleImageViewer
               enableInteractionLayer={enableDrawing}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
@@ -177,7 +177,7 @@ class MultiFrameViewerContainer extends React.Component {
         />
         <SVGContext.Provider value={{ svg }}>
           <SVGPanZoom
-            img={this.subjectImage.current}
+            img={img}
             maxZoom={5}
             naturalHeight={naturalHeight}
             naturalWidth={naturalWidth}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -11,7 +11,8 @@ function SVGPanZoom ({
   naturalWidth,
   setOnDrag,
   setOnPan,
-  setOnZoom
+  setOnZoom,
+  src
 }) {
   const scrollContainer = useRef()
   const defaultViewBox = {
@@ -55,7 +56,7 @@ function SVGPanZoom ({
   useEffect(() => {
     setZoom(1)
     setViewBox(defaultViewBox)
-  }, [img])
+  }, [src])
 
   function imageScale (img) {
     const { width: clientWidth, height: clientHeight } = img ? img.getBoundingClientRect() : {}
@@ -143,7 +144,8 @@ SVGPanZoom.propTypes = {
   naturalHeight: PropTypes.number.isRequired,
   naturalWidth: PropTypes.number.isRequired,
   setOnPan: PropTypes.func,
-  setOnZoom: PropTypes.func
+  setOnZoom: PropTypes.func,
+  src: PropTypes.string.isRequired
 }
 
 SVGPanZoom.defaultProps = {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -52,6 +52,11 @@ function SVGPanZoom ({
     setViewBox(newViewBox)
   }, [zoom])
 
+  useEffect(() => {
+    setZoom(1)
+    setViewBox(defaultViewBox)
+  }, [img])
+
   function imageScale (img) {
     const { width: clientWidth, height: clientHeight } = img ? img.getBoundingClientRect() : {}
     const scale = clientWidth / naturalWidth

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
@@ -99,41 +99,25 @@ describe('Components > SVGPanZoom', function () {
     expect(viewBox).to.equal('18.5 9.5 363 181')
   })
 
-  it('should reset pan with new img', function () {
+  it('should reset pan with new src', function () {
     onPan(-1, 0)
     wrapper.update()
     let viewBox = wrapper.find('svg').prop('viewBox')
     expect(viewBox).to.equal('10 0 400 200')
 
-    const nextImg = {
-      getBoundingClientRect () {
-        return {
-          height: 200,
-          width: 100
-        }
-      }
-    }
-    wrapper.setProps({ img: nextImg, naturalHeight: 400, naturalWidth: 200 })
+    wrapper.setProps({ naturalHeight: 400, naturalWidth: 200, src: 'http://placekitten.com/200/400' })
     wrapper.update()
     viewBox = wrapper.find('svg').prop('viewBox')
     expect(viewBox).to.equal('0 0 200 400')
   })
 
-  it('should reset zoom with new img', function () {
+  it('should reset zoom with new src', function () {
     onZoom('zoomin', 1)
     wrapper.update()
     let viewBox = wrapper.find('svg').prop('viewBox')
     expect(viewBox).to.equal('18.5 9.5 363 181')
 
-    const nextImg = {
-      getBoundingClientRect () {
-        return {
-          height: 200,
-          width: 100
-        }
-      }
-    }
-    wrapper.setProps({ img: nextImg, naturalHeight: 400, naturalWidth: 200 })
+    wrapper.setProps({ naturalHeight: 400, naturalWidth: 200, src: 'http://placekitten.com/200/400' })
     wrapper.update()
     viewBox = wrapper.find('svg').prop('viewBox')
     expect(viewBox).to.equal('0 0 200 400')

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
@@ -98,4 +98,44 @@ describe('Components > SVGPanZoom', function () {
     viewBox = wrapper.find('svg').prop('viewBox')
     expect(viewBox).to.equal('18.5 9.5 363 181')
   })
+
+  it('should reset pan with new img', function () {
+    onPan(-1, 0)
+    wrapper.update()
+    let viewBox = wrapper.find('svg').prop('viewBox')
+    expect(viewBox).to.equal('10 0 400 200')
+
+    const nextImg = {
+      getBoundingClientRect () {
+        return {
+          height: 200,
+          width: 100
+        }
+      }
+    }
+    wrapper.setProps({ img: nextImg, naturalHeight: 400, naturalWidth: 200 })
+    wrapper.update()
+    viewBox = wrapper.find('svg').prop('viewBox')
+    expect(viewBox).to.equal('0 0 200 400')
+  })
+
+  it('should reset zoom with new img', function () {
+    onZoom('zoomin', 1)
+    wrapper.update()
+    let viewBox = wrapper.find('svg').prop('viewBox')
+    expect(viewBox).to.equal('18.5 9.5 363 181')
+
+    const nextImg = {
+      getBoundingClientRect () {
+        return {
+          height: 200,
+          width: 100
+        }
+      }
+    }
+    wrapper.setProps({ img: nextImg, naturalHeight: 400, naturalWidth: 200 })
+    wrapper.update()
+    viewBox = wrapper.find('svg').prop('viewBox')
+    expect(viewBox).to.equal('0 0 200 400')
+  })
 })

--- a/packages/lib-classifier/src/store/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.js
@@ -90,6 +90,7 @@ const SubjectViewer = types
           naturalWidth = 0
         } = target
         self.dimensions.push({ clientHeight, clientWidth, naturalHeight, naturalWidth })
+        self.rotation = 0
         self.loadingState = asyncStates.success
       },
 

--- a/packages/lib-classifier/src/store/SubjectViewerStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore.spec.js
@@ -104,7 +104,15 @@ describe('Model > SubjectViewerStore', function () {
 
     it('should reset the rotation angle when there is a new active subject', function () {
       subjectViewerStore.rotate()
+      expect(subjectViewerStore.rotation).to.equal(-90)
       subjectViewerStore.resetSubject()
+      expect(subjectViewerStore.rotation).to.equal(0)
+    })
+
+    it('should reset the rotation angle when subject is ready', function () {
+      subjectViewerStore.rotate()
+      expect(subjectViewerStore.rotation).to.equal(-90)
+      subjectViewerStore.onSubjectReady()
       expect(subjectViewerStore.rotation).to.equal(0)
     })
 


### PR DESCRIPTION
Package: lib-classifier

Towards #1538, however, this refactors for transcription workflows. **Conditionally setting pan, zoom and rotation based on task or workflow is still needed.**

Describe your changes:
- refactors SVGPanZoom to reset on new image
- refactors SubjectViewerStore to reset rotation in `onSubjectReady`

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
