### PR TITLE
Fix layout issues for transcription projects

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -15,7 +15,7 @@ import withKeyZoom from '../withKeyZoom'
 class ImageToolbar extends Component {
   render () {
     return (
-      <Box {...this.props}>
+      <Box height='min-content' {...this.props}>
         <Box
           background={{
             dark: 'dark-3',

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/DefaultLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/DefaultLayout.js
@@ -16,7 +16,6 @@ const ContainerGrid = styled.div`
   display: grid;
   grid-gap: 30px;
   grid-template-areas: "viewer task";
-  overflow: hidden;
   position: relative;
 
   @media (min-width: 701px) {
@@ -32,8 +31,13 @@ const ContainerGrid = styled.div`
   }
 `
 
-const StyledTaskArea = styled(TaskArea)`
+const StyledTaskAreaContainer = styled.div`
   grid-area: task;
+`
+
+const StyledTaskArea = styled(TaskArea)`
+  position: sticky;
+  top: 10px;
 `
 
 const ViewerGrid = styled.section`
@@ -43,8 +47,13 @@ const ViewerGrid = styled.section`
   grid-template-areas: "subject toolbar" "metatools ...";
 `
 
-const StyledImageToolbar = styled(ImageToolbar)`
+const StyledImageToolbarContainer = styled.div`
   grid-area: toolbar;
+`
+
+const StyledImageToolbar = styled(ImageToolbar)`
+  position: sticky;
+  top: 10px;
 `
 
 const StyledMetaTools = styled(MetaTools)`
@@ -60,10 +69,14 @@ function DefaultLayout (props) {
           <Banners />
           <SubjectViewer />
         </Box>
-        <StyledImageToolbar />
+        <StyledImageToolbarContainer>
+          <StyledImageToolbar />
+        </StyledImageToolbarContainer>
         <StyledMetaTools />
       </ViewerGrid>
-      <StyledTaskArea />
+      <StyledTaskAreaContainer>
+        <StyledTaskArea />
+      </StyledTaskAreaContainer>
       <FeedbackModal />
     </ContainerGrid>
   )

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
@@ -96,6 +96,7 @@ export const StyledFrameList = styled.ul`
   align-items: center;
   display: flex;
   flex-direction: column;
+  flex: 1 0 auto;
   margin: 0;
   overflow: auto;
   padding: 0;


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

Closes #1703 

This includes several improvements for the layout of the classifier including:
- Setting the height on the image toolbar to `min-content` so it doesn't stretch to the height of the subject
- Setting the height for the task area to `min-content` for the same reason
- Wrapping the task area and image toolbar in containers and giving the child items position sticky when the top of the element hits the 10px from the top viewport. What this does is finally give us this UX (@beckyrother !!!):

![position-sticky](https://user-images.githubusercontent.com/5016731/99460276-3074ed80-28f5-11eb-8b56-21e941f16bb6.gif)

The containers give us the height necessary for the position sticky to work. I also had to remove that `overflow: hidden` set on one of the parent containers to get position sticky to work (see this stack overflow about this gotcha: https://stackoverflow.com/questions/43909940/why-does-overflowhidden-prevent-positionsticky-from-working). I'm not totally sure what the impact this might have, so something for us to watch out for. 

- Set `flex: 1 0 auto` on the unordered list for the multi-frame viewer frame carousel, so now the next button is positioned at the bottom of the height it is set at:

<img width="223" alt="Screen Shot 2020-11-17 at 4 45 37 PM" src="https://user-images.githubusercontent.com/5016731/99460374-58645100-28f5-11eb-8631-e6f950ce0d8e.png">

These can be previewed by running the dev classifier, `yarn dev` in the `lib-classifier` folder, and going to ASM staging test project: https://localhost:8080/?project=1764

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
