### PR TITLE
Content pages: Abort static page builds on API errors

### DIFF
--- a/packages/app-content-pages/src/screens/Publications/PublicationsContainer.js
+++ b/packages/app-content-pages/src/screens/Publications/PublicationsContainer.js
@@ -8,17 +8,11 @@ import Publications from './Publications'
 counterpart.registerTranslations('en', en)
 
 function PublicationsContainer(props) {
-  const { error, publicationsData } = props
+  const { publicationsData } = props
   const [activeFilter, setActiveFilter] = useState(null)
 
   const filters = createFilters(publicationsData, activeFilter, setActiveFilter)
   const filteredPublicationsData = createFilteredPublicationsData(publicationsData, activeFilter)
-
-  if (error) {
-    return (
-      <div>{counterpart('Publications.error')}</div>
-    )
-  }
 
   return (
     <Publications filters={filters} data={filteredPublicationsData} />
@@ -26,8 +20,7 @@ function PublicationsContainer(props) {
 }
 
 PublicationsContainer.propTypes = {
-  error: string,
-  publicationsData: array,
+  publicationsData: array
 }
 
 PublicationsContainer.defaultProps = {

--- a/packages/app-content-pages/src/screens/Publications/getStaticProps.js
+++ b/packages/app-content-pages/src/screens/Publications/getStaticProps.js
@@ -1,18 +1,17 @@
 import PublicationsAPI  from '../../api/publications'
+import { logNodeError } from '../../helpers/logger'
 
 export default async function getStaticProps() {
-  let error = null
-  let publicationsData = []
   try {
-    publicationsData = await PublicationsAPI.createPublicationsResponse()
-  } catch (err) {
-    error = err.message
-  }
-  return {
-    props: {
-      error,
-      publicationsData
-    },
-    unstable_revalidate: 60 * 60 * 1
+    const  publicationsData = await PublicationsAPI.createPublicationsResponse()
+    return {
+      props: {
+        publicationsData
+      },
+      unstable_revalidate: 60 * 60 * 1
+    }
+  } catch (error) {
+    logNodeError(error)
+    throw error
   }
 }

--- a/packages/app-content-pages/src/screens/Publications/getStaticProps.spec.js
+++ b/packages/app-content-pages/src/screens/Publications/getStaticProps.spec.js
@@ -19,7 +19,6 @@ describe('Component > PublicationsContainer > getStaticProps', function () {
       getpublicationsDataStub = sinon.stub(PublicationsAPI, 'createPublicationsResponse').returns(Promise.resolve(DATA))
       const { props } = await getStaticProps({})
       expect(props).to.deep.equal({
-        error: null,
         publicationsData: DATA
       })
     })
@@ -28,20 +27,22 @@ describe('Component > PublicationsContainer > getStaticProps', function () {
       getpublicationsDataStub = sinon.stub(PublicationsAPI, 'createPublicationsResponse').returns(Promise.resolve([]))
       const { props } = await getStaticProps({})
       expect(props).to.deep.equal({
-        error: null,
         publicationsData: []
       })
     })
 
-    it('should handle API errors', async () => {
-      var errorMsg = 'failed to connect to API'
-      var errorPromise = Promise.reject(new Error(errorMsg))
+    it('should throw on API errors', async () => {
+      const errorMsg = 'failed to connect to API'
+      const mockError = new Error(errorMsg)
+      const errorPromise = Promise.reject(mockError)
       getpublicationsDataStub = sinon.stub(PublicationsAPI, 'createPublicationsResponse').returns(errorPromise)
-      const { props } = await getStaticProps({})
-      expect(props).to.deep.equal({
-        error: errorMsg,
-        publicationsData: []
-      })
+      let actualError
+      try {
+        const { props } = await getStaticProps({})
+      } catch (error) {
+        actualError = error
+      }
+      expect(actualError).to.equal(mockError)
     })
   })
 })

--- a/packages/app-content-pages/src/screens/Team/TeamContainer.js
+++ b/packages/app-content-pages/src/screens/Team/TeamContainer.js
@@ -8,17 +8,11 @@ import Team from './Team'
 counterpart.registerTranslations('en', en)
 
 function TeamContainer (props) {
-  const { error, teamData } = props
+  const { teamData } = props
   const [activeFilter, setActiveFilter] = useState(null)
 
   const filters = createFilters(teamData, activeFilter, setActiveFilter)
   const filteredTeamData = createFilteredTeamData(teamData, activeFilter)
-
-  if (error) {
-    return (
-      <div>{counterpart('Team.error')}</div>
-    )
-  }
 
   return (
     <Team filters={filters} data={filteredTeamData} />
@@ -26,8 +20,7 @@ function TeamContainer (props) {
 }
 
 TeamContainer.propTypes = {
-  error: string,
-  teamData: array,
+  teamData: array
 }
 
 TeamContainer.defaultProps = {

--- a/packages/app-content-pages/src/screens/Team/getStaticProps.js
+++ b/packages/app-content-pages/src/screens/Team/getStaticProps.js
@@ -1,18 +1,17 @@
 import TeamAPI  from '../../api/team'
+import { logNodeError } from '../../helpers/logger'
 
 export default async function getStaticProps() {
-  let error = null
-  let teamData = []
   try {
-    teamData = await TeamAPI.createTeamResponse()
-  } catch (err) {
-    error = err.message
-  }
-  return {
-    props: {
-      error,
-      teamData
-    },
-    unstable_revalidate: 60 * 60 * 1
+    const  teamData = await TeamAPI.createTeamResponse()
+    return {
+      props: {
+        teamData
+      },
+      unstable_revalidate: 60 * 60 * 1
+    }
+  } catch (error) {
+    logNodeError(error)
+    throw error
   }
 }

--- a/packages/app-content-pages/src/screens/Team/getStaticProps.spec.js
+++ b/packages/app-content-pages/src/screens/Team/getStaticProps.spec.js
@@ -19,7 +19,6 @@ describe('Component > TeamContainer > getStaticProps', function () {
       getTeamDataStub = sinon.stub(TeamAPI, 'createTeamResponse').returns(Promise.resolve(DATA))
       const { props } = await getStaticProps({})
       expect(props).to.deep.equal({
-        error: null,
         teamData: DATA
       })
     })
@@ -28,20 +27,22 @@ describe('Component > TeamContainer > getStaticProps', function () {
       getTeamDataStub = sinon.stub(TeamAPI, 'createTeamResponse').returns(Promise.resolve([]))
       const { props } = await getStaticProps({})
       expect(props).to.deep.equal({
-        error: null,
         teamData: []
       })
     })
 
-    it('should handle API errors', async () => {
-      var errorMsg = 'failed to connect to API'
-      var errorPromise = Promise.reject(new Error(errorMsg))
+    it('should throw on API errors', async () => {
+      const errorMsg = 'failed to connect to API'
+      const mockError = new Error(errorMsg)
+      const errorPromise = Promise.reject(mockError)
       getTeamDataStub = sinon.stub(TeamAPI, 'createTeamResponse').returns(errorPromise)
-      const { props } = await getStaticProps({})
-      expect(props).to.deep.equal({
-        error: errorMsg,
-        teamData: []
-      })
+      let actualError
+      try {
+        const { props } = await getStaticProps({})
+      } catch (error) {
+        actualError = error
+      }
+      expect(actualError).to.equal(mockError)
     })
   })
 })

--- a/packages/app-content-pages/src/screens/Team/locales/en.json
+++ b/packages/app-content-pages/src/screens/Team/locales/en.json
@@ -1,6 +1,5 @@
 {
   "Team": {
-    "error": "There was an error fetching the Team data. Please refresh and try again.",
     "description": "The people who make the Zooniverse.",
     "showAll": "Show all",
     "title": "Our Team"


### PR DESCRIPTION
On API errors, we don't want to build a static page which is then served for the next hour. Instead, log the error to Sentry and rethrow. NextJS should serve up its default 500 error page, then attempt to rebuild on the next request.

Package:
app-content-pages

Closes #1687.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
