### PR TITLE
Reorganize task stories. Make TranscriptionLine task type flexible for color

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.stories.js
@@ -62,7 +62,7 @@ rootStore.workflows.setActive(workflowSnapshot.id)
 rootStore.subjects.setResource(subjectSnapshot)
 rootStore.subjects.setActive(subjectSnapshot.id)
 
-storiesOf('TranscribedLines', module)
+storiesOf('Drawing Tools | TranscribedLines', module)
   .add('default', () => (
     <Provider classifierStore={rootStore}>
       <Grommet theme={zooTheme}>

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.stories.js
@@ -45,7 +45,7 @@ class DraggableStory extends Component {
     )
   }
 }
-storiesOf('draggable', module)
+storiesOf('Drawing Tools | draggable', module)
   .addDecorator(withKnobs)
   .addParameters({
     viewport: {

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.js
@@ -14,9 +14,9 @@ const COLOURS = {
   complete: '#8c8c8c'
 }
 
-function TranscriptionLine ({ active, mark, onFinish, scale, state }) {
-  state = active ? 'active' : state
-  const colour = COLOURS[state]
+function TranscriptionLine ({ active, color, mark, onFinish, scale, state }) {
+  // state = active ? 'active' : state
+  const colour = color || COLOURS[state]
   const { x1, y1, x2, y2, finished } = mark
   const handleRadius = HANDLE_RADIUS / scale
 
@@ -94,6 +94,7 @@ function TranscriptionLine ({ active, mark, onFinish, scale, state }) {
 
 TranscriptionLine.propTypes = {
   active: PropTypes.bool,
+  color: PropTypes.string,
   mark: PropTypes.object.isRequired,
   onFinish: PropTypes.func,
   scale: PropTypes.number,
@@ -102,9 +103,10 @@ TranscriptionLine.propTypes = {
 
 TranscriptionLine.defaultProps = {
   active: false,
+  color: '',
   onFinish: () => true,
   scale: 1,
-  state: 'default'
+  state: ''
 }
 
 export default TranscriptionLine

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.spec.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme'
 import TranscriptionLine from './TranscriptionLine'
 import { TranscriptionLine as TranscriptionLineMark } from '../../models/marks'
 import { DragHandle } from '@plugins/drawingTools/components'
+import zooTheme from '@zooniverse/grommet-theme'
 
 describe('Components > Drawing marks > Transcription line', function () {
   let mark
@@ -18,15 +19,17 @@ describe('Components > Drawing marks > Transcription line', function () {
   })
 
   it('should render without crashing', function () {
-    const wrapper = shallow(<TranscriptionLine
-      mark={mark}
-    />)
+    const wrapper = shallow(
+      <TranscriptionLine
+        mark={mark}
+      />
+    )
     expect(wrapper).to.be.ok()
   })
 
   describe('when active', function () {
     it('should not be closed at first', function () {
-      const wrapper = shallow(<TranscriptionLine
+      shallow(<TranscriptionLine
         active
         mark={mark}
       />)
@@ -90,6 +93,26 @@ describe('Components > Drawing marks > Transcription line', function () {
       />)
       wrapper.find('circle[cx=300]').simulate('pointerdown')
       expect(mark.finished).to.be.true()
+    })
+  })
+
+  describe('when used by the drawing task', function () {
+    it('should use the color set for the tool passed as a prop', function () {
+      const tool = {
+        color: zooTheme.global.colors['drawing-orange']
+      }
+      const wrapper = shallow(
+        <TranscriptionLine
+          active
+          color={tool.color}
+          mark={mark}
+        />
+      )
+
+      const outerGroupNode = wrapper.find('g').first()
+      expect(outerGroupNode.props().color).to.equal(tool.color)
+      expect(outerGroupNode.props().fill).to.equal(tool.color)
+      expect(outerGroupNode.props().stroke).to.equal(tool.color)
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
@@ -24,7 +24,7 @@ const drawingTaskSnapshot = DrawingTaskFactory.build({
   instruction: 'Draw a line under the text',
   taskKey: 'T1',
   tools: [{
-    color: zooTheme.global.colors['drawing-red'],
+    color: zooTheme.global.colors['drawing-orange'],
     type: 'transcriptionLine'
   }],
   type: 'drawing'
@@ -38,16 +38,15 @@ const subTasksSnapshot = [
   }
 ]
 
-function setupStores({ activeMark, subtask, lineState }) {
-  lineState ||= {}
+function setupStores({ activeMark, finished, subtask }) {
   if (subtask) {
     drawingTaskSnapshot.tools[0].details = subTasksSnapshot
     drawingTaskSnapshot.subTaskVisibility = true
     // should think of a better way to do this for the story
     // this is a rough approximation of what the positioning is like now
     drawingTaskSnapshot.subTaskMarkBounds = {
-      x: 175,
-      y: 120,
+      x: 245,
+      y: 165,
       width: 0,
       height: 0,
       top: 0,
@@ -60,22 +59,8 @@ function setupStores({ activeMark, subtask, lineState }) {
   const drawingTask = DrawingTask.create(drawingTaskSnapshot)
   drawingTask.setActiveTool(0)
   const transcriptionLine = drawingTask.activeTool.createMark({ x1: 100, y1: 100, x2: 200, y2: 105 })
-  if (lineState.finished) transcriptionLine.finish()
+  if (finished) transcriptionLine.finish()
 
-  if (lineState.transcribed) {
-    subject.transcribedLines = {
-      lines: [
-        { consensusReached: false }
-      ]
-    }
-  }
-  if (lineState.consensus) {
-    subject.transcribedLines = {
-      lines: [
-        { consensusReached: true }
-      ]
-    }
-  }
   const mockStores = {
     classifications: ClassificationStore.create(),
     subjects: {
@@ -137,34 +122,29 @@ class DrawingStory extends Component {
   }
 }
 
-storiesOf('Drawing Tools | Transcription Line', module)
+storiesOf('Drawing Tools | TranscriptionLine', module)
   .addDecorator(withKnobs)
   .addParameters({
     viewport: {
       defaultViewport: 'responsive'
     }
   })
-  .add('drawing finished', function () {
-    const stores = setupStores({ activeMark: false, subtask: false, lineState: { finished: true } })
+  .add('in drawing task, drawing complete', function () {
+    const stores = setupStores({ activeMark: false, finished: true, subtask: false })
     return (
       <DrawingStory stores={stores} />
     )
   })
-  .add('active, unfinished', function () {
+  .add('in drawing task, active', function () {
     const stores = setupStores({ activeMark: true, subtask: false })
     return (
       <DrawingStory stores={stores} />
     )
   })
-  .add('transcribed, no consensus', function () {
-    const stores = setupStores({ activeMark: false, subtask: true, lineState: { transcribed: true } })
+  .add('in drawing task, active, with sub-task', function () {
+    const stores = setupStores({ activeMark: true, subtask: true })
     return (
       <DrawingStory stores={stores} />
     )
   })
-  .add('transcribed, consensus reached', function () {
-    const stores = setupStores({ activeMark: false, subtask: true, lineState: { consensus: true } })
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
+

--- a/packages/lib-classifier/src/plugins/tasks/DataVisAnnotationTask/components/DataVisAnnotationTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/DataVisAnnotationTask/components/DataVisAnnotationTask.stories.js
@@ -6,7 +6,7 @@ import { types } from 'mobx-state-tree'
 import React from 'react'
 import { Box, Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
-import { Tasks } from './Tasks'
+import { Tasks } from '../../../../components/Classifier/components/TaskArea/components/Tasks/Tasks'
 import ClassificationStore from '@store/ClassificationStore'
 import SubjectStore from '@store/SubjectStore'
 import WorkflowStore from '@store/WorkflowStore'
@@ -32,24 +32,24 @@ function createStore() {
     workflows: WorkflowStore,
     workflowSteps: WorkflowStepStore
   })
-  .create({
-    classifications,
-    subjects: SubjectStore.create({}),
-    workflows: WorkflowStore.create({}),
-    workflowSteps: WorkflowStepStore.create({})
-  })
+    .create({
+      classifications,
+      subjects: SubjectStore.create({}),
+      workflows: WorkflowStore.create({}),
+      workflowSteps: WorkflowStepStore.create({})
+    })
   classifications.createClassification(mockSubject, mockWorkflow, mockProject)
   return store
 }
 
 const store = createStore()
-function addStepToStore (step, tasks) {
-  const steps = [ ['S1', step] ]
+function addStepToStore(step, tasks) {
+  const steps = [['S1', step]]
   store.workflowSteps.setStepsAndTasks({ steps, tasks })
   store.workflowSteps.active.tasks.forEach(task => store.classifications.addAnnotation(task))
 }
 
-function MockTask (props) {
+function MockTask(props) {
   const { dark, ...taskProps } = props
 
   return (
@@ -77,53 +77,31 @@ function MockTask (props) {
   )
 }
 
-storiesOf('Tasks | General', module)
+storiesOf('Tasks | Data Visualization Annotation', module)
   .addDecorator(withKnobs)
   .addParameters({
     viewport: {
       defaultViewport: 'responsive'
     }
   })
-  .add('loading', function () {
-    return (
-      <Provider classifierStore={{}}>
-        <MockTask
-          loadingState={asyncStates.loading}
-        />
-      </Provider>
-    )
-  })
-  .add('error', function () {
-    return (
-      <Provider classifierStore={{}}>
-        <MockTask
-          loadingState={asyncStates.error}
-        />
-      </Provider>
-    )
-  })
-  .add('multiple tasks', function () {
+  .add('light theme', function () {
     const tasks = {
-      init: {
-        answers: [{ label: 'yes' }, { label: 'no' }],
-        help: 'Choose an answer from the choices given, then press Done.',
-        question: 'Is there a cat?',
-        required: boolean('Required', false),
-        taskKey: 'init',
-        type: 'single'
-      },
-      T1: {
-        answers: [{ label: 'sleeping' }, { label: 'playing' }, { label: 'looking indifferent' }],
-        help: 'Pick as many answers as apply, then press Done.',
-        question: 'What is it doing?',
-        required: false,
-        taskKey: 'T1',
-        type: 'multiple'
+      T4: {
+        instruction: 'Do you spot a transit?',
+        taskKey: 'T4',
+        tools: [
+          {
+            help: '',
+            label: 'Transit?',
+            type: 'graph2dRangeX'
+          }
+        ],
+        type: 'dataVisAnnotation'
       }
     }
     const step = {
       stepKey: 'S1',
-      taskKeys: ['init', 'T1']
+      taskKeys: ['T4']
     }
     addStepToStore(step, tasks)
     const dark = boolean('Dark theme', false)

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/components/DrawingTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/components/DrawingTask.stories.js
@@ -6,7 +6,7 @@ import { types } from 'mobx-state-tree'
 import React from 'react'
 import { Box, Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
-import { Tasks } from './Tasks'
+import { Tasks } from '../../../../components/Classifier/components/TaskArea/components/Tasks/Tasks'
 import ClassificationStore from '@store/ClassificationStore'
 import SubjectStore from '@store/SubjectStore'
 import WorkflowStore from '@store/WorkflowStore'
@@ -32,24 +32,24 @@ function createStore() {
     workflows: WorkflowStore,
     workflowSteps: WorkflowStepStore
   })
-  .create({
-    classifications,
-    subjects: SubjectStore.create({}),
-    workflows: WorkflowStore.create({}),
-    workflowSteps: WorkflowStepStore.create({})
-  })
+    .create({
+      classifications,
+      subjects: SubjectStore.create({}),
+      workflows: WorkflowStore.create({}),
+      workflowSteps: WorkflowStepStore.create({})
+    })
   classifications.createClassification(mockSubject, mockWorkflow, mockProject)
   return store
 }
 
 const store = createStore()
-function addStepToStore (step, tasks) {
-  const steps = [ ['S1', step] ]
+function addStepToStore(step, tasks) {
+  const steps = [['S1', step]]
   store.workflowSteps.setStepsAndTasks({ steps, tasks })
   store.workflowSteps.active.tasks.forEach(task => store.classifications.addAnnotation(task))
 }
 
-function MockTask (props) {
+function MockTask(props) {
   const { dark, ...taskProps } = props
 
   return (
@@ -77,53 +77,55 @@ function MockTask (props) {
   )
 }
 
-storiesOf('Tasks | General', module)
+storiesOf('Tasks | Drawing Task', module)
   .addDecorator(withKnobs)
   .addParameters({
     viewport: {
       defaultViewport: 'responsive'
     }
   })
-  .add('loading', function () {
-    return (
-      <Provider classifierStore={{}}>
-        <MockTask
-          loadingState={asyncStates.loading}
-        />
-      </Provider>
-    )
-  })
-  .add('error', function () {
-    return (
-      <Provider classifierStore={{}}>
-        <MockTask
-          loadingState={asyncStates.error}
-        />
-      </Provider>
-    )
-  })
-  .add('multiple tasks', function () {
+  .add('drawing', function () {
     const tasks = {
-      init: {
-        answers: [{ label: 'yes' }, { label: 'no' }],
-        help: 'Choose an answer from the choices given, then press Done.',
-        question: 'Is there a cat?',
-        required: boolean('Required', false),
-        taskKey: 'init',
-        type: 'single'
-      },
-      T1: {
-        answers: [{ label: 'sleeping' }, { label: 'playing' }, { label: 'looking indifferent' }],
-        help: 'Pick as many answers as apply, then press Done.',
-        question: 'What is it doing?',
-        required: false,
-        taskKey: 'T1',
-        type: 'multiple'
+      T2: {
+        help: 'Draw on the image.',
+        instruction: 'Draw something',
+        taskKey: 'T2',
+        tools: [
+          {
+            color: zooTheme.global.colors['drawing-red'],
+            help: '',
+            label: 'Draw a line',
+            type: 'line'
+          }, {
+            color: zooTheme.global.colors['drawing-blue'],
+            help: '',
+            label: 'Point please.',
+            min: 1,
+            max: 2,
+            type: 'point',
+          }, {
+            color: zooTheme.global.colors['drawing-green'],
+            help: '',
+            label: 'Draw under the text',
+            type: 'transcriptionLine'
+          }, {
+            color: zooTheme.global.colors['drawing-orange'],
+            help: '',
+            label: 'Draw a rectangle',
+            type: 'rectangle',
+          }, {
+            color: zooTheme.global.colors['drawing-yellow'],
+            help: '',
+            label: 'Draw an ellipse',
+            type: 'ellipse',
+          }
+        ],
+        type: 'drawing'
       }
     }
     const step = {
       stepKey: 'S1',
-      taskKeys: ['init', 'T1']
+      taskKeys: ['T2']
     }
     addStepToStore(step, tasks)
     const dark = boolean('Dark theme', false)

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.stories.js
@@ -6,7 +6,7 @@ import { types } from 'mobx-state-tree'
 import React from 'react'
 import { Box, Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
-import { Tasks } from './Tasks'
+import { Tasks } from '../../../../components/Classifier/components/TaskArea/components/Tasks/Tasks'
 import ClassificationStore from '@store/ClassificationStore'
 import SubjectStore from '@store/SubjectStore'
 import WorkflowStore from '@store/WorkflowStore'
@@ -32,24 +32,24 @@ function createStore() {
     workflows: WorkflowStore,
     workflowSteps: WorkflowStepStore
   })
-  .create({
-    classifications,
-    subjects: SubjectStore.create({}),
-    workflows: WorkflowStore.create({}),
-    workflowSteps: WorkflowStepStore.create({})
-  })
+    .create({
+      classifications,
+      subjects: SubjectStore.create({}),
+      workflows: WorkflowStore.create({}),
+      workflowSteps: WorkflowStepStore.create({})
+    })
   classifications.createClassification(mockSubject, mockWorkflow, mockProject)
   return store
 }
 
 const store = createStore()
-function addStepToStore (step, tasks) {
-  const steps = [ ['S1', step] ]
+function addStepToStore(step, tasks) {
+  const steps = [['S1', step]]
   store.workflowSteps.setStepsAndTasks({ steps, tasks })
   store.workflowSteps.active.tasks.forEach(task => store.classifications.addAnnotation(task))
 }
 
-function MockTask (props) {
+function MockTask(props) {
   const { dark, ...taskProps } = props
 
   return (
@@ -77,41 +77,15 @@ function MockTask (props) {
   )
 }
 
-storiesOf('Tasks | General', module)
+storiesOf('Tasks | Multiple Choice Question', module)
   .addDecorator(withKnobs)
   .addParameters({
     viewport: {
       defaultViewport: 'responsive'
     }
   })
-  .add('loading', function () {
-    return (
-      <Provider classifierStore={{}}>
-        <MockTask
-          loadingState={asyncStates.loading}
-        />
-      </Provider>
-    )
-  })
-  .add('error', function () {
-    return (
-      <Provider classifierStore={{}}>
-        <MockTask
-          loadingState={asyncStates.error}
-        />
-      </Provider>
-    )
-  })
-  .add('multiple tasks', function () {
+.add('light theme', function () {
     const tasks = {
-      init: {
-        answers: [{ label: 'yes' }, { label: 'no' }],
-        help: 'Choose an answer from the choices given, then press Done.',
-        question: 'Is there a cat?',
-        required: boolean('Required', false),
-        taskKey: 'init',
-        type: 'single'
-      },
       T1: {
         answers: [{ label: 'sleeping' }, { label: 'playing' }, { label: 'looking indifferent' }],
         help: 'Pick as many answers as apply, then press Done.',
@@ -123,7 +97,7 @@ storiesOf('Tasks | General', module)
     }
     const step = {
       stepKey: 'S1',
-      taskKeys: ['init', 'T1']
+      taskKeys: ['T1']
     }
     addStepToStore(step, tasks)
     const dark = boolean('Dark theme', false)

--- a/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.stories.js
@@ -6,7 +6,7 @@ import { types } from 'mobx-state-tree'
 import React from 'react'
 import { Box, Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
-import { Tasks } from './Tasks'
+import { Tasks } from '../../../../components/Classifier/components/TaskArea/components/Tasks/Tasks'
 import ClassificationStore from '@store/ClassificationStore'
 import SubjectStore from '@store/SubjectStore'
 import WorkflowStore from '@store/WorkflowStore'
@@ -32,24 +32,24 @@ function createStore() {
     workflows: WorkflowStore,
     workflowSteps: WorkflowStepStore
   })
-  .create({
-    classifications,
-    subjects: SubjectStore.create({}),
-    workflows: WorkflowStore.create({}),
-    workflowSteps: WorkflowStepStore.create({})
-  })
+    .create({
+      classifications,
+      subjects: SubjectStore.create({}),
+      workflows: WorkflowStore.create({}),
+      workflowSteps: WorkflowStepStore.create({})
+    })
   classifications.createClassification(mockSubject, mockWorkflow, mockProject)
   return store
 }
 
 const store = createStore()
-function addStepToStore (step, tasks) {
-  const steps = [ ['S1', step] ]
+function addStepToStore(step, tasks) {
+  const steps = [['S1', step]]
   store.workflowSteps.setStepsAndTasks({ steps, tasks })
   store.workflowSteps.active.tasks.forEach(task => store.classifications.addAnnotation(task))
 }
 
-function MockTask (props) {
+function MockTask(props) {
   const { dark, ...taskProps } = props
 
   return (
@@ -76,33 +76,14 @@ function MockTask (props) {
     </Grommet>
   )
 }
-
-storiesOf('Tasks | General', module)
+storiesOf('Tasks | Single Choice Question', module)
   .addDecorator(withKnobs)
   .addParameters({
     viewport: {
       defaultViewport: 'responsive'
     }
   })
-  .add('loading', function () {
-    return (
-      <Provider classifierStore={{}}>
-        <MockTask
-          loadingState={asyncStates.loading}
-        />
-      </Provider>
-    )
-  })
-  .add('error', function () {
-    return (
-      <Provider classifierStore={{}}>
-        <MockTask
-          loadingState={asyncStates.error}
-        />
-      </Provider>
-    )
-  })
-  .add('multiple tasks', function () {
+  .add('light theme', function () {
     const tasks = {
       init: {
         answers: [{ label: 'yes' }, { label: 'no' }],
@@ -111,19 +92,11 @@ storiesOf('Tasks | General', module)
         required: boolean('Required', false),
         taskKey: 'init',
         type: 'single'
-      },
-      T1: {
-        answers: [{ label: 'sleeping' }, { label: 'playing' }, { label: 'looking indifferent' }],
-        help: 'Pick as many answers as apply, then press Done.',
-        question: 'What is it doing?',
-        required: false,
-        taskKey: 'T1',
-        type: 'multiple'
       }
     }
     const step = {
       stepKey: 'S1',
-      taskKeys: ['init', 'T1']
+      taskKeys: ['init']
     }
     addStepToStore(step, tasks)
     const dark = boolean('Dark theme', false)

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.stories.js
@@ -6,7 +6,7 @@ import { types } from 'mobx-state-tree'
 import React from 'react'
 import { Box, Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
-import { Tasks } from './Tasks'
+import { Tasks } from '../../../../../components/Classifier/components/TaskArea/components/Tasks/Tasks'
 import ClassificationStore from '@store/ClassificationStore'
 import SubjectStore from '@store/SubjectStore'
 import WorkflowStore from '@store/WorkflowStore'
@@ -32,24 +32,24 @@ function createStore() {
     workflows: WorkflowStore,
     workflowSteps: WorkflowStepStore
   })
-  .create({
-    classifications,
-    subjects: SubjectStore.create({}),
-    workflows: WorkflowStore.create({}),
-    workflowSteps: WorkflowStepStore.create({})
-  })
+    .create({
+      classifications,
+      subjects: SubjectStore.create({}),
+      workflows: WorkflowStore.create({}),
+      workflowSteps: WorkflowStepStore.create({})
+    })
   classifications.createClassification(mockSubject, mockWorkflow, mockProject)
   return store
 }
 
 const store = createStore()
-function addStepToStore (step, tasks) {
-  const steps = [ ['S1', step] ]
+function addStepToStore(step, tasks) {
+  const steps = [['S1', step]]
   store.workflowSteps.setStepsAndTasks({ steps, tasks })
   store.workflowSteps.active.tasks.forEach(task => store.classifications.addAnnotation(task))
 }
 
-function MockTask (props) {
+function MockTask(props) {
   const { dark, ...taskProps } = props
 
   return (
@@ -77,53 +77,26 @@ function MockTask (props) {
   )
 }
 
-storiesOf('Tasks | General', module)
+storiesOf('Tasks | Text', module)
   .addDecorator(withKnobs)
   .addParameters({
     viewport: {
       defaultViewport: 'responsive'
     }
   })
-  .add('loading', function () {
-    return (
-      <Provider classifierStore={{}}>
-        <MockTask
-          loadingState={asyncStates.loading}
-        />
-      </Provider>
-    )
-  })
-  .add('error', function () {
-    return (
-      <Provider classifierStore={{}}>
-        <MockTask
-          loadingState={asyncStates.error}
-        />
-      </Provider>
-    )
-  })
-  .add('multiple tasks', function () {
+.add('light theme', function () {
     const tasks = {
-      init: {
-        answers: [{ label: 'yes' }, { label: 'no' }],
-        help: 'Choose an answer from the choices given, then press Done.',
-        question: 'Is there a cat?',
-        required: boolean('Required', false),
-        taskKey: 'init',
-        type: 'single'
-      },
-      T1: {
-        answers: [{ label: 'sleeping' }, { label: 'playing' }, { label: 'looking indifferent' }],
-        help: 'Pick as many answers as apply, then press Done.',
-        question: 'What is it doing?',
-        required: false,
-        taskKey: 'T1',
-        type: 'multiple'
+      T0: {
+        help: 'Type something into the text box.',
+        instruction: 'Type something here',
+        taskKey: 'T0',
+        text_tags: ['insertion', 'deletion'],
+        type: 'text'
       }
     }
     const step = {
       stepKey: 'S1',
-      taskKeys: ['init', 'T1']
+      taskKeys: ['T0']
     }
     addStepToStore(step, tasks)
     const dark = boolean('Dark theme', false)

--- a/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/TranscriptionTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/TranscriptionTask.stories.js
@@ -6,7 +6,7 @@ import { types } from 'mobx-state-tree'
 import React from 'react'
 import { Box, Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
-import { Tasks } from './Tasks'
+import { Tasks } from '../../../../components/Classifier/components/TaskArea/components/Tasks/Tasks'
 import ClassificationStore from '@store/ClassificationStore'
 import SubjectStore from '@store/SubjectStore'
 import WorkflowStore from '@store/WorkflowStore'
@@ -32,24 +32,24 @@ function createStore() {
     workflows: WorkflowStore,
     workflowSteps: WorkflowStepStore
   })
-  .create({
-    classifications,
-    subjects: SubjectStore.create({}),
-    workflows: WorkflowStore.create({}),
-    workflowSteps: WorkflowStepStore.create({})
-  })
+    .create({
+      classifications,
+      subjects: SubjectStore.create({}),
+      workflows: WorkflowStore.create({}),
+      workflowSteps: WorkflowStepStore.create({})
+    })
   classifications.createClassification(mockSubject, mockWorkflow, mockProject)
   return store
 }
 
 const store = createStore()
-function addStepToStore (step, tasks) {
-  const steps = [ ['S1', step] ]
+function addStepToStore(step, tasks) {
+  const steps = [['S1', step]]
   store.workflowSteps.setStepsAndTasks({ steps, tasks })
   store.workflowSteps.active.tasks.forEach(task => store.classifications.addAnnotation(task))
 }
 
-function MockTask (props) {
+function MockTask(props) {
   const { dark, ...taskProps } = props
 
   return (
@@ -77,53 +77,32 @@ function MockTask (props) {
   )
 }
 
-storiesOf('Tasks | General', module)
+storiesOf('Tasks | Transcription', module)
   .addDecorator(withKnobs)
   .addParameters({
     viewport: {
       defaultViewport: 'responsive'
     }
   })
-  .add('loading', function () {
-    return (
-      <Provider classifierStore={{}}>
-        <MockTask
-          loadingState={asyncStates.loading}
-        />
-      </Provider>
-    )
-  })
-  .add('error', function () {
-    return (
-      <Provider classifierStore={{}}>
-        <MockTask
-          loadingState={asyncStates.error}
-        />
-      </Provider>
-    )
-  })
-  .add('multiple tasks', function () {
+  .add('light theme', function () {
     const tasks = {
-      init: {
-        answers: [{ label: 'yes' }, { label: 'no' }],
-        help: 'Choose an answer from the choices given, then press Done.',
-        question: 'Is there a cat?',
-        required: boolean('Required', false),
-        taskKey: 'init',
-        type: 'single'
-      },
-      T1: {
-        answers: [{ label: 'sleeping' }, { label: 'playing' }, { label: 'looking indifferent' }],
-        help: 'Pick as many answers as apply, then press Done.',
-        question: 'What is it doing?',
-        required: false,
-        taskKey: 'T1',
-        type: 'multiple'
+      T3: {
+        help: 'Underline the line to transcribe with two clicks, then enter in the text transcription.',
+        instruction: 'Underline and transcribe',
+        taskKey: 'T3',
+        tools: [
+          {
+            help: '',
+            label: 'Draw under the text',
+            type: 'transcriptionLine'
+          }
+        ],
+        type: 'transcription'
       }
     }
     const step = {
       stepKey: 'S1',
-      taskKeys: ['init', 'T1']
+      taskKeys: ['T3']
     }
     addStepToStore(step, tasks)
     const dark = boolean('Dark theme', false)

--- a/packages/lib-classifier/test/factories/tasks/TranscriptionTaskFactory.js
+++ b/packages/lib-classifier/test/factories/tasks/TranscriptionTaskFactory.js
@@ -1,0 +1,14 @@
+import { Factory } from 'rosie'
+
+export default new Factory()
+  .attr('help', '')
+  .attr('instruction', 'Please transcribe the text')
+  .attr('tools', [{
+    details: [{
+      instruction: 'transcribe the text.',
+      taskKey: 'T0.0',
+      type: 'text'
+    }],
+    type: 'transcriptionLine'
+  }])
+  .attr('type', 'transcription')


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

Describe your changes:
Reorganizes the stories to be closer to their code and enables us to add multiple stories per task. Refactored `TranscriptionLine` to be task flexible as we want to allow project builders to use the tool type in either the drawing task or transcription task. The colors are only hardcoded and have meaning for the transcription task, so this adds a `color` prop back to the `TranscriptionLine` and set the default state to be an empty string. The `state` prop will only be set by the TranscriptionTask or TranscribedLines models in a follow up PR.

As an aside, the task stories refactor and the TranscriptionLine refactor don't really have to be in the same PR, so happy to split out if requested. I just got there because I like starting with stories and the organization was just confusing previously. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
