### PR TITLE
Refactor zoom controls to be part of ScatterPlotViewer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.stories.js
@@ -4,7 +4,11 @@ import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Grommet } from 'grommet'
 import { withKnobs, boolean, text, object } from '@storybook/addon-knobs'
 import { Factory } from 'rosie'
+import { Provider } from 'mobx-react'
+
 import DataImageViewerContainer from './DataImageViewerContainer'
+import ImageToolbar from '../../../ImageToolbar'
+import SubjectViewerStore from '@store/SubjectViewerStore'
 import readme from './README.md'
 import backgrounds from '../../../../../../../.storybook/lib/backgrounds'
 
@@ -14,14 +18,36 @@ const config = {
   }
 }
 
-let zoomCallback
-
-function onZoom(type) {
-  zoomCallback(type)
+const mockStore = {
+  classifications: {
+    active: {
+      annotations: new Map()
+    }
+  },
+  fieldGuide: {},
+  subjectViewer: SubjectViewerStore.create({}),
+  workflowSteps: {
+    activeStepTasks: []
+  }
 }
 
-function setZoomCallback(callback) {
-  zoomCallback = callback
+
+function ViewerContext (props) {
+  const { children, theme, mode } = props
+  return (
+    <Provider classifierStore={mockStore}>
+      <Grommet
+        background={{
+          dark: 'dark-1',
+          light: 'light-1'
+        }}
+        theme={theme}
+        themeMode={mode}
+      >
+        {children}
+      </Grommet>
+    </Provider>
+  )
 }
 
 const stories = storiesOf('Subject Viewers | DataImageViewer', module)
@@ -43,7 +69,14 @@ const subject = Factory.build('subject', {
 stories
   .add('light theme', () => {
     return (
-      <Grommet theme={zooTheme}>
+      <Grommet
+        background={{
+          dark: 'dark-1',
+          light: 'light-1'
+        }}
+        theme={zooTheme}
+        themeMode='light'
+      >
         <Box height='500px' width='700px'>
           <DataImageViewerContainer
             subject={subject}
@@ -55,7 +88,14 @@ stories
   .add('dark theme', () => {
     const darkZooTheme = Object.assign({}, zooTheme, { dark: true })
     return (
-      <Grommet theme={darkZooTheme}>
+      <Grommet
+        background={{
+          dark: 'dark-1',
+          light: 'light-1'
+        }}
+        theme={darkZooTheme}
+        themeMode='dark'
+      >
         <Box height='500px' width='large'>
           <DataImageViewerContainer
             subject={subject}
@@ -65,9 +105,15 @@ stories
     )
   }, { backgrounds: backgrounds.darkDefault, viewport: { defaultViewport: 'responsive' }, ...config })
   .add('narrow view', () => {
-    const darkZooTheme = Object.assign({}, zooTheme, { dark: true })
     return (
-      <Grommet theme={darkZooTheme}>
+      <Grommet
+        background={{
+          dark: 'dark-1',
+          light: 'light-1'
+        }}
+        theme={zooTheme}
+        themeMode='light'
+      >
         <Box height='500px' width='large'>
           <DataImageViewerContainer
             subject={subject}
@@ -76,3 +122,15 @@ stories
       </Grommet>
     )
   }, { viewport: { defaultViewport: 'iphone5' }, ...config })
+  .add('pan / zoom', () => {
+    return (
+      <ViewerContext mode='light' theme={zooTheme}>
+        <Box direction='row' height='500px' width='large'>
+          <DataImageViewerContainer
+            subject={subject}
+          />
+          <ImageToolbar />
+        </Box>
+      </ViewerContext>
+    )
+  }, config)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/ScatterPlotViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/ScatterPlotViewer.js
@@ -4,26 +4,25 @@ import { withParentSize } from '@vx/responsive'
 import { withTheme } from 'styled-components'
 import ZoomingScatterPlot from './components/ZoomingScatterPlot'
 import ScatterPlot from './components/ScatterPlot'
+import ZoomControlButton from './components/ZoomControlButton'
 
 const ScatterPlotViewer = React.forwardRef(function ScatterPlotViewer (props, ref) {
   const {
+    zoomControlFn,
     zooming
   } = props
 
-  if (zooming) {
-    return (
-      <ZoomingScatterPlot
+  const Plot = (zooming) ? ZoomingScatterPlot : ScatterPlot
+
+  return (
+    <>
+      {zoomControlFn &&
+        <ZoomControlButton onClick={zoomControlFn} zooming={zooming} />}
+      <Plot
         forwardedRef={ref}
         {...props}
       />
-    )
-  }
-
-  return (
-    <ScatterPlot
-      forwardedRef={ref}
-      {...props}
-    />
+    </>
   )
 })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/ScatterPlotViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/ScatterPlotViewer.spec.js
@@ -1,12 +1,15 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
 import ScatterPlot from './components/ScatterPlot'
 import ZoomingScatterPlot from './components/ZoomingScatterPlot'
+import ZoomControlButton from './components/ZoomControlButton'
 import { ScatterPlotViewer } from './ScatterPlotViewer'
 import { parentHeight, parentWidth, randomSingleSeriesData } from './helpers/mockData'
 
 describe('Component > ScatterPlotViewer', function () {
   let wrapper
+  const zoomControlFnSpy = sinon.spy()
   before(function () {
     wrapper = shallow(
       <ScatterPlotViewer
@@ -42,4 +45,20 @@ describe('Component > ScatterPlotViewer', function () {
     expect(wrapper.find(ZoomingScatterPlot).props().parentWidth).to.equal(parentWidth)
     wrapper.setProps({ zooming: false })
   })
+
+  it('should not render a ZoomControlButton by default', function () {
+    expect(wrapper.find(ZoomControlButton)).to.have.lengthOf(0)
+  })
+
+  it('should render a ZoomControlButton when zoomControlFn is defined', function () {
+    wrapper.setProps({ zoomControlFn: zoomControlFnSpy })
+    expect(wrapper.find(ZoomControlButton)).to.have.lengthOf(1)
+  })
+
+  it('should pass along the zoomControlFn and zooming props to the ZoomControlButton', function () {
+    const button = wrapper.find(ZoomControlButton)
+    expect(button.props().onClick).to.equal(zoomControlFnSpy)
+    expect(button.props().zooming).to.be.false()
+  })
+
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomControlButton/ZoomControlButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomControlButton/ZoomControlButton.js
@@ -4,17 +4,17 @@ import { Box } from 'grommet'
 import { ZoomIn } from 'grommet-icons'
 import { MetaToolsButton } from '@zooniverse/react-components'
 import counterpart from 'counterpart'
-import en from '../../locales/en'
+import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
 
-function ZoomEnableButton (props) {
+function ZoomControlButton (props) {
   const {
     onClick = () => {},
     zooming = false
   } = props
 
-  const label = (zooming) ? counterpart('VariableStarViewer.zoomEnabled') : counterpart('VariableStarViewer.enableZoom')
+  const label = (zooming) ? counterpart('ZoomControlButton.zoomEnabled') : counterpart('ZoomControlButton.enableZoom')
 
   return (
     <Box direction='row' justify='center' style={{ position: 'absolute', top: 0 }} width='100%'>
@@ -30,9 +30,9 @@ function ZoomEnableButton (props) {
   )
 }
 
-ZoomEnableButton.propTypes = {
+ZoomControlButton.propTypes = {
   onClick: PropTypes.func,
   zooming: PropTypes.bool
 }
 
-export default ZoomEnableButton
+export default ZoomControlButton

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomControlButton/ZoomControlButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomControlButton/ZoomControlButton.spec.js
@@ -1,16 +1,16 @@
 import { shallow } from 'enzyme'
 import sinon from 'sinon'
 import React from 'react'
-import ZoomEnableButton from './ZoomEnableButton'
+import ZoomControlButton from './ZoomControlButton'
 import { MetaToolsButton } from '@zooniverse/react-components'
-import en from '../../locales/en'
+import en from './locales/en'
 
-describe('Component > ZoomEnableButton', function () {
+describe('Component > ZoomControlButton', function () {
   let wrapper, onClickSpy
   beforeEach(function () {
     onClickSpy = sinon.spy()
     wrapper = shallow(
-      <ZoomEnableButton onClick={onClickSpy} />
+      <ZoomControlButton onClick={onClickSpy} />
     )
   })
   it('should render without crashing', function () {
@@ -18,9 +18,9 @@ describe('Component > ZoomEnableButton', function () {
   })
 
   it('should label text the button according to the zooming prop', function () {
-    expect(wrapper.find(MetaToolsButton).props().text).to.equal(en.VariableStarViewer.enableZoom)
+    expect(wrapper.find(MetaToolsButton).props().text).to.equal(en.ZoomControlButton.enableZoom)
     wrapper.setProps({ zooming: true })
-    expect(wrapper.find(MetaToolsButton).props().text).to.equal(en.VariableStarViewer.zoomEnabled)
+    expect(wrapper.find(MetaToolsButton).props().text).to.equal(en.ZoomControlButton.zoomEnabled)
   })
 
   it('should set the aria-checked state according to the zooming prop', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomControlButton/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomControlButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './ZoomControlButton'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomControlButton/locales/en.json
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomControlButton/locales/en.json
@@ -1,0 +1,6 @@
+{
+  "ZoomControlButton": {
+    "enableZoom": "enable zoom",
+    "zoomEnabled": "zoom enabled"
+  }
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled, { withTheme } from 'styled-components'
+import { withTheme } from 'styled-components'
 import {
   Box,
   Grid
@@ -11,7 +11,6 @@ import { ScatterPlotViewer } from '../ScatterPlotViewer'
 import { SingleImageViewer } from '../SingleImageViewer'
 import { BarChartViewer } from '../BarChartViewer'
 import Controls from './components/Controls'
-import ZoomEnableButton from './components/ZoomEnableButton'
 import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
@@ -89,7 +88,6 @@ const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, r
         gridArea='phasedJSON'
         style={{ position: 'relative' }}
       >
-        <ZoomEnableButton onClick={() => setAllowPanZoom('phasedJSON')} zooming={zoomEnabled.phasedJSON} />
         <ScatterPlotViewer
           data={phasedJSON.data}
           invertAxes={{ x: false, y: invertYAxis }}
@@ -107,6 +105,7 @@ const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, r
           yAxisLabel={phasedJSON.chartOptions.yAxisLabel}
           yAxisNumTicks={8}
           visibleSeries={visibleSeries}
+          zoomControlFn={(zoomEnabled.phasedJSON) ? () => setAllowPanZoom('') : () => setAllowPanZoom('phasedJSON')}
           zooming={zoomEnabled.phasedJSON}
         />
       </Box>
@@ -115,7 +114,6 @@ const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, r
         gridArea='rawJSON'
         style={{ position: 'relative' }}
       >
-        <ZoomEnableButton onClick={() => setAllowPanZoom('rawJSON')} zooming={zoomEnabled.rawJSON} />
         <ScatterPlotViewer
           data={scatterPlot.data}
           invertAxes={{ x: false, y: invertYAxis }}
@@ -132,6 +130,7 @@ const VariableStarViewer = React.forwardRef(function VariableStarViewer(props, r
           yAxisLabel={scatterPlot.chartOptions.yAxisLabel}
           yAxisNumTicks={6}
           visibleSeries={visibleSeries}
+          zoomControlFn={(zoomEnabled.rawJSON) ? () => setAllowPanZoom('') : () => setAllowPanZoom('rawJSON')}
           zooming={zoomEnabled.rawJSON}
         />
       </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.spec.js
@@ -3,7 +3,6 @@ import React from 'react'
 import sinon from 'sinon'
 import zooTheme from '@zooniverse/grommet-theme'
 import { VariableStarViewer } from './VariableStarViewer'
-import ZoomEnableButton from './components/ZoomEnableButton'
 import { SingleImageViewer } from '../SingleImageViewer'
 import { ScatterPlotViewer } from '../ScatterPlotViewer'
 import en from './locales/en'
@@ -107,14 +106,6 @@ describe('Component > VariableStarViewer', function () {
         setAllowPanZoomSpy.resetHistory()
       })
 
-      it('should render the ZoomEnableButton', function () {
-        expect(wrapperDiv.find(ZoomEnableButton)).to.have.lengthOf(1)
-      })
-
-      it('should render the ZoomEnableButton with a false zooming prop', function () {
-        expect(wrapperDiv.find(ZoomEnableButton).props().zooming).to.be.false()
-      })
-
       it('should have zooming set to false', function () {
         expect(phasedScatterPlot.props().zooming).to.be.false()
       })
@@ -123,9 +114,8 @@ describe('Component > VariableStarViewer', function () {
         expect(wrapperDiv.props().border).to.be.false()
       })
 
-      it('should call setAllowPanZoom with phasedJSON when the ZoomEnableButton is clicked', function () {
-        const button = wrapperDiv.find(ZoomEnableButton)
-        button.simulate('click')
+      it('should set the zoomControlFn prop to setAllowPanZoom with phasedJSON as the argument', function () {
+        wrapperDiv.children().props().zoomControlFn()
         expect(setAllowPanZoomSpy).to.have.been.calledOnceWith('phasedJSON')
       })
     })
@@ -143,16 +133,17 @@ describe('Component > VariableStarViewer', function () {
         setAllowPanZoomSpy.resetHistory()
       })
 
-      it('should render the ZoomEnableButton with zooming prop as true', function () {
-        expect(wrapperDiv.find(ZoomEnableButton).props().zooming).to.be.true()
-      })
-
       it('should set zooming to true', function () {
         expect(phasedScatterPlot.props().zooming).to.be.true()
       })
 
       it('should have a border defined for its wrapper div', function () {
         expect(wrapperDiv.props().border).to.deep.equal({ color: 'brand', size: 'xsmall' })
+      })
+
+      it('should set the zoomControlFn prop to setAllowPanZoom with an empty string argument', function () {
+        wrapperDiv.children().props().zoomControlFn()
+        expect(setAllowPanZoomSpy).to.have.been.calledOnceWith('')
       })
     })
   })
@@ -223,14 +214,6 @@ describe('Component > VariableStarViewer', function () {
         setAllowPanZoomSpy.resetHistory()
       })
 
-      it('should render a ZoomEnableButton', function () {
-        expect(wrapperDiv.find(ZoomEnableButton)).to.have.lengthOf(1)
-      })
-
-      it('should render a ZoomEnableButton with zooming prop as false', function () {
-        expect(wrapperDiv.find(ZoomEnableButton).props().zooming).to.be.false()
-      })
-
       it('should have zooming set to false', function () {
         expect(rawScatterPlot.props().zooming).to.be.false()
       })
@@ -239,9 +222,8 @@ describe('Component > VariableStarViewer', function () {
         expect(wrapperDiv.props().border).to.be.false()
       })
 
-      it('should call setAllowPanZoom with rawJSON when the overlayed button is clicked', function () {
-        const button = wrapperDiv.find(ZoomEnableButton)
-        button.simulate('click')
+      it('should set the zoomControlFn prop to setAllowPanZoom with rawJSON as the argument', function () {
+        wrapperDiv.children().props().zoomControlFn()
         expect(setAllowPanZoomSpy).to.have.been.calledOnceWith('rawJSON')
       })
     })
@@ -259,8 +241,9 @@ describe('Component > VariableStarViewer', function () {
         setAllowPanZoomSpy.resetHistory()
       })
 
-      it('should display the ZoomEnableButton zooming prop as true', function () {
-        expect(wrapperDiv.find(ZoomEnableButton).props().zooming).to.be.true()
+      it('should set the zoomControlFn prop to setAllowPanZoom with an empty string argument', function () {
+        wrapperDiv.children().props().zoomControlFn()
+        expect(setAllowPanZoomSpy).to.have.been.calledOnceWith('')
       })
 
       it('should set zooming to true', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/ZoomEnableButton/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/ZoomEnableButton/index.js
@@ -1,1 +1,0 @@
-export { default } from './ZoomEnableButton'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/locales/en.json
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/locales/en.json
@@ -1,7 +1,6 @@
 {
   "VariableStarViewer": {
     "controls": "controls",
-    "enableZoom": "enable zoom",
     "flip": "flip",
     "focus": "focus",
     "imageTitle": "HR Diagram",
@@ -10,7 +9,6 @@
     "phase": "phase",
     "phaseFocus": "phase focus",
     "temperature": "temperature",
-    "visibility": "visibility",
-    "zoomEnabled": "zoom enabled"
+    "visibility": "visibility"
   }
 }


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

Toward #1761

Describe your changes:
This is a refactoring of the control for enabling zoom added to the VSLCV to be part of the underlying ScatterPlotViewer instead. This enables us to have it available to any viewer that may use the ScatterPlotViewer. Following this, the DataImageViewer will have a state added to control the zoom behavior.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
