### PR TITLE
Refactor TranscribedLinesContainer for frame and shownMarks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.spec.js
@@ -56,7 +56,7 @@ describe('Component > InteractionLayerContainer', function () {
     })
   })
 
-  describe('with annotations from previous reduced drawing or transcription tasks', function () {
+  describe('with annotations from previous drawing or transcription tasks', function () {
     it('should render DrawingToolMarks', function () {
       const wrapper = shallow(
         <InteractionLayerContainer.wrappedComponent

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesContainer.js
@@ -1,10 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { MobXProviderContext, observer } from 'mobx-react'
+import SHOWN_MARKS from '@helpers/shownMarks'
 import TranscribedLines from './TranscribedLines'
 
 function useStores () {
   const stores = React.useContext(MobXProviderContext)
+  const { frame } = stores.classifierStore.subjectViewer
   const {
     active: workflow
   } = stores.classifierStore.workflows
@@ -14,22 +16,26 @@ function useStores () {
   const subject = stores.classifierStore.subjects.active
   const { consensusLines } = subject.transcriptionReductions || {}
   const [activeTranscriptionTask] = activeStepTasks.filter(task => task.type === 'transcription')
-  return { activeTranscriptionTask, consensusLines, workflow }
+  return { activeTranscriptionTask, consensusLines, frame, workflow }
 }
 
 function TranscribedLinesContainer ({ scale = 1 }) {
   const { 
     activeTranscriptionTask = {},
+    frame = 0,
     consensusLines = [], 
     workflow = {
       usesTranscriptionTask: false
     }
   } = useStores()
 
-  if (workflow?.usesTranscriptionTask) {
+  const { shownMarks } = activeTranscriptionTask
+  const visibleLinesPerFrame = consensusLines.filter(line => line.frame === frame)
+
+  if (workflow?.usesTranscriptionTask && shownMarks === SHOWN_MARKS.ALL && visibleLinesPerFrame.length > 0) {
     return (
       <TranscribedLines
-        lines={consensusLines}
+        lines={visibleLinesPerFrame}
         scale={scale}
         task={activeTranscriptionTask}
       />


### PR DESCRIPTION
Package: lib-classifier

Towards #1719.

Describe your changes:
- add tests for transcribed lines filtered by frame and shownMarks
- refactor TranscribedLinesContainer to return null if shownMarks not all or no lines per frame
- refactor TranscribedLinesContainer to render TranscribedLines with only lines per frame

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
