### PR TITLE
Upgrade to mobx-react 6

### DIFF
--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -34,7 +34,7 @@
     "lodash": "~4.17.11",
     "mobx": "~5.5.0",
     "mobx-devtools-mst": "~0.9.18",
-    "mobx-react": "~5.2.8",
+    "mobx-react": "~6.1.4",
     "mobx-state-tree": "~3.15.0",
     "morgan": "^1.10.0",
     "newrelic": "^5.10.0",

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -41,7 +41,7 @@
     "luxon": "~1.16.0",
     "mobx": "~5.15.0",
     "mobx-devtools-mst": "~0.9.21",
-    "mobx-react": "~5.4.4",
+    "mobx-react": "~6.1.4",
     "mobx-state-tree": "~3.15.0",
     "morgan": "^1.10.0",
     "newrelic": "~5.10.0",

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -11,7 +11,7 @@ class ClassifyPageContainer extends Component {
   }
 
   addToCollection (subjectId) {
-    this.collectionsModal.current.wrappedInstance.open(subjectId)
+    this.collectionsModal.current.open(subjectId)
   }
 
   render () {

--- a/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.js
@@ -14,7 +14,7 @@ export default function CollectionsButton (props) {
   const collectionsModal = React.createRef()
 
   function addToCollections () {
-    collectionsModal.current.wrappedInstance.open(subject.id)
+    collectionsModal.current.open(subject.id)
     onClick()
   }
 

--- a/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.spec.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.spec.js
@@ -1,7 +1,6 @@
 import { mount, shallow } from 'enzyme'
 import React from 'react'
 import sinon from 'sinon'
-import CollectionsModal from '@shared/components/CollectionsModal'
 import { MetaToolsButton } from '@zooniverse/react-components'
 import CollectionsButton from './CollectionsButton'
 import CollectionsIcon from './CollectionsIcon'
@@ -43,18 +42,13 @@ describe('Component > CollectionsButton', function () {
           subject={subject}
         />
       )
-      collectionsModal = wrapper.find(CollectionsModal).instance().wrappedInstance
+      collectionsModal = wrapper.find('CollectionsModalContainer').instance()
       sinon.stub(collectionsModal, 'open')
-      sinon.stub(console, 'error')
     })
 
     afterEach(function () {
       collectionsModal.open.resetHistory()
       onClick.resetHistory()
-    })
-
-    after(function () {
-      console.error.restore()
     })
 
     it('should open a collections modal', function () {
@@ -81,7 +75,7 @@ describe('Component > CollectionsButton', function () {
           subject={subject}
         />
       )
-      collectionsModal = wrapper.find(CollectionsModal).instance().wrappedInstance
+      collectionsModal = wrapper.find('CollectionsModalContainer').instance()
       sinon.spy(collectionsModal, 'open')
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10014,7 +10014,7 @@ hoist-non-react-statics@^1.0.0:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
   integrity sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=
 
-hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.3.1:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
@@ -12458,22 +12458,6 @@ mobx-react-lite@^1.4.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-1.5.1.tgz#8eac90985b4d2bee475dd90a0d4d903be578f154"
   integrity sha512-40Gn8hFq+MuNHqCaeSo2adN4WvpWkIeSYZVJWzRzm0rbEf0BFow6Ir9IefErql0pX9q650TN1JAQXvrXxKR8Mg==
-
-mobx-react@~5.2.8:
-  version "5.2.8"
-  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-5.2.8.tgz#059c7f29254d7cd36e103d79113103b40348d3bf"
-  integrity sha512-VAkeqkrIpdoy3VPPoqvxjdQmcTT6hi7i3TsZSwcKbSrPbSTuWc7cp1EOiX/zV1wPWEuoNAQ22bCrskQwvdYTJA==
-  dependencies:
-    hoist-non-react-statics "^2.5.0"
-    react-lifecycles-compat "^3.0.2"
-
-mobx-react@~5.4.4:
-  version "5.4.4"
-  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-5.4.4.tgz#b3de9c6eabcd0ed8a40036888cb0221ab9568b80"
-  integrity sha512-2mTzpyEjVB/RGk2i6KbcmP4HWcAUFox5ZRCrGvSyz49w20I4C4qql63grPpYrS9E9GKwgydBHQlA4y665LuRCQ==
-  dependencies:
-    hoist-non-react-statics "^3.0.0"
-    react-lifecycles-compat "^3.0.2"
 
 mobx-react@~6.1.4:
   version "6.1.4"


### PR DESCRIPTION
Upgrade the NextJS apps to mobx-react 6.1.4.

The upgrade breaks refs in a couple of places in the project app, so there are some changes to the 'add to collections' modal in order to fix those.

Package:
app-content-pages
app-project


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
