### PR TITLE
Classifier: add a console message when loading Subjects

### DIFF
--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -121,6 +121,8 @@ const SubjectStore = types
 
       const nextSubject = self.resources.values().next().value
       self.active = nextSubject && nextSubject.id
+      if (process.env.NODE_ENV !== 'test') console.log('Loading subject', nextSubject && nextSubject.id)
+      
       if (self.resources.size < MINIMUM_QUEUE_SIZE) {
         console.log('Fetching more subjects')
         self.populateQueue()


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`

This PR adds a console message that helps us track Subject IDs.

- The message `Loading subject 12345` appears in the dev console when a new Subject is loaded, where 12345 is the Subject's ID.
- This is mostly useful for Sentry error logging, to identify which Subject was encountered before/during a crash.

Context: this addition is being made to help debug a TESS bug that's difficult to replicate locally. Our suspicion is that specific subjects are causing the crash, but we don't have enough data in our logs to determine which subjects.

### Testing

- Open any project with Subjects, e.g. `https://local.zooniverse.org:8080/?env=production&project=12754`
- The message should appear whenever a new Subject loads, i.e. getting the first Subject on page load and after clicking "Done" to move to the next one.

### Status

Ready for review, though I'm not sure if targeting to merge `master` is the right call for out current debug efforts - are we still deploying older commits to stabilise the TESS bug at the moment?