### PR TITLE
Fix VSLCV style regression introduced from grommet upgrade

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/PeriodMultipleControls/PeriodMultipleControls.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/PeriodMultipleControls/PeriodMultipleControls.js
@@ -10,6 +10,10 @@ import theme from './theme'
 counterpart.registerTranslations('en', en)
 
 export const StyledRadioButtonGroup = styled(RadioButtonGroup)`
+  label {
+    flex-direction: column;
+  }
+
   > div {
     position: relative;
   }
@@ -33,7 +37,6 @@ export function PeriodMultipleControls (props) {
     <FormField
       htmlFor='periodMultiple'
       label={<SpacedText size='10px' weight='bold'>{counterpart('VariableStarViewer.periodMultiple')}</SpacedText>}
-      style={{ position: 'relative' }}
     >
       <StyledRadioButtonGroup
         color={theme.global.colors['light-6']}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/PeriodMultipleControls/theme.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/PeriodMultipleControls/theme.js
@@ -25,9 +25,7 @@ const theme = {
       }
     },
     extend: () => css`
-      flex-direction: column;
       position: relative;
-      z-index: 100;
 
       input:not(:checked) + div {
         height: 5px;


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package:

Fix style regression with the phase controls. Also Closes #1857. I don't remember what the z-index is for and it doesn't seem necessary now.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
