### PR TITLE
Classifier: add Required to dropdown stories

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/components/SimpleDropdownTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/components/SimpleDropdownTask.stories.js
@@ -1,4 +1,4 @@
-import { withKnobs, boolean, select } from '@storybook/addon-knobs'
+import { withKnobs, boolean, radios, select } from '@storybook/addon-knobs'
 import asyncStates from '@zooniverse/async-states'
 import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
@@ -77,22 +77,6 @@ function MockTask(props) {
   )
 }
 
-const simpleDropdownTask = {
-  instruction: 'Choose your favourite colour',
-  allowCreate: false,
-  options: [
-    'Red',
-    'Blue',
-    'Yellow',
-    'Green',
-    'White',
-    'Black',
-  ],
-  required: false,
-  taskKey: 'init',
-  type: 'dropdown-simple',
-}
-
 storiesOf('Tasks | Simple Dropdown Task', module)
   .addDecorator(withKnobs)
   .addParameters({
@@ -101,6 +85,21 @@ storiesOf('Tasks | Simple Dropdown Task', module)
     }
   })
   .add('light theme', function () {
+    const simpleDropdownTask = {
+      instruction: 'Choose your favourite colour',
+      allowCreate: false,
+      options: [
+        'Red',
+        'Blue',
+        'Yellow',
+        'Green',
+        'White',
+        'Black',
+      ],
+      required: radios('Required', { true: 'true', false: '' }, ''),
+      taskKey: 'init',
+      type: 'dropdown-simple',
+    }
     const tasks = {
       init: simpleDropdownTask
     }


### PR DESCRIPTION
Add a required toggle to the simple dropdown stories.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
