### PR TITLE
Patch React Components

### DIFF
--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.0.1] 2020-07-15
-- Export ZooniverseLogotype, which renders the Zooniverse logo as an SVG
+- Export ZooniverseLogotype, which renders the Zooniverse logotype as an SVG that
+is often used in a site's footer
 
 ## [1.0.0] 2020-06-29
 - Publish rebuild of library. This allows the following components to be accessible via the `@zooniverse/react-components` package:  

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.1] 2020-07-15
+- Export ZooniverseLogotype, which renders the Zooniverse logo as an SVG
+
 ## [1.0.0] 2020-06-29
 - Publish rebuild of library. This allows the following components to be accessible via the `@zooniverse/react-components` package:  
   - AdminCheckbox
@@ -24,7 +27,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - ZooFooter
   - ZooHeader
   - ZooniverseLogo
-  - ZooniverseLogotype
 
 ## [Unpublished] 2018-09-12
 

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -5,8 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.0.1] 2020-07-15
-- Export ZooniverseLogotype, which renders the Zooniverse logotype as an SVG that
-is often used in a site's footer
+- Export ZooniverseLogotype, which renders the Zooniverse logotype as an SVG that is often used in a site's footer
 
 ## [1.0.0] 2020-06-29
 - Publish rebuild of library. This allows the following components to be accessible via the `@zooniverse/react-components` package:  

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -3,7 +3,7 @@
   "description": "Zooniverse React Components",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/main.js",
   "scripts": {
     "build": "webpack --config ./webpack.dist.js",


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-react-components

Closes #1708 

Describe your changes:
With #1710 merged, the lib-react-components package is ready for a patch push to npm, allowing the ZooniverseLogoType to be exported.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
