### PR TITLE
Classifier Dropdown Task pt2 (v2) - Component UI/UX

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/README.md
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/README.md
@@ -3,8 +3,18 @@
 The Dropdown Task for the Classifier is exactly what it says on the tin.
 
 - The simplest form of the Dropdown Task allows users to make annotations by choosing from a range of pre-set options from a dropdown list.
-- Dropdowns can have the option for an "Other" choice, allowing a user to type in any value they want. (i.e. functioning as a Text Task.)
+- ~~Dropdowns can have the option for an "Other" choice, allowing a user to type in any value they want. (i.e. functioning as a Text Task.)~~ See _No "Other" option,_ below.
 - An advanced (if unimplemented as of 2020) feature would allow dropdowns to be "chained" together to create a cascade of choices. e.g. Country > State (filtered by Country) > City (filtered by State)
+
+## Dev Notes
+
+**No "Other" option** - Aug 2020
+
+- As of the Engaging Crowds project (Aug 2020), the "Other" option (aka "let users type in free answers") has been built, but has been _artificially disabled._
+- The reasons: 1. we want to encourage project owners to use Dropdown Tasks in a specific way (i.e. just a plain simple dropdown with no free answers) and 2. the [aggregation code gets funky when there are free answers(??)](https://github.com/zooniverse/caesar/issues/841)
+- Please see [the original PR that added this Dropdown component for Engaging Crowds](https://github.com/zooniverse/front-end-monorepo/pull/1750) and [the associated issue .](https://github.com/zooniverse/front-end-monorepo/issues/1751)
+
+We may consider re-enabling the "Other" option again in the future, if/when we want to migrate all PFE projects to the monorepo while maintaining feature parity. Should this day come, please look at `components/DdSelect.js` and change the line that says `const ENABLE_OTHER_OPTION = false` to `true`.
 
 ## Context/History
 
@@ -92,7 +102,7 @@ Dropdown annotation (classification) data structure, example:
        "task":"T0",
        "value":[
           {
-             "value":"THIS IS A FREE ANSWER",
+             "value":"THIS IS A FREE ANSWER",  // (assuming someone set ENABLE_OTHER_OPTION=true in the DdSelect.js code)
              "option":false
           }
        ]

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
@@ -1,0 +1,114 @@
+import { Markdownz, pxToRem } from '@zooniverse/react-components'
+import { Box, Select, Text } from 'grommet'
+import PropTypes from 'prop-types'
+import React from 'react'
+import styled, { css } from 'styled-components'
+
+// TODO: clean up above
+
+const maxWidth = pxToRem(60)
+const StyledBox = styled(Box)`
+  img:only-child, svg:only-child {
+    ${props => props.theme && css`background: ${props.theme.global.colors.brand};`}
+    max-width: ${maxWidth};
+  }
+`
+
+const StyledText = styled(Text)`
+  margin: 0;
+  padding: 0;
+  width: 100%;
+
+  > *:first-child {
+    margin-top: 0;
+  }
+`
+
+function DdSelect (props) {
+  const {
+    annotationValue,
+    index,
+    options,
+    selectConfig,
+    setAnnotation,
+    theme,
+  } = props
+  
+  function onSelectChange ({ option }) {
+    const isPresetOption = option !== otherOption
+    setAnnotation(option.value, isPresetOption, index)
+  }
+  
+  const otherOption = {
+    label: '((other))',
+    value: '*',
+  }
+  
+  const optionsToDisplay = options.slice()
+  if (selectConfig.allowCreate) {
+    optionsToDisplay.push(otherOption)
+  }
+  
+  let so = undefined
+  if (annotationValue) {
+    so = (annotationValue.option)
+      ? optionsToDisplay.find(o => annotationValue.value === o.value)
+      : otherOption
+  }
+  const [selectedOption, setSelectedOption] = React.useState(so);
+  
+  return (
+    <StyledBox
+      border="dashed"
+      pad="small"
+      theme={theme}
+    >
+      <StyledText size='small' tag='legend'>
+        <Markdownz>
+          {selectConfig.title}
+        </Markdownz>
+      </StyledText>
+
+      <StyledText size='small' tag='legend'>
+        allowCreate: {(selectConfig.allowCreate) ? 'yes' : 'no'}
+        &nbsp;
+        required: {(selectConfig.required) ? 'yes' : 'no'}
+      </StyledText>
+
+      <Select
+        options={optionsToDisplay}
+        placeholder={'Select an option'}
+        onChange={onSelectChange.bind(this)}
+        labelKey={'label'}
+        valueKey={'value'}
+        value={selectedOption}
+      />
+    </StyledBox>
+    
+
+  )
+}
+
+DdSelect.defaultProps = {
+  annotationValue: undefined,
+  index: 0,
+  options: {},
+  selectConfig: {},
+  setAnnotation: () => {},
+  theme: {
+    global: {
+      colors: {}
+    }
+  },
+}
+
+DdSelect.propTypes = {
+  annotationValue: PropTypes.object,
+  index: PropTypes.number,
+  options: PropTypes.object,
+  selectConfig: PropTypes.object,
+  setAnnotation: PropTypes.func,
+  theme: PropTypes.object,
+}
+
+export default DdSelect

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
@@ -1,15 +1,19 @@
 import { Markdownz, pxToRem } from '@zooniverse/react-components'
 import { Box, Select, Text, TextInput } from 'grommet'
+import { Down } from 'grommet-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css } from 'styled-components'
+import counterpart from 'counterpart'
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
 
 // TODO: clean up above
 
 const maxWidth = pxToRem(60)
 const StyledBox = styled(Box)`
   img:only-child, svg:only-child {
-    ${props => props.theme && css`background: ${props.theme.global.colors.brand};`}
     max-width: ${maxWidth};
   }
 `
@@ -56,7 +60,7 @@ function DdSelect (props) {
   }
   
   const otherOption = {
-    label: '((other))',
+    label: counterpart('Dropdown.otherLabel'),
     value: '*',
   }
   
@@ -102,18 +106,19 @@ function DdSelect (props) {
       </StyledText>
 
       <Select
-        options={optionsToDisplay}
-        placeholder={'Select an option'}
-        onChange={onSelectChange}
         labelKey={'label'}
+        onChange={onSelectChange}
+        options={optionsToDisplay}
+        placeholder={counterpart('Dropdown.selectPlaceholder')}
         valueKey={'value'}
         value={selectedOption}
       />
       
       {(customInputVisibility) &&
         <TextInput
-          ref={customInput}
           onChange={onTextInputChange}
+          placeholder={counterpart('Dropdown.customInputPlaceholder')}
+          ref={customInput}
           value={customValue}
         />
       }

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
@@ -37,6 +37,7 @@ function DdSelect (props) {
   function onSelectChange ({ option }) {
     const isPresetOption = option !== otherOption
     setAnnotation(option.value, isPresetOption, index)
+    setSelectedOption(option)
   }
   
   const otherOption = {
@@ -73,6 +74,8 @@ function DdSelect (props) {
         allowCreate: {(selectConfig.allowCreate) ? 'yes' : 'no'}
         &nbsp;
         required: {(selectConfig.required) ? 'yes' : 'no'}
+        &nbsp;
+        value: ({selectedOption && selectedOption.value})
       </StyledText>
 
       <Select
@@ -92,7 +95,7 @@ function DdSelect (props) {
 DdSelect.defaultProps = {
   annotationValue: undefined,
   index: 0,
-  options: {},
+  options: [],
   selectConfig: {},
   setAnnotation: () => {},
   theme: {
@@ -105,7 +108,7 @@ DdSelect.defaultProps = {
 DdSelect.propTypes = {
   annotationValue: PropTypes.object,
   index: PropTypes.number,
-  options: PropTypes.object,
+  options: PropTypes.arrayOf(PropTypes.object),
   selectConfig: PropTypes.object,
   setAnnotation: PropTypes.func,
   theme: PropTypes.object,

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
@@ -36,7 +36,7 @@ function DdSelect (props) {
   
   function onSelectChange ({ option }) {
     const isPresetOption = option !== otherOption
-    setAnnotation(option.value, isPresetOption, index)
+    setAnnotation(option.value, index, isPresetOption)
     setSelectedOption(option)
   }
   

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
@@ -1,5 +1,5 @@
 import { Markdownz, pxToRem } from '@zooniverse/react-components'
-import { Box, Select, Text } from 'grommet'
+import { Box, Select, Text, TextInput } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css } from 'styled-components'
@@ -35,9 +35,24 @@ function DdSelect (props) {
   } = props
   
   function onSelectChange ({ option }) {
-    const isPresetOption = option !== otherOption
-    setAnnotation(option.value, index, isPresetOption)
     setSelectedOption(option)
+    const isPresetOption = option !== otherOption
+    
+    if (isPresetOption) {
+      setAnnotation(option.value, index, true)
+      setCustomInputVisibility(false)
+      setCustomValue('')
+    } else {
+      setAnnotation('', index, false)
+      setCustomInputVisibility(true)
+      setCustomValue('')
+    }
+  }
+  
+  function onTextInputChange () {
+    const ele = customInput && customInput.current || { value: '' }
+    setAnnotation(ele.value, index, false)
+    setCustomValue(ele.value)
   }
   
   const otherOption = {
@@ -50,13 +65,17 @@ function DdSelect (props) {
     optionsToDisplay.push(otherOption)
   }
   
-  let so = undefined
+  let initialOption = undefined
   if (annotationValue) {
-    so = (annotationValue.option)
+    initialOption = (annotationValue.option)
       ? optionsToDisplay.find(o => annotationValue.value === o.value)
       : otherOption
   }
-  const [selectedOption, setSelectedOption] = React.useState(so);
+  
+  const [selectedOption, setSelectedOption] = React.useState(initialOption)
+  const [customValue, setCustomValue] = React.useState(annotationValue && annotationValue.value)
+  const [customInputVisibility, setCustomInputVisibility] = React.useState(selectedOption === otherOption)
+  const customInput = React.useRef()
   
   return (
     <StyledBox
@@ -75,17 +94,29 @@ function DdSelect (props) {
         &nbsp;
         required: {(selectConfig.required) ? 'yes' : 'no'}
         &nbsp;
-        value: ({selectedOption && selectedOption.value})
+        annotationValue: ({annotationValue && annotationValue.value})
+        &nbsp;
+        selectedOptionValue: ({selectedOption && selectedOption.value})
+        &nbsp;
+        customValue: ({customValue})
       </StyledText>
 
       <Select
         options={optionsToDisplay}
         placeholder={'Select an option'}
-        onChange={onSelectChange.bind(this)}
+        onChange={onSelectChange}
         labelKey={'label'}
         valueKey={'value'}
         value={selectedOption}
       />
+      
+      {(customInputVisibility) &&
+        <TextInput
+          ref={customInput}
+          onChange={onTextInputChange}
+          value={customValue}
+        />
+      }
     </StyledBox>
     
 

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
@@ -9,13 +9,6 @@ import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
 
-const maxWidth = pxToRem(60)
-const StyledBox = styled(Box)`
-  img:only-child, svg:only-child {
-    max-width: ${maxWidth};
-  }
-`
-
 const StyledText = styled(Text)`
   margin: 0;
   padding: 0;
@@ -83,7 +76,7 @@ function DdSelect (props) {
   const customInput = React.useRef()
   
   return (
-    <StyledBox
+    <Box
       margin={{ vertical: 'xsmall' }}
     >
       <StyledText size='small' tag='legend'>
@@ -116,7 +109,7 @@ function DdSelect (props) {
           />
         }
       </Box>
-    </StyledBox>
+    </Box>
   )
 }
 

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
@@ -37,7 +37,6 @@ function DdSelect (props) {
     options,
     selectConfig,
     setAnnotation,
-    theme,
   } = props
   
   function onSelectChange ({ option }) {
@@ -86,7 +85,6 @@ function DdSelect (props) {
   return (
     <StyledBox
       margin={{ vertical: 'xsmall' }}
-      theme={theme}
     >
       <StyledText size='small' tag='legend'>
         <Markdownz>
@@ -128,11 +126,6 @@ DdSelect.defaultProps = {
   options: [],
   selectConfig: {},
   setAnnotation: () => {},
-  theme: {
-    global: {
-      colors: {}
-    }
-  },
 }
 
 DdSelect.propTypes = {
@@ -141,7 +134,6 @@ DdSelect.propTypes = {
   options: PropTypes.arrayOf(PropTypes.object),
   selectConfig: PropTypes.object,
   setAnnotation: PropTypes.func,
-  theme: PropTypes.object,
 }
 
 export default DdSelect

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
@@ -1,6 +1,6 @@
 import { Markdownz, pxToRem } from '@zooniverse/react-components'
 import { Box, Select, Text, TextInput } from 'grommet'
-import { Down } from 'grommet-icons'
+import { Down, FormNext } from 'grommet-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css } from 'styled-components'
@@ -83,8 +83,7 @@ function DdSelect (props) {
   
   return (
     <StyledBox
-      border="dashed"
-      pad="small"
+      margin={{ vertical: 'xsmall' }}
       theme={theme}
     >
       <StyledText size='small' tag='legend'>
@@ -93,35 +92,30 @@ function DdSelect (props) {
         </Markdownz>
       </StyledText>
 
-      <StyledText size='small' tag='legend'>
-        allowCreate: {(selectConfig.allowCreate) ? 'yes' : 'no'}
-        &nbsp;
-        required: {(selectConfig.required) ? 'yes' : 'no'}
-        &nbsp;
-        annotationValue: ({annotationValue && annotationValue.value})
-        &nbsp;
-        selectedOptionValue: ({selectedOption && selectedOption.value})
-        &nbsp;
-        customValue: ({customValue})
-      </StyledText>
-
-      <Select
-        labelKey={'label'}
-        onChange={onSelectChange}
-        options={optionsToDisplay}
-        placeholder={counterpart('Dropdown.selectPlaceholder')}
-        valueKey={'value'}
-        value={selectedOption}
-      />
-      
-      {(customInputVisibility) &&
-        <TextInput
-          onChange={onTextInputChange}
-          placeholder={counterpart('Dropdown.customInputPlaceholder')}
-          ref={customInput}
-          value={customValue}
+      <Box
+        gap='xsmall'
+      >
+        <Select
+          icon={<Down size='small' />}
+          labelKey='label'
+          onChange={onSelectChange}
+          options={optionsToDisplay}
+          placeholder={counterpart('Dropdown.selectPlaceholder')}
+          size='small'
+          value={selectedOption}
+          valueKey='value'
         />
-      }
+
+        {(customInputVisibility) &&
+          <TextInput
+            onChange={onTextInputChange}
+            placeholder={counterpart('Dropdown.customInputPlaceholder')}
+            ref={customInput}
+            size='small'
+            value={customValue}
+          />
+        }
+      </Box>
     </StyledBox>
     
 

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
@@ -1,6 +1,6 @@
 import { Markdownz, pxToRem } from '@zooniverse/react-components'
 import { Box, Select, Text, TextInput } from 'grommet'
-import { Down, FormNext } from 'grommet-icons'
+import { Down } from 'grommet-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css } from 'styled-components'
@@ -8,8 +8,6 @@ import counterpart from 'counterpart'
 import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
-
-// TODO: clean up above
 
 const maxWidth = pxToRem(60)
 const StyledBox = styled(Box)`
@@ -117,8 +115,6 @@ function DdSelect (props) {
         }
       </Box>
     </StyledBox>
-    
-
   )
 }
 

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.js
@@ -26,6 +26,10 @@ const StyledText = styled(Text)`
   }
 `
 
+// The 'other' option, aka 'allow user to create any answer' option, is
+// artificially disabled. Please refer to the README. (@shaunanoordin 20200820)
+const ENABLE_OTHER_OPTION = false
+
 function DdSelect (props) {
   const {
     annotationValue,
@@ -63,7 +67,7 @@ function DdSelect (props) {
   }
   
   const optionsToDisplay = options.slice()
-  if (selectConfig.allowCreate) {
+  if (selectConfig.allowCreate && ENABLE_OTHER_OPTION) {
     optionsToDisplay.push(otherOption)
   }
   

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DdSelect.spec.js
@@ -1,0 +1,103 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { expect } from 'chai'
+import sinon from 'sinon'
+import DdSelect from './DdSelect'
+
+describe('DropdownTask > DdSelect', function () {
+  
+  const options = [
+    {
+      label: 'Red',
+      value: 'hashed-value-R',
+    },
+    {
+      label: 'Green',
+      value: 'hashed-value-G',
+    },
+    {
+      label: 'Blue',
+      value: 'hashed-value-B',
+    },
+  ]
+  
+  const selectConfig = {
+    allowCreate: false,
+    required: false,
+    title: 'Favourite colour',
+  }
+  
+  describe('when it renders', function () {
+    let wrapper
+    before(function () {
+      wrapper = shallow(
+        <DdSelect
+          annotationValue={undefined}
+          index={0}
+          options={options}
+          selectConfig={selectConfig}
+          setAnnotation={() => {}}
+        />
+      )
+    })
+
+    it('should render without crashing', function () {
+      expect(wrapper).to.be.ok()
+    })
+    
+    it('should render the title', function () {
+      expect(wrapper.contains(selectConfig.title)).to.be.true()
+      console.log(wrapper.debug())
+    })
+    
+    it('should have no initial value', function () {
+      const grommetSelect = wrapper.find('Select')
+      expect(grommetSelect.props()['value']).to.equal(undefined)
+    })
+    
+    it('should have a Grommet Select component set up to correctly read its option-values', function () {
+      const grommetSelect = wrapper.find('Select')
+      expect(grommetSelect.props()['labelKey']).to.equal('label')
+      expect(grommetSelect.props()['valueKey']).to.equal('value')
+    })
+    
+    it('should render the correct number of options', function () {
+      const grommetSelect = wrapper.find('Select')
+      const renderedOptions = grommetSelect.props()['options'] || []
+      expect(renderedOptions).to.have.length(3)
+      expect(renderedOptions[0]).to.equal(options[0])
+      expect(renderedOptions[1]).to.equal(options[1])
+      expect(renderedOptions[2]).to.equal(options[2])
+    })
+  })
+
+  describe('with an annotation', function () {
+    let wrapper
+    
+    const annotationValue = {
+      value: 'hashed-value-B',
+      option: true,
+    }
+
+    before(function () {
+      wrapper = shallow(
+        <DdSelect
+          annotationValue={annotationValue}
+          index={0}
+          options={options}
+          selectConfig={selectConfig}
+          setAnnotation={() => {}}
+        />
+      )
+    })
+
+    it('should pass the annotation value to the Grommet Select in the correct form', function () {
+      // Note that the annotation value is DIFFERENT from the value passed to Grommet's <Select>
+      // annotation value       = { value: 'hashed-value-B', option: true }
+      // value passed to Select = { value: 'hashed-value-B', label: 'Blue' }
+      
+      const grommetSelect = wrapper.find('Select')
+      expect(grommetSelect.props()['value']).to.equal(options[2])
+    })
+  })
+})

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
@@ -35,7 +35,6 @@ function DropdownTask (props) {
   
   function onDropdownChange ({ option }) {
     const isPresetOption = option !== otherOption
-    console.log('+++ onDropdownChange: ', option, option.value, isPresetOption)
     setAnnotation(option.value, isPresetOption)
   }
   
@@ -66,15 +65,13 @@ function DropdownTask (props) {
     defaultOptions.push(otherOption)
   }
   
-  let defaultValue = undefined
+  let selectedOption = undefined
   const currentAnnotationValue = value && value[0]
   if (currentAnnotationValue) {
-    defaultValue = (currentAnnotationValue.option)
+    selectedOption = (currentAnnotationValue.option)
       ? defaultOptions.find(o => currentAnnotationValue.value === o.value)
       : otherOption
   }
-  
-  console.log('+++ Dropdown component starting value: ', defaultValue)
   
   return (
     <StyledBox
@@ -111,7 +108,7 @@ function DropdownTask (props) {
           onChange={onDropdownChange.bind(this)}
           labelKey={'label'}
           valueKey={'value'}
-          value={defaultValue}
+          value={selectedOption}
         />
 
         {/*defaultOptions.map((option, index) => {

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
@@ -8,7 +8,6 @@ import DdSelect from './DdSelect'
 const maxWidth = pxToRem(60)
 const StyledBox = styled(Box)`
   img:only-child, svg:only-child {
-    ${props => props.theme && css`background: ${props.theme.global.colors.brand};`}
     max-width: ${maxWidth};
   }
 `

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
@@ -33,8 +33,10 @@ function DropdownTask (props) {
   } = props
   const { value } = annotation
   
-  function onDropdownChange (value, event) {
-    if (event.target.checked) setAnnotation(value, true)
+  function onDropdownChange ({ option }) {
+    const isPresetOption = option !== otherOption
+    console.log('+++ onDropdownChange: ', option, option.value, isPresetOption)
+    setAnnotation(option.value, isPresetOption)
   }
   
   function setAnnotation (value, isPresetOption = false) {
@@ -52,25 +54,20 @@ function DropdownTask (props) {
   }
   
   const defaultOptions = (defaultSelect.options['*'])
-    ? defaultSelect.options['*'].map(option => {
-        return {
-          label: option.label,
-          value: option.value,
-          presetOption: true,
-        }
-      })
+    ? defaultSelect.options['*'].slice()
     : []
   
-  if (defaultSelect.allowCreate) {
-    defaultOptions.push({
-      label: '((other))',
-      value: '*',
-      presetOption: false,
-    })
+  const otherOption = {
+    label: '((other))',
+    value: '*',
   }
   
-  const defaultValue = undefined  // TODO, use 'value'
-  console.log('+++ YO YO: ', value, value[0])
+  if (defaultSelect.allowCreate) {
+    defaultOptions.push(otherOption)
+  }
+  
+  const defaultValue = value && value[0]
+  console.log('+++ Dropdown component starting value: ', defaultValue)
   
   return (
     <StyledBox
@@ -104,9 +101,7 @@ function DropdownTask (props) {
         <Select
           options={defaultOptions}
           placeholder={'Select an option'}
-          onChange={({ option, value }) => {
-            console.log('+++ Selected: ', option, value)
-          }}
+          onChange={onDropdownChange.bind(this)}
           labelKey={'label'}
           valueKey={'value'}
         />

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
@@ -66,7 +66,14 @@ function DropdownTask (props) {
     defaultOptions.push(otherOption)
   }
   
-  const defaultValue = value && value[0]
+  let defaultValue = undefined
+  const currentAnnotationValue = value && value[0]
+  if (currentAnnotationValue) {
+    defaultValue = (currentAnnotationValue.option)
+      ? defaultOptions.find(o => currentAnnotationValue.value === o.value)
+      : otherOption
+  }
+  
   console.log('+++ Dropdown component starting value: ', defaultValue)
   
   return (
@@ -104,6 +111,7 @@ function DropdownTask (props) {
           onChange={onDropdownChange.bind(this)}
           labelKey={'label'}
           valueKey={'value'}
+          value={defaultValue}
         />
 
         {/*defaultOptions.map((option, index) => {

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
@@ -38,7 +38,7 @@ function DropdownTask (props) {
     setAnnotation(option.value, isPresetOption)
   }
   
-  function setAnnotation (value, isPresetOption = false) {
+  function setAnnotation (value, isPresetOption = false, index = 0) {
     annotation.update([{
       value: value,
       option: isPresetOption,
@@ -56,23 +56,6 @@ function DropdownTask (props) {
     ? defaultSelect.options['*'].slice()
     : []
   
-  const otherOption = {
-    label: '((other))',
-    value: '*',
-  }
-  
-  if (defaultSelect.allowCreate) {
-    defaultOptions.push(otherOption)
-  }
-  
-  let selectedOption = undefined
-  const currentAnnotationValue = value && value[0]
-  if (currentAnnotationValue) {
-    selectedOption = (currentAnnotationValue.option)
-      ? defaultOptions.find(o => currentAnnotationValue.value === o.value)
-      : otherOption
-  }
-  
   return (
     <StyledBox
       className={className}
@@ -84,40 +67,13 @@ function DropdownTask (props) {
           {task.instruction}
         </Markdownz>
       </StyledText>
-    
-      <StyledBox
-        border="dashed"
-        pad="small"
-        theme={theme}
-      >
-        <StyledText size='small' tag='legend'>
-          <Markdownz>
-            {defaultSelect.title}
-          </Markdownz>
-        </StyledText>
-    
-        <StyledText size='small' tag='legend'>
-          allowCreate: {(defaultSelect.allowCreate) ? 'yes' : 'no'}
-          &nbsp;
-          required: {(defaultSelect.required) ? 'yes' : 'no'}
-        </StyledText>
-        
-        <Select
-          options={defaultOptions}
-          placeholder={'Select an option'}
-          onChange={onDropdownChange.bind(this)}
-          labelKey={'label'}
-          valueKey={'value'}
-          value={selectedOption}
-        />
-      </StyledBox>
         
       <DdSelect
         annotationValue={undefined}
         index={0}
         options={defaultOptions}
         selectConfig={defaultSelect}
-        setAnnotation={() => {}}
+        setAnnotation={setAnnotation}
         theme={theme}
       />
     </StyledBox>

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
@@ -69,7 +69,7 @@ function DropdownTask (props) {
       </StyledText>
         
       <DdSelect
-        annotationValue={undefined}
+        annotationValue={value && value[0]}
         index={0}
         options={defaultOptions}
         selectConfig={defaultSelect}

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
@@ -33,18 +33,18 @@ function DropdownTask (props) {
   } = props
   const { value } = annotation
   
-  function onDropdownChange ({ option }) {
-    const isPresetOption = option !== otherOption
-    setAnnotation(option.value, isPresetOption)
-  }
-  
-  function setAnnotation (value, isPresetOption = false, index = 0) {
-    annotation.update([{
-      value: value,
+  function setAnnotation (optionValue, optionIndex = 0, isPresetOption = false) {
+    const newAnnotationValue = (value && value.slice()) || []
+    newAnnotationValue[optionIndex] = {
+      value: optionValue,
       option: isPresetOption,
-    }])
+    }
+    annotation.update(newAnnotationValue)
+    
+    // TODO: if using cascading dropdowns, we probably need to wipe out all existing answers past optionIndex.
   }
   
+  // Simple Dropdown: only the first <select> matters
   const defaultSelect = task.selects[0] || {
     allowCreate: false,
     options: {},
@@ -52,6 +52,7 @@ function DropdownTask (props) {
     title: '',
   }
   
+  // Simple Dropdown: only the first set of <option>s matters
   const defaultOptions = (defaultSelect.options['*'])
     ? defaultSelect.options['*'].slice()
     : []

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
@@ -3,7 +3,7 @@ import { Box, Select, Text } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css } from 'styled-components'
-import TaskInput from '../../components/TaskInput'
+import DdSelect from './DdSelect'
 
 const maxWidth = pxToRem(60)
 const StyledBox = styled(Box)`
@@ -110,25 +110,16 @@ function DropdownTask (props) {
           valueKey={'value'}
           value={selectedOption}
         />
-
-        {/*defaultOptions.map((option, index) => {
-          const checked = (value + 1) ? index === value : false
-          return (
-            <TaskInput
-              autoFocus={checked}
-              checked={checked}
-              disabled={disabled}
-              index={index}
-              key={`${task.taskKey}_${index}`}
-              label={option.label}
-              name={task.taskKey}
-              onChange={onDropdownChange.bind(this, option.value)}
-              required={task.required}
-              type='radio'
-            />
-          )
-        })*/}
       </StyledBox>
+        
+      <DdSelect
+        annotationValue={undefined}
+        index={0}
+        options={defaultOptions}
+        selectConfig={defaultSelect}
+        setAnnotation={() => {}}
+        theme={theme}
+      />
     </StyledBox>
   )
 }

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
@@ -5,13 +5,6 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 import DdSelect from './DdSelect'
 
-const maxWidth = pxToRem(60)
-const StyledBox = styled(Box)`
-  img:only-child, svg:only-child {
-    max-width: ${maxWidth};
-  }
-`
-
 const StyledText = styled(Text)`
   margin: 0;
   padding: 0;
@@ -28,7 +21,6 @@ function DropdownTask (props) {
     className,
     disabled,
     task,
-    theme
   } = props
   const { value } = annotation
   
@@ -57,10 +49,9 @@ function DropdownTask (props) {
     : []
   
   return (
-    <StyledBox
+    <Box
       className={className}
       disabled={disabled}
-      theme={theme}
     >
       <StyledText size='small' tag='legend'>
         <Markdownz>
@@ -74,20 +65,14 @@ function DropdownTask (props) {
         options={defaultOptions}
         selectConfig={defaultSelect}
         setAnnotation={setAnnotation}
-        theme={theme}
       />
-    </StyledBox>
+    </Box>
   )
 }
 
 DropdownTask.defaultProps = {
   className: '',
   disabled: false,
-  theme: {
-    global: {
-      colors: {}
-    }
-  }
 }
 
 DropdownTask.propTypes = {
@@ -109,7 +94,6 @@ DropdownTask.propTypes = {
       title: PropTypes.string,
     }))
   }).isRequired,
-  theme: PropTypes.object
 }
 
 export default DropdownTask

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
@@ -1,5 +1,5 @@
 import { Markdownz, pxToRem } from '@zooniverse/react-components'
-import { Box, Text } from 'grommet'
+import { Box, Select, Text } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css } from 'styled-components'
@@ -51,7 +51,26 @@ function DropdownTask (props) {
     title: '',
   }
   
-  const defaultOptions = defaultSelect.options['*'] || []
+  const defaultOptions = (defaultSelect.options['*'])
+    ? defaultSelect.options['*'].map(option => {
+        return {
+          label: option.label,
+          value: option.value,
+          presetOption: true,
+        }
+      })
+    : []
+  
+  if (defaultSelect.allowCreate) {
+    defaultOptions.push({
+      label: '((other))',
+      value: '*',
+      presetOption: false,
+    })
+  }
+  
+  const defaultValue = undefined  // TODO, use 'value'
+  console.log('+++ YO YO: ', value, value[0])
   
   return (
     <StyledBox
@@ -81,8 +100,18 @@ function DropdownTask (props) {
           &nbsp;
           required: {(defaultSelect.required) ? 'yes' : 'no'}
         </StyledText>
+        
+        <Select
+          options={defaultOptions}
+          placeholder={'Select an option'}
+          onChange={({ option, value }) => {
+            console.log('+++ Selected: ', option, value)
+          }}
+          labelKey={'label'}
+          valueKey={'value'}
+        />
 
-        {defaultOptions.map((option, index) => {
+        {/*defaultOptions.map((option, index) => {
           const checked = (value + 1) ? index === value : false
           return (
             <TaskInput
@@ -98,7 +127,7 @@ function DropdownTask (props) {
               type='radio'
             />
           )
-        })}
+        })*/}
       </StyledBox>
     </StyledBox>
   )

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
@@ -1,5 +1,5 @@
 import { Markdownz, pxToRem } from '@zooniverse/react-components'
-import { Box, Select, Text } from 'grommet'
+import { Box, Text } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css } from 'styled-components'

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.spec.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import { expect } from 'chai'
 import DropdownTask from './DropdownTask'
 import DdSelect from './DdSelect'
@@ -34,7 +34,7 @@ const dropdownTask = {
   type: 'dropdown'
 }
 
-describe.only('DropdownTask', function () {
+describe('DropdownTask', function () {
   const task = Task.TaskModel.create(dropdownTask)
   const annotation = task.defaultAnnotation
 
@@ -73,32 +73,10 @@ describe.only('DropdownTask', function () {
       )
     })
 
-    it('should check the selected answer', function () {
-      const answer = task.answers[0]
-      const input = wrapper.find({ label: answer.label })
-      expect(input.prop('checked')).to.be.true()
-    })
-  })
-
-  describe('onChange event handler', function () {
-    let wrapper
-    beforeEach(function () {
-      annotation.update(null)
-      wrapper = shallow(<DropdownTask annotation={annotation} task={task} />)
-    })
-
-    it('should update the annotation', function () {
-      task.answers.forEach((answer, index) => {
-        const node = wrapper.find({ label: answer.label })
-        node.simulate('change', { target: { checked: true } })
-        expect(annotation.value).to.equal(index)
-      })
-    })
-
-    it('should not update the annotation if the answer is not checked', function () {
-      const node = wrapper.find({ label: task.answers[1].label })
-      node.simulate('change', { target: { checked: false } })
-      expect(annotation.value).to.be.null()
+    it('should pass the selected annotation to the Select sub-element', function () {
+      const ddSelectAnnotationValue = wrapper.find(DdSelect).first().prop('annotationValue') || {}
+      expect(ddSelectAnnotationValue.value).to.equal('hashed-value-R')
+      expect(ddSelectAnnotationValue.option).to.equal(true)
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.spec.js
@@ -27,7 +27,7 @@ const dropdownTask = {
       ],
     },
     required: false,
-    title: 'Colour',
+    title: 'Favourite colour',
   }],
   required: false,
   taskKey: 'T1',

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.spec.js
@@ -2,18 +2,40 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { expect } from 'chai'
 import DropdownTask from './DropdownTask'
+import DdSelect from './DdSelect'
 import { default as Task } from '@plugins/tasks/DropdownTask'
 
-/*
+const dropdownTask = {
+  instruction: 'Choose your favourite things.',
+  selects: [{
+    allowCreate: false,
+    id: 'dropdown-select-1',
+    options: {
+      '*': [
+        {
+          label: 'Red',
+          value: 'hashed-value-R',
+        },
+        {
+          label: 'Green',
+          value: 'hashed-value-G',
+        },
+        {
+          label: 'Blue',
+          value: 'hashed-value-B',
+        },
+      ],
+    },
+    required: false,
+    title: 'Colour',
+  }],
+  required: false,
+  taskKey: 'T1',
+  type: 'dropdown'
+}
 
-describe('DropdownTask', function () {
-  const task = Task.TaskModel.create({
-    answers: [{ label: 'yes' }, { label: 'no' }],
-    question: 'Is there a cat?',
-    required: true,
-    taskKey: 'init',
-    type: 'dropdown'
-  })
+describe.only('DropdownTask', function () {
+  const task = Task.TaskModel.create(dropdownTask)
   const annotation = task.defaultAnnotation
 
   describe('when it renders', function () {
@@ -26,14 +48,12 @@ describe('DropdownTask', function () {
       expect(wrapper).to.be.ok()
     })
 
-    it('should have a question', function () {
-      expect(wrapper.contains(task.question)).to.be.true()
+    it('should have a question/some instructions', function () {
+      expect(wrapper.contains(task.instruction)).to.be.true()
     })
 
-    it('should render the correct number of answer choices', function () {
-      task.answers.forEach((answer) => {
-        expect(wrapper.find({ label: answer.label })).to.have.lengthOf(1)
-      })
+    it('(for a simple dropdown) should render a single <select> element', function () {
+      expect(wrapper.find(DdSelect)).to.have.lengthOf(1)
     })
   })
 
@@ -41,7 +61,10 @@ describe('DropdownTask', function () {
     let wrapper
 
     before(function () {
-      annotation.update(0)
+      annotation.update([{
+        value: 'hashed-value-R',
+        option: true,
+      }])
       wrapper = shallow(
         <DropdownTask
           annotation={annotation}
@@ -79,5 +102,3 @@ describe('DropdownTask', function () {
     })
   })
 })
-
-*/

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.stories.js
@@ -12,8 +12,6 @@ import SubjectStore from '@store/SubjectStore'
 import WorkflowStore from '@store/WorkflowStore'
 import WorkflowStepStore from '@store/WorkflowStepStore'
 
-/*
-
 function createStore() {
   const classifications = ClassificationStore.create()
   const mockSubject = {
@@ -78,6 +76,36 @@ function MockTask(props) {
     </Grommet>
   )
 }
+
+const dropdownTask = {
+  instruction: 'Choose your favourite things.',
+  selects: [{
+    allowCreate: false,
+    id: 'dropdown-select-1',
+    options: {
+      '*': [
+        {
+          label: 'Red',
+          value: 'hashed-value-R',
+        },
+        {
+          label: 'Green',
+          value: 'hashed-value-G',
+        },
+        {
+          label: 'Blue',
+          value: 'hashed-value-B',
+        },
+      ],
+    },
+    required: false,
+    title: 'Favourite colour',
+  }],
+  required: false,
+  taskKey: 'init',
+  type: 'dropdown',
+}
+
 storiesOf('Tasks | Dropdown Task', module)
   .addDecorator(withKnobs)
   .addParameters({
@@ -87,14 +115,7 @@ storiesOf('Tasks | Dropdown Task', module)
   })
   .add('light theme', function () {
     const tasks = {
-      init: {
-        answers: [{ label: 'yes' }, { label: 'no' }],
-        help: 'Choose an answer from the choices given, then press Done.',
-        question: 'Is there a cat?',
-        required: boolean('Required', false),
-        taskKey: 'init',
-        type: 'single'
-      }
+      init: dropdownTask
     }
     const step = {
       stepKey: 'S1',
@@ -117,4 +138,3 @@ storiesOf('Tasks | Dropdown Task', module)
       </Provider>
     )
   })
-*/

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/locales/en.json
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/locales/en.json
@@ -1,0 +1,7 @@
+{
+  "Dropdown": {
+    "customInputPlaceholder": "Input something",
+    "otherLabel": "- Other -",
+    "selectPlaceholder": "Choose an answer"
+  }
+}

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/locales/en.json
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/locales/en.json
@@ -1,7 +1,7 @@
 {
   "Dropdown": {
     "customInputPlaceholder": "Input something",
-    "otherLabel": "- Other -",
+    "otherLabel": "Other...",
     "selectPlaceholder": "Choose an answer"
   }
 }


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`
Associated RFC issue: #1679
Associated Project: Engaging Crowds
Follows: #1742

This is part of a series of PRs that introduces the Dropdown Task to the monorepo Classifier

- Part 1 is described in #1742 
- Part 2 introduces the dropdown React component.

For this PR, the goal is to create a **simple dropdown**, as per the design: https://projects.invisionapp.com/d/main#/console/12923997/270495290/preview

As stated in #1679, there is currently a discussion on how dropdown tasks should be designed (data model-wise, mostly) moving forward.

### Dev Notes

A simple dropdown is relatively simple (once I sorted out the kinks in the Grommet Select component, derp derp) so the big questions are...

- UI/UX: what _type_ of component should we use? A classic `<select>` style (as designed, and kinda like Google Forms) or PFE's "modified text input which, come to think of it, is kinda like a textbox with suggestions"
  - (Thoughts: I'm definitely in favour of Becky's design, but I'll try to prototype the PFE version for argument's sake.)
  - (Note to self: check out our library of React components, I think Sarah already built exactly that kind of textbox-with-suggestions for, uh, Transcription projects I think?)
  - (Note to self: you reviewed the PR doofus, how did you forget)
- Can we have a "search" functionality if we use a classic `<select>` pattern?
  - (Note to self: [Grommet.Select.onSearch](https://v2.grommet.io/select))
- How should the dropdown UI handle the "Other" option, which allows a user to type in free-form text?

That last one might be a separate issue/PR, actually. Hmm.

### Status

WIP