### PR TITLE
Classifier: generic Task connector

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -3,7 +3,6 @@ import { Box, Paragraph } from 'grommet'
 import { inject, observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { withTheme } from 'styled-components'
 
 import Task from './components/Task'
 import TaskHelp from './components/TaskHelp'
@@ -38,7 +37,7 @@ class Tasks extends React.Component {
   }
 
   [asyncStates.success] () {
-    const { classification, isThereTaskHelp, subjectReadyState, step, theme } = this.props
+    const { classification, isThereTaskHelp, subjectReadyState, step } = this.props
     const ready = subjectReadyState === asyncStates.success
     if (classification && step.tasks.length > 0) {
       // setting the wrapping box of the task component to a basis of 246px feels hacky,
@@ -48,7 +47,6 @@ class Tasks extends React.Component {
       // but works for now
       return (
         <Box
-          key={classification.id}
           as='form'
           gap='small'
           justify='between'
@@ -58,8 +56,6 @@ class Tasks extends React.Component {
             <Task
               key={task.taskKey}
               {...this.props}
-              classification={classification}
-              disabled={!ready}
               task={task}
             />
           ))}
@@ -91,7 +87,6 @@ Tasks.defaultProps = {
 }
 
 @inject(storeMapper)
-@withTheme
 @observer
 class DecoratedTasks extends Tasks {}
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -47,6 +47,7 @@ class Tasks extends React.Component {
       // but works for now
       return (
         <Box
+          key={classification.id}
           as='form'
           gap='small'
           justify='between'

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.spec.js
@@ -14,6 +14,7 @@ describe('Components > Task', function () {
   let classification
   let activeTask
   let TaskComponent
+  let store
 
   const taskTypes = Object.keys(taskRegistry.register)
 
@@ -96,13 +97,14 @@ describe('Components > Task', function () {
       classification = rootStore.classifications.active
       const step = rootStore.workflowSteps.active
       activeTask = step.tasks[0]
+      store = { classifierStore: rootStore }
     })
 
     describe(`Task ${taskType}`, function () {
       it('should render without crashing', function () {
         const wrapper = mount(
           <Task
-            classification={classification}
+            store={store}
             task={activeTask}
           />
         )
@@ -112,23 +114,23 @@ describe('Components > Task', function () {
       it('should render the correct task component', function () {
         const wrapper = mount(
           <Task
-            classification={classification}
+            store={store}
             task={activeTask}
           />
         )
         // Is there a better way to do this?
-        expect(wrapper.find(TaskComponent.displayName)).to.have.lengthOf(1)
+        expect(wrapper.find(TaskComponent)).to.have.lengthOf(1)
       })
 
       it('should pass the active annotation down to the task component', function () {
         const wrapper = mount(
           <Task
-            classification={classification}
+            store={store}
             task={activeTask}
           />
         )
         const activeAnnotation = classification.addAnnotation(activeTask)
-        const taskComponent = wrapper.find(TaskComponent.displayName)
+        const taskComponent = wrapper.find(TaskComponent)
         expect(taskComponent.prop('annotation')).to.deep.equal(activeAnnotation)
       })
 
@@ -137,14 +139,14 @@ describe('Components > Task', function () {
 
         describe('while the subject is loading', function () {
           before(function () {
+            store.classifierStore.subjectViewer.resetSubject()
             const wrapper = mount(
               <Task
-                classification={classification}
-                disabled={true}
+                store={store}
                 task={activeTask}
               />
             )
-            taskWrapper = wrapper.find(TaskComponent.displayName)
+            taskWrapper = wrapper.find(TaskComponent)
           })
 
           it('should be disabled', function () {
@@ -154,14 +156,14 @@ describe('Components > Task', function () {
 
         describe('when the subject viewer is ready', function () {
           before(function () {
+            store.classifierStore.subjectViewer.onSubjectReady()
             const wrapper = mount(
               <Task
-                classification={classification}
-                disabled={false}
+                store={store}
                 task={activeTask}
               />
             )
-            taskWrapper = wrapper.find(TaskComponent.displayName)
+            taskWrapper = wrapper.find(TaskComponent)
           })
 
           it('should be enabled', function () {


### PR DESCRIPTION
Connect up the Task component so that it gets its annotation and disabled state from the store. Replace useContext and useState with a useStores hook in the Task component. Add an optional store prop for passing stores in during tests.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
