### PR TITLE
Add activeMark subTaskVisibility check to SubTaskPopup render

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopupContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopupContainer.js
@@ -21,7 +21,7 @@ export default observer(function SubTaskPopupContainer (props) {
     activeMark
   } = useStores()
 
-  if (!activeMark) return null
+  if (!activeMark || !activeMark.subTaskVisibility) return null
 
   return (
     <SubTaskPopup

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopupContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopupContainer.spec.js
@@ -42,39 +42,51 @@ describe('Component > SubTaskPopupContainer', function () {
   describe('when the task is drawing', function () {
     it('should render nothing when an active mark isn\'t defined', function () {
       mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('drawing'))
-      const wrapper = shallow(<SubTaskPopupContainer />)
+      wrapper = shallow(<SubTaskPopupContainer />)
+      expect(wrapper.html()).to.be.null()
+    })
+
+    it('should render nothing when an active mark subTaskVisibility is false', function () {
+      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('drawing', { id: 'mark1', subTaskVisibility: false }))
+      wrapper = shallow(<SubTaskPopupContainer />)
       expect(wrapper.html()).to.be.null()
     })
 
     it('should render a SubTaskPopup', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('drawing', { id: 'mark1' }))
+      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('drawing', { id: 'mark1', subTaskVisibility: true }))
       wrapper = shallow(<SubTaskPopupContainer />)
       expect(wrapper.find(SubTaskPopup)).to.have.lengthOf(1)
     })
 
     it('should pass the activeMark to the SubTaskPopup', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('drawing', { id: 'mark1' }))
-      expect(wrapper.find(SubTaskPopup).props().activeMark).to.deep.equal({ id: 'mark1' })
+      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('drawing', { id: 'mark1', subTaskVisibility: true }))
+      expect(wrapper.find(SubTaskPopup).props().activeMark).to.deep.equal({ id: 'mark1', subTaskVisibility: true })
     })
   })
 
   describe('when the task is transcription', function () {
     it('should render nothing when an active mark isn\'t defined', function () {
       mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('transcription'))
-      const wrapper = shallow(<SubTaskPopupContainer />)
+      wrapper = shallow(<SubTaskPopupContainer />)
+      expect(wrapper.html()).to.be.null()
+    })
+
+    it('should render nothing when an active mark subTaskVisibility is false', function () {
+      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('transcription', { id: 'mark2', subTaskVisibility: false }))
+      wrapper = shallow(<SubTaskPopupContainer />)
       expect(wrapper.html()).to.be.null()
     })
 
     it('should render a SubTaskPopup', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('transcription', { id: 'mark2' }))
+      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('transcription', { id: 'mark2', subTaskVisibility: true }))
       wrapper = shallow(<SubTaskPopupContainer />)
       expect(wrapper.find(SubTaskPopup)).to.have.lengthOf(1)
     })
 
     it('should pass the activeMark to the SubTaskPopup', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('transcription', { id: 'mark2' }))
+      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('transcription', { id: 'mark2', subTaskVisibility: true }))
       wrapper = shallow(<SubTaskPopupContainer />)
-      expect(wrapper.find(SubTaskPopup).props().activeMark).to.deep.equal({ id: 'mark2' })
+      expect(wrapper.find(SubTaskPopup).props().activeMark).to.deep.equal({ id: 'mark2', subTaskVisibility: true })
     })
   })
 })


### PR DESCRIPTION
Package: lib-classifier

Describe your changes:
- in SubTaskPopupContainer adds check for `activeMark.subTaskVisibility`, if `false` return `null`, if `true` return `SubTaskPopup` component

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
