### PR TITLE
Add a subject set store to workflows

### DIFF
--- a/packages/lib-classifier/dev/components/App/App.js
+++ b/packages/lib-classifier/dev/components/App/App.js
@@ -109,6 +109,7 @@ class App extends React.Component {
               onAddToCollection={(subjectId) => console.log(subjectId)}
               onCompleteClassification={(classification, subject) => console.log('onComplete', classification, subject)}
               project={this.state.project}
+              subjectSetID={this.props.subjectSetID}
               workflowID={this.props.workflowID}
             />
           </Box>

--- a/packages/lib-classifier/dev/index.js
+++ b/packages/lib-classifier/dev/index.js
@@ -3,18 +3,14 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './components/App'
 
-function getWorkflowID() {
+function getQueryParams() {
   if (window.location && window.location.search) {
-    const { workflow } = queryString.parse(window.location.search) // Search the query string for the 'project='
-    if (workflow) {
-      return workflow
-    }
-
-    return undefined
+    const { subjectSet, workflow } = queryString.parse(window.location.search)
+    return { subjectSet, workflow }
   }
 
-  return undefined
+  return {}
 }
 
-const workflowID = getWorkflowID()
-ReactDOM.render(<App workflowID={workflowID} />, document.getElementById('root'))
+const { subjectSet, workflow } = getQueryParams()
+ReactDOM.render(<App subjectSetID={subjectSet} workflowID={workflow} />, document.getElementById('root'))

--- a/packages/lib-classifier/src/store/Workflow/SubjectSet/SubjectSet.js
+++ b/packages/lib-classifier/src/store/Workflow/SubjectSet/SubjectSet.js
@@ -1,0 +1,11 @@
+import { types } from 'mobx-state-tree'
+import Resource from '../../Resource'
+
+const SubjectSet = types
+  .model('SubjectSet', {
+    display_name: types.string,
+    links: types.frozen({}),
+    set_member_subjects_count: types.number
+  })
+
+export default types.compose('SubjectSetResource', Resource, SubjectSet)

--- a/packages/lib-classifier/src/store/Workflow/SubjectSet/SubjectSet.spec.js
+++ b/packages/lib-classifier/src/store/Workflow/SubjectSet/SubjectSet.spec.js
@@ -1,0 +1,26 @@
+import SubjectSet from './SubjectSet'
+
+describe('Model > SubjectSet', function () {
+  let model
+
+  before(function () {
+    model = SubjectSet.create({
+      id: '1234',
+      display_name: 'Hello there!',
+      set_member_subjects_count: 19
+    })
+  })
+
+  it('should exist', function () {
+    expect(model).to.be.ok()
+    expect(model).to.be.an('object')
+  })
+
+  it('should have a display name', function () {
+    expect(model.display_name).to.equal('Hello there!')
+  })
+
+  it('should have a subject count', function () {
+    expect(model.set_member_subjects_count).to.equal(19)
+  })
+})

--- a/packages/lib-classifier/src/store/Workflow/SubjectSet/index.js
+++ b/packages/lib-classifier/src/store/Workflow/SubjectSet/index.js
@@ -1,0 +1,1 @@
+export { default } from './SubjectSet'

--- a/packages/lib-classifier/src/store/Workflow/SubjectSetStore/SubjectSetStore.js
+++ b/packages/lib-classifier/src/store/Workflow/SubjectSetStore/SubjectSetStore.js
@@ -1,0 +1,12 @@
+import { types } from 'mobx-state-tree'
+import SubjectSet from '../SubjectSet'
+import ResourceStore from '../../ResourceStore'
+
+const SubjectSetStore = types
+  .model('SubjectSetStore', {
+    active: types.safeReference(SubjectSet),
+    resources: types.map(SubjectSet),
+    type: types.optional(types.string, 'subject_sets')
+  })
+
+export default types.compose('SubjectSetResourceStore', ResourceStore, SubjectSetStore)

--- a/packages/lib-classifier/src/store/Workflow/SubjectSetStore/SubjectSetStore.spec.js
+++ b/packages/lib-classifier/src/store/Workflow/SubjectSetStore/SubjectSetStore.spec.js
@@ -1,8 +1,9 @@
+import { SubjectSetFactory } from '@test/factories'
 import SubjectSetStore from './SubjectSetStore'
 
 describe('Model > SubjectSetStore', function () {
   let model
-  const subjectSet = {
+  const subjectSet = SubjectSetFactory.build({
     id: '1234',
     display_name: 'Hello there!',
     set_member_subjects_count: 73,
@@ -10,7 +11,7 @@ describe('Model > SubjectSetStore', function () {
       projects: ['12345'],
       workflows: ['12345']
     }
-  }
+  })
 
   before(function () {
     model = SubjectSetStore.create({})

--- a/packages/lib-classifier/src/store/Workflow/SubjectSetStore/SubjectSetStore.spec.js
+++ b/packages/lib-classifier/src/store/Workflow/SubjectSetStore/SubjectSetStore.spec.js
@@ -1,0 +1,29 @@
+import SubjectSetStore from './SubjectSetStore'
+
+describe('Model > SubjectSetStore', function () {
+  let model
+  const subjectSet = {
+    id: '1234',
+    display_name: 'Hello there!',
+    set_member_subjects_count: 73,
+    links: {
+      projects: ['12345'],
+      workflows: ['12345']
+    }
+  }
+
+  before(function () {
+    model = SubjectSetStore.create({})
+  })
+
+  it('should exist', function () {
+    expect(model).to.be.ok()
+    expect(model).to.be.an('object')
+  })
+
+  it('should store subject sets', function () {
+    model.setResources([subjectSet])
+    model.setActive('1234')
+    expect(model.active).to.deep.equal(subjectSet)
+  })
+})

--- a/packages/lib-classifier/src/store/Workflow/SubjectSetStore/index.js
+++ b/packages/lib-classifier/src/store/Workflow/SubjectSetStore/index.js
@@ -1,0 +1,1 @@
+export { default } from './SubjectSetStore'

--- a/packages/lib-classifier/src/store/Workflow/Workflow.js
+++ b/packages/lib-classifier/src/store/Workflow/Workflow.js
@@ -1,4 +1,4 @@
-import { flow, types } from 'mobx-state-tree'
+import { flow, tryReference, types } from 'mobx-state-tree'
 import Resource from '../Resource'
 import SubjectSetStore from './SubjectSetStore'
 import WorkflowConfiguration from './WorkflowConfiguration'
@@ -25,7 +25,8 @@ const Workflow = types
     get subjectSetId () {
       // TODO: enable selection of a subject set from the links array.
       const [ subjectSetId ] = self.links.subject_sets
-      return self.subjectSets.active?.id || subjectSetId
+      const activeSet = tryReference(() => self.subjectSets.active)
+      return activeSet?.id || subjectSetId
     },
 
     get usesTranscriptionTask () {
@@ -38,7 +39,7 @@ const Workflow = types
   .actions(self => {
     function * selectSubjectSet(id) {
       yield self.subjectSets.setActive(id)
-      return self.subjectSets.active
+      return tryReference(() => self.subjectSets.active)
     }
 
     return {

--- a/packages/lib-classifier/src/store/Workflow/Workflow.js
+++ b/packages/lib-classifier/src/store/Workflow/Workflow.js
@@ -1,5 +1,6 @@
-import { types } from 'mobx-state-tree'
+import { flow, types } from 'mobx-state-tree'
 import Resource from '../Resource'
+import SubjectSetStore from './SubjectSetStore'
 import WorkflowConfiguration from './WorkflowConfiguration'
 
 // The db type for steps is jsonb which is being serialized as an empty object when not defined.
@@ -7,7 +8,6 @@ import WorkflowConfiguration from './WorkflowConfiguration'
 const Workflow = types
   .model('Workflow', {
     active: types.optional(types.boolean, false),
-    activeSubjectSet: types.optional(types.string, ''),
     configuration: WorkflowConfiguration,
     display_name: types.string,
     first_task: types.optional(types.string, ''),
@@ -16,6 +16,7 @@ const Workflow = types
     steps: types.union(types.frozen({}), types.array(types.array(
       types.union(types.string, types.frozen())
     ))),
+    subjectSets: types.optional(SubjectSetStore, () => SubjectSetStore.create({})),
     tasks: types.maybe(types.frozen()),
     version: types.string
   })
@@ -24,7 +25,7 @@ const Workflow = types
     get subjectSetId () {
       // TODO: enable selection of a subject set from the links array.
       const [ subjectSetId ] = self.links.subject_sets
-      return self.activeSubjectSet || subjectSetId
+      return self.subjectSets.active?.id || subjectSetId
     },
 
     get usesTranscriptionTask () {
@@ -35,12 +36,13 @@ const Workflow = types
   }))
 
   .actions(self => {
-    function selectSubjectSet(id) {
-      self.activeSubjectSet = id
+    function * selectSubjectSet(id) {
+      yield self.subjectSets.setActive(id)
+      return self.subjectSets.active
     }
 
     return {
-      selectSubjectSet
+      selectSubjectSet: flow(selectSubjectSet)
     }
   })
 

--- a/packages/lib-classifier/src/store/Workflow/Workflow.spec.js
+++ b/packages/lib-classifier/src/store/Workflow/Workflow.spec.js
@@ -64,18 +64,17 @@ describe('Model > Workflow', function () {
       const workflowSnapshot = WorkflowFactory.build({
         id: 'workflow1',
         display_name: 'A test workflow',
-        version: '0.0',
-        links: {
-          subject_sets: ['1', '2', '3','4']
-        }
+        version: '0.0'
       })
       workflow = Workflow.create(workflowSnapshot)
     })
 
     it('should set the active subject set', function () {
-      expect(workflow.subjectSetId).to.equal('1')
-      workflow.selectSubjectSet('4')
-      expect(workflow.subjectSetId).to.equal('4')
+      const defaultID = workflow.links.subject_sets[0]
+      expect(workflow.subjectSetId).to.equal(defaultID)
+      const subjectSetID = workflow.links.subject_sets[1]
+      workflow.selectSubjectSet(subjectSetID)
+      expect(workflow.subjectSetId).to.equal(subjectSetID)
     })
   })
 })

--- a/packages/lib-classifier/src/store/Workflow/Workflow.spec.js
+++ b/packages/lib-classifier/src/store/Workflow/Workflow.spec.js
@@ -1,5 +1,6 @@
 import { WorkflowFactory } from '@test/factories'
 import { Factory } from 'rosie'
+import sinon from 'sinon'
 import Workflow from './Workflow'
 
 describe('Model > Workflow', function () {
@@ -96,10 +97,12 @@ describe('Model > Workflow', function () {
     describe('with an invalid subject set', function () {
 
       it('should return undefined', async function () {
+        sinon.stub(workflow.subjectSets, 'fetchResource').callsFake(async () => undefined)
         const defaultID = workflow.links.subject_sets[0]
         expect(workflow.subjectSetId).to.equal(defaultID)
         const subjectSet = await workflow.selectSubjectSet('abcdefg')
         expect(subjectSet).to.be.undefined()
+        workflow.subjectSets.fetchResource.restore()
       })
     })
   })
@@ -141,10 +144,12 @@ describe('Model > Workflow', function () {
     describe('with an invalid subject set', function () {
 
       it('should return the default subject set', async function () {
+        sinon.stub(workflow.subjectSets, 'fetchResource').callsFake(async () => undefined)
         const defaultID = workflow.links.subject_sets[0]
         expect(workflow.subjectSetId).to.equal(defaultID)
         await workflow.selectSubjectSet('abcdefg')
         expect(workflow.subjectSetId).to.equal(defaultID)
+        workflow.subjectSets.fetchResource.restore()
       })
     })
   })

--- a/packages/lib-classifier/src/store/Workflow/Workflow.spec.js
+++ b/packages/lib-classifier/src/store/Workflow/Workflow.spec.js
@@ -1,4 +1,5 @@
 import { WorkflowFactory } from '@test/factories'
+import { Factory } from 'rosie'
 import Workflow from './Workflow'
 
 describe('Model > Workflow', function () {
@@ -61,9 +62,20 @@ describe('Model > Workflow', function () {
     let workflow
 
     beforeEach(function () {
+      const subjectSets = Factory.buildList('subject_set', 5)
+      const subjectSetMap = {}
+      subjectSets.forEach(subjectSet => {
+        subjectSetMap[subjectSet.id] = subjectSet
+      })
       const workflowSnapshot = WorkflowFactory.build({
         id: 'workflow1',
         display_name: 'A test workflow',
+        links: {
+          subject_sets: Object.keys(subjectSetMap)
+        },
+        subjectSets: {
+          resources: subjectSetMap
+        },
         version: '0.0'
       })
       workflow = Workflow.create(workflowSnapshot)
@@ -96,9 +108,20 @@ describe('Model > Workflow', function () {
     let workflow
 
     beforeEach(function () {
+      const subjectSets = Factory.buildList('subject_set', 5)
+      const subjectSetMap = {}
+      subjectSets.forEach(subjectSet => {
+        subjectSetMap[subjectSet.id] = subjectSet
+      })
       const workflowSnapshot = WorkflowFactory.build({
         id: 'workflow1',
         display_name: 'A test workflow',
+        links: {
+          subject_sets: Object.keys(subjectSetMap)
+        },
+        subjectSets: {
+          resources: subjectSetMap
+        },
         version: '0.0'
       })
       workflow = Workflow.create(workflowSnapshot)

--- a/packages/lib-classifier/src/store/Workflow/Workflow.spec.js
+++ b/packages/lib-classifier/src/store/Workflow/Workflow.spec.js
@@ -60,7 +60,7 @@ describe('Model > Workflow', function () {
   describe('Actions > selectSubjectSet', function () {
     let workflow
 
-    before(function () {
+    beforeEach(function () {
       const workflowSnapshot = WorkflowFactory.build({
         id: 'workflow1',
         display_name: 'A test workflow',
@@ -69,12 +69,60 @@ describe('Model > Workflow', function () {
       workflow = Workflow.create(workflowSnapshot)
     })
 
-    it('should set the active subject set', function () {
-      const defaultID = workflow.links.subject_sets[0]
-      expect(workflow.subjectSetId).to.equal(defaultID)
-      const subjectSetID = workflow.links.subject_sets[1]
-      workflow.selectSubjectSet(subjectSetID)
-      expect(workflow.subjectSetId).to.equal(subjectSetID)
+    describe('with a valid subject set', function () {
+
+      it('should set the active subject set', async function () {
+        const defaultID = workflow.links.subject_sets[0]
+        expect(workflow.subjectSetId).to.equal(defaultID)
+        const subjectSetID = workflow.links.subject_sets[1]
+        const subjectSet = await workflow.selectSubjectSet(subjectSetID)
+        expect(subjectSet.id).to.equal(subjectSetID)
+        expect(subjectSet).to.deep.equal(workflow.subjectSets.active)
+      })
+    })
+
+    describe('with an invalid subject set', function () {
+
+      it('should return undefined', async function () {
+        const defaultID = workflow.links.subject_sets[0]
+        expect(workflow.subjectSetId).to.equal(defaultID)
+        const subjectSet = await workflow.selectSubjectSet('abcdefg')
+        expect(subjectSet).to.be.undefined()
+      })
+    })
+  })
+
+  describe('Views > subjectSetId', function () {
+    let workflow
+
+    beforeEach(function () {
+      const workflowSnapshot = WorkflowFactory.build({
+        id: 'workflow1',
+        display_name: 'A test workflow',
+        version: '0.0'
+      })
+      workflow = Workflow.create(workflowSnapshot)
+    })
+
+    describe('with a valid subject set', function () {
+
+      it('should return the active subject set', async function () {
+        const defaultID = workflow.links.subject_sets[0]
+        expect(workflow.subjectSetId).to.equal(defaultID)
+        const subjectSetID = workflow.links.subject_sets[1]
+        await workflow.selectSubjectSet(subjectSetID)
+        expect(workflow.subjectSetId).to.equal(subjectSetID)
+      })
+    })
+
+    describe('with an invalid subject set', function () {
+
+      it('should return the default subject set', async function () {
+        const defaultID = workflow.links.subject_sets[0]
+        expect(workflow.subjectSetId).to.equal(defaultID)
+        await workflow.selectSubjectSet('abcdefg')
+        expect(workflow.subjectSetId).to.equal(defaultID)
+      })
     })
   })
 })

--- a/packages/lib-classifier/src/store/WorkflowStore/WorkflowStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/WorkflowStore.js
@@ -61,7 +61,8 @@ const WorkflowStore = types
         self.resources.put(workflow)
         if (subjectSetID) {
           const selectedWorkflow = self.resources.get(id)
-          selectedWorkflow.selectSubjectSet(subjectSetID)
+          // wait for the subject set to load before activating the workflow
+          const subjectSet = yield selectedWorkflow.selectSubjectSet(subjectSetID)
         }
         self.setActive(id)
       } else {

--- a/packages/lib-classifier/src/store/WorkflowStore/WorkflowStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/WorkflowStore.spec.js
@@ -121,7 +121,7 @@ describe('Model > WorkflowStore', function () {
       before(async function () {
         const workflows = Factory.buildList('workflow', 5)
         workflowID = workflows[2].id
-        subjectSetID = workflows[2].links.subject_sets[3]
+        subjectSetID = workflows[2].links.subject_sets[1]
         const panoptesClientStub = stubPanoptesJs({
           subjects: Factory.buildList('subject', 10),
           workflows: workflows[2]

--- a/packages/lib-classifier/src/store/WorkflowStore/WorkflowStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/WorkflowStore.spec.js
@@ -1,5 +1,6 @@
 import { Factory } from 'rosie'
 import RootStore from '../RootStore'
+import Workflow from '../Workflow'
 import WorkflowStore from './WorkflowStore'
 import {
   SingleChoiceTaskFactory,
@@ -119,17 +120,33 @@ describe('Model > WorkflowStore', function () {
       let workflowID
 
       before(async function () {
-        const workflows = Factory.buildList('workflow', 5)
-        workflowID = workflows[2].id
-        subjectSetID = workflows[2].links.subject_sets[1]
+        const subjectSets = Factory.buildList('subject_set', 5)
+        const subjectSetMap = {}
+        subjectSets.forEach(subjectSet => {
+          subjectSetMap[subjectSet.id] = subjectSet
+        })
+        const workflowSnapshot = WorkflowFactory.build({
+          id: 'workflow1',
+          display_name: 'A test workflow',
+          links: {
+            subject_sets: Object.keys(subjectSetMap)
+          },
+          subjectSets: {
+            resources: subjectSetMap
+          },
+          version: '0.0'
+        })
+        const workflow = Workflow.create(workflowSnapshot)
+        workflowID = workflow.id
+        subjectSetID = workflow.links.subject_sets[1]
         const panoptesClientStub = stubPanoptesJs({
           subjects: Factory.buildList('subject', 10),
-          workflows: workflows[2]
+          workflows: workflow
         })
 
         rootStore = setupStores(panoptesClientStub, projectWithoutDefault)
         rootStore.workflows.reset()
-        rootStore.workflows.setResources(workflows)
+        rootStore.workflows.setResources([workflow])
         await rootStore.workflows.selectWorkflow(workflowID, subjectSetID)
       })
 

--- a/packages/lib-classifier/test/factories/SubjectSetFactory.js
+++ b/packages/lib-classifier/test/factories/SubjectSetFactory.js
@@ -1,6 +1,6 @@
 import { Factory } from 'rosie'
 
-export default Factory.define('subject_sets')
+export default Factory.define('subject_set')
   .sequence('id', (id) => { return id.toString() })
   .attr('display_name', 'Hello there!')
   .attr('set_member_subjects_count', 56)

--- a/packages/lib-classifier/test/factories/SubjectSetFactory.js
+++ b/packages/lib-classifier/test/factories/SubjectSetFactory.js
@@ -1,0 +1,7 @@
+import { Factory } from 'rosie'
+
+export default Factory.define('subject_sets')
+  .sequence('id', (id) => { return id.toString() })
+  .attr('display_name', 'Hello there!')
+  .attr('set_member_subjects_count', 56)
+  .attr('links', {})

--- a/packages/lib-classifier/test/factories/WorkflowFactory.js
+++ b/packages/lib-classifier/test/factories/WorkflowFactory.js
@@ -2,10 +2,6 @@ import { Factory } from 'rosie'
 import SubjectSetFactory from './SubjectSetFactory'
 
 const subjectSets = Factory.buildList('subject_set', 5)
-const subjectSetMap = {}
-subjectSets.forEach(subjectSet => {
-  subjectSetMap[subjectSet.id] = subjectSet
-})
 
 export default Factory.define('workflow')
   .sequence('id', (id) => { return id.toString() })
@@ -17,11 +13,11 @@ export default Factory.define('workflow')
   .attr('first_task', '')
   .attr('grouped', false)
   .attr('links', {
-    subject_sets: Object.keys(subjectSetMap)
+    subject_sets: subjectSets.map(subjectSet => subjectSet.id)
   })
   .attr('tasks', {})
   .attr('steps', [])
   .attr('subjectSets', {
-    resources: subjectSetMap
+    resources: {}
   })
   .attr('version', '1.0')

--- a/packages/lib-classifier/test/factories/WorkflowFactory.js
+++ b/packages/lib-classifier/test/factories/WorkflowFactory.js
@@ -1,4 +1,9 @@
 import { Factory } from 'rosie'
+import SubjectSetFactory from './SubjectSetFactory'
+
+const subjectSets = SubjectSetFactory.buildList('subject_sets', 10)
+const subjectSetMap = {}
+subjectSets.forEach(subjectSet => subjectSetMap[subjectSet.id] = subjectSet)
 
 export default Factory.define('workflow')
   .sequence('id', (id) => { return id.toString() })
@@ -11,25 +16,14 @@ export default Factory.define('workflow')
   .attr('grouped', false)
   .attr('links', ['id'], function (id) {
     return {
-      subject_sets: [`${id}1`, `${id}2`]
+      subject_sets: subjectSets.map(subjectSet => subjectSet.id)
     }
   })
   .attr('tasks', {})
   .attr('steps', [])
   .attr('subjectSets', ['id'], function (id) {
     return {
-      resources: {
-        [`${id}1`]: {
-          id: `${id}1`,
-          display_name: 'A Subject Set',
-          set_member_subjects_count: 6
-        },
-        [`${id}2`]: {
-          id: `${id}2`,
-          display_name: 'Another Subject Set',
-          set_member_subjects_count: 9
-        }
-      }
+      resources: subjectSetMap
     }
   })
   .attr('version', '1.0')

--- a/packages/lib-classifier/test/factories/WorkflowFactory.js
+++ b/packages/lib-classifier/test/factories/WorkflowFactory.js
@@ -9,9 +9,27 @@ export default Factory.define('workflow')
   .attr('configuration', {})
   .attr('first_task', '')
   .attr('grouped', false)
-  .attr('links', {
-    subject_sets: ['1', '2', '3', '4', '5']
+  .attr('links', ['id'], function (id) {
+    return {
+      subject_sets: [`${id}1`, `${id}2`]
+    }
   })
   .attr('tasks', {})
   .attr('steps', [])
+  .attr('subjectSets', ['id'], function (id) {
+    return {
+      resources: {
+        [`${id}1`]: {
+          id: `${id}1`,
+          display_name: 'A Subject Set',
+          set_member_subjects_count: 6
+        },
+        [`${id}2`]: {
+          id: `${id}2`,
+          display_name: 'Another Subject Set',
+          set_member_subjects_count: 9
+        }
+      }
+    }
+  })
   .attr('version', '1.0')

--- a/packages/lib-classifier/test/factories/WorkflowFactory.js
+++ b/packages/lib-classifier/test/factories/WorkflowFactory.js
@@ -1,9 +1,11 @@
 import { Factory } from 'rosie'
 import SubjectSetFactory from './SubjectSetFactory'
 
-const subjectSets = SubjectSetFactory.buildList('subject_sets', 10)
+const subjectSets = Factory.buildList('subject_set', 5)
 const subjectSetMap = {}
-subjectSets.forEach(subjectSet => subjectSetMap[subjectSet.id] = subjectSet)
+subjectSets.forEach(subjectSet => {
+  subjectSetMap[subjectSet.id] = subjectSet
+})
 
 export default Factory.define('workflow')
   .sequence('id', (id) => { return id.toString() })
@@ -14,16 +16,12 @@ export default Factory.define('workflow')
   .attr('configuration', {})
   .attr('first_task', '')
   .attr('grouped', false)
-  .attr('links', ['id'], function (id) {
-    return {
-      subject_sets: subjectSets.map(subjectSet => subjectSet.id)
-    }
+  .attr('links', {
+    subject_sets: Object.keys(subjectSetMap)
   })
   .attr('tasks', {})
   .attr('steps', [])
-  .attr('subjectSets', ['id'], function (id) {
-    return {
-      resources: subjectSetMap
-    }
+  .attr('subjectSets', {
+    resources: subjectSetMap
   })
   .attr('version', '1.0')

--- a/packages/lib-classifier/test/factories/index.js
+++ b/packages/lib-classifier/test/factories/index.js
@@ -10,6 +10,7 @@ export { default as UserFactory } from './UserFactory'
 export { default as ClassificationFactory } from './ClassificationFactory'
 export { default as FieldGuideFactory } from './FieldGuideFactory'
 export { default as FeedbackFactory } from './FeedbackFactory'
+export { default as SubjectSetFactory } from './SubjectSetFactory'
 export { FieldGuideMediumFactory, TutorialMediumFactory }
 
 // Workflow Task Factories


### PR DESCRIPTION
Add `workflow.subjectSets`, which is a `SubjectSetStore`. Use `workflow.subjectSets.active` for subject selection.

Based off #1804.

~~Set to draft because workflow store tests are failing with invalid reference errors.~~

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
