### PR TITLE
Classifier: Add an id parameter to task default annotations

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtonsContainer.spec.js
@@ -116,9 +116,9 @@ describe('TaskNavButtonsContainer', function () {
       const classification = classificationStore.active
 
       activeStepTasks.forEach((task) => {
-        const { defaultAnnotation } = task
-        expect(classification.annotation(task).task).to.equal(defaultAnnotation.task)
-        expect(classification.annotation(task).value).to.deep.equal(defaultAnnotation.value)
+        const { task: taskKey, value } = task.defaultAnnotation()
+        expect(classification.annotation(task).task).to.equal(taskKey)
+        expect(classification.annotation(task).value).to.deep.equal(value)
       })
     })
 
@@ -218,9 +218,9 @@ describe('TaskNavButtonsContainer', function () {
       const classification = classificationStore.active
 
       activeStepTasks.forEach((task) => {
-        const { defaultAnnotation } = task
-        expect(classification.annotation(task).task).to.equal(defaultAnnotation.task)
-        expect(classification.annotation(task).value).to.deep.equal(defaultAnnotation.value)
+        const { task: taskKey, value } = task.defaultAnnotation()
+        expect(classification.annotation(task).task).to.equal(taskKey)
+        expect(classification.annotation(task).value).to.deep.equal(value)
       })
     })
 

