### PR TITLE
Add frame to InteractionLayer mark creation

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -18,6 +18,7 @@ function InteractionLayer ({
   activeToolIndex,
   children,
   disabled,
+  frame,
   height,
   marks,
   move,
@@ -59,6 +60,7 @@ function InteractionLayer ({
 
     const activeMark = activeTool.createMark({
       id: cuid(),
+      frame,
       toolIndex: activeToolIndex
     })
     activeMark.initialPosition(convertEvent(event))
@@ -127,6 +129,7 @@ InteractionLayer.propTypes = {
   activeMark: PropTypes.object,
   activeTool: PropTypes.object.isRequired,
   activeToolIndex: PropTypes.number,
+  frame: PropTypes.number,
   marks: PropTypes.array,
   setActiveMark: PropTypes.func,
   setSubTaskVisibility: PropTypes.func,
@@ -139,6 +142,7 @@ InteractionLayer.propTypes = {
 InteractionLayer.defaultProps = {
   activeMark: undefined,
   activeToolIndex: 0,
+  frame: 0,
   marks: [],
   setActiveMark: () => {},
   setSubTaskVisibility: () => {},

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -70,6 +70,7 @@ describe('Component > InteractionLayer', function () {
           <InteractionLayer
             activeMark={activeMark}
             activeTool={activeTool}
+            frame={2}
             setActiveMark={setActiveMark}
             height={400}
             width={600}
@@ -116,6 +117,20 @@ describe('Component > InteractionLayer', function () {
         }
         wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
         expect(activeTool.createMark).to.have.been.calledOnce()
+      })
+
+      it('should create a mark with current frame', function () {
+        const fakeEvent = {
+          pointerId: 'fakePointer',
+          type: 'pointerdown',
+          target: {
+            setPointerCapture: sinon.stub(),
+            releasePointerCapture: sinon.stub()
+          }
+        }
+        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+        const createMarkArgs = activeTool.createMark.args[0][0]
+        expect(createMarkArgs.frame).to.equal(2)
       })
 
       it('should place a new mark on pointer down', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -13,6 +13,7 @@ function storeMapper (stores) {
     activeStepTasks
   } = stores.classifierStore.workflowSteps
   const {
+    frame,
     move
   } = stores.classifierStore.subjectViewer
   const {
@@ -30,6 +31,7 @@ function storeMapper (stores) {
   return {
     activeInteractionTask,
     consensusLines,
+    frame,
     interactionTaskAnnotations,
     move,
     workflow
@@ -43,6 +45,7 @@ class InteractionLayerContainer extends Component {
     const {
       activeInteractionTask,
       consensusLines,
+      frame,
       height,
       interactionTaskAnnotations,
       move,
@@ -82,6 +85,7 @@ class InteractionLayerContainer extends Component {
             activeTool={activeTool}
             activeToolIndex={activeToolIndex}
             disabled={activeTool.disabled}
+            frame={frame}
             height={height}
             key={taskKey}
             marks={visibleMarks}
@@ -124,6 +128,7 @@ InteractionLayerContainer.wrappedComponent.propTypes = {
   }),
   consensusLines: PropTypes.array,
   disabled: PropTypes.bool,
+  frame: PropTypes.number,
   height: PropTypes.number.isRequired,
   interactionTaskAnnotations: PropTypes.array,
   move: PropTypes.bool,
@@ -147,6 +152,7 @@ InteractionLayerContainer.wrappedComponent.defaultProps = {
   },
   consensusLines: [],
   disabled: false,
+  frame: 0,
   interactionTaskAnnotations: [],
   move: false,
   scale: 1,


### PR DESCRIPTION
Package: lib-classifier
- http://localhost:8080/?project=1876&workflow=3363

Describe your changes:
- adds related test and refactor to save current frame when creating mark

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
