### PR TITLE
Classifier: Remove updateClassificationMetadata

### DIFF
--- a/packages/lib-classifier/src/store/Classification.js
+++ b/packages/lib-classifier/src/store/Classification.js
@@ -35,6 +35,13 @@ const ClassificationMetadata = types.model('ClassificationMetadata', {
   }),
   workflowVersion: types.string
 })
+  .actions(self => ({
+    update (newMetadata) {
+      Object.keys(newMetadata).forEach(key => {
+        self[key] = newMetadata[key]
+      })
+    }
+  }))
 
 const Classification = types
   .model('Classification', {

--- a/packages/lib-classifier/src/store/Classification/Classification.js
+++ b/packages/lib-classifier/src/store/Classification/Classification.js
@@ -1,47 +1,9 @@
 import cuid from 'cuid'
 import { types, getSnapshot, getType } from 'mobx-state-tree'
 import { annotationModels } from '@plugins/tasks'
-import AnnotationsStore from './AnnotationsStore'
-import Resource from './Resource'
-
-const ClassificationMetadata = types.model('ClassificationMetadata', {
-  classifier_version: types.literal('2.0'),
-  feedback: types.frozen({}),
-  finishedAt: types.maybe(types.string),
-  session: types.maybe(types.string),
-  source: types.enumeration(['api', 'sugar']),
-  startedAt: types.optional(types.string, (new Date()).toISOString()),
-  subjectDimensions: types.array(types.frozen({
-    clientHeight: types.integer,
-    clientWidth: types.integer,
-    naturalHeight: types.integer,
-    naturalWidth: types.integer
-  })),
-  subjectSelectionState: types.frozen({
-    already_seen: types.optional(types.boolean, false),
-    finished_workflow: types.optional(types.boolean, false),
-    retired: types.optional(types.boolean, false),
-    selected_at: types.maybe(types.string),
-    selection_state: types.maybe(types.string),
-    user_has_finished_workflow: types.optional(types.boolean, false)
-  }),
-  subject_flagged: types.optional(types.boolean, false),
-  userAgent: types.optional(types.string, navigator.userAgent),
-  userLanguage: types.string,
-  utcOffset: types.optional(types.string, ((new Date()).getTimezoneOffset() * 60).toString()),
-  viewport: types.frozen({
-    height: types.optional(types.integer, window.innerHeight),
-    width: types.optional(types.integer, window.innerWidth)
-  }),
-  workflowVersion: types.string
-})
-  .actions(self => ({
-    update (newMetadata) {
-      Object.keys(newMetadata).forEach(key => {
-        self[key] = newMetadata[key]
-      })
-    }
-  }))
+import AnnotationsStore from '@store/AnnotationsStore'
+import Resource from '@store/Resource'
+import ClassificationMetadata  from './ClassificationMetadata'
 
 const Classification = types
   .model('Classification', {
@@ -90,5 +52,4 @@ const Classification = types
     return newSnapshot
   })
 
-export { ClassificationMetadata }
 export default types.compose('ClassificationResource', Resource, AnnotationsStore, Classification)

--- a/packages/lib-classifier/src/store/Classification/Classification.spec.js
+++ b/packages/lib-classifier/src/store/Classification/Classification.spec.js
@@ -1,6 +1,6 @@
 import { getSnapshot } from 'mobx-state-tree'
 import taskRegistry from '@plugins/tasks'
-import Classification, { ClassificationMetadata } from './Classification'
+import Classification, { ClassificationMetadata } from './'
 
 describe('Model > Classification', function () {
   let model

--- a/packages/lib-classifier/src/store/Classification/ClassificationMetadata.js
+++ b/packages/lib-classifier/src/store/Classification/ClassificationMetadata.js
@@ -1,0 +1,43 @@
+import { types } from 'mobx-state-tree'
+
+const ClassificationMetadata = types.model('ClassificationMetadata', {
+  classifier_version: types.literal('2.0'),
+  feedback: types.frozen({}),
+  finishedAt: types.maybe(types.string),
+  session: types.maybe(types.string),
+  source: types.enumeration(['api', 'sugar']),
+  startedAt: types.optional(types.string, (new Date()).toISOString()),
+  subjectDimensions: types.array(types.frozen({
+    clientHeight: types.integer,
+    clientWidth: types.integer,
+    naturalHeight: types.integer,
+    naturalWidth: types.integer
+  })),
+  subjectSelectionState: types.frozen({
+    already_seen: types.optional(types.boolean, false),
+    finished_workflow: types.optional(types.boolean, false),
+    retired: types.optional(types.boolean, false),
+    selected_at: types.maybe(types.string),
+    selection_state: types.maybe(types.string),
+    user_has_finished_workflow: types.optional(types.boolean, false)
+  }),
+  subject_flagged: types.optional(types.boolean, false),
+  userAgent: types.optional(types.string, navigator.userAgent),
+  userLanguage: types.string,
+  utcOffset: types.optional(types.string, ((new Date()).getTimezoneOffset() * 60).toString()),
+  viewport: types.frozen({
+    height: types.optional(types.integer, window.innerHeight),
+    width: types.optional(types.integer, window.innerWidth)
+  }),
+  workflowVersion: types.string
+})
+  .actions(self => ({
+    update (newMetadata) {
+      Object.keys(newMetadata).forEach(key => {
+        self[key] = newMetadata[key]
+      })
+    }
+  }))
+
+export default ClassificationMetadata
+  

--- a/packages/lib-classifier/src/store/Classification/ClassificationMetadata.spec.js
+++ b/packages/lib-classifier/src/store/Classification/ClassificationMetadata.spec.js
@@ -1,0 +1,53 @@
+import { getSnapshot } from 'mobx-state-tree'
+import ClassificationMetadata from './ClassificationMetadata'
+
+describe('Model > ClassificationMetadata', function () {
+  let model
+
+  before(function () {
+    model = ClassificationMetadata.create({
+      classifier_version: '2.0',
+      source: 'api',
+      userLanguage: 'en',
+      workflowVersion: '1.0'
+    })
+  })
+
+  it('should exist', function () {
+    expect(model).to.be.ok()
+    expect(model).to.be.an('object')
+  })
+
+  it('should have a classifier version', function () {
+    expect(model.classifier_version).to.equal('2.0')
+  })
+  
+  describe('update', function() {
+    let snapshot
+
+    before(function() {
+      model.update({
+        userLanguage: 'fr',
+        session: 'test session',
+        unknownKey: 5
+      })
+      snapshot = getSnapshot(model)
+    })
+
+    it('should preserve unchanged keys', function () {
+      expect(snapshot.classifier_version).to.equal('2.0')
+    })
+
+    it('should update existing keys', function () {
+      expect(snapshot.userLanguage).to.equal('fr')
+    })
+
+    it('should add new values for known keys', function () {
+      expect(snapshot.session).to.equal('test session')
+    })
+
+    it('should ignore unknown keys', function () {
+      expect(snapshot.unknownKey).to.be.undefined()
+    })
+  })
+})

--- a/packages/lib-classifier/src/store/Classification/index.js
+++ b/packages/lib-classifier/src/store/Classification/index.js
@@ -1,0 +1,2 @@
+export { default } from './Classification'
+export { default as ClassificationMetadata } from './ClassificationMetadata'

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -83,18 +83,6 @@ const ClassificationStore = types
       self.loadingState = asyncStates.success
     }
 
-    function updateClassificationMetadata (newMetadata) {
-      const validClassificationReference = isValidReference(() => self.active)
-      if (validClassificationReference) {
-        const classification = self.active
-        classification.metadata = Object.assign({}, classification.metadata, newMetadata)
-      } else {
-        if (process.browser) {
-          console.error('No active classification. Cannot update metadata')
-        }
-      }
-    }
-
     function addAnnotation (task, annotationValue) {
       const validClassificationReference = isValidReference(() => self.active)
 
@@ -152,7 +140,7 @@ const ClassificationStore = types
         }
 
         // TODO store intervention metadata if we have a user...
-        self.updateClassificationMetadata(metadata)
+        classification.metadata.update(metadata)
 
         classification.completed = true
         // Convert from observables
@@ -206,8 +194,7 @@ const ClassificationStore = types
       onClassificationSaved,
       removeAnnotation,
       setOnComplete,
-      submitClassification: flow(submitClassification),
-      updateClassificationMetadata
+      submitClassification: flow(submitClassification)
     }
   })
 

