### PR TITLE
Classifier Dropdown Task pt3 (v2) - Cascading Dropdowns

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/README.md
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/README.md
@@ -118,3 +118,90 @@ Dropdown annotation (classification) data structure, example:
     }
  ]
 ```
+
+## Data Models (Cascading)
+
+Addendum - Dropdown task data structure (cascading), example:
+
+```
+"T0": {
+    "help": "",
+    "type": "dropdown",
+    "selects": [
+        {
+            "id": "e6648d9524038",
+            "title": "Country",
+            "options": {
+                "*": [
+                    {
+                        "label": "UK",
+                        "value": "8d2b49f2ab18a"
+                    },
+                    {
+                        "label": "USA",
+                        "value": "a893ad87b8b8c"
+                    },
+                    {
+                        "label": "Japan",
+                        "value": "cc8773d27f0aa"
+                    }
+                ]
+            },
+            "required": true,
+            "allowCreate": false
+        },
+        {
+            "id": "d6697219c5d3a",
+            "title": "City",
+            "options": {
+                "8d2b49f2ab18a": [
+                    {
+                        "label": "London",
+                        "value": "80623599d84d1"
+                    },
+                    {
+                        "label": "Oxford",
+                        "value": "44784c24e641"
+                    },
+                    {
+                        "label": "Birmingham",
+                        "value": "f7b67c6758cf8"
+                    }
+                ],
+                "a893ad87b8b8c": [
+                    {
+                        "label": "Chicago",
+                        "value": "78ca14613967c"
+                    },
+                    {
+                        "label": "Minneapolis",
+                        "value": "225c8911a4db3"
+                    },
+                    {
+                        "label": "Washington",
+                        "value": "85c4b3bea4071"
+                    }
+                ],
+                "cc8773d27f0aa": [
+                    {
+                        "label": "Tokyo",
+                        "value": "7f2981b163d1e"
+                    },
+                    {
+                        "label": "Osaka",
+                        "value": "3886cd84d705c"
+                    },
+                    {
+                        "label": "Kyoto",
+                        "value": "e50ca74547915"
+                    }
+                ]
+            },
+            "required": false,
+            "condition": "e6648d9524038",
+            "allowCreate": true
+        }
+    ],
+    "instruction": "Where did this character come form?"
+}
+```

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/README.md
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/README.md
@@ -119,9 +119,11 @@ Dropdown annotation (classification) data structure, example:
  ]
 ```
 
-## Data Models (Cascading)
+## Advanced - Cascading Dropdown Task
 
-Addendum - Dropdown task data structure (cascading), example:
+BEWARE, here be dragons.
+
+Dropdown task data structure (cascading), example:
 
 ```
 "T0": {
@@ -205,3 +207,33 @@ Addendum - Dropdown task data structure (cascading), example:
     "instruction": "Where did this character come form?"
 }
 ```
