### PR TITLE
Refactor InteractionLayerContainer to filter previous annotation values per frame

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -61,13 +61,16 @@ class InteractionLayerContainer extends Component {
 
     return (
       <>
-        {shownMarks === SHOWN_MARKS.ALL && interactionTaskAnnotations.map(annotation =>
-          <DrawingToolMarks
-            key={annotation.task}
-            marks={annotation.value}
-            scale={scale}
-          />
-        )}
+        {shownMarks === SHOWN_MARKS.ALL && interactionTaskAnnotations.map((annotation) => {
+          const annotationValuesPerFrame = annotation.value.filter(value => value.frame === frame)
+          return (
+            <DrawingToolMarks
+              key={annotation.task}
+              marks={annotationValuesPerFrame}
+              scale={scale}
+            />
+          )
+        })}
         {activeInteractionTask && activeTool &&
           <InteractionLayer
             activeMark={activeMark}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.spec.js
@@ -16,7 +16,10 @@ describe('Component > InteractionLayerContainer', function () {
   }, {
     task: 'T3',
     value: [
-      { id: 'line1', frame: 0, toolIndex: 0, x1: 100, y1: 200, x2: 150, y2: 200 }
+      { id: 'line1', frame: 0, toolIndex: 0, x1: 100, y1: 200, x2: 150, y2: 200 },
+      { id: 'line2', frame: 0, toolIndex: 0, x1: 200, y1: 300, x2: 250, y2: 300 },
+      { id: 'line3', frame: 1, toolIndex: 0, x1: 150, y1: 250, x2: 100, y2: 250 },
+      { id: 'line4', frame: 1, toolIndex: 0, x1: 250, y1: 350, x2: 200, y2: 350 }
     ]
   }]
   const drawingTask = {
@@ -61,11 +64,26 @@ describe('Component > InteractionLayerContainer', function () {
       const wrapper = shallow(
         <InteractionLayerContainer.wrappedComponent
           interactionTaskAnnotations={drawingAnnotations}
+          frame={0}
           height={height}
           width={width}
         />
       )
       expect(wrapper.find(DrawingToolMarks)).to.have.lengthOf(2)
+    })
+
+    it('should render DrawingToolMarks with marks per frame', function () {
+      const wrapper = shallow(
+        <InteractionLayerContainer.wrappedComponent
+          interactionTaskAnnotations={drawingAnnotations}
+          frame={0}
+          height={height}
+          width={width}
+        />
+      )
+
+      expect(wrapper.find(DrawingToolMarks).first().prop('marks')).to.have.lengthOf(1)
+      expect(wrapper.find(DrawingToolMarks).last().prop('marks')).to.have.lengthOf(2)
     })
   })
 


### PR DESCRIPTION
Package: lib-classifier

Towards #1719. 

Describe your changes:
- refactor InteractionLayerContainer tests for previous annotation values from multiple frames
- refactor InteractionLayerContainer to filter previous annotation values per frame

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