--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -163,7 +163,14 @@ describe('Model > ClassificationStore', function () {
           drawing: {},
           feedback: invalidFeedbackSnapshot,
           fieldGuide: {},
-          subjectViewer: {},
+          subjectViewer: {
+            dimensions: [{
+              clientHeight: 100,
+              clientWidth: 300,
+              naturalHeight: 200,
+              naturalWidth: 600
+            }]
+          },
           tutorials: {},
           workflowSteps: {},
           userProjectPreferences: {}

--- a/packages/lib-classifier/src/store/WorkflowStepStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.spec.js
@@ -244,7 +244,7 @@ describe('Model > WorkflowStepStore', function () {
       const panoptesClientStub = stubPanoptesJs({ workflows: hiddenSummaryWorkflow, subjects })
       const rootStore = setupStores(panoptesClientStub, project, hiddenSummaryWorkflow)
       rootStore.classifications.createClassification(subject, hiddenSummaryWorkflow, project)
-      rootStore.classifications.updateClassificationMetadata({ subject_flagged: true })
+      rootStore.classifications.active.metadata.update({ subject_flagged: true })
       rootStore.workflowSteps.selectStep('S2')
       expect(rootStore.workflowSteps.shouldWeShowDoneAndTalkButton).to.be.false()
     })


### PR DESCRIPTION
Replace updateClassificationMetadata() with classification.metadata.update().

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
