### PR TITLE
Only calculate period bar chart

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/README.md
@@ -91,8 +91,8 @@ The multiple series JSON shape is an object consisting of an object for `scatter
         "yAxisLabel": "Brightness"
       }
     },
-    "barCharts": [
-      { 
+    "barCharts": {
+      "period": { 
         "data": [
           {
             "color": "drawing-red",
@@ -109,7 +109,8 @@ The multiple series JSON shape is an object consisting of an object for `scatter
           "xAxisLabel": "Period",
           "yAxisLabel": ""
         }
-      }, {
+      }, 
+      "amplitude": {
         "data": [
           {
             "color": "drawing-red",
@@ -127,7 +128,7 @@ The multiple series JSON shape is an object consisting of an object for `scatter
           "yAxisLabel": ""
         }
       }
-    ]
+    }
   }
 }
 ```

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.js
@@ -19,10 +19,7 @@ counterpart.registerTranslations('en', en)
 const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, ref) {
   const {
     allowPanZoom,
-    barJSON: {
-      amplitude,
-      period
-    },
+    barJSON,
     imageSrc,
     invertYAxis,
     periodMultiple,
@@ -53,6 +50,8 @@ const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, r
     phasedJSON: allowPanZoom === 'phasedJSON',
     rawJSON: allowPanZoom === 'rawJSON'
   }
+
+  console.log('BarJSON', props.barJSON)
 
   return (
     <Grid
@@ -135,22 +134,19 @@ const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, r
       <Box
         background='#ffffff'
         direction='row'
-        gap='small'
+        gap='xsmall'
         gridArea='barCharts'
         pad='small'
-      >
-        <BarChartViewer
-          key={`${period.chartOptions.yAxisLabel} vs ${period.chartOptions.xAxisLabel}`}
-          data={period.data}
-          xAxisLabel={period.chartOptions.xAxisLabel}
-          yAxisLabel={period.chartOptions.yAxisLabel}
-        />
-        <BarChartViewer
-          key={`${amplitude.chartOptions.yAxisLabel} vs ${amplitude.chartOptions.xAxisLabel}`}
-          data={amplitude.data}
-          xAxisLabel={amplitude.chartOptions.xAxisLabel}
-          yAxisLabel={amplitude.chartOptions.yAxisLabel}
-        />
+      >{Object.keys(barJSON).map((barChartKey) => {
+        //Let's keep the rendering of the bar chart flexible in case more plots are added in the future
+        return (
+          <BarChartViewer
+            data={barJSON[barChartKey].data}
+            key={barChartKey}
+            xAxisLabel={barJSON[barChartKey].chartOptions.xAxisLabel}
+            yAxisLabel={barJSON[barChartKey].chartOptions.yAxisLabel}
+          />
+        )})}
       </Box>
       <Box
         as='figure'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.js
@@ -19,7 +19,10 @@ counterpart.registerTranslations('en', en)
 const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, ref) {
   const {
     allowPanZoom,
-    barJSON,
+    barJSON: {
+      amplitude,
+      period
+    },
     imageSrc,
     invertYAxis,
     periodMultiple,
@@ -136,16 +139,18 @@ const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, r
         gridArea='barCharts'
         pad='small'
       >
-      {barJSON.map((barChart) => {
-        return (
-          <BarChartViewer
-            key={`${barChart.chartOptions.yAxisLabel} vs ${barChart.chartOptions.xAxisLabel}`}
-            data={barChart.data}
-            xAxisLabel={barChart.chartOptions.xAxisLabel}
-            yAxisLabel={barChart.chartOptions.yAxisLabel}
-          />
-        )
-      })}
+        <BarChartViewer
+          key={`${period.chartOptions.yAxisLabel} vs ${period.chartOptions.xAxisLabel}`}
+          data={period.data}
+          xAxisLabel={period.chartOptions.xAxisLabel}
+          yAxisLabel={period.chartOptions.yAxisLabel}
+        />
+        <BarChartViewer
+          key={`${amplitude.chartOptions.yAxisLabel} vs ${amplitude.chartOptions.xAxisLabel}`}
+          data={amplitude.data}
+          xAxisLabel={amplitude.chartOptions.xAxisLabel}
+          yAxisLabel={amplitude.chartOptions.yAxisLabel}
+        />
       </Box>
       <Box
         as='figure'
@@ -176,15 +181,16 @@ const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, r
 
 VariableStarViewer.defaultProps = {
   allowPanZoom: '',
-  barJSON: [
-    {
+  barJSON: {
+    amplitude: {
       data: [],
-      chartOptions: {
-        xAxisLabel: '',
-        yAxisLabel: ''
-      } 
+      chartOptions: {}
+    },
+    period: {
+      data: [],
+      chartOptions: {}
     }
-  ],
+  },
   imageSrc: '',
   invertYAxis: false,
   periodMultiple: 1,
@@ -198,7 +204,7 @@ VariableStarViewer.defaultProps = {
       data: [],
       chartOptions: {}
     },
-    barCharts: []
+    barCharts: {}
   },
   setOnPan: () => true,
   setOnZoom: () => true,
@@ -218,12 +224,16 @@ VariableStarViewer.defaultProps = {
 
 VariableStarViewer.propTypes = {
   allowPanZoom: PropTypes.string,
-  barJSON: PropTypes.arrayOf(
-    PropTypes.shape({
+  barJSON: PropTypes.shape({
+    amplitude: PropTypes.shape({
       data: PropTypes.array,
       options: PropTypes.object
-    })
-  ),
+    }),
+    period: PropTypes.shape({
+      data: PropTypes.array,
+      options: PropTypes.object
+    }),
+  }),
   imageSrc: PropTypes.string,
   invertYAxis: PropTypes.bool,
   periodMultiple: PropTypes.number,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.js
@@ -51,8 +51,6 @@ const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, r
     rawJSON: allowPanZoom === 'rawJSON'
   }
 
-  console.log('BarJSON', props.barJSON)
-
   return (
     <Grid
       forwardedRef={ref}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.stories.js
@@ -53,7 +53,7 @@ function ViewerContext (props) {
 const subject = Factory.build('subject', {
   locations: [
     {
-      'application/json': 'https://raw.githubusercontent.com/zooniverse/front-end-monorepo/master/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/mockLightCurves/variableStar.json'
+      'application/json': 'https://raw.githubusercontent.com/zooniverse/front-end-monorepo/only-calculate-period-bar-chart/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/mockLightCurves/variableStar.json'
     },
     { 'image/png': 'https://raw.githubusercontent.com/zooniverse/front-end-monorepo/master/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/mocks/temperature.png' }
   ]

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.js
@@ -25,12 +25,16 @@ class VariableStarViewerContainer extends Component {
     this.viewer = React.createRef()
     this.state = {
       allowPanZoom: '',
-      barJSON: [
-        {
+      barJSON: {
+        amplitude: {
+          data: [],
+          chartOptions: {}
+        },
+        period: {
           data: [],
           chartOptions: {}
         }
-      ],
+      },
       imageSrc: '',
       invertYAxis: false,
       loadingState: asyncStates.initialized,
@@ -46,15 +50,16 @@ class VariableStarViewerContainer extends Component {
           data: [],
           chartOptions: {}
         },
-        barCharts: [
-          {
+        barCharts: {
+          amplitude: {
             data: [],
             chartOptions: {}
-          }, {
+          },
+          period: {
             data: [],
             chartOptions: {}
           }
-        ]
+        }
       },
       visibleSeries: []
     }
@@ -173,13 +178,16 @@ class VariableStarViewerContainer extends Component {
 
   calculateBarJSON (barChartJSON) {
     const { periodMultiple } = this.state
-    let phasedBarChartJSON = []
-    barChartJSON.forEach((series, seriesIndex) => {
-      phasedBarChartJSON.push({ data: [], chartOptions: series.chartOptions })
-      series.data.forEach((datum) => {
-        const phasedDatum = Object.assign({}, datum, { value: Math.abs(datum.value) * periodMultiple })
-        phasedBarChartJSON[seriesIndex].data.push(phasedDatum)
-      })
+    let phasedBarChartJSON = { 
+      amplitude: barChartJSON.amplitude, 
+      period: { 
+        data: [], 
+        chartOptions: barChartJSON.period.chartOptions
+      }
+    }
+    barChartJSON.period.data.forEach((datum) => {
+      const phasedDatum = Object.assign({}, datum, { value: Math.abs(datum.value) * periodMultiple })
+      phasedBarChartJSON.period.data.push(phasedDatum)
     })
     return phasedBarChartJSON
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.spec.js
@@ -53,8 +53,8 @@ const nextSubjectJSON = {
       "yAxisLabel": "Brightness"
     }
   }, 
-  barCharts: [
-    { 
+  barCharts: {
+    period: { 
       data: [
         { label: 'A', value: 0.34742 },
         { label: 'B', value: 2.37438 }
@@ -63,7 +63,8 @@ const nextSubjectJSON = {
         xAxisLabel: 'Period',
         yAxisLabel: ''
       }
-    }, {
+    },
+    amplitude: {
       data: [
         { color: 'accent-1', label: 'X', value: 34.3747 },
         { color: 'accent-2', label: 'Y', value: 236.3637 }
@@ -73,18 +74,22 @@ const nextSubjectJSON = {
         yAxisLabel: ''
       }
     }
-  ]
+  }
 }
 
 describe('Component > VariableStarViewerContainer', function () {
   const mockState = {
     allowPanZoom: '',
-    barJSON: [
-      {
+    barJSON: {
+      amplitude: {
+        data: [],
+        chartOptions: {}
+      },
+      period: {
         data: [],
         chartOptions: {}
       }
-    ],
+    },
     imageSrc: '',
     invertYAxis: false,
     loadingState: asyncStates.initialized,
@@ -100,15 +105,16 @@ describe('Component > VariableStarViewerContainer', function () {
         data: [],
         chartOptions: {}
       },
-      barCharts: [
-        {
+      barCharts: {
+        amplitude: {
           data: [],
           chartOptions: {}
-        }, {
+        },
+        period: {
           data: [],
           chartOptions: {}
         }
-      ]
+      }
     },
     visibleSeries: []
   }
@@ -519,10 +525,10 @@ describe('Component > VariableStarViewerContainer', function () {
 
       cdmSpy.returnValues[0].then(() => {
         const phasedBarJSONState = wrapper.state().barJSON
-        expect(phasedBarJSONState[0].data.length).to.be.at.least(variableStar.barCharts[0].data.length)
-        expect(phasedBarJSONState[0].chartOptions).to.deep.equal(variableStar.barCharts[0].chartOptions)
-        expect(phasedBarJSONState[1].data.length).to.be.at.least(variableStar.barCharts[1].data.length)
-        expect(phasedBarJSONState[1].chartOptions).to.deep.equal(variableStar.barCharts[1].chartOptions)
+        expect(phasedBarJSONState.period.data.length).to.be.at.least(variableStar.barCharts.period.data.length)
+        expect(phasedBarJSONState.period.chartOptions).to.deep.equal(variableStar.barCharts.period.chartOptions)
+        expect(phasedBarJSONState.amplitude.data.length).to.deep.equal(variableStar.barCharts.amplitude.data.length)
+        expect(phasedBarJSONState.amplitude.chartOptions).to.deep.equal(variableStar.barCharts.amplitude.chartOptions)
       }).then(done, done)
     })
 
@@ -537,10 +543,10 @@ describe('Component > VariableStarViewerContainer', function () {
 
       cduSpy.returnValues[0].then(() => {
         const phasedBarJSONState = wrapper.state().barJSON
-        expect(phasedBarJSONState[0].data.length).to.be.at.least(nextSubjectJSON.barCharts[0].data.length)
-        expect(phasedBarJSONState[0].chartOptions).to.deep.equal(nextSubjectJSON.barCharts[0].chartOptions)
-        expect(phasedBarJSONState[1].data.length).to.be.at.least(nextSubjectJSON.barCharts[1].data.length)
-        expect(phasedBarJSONState[1].chartOptions).to.deep.equal(nextSubjectJSON.barCharts[1].chartOptions)
+        expect(phasedBarJSONState.period.data.length).to.be.at.least(nextSubjectJSON.barCharts.period.data.length)
+        expect(phasedBarJSONState.period.chartOptions).to.deep.equal(nextSubjectJSON.barCharts.period.chartOptions)
+        expect(phasedBarJSONState.amplitude.data.length).to.be.at.least(nextSubjectJSON.barCharts.amplitude.data.length)
+        expect(phasedBarJSONState.amplitude.chartOptions).to.deep.equal(nextSubjectJSON.barCharts.amplitude.chartOptions)
       }).then(done, done)
     })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/mockLightCurves/variableStar.json
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/mockLightCurves/variableStar.json
@@ -764,8 +764,8 @@
       "yAxisLabel": "Brightness"
     }
   },
-  "barCharts": [
-    { 
+  "barCharts": {
+    "period": { 
       "data": [
         { 
           "color": "drawing-red",
@@ -781,7 +781,8 @@
         "xAxisLabel": "Period",
         "yAxisLabel": ""
       }
-    }, {
+    },
+    "amplitude": {
       "data": [
         {
           "color": "drawing-red",
@@ -798,5 +799,5 @@
         "yAxisLabel": ""
       }
     }
-  ]
+  }
 }


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

Describe your changes:
Based on feedback from the researcher, I'm modifying the period calculation to only apply the result to the period bar chart. ~Draft PR pending on ok from the researchers on this change.~ Researcher's have approved change.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
