### PR TITLE
Task models: remove unused actions and use tryReference to access annotations

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/README.md
+++ b/packages/lib-classifier/src/plugins/drawingTools/README.md
@@ -120,13 +120,13 @@ let annotation = line1.addAnnotation({ task })
 
 task.setAnnotation(annotation)
 
-task.updateAnnotation('Hello! This is the first line.')
+annotation.update('Hello! This is the first line.')
 
 annotation = line2.addAnnotation({ task })
 
 task.setAnnotation(annotation)
 
-task.updateAnnotation('This is the second line of text.')
+annotation.update('This is the second line of text.')
 
 // check if a line has been completed.
 

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Ellipse/Ellipse.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Ellipse/Ellipse.stories.js
@@ -91,7 +91,6 @@ function setupStores({ activeMark, subtask }) {
   }
 
   mockStores.classifications.createClassification(subject, workflow, project)
-  mockStores.workflowSteps.activeStepTasks[0].updateAnnotation()
   if (activeMark) {
     mockStores.workflowSteps.activeStepTasks[0].setActiveMark(ellipse.id)
   }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.stories.js
@@ -91,7 +91,6 @@ function setupStores({ activeMark, subtask }) {
   }
 
   mockStores.classifications.createClassification(subject, workflow, project)
-  mockStores.workflowSteps.activeStepTasks[0].updateAnnotation()
   if (activeMark) {
     mockStores.workflowSteps.activeStepTasks[0].setActiveMark(line.id)
   }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.stories.js
@@ -90,7 +90,6 @@ function setupStores ({ activeMark, subtask }) {
   }
 
   mockStores.classifications.createClassification(subject, workflow, project)
-  mockStores.workflowSteps.activeStepTasks[0].updateAnnotation()
   if (activeMark) {
     mockStores.workflowSteps.activeStepTasks[0].setActiveMark(point.id)
   }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Rectangle/Rectangle.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Rectangle/Rectangle.stories.js
@@ -91,7 +91,6 @@ function setupStores({ activeMark, subtask }) {
   }
 
   mockStores.classifications.createClassification(subject, workflow, project)
-  mockStores.workflowSteps.activeStepTasks[0].updateAnnotation()
   if (activeMark) {
     mockStores.workflowSteps.activeStepTasks[0].setActiveMark(rectangle.id)
   }

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
@@ -81,7 +81,6 @@ function setupStores({ activeMark, finished, subtask }) {
   }
 
   mockStores.classifications.createClassification(subject, workflow, project)
