### PR TITLE
Added a check for active tool

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -1,20 +1,24 @@
-import cuid from 'cuid'
-import PropTypes from 'prop-types'
-import React from 'react'
-import styled, { css } from 'styled-components'
-import SVGContext from '@plugins/drawingTools/shared/SVGContext'
-import DrawingToolMarks from './components/DrawingToolMarks'
-import TranscribedLines from './components/TranscribedLines'
-import SubTaskPopup from './components/SubTaskPopup'
+import cuid from "cuid";
+import PropTypes from "prop-types";
+import React from "react";
+import styled, { css } from "styled-components";
+import SVGContext from "@plugins/drawingTools/shared/SVGContext";
+import DrawingToolMarks from "./components/DrawingToolMarks";
+import TranscribedLines from "./components/TranscribedLines";
+import SubTaskPopup from "./components/SubTaskPopup";
 
-const StyledRect = styled('rect')`
-  ${props => props.disabled ? 
-    css`cursor: not-allowed;` :
-    css`cursor: crosshair;`
-  }
-`
+const StyledRect = styled("rect")`
+  ${props =>
+    props.disabled
+      ? css`
+          cursor: not-allowed;
+        `
+      : css`
+          cursor: crosshair;
+        `}
+`;
 
-function InteractionLayer ({
+function InteractionLayer({
   activeMark,
   activeTool,
   activeToolIndex,
@@ -27,105 +31,105 @@ function InteractionLayer ({
   scale,
   width
 }) {
-  const [ creating, setCreating ] = React.useState(false)
-  const { svg, getScreenCTM } = React.useContext(SVGContext)
+  const [creating, setCreating] = React.useState(false);
+  const { svg, getScreenCTM } = React.useContext(SVGContext);
 
-  function convertEvent (event) {
-    const type = event.type
+  function convertEvent(event) {
+    const type = event.type;
 
-    const svgEventOffset = getEventOffset(event)
+    const svgEventOffset = getEventOffset(event);
 
     const svgCoordinateEvent = {
       pointerId: event.pointerId,
       type,
       x: svgEventOffset.x,
       y: svgEventOffset.y
-    }
+    };
 
-    return svgCoordinateEvent
+    return svgCoordinateEvent;
   }
 
-  function getEventOffset (event) {
-    const svgPoint = svg.createSVGPoint()
-    svgPoint.x = event.clientX
-    svgPoint.y = event.clientY
-    const svgEventOffset = svgPoint.matrixTransform(getScreenCTM().inverse())
-    return svgEventOffset
+  function getEventOffset(event) {
+    const svgPoint = svg.createSVGPoint();
+    svgPoint.x = event.clientX;
+    svgPoint.y = event.clientY;
+    const svgEventOffset = svgPoint.matrixTransform(getScreenCTM().inverse());
+    return svgEventOffset;
   }
 
-  function onPointerDown (event) {
+  function onPointerDown(event) {
     if (disabled || move) {
-      return true
+      return true;
     }
 
-    const activeMark = activeTool.createMark({
-      id: cuid(),
-      frame,
-      toolIndex: activeToolIndex
-    })
-    activeMark.initialPosition(convertEvent(event))
-    setActiveMark(activeMark)
-    setCreating(true)
-    activeMark.setSubTaskVisibility(false)
-    return false
+    console.log("activeTool: ", activeTool);
+
+    if (activeTool.type) {
+      const activeMark = activeTool.createMark({
+        id: cuid(),
+        frame,
+        toolIndex: activeToolIndex
+      });
+      activeMark.initialPosition(convertEvent(event));
+      setActiveMark(activeMark);
+      setCreating(true);
+      activeMark.setSubTaskVisibility(false);
+      return false;
+    }
+    return;
   }
 
-  function onPointerMove (event) {
+  function onPointerMove(event) {
     if (creating) {
-      const { target, pointerId } = event
-      target.setPointerCapture(pointerId)
-      activeMark.initialDrag(convertEvent(event))
+      const { target, pointerId } = event;
+      target.setPointerCapture(pointerId);
+      activeMark.initialDrag(convertEvent(event));
     }
   }
 
-  function onFinish (event, node) {
-    const { target, pointerId } = event
+  function onFinish(event, node) {
+    const { target, pointerId } = event;
 
-    setCreating(false)
+    setCreating(false);
     if (activeMark && !activeMark.isValid) {
-      activeTool.deleteMark(activeMark)
-      setActiveMark(undefined)
+      activeTool.deleteMark(activeMark);
+      setActiveMark(undefined);
     } else {
-      activeMark.setSubTaskVisibility(true, node)
+      activeMark.setSubTaskVisibility(true, node);
     }
 
     if (target && pointerId) {
-      target.releasePointerCapture(pointerId)
+      target.releasePointerCapture(pointerId);
     }
   }
 
   return (
-    <g
-      onPointerMove={onPointerMove}
-      touch-action='none'
-    >
+    <g onPointerMove={onPointerMove} touch-action="none">
       <StyledRect
         disabled={disabled || move}
-        pointerEvents={move ? 'none' : 'all'}
+        pointerEvents={move ? "none" : "all"}
         width={width}
         height={height}
-        fill='transparent'
+        fill="transparent"
         onPointerDown={onPointerDown}
       />
-      <TranscribedLines
-        scale={scale}
-      />
+      <TranscribedLines scale={scale} />
       <SubTaskPopup />
-      {marks &&
+      {marks && (
         <DrawingToolMarks
           activeMark={activeMark}
           marks={marks}
           onDelete={() => {
-            setActiveMark(undefined)
+            setActiveMark(undefined);
           }}
           onFinish={onFinish}
           onSelectMark={mark => setActiveMark(mark)}
           onMove={(mark, difference) => mark.move(difference)}
           scale={scale}
         />
-      }
+      )}
     </g>
-  )
+  );
 }
 
 InteractionLayer.propTypes = {
@@ -139,7 +143,7 @@ InteractionLayer.propTypes = {
   disabled: PropTypes.bool,
   scale: PropTypes.number,
   width: PropTypes.number.isRequired
-}
+};
 
 InteractionLayer.defaultProps = {
   activeMark: undefined,
@@ -149,7 +153,7 @@ InteractionLayer.defaultProps = {
   setActiveMark: () => {},
   disabled: false,
   scale: 1
-}
+};
 
-export default InteractionLayer
-export { StyledRect }
+export default InteractionLayer;
+export { StyledRect };

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -1,24 +1,20 @@
-import cuid from "cuid";
-import PropTypes from "prop-types";
-import React from "react";
-import styled, { css } from "styled-components";
-import SVGContext from "@plugins/drawingTools/shared/SVGContext";
-import DrawingToolMarks from "./components/DrawingToolMarks";
-import TranscribedLines from "./components/TranscribedLines";
-import SubTaskPopup from "./components/SubTaskPopup";
+import cuid from 'cuid'
+import PropTypes from 'prop-types'
+import React from 'react'
+import styled, { css } from 'styled-components'
+import SVGContext from '@plugins/drawingTools/shared/SVGContext'
+import DrawingToolMarks from './components/DrawingToolMarks'
+import TranscribedLines from './components/TranscribedLines'
+import SubTaskPopup from './components/SubTaskPopup'
 
-const StyledRect = styled("rect")`
-  ${props =>
-    props.disabled
-      ? css`
-          cursor: not-allowed;
-        `
-      : css`
-          cursor: crosshair;
-        `}
-`;
+const StyledRect = styled('rect')`
+  ${props => props.disabled ? 
+    css`cursor: not-allowed;` :
+    css`cursor: crosshair;`
+  }
+`
 
-function InteractionLayer({
+function InteractionLayer ({
   activeMark,
   activeTool,
   activeToolIndex,
@@ -31,105 +27,105 @@ function InteractionLayer({
   scale,
   width
 }) {
-  const [creating, setCreating] = React.useState(false);
-  const { svg, getScreenCTM } = React.useContext(SVGContext);
+  const [ creating, setCreating ] = React.useState(false)
+  const { svg, getScreenCTM } = React.useContext(SVGContext)
 
-  function convertEvent(event) {
-    const type = event.type;
+  function convertEvent (event) {
+    const type = event.type
 
-    const svgEventOffset = getEventOffset(event);
+    const svgEventOffset = getEventOffset(event)
 
     const svgCoordinateEvent = {
       pointerId: event.pointerId,
       type,
       x: svgEventOffset.x,
       y: svgEventOffset.y
-    };
+    }
 
-    return svgCoordinateEvent;
+    return svgCoordinateEvent
   }
 
-  function getEventOffset(event) {
-    const svgPoint = svg.createSVGPoint();
-    svgPoint.x = event.clientX;
-    svgPoint.y = event.clientY;
-    const svgEventOffset = svgPoint.matrixTransform(getScreenCTM().inverse());
-    return svgEventOffset;
+  function getEventOffset (event) {
+    const svgPoint = svg.createSVGPoint()
+    svgPoint.x = event.clientX
+    svgPoint.y = event.clientY
+    const svgEventOffset = svgPoint.matrixTransform(getScreenCTM().inverse())
+    return svgEventOffset
   }
 
-  function onPointerDown(event) {
+  function onPointerDown (event) {
     if (disabled || move) {
-      return true;
+      return true
     }
 
-    console.log("activeTool: ", activeTool);
-
-    if (activeTool.type) {
-      const activeMark = activeTool.createMark({
-        id: cuid(),
-        frame,
-        toolIndex: activeToolIndex
-      });
-      activeMark.initialPosition(convertEvent(event));
-      setActiveMark(activeMark);
-      setCreating(true);
-      activeMark.setSubTaskVisibility(false);
-      return false;
-    }
-    return;
+    const activeMark = activeTool.createMark({
+      id: cuid(),
+      frame,
+      toolIndex: activeToolIndex
+    })
+    activeMark.initialPosition(convertEvent(event))
+    setActiveMark(activeMark)
+    setCreating(true)
+    activeMark.setSubTaskVisibility(false)
+    return false
   }
 
-  function onPointerMove(event) {
+  function onPointerMove (event) {
     if (creating) {
-      const { target, pointerId } = event;
-      target.setPointerCapture(pointerId);
-      activeMark.initialDrag(convertEvent(event));
+      const { target, pointerId } = event
+      target.setPointerCapture(pointerId)
+      activeMark.initialDrag(convertEvent(event))
     }
   }
 
-  function onFinish(event, node) {
-    const { target, pointerId } = event;
+  function onFinish (event, node) {
+    const { target, pointerId } = event
 
-    setCreating(false);
+    setCreating(false)
     if (activeMark && !activeMark.isValid) {
-      activeTool.deleteMark(activeMark);
-      setActiveMark(undefined);
+      activeTool.deleteMark(activeMark)
+      setActiveMark(undefined)
     } else {
-      activeMark.setSubTaskVisibility(true, node);
+      activeMark.setSubTaskVisibility(true, node)
     }
 
     if (target && pointerId) {
-      target.releasePointerCapture(pointerId);
+      target.releasePointerCapture(pointerId)
     }
   }
 
   return (
-    <g onPointerMove={onPointerMove} touch-action="none">
+    <g
+      onPointerMove={onPointerMove}
+      touch-action='none'
+    >
       <StyledRect
         disabled={disabled || move}
-        pointerEvents={move ? "none" : "all"}
+        pointerEvents={move ? 'none' : 'all'}
         width={width}
         height={height}
-        fill="transparent"
+        fill='transparent'
         onPointerDown={onPointerDown}
       />
-      <TranscribedLines scale={scale} />
+      <TranscribedLines
+        scale={scale}
+      />
       <SubTaskPopup />
-      {marks && (
+      {marks &&
         <DrawingToolMarks
           activeMark={activeMark}
           marks={marks}
           onDelete={() => {
-            setActiveMark(undefined);
+            setActiveMark(undefined)
           }}
           onFinish={onFinish}
           onSelectMark={mark => setActiveMark(mark)}
           onMove={(mark, difference) => mark.move(difference)}
           scale={scale}
         />
-      )}
+      }
     </g>
-  );
+  )
 }
 
 InteractionLayer.propTypes = {
@@ -143,7 +139,7 @@ InteractionLayer.propTypes = {
   disabled: PropTypes.bool,
   scale: PropTypes.number,
   width: PropTypes.number.isRequired
-};
+}
 
 InteractionLayer.defaultProps = {
   activeMark: undefined,
@@ -153,7 +149,7 @@ InteractionLayer.defaultProps = {
   setActiveMark: () => {},
   disabled: false,
   scale: 1
-};
+}
 
-export default InteractionLayer;
-export { StyledRect };
+export default InteractionLayer
+export { StyledRect }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -58,6 +58,10 @@ function InteractionLayer ({
       return true
     }
 
+    if (!activeTool.type) {
+      return false;
+    }
+
     const activeMark = activeTool.createMark({
       id: cuid(),
       frame,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -1,23 +1,23 @@
-import { shallow } from "enzyme";
-import React from "react";
-import sinon from "sinon";
+import { shallow } from 'enzyme'
+import React from 'react'
+import sinon from 'sinon'
 
-import SVGContext from "@plugins/drawingTools/shared/SVGContext";
-import InteractionLayer, { StyledRect } from "./InteractionLayer";
-import TranscribedLines from "./components/TranscribedLines";
-import SubTaskPopup from "./components/SubTaskPopup";
-import DrawingTask from "@plugins/tasks/DrawingTask";
-import { Line, Point } from "@plugins/drawingTools/components";
+import SVGContext from '@plugins/drawingTools/shared/SVGContext'
+import InteractionLayer, { StyledRect } from './InteractionLayer'
+import TranscribedLines from './components/TranscribedLines'
+import SubTaskPopup from './components/SubTaskPopup'
+import DrawingTask from '@plugins/tasks/DrawingTask'
+import { Line, Point } from '@plugins/drawingTools/components'
 
-describe.only("Component > InteractionLayer", function() {
-  let wrapper;
-  let activeTool;
+describe('Component > InteractionLayer', function () {
+  let wrapper
+  let activeTool
   const mockMark = {
     initialDrag: sinon.stub(),
     initialPosition: sinon.stub(),
     setCoordinates: sinon.stub(),
     setSubTaskVisibility: sinon.stub()
-  };
+  }
   const mockSVGPoint = {
     x: 100,
     y: 200,
@@ -25,7 +25,7 @@ describe.only("Component > InteractionLayer", function() {
       x: 100,
       y: 200
     }))
-  };
+  }
   const mockScreenCTM = {
     a: 1,
     b: 1,
@@ -41,35 +41,35 @@ describe.only("Component > InteractionLayer", function() {
       e: 1,
       f: 1
     })
-  };
-  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  svg.createSVGPoint = () => mockSVGPoint;
-  const getScreenCTM = () => mockScreenCTM;
+  }
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  svg.createSVGPoint = () => mockSVGPoint
+  const getScreenCTM = () => mockScreenCTM
 
-  describe("when enabled", function() {
-    beforeEach(function() {
+  describe('when enabled', function () {
+    beforeEach(function () {
       const mockDrawingTask = DrawingTask.TaskModel.create({
         activeToolIndex: 0,
-        instruction: "draw a mark",
-        taskKey: "T0",
+        instruction: 'draw a mark',
+        taskKey: 'T0',
         tools: [
           {
             marks: {},
             max: 2,
             toolComponent: Point,
-            type: "point"
+            type: 'point'
           },
           {
             marks: {},
             toolComponent: Line,
-            type: "line"
+            type: 'line'
           }
         ],
-        type: "drawing"
-      });
-      const setActiveMarkStub = sinon.stub().callsFake(() => mockMark);
-      activeTool = mockDrawingTask.activeTool;
-      sinon.stub(activeTool, "createMark").callsFake(() => mockMark);
+        type: 'drawing'
+      })
+      const setActiveMarkStub = sinon.stub().callsFake(() => mockMark)
+      activeTool = mockDrawingTask.activeTool
+      sinon.stub(activeTool, 'createMark').callsFake(() => mockMark)
       wrapper = shallow(
         <InteractionLayer
           activeMark={mockMark}
@@ -79,174 +79,169 @@ describe.only("Component > InteractionLayer", function() {
           height={400}
           width={600}
         />
-      );
-    });
+      )
+    })
 
-    afterEach(function() {
-      mockMark.initialDrag.resetHistory();
-      mockMark.initialPosition.resetHistory();
-      mockMark.setCoordinates.resetHistory();
-      activeTool.createMark.restore();
-    });
+    afterEach(function () {
+      mockMark.initialDrag.resetHistory()
+      mockMark.initialPosition.resetHistory()
+      mockMark.setCoordinates.resetHistory()
+      activeTool.createMark.restore()
+    })
 
-    it("should render without crashing", function() {
-      expect(wrapper).to.be.ok();
-    });
+    it('should render without crashing', function () {
+      expect(wrapper).to.be.ok()
+    })
 
-    it("should render a transparent rect", function() {
-      const rect = wrapper.find(StyledRect);
-      expect(rect.exists()).to.be.true();
-      expect(rect.prop("fill")).to.equal("transparent");
-    });
+    it('should render a transparent rect', function () {
+      const rect = wrapper.find(StyledRect)
+      expect(rect.exists()).to.be.true()
+      expect(rect.prop('fill')).to.equal('transparent')
+    })
 
-    it("should render TranscribedLines", function() {
-      expect(wrapper.find(TranscribedLines)).to.have.lengthOf(1);
-    });
+    it('should render TranscribedLines', function () {
+      expect(wrapper.find(TranscribedLines)).to.have.lengthOf(1)
+    })
 
-    it("should render SubTaskPopup", function() {
-      expect(wrapper.find(SubTaskPopup)).to.have.lengthOf(1);
-    });
+    it('should render SubTaskPopup', function () {
+      expect(wrapper.find(SubTaskPopup)).to.have.lengthOf(1)
+    })
 
-    describe("on pointer events", function() {
-      let mockedContext;
-      before(function() {
-        mockedContext = sinon.stub(React, "useContext").callsFake(() => {
-          return { svg, getScreenCTM };
-        });
-      });
+    describe('on pointer events', function () {
+      let mockedContext
+      before(function () {
+        mockedContext = sinon.stub(React, 'useContext').callsFake(() => { return { svg, getScreenCTM } })
+      })
 
-      after(function() {
-        mockedContext.restore();
-      });
+      after(function () {
+        mockedContext.restore()
+      })
 
-      it("should create a mark on pointer down", function() {
+      it('should create a mark on pointer down', function () {
         const fakeEvent = {
-          pointerId: "fakePointer",
-          type: "pointerdown",
+          pointerId: 'fakePointer',
+          type: 'pointerdown',
           target: {
             setPointerCapture: sinon.stub(),
             releasePointerCapture: sinon.stub()
           }
-        };
-        wrapper.find(StyledRect).simulate("pointerdown", fakeEvent);
-        expect(activeTool.createMark).to.have.been.calledOnce();
-      });
+        }
+        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+        expect(activeTool.createMark).to.have.been.calledOnce()
+      })
 
-      it("should create a mark with current frame", function() {
+      it('should create a mark with current frame', function () {
         const fakeEvent = {
-          pointerId: "fakePointer",
-          type: "pointerdown",
+          pointerId: 'fakePointer',
+          type: 'pointerdown',
           target: {
             setPointerCapture: sinon.stub(),
             releasePointerCapture: sinon.stub()
           }
-        };
-        wrapper.find(StyledRect).simulate("pointerdown", fakeEvent);
-        const createMarkArgs = activeTool.createMark.args[0][0];
-        expect(createMarkArgs.frame).to.equal(2);
-      });
+        }
+        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+        const createMarkArgs = activeTool.createMark.args[0][0]
+        expect(createMarkArgs.frame).to.equal(2)
+      })
 
-      it("should place a new mark on pointer down", function() {
+      it('should place a new mark on pointer down', function () {
         const fakeEvent = {
-          pointerId: "fakePointer",
-          type: "pointerdown",
+          pointerId: 'fakePointer',
+          type: 'pointerdown',
           target: {
             setPointerCapture: sinon.stub(),
             releasePointerCapture: sinon.stub()
           }
-        };
-        wrapper.find(StyledRect).simulate("pointerdown", fakeEvent);
-        expect(mockMark.initialPosition).to.have.been.calledOnce();
-      });
+        }
+        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+        expect(mockMark.initialPosition).to.have.been.calledOnce()
+      })
 
-      it("should drag the new mark on pointer down + move", function() {
+      it('should drag the new mark on pointer down + move', function () {
         const fakeEvent = {
-          pointerId: "fakePointer",
-          type: "pointer",
+          pointerId: 'fakePointer',
+          type: 'pointer',
           target: {
             setPointerCapture: sinon.stub(),
             releasePointerCapture: sinon.stub()
           }
-        };
-        wrapper.find(StyledRect).simulate("pointerdown", fakeEvent);
-        wrapper.simulate("pointermove", fakeEvent);
-        expect(mockMark.initialDrag).to.have.been.calledOnce();
-      });
+        }
+        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+        wrapper.simulate('pointermove', fakeEvent)
+        expect(mockMark.initialDrag).to.have.been.calledOnce()
+      })
 
-      it("should capture the pointer on pointer down + move", function() {
+      it('should capture the pointer on pointer down + move', function () {
         const fakeEvent = {
-          pointerId: "fakePointer",
-          type: "pointer",
+          pointerId: 'fakePointer',
+          type: 'pointer',
           target: {
             setPointerCapture: sinon.stub(),
             releasePointerCapture: sinon.stub()
           }
-        };
-        wrapper.find(StyledRect).simulate("pointerdown", fakeEvent);
-        wrapper.simulate("pointermove", fakeEvent);
-        expect(
-          fakeEvent.target.setPointerCapture.withArgs("fakePointer")
-        ).to.have.been.calledOnce();
-      });
-    });
-  });
+        }
+        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+        wrapper.simulate('pointermove', fakeEvent)
+        expect(fakeEvent.target.setPointerCapture.withArgs('fakePointer')).to.have.been.calledOnce()
+      })
+    })
+  })
 
-  describe("when disabled", function() {
-    beforeEach(function() {
+  describe('when disabled', function () {
+    beforeEach(function () {
       const mockDrawingTask = DrawingTask.TaskModel.create({
         activeToolIndex: 0,
-        instruction: "draw a mark",
-        taskKey: "T0",
+        instruction: 'draw a mark',
+        taskKey: 'T0',
         tools: [
           {
             marks: {},
             max: 2,
             toolComponent: Point,
-            type: "point"
+            type: 'point'
           },
           {
             marks: {},
             toolComponent: Line,
-            type: "line"
+            type: 'line'
           }
         ],
-        type: "drawing"
-      });
-      activeTool = mockDrawingTask.activeTool;
-      sinon.stub(activeTool, "createMark").callsFake(() => mockMark);
-      activeTool.createMark.resetHistory();
+        type: 'drawing'
+      })
+      activeTool = mockDrawingTask.activeTool
+      sinon.stub(activeTool, 'createMark').callsFake(() => mockMark)
+      activeTool.createMark.resetHistory()
       wrapper = shallow(
-        <InteractionLayer
-          activeTool={activeTool}
-          disabled
-          height={400}
-          width={600}
-        />,
-        {
+          <InteractionLayer
+            activeTool={activeTool}
+            disabled
+            height={400}
+            width={600}
+          />, {
           wrappingComponent: SVGContext.Provider,
           wrappingComponentProps: { value: { svg, getScreenCTM } }
         }
-      );
-    });
+      )
+    })
 
-    afterEach(function() {
-      mockMark.initialDrag.resetHistory();
-      mockMark.initialPosition.resetHistory();
-      mockMark.setCoordinates.resetHistory();
-      activeTool.createMark.restore();
-    });
+    afterEach(function () {
+      mockMark.initialDrag.resetHistory()
+      mockMark.initialPosition.resetHistory()
+      mockMark.setCoordinates.resetHistory()
+      activeTool.createMark.restore()
+    })
 
-    it("should not create a mark on pointer down", function() {
+    it('should not create a mark on pointer down', function () {
       const fakeEvent = {
-        pointerId: "fakePointer",
-        type: "pointer",
+        pointerId: 'fakePointer',
+        type: 'pointer',
         target: {
           setPointerCapture: sinon.stub(),
           releasePointerCapture: sinon.stub()
         }
-      };
-      wrapper.find(StyledRect).simulate("pointerdown", fakeEvent);
-      expect(activeTool.createMark).to.have.not.been.called();
-    });
-  });
-});
+      }
+      wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+      expect(activeTool.createMark).to.have.not.been.called()
+    })
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -1,23 +1,23 @@
-import { shallow } from 'enzyme'
-import React from 'react'
-import sinon from 'sinon'
+import { shallow } from "enzyme";
+import React from "react";
+import sinon from "sinon";
 
-import SVGContext from '@plugins/drawingTools/shared/SVGContext'
-import InteractionLayer, { StyledRect } from './InteractionLayer'
-import TranscribedLines from './components/TranscribedLines'
-import SubTaskPopup from './components/SubTaskPopup'
-import DrawingTask from '@plugins/tasks/DrawingTask'
-import { Line, Point } from '@plugins/drawingTools/components'
+import SVGContext from "@plugins/drawingTools/shared/SVGContext";
+import InteractionLayer, { StyledRect } from "./InteractionLayer";
+import TranscribedLines from "./components/TranscribedLines";
+import SubTaskPopup from "./components/SubTaskPopup";
+import DrawingTask from "@plugins/tasks/DrawingTask";
+import { Line, Point } from "@plugins/drawingTools/components";
 
-describe('Component > InteractionLayer', function () {
-  let wrapper
-  let activeTool
+describe.only("Component > InteractionLayer", function() {
+  let wrapper;
+  let activeTool;
   const mockMark = {
     initialDrag: sinon.stub(),
     initialPosition: sinon.stub(),
     setCoordinates: sinon.stub(),
     setSubTaskVisibility: sinon.stub()
-  }
+  };
   const mockSVGPoint = {
     x: 100,
     y: 200,
@@ -25,7 +25,7 @@ describe('Component > InteractionLayer', function () {
       x: 100,
       y: 200
     }))
-  }
+  };
   const mockScreenCTM = {
     a: 1,
     b: 1,
@@ -41,35 +41,35 @@ describe('Component > InteractionLayer', function () {
       e: 1,
       f: 1
     })
-  }
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-  svg.createSVGPoint = () => mockSVGPoint
-  const getScreenCTM = () => mockScreenCTM
+  };
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.createSVGPoint = () => mockSVGPoint;
+  const getScreenCTM = () => mockScreenCTM;
 
-  describe('when enabled', function () {
-    beforeEach(function () {
+  describe("when enabled", function() {
+    beforeEach(function() {
       const mockDrawingTask = DrawingTask.TaskModel.create({
         activeToolIndex: 0,
-        instruction: 'draw a mark',
-        taskKey: 'T0',
+        instruction: "draw a mark",
+        taskKey: "T0",
         tools: [
           {
             marks: {},
             max: 2,
             toolComponent: Point,
-            type: 'point'
+            type: "point"
           },
           {
             marks: {},
             toolComponent: Line,
-            type: 'line'
+            type: "line"
           }
         ],
-        type: 'drawing'
-      })
-      const setActiveMarkStub = sinon.stub().callsFake(() => mockMark)
-      activeTool = mockDrawingTask.activeTool
-      sinon.stub(activeTool, 'createMark').callsFake(() => mockMark)
+        type: "drawing"
+      });
+      const setActiveMarkStub = sinon.stub().callsFake(() => mockMark);
+      activeTool = mockDrawingTask.activeTool;
+      sinon.stub(activeTool, "createMark").callsFake(() => mockMark);
       wrapper = shallow(
         <InteractionLayer
           activeMark={mockMark}
@@ -79,169 +79,174 @@ describe('Component > InteractionLayer', function () {
           height={400}
           width={600}
         />
-      )
-    })
+      );
+    });
 
-    afterEach(function () {
-      mockMark.initialDrag.resetHistory()
-      mockMark.initialPosition.resetHistory()
-      mockMark.setCoordinates.resetHistory()
-      activeTool.createMark.restore()
-    })
+    afterEach(function() {
+      mockMark.initialDrag.resetHistory();
+      mockMark.initialPosition.resetHistory();
+      mockMark.setCoordinates.resetHistory();
+      activeTool.createMark.restore();
+    });
 
-    it('should render without crashing', function () {
-      expect(wrapper).to.be.ok()
-    })
+    it("should render without crashing", function() {
+      expect(wrapper).to.be.ok();
+    });
 
-    it('should render a transparent rect', function () {
-      const rect = wrapper.find(StyledRect)
-      expect(rect.exists()).to.be.true()
-      expect(rect.prop('fill')).to.equal('transparent')
-    })
+    it("should render a transparent rect", function() {
+      const rect = wrapper.find(StyledRect);
+      expect(rect.exists()).to.be.true();
+      expect(rect.prop("fill")).to.equal("transparent");
+    });
 
-    it('should render TranscribedLines', function () {
-      expect(wrapper.find(TranscribedLines)).to.have.lengthOf(1)
-    })
+    it("should render TranscribedLines", function() {
+      expect(wrapper.find(TranscribedLines)).to.have.lengthOf(1);
+    });
 
-    it('should render SubTaskPopup', function () {
-      expect(wrapper.find(SubTaskPopup)).to.have.lengthOf(1)
-    })
+    it("should render SubTaskPopup", function() {
+      expect(wrapper.find(SubTaskPopup)).to.have.lengthOf(1);
+    });
 
-    describe('on pointer events', function () {
-      let mockedContext
-      before(function () {
-        mockedContext = sinon.stub(React, 'useContext').callsFake(() => { return { svg, getScreenCTM } })
-      })
+    describe("on pointer events", function() {
+      let mockedContext;
+      before(function() {
+        mockedContext = sinon.stub(React, "useContext").callsFake(() => {
+          return { svg, getScreenCTM };
+        });
+      });
 
-      after(function () {
-        mockedContext.restore()
-      })
+      after(function() {
+        mockedContext.restore();
+      });
 
-      it('should create a mark on pointer down', function () {
+      it("should create a mark on pointer down", function() {
         const fakeEvent = {
-          pointerId: 'fakePointer',
-          type: 'pointerdown',
+          pointerId: "fakePointer",
+          type: "pointerdown",
           target: {
             setPointerCapture: sinon.stub(),
             releasePointerCapture: sinon.stub()
           }
-        }
-        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
-        expect(activeTool.createMark).to.have.been.calledOnce()
-      })
+        };
+        wrapper.find(StyledRect).simulate("pointerdown", fakeEvent);
+        expect(activeTool.createMark).to.have.been.calledOnce();
+      });
 
-      it('should create a mark with current frame', function () {
+      it("should create a mark with current frame", function() {
         const fakeEvent = {
-          pointerId: 'fakePointer',
-          type: 'pointerdown',
+          pointerId: "fakePointer",
+          type: "pointerdown",
           target: {
             setPointerCapture: sinon.stub(),
             releasePointerCapture: sinon.stub()
           }
-        }
-        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
-        const createMarkArgs = activeTool.createMark.args[0][0]
-        expect(createMarkArgs.frame).to.equal(2)
-      })
+        };
+        wrapper.find(StyledRect).simulate("pointerdown", fakeEvent);
+        const createMarkArgs = activeTool.createMark.args[0][0];
+        expect(createMarkArgs.frame).to.equal(2);
+      });
 
-      it('should place a new mark on pointer down', function () {
+      it("should place a new mark on pointer down", function() {
         const fakeEvent = {
-          pointerId: 'fakePointer',
-          type: 'pointerdown',
+          pointerId: "fakePointer",
+          type: "pointerdown",
           target: {
             setPointerCapture: sinon.stub(),
             releasePointerCapture: sinon.stub()
           }
-        }
-        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
-        expect(mockMark.initialPosition).to.have.been.calledOnce()
-      })
+        };
+        wrapper.find(StyledRect).simulate("pointerdown", fakeEvent);
+        expect(mockMark.initialPosition).to.have.been.calledOnce();
+      });
 
-      it('should drag the new mark on pointer down + move', function () {
+      it("should drag the new mark on pointer down + move", function() {
         const fakeEvent = {
-          pointerId: 'fakePointer',
-          type: 'pointer',
+          pointerId: "fakePointer",
+          type: "pointer",
           target: {
             setPointerCapture: sinon.stub(),
             releasePointerCapture: sinon.stub()
           }
-        }
-        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
-        wrapper.simulate('pointermove', fakeEvent)
-        expect(mockMark.initialDrag).to.have.been.calledOnce()
-      })
+        };
+        wrapper.find(StyledRect).simulate("pointerdown", fakeEvent);
+        wrapper.simulate("pointermove", fakeEvent);
+        expect(mockMark.initialDrag).to.have.been.calledOnce();
+      });
 
-      it('should capture the pointer on pointer down + move', function () {
+      it("should capture the pointer on pointer down + move", function() {
         const fakeEvent = {
-          pointerId: 'fakePointer',
-          type: 'pointer',
+          pointerId: "fakePointer",
+          type: "pointer",
           target: {
             setPointerCapture: sinon.stub(),
             releasePointerCapture: sinon.stub()
           }
-        }
-        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
-        wrapper.simulate('pointermove', fakeEvent)
-        expect(fakeEvent.target.setPointerCapture.withArgs('fakePointer')).to.have.been.calledOnce()
-      })
-    })
-  })
+        };
+        wrapper.find(StyledRect).simulate("pointerdown", fakeEvent);
+        wrapper.simulate("pointermove", fakeEvent);
+        expect(
+          fakeEvent.target.setPointerCapture.withArgs("fakePointer")
+        ).to.have.been.calledOnce();
+      });
+    });
+  });
 
-  describe('when disabled', function () {
-    beforeEach(function () {
+  describe("when disabled", function() {
+    beforeEach(function() {
       const mockDrawingTask = DrawingTask.TaskModel.create({
         activeToolIndex: 0,
-        instruction: 'draw a mark',
-        taskKey: 'T0',
+        instruction: "draw a mark",
+        taskKey: "T0",
         tools: [
           {
             marks: {},
             max: 2,
             toolComponent: Point,
-            type: 'point'
+            type: "point"
           },
           {
             marks: {},
             toolComponent: Line,
-            type: 'line'
+            type: "line"
           }
         ],
-        type: 'drawing'
-      })
-      activeTool = mockDrawingTask.activeTool
-      sinon.stub(activeTool, 'createMark').callsFake(() => mockMark)
-      activeTool.createMark.resetHistory()
+        type: "drawing"
+      });
+      activeTool = mockDrawingTask.activeTool;
+      sinon.stub(activeTool, "createMark").callsFake(() => mockMark);
+      activeTool.createMark.resetHistory();
       wrapper = shallow(
-          <InteractionLayer
-            activeTool={activeTool}
-            disabled
-            height={400}
-            width={600}
-          />, {
+        <InteractionLayer
+          activeTool={activeTool}
+          disabled
+          height={400}
+          width={600}
+        />,
+        {
           wrappingComponent: SVGContext.Provider,
           wrappingComponentProps: { value: { svg, getScreenCTM } }
         }
-      )
-    })
+      );
+    });
 
-    afterEach(function () {
-      mockMark.initialDrag.resetHistory()
-      mockMark.initialPosition.resetHistory()
-      mockMark.setCoordinates.resetHistory()
-      activeTool.createMark.restore()
-    })
+    afterEach(function() {
+      mockMark.initialDrag.resetHistory();
+      mockMark.initialPosition.resetHistory();
+      mockMark.setCoordinates.resetHistory();
+      activeTool.createMark.restore();
+    });
 
-    it('should not create a mark on pointer down', function () {
+    it("should not create a mark on pointer down", function() {
       const fakeEvent = {
-        pointerId: 'fakePointer',
-        type: 'pointer',
+        pointerId: "fakePointer",
+        type: "pointer",
         target: {
           setPointerCapture: sinon.stub(),
           releasePointerCapture: sinon.stub()
         }
-      }
-      wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
-      expect(activeTool.createMark).to.have.not.been.called()
-    })
-  })
-})
+      };
+      wrapper.find(StyledRect).simulate("pointerdown", fakeEvent);
+      expect(activeTool.createMark).to.have.not.been.called();
+    });
+  });
+});


### PR DESCRIPTION
Package: `lib-classifier`
Fixes #1688 

Describe your changes:
`onPointerDown` method now checks for an active tool before running. Several prettier updates.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
