### PR TITLE
Refactor transcribed lines ref for subtask positioning

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
@@ -22,7 +22,6 @@ class TranscribedLines extends React.Component {
   constructor () {
     super()
 
-    this.ref = React.createRef()
     this.state = {
       bounds: {},
       line: {
@@ -37,7 +36,7 @@ class TranscribedLines extends React.Component {
     this.showConsensus = this.showConsensus.bind(this)
   }
 
-  createMark (line) {
+  createMark (line, ref) {
     const { activeTool, activeToolIndex, setActiveMark } = this.props.task
     const [{ x: x1, y: y1 }, { x: x2, y: y2 }] = line.points
     const markSnapshot = { x1, y1, x2, y2, toolIndex: activeToolIndex }
@@ -57,12 +56,12 @@ class TranscribedLines extends React.Component {
         }
         previousAnnotationValuesForEachMark.push(previousAnnotationValuesForThisMark)
       })
-      mark.setSubTaskVisibility(true, this.ref.current, previousAnnotationValuesForEachMark)
+      mark.setSubTaskVisibility(true, ref?.current, previousAnnotationValuesForEachMark)
     }
   }
 
-  showConsensus (line) {
-    const bounds = this.ref?.current?.getBoundingClientRect() || {}
+  showConsensus (line, ref) {
+    const bounds = ref?.current?.getBoundingClientRect() || {}
     this.setState({
       bounds,
       line,
@@ -70,14 +69,14 @@ class TranscribedLines extends React.Component {
     })
   }
 
-  onClick (callback, line) {
-    callback(line)
+  onClick (callback, line, ref) {
+    callback(line, ref)
   }
 
-  onKeyDown (event, callback, line) {
+  onKeyDown (event, callback, line, ref) {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
-      callback(line)
+      callback(line, ref)
     }
   }
 
@@ -106,13 +105,15 @@ class TranscribedLines extends React.Component {
 
     const focusColor = theme.global.colors[theme.global.colors.focus]
     return (
-      <g ref={this.ref}>
+      <g>
         {completedLines
           .map((line, index) => {
             const [{ x: x1, y: y1 }, { x: x2, y: y2 }] = line.points
             const length = Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2))
             const mark = { length, x1, y1, x2, y2 }
             const id = `complete-${index}`
+            const ref = React.createRef()
+
             return (
               <Tooltip
                 id={id}
@@ -120,12 +121,13 @@ class TranscribedLines extends React.Component {
                 label={<TooltipLabel fill={fills.complete} label={counterpart('TranscribedLines.complete')} />}
               >
                 <ConsensusLine
+                  ref={ref}
                   role='button'
                   aria-describedby={id}
                   aria-label={line.consensusText}
                   focusColor={focusColor}
-                  onClick={() => this.onClick(this.showConsensus, line)}
-                  onKeyDown={event => this.onKeyDown(event, this.showConsensus, line)}
+                  onClick={() => this.onClick(this.showConsensus, line, ref)}
+                  onKeyDown={event => this.onKeyDown(event, this.showConsensus, line, ref)}
                   tabIndex={0}
                 >
                   <TranscriptionLine
@@ -144,6 +146,8 @@ class TranscribedLines extends React.Component {
             const length = Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2))
             const mark = { length, x1, y1, x2, y2 }
             const id = `transcribed-${index}`
+            const ref = React.createRef()
+
             return (
               <Tooltip
                 id={id}
@@ -151,16 +155,17 @@ class TranscribedLines extends React.Component {
                 label={<TooltipLabel fill={fills.transcribed} label={counterpart('TranscribedLines.transcribed')} />}
               >
                 <ConsensusLine
+                  ref={ref}
                   role='button'
                   aria-describedby={id}
                   aria-disabled={disabled.toString()}
                   aria-label={line.consensusText}
                   focusColor={focusColor}
                   onClick={() => {
-                    if (!disabled) this.onClick(this.createMark, line)
+                    if (!disabled) this.onClick(this.createMark, line, ref)
                   }}
                   onKeyDown={(event) => {
-                    if (!disabled) this.onKeyDown(event, this.createMark, line)
+                    if (!disabled) this.onKeyDown(event, this.createMark, line, ref)
                   }}
                   tabIndex={0}
                 >

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js
@@ -76,6 +76,21 @@ describe('Component > TranscribedLines', function () {
     })
   })
 
+  describe('with all lines', function () {
+    before(function () {
+      sinon.spy(React, 'createRef')
+      wrapper = shallow(<TranscribedLines lines={consensusLines} task={task} />)
+    })
+
+    after(function () {
+      React.createRef.restore()
+    })
+
+    it('should call React createRef for each line', function () {
+      expect(React.createRef.callCount).to.equal(consensusLines.length)
+    })
+  })
+
   describe('incomplete lines', function () {
     let lines
     before(function () {


### PR DESCRIPTION
Package: lib-classifier

Closes #1702.

Describe your changes:
- refactors `React.createRef()` within completed and transcribed lines map, now creating ref per line
- updates callbacks, `createMark`, `showConsensus` accordingly ^

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
