### PR TITLE
Project: Add app-project express server

### DIFF
--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -36,7 +36,7 @@
     "mobx-devtools-mst": "~0.9.18",
     "mobx-react": "~5.2.8",
     "mobx-state-tree": "~3.15.0",
-    "morgan": "^1.9.1",
+    "morgan": "^1.10.0",
     "newrelic": "^5.10.0",
     "next": "~9.4.1",
     "next-absolute-url": "~1.1.1",

--- a/packages/app-content-pages/server/set-logging.js
+++ b/packages/app-content-pages/server/set-logging.js
@@ -9,12 +9,12 @@ function setLogging (expressInstance) {
   if (production) {
     expressInstance.use(morgan('combined', {
       skip: (req, res) => res.statusCode < 400,
-      stream: process.stdout
+      stream: process.stderr
     }))
 
     expressInstance.use(morgan('combined', {
       skip: (req, res) => res.statusCode >= 400,
-      stream: process.stderr
+      stream: process.stdout
     }))
   }
 }

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "PANOPTES_ENV=${PANOPTES_ENV:-production} next build",
     "build-storybook": "build-storybook -s public",
-    "dev": "PANOPTES_ENV=${PANOPTES_ENV:-production} node server/server.js",
+    "dev": "PANOPTES_ENV=${PANOPTES_ENV:-staging} node server/server.js",
     "lint": "zoo-standard --fix | snazzy",
     "start": "NODE_ENV=${NODE_ENV:-production} node server/server.js",
     "storybook": "start-storybook -p 9001 -c .storybook -s public",

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -8,9 +8,9 @@
   "scripts": {
     "build": "PANOPTES_ENV=${PANOPTES_ENV:-production} next build",
     "build-storybook": "build-storybook -s public",
-    "dev": "next",
+    "dev": "PANOPTES_ENV=${PANOPTES_ENV:-production} node server/server.js",
     "lint": "zoo-standard --fix | snazzy",
-    "start": "NODE_ENV=${NODE_ENV:-production} next start",
+    "start": "NODE_ENV=${NODE_ENV:-production} node server/server.js",
     "storybook": "start-storybook -p 9001 -c .storybook -s public",
     "test": "BABEL_ENV=test mocha",
     "test:ci": "BABEL_ENV=test mocha --reporter=min"
@@ -33,6 +33,7 @@
     "counterpart": "~0.18.6",
     "d3": "~5.9.7",
     "dotenv-webpack": "~1.7.0",
+    "express": "^4.17.1",
     "graphql-request": "~1.8.2",
     "grommet": "~2.11.1",
     "grommet-icons": "~4.4.0",
@@ -42,6 +43,7 @@
     "mobx-devtools-mst": "~0.9.21",
     "mobx-react": "~5.4.4",
     "mobx-state-tree": "~3.15.0",
+    "morgan": "^1.10.0",
     "newrelic": "~5.10.0",
     "next": "~9.4.1",
     "panoptes-client": "~3.2.1",

--- a/packages/app-project/server/server.js
+++ b/packages/app-project/server/server.js
@@ -1,0 +1,30 @@
+if (process.env.NEWRELIC_LICENSE_KEY) {
+  require('newrelic')
+}
+
+const express = require('express')
+const next = require('next')
+
+const setLogging = require('./set-logging')
+const setCacheHeaders = require('./set-cache-headers')
+
+const port = parseInt(process.env.PORT, 10) || 3000
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+app.prepare().then(() => {
+  const server = express()
+
+  setLogging(server)
+
+  server.get('*', (req, res) => {
+    setCacheHeaders(req, res)
+    return handle(req, res)
+  })
+
+  server.listen(port, err => {
+    if (err) throw err
+    console.log(`> Ready on http://localhost:${port}`)
+  })
+})

--- a/packages/app-project/server/set-cache-headers.js
+++ b/packages/app-project/server/set-cache-headers.js
@@ -1,0 +1,25 @@
+// Sets cache headers dependent on asset type. Caching headers are set here so
+// that they are respected downstream by CloudFront.
+//
+// Javascript files can have a massive `max-age` as they are cache-busted
+// by filename. Everything else is set to a minute.
+
+const process = require('process')
+
+const enableCacheHeaders = process.env.ENABLE_CACHE_HEADERS === 'true'
+const DEFAULT_MAX_AGE = process.env.DEFAULT_MAX_AGE || 60 // 1 minute
+const JS_MAX_AGE = process.env.JS_MAX_AGE || 31536000 // 1 year
+
+function setCacheHeaders (req, res) {
+  if (enableCacheHeaders) {
+    let maxAge = isJsRequest(req) ? JS_MAX_AGE : DEFAULT_MAX_AGE
+    res.setHeader('Cache-Control', `max-age=${maxAge}`)
+  }
+}
+
+function isJsRequest (req) {
+  const regex = /\.js$/i
+  return regex.test(req.path)
+}
+
+module.exports = setCacheHeaders

--- a/packages/app-project/server/set-cache-headers.spec.js
+++ b/packages/app-project/server/set-cache-headers.spec.js
@@ -1,0 +1,79 @@
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+describe('Server > setCacheHeaders', function () {
+  let setCacheHeaders
+  const mockRes = {
+    setHeader: Function.prototype
+  }
+  const setHeaderSpy = sinon.spy(mockRes, 'setHeader')
+
+  describe('default behaviour', function () {
+    before(function () {
+      setCacheHeaders = require('./set-cache-headers')
+    })
+
+    afterEach(function () {
+      setHeaderSpy.resetHistory()
+    })
+
+    it(`shouldn't set any extra headers`, function () {
+      setCacheHeaders({ path: '/foo.html' }, mockRes)
+      expect(setHeaderSpy).to.have.not.been.called()
+    })
+  })
+
+  describe('behaviour with caching enabled', function () {
+    before(function () {
+      setCacheHeaders = proxyquire('./set-cache-headers', {
+        process: {
+          env: {
+            ENABLE_CACHE_HEADERS: 'true'
+          }
+        }
+      })
+    })
+
+    afterEach(function () {
+      setHeaderSpy.resetHistory()
+    })
+
+    it('should set the max-age to 1 minute by default', function () {
+      setCacheHeaders({ path: '/foo.html' }, mockRes)
+      expect(setHeaderSpy).to.be.calledWith('Cache-Control', 'max-age=60')
+    })
+
+    it('should set the max-age to 1 year for `.js` files', function () {
+      setCacheHeaders({ path: '/foo.js' }, mockRes)
+      expect(setHeaderSpy).to.be.calledWith('Cache-Control', 'max-age=31536000')
+    })
+  })
+
+  describe('configured behaviour with caching enabled', function () {
+    before(function () {
+      setCacheHeaders = proxyquire('./set-cache-headers', {
+        process: {
+          env: {
+            DEFAULT_MAX_AGE: '100',
+            ENABLE_CACHE_HEADERS: 'true',
+            JS_MAX_AGE: '200'
+          }
+        }
+      })
+    })
+
+    afterEach(function () {
+      setHeaderSpy.resetHistory()
+    })
+
+    it('should set the default max-age to the value of `DEFAULT_MAX_AGE`', function () {
+      setCacheHeaders({ path: '/foo.html' }, mockRes)
+      expect(setHeaderSpy).to.be.calledWith('Cache-Control', 'max-age=100')
+    })
+
+    it('should set the max-age for `.js` files to the value of `JS_MAX_AGE`', function () {
+      setCacheHeaders({ path: '/foo.js' }, mockRes)
+      expect(setHeaderSpy).to.be.calledWith('Cache-Control', 'max-age=200')
+    })
+  })
+})

--- a/packages/app-project/server/set-logging.js
+++ b/packages/app-project/server/set-logging.js
@@ -1,0 +1,22 @@
+// Sets up morgan for request logging in production
+
+const morgan = require('morgan')
+const process = require('process')
+
+const production = process.env.NODE_ENV === 'production'
+
+function setLogging (expressInstance) {
+  if (production) {
+    expressInstance.use(morgan('combined', {
+      skip: (req, res) => res.statusCode < 400,
+      stream: process.stdout
+    }))
+
+    expressInstance.use(morgan('combined', {
+      skip: (req, res) => res.statusCode >= 400,
+      stream: process.stderr
+    }))
+  }
+}
+
+module.exports = setLogging

--- a/packages/app-project/server/set-logging.js
+++ b/packages/app-project/server/set-logging.js
@@ -9,12 +9,12 @@ function setLogging (expressInstance) {
   if (production) {
     expressInstance.use(morgan('combined', {
       skip: (req, res) => res.statusCode < 400,
-      stream: process.stdout
+      stream: process.stderr
     }))
 
     expressInstance.use(morgan('combined', {
       skip: (req, res) => res.statusCode >= 400,
-      stream: process.stderr
+      stream: process.stdout
     }))
   }
 }

--- a/packages/app-project/server/set-logging.spec.js
+++ b/packages/app-project/server/set-logging.spec.js
@@ -1,0 +1,46 @@
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+describe('Server > setLogging', function () {
+  let setLogging
+  const expressInstance = {
+    use: Function.prototype
+  }
+  const useSpy = sinon.spy(expressInstance, 'use')
+
+  describe('default behaviour', function () {
+    before(function () {
+      setLogging = require('./set-logging')
+    })
+
+    afterEach(function () {
+      useSpy.resetHistory()
+    })
+
+    it(`shouldn't enable morgan`, function () {
+      setLogging(expressInstance)
+      expect(useSpy).to.have.not.been.called()
+    })
+  })
+
+  describe('production behaviour', function () {
+    before(function () {
+      setLogging = proxyquire('./set-logging', {
+        process: {
+          env: {
+            NODE_ENV: 'production'
+          }
+        }
+      })
+    })
+
+    afterEach(function () {
+      useSpy.resetHistory()
+    })
+
+    it('should enable morgan', function () {
+      setLogging(expressInstance)
+      expect(useSpy).to.have.been.called()
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5447,7 +5447,7 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-basic-auth@~2.0.0:
+basic-auth@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
   integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
@@ -7721,6 +7721,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 deprecation@^2.0.0:
   version "2.3.1"
@@ -12581,16 +12586,16 @@ moo@^0.4.3:
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
   integrity sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==
 
-morgan@^1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
-  integrity sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==
+morgan@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"
+  integrity sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==
   dependencies:
-    basic-auth "~2.0.0"
+    basic-auth "~2.0.1"
     debug "2.6.9"
-    depd "~1.1.2"
+    depd "~2.0.0"
     on-finished "~2.3.0"
-    on-headers "~1.0.1"
+    on-headers "~1.0.2"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -13345,7 +13350,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-on-headers@~1.0.1, on-headers@~1.0.2:
+on-headers@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
   integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==


### PR DESCRIPTION
Add express to the project app, with [morgan](https://github.com/expressjs/morgan) for request logging. The server setup is copied from #950, including cache headers.

Bumps morgan to 1.10.

Package:
app-project

Closes #1468.
Closes #1807.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
