### PR TITLE
Refactor VSLCV to use connector component

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.stories.js
@@ -5,6 +5,7 @@ import { Box, Grommet } from 'grommet'
 import { withKnobs, boolean, text, object } from '@storybook/addon-knobs'
 import { Factory } from 'rosie'
 import VariableStarViewer from './VariableStarViewerContainer'
+import VariableStarViewerConnector from './VariableStarViewerConnector'
 import { Provider } from 'mobx-react'
 import SubjectViewerStore from '@store/SubjectViewerStore'
 import ImageToolbar from '../../../ImageToolbar'
@@ -24,6 +25,14 @@ stories.addDecorator(withKnobs)
 
 const { colors } = zooTheme.global
 
+const subject = Factory.build('subject', {
+  locations: [
+    {
+      'application/json': 'https://raw.githubusercontent.com/zooniverse/front-end-monorepo/master/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/mockLightCurves/variableStar.json'
+    },
+    { 'image/png': 'https://raw.githubusercontent.com/zooniverse/front-end-monorepo/master/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/mocks/temperature.png' }
+  ]
+})
 
 const mockStore = {
   classifications: {
@@ -32,6 +41,9 @@ const mockStore = {
     }
   },
   fieldGuide: {},
+  subjects: {
+    active: subject
+  },
   subjectViewer: SubjectViewerStore.create({}),
   workflowSteps: {
     activeStepTasks: []
@@ -56,15 +68,6 @@ function ViewerContext (props) {
     </Provider>
   )
 }
-
-const subject = Factory.build('subject', {
-  locations: [
-    {
-      'application/json': 'https://raw.githubusercontent.com/zooniverse/front-end-monorepo/master/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/mockLightCurves/variableStar.json'
-    },
-    { 'image/png': 'https://raw.githubusercontent.com/zooniverse/front-end-monorepo/master/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/mocks/temperature.png' }
-  ]
-})
 
 stories
   .add('light theme', () => {
@@ -105,9 +108,7 @@ stories
     return (
       <ViewerContext theme={zooTheme} mode='light'>
         <Box direction='row' height='500px' width='large'>
-          <VariableStarViewer
-            subject={subject}
-          />
+          <VariableStarViewerConnector />
           <ImageToolbar />
         </Box>
       </ViewerContext>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerConnector.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerConnector.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import { MobXProviderContext, observer } from 'mobx-react'
+import VariableStarViewerContainer from './VariableStarViewerContainer'
+
+function useStores() {
+  const stores = React.useContext(MobXProviderContext)
+
+  const {
+    active: subject
+  } = stores.classifierStore.subjects
+
+  const {
+    setOnZoom,
+    setOnPan
+  } = stores.classifierStore.subjectViewer
+
+  return {
+    setOnZoom,
+    setOnPan,
+    subject
+  }
+}
+
+function VariableStarViewerConnector(props) {
+  const {
+    setOnPan,
+    setOnZoom,
+    subject
+  } = useStores()
+
+  return (
+    <VariableStarViewerContainer
+      setOnPan={setOnPan}
+      setOnZoom={setOnZoom}
+      subject={subject}
+      {...props}
+    />
+  )
+}
+
+export default observer(VariableStarViewerConnector)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerConnector.spec.js
@@ -1,0 +1,48 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import sinon from 'sinon'
+import VariableStarViewerConnector from './VariableStarViewerConnector'
+import VariableStarViewerContainer from './VariableStarViewerContainer'
+
+const mockStore = {
+  classifierStore: {
+    subjects: {
+      active: { id: '1' }
+    },
+    subjectViewer: {
+      setOnPan: sinon.spy(),
+      setOnZoom: sinon.spy()
+    }
+  }
+}
+
+describe('VariableStarViewerConnector', function () {
+  let wrapper, useContextMock, containerProps
+  before(function () {
+    useContextMock = sinon.stub(React, 'useContext').callsFake(() => mockStore)
+    wrapper = shallow(
+      <VariableStarViewerConnector />
+    )
+    containerProps = wrapper.find(VariableStarViewerContainer).props()
+  })
+
+  after(function () {
+    useContextMock.restore()
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should pass the active subject as a prop', function () {
+    expect(containerProps.subject).to.deep.equal(mockStore.classifierStore.subjects.active)
+  })
+
+  it('should pass the setOnPan function', function () {
+    expect(containerProps.setOnPan).to.deep.equal(mockStore.classifierStore.subjectViewer.setOnPan)
+  })
+
+  it('should pass the setOnZoom function', function () {
+    expect(containerProps.setOnZoom).to.deep.equal(mockStore.classifierStore.subjectViewer.setOnZoom)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.js
@@ -2,22 +2,9 @@ import asyncStates from '@zooniverse/async-states'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import request from 'superagent'
-import { inject, observer } from 'mobx-react'
 
 import VariableStarViewer from './VariableStarViewer'
 import locationValidator from '../../helpers/locationValidator'
-
-function storeMapper(stores) {
-  const {
-    setOnZoom,
-    setOnPan
-  } = stores.classifierStore.subjectViewer
-
-  return {
-    setOnZoom,
-    setOnPan
-  }
-}
 
 class VariableStarViewerContainer extends Component {
   constructor () {
@@ -286,6 +273,8 @@ VariableStarViewerContainer.defaultProps = {
   loadingState: asyncStates.initialized,
   onError: () => true,
   onReady: () => true,
+  setOnPan: () => {},
+  setOnZoom: () => {},
   subject: {
     id: '',
     locations: []
@@ -296,15 +285,12 @@ VariableStarViewerContainer.propTypes = {
   loadingState: PropTypes.string,
   onError: PropTypes.func,
   onReady: PropTypes.func,
+  setOnPan: PropTypes.func,
+  setOnZoom: PropTypes.func,
   subject: PropTypes.shape({
     id: PropTypes.string,
     locations: PropTypes.arrayOf(locationValidator)
   })
 }
 
-@inject(storeMapper)
-@observer
-class DecoratedVariableStarViewerContainer extends VariableStarViewerContainer { }
-
-export default DecoratedVariableStarViewerContainer
-export { VariableStarViewerContainer }
+export default VariableStarViewerContainer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewerContainer.spec.js
@@ -5,7 +5,7 @@ import nock from 'nock'
 import sinon from 'sinon'
 import { Factory } from 'rosie'
 
-import { VariableStarViewerContainer } from './VariableStarViewerContainer'
+import VariableStarViewerContainer from './VariableStarViewerContainer'
 import VariableStarViewer from './VariableStarViewer'
 import variableStar from '@viewers/helpers/mockLightCurves/variableStar'
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/index.js
@@ -1,2 +1,2 @@
-export { default } from './VariableStarViewerContainer'
+export { default } from './VariableStarViewerConnector'
 export { default as VariableStarViewer } from './VariableStarViewer'


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

Describe your changes:
I've added a connector component to connect the VSLCV to the stores. This is similar to what I've recently done with the `DataImageViewer`. It provides a separation of concerns and the ability for us to more easily test the store connection in isolation.

In addition, the VSLCV is now actually connected to the stores to get the active subject.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
