### PR TITLE
Allow for configuration of several more viewers

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/index.js
@@ -1,1 +1,1 @@
-export default from './DataImageViewerConnector'
+export { default } from './DataImageViewerConnector'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getViewer/getViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getViewer/getViewer.js
@@ -1,3 +1,4 @@
+import DataImageViewer from '../../components/DataImageViewer'
 import SubjectGroupViewer from '../../components/SubjectGroupViewer'
 import SingleImageViewer from '../../components/SingleImageViewer'
 import LightCurveViewer from '../../components/LightCurveViewer'
@@ -5,6 +6,7 @@ import MultiFrameViewer from '../../components/MultiFrameViewer'
 import VariableStarViewer from '../../components/VariableStarViewer'
 
 const viewers = {
+  dataImage: DataImageViewer,
   subjectGroup: SubjectGroupViewer,
   singleImage: SingleImageViewer,
   lightCurve: LightCurveViewer,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getViewer/getViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getViewer/getViewer.spec.js
@@ -1,7 +1,11 @@
 import getViewer from './getViewer'
 
+import DataImageViewer from '../../components/DataImageViewer'
+import SubjectGroupViewer from '../../components/SubjectGroupViewer'
 import SingleImageViewer from '../../components/SingleImageViewer'
+import LightCurveViewer from '../../components/LightCurveViewer'
 import MultiFrameViewer from '../../components/MultiFrameViewer'
+import VariableStarViewer from '../../components/VariableStarViewer'
 
 describe('Helpers > getViewer', function () {
   it('should return the `SingleImageViewer` component if passed `singleImage`', function () {
@@ -10,6 +14,22 @@ describe('Helpers > getViewer', function () {
 
   it('should return the `MultiFrameViewer` component if passed `multiFrame`', function () {
     expect(getViewer('multiFrame')).to.equal(MultiFrameViewer)
+  })
+
+  it('should return the `DataImageViewer` component if passed `dataImage`', function () {
+    expect(getViewer('dataImage')).to.equal(DataImageViewer)
+  })
+
+  it('should return the `SubjectGroupViewer` component if passed `subjectGroup`', function () {
+    expect(getViewer('subjectGroup')).to.equal(SubjectGroupViewer)
+  })
+
+  it('should return the `LightCurveViewer` component if passed `lightCurve`', function () {
+    expect(getViewer('lightCurve')).to.equal(LightCurveViewer)
+  })
+
+  it('should return the `VariableStarViewer` component if passed `variableStar`', function () {
+    expect(getViewer('variableStar')).to.equal(VariableStarViewer)
   })
 
   it('should return null if it can\'t match a viewer', function () {

--- a/packages/lib-classifier/src/helpers/subjectViewers/subjectViewers.js
+++ b/packages/lib-classifier/src/helpers/subjectViewers/subjectViewers.js
@@ -20,6 +20,18 @@ Object.defineProperty(subjectViewers, 'subjectGroup', {
   enumerable: true
 })
 
+Object.defineProperty(subjectViewers, 'dataImage', {
+  value: 'dataImage',
+  enumerable: true
+})
+
+
+Object.defineProperty(subjectViewers, 'variableStar', {
+  value: 'variableStar',
+  enumerable: true
+})
+
+
 // helper for returning subject viewers (e.g. for use in MST enumerable type)
 Object.defineProperty(subjectViewers, 'values', {
   value: Object.values(subjectViewers)

--- a/packages/lib-classifier/src/helpers/subjectViewers/subjectViewers.spec.js
+++ b/packages/lib-classifier/src/helpers/subjectViewers/subjectViewers.spec.js
@@ -5,7 +5,9 @@ describe('Helpers > subjectViewers', function () {
     'singleImage',
     'lightCurve',
     'multiFrame',
-    'subjectGroup'
+    'subjectGroup',
+    'dataImage',
+    'variableStar'
   ]
 
   viewers.forEach(function (viewer) {

--- a/packages/lib-classifier/src/store/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
+++ b/packages/lib-classifier/src/store/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
@@ -5,7 +5,14 @@ const WorkflowConfiguration = types.model({
   enable_switching_flipbook_and_separate: types.optional(types.boolean, false),
   hide_classification_summaries: types.optional(types.boolean, false),
   multi_image_mode: types.optional(types.enumeration('multiImageMode', ['flipbook', 'separate']), 'flipbook'),
-  subject_viewer: types.maybe(types.enumeration('subjectViewer', ['lightcurve', 'multiFrame', 'subjectGroup'])),
+  subject_viewer: types.maybe(types.enumeration('subjectViewer', [
+    'dataImage',
+    'lightcurve',
+    'multiFrame',
+    'singleImage',
+    'subjectGroup',
+    'variableStar'
+  ])),
   subject_viewer_config: types.frozen({})
 })
   .views(self => ({

--- a/packages/lib-classifier/src/store/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
+++ b/packages/lib-classifier/src/store/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
@@ -11,14 +11,23 @@ const WorkflowConfiguration = types.model({
   .views(self => ({
     get viewerType () {
       switch (self.subject_viewer) {
+        case 'dataImage': {
+          return subjectViewers.dataImage
+        }
         case 'lightcurve': {
           return subjectViewers.lightCurve
         }
         case 'multiFrame': {
           return subjectViewers.multiFrame
         }
+        case 'singleImage': {
+          return subjectViewers.singleImage
+        }
         case 'subjectGroup': {
           return subjectViewers.subjectGroup
+        }
+        case 'variableStar': {
+          return subjectViewers.variableStar
         }
         default: {
           return null


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

Describe your changes:
This finishes adding support for several more specific subject viewers, including the VSLCV, so that we can actually load a workflow with this configuration.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