-  mockStores.workflowSteps.activeStepTasks[0].updateAnnotation()
   if (activeMark) {
     mockStores.workflowSteps.activeStepTasks[0].setActiveMark(transcriptionLine.id)
   }

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
@@ -70,7 +70,7 @@ export const Drawing = types.model('Drawing', {
     }
 
     function complete () {
-      self.updateAnnotation(self.marks)
+      self.annotation.update(self.marks)
     }
 
     function reset () {

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/models/MultipleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/models/MultipleChoiceTask.spec.js
@@ -51,11 +51,12 @@ describe('Model > MultipleChoiceTask', function () {
   })
 
   describe('with an annotation', function () {
+    let annotation
     let task
 
     before(function () {
       task = MultipleChoiceTask.TaskModel.create(multipleChoiceTask)
-      const annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation
       const store = types.model('MockStore', {
         annotation: MultipleChoiceTask.AnnotationModel,
         task: MultipleChoiceTask.TaskModel
@@ -72,18 +73,19 @@ describe('Model > MultipleChoiceTask', function () {
     })
 
     it('should update annotations', function () {
-      task.updateAnnotation([1])
+      annotation.update([1])
       expect(task.annotation.value).to.deep.equal([1])
     })
   })
 
   describe('when required', function () {
+    let annotation
     let task
 
     before(function () {
       const requiredTask = Object.assign({}, multipleChoiceTask, { required: 'true' })
       task = MultipleChoiceTask.TaskModel.create(requiredTask)
-      const annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation
       const store = types.model('MockStore', {
         annotation: MultipleChoiceTask.AnnotationModel,
         task: MultipleChoiceTask.TaskModel
@@ -103,7 +105,7 @@ describe('Model > MultipleChoiceTask', function () {
 
     describe('with a complete annotation', function () {
       it('should be complete', function () {
-        task.updateAnnotation([1])
+        annotation.update([1])
         expect(task.isComplete).to.be.true()
       })
     })

--- a/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/models/SimpleDropdownTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/models/SimpleDropdownTask.spec.js
@@ -37,11 +37,12 @@ describe('Model > SimpleDropdownTask', function () {
   })
 
   describe('with an annotation', function () {
+    let annotation
     let task
 
     before(function () {
       task = TaskModel.create(simpleDropdownTask)
-      const annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation
       const store = types.model('MockStore', {
         annotation: AnnotationModel,
         task: TaskModel
@@ -58,7 +59,7 @@ describe('Model > SimpleDropdownTask', function () {
     })
 
     it('should update annotations', function () {
-      task.updateAnnotation({
+      annotation.update({
         selection: 5,  // Corresponds to "Black"
         option: true,
       })
@@ -68,12 +69,13 @@ describe('Model > SimpleDropdownTask', function () {
   })
 
   describe('when required', function () {
+    let annotation
     let task
 
     before(function () {
       const requiredTask = Object.assign({}, simpleDropdownTask, { required: true })
       task = TaskModel.create(requiredTask)
-      const annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation
       const store = types.model('MockStore', {
         annotation: AnnotationModel,
         task: TaskModel
@@ -93,7 +95,7 @@ describe('Model > SimpleDropdownTask', function () {
 
     describe('with a complete annotation', function () {
       it('should be complete', function () {
-        task.updateAnnotation({
+        annotation.update({
           selection: 5,
           option: true,
         })

--- a/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/models/SingleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/models/SingleChoiceTask.spec.js
@@ -30,11 +30,12 @@ describe('Model > SingleChoiceTask', function () {
   })
 
   describe('with an annotation', function () {
+    let annotation
     let task
 
     before(function () {
       task = SingleChoiceTask.TaskModel.create(singleChoiceTask)
-      const annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation
       const store = types.model('MockStore', {
         annotation: SingleChoiceTask.AnnotationModel,
         task: SingleChoiceTask.TaskModel
@@ -51,7 +52,7 @@ describe('Model > SingleChoiceTask', function () {
     })
 
     it('should update annotations', function () {
-      task.updateAnnotation(1)
+      annotation.update(1)
       expect(task.annotation.value).to.equal(1)
     })
   })
@@ -78,12 +79,13 @@ describe('Model > SingleChoiceTask', function () {
   })
 
   describe('when required', function () {
+    let annotation
     let task
 
     before(function () {
       const requiredTask = Object.assign({}, singleChoiceTask, { required: 'true' })
       task = SingleChoiceTask.TaskModel.create(requiredTask)
-      const annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation
       const store = types.model('MockStore', {
         annotation: SingleChoiceTask.AnnotationModel,
         task: SingleChoiceTask.TaskModel
@@ -103,7 +105,7 @@ describe('Model > SingleChoiceTask', function () {
 
     describe('with a complete annotation', function () {
       it('should be complete', function () {
-        task.updateAnnotation(1)
+        annotation.update(1)
         expect(task.isComplete).to.be.true()
       })
     })

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.spec.js
@@ -57,12 +57,13 @@ describe('Model > TextTask', function () {
     })
   })
 
-  describe('with a classification', function () {
+  describe('with an annotation', function () {
+    let annotation
     let task
 
     before(function () {
       task = TextTask.TaskModel.create(textTask)
-      const annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation
       const store = types.model('MockStore', {
         annotation: TextTask.AnnotationModel,
         task: TextTask.TaskModel
@@ -79,7 +80,7 @@ describe('Model > TextTask', function () {
     })
 
     it('should update annotations', function () {
-      task.updateAnnotation('Hello there!')
+      annotation.update('Hello there!')
       expect(task.annotation.value).to.equal('Hello there!')
     })
   })

--- a/packages/lib-classifier/src/plugins/tasks/models/Task.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Task.js
@@ -44,7 +44,7 @@ const Task = types.model('Task', {
     },
 
     setAnnotation (annotation) {
-      self.annotation = annotation
+      self.annotation = annotation.id
     },
 
     start () {

--- a/packages/lib-classifier/src/plugins/tasks/models/Task.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Task.js
@@ -1,5 +1,5 @@
 import cuid from 'cuid'
-import { types } from 'mobx-state-tree'
+import { tryReference, types } from 'mobx-state-tree'
 import Annotation from './Annotation'
 
 const Task = types.model('Task', {
@@ -21,18 +21,20 @@ const Task = types.model('Task', {
     },
 
     get isComplete () {
-      return !self.required || !!self.annotation && self.annotation.isComplete
+      const annotation = tryReference(() => self.annotation)
+      return !self.required || !!annotation?.isComplete
     }
   }))
   .actions(self => ({
     updateAnnotation (value) {
-      self.annotation && self.annotation.update(value)
+      const annotation = tryReference(() => self.annotation)
+      annotation?.update(value)
     },
 
     complete () {
       // set an annotation for this task if there wasn't one already.
-      const { value } = self.annotation
-      self.updateAnnotation(value)
+      const annotation = tryReference(() => self.annotation)
+      self.updateAnnotation(annotation?.value)
     },
 
     createAnnotation () {

--- a/packages/lib-classifier/src/plugins/tasks/models/Task.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Task.js
@@ -26,15 +26,10 @@ const Task = types.model('Task', {
     }
   }))
   .actions(self => ({
-    updateAnnotation (value) {
-      const annotation = tryReference(() => self.annotation)
-      annotation?.update(value)
-    },
-
     complete () {
-      // set an annotation for this task if there wasn't one already.
-      const annotation = tryReference(() => self.annotation)
-      self.updateAnnotation(annotation?.value)
+      /*
+      Override this with any actions that should run on task completion.
+      */
     },
 
     createAnnotation () {

--- a/packages/lib-classifier/src/plugins/tasks/readme.md
+++ b/packages/lib-classifier/src/plugins/tasks/readme.md
@@ -39,9 +39,10 @@ The registry is a simple map of unique task types (`single`, `multiple`, `text`,
 A React component for a task takes a Task model and renders it as HTML. The basic shape is:
 ```jsx
 const SingleChoiceTask = taskRegistry.get('single').TaskComponent
-<SingleChoiceTask disabled task={task} />
+<SingleChoiceTask disabled annotation={annotation} task={task} />
 ```
 
+ - _annotation_ is an annotation for this task. An individual task may have multiple annotations. It's the responsibility of the Task component's container to pass the correct annotation for the current task eg. the correct line for a text transcription task.
  - _task_ is the task model to render.
  - _disabled_ should be set if the task is disabled eg. while waiting for a subject to load.
 
@@ -56,7 +57,6 @@ The [base Task model](https://github.com/zooniverse/front-end-monorepo/tree/mast
 - _annotation (Annotation)_ The classification annotation for this task's task key.
 - _isComplete (boolean = true)_ False if the task's annotation is invalid.
 - _createAnnotation() (Annotation)_ Returns a new, empty annotation for this task. 
-- _updateAnnotation(value)_ Annotate the task's classification annotation with _value_.
 
 
 All tasks should extend the Task model by implementing the following:
@@ -77,6 +77,7 @@ The [base Annotation model](https://github.com/zooniverse/front-end-monorepo/tre
 
 - _task (string)_ An identifier for the task that created this annotation eg. `T0`
 - _taskType (string)_ The task type that creates these annotations. Set by the annotation's task.
+- _update(value)_ Set the annotation's value.
 
 All annotations should extend the Annotation model by implementing the following:
 

--- a/packages/lib-classifier/src/store/Step.spec.js
+++ b/packages/lib-classifier/src/store/Step.spec.js
@@ -52,6 +52,8 @@ describe('Model > Step', function () {
   })
 
   describe('with only required tasks', function () {
+    let multipleChoiceAnnotation
+    let singleChoiceAnnotation
     let step
     let tasks
     before(function () {
@@ -60,8 +62,8 @@ describe('Model > Step', function () {
         SingleChoiceTask.TaskModel.create(SingleChoiceTaskFactory.build({ taskKey: 'T2', required: 'true' }))
       ]
       step = Step.create({ stepKey: 'S1', taskKeys: ['T1', 'T2'], tasks })
-      const multipleChoiceAnnotation = tasks[0].defaultAnnotation
-      const singleChoiceAnnotation = tasks[1].defaultAnnotation
+      multipleChoiceAnnotation = tasks[0].defaultAnnotation
+      singleChoiceAnnotation = tasks[1].defaultAnnotation
       const store = types.model({
         annotations: types.array(types.union(MultipleChoiceTask.AnnotationModel, SingleChoiceTask.AnnotationModel)),
         step: Step
@@ -83,7 +85,7 @@ describe('Model > Step', function () {
 
     describe('after annotating task T1', function () {
       it('should still be incomplete', function () {
-        tasks[0].updateAnnotation([1])
+        multipleChoiceAnnotation.update([1])
         expect(step.isComplete).to.be.false()
       })
 
@@ -95,7 +97,7 @@ describe('Model > Step', function () {
 
     describe('after annotating tasks T1 & T2', function () {
       it('should be complete', function () {
-        tasks[1].updateAnnotation(1)
+        singleChoiceAnnotation.update(1)
         expect(step.isComplete).to.be.true()
       })
 


### PR DESCRIPTION
Wrap any calls to `self.annotation` inside `tryReference`, since `task.annotation` stores a reference to an annotation and not the annotation itself.
Remove `task.updateAnnotation(value)`. Task components should call `annotation.update(value)` on their annotation prop.
Fix annotation references to explicitly use the annotation ID.

https://mobx-state-tree.js.org/concepts/references


Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
