### PR TITLE
ZRC: export ZooniverseLogotype

### DIFF
--- a/packages/lib-react-components/src/index.js
+++ b/packages/lib-react-components/src/index.js
@@ -17,6 +17,7 @@ export { default as Tooltip } from './Tooltip'
 export { default as ZooFooter } from './ZooFooter'
 export { default as ZooHeader } from './ZooHeader'
 export { default as ZooniverseLogo } from './ZooniverseLogo'
+export { default as ZooniverseLogotype } from './ZooniverseLogotype'
 
 export { default as pxToRem } from './helpers/pxToRem'
 export { default as withCustomFormik } from './helpers/withCustomFormik'


### PR DESCRIPTION
Export the ZooniverseLogotype component from Zooniverse React Components.

Package:
lib-react-components

Closes #1708.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