--- a/packages/lib-classifier/src/plugins/tasks/DataVisAnnotationTask/models/DataVisAnnotationTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DataVisAnnotationTask/models/DataVisAnnotationTask.js
@@ -22,9 +22,9 @@ const DataVisTaskModel = types.model('DataVisTaskModel', {
       return self.tools[self.activeToolIndex]
     },
 
-    get defaultAnnotation () {
+    defaultAnnotation (id = cuid()) {
       return DataVisAnnotation.create({
-        id: cuid(),
+        id,
         task: self.taskKey,
         taskType: self.type
       })

--- a/packages/lib-classifier/src/plugins/tasks/DataVisAnnotationTask/models/DataVisAnnotationTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DataVisAnnotationTask/models/DataVisAnnotationTask.spec.js
@@ -37,15 +37,15 @@ describe('Model > DataVisAnnotationTask', function () {
     })
 
     it('should be a valid annotation', function () {
-      const annotation = task.defaultAnnotation
+      const annotation = task.defaultAnnotation()
       expect(annotation.id).to.be.ok()
       expect(annotation.task).to.equal('T3')
       expect(annotation.taskType).to.equal('dataVisAnnotation')
     })
 
     it('should generate unique annotations', function () {
-      const firstAnnotation = task.defaultAnnotation
-      const secondAnnotation = task.defaultAnnotation
+      const firstAnnotation = task.defaultAnnotation()
+      const secondAnnotation = task.defaultAnnotation()
       expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
     })
   })

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
@@ -40,9 +40,9 @@ export const Drawing = types.model('Drawing', {
       return self.tools[self.activeToolIndex]
     },
 
-    get defaultAnnotation () {
+    defaultAnnotation (id = cuid()) {
       return DrawingAnnotation.create({
-        id: cuid(),
+        id,
         task: self.taskKey,
         taskType: self.type
       })

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
@@ -78,15 +78,15 @@ describe('Model > DrawingTask', function () {
     })
 
     it('should be a valid annotation', function () {
-      const annotation = task.defaultAnnotation
+      const annotation = task.defaultAnnotation()
       expect(annotation.id).to.be.ok()
       expect(annotation.task).to.equal('T3')
       expect(annotation.taskType).to.equal('drawing')
     })
 
     it('should generate unique annotations', function () {
-      const firstAnnotation = task.defaultAnnotation
-      const secondAnnotation = task.defaultAnnotation
+      const firstAnnotation = task.defaultAnnotation()
+      const secondAnnotation = task.defaultAnnotation()
       expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
     })
   })
@@ -146,7 +146,7 @@ describe('Model > DrawingTask', function () {
     before(function () {
       task = DrawingTask.TaskModel.create(drawingTaskSnapshot)
       pointSubTask = task.tools[0].tasks[1]
-      const annotation = task.defaultAnnotation
+      const annotation = task.defaultAnnotation()
       const store = types.model('MockStore', {
         annotation: DrawingTask.AnnotationModel,
         task: DrawingTask.TaskModel
@@ -199,7 +199,7 @@ describe('Model > DrawingTask', function () {
 
     before(function () {
       task = DrawingTask.TaskModel.create(drawingTaskSnapshot)
-      const annotation = task.defaultAnnotation
+      const annotation = task.defaultAnnotation()
       const store = types.model('MockStore', {
         annotation: DrawingTask.AnnotationModel,
         task: DrawingTask.TaskModel
@@ -228,7 +228,7 @@ describe('Model > DrawingTask', function () {
 
     before(function () {
       task = DrawingTask.TaskModel.create(drawingTaskSnapshot)
-      const annotation = task.defaultAnnotation
+      const annotation = task.defaultAnnotation()
       types.model('MockStore', {
         annotation: DrawingTask.AnnotationModel,
         task: DrawingTask.TaskModel

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.spec.js
@@ -13,7 +13,7 @@ describe('MultipleChoiceTask', function () {
     type: 'multiple'
   })
 
-  const annotation = task.defaultAnnotation
+  const annotation = task.defaultAnnotation()
 
   describe('when it renders', function () {
     let wrapper

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/models/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/models/MultipleChoiceTask.js
@@ -16,9 +16,9 @@ const MultipleChoice = types.model('MultipleChoice', {
   type: types.literal('multiple')
 })
   .views(self => ({
-    get defaultAnnotation () {
+    defaultAnnotation (id = cuid()) {
       return MultipleChoiceAnnotation.create({
-        id: cuid(),
+        id,
         task: self.taskKey,
         taskType: self.type
       })

--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/models/MultipleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/models/MultipleChoiceTask.spec.js
@@ -37,15 +37,15 @@ describe('Model > MultipleChoiceTask', function () {
     })
 
     it('should be a valid annotation', function () {
-      const annotation = task.defaultAnnotation
+      const annotation = task.defaultAnnotation()
       expect(annotation.id).to.be.ok()
       expect(annotation.task).to.equal('T2')
       expect(annotation.taskType).to.equal('multiple')
     })
 
     it('should generate unique annotations', function () {
-      const firstAnnotation = task.defaultAnnotation
-      const secondAnnotation = task.defaultAnnotation
+      const firstAnnotation = task.defaultAnnotation()
+      const secondAnnotation = task.defaultAnnotation()
       expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
     })
   })
@@ -56,7 +56,7 @@ describe('Model > MultipleChoiceTask', function () {
 
     before(function () {
       task = MultipleChoiceTask.TaskModel.create(multipleChoiceTask)
-      annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation()
       const store = types.model('MockStore', {
         annotation: MultipleChoiceTask.AnnotationModel,
         task: MultipleChoiceTask.TaskModel
@@ -85,7 +85,7 @@ describe('Model > MultipleChoiceTask', function () {
     before(function () {
       const requiredTask = Object.assign({}, multipleChoiceTask, { required: 'true' })
       task = MultipleChoiceTask.TaskModel.create(requiredTask)
-      annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation()
       const store = types.model('MockStore', {
         annotation: MultipleChoiceTask.AnnotationModel,
         task: MultipleChoiceTask.TaskModel

--- a/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.spec.js
@@ -12,7 +12,7 @@ describe('SingleChoiceTask', function () {
     taskKey: 'init',
     type: 'single'
   })
-  const annotation = task.defaultAnnotation
+  const annotation = task.defaultAnnotation()
 
   describe('when it renders', function () {
     let wrapper

--- a/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/models/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/models/SingleChoiceTask.js
@@ -17,9 +17,9 @@ const SingleChoice = types.model('SingleChoice', {
   type: types.literal('single')
 })
   .views(self => ({
-    get defaultAnnotation () {
+    defaultAnnotation (id = cuid()) {
       return SingleChoiceAnnotation.create({
-        id: cuid(),
+        id,
         task: self.taskKey,
         taskType: self.type
       })

--- a/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/models/SingleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/models/SingleChoiceTask.spec.js
@@ -35,7 +35,7 @@ describe('Model > SingleChoiceTask', function () {
 
     before(function () {
       task = SingleChoiceTask.TaskModel.create(singleChoiceTask)
-      annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation()
       const store = types.model('MockStore', {
         annotation: SingleChoiceTask.AnnotationModel,
         task: SingleChoiceTask.TaskModel
@@ -65,15 +65,15 @@ describe('Model > SingleChoiceTask', function () {
     })
 
     it('should be a valid annotation', function () {
-      const annotation = task.defaultAnnotation
+      const annotation = task.defaultAnnotation()
       expect(annotation.id).to.be.ok()
       expect(annotation.task).to.equal('T1')
       expect(annotation.taskType).to.equal('single')
     })
 
     it('should generate unique annotations', function () {
-      const firstAnnotation = task.defaultAnnotation
-      const secondAnnotation = task.defaultAnnotation
+      const firstAnnotation = task.defaultAnnotation()
+      const secondAnnotation = task.defaultAnnotation()
       expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
     })
   })
@@ -85,7 +85,7 @@ describe('Model > SingleChoiceTask', function () {
     before(function () {
       const requiredTask = Object.assign({}, singleChoiceTask, { required: 'true' })
       task = SingleChoiceTask.TaskModel.create(requiredTask)
-      annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation()
       const store = types.model('MockStore', {
         annotation: SingleChoiceTask.AnnotationModel,
         task: SingleChoiceTask.TaskModel

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.spec.js
@@ -16,7 +16,7 @@ describe('TextTask', function () {
     text_tags: ['insertion', 'deletion'],
     type: 'text'
   })
-  const annotation = task.defaultAnnotation
+  const annotation = task.defaultAnnotation()
 
   before(function () {
     types.model('MockStore', {

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/components/DefaultTextTask/DefaultTextTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/components/DefaultTextTask/DefaultTextTask.spec.js
@@ -12,7 +12,7 @@ describe('TextTask > Components > DefaultTextTask', function () {
     text_tags: ['insertion', 'deletion'],
     type: 'text'
   })
-  const annotation = task.defaultAnnotation
+  const annotation = task.defaultAnnotation()
 
   before(function () {
     wrapper = shallow(

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
@@ -12,7 +12,7 @@ describe('TextTask > Components > TextTaskWithSuggestions', function () {
     text_tags: ['insertion', 'deletion'],
     type: 'text'
   })
-  const annotation = task.defaultAnnotation
+  const annotation = task.defaultAnnotation()
 
   before(function () {
     wrapper = shallow(

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.js
@@ -12,9 +12,9 @@ const Text = types.model('Text', {
   type: types.literal('text')
 })
   .views(self => ({
-    get defaultAnnotation () {
+    defaultAnnotation (id = cuid()) {
       return TextAnnotation.create({
-        id: cuid(),
+        id,
         task: self.taskKey,
         taskType: self.type
       })

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/models/TextTask.spec.js
@@ -44,15 +44,15 @@ describe('Model > TextTask', function () {
     })
 
     it('should be a valid annotation', function () {
-      const annotation = task.defaultAnnotation
+      const annotation = task.defaultAnnotation()
       expect(annotation.id).to.be.ok()
       expect(annotation.task).to.equal('T0')
       expect(annotation.taskType).to.equal('text')
     })
 
     it('should generate unique annotations', function () {
-      const firstAnnotation = task.defaultAnnotation
-      const secondAnnotation = task.defaultAnnotation
+      const firstAnnotation = task.defaultAnnotation()
+      const secondAnnotation = task.defaultAnnotation()
       expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
     })
   })
@@ -63,7 +63,7 @@ describe('Model > TextTask', function () {
 
     before(function () {
       task = TextTask.TaskModel.create(textTask)
-      annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation()
       const store = types.model('MockStore', {
         annotation: TextTask.AnnotationModel,
         task: TextTask.TaskModel

--- a/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionTask.js
@@ -27,9 +27,9 @@ const Transcription = types.model('Transcription', {
   }
 })
 .views(self => ({
-  get defaultAnnotation() {
+  defaultAnnotation(id = cuid()) {
     return TranscriptionAnnotation.create({
-      id: cuid(),
+      id,
       task: self.taskKey,
       taskType: self.type
     })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionTask.spec.js
@@ -59,15 +59,15 @@ describe('Model > TranscriptionTask', function () {
     })
 
     it('should be a valid annotation', function () {
-      const annotation = task.defaultAnnotation
+      const annotation = task.defaultAnnotation()
       expect(annotation.id).to.be.ok()
       expect(annotation.task).to.equal('T3')
       expect(annotation.taskType).to.equal('transcription')
     })
 
     it('should generate unique annotations', function () {
-      const firstAnnotation = task.defaultAnnotation
-      const secondAnnotation = task.defaultAnnotation
+      const firstAnnotation = task.defaultAnnotation()
+      const secondAnnotation = task.defaultAnnotation()
       expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
     })
   })
@@ -124,7 +124,7 @@ describe('Model > TranscriptionTask', function () {
     before(function () {
       task = TranscriptionTask.TaskModel.create(transcriptionTaskSnapshot)
       textSubTask = task.tools[0].tasks[0]
-      const annotation = task.defaultAnnotation
+      const annotation = task.defaultAnnotation()
       types.model('MockStore', {
         annotation: TranscriptionTask.AnnotationModel,
         task: TranscriptionTask.TaskModel
@@ -159,7 +159,7 @@ describe('Model > TranscriptionTask', function () {
 
     before(function () {
       task = TranscriptionTask.TaskModel.create(transcriptionTaskSnapshot)
-      const annotation = task.defaultAnnotation
+      const annotation = task.defaultAnnotation()
       const store = types.model('MockStore', {
         annotation: TranscriptionTask.AnnotationModel,
         task: TranscriptionTask.TaskModel
@@ -185,7 +185,7 @@ describe('Model > TranscriptionTask', function () {
 
     before(function () {
       task = TranscriptionTask.TaskModel.create(transcriptionTaskSnapshot)
-      const annotation = task.defaultAnnotation
+      const annotation = task.defaultAnnotation()
       types.model('MockStore', {
         annotation: TranscriptionTask.AnnotationModel,
         task: TranscriptionTask.TaskModel

--- a/packages/lib-classifier/src/plugins/tasks/models/Task.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Task.js
@@ -11,10 +11,10 @@ const Task = types.model('Task', {
 })
   .views(self => ({
 
-    get defaultAnnotation () {
+    defaultAnnotation (id = cuid()) {
     // Override this in a real task
       return Annotation.create({
-        id: cuid(),
+        id,
         task: self.taskKey,
         taskType: self.type
       })
@@ -33,7 +33,7 @@ const Task = types.model('Task', {
     },
 
     createAnnotation () {
-      const newAnnotation = self.defaultAnnotation
+      const newAnnotation = self.defaultAnnotation()
       return newAnnotation
     },
 

--- a/packages/lib-classifier/src/plugins/tasks/models/Task.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Task.spec.js
@@ -33,15 +33,15 @@ describe('Model > Task', function () {
     })
 
     it('should be a valid annotation', function () {
-      const annotation = task.defaultAnnotation
+      const annotation = task.defaultAnnotation()
       expect(annotation.id).to.be.ok()
       expect(annotation.task).to.equal('T0')
       expect(annotation.taskType).to.equal('default')
     })
 
     it('should generate unique annotations', function () {
-      const firstAnnotation = task.defaultAnnotation
-      const secondAnnotation = task.defaultAnnotation
+      const firstAnnotation = task.defaultAnnotation()
+      const secondAnnotation = task.defaultAnnotation()
       expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
     })
   })

--- a/packages/lib-classifier/src/plugins/tasks/readme.md
+++ b/packages/lib-classifier/src/plugins/tasks/readme.md
@@ -61,7 +61,7 @@ The [base Task model](https://github.com/zooniverse/front-end-monorepo/tree/mast
 
 All tasks should extend the Task model by implementing the following:
 
-- _defaultAnnotation(id) (Annotation)_ return a new default annotation for this task. The `id` parameter is optional.
+- _defaultAnnotation(id) (Annotation)_ return a new default annotation for this task. The `id` parameter is optional and defaults to a generated id using cuid.
 - _type (string)_ the type of task eg. `single`, `text`, `drawing`. Types must be unique to each Task model.
 
 Tasks may implement the following actions to hook into the workflow classification lifecycle

--- a/packages/lib-classifier/src/plugins/tasks/readme.md
+++ b/packages/lib-classifier/src/plugins/tasks/readme.md
@@ -61,7 +61,7 @@ The [base Task model](https://github.com/zooniverse/front-end-monorepo/tree/mast
 
 All tasks should extend the Task model by implementing the following:
 
-- _defaultAnnotation (Annotation)_ the default annotation for this task.
+- _defaultAnnotation(id) (Annotation)_ return a new default annotation for this task. The `id` parameter is optional.
 - _type (string)_ the type of task eg. `single`, `text`, `drawing`. Types must be unique to each Task model.
 
 Tasks may implement the following actions to hook into the workflow classification lifecycle

--- a/packages/lib-classifier/src/store/Step.spec.js
+++ b/packages/lib-classifier/src/store/Step.spec.js
@@ -62,8 +62,8 @@ describe('Model > Step', function () {
         SingleChoiceTask.TaskModel.create(SingleChoiceTaskFactory.build({ taskKey: 'T2', required: 'true' }))
       ]
       step = Step.create({ stepKey: 'S1', taskKeys: ['T1', 'T2'], tasks })
-      multipleChoiceAnnotation = tasks[0].defaultAnnotation
-      singleChoiceAnnotation = tasks[1].defaultAnnotation
+      multipleChoiceAnnotation = tasks[0].defaultAnnotation()
+      singleChoiceAnnotation = tasks[1].defaultAnnotation()
       const store = types.model({
         annotations: types.array(types.union(MultipleChoiceTask.AnnotationModel, SingleChoiceTask.AnnotationModel)),
         step: Step


### PR DESCRIPTION
Add an optional id parameter to `task.defaultAnnotation` and change the code throughout to use `task.defaultAnnotation()`.

_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
