### PR TITLE
Add marks filter per frame

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -69,6 +69,7 @@ class InteractionLayerContainer extends Component {
     } = activeInteractionTask
 
     const visibleMarks = hidePreviousMarks ? marks.slice(hidingIndex) : marks
+    const visibleMarksPerFrame = visibleMarks?.filter(mark => mark.frame === frame)
 
     return (
       <>
@@ -88,7 +89,7 @@ class InteractionLayerContainer extends Component {
             frame={frame}
             height={height}
             key={taskKey}
-            marks={visibleMarks}
+            marks={visibleMarksPerFrame}
             move={move}
             scale={scale}
             setActiveMark={setActiveMark}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.spec.js
@@ -103,6 +103,59 @@ describe('Component > InteractionLayerContainer', function () {
       expect(wrapper.find(TranscribedLines)).to.have.lengthOf(1)
     })
 
+    it('should render TranscribedLines exclusively per frame', function () {
+      const activeTask = {
+        hidePreviousMarks: false,
+        hidingIndex: 0,
+        marks: [
+          {
+            id: '1',
+            frame: 0,
+            toolIndex: 0,
+            toolType: 'transcriptionLine',
+            x1: 100,
+            y1: 100,
+            x2: 400,
+            y2: 101
+          },
+          {
+            id: '2',
+            frame: 0,
+            toolIndex: 0,
+            toolType: 'transcriptionLine',
+            x1: 100,
+            y1: 200,
+            x2: 400,
+            y2: 201
+          },
+          {
+            id: '3',
+            frame: 1,
+            toolIndex: 0,
+            toolType: 'transcriptionLine',
+            x1: 100,
+            y1: 100,
+            x2: 400,
+            y2: 101
+          }
+        ]
+      }
+      const activeTranscriptionTask = Object.assign(activeTask, transcriptionTask)
+
+      const wrapper = shallow(
+        <InteractionLayerContainer.wrappedComponent
+          height={height}
+          width={width}
+          frame={1}
+          activeInteractionTask={activeTranscriptionTask}
+          workflow={{ usesTranscriptionTask: true }}
+        />
+      )
+
+      const { marks } = wrapper.find(InteractionLayer).props()
+      expect(marks).to.have.lengthOf(1)
+    })
+
     describe('and hiding previous marks', function () {
       let wrapper
 
@@ -110,7 +163,7 @@ describe('Component > InteractionLayerContainer', function () {
         const hidingTask = {
           hidePreviousMarks: true,
           hidingIndex: 1,
-          marks: [{ x: 0, y: 0 }, { x: 5, y: 5}]
+          marks: [{ x: 0, y: 0, frame: 0 }, { x: 5, y: 5, frame: 0 }]
         }
         const hidingMarksInteractionTask = Object.assign(hidingTask, transcriptionTask)
         wrapper = shallow(

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.spec.js
@@ -140,20 +140,23 @@ describe('Component > InteractionLayerContainer', function () {
           }
         ]
       }
-      const activeTranscriptionTask = Object.assign(activeTask, transcriptionTask)
+      const activeTranscriptionTask = Object.assign({}, activeTask, transcriptionTask)
 
       const wrapper = shallow(
         <InteractionLayerContainer.wrappedComponent
           height={height}
           width={width}
-          frame={1}
+          frame={0}
           activeInteractionTask={activeTranscriptionTask}
           workflow={{ usesTranscriptionTask: true }}
         />
       )
 
-      const { marks } = wrapper.find(InteractionLayer).props()
-      expect(marks).to.have.lengthOf(1)
+      const firstFrameMarks = wrapper.find(InteractionLayer).prop('marks')
+      expect(firstFrameMarks).to.have.lengthOf(2)
+      wrapper.setProps({ frame: 1 })
+      const secondFrameMarks = wrapper.find(InteractionLayer).prop('marks')
+      expect(secondFrameMarks).to.have.lengthOf(1)
     })
 
     describe('and hiding previous marks', function () {


### PR DESCRIPTION
Package: lib-classifier

Towards #1625. 

Describe your changes:
- filters marks by current frame

For a subsequent PR - filtering marks by frame should be dependent on [workflow/subject-viewer configuration](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/store/Workflow/WorkflowConfiguration/WorkflowConfiguration.js#L9) as while a transcription workflow would likely want this behavior a survey workflow may not, similar to #1538. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
