### PR TITLE
Add observers to the classifier task stories

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/MultipleChoiceTask/components/MultipleChoiceTask.stories.js
@@ -5,7 +5,7 @@ import zooTheme from '@zooniverse/grommet-theme'
 import { types } from 'mobx-state-tree'
 import React from 'react'
 import { Box, Grommet } from 'grommet'
-import { Provider } from 'mobx-react'
+import { Provider, observer } from 'mobx-react'
 import { Tasks } from '../../../../components/Classifier/components/TaskArea/components/Tasks/Tasks'
 import ClassificationStore from '@store/ClassificationStore'
 import SubjectStore from '@store/SubjectStore'
@@ -49,6 +49,8 @@ function addStepToStore(step, tasks) {
   store.workflowSteps.active.tasks.forEach(task => store.classifications.addAnnotation(task))
 }
 
+const ObservedTasks = observer(Tasks)
+
 function MockTask(props) {
   const { dark, ...taskProps } = props
 
@@ -69,7 +71,7 @@ function MockTask(props) {
         pad='1em'
         width='380px'
       >
-        <Tasks
+        <ObservedTasks
           {...taskProps}
         />
       </Box>

--- a/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/components/SimpleDropdownTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/components/SimpleDropdownTask.stories.js
@@ -5,7 +5,7 @@ import zooTheme from '@zooniverse/grommet-theme'
 import { types } from 'mobx-state-tree'
 import React from 'react'
 import { Box, Grommet } from 'grommet'
-import { Provider } from 'mobx-react'
+import { Provider, observer } from 'mobx-react'
 import { Tasks } from '../../../../components/Classifier/components/TaskArea/components/Tasks/Tasks'
 import ClassificationStore from '@store/ClassificationStore'
 import SubjectStore from '@store/SubjectStore'
@@ -49,6 +49,8 @@ function addStepToStore(step, tasks) {
   store.workflowSteps.active.tasks.forEach(task => store.classifications.addAnnotation(task))
 }
 
+const ObservedTasks = observer(Tasks)
+
 function MockTask(props) {
   const { dark, ...taskProps } = props
 
@@ -69,7 +71,7 @@ function MockTask(props) {
         pad='1em'
         width='380px'
       >
-        <Tasks
+        <ObservedTasks
           {...taskProps}
         />
       </Box>

--- a/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/SingleChoiceTask/components/SingleChoiceTask.stories.js
@@ -5,7 +5,7 @@ import zooTheme from '@zooniverse/grommet-theme'
 import { types } from 'mobx-state-tree'
 import React from 'react'
 import { Box, Grommet } from 'grommet'
-import { Provider } from 'mobx-react'
+import { Provider, observer } from 'mobx-react'
 import { Tasks } from '../../../../components/Classifier/components/TaskArea/components/Tasks/Tasks'
 import ClassificationStore from '@store/ClassificationStore'
 import SubjectStore from '@store/SubjectStore'
@@ -49,6 +49,8 @@ function addStepToStore(step, tasks) {
   store.workflowSteps.active.tasks.forEach(task => store.classifications.addAnnotation(task))
 }
 
+const ObservedTasks = observer(Tasks)
+
 function MockTask(props) {
   const { dark, ...taskProps } = props
 
@@ -69,7 +71,7 @@ function MockTask(props) {
         pad='1em'
         width='380px'
       >
-        <Tasks
+        <ObservedTasks
           {...taskProps}
         />
       </Box>

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/TextTask.stories.js
@@ -5,7 +5,7 @@ import zooTheme from '@zooniverse/grommet-theme'
 import { types } from 'mobx-state-tree'
 import React from 'react'
 import { Box, Grommet } from 'grommet'
-import { Provider } from 'mobx-react'
+import { Provider, observer } from 'mobx-react'
 import { Tasks } from '../../../../../components/Classifier/components/TaskArea/components/Tasks/Tasks'
 import ClassificationStore from '@store/ClassificationStore'
 import SubjectStore from '@store/SubjectStore'
@@ -49,6 +49,8 @@ function addStepToStore(step, tasks) {
   store.workflowSteps.active.tasks.forEach(task => store.classifications.addAnnotation(task))
 }
 
+const ObservedTasks = observer(Tasks)
+
 function MockTask(props) {
   const { dark, ...taskProps } = props
 
@@ -69,7 +71,7 @@ function MockTask(props) {
         pad='1em'
         width='380px'
       >
-        <Tasks
+        <ObservedTasks
           {...taskProps}
         />
       </Box>


### PR DESCRIPTION
Add observers to the `Tasks` component in task stories, so that each story reacts to changes in the mock classification and step.

Package:
lib-classifier

Closes #1906.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
