### PR TITLE
Add generic onPointerDown to Tool model

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool.js
@@ -18,7 +18,7 @@ const TranscriptionLineTool = types.model('TranscriptionLine', {
         }
       }
 
-      return createMark(mark)
+      return self.createMark(mark)
     }
 
     function createMark (mark) {

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
@@ -46,6 +46,10 @@ const Tool = types.model('Tool', {
     }
   }))
   .actions(self => {
+    function onPointerDown (mark) {
+      return self.createMark(mark)
+    }
+  
     function createMark (mark) {
       const newMark = Mark.create(Object.assign({}, mark, { toolType: self.type }))
       self.marks.put(newMark)
@@ -74,6 +78,7 @@ const Tool = types.model('Tool', {
       createMark,
       createTask,
       deleteMark,
+      onPointerDown,
       reset
     }
   })


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

This a suggested change to make sure the other tools still continue to work. 


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
