### PR TITLE
ZRC: Fix modal default colours

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.js
@@ -49,6 +49,7 @@ function SubTaskPopup(props) {
         minWidth: MIN_POPUP_WIDTH,
         position: defaultPosition
       }}
+      titleColor=''
     >
       <Box gap='small'>
         {tasks.map((task, index) => {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.spec.js
@@ -5,13 +5,29 @@ import sinon from 'sinon'
 import cuid from 'cuid'
 import SubTaskPopup from './SubTaskPopup'
 import SaveButton from './components/SaveButton'
-import { CloseButton } from '@zooniverse/react-components'
+import { CloseButton, MovableModal } from '@zooniverse/react-components'
 import * as Tools from '@plugins/drawingTools/models/tools'
 
 describe('SubTaskPopup', function () {
   it('should render without crashing', function () {
     const wrapper = shallow(<SubTaskPopup />)
     expect(wrapper).to.be.ok()
+  })
+
+  describe('title bar', function () {
+    let modal
+    before(function () {
+      const activeMark = { subTaskVisibility: true }
+      modal = shallow(<SubTaskPopup activeMark={activeMark} />).find(MovableModal)
+    })
+
+    it('should have a transparent background', function () {
+      expect(modal.prop('headingBackground')).to.equal('transparent')
+    })
+
+    it('should use the default text colour', function () {
+      expect(modal.prop('titleColor')).to.equal('')
+    })
   })
 
   Object.keys(Tools).forEach((toolKey) => {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.js
@@ -53,6 +53,7 @@ export default function ConsensusPopup (props) {
         position
       }}
       title={counterpart('ConsensusPopup.title')}
+      titleColor=''
     >
       <Paragraph>
         {counterpart('ConsensusPopup.explanation', { count: line.textOptions.length })}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.spec.js
@@ -28,6 +28,24 @@ describe('TranscribedLines > Component > ConsensusPopup', function () {
       expect(wrapper.find(MovableModal)).to.have.lengthOf(1)
     })
 
+    describe('title bar', function () {
+      let modal
+      before(function () {
+        modal = wrapper.find(MovableModal)
+      })
+
+      it('should have a themed background', function () {
+        expect(modal.prop('headingBackground')).to.deep.equal({
+          dark: 'dark-5',
+          light: 'neutral-6'
+        })
+      })
+
+      it('should use the default text colour', function () {
+        expect(modal.prop('titleColor')).to.equal('')
+      })
+    })
+
     it('should render an explanatory text with the number of textOptions from the line data', function () {
       const firstParagraph = wrapper.find(Paragraph).first()
       expect(firstParagraph.contains(`These ${completedLines[0].textOptions.length} transcriptions have been submitted by previous volunteers and cannot be modified.`)).to.be.true()

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unpublished]
 ### Fixed
 - Arrow position is now correct based on the position set by tippyjs-react for the Tooltip
+- Restore default colours for the Modal and MovableModal components.
+- Update Modal spacing to reflect the Zooniverse design system.
+- Allow the colour of the Modal close button to be changed based on the ModalHeading text colour.
 
 ## [1.0.2] 2020-07-15
 - Patch fix previous version with correctly built package

--- a/packages/lib-react-components/src/CloseButton/CloseButton.js
+++ b/packages/lib-react-components/src/CloseButton/CloseButton.js
@@ -27,11 +27,11 @@ const StyledButton = styled(Button)`
   }
 `
 
-function CloseButton ({ closeFn, ...rest }) {
+function CloseButton ({ closeFn, color, ...rest }) {
   return (
     <StyledButton
       a11yTitle={counterpart('CloseButton.close')}
-      icon={<CloseIcon size='1em' />}
+      icon={<CloseIcon color={color} size='1em' />}
       onClick={closeFn}
       {...rest}
     />

--- a/packages/lib-react-components/src/CloseButton/CloseButton.spec.js
+++ b/packages/lib-react-components/src/CloseButton/CloseButton.spec.js
@@ -17,4 +17,12 @@ describe('<CloseButton />', function () {
     wrapper.simulate('click')
     expect(wrapper.props().onClick).to.have.been.calledOnce()
   })
+
+  describe('with a color prop', function () {
+    it('should set the icon colour', function () {
+      const colouredButton = shallow(<CloseButton color='neutral-6' closeFn={sinon.spy()} />)
+      const icon = colouredButton.prop('icon')
+      expect(icon.props.color).to.equal('neutral-6')
+    })
+  })
 })

--- a/packages/lib-react-components/src/CloseButton/CloseButton.stories.js
+++ b/packages/lib-react-components/src/CloseButton/CloseButton.stories.js
@@ -67,7 +67,7 @@ storiesOf('CloseButton', module)
         justify='center'
         width='small'
       >
-        <CloseButton closeFn={() => { }} />
+        <CloseButton color='neutral-6' closeFn={() => { }} />
       </Box>
     </Grommet>
   ), config)

--- a/packages/lib-react-components/src/CloseButton/README.md
+++ b/packages/lib-react-components/src/CloseButton/README.md
@@ -1,7 +1,8 @@
 # CloseButton
 
-A styled Grommet `Button` component that displays a close icon. Has the same API as Grommet's `Button`.
+A styled Grommet `Button` component that displays a close icon. Has the same API as [Grommet's `Button`](https://v2.grommet.io/button).
 
 ## props
 
 - `closeFn` (function): the function called onClick of the button
+- `color` (string|object): the colour of the button's close icon.

--- a/packages/lib-react-components/src/Modal/Modal.js
+++ b/packages/lib-react-components/src/Modal/Modal.js
@@ -25,11 +25,11 @@ class Modal extends React.Component {
       children,
       className = '',
       closeFn = () => {},
-      headingBackground = '',
+      headingBackground,
       overflow = 'auto',
       pad,
       title = '',
-      titleColor = '',
+      titleColor,
       ...props
     } = this.props
 

--- a/packages/lib-react-components/src/Modal/components/ModalBody/ModalBody.js
+++ b/packages/lib-react-components/src/Modal/components/ModalBody/ModalBody.js
@@ -31,7 +31,11 @@ ModalBody.propTypes = {
 ModalBody.defaultProps = {
   className: '',
   overflow: 'auto',
-  pad: 'medium'
+  pad: {
+    bottom: 'medium',
+    horizontal: 'medium',
+    top: 'small'
+  }
 }
 
 export default ModalBody

--- a/packages/lib-react-components/src/Modal/components/ModalBody/ModalBody.spec.js
+++ b/packages/lib-react-components/src/Modal/components/ModalBody/ModalBody.spec.js
@@ -14,6 +14,25 @@ describe('Modal > ModalBody', function () {
     shallow(<ModalBody>{content}</ModalBody>)
   })
 
+  describe('default padding', function () {
+    let pad = {}
+
+    before(function () {
+      pad = shallow(<ModalBody>{content}</ModalBody>).prop('pad')
+    })
+
+    it('should be small at the top', function () {
+      expect(pad.top).to.equal('small')
+    })
+
+    it('should be medium at the bottom', function () {
+      expect(pad.bottom).to.equal('medium')
+    })
+
+    it('should be medium at the sides', function () {
+      expect(pad.horizontal).to.equal('medium')
+    })
+  })
   it('should render its children', function () {
     const wrapper = shallow(<ModalBody>{content}</ModalBody>)
     const contentWrapper = shallow(content)

--- a/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
+++ b/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
@@ -9,16 +9,6 @@ const StyledBox = styled(Box)`
   min-height: 30px;
 `
 
-const Heading = styled.h2`
-  color: white;
-  font-size: 1rem;
-  font-weight: bold;
-  letter-spacing: 0.18em;
-  margin: 0;
-  text-shadow: 0 2px 2px rgba(0,0,0,0.22);
-  text-transform: uppercase;
-`
-
 function ModalHeading ({ background = 'brand', color = 'neutral-6', className = '', closeFn, title = '' }) {
   const horizontalPad = (title) ? 'medium' : 'xsmall'
   return (
@@ -32,10 +22,14 @@ function ModalHeading ({ background = 'brand', color = 'neutral-6', className = 
       pad={{ horizontal: horizontalPad, vertical: 'none' }}
     >
       {title &&
-        <SpacedHeading color={color}>
+        <SpacedHeading
+          color={color}
+        >
           {title}
         </SpacedHeading>}
-      <CloseButton closeFn={closeFn} />
+      <CloseButton
+        closeFn={closeFn}
+      />
     </StyledBox>
   )
 }

--- a/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
+++ b/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
@@ -9,8 +9,13 @@ const StyledBox = styled(Box)`
   min-height: 30px;
 `
 
+const StyledHeading = styled(SpacedHeading)`
+  line-height: 0;
+`
+
 function ModalHeading ({ background = 'brand', color = 'neutral-6', className = '', closeFn, title = '' }) {
   const horizontalPad = (title) ? 'medium' : 'xsmall'
+  const headingMargin = 'none'
   return (
     <StyledBox
       align='center'
@@ -22,11 +27,12 @@ function ModalHeading ({ background = 'brand', color = 'neutral-6', className = 
       pad={{ horizontal: horizontalPad, vertical: 'none' }}
     >
       {title &&
-        <SpacedHeading
+        <StyledHeading
           color={color}
+          margin={headingMargin}
         >
           {title}
-        </SpacedHeading>}
+        </StyledHeading>}
       <CloseButton
         closeFn={closeFn}
         color={color}
@@ -44,3 +50,4 @@ ModalHeading.propTypes = {
 }
 
 export default ModalHeading
+export { StyledHeading }

--- a/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
+++ b/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.js
@@ -29,6 +29,7 @@ function ModalHeading ({ background = 'brand', color = 'neutral-6', className = 
         </SpacedHeading>}
       <CloseButton
         closeFn={closeFn}
+        color={color}
       />
     </StyledBox>
   )

--- a/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.spec.js
+++ b/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.spec.js
@@ -33,7 +33,7 @@ describe('Modal > ModalHeading', function () {
 
   describe('when there is a title', function () {
     let wrapper
-    before(function () {
+    beforeEach(function () {
       wrapper = shallow(<ModalHeading closeFn={() => { }} title={title} />)
     })
 
@@ -45,10 +45,18 @@ describe('Modal > ModalHeading', function () {
       expect(wrapper.render().children().eq(0).is('h2')).to.be.true()
     })
 
-    it('should set the color by prop', function () {
-      expect(wrapper.find(SpacedHeading).props().color).to.equal('neutral-6')
-      wrapper.setProps({ color: 'accent-2' })
-      expect(wrapper.find(SpacedHeading).props().color).to.equal('accent-2')
+    describe('with a color prop', function () {
+      it('should set the heading text colour', function () {
+        expect(wrapper.find(SpacedHeading).props().color).to.equal('neutral-6')
+        wrapper.setProps({ color: 'accent-2' })
+        expect(wrapper.find(SpacedHeading).props().color).to.equal('accent-2')
+      })
+      
+      it('should set the close button colour', function () {
+        expect(wrapper.find(CloseButton).props().color).to.equal('neutral-6')
+        wrapper.setProps({ color: 'accent-2' })
+        expect(wrapper.find(CloseButton).props().color).to.equal('accent-2')
+      })
     })
 
     it('should justify the wrapper flex box by between', function () {

--- a/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.spec.js
+++ b/packages/lib-react-components/src/Modal/components/ModalHeading/ModalHeading.spec.js
@@ -1,9 +1,8 @@
 import { shallow } from 'enzyme'
 import sinon from 'sinon'
 import React from 'react'
-import SpacedHeading from '../../../SpacedHeading'
 import CloseButton from '../../../CloseButton'
-import ModalHeading from './ModalHeading'
+import ModalHeading, { StyledHeading } from './ModalHeading'
 
 const title = 'Modal Heading'
 
@@ -41,15 +40,19 @@ describe('Modal > ModalHeading', function () {
       expect(wrapper.render().text()).to.equal(title)
     })
 
+    it('should have no margins', function () {
+      expect(wrapper.find(StyledHeading).props().margin).to.equal('none')
+    })
+
     it('should render the title as an h2', function () {
       expect(wrapper.render().children().eq(0).is('h2')).to.be.true()
     })
 
     describe('with a color prop', function () {
       it('should set the heading text colour', function () {
-        expect(wrapper.find(SpacedHeading).props().color).to.equal('neutral-6')
+        expect(wrapper.find(StyledHeading).props().color).to.equal('neutral-6')
         wrapper.setProps({ color: 'accent-2' })
-        expect(wrapper.find(SpacedHeading).props().color).to.equal('accent-2')
+        expect(wrapper.find(StyledHeading).props().color).to.equal('accent-2')
       })
       
       it('should set the close button colour', function () {
@@ -75,7 +78,7 @@ describe('Modal > ModalHeading', function () {
     })
 
     it('should not render an h2', function () {
-      expect(wrapper.find(SpacedHeading)).to.have.lengthOf(0)
+      expect(wrapper.find(StyledHeading)).to.have.lengthOf(0)
     })
 
     it('should justify the wrapper flex box by end', function () {

--- a/packages/lib-react-components/src/MovableModal/MovableModal.js
+++ b/packages/lib-react-components/src/MovableModal/MovableModal.js
@@ -80,7 +80,6 @@ function MovableModal (props) {
 
 MovableModal.defaultProps = {
   closeFn: () => {},
-  headingBackground: '',
   overflow: 'auto',
   rndProps: {
     minHeight: 100,
@@ -90,8 +89,7 @@ MovableModal.defaultProps = {
       y: 0
     }
   },
-  title: '',
-  titleColor: ''
+  title: ''
 }
 
 MovableModal.propTypes = {

--- a/packages/lib-react-components/src/MovableModal/MovableModal.stories.js
+++ b/packages/lib-react-components/src/MovableModal/MovableModal.stories.js
@@ -47,7 +47,7 @@ storiesOf('MovableModal', module)
       <MovableModal
         active={boolean('Active', true)}
         animate={boolean('Animate layer', false)}
-        headingBackground={text('Heading background color', '')}
+        headingBackground={text('Heading background color', 'brand')}
         closeFn={action('Close modal')}
         pad={text('Modal body padding', 'medium')}
         plain={boolean('Plain layer', false)}
@@ -73,7 +73,7 @@ storiesOf('MovableModal', module)
         active={boolean('Active', true)}
         animate={boolean('Animate layer', false)}
         closeFn={action('Close modal')}
-        headingBackground={text('Heading background color', '')}
+        headingBackground={text('Heading background color', 'brand')}
         pad={text('Modal body padding', 'medium')}
         plain={boolean('Plain layer', false)}
         position={select('Layer position', layerPositions, 'center')}
@@ -104,6 +104,7 @@ storiesOf('MovableModal', module)
         position={select('Layer position', layerPositions, 'top-left')}
         rndProps={object('RND props')}
         title={text('Title', '')}
+        titleColor=''
       >
         <Box gap='xsmall'>
           <label>


### PR DESCRIPTION
Package:
lib-classifier
lib-react-components

Closes #1785.

Describe your changes:
Remove the default heading colours from the `Modal` component, so that the defaults in `ModalHeading` are used.
Fixes padding around the content in `ModalBody` too.
Adds a few tests to check default props, where styles are passed as props.

TODO:
- [ ] Fix the colour of the close button so that it matches the heading text.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [x] Is the documentation up to date?

## Components
- [x] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