+
+Dropdown annotation (classification) data structure, example:
+
+```
+"annotations":[
+  {
+    task: "T0",
+    value: [
+      {
+        value: "a893ad87b8b8c",  // USA
+        option: true
+      },
+      {
+        value: "78ca14613967c",  // Chicago
+        option: true
+      }
+    ]
+  }
+]
+```
+
+
+Some observations about implementation in PFE:
+
+- When we have a cascading dropdown task like the example above, both a `<select>` for Country and a `<select>` for City appear.
+- If City depends on Country, but the selected Country has no valid Cities to list, (either because 1. no Country was selected, 2. the Country has no Cities associated with it, or 3. the Country allowed free text entry and the user typed in something ridiculous like "The Lost Continent of Atlantis") the the City's `<select>` will be disabled with a "N/A" text.
+- (!!!) Exception: if the Country allows free text entry, the user can ALWAYS type in any answer.
+- If a dropdown had no answer selected for any reason, the annotation value will be `{value: null, option: false}`
+
+The important thing to note here is the exception. If we start to support free text entry, we need to seriously consider the UI what to do when a _dependent dropdown_ allows free text.

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
@@ -25,7 +25,7 @@ function DropdownTask (props) {
   const { value } = annotation
   
   function setAnnotation (optionValue, optionIndex = 0, isPresetOption = false) {
-    const newAnnotationValue = (value && value.slice()) || []
+    const newAnnotationValue = (value && value.slice(0, optionIndex)) || []
     newAnnotationValue[optionIndex] = {
       value: optionValue,
       option: isPresetOption,
@@ -35,18 +35,7 @@ function DropdownTask (props) {
     // TODO: if using cascading dropdowns, we probably need to wipe out all existing answers past optionIndex.
   }
   
-  // Simple Dropdown: only the first <select> matters
-  const defaultSelect = task.selects[0] || {
-    allowCreate: false,
-    options: {},
-    required: false,
-    title: '',
-  }
-  
-  // Simple Dropdown: only the first set of <option>s matters
-  const defaultOptions = (defaultSelect.options['*'])
-    ? defaultSelect.options['*'].slice()
-    : []
+  console.log('+++ annotation value: ', value.toJSON())
   
   return (
     <Box
@@ -61,8 +50,6 @@ function DropdownTask (props) {
       
       {task.selects.map((select, index) => {
         let options = []
-        
-        console.log('+++ annotation value: ', value.toJSON())
         
         if (index === 0) {
           options = select.options['*'].slice()

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
@@ -25,17 +25,14 @@ function DropdownTask (props) {
   const { value } = annotation
   
   function setAnnotation (optionValue, optionIndex = 0, isPresetOption = false) {
+    // Note: for cascading dropdowns, we wipe out all existing answers past optionIndex.
     const newAnnotationValue = (value && value.slice(0, optionIndex)) || []
     newAnnotationValue[optionIndex] = {
       value: optionValue,
       option: isPresetOption,
     }
     annotation.update(newAnnotationValue)
-    
-    // TODO: if using cascading dropdowns, we probably need to wipe out all existing answers past optionIndex.
   }
-  
-  console.log('+++ annotation value: ', value.toJSON())
   
   return (
     <Box
@@ -51,15 +48,20 @@ function DropdownTask (props) {
       {task.selects.map((select, index) => {
         let options = []
         
-        if (index === 0) {
+        // For cascading dropdowns, find the parent (condition) dropdown.
+        const indexOfParent = task.selects.findIndex(s => s.id === select.condition)
+        
+        if (indexOfParent < 0) {  // Usually means this is the first dropdown in the chain, or the only dropdown 
           options = select.options['*'].slice()
         } else {
-          const answerToPreviousSelect = value[index-1]
-          if (answerToPreviousSelect) {
-            options = select.options[answerToPreviousSelect.value]
-          }
+          const answerKey = (value[indexOfParent])
+            ? value[indexOfParent].value
+            : ''
+          options = (select.options[answerKey])
+            ? select.options[answerKey].slice()
+            : []
         }
-    
+        
         return (
           <DdSelect
             annotationValue={value && value[index]}

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/components/DropdownTask.js
@@ -58,14 +58,31 @@ function DropdownTask (props) {
           {task.instruction}
         </Markdownz>
       </StyledText>
+      
+      {task.selects.map((select, index) => {
+        let options = []
         
-      <DdSelect
-        annotationValue={value && value[0]}
-        index={0}
-        options={defaultOptions}
-        selectConfig={defaultSelect}
-        setAnnotation={setAnnotation}
-      />
+        console.log('+++ annotation value: ', value.toJSON())
+        
+        if (index === 0) {
+          options = select.options['*'].slice()
+        } else {
+          const answerToPreviousSelect = value[index-1]
+          if (answerToPreviousSelect) {
+            options = select.options[answerToPreviousSelect.value]
+          }
+        }
+    
+        return (
+          <DdSelect
+            annotationValue={value && value[index]}
+            index={index}
+            options={options}
+            selectConfig={select}
+            setAnnotation={setAnnotation}
+          />
+        )
+      })}
     </Box>
   )
 }

--- a/packages/lib-classifier/src/plugins/tasks/DropdownTask/models/DropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DropdownTask/models/DropdownTask.js
@@ -17,6 +17,7 @@ const Dropdown = types.model('Dropdown', {
   instruction: types.optional(types.string, ''),
   selects: types.array(types.frozen({
     allowCreate: types.boolean,
+    condition: types.optional(types.string, ''),  // Used by cascading dropdowns, to determine the parent dropdown.
     id: types.string,
     options: types.map(DropdownOptions),
     required: types.optional(types.boolean, false),


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`
Associated Project: Engaging Crowds / general PFE migration
Follows: #1750

This is part of a series of PRs that introduces the Dropdown Task to the monorepo Classifier

- Part 1 is described in #1742 
- Part 2 is described in #1750
- Part 3 is an experimental expansion of work that attempts to add the "cascading dropdowns" feature, which was previously discarded in Pt 1 and Pt 2 in favour of the "simple dropdowns only" goal.

The goal of this new experimental work is to bring the monorepo `dropdown` task closer to feature parity with PFE `dropdown` tasks

### Dev Notes

Let's be clear: _nobody asked for this right now and it's not on any project road map._ But I suddenly had an idea (also, week-long insomnia) and needed to work with it before it escaped my brain. And hey, a lot of it is working!

At the moment:

- Good: we can have multiple cascading `<selects>` per Dropdown task.
- Good: the options in a child Select will change depending of the value of the parent Select.
- Bad: if you change the value of a _parent Select,_ the child Selects that depend on that parent _won't reset to empty._ This seems to be a React thing, nyeh.

It's basically this:

```
<DropdownTask>  // Value from store is: { country: 'uk', city: 'london' }
  <SelectSubComponent title="Country" value="UK" options={[ 'UK', 'USA' ]} />
  <SelectSubComponent title="City" value="London" options={[ 'London', 'Oxford' ]} />
</DropdownTask>
```

If I change the Country to USA, the "City" component should, 1. clear/empty the value, and 2. change the options to ['Chicago', 'Minneapolis']. Unfortunately, that (1) isn't happening. The store is updating properly, the options are changing correctly, but the selected value ain't nixed.

SUDDEN IDEA: wait, maybe that's because I'm letting the `DdSelect` subcomponents manage their own states. Maybe I need to make it so only the Dropdown Task component uses state, and pass an "onChange" function to the DdSelect subcomponents instead.

Also: best look at the updated README.md for all my notes on how cascading dropdowns work, and some quirks we need to factor in. Also also, "free text" answers for cascading dropdowns can go straight to UI/UX hell.

### Status

WIP - purely experimental at this stage and possessing no priority. I'll come back to this if I have the time & energy, or am unable to sleep again.

Note: Pt3 was originally supposed to be design updates based on Becky's feedback, but that's now going to be Pt 4.