### PR TITLE
Project: Fix the workflows helper when all workflows are complete

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/helpers/fetchWorkflowsHelper/fetchWorkflowsHelper.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/helpers/fetchWorkflowsHelper/fetchWorkflowsHelper.js
@@ -9,7 +9,7 @@ async function fetchWorkflowData (activeWorkflows) {
       include: 'subject_sets'
     })
   const { workflows, linked } = response.body
-  const subjectSets = linked.subject_sets
+  const subjectSets = linked ? linked.subject_sets : []
   await Promise.allSettled(subjectSets.map(fetchPreviewImage))
   return { subjectSets, workflows }
 }

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/helpers/fetchWorkflowsHelper/fetchWorkflowsHelper.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/helpers/fetchWorkflowsHelper/fetchWorkflowsHelper.spec.js
@@ -184,6 +184,25 @@ describe('Helpers > fetchWorkflowsHelper', function () {
     })
   })
 
+  describe('when all active workflows are complete', function () {
+    it('should return an empty array.', async function () {
+      const scope = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/translations')
+        .query(true)
+        .reply(200, {
+          translations: TRANSLATIONS
+        })
+        .get('/workflows')
+        .query(true)
+        .reply(200, {
+          workflows: []
+        })
+
+      const result = await fetchWorkflowsHelper('en', ['1', '2'], '2')
+      expect(result).to.be.empty()
+    })
+  })
+
   describe(`when there's an error`, function () {
     it('should allow the error to be thrown for the consumer to handle', async function () {
       const error = {


### PR DESCRIPTION
Package:
app-project

When a project's workflows are complete, the active workflows query returns an empty response. This adds a test to `fetchWorkflowsHelper` for that case, and fixes the API handler to return an empty response for the project Hero component.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
