### PR TITLE
Classifier: Test default annotations for tasks

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/DataVisAnnotationTask/models/DataVisAnnotationTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DataVisAnnotationTask/models/DataVisAnnotationTask.spec.js
@@ -29,6 +29,27 @@ describe('Model > DataVisAnnotationTask', function () {
     expect(model).to.be.an('object')
   })
 
+  describe('Views > defaultAnnotation', function () {
+    let task
+
+    before(function () {
+      task = DataVisAnnotationTask.create(dataVisAnnotationTaskSnapshot)
+    })
+
+    it('should be a valid annotation', function () {
+      const annotation = task.defaultAnnotation
+      expect(annotation.id).to.be.ok()
+      expect(annotation.task).to.equal('T3')
+      expect(annotation.taskType).to.equal('dataVisAnnotation')
+    })
+
+    it('should generate unique annotations', function () {
+      const firstAnnotation = task.defaultAnnotation
+      const secondAnnotation = task.defaultAnnotation
+      expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
+    })
+  })
+
   describe('the active tool', function () {
     it('should default to the first tool', function () {
       expect(model.activeTool).to.equal(model.tools[0])

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
@@ -70,6 +70,27 @@ describe('Model > DrawingTask', function () {
     subtasks.forEach((task, i) => expect(task.taskKey).to.equal(`T3.0.${i}`))
   })
 
+  describe('Views > defaultAnnotation', function () {
+    let task
+
+    before(function () {
+      task = DrawingTask.TaskModel.create(drawingTaskSnapshot)
+    })
+
+    it('should be a valid annotation', function () {
+      const annotation = task.defaultAnnotation
+      expect(annotation.id).to.be.ok()
+      expect(annotation.task).to.equal('T3')
+      expect(annotation.taskType).to.equal('drawing')
+    })
+
+    it('should generate unique annotations', function () {
+      const firstAnnotation = task.defaultAnnotation
+      const secondAnnotation = task.defaultAnnotation
+      expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
+    })
+  })
+
   describe('drawn marks', function () {
     let marks
     before(function () {

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/models/MultipleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/models/MultipleChoiceTask.spec.js
@@ -29,6 +29,27 @@ describe('Model > MultipleChoiceTask', function () {
     expect(errorThrown).to.be.true()
   })
 
+  describe('Views > defaultAnnotation', function () {
+    let task
+
+    before(function () {
+      task = MultipleChoiceTask.TaskModel.create(multipleChoiceTask)
+    })
+
+    it('should be a valid annotation', function () {
+      const annotation = task.defaultAnnotation
+      expect(annotation.id).to.be.ok()
+      expect(annotation.task).to.equal('T2')
+      expect(annotation.taskType).to.equal('multiple')
+    })
+
+    it('should generate unique annotations', function () {
+      const firstAnnotation = task.defaultAnnotation
+      const secondAnnotation = task.defaultAnnotation
+      expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
+    })
+  })
+
   describe('with an annotation', function () {
     let task
 

--- a/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/models/SingleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/models/SingleChoiceTask.spec.js
@@ -56,6 +56,27 @@ describe('Model > SingleChoiceTask', function () {
     })
   })
 
+  describe('Views > defaultAnnotation', function () {
+    let task
+
+    before(function () {
+      task = SingleChoiceTask.TaskModel.create(singleChoiceTask)
+    })
+
+    it('should be a valid annotation', function () {
+      const annotation = task.defaultAnnotation
+      expect(annotation.id).to.be.ok()
+      expect(annotation.task).to.equal('T1')
+      expect(annotation.taskType).to.equal('single')
+    })
+
+    it('should generate unique annotations', function () {
+      const firstAnnotation = task.defaultAnnotation
+      const secondAnnotation = task.defaultAnnotation
+      expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
+    })
+  })
+
   describe('when required', function () {
     let task
 

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.spec.js
@@ -36,6 +36,27 @@ describe('Model > TextTask', function () {
     expect(errorThrown).to.be.true()
   })
 
+  describe('Views > defaultAnnotation', function () {
+    let task
+
+    before(function () {
+      task = TextTask.TaskModel.create(textTask)
+    })
+
+    it('should be a valid annotation', function () {
+      const annotation = task.defaultAnnotation
+      expect(annotation.id).to.be.ok()
+      expect(annotation.task).to.equal('T0')
+      expect(annotation.taskType).to.equal('text')
+    })
+
+    it('should generate unique annotations', function () {
+      const firstAnnotation = task.defaultAnnotation
+      const secondAnnotation = task.defaultAnnotation
+      expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
+    })
+  })
+
   describe('with a classification', function () {
     let task
 

--- a/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionTask.spec.js
@@ -51,6 +51,27 @@ describe('Model > TranscriptionTask', function () {
     expect(textSubtask.taskKey).to.equal('T3.0.0')
   })
 
+  describe('Views > defaultAnnotation', function () {
+    let task
+
+    before(function () {
+      task = TranscriptionTask.TaskModel.create(transcriptionTaskSnapshot)
+    })
+
+    it('should be a valid annotation', function () {
+      const annotation = task.defaultAnnotation
+      expect(annotation.id).to.be.ok()
+      expect(annotation.task).to.equal('T3')
+      expect(annotation.taskType).to.equal('transcription')
+    })
+
+    it('should generate unique annotations', function () {
+      const firstAnnotation = task.defaultAnnotation
+      const secondAnnotation = task.defaultAnnotation
+      expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
+    })
+  })
+
   describe('drawn marks', function () {
     let marks
     before(function () {

--- a/packages/lib-classifier/src/plugins/tasks/models/Task.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Task.spec.js
@@ -25,6 +25,27 @@ describe('Model > Task', function () {
     expect(errorThrown).to.be.true()
   })
 
+  describe('Views > defaultAnnotation', function () {
+    let task
+
+    before(function () {
+      task = Task.create(mockTask)
+    })
+
+    it('should be a valid annotation', function () {
+      const annotation = task.defaultAnnotation
+      expect(annotation.id).to.be.ok()
+      expect(annotation.task).to.equal('T0')
+      expect(annotation.taskType).to.equal('default')
+    })
+
+    it('should generate unique annotations', function () {
+      const firstAnnotation = task.defaultAnnotation
+      const secondAnnotation = task.defaultAnnotation
+      expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
+    })
+  })
+
   describe('with an annotation', function () {
     let task
 


### PR DESCRIPTION
Test `task.defaultAnnotation` for each task type. Verify that it generates unique annotation IDs.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
