### PR TITLE
Add missing ID parameter to Simple Dropdown and Subject Group Comparison Tasks

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/components/SimpleDropdownTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/components/SimpleDropdownTask.spec.js
@@ -23,7 +23,7 @@ const simpleDropdownTask = {
 
 describe('SimpleDropdownTask', function () {
   const task = Task.TaskModel.create(simpleDropdownTask)
-  const annotation = task.defaultAnnotation
+  const annotation = task.defaultAnnotation()
 
   describe('when it renders', function () {
     let wrapper

--- a/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/models/SimpleDropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/models/SimpleDropdownTask.js
@@ -27,9 +27,9 @@ const SimpleDropdown = types.model('SimpleDropdown', {
     return legacyDropdownAdapter(snapshot)
   })
   .views(self => ({
-    get defaultAnnotation () {
+    defaultAnnotation (id = cuid()) {
       return SimpleDropdownAnnotation.create({
-        id: cuid(),
+        id,
         task: self.taskKey,
         taskType: self.type
       })

--- a/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/models/SimpleDropdownTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/models/SimpleDropdownTask.spec.js
@@ -42,7 +42,7 @@ describe('Model > SimpleDropdownTask', function () {
 
     before(function () {
       task = TaskModel.create(simpleDropdownTask)
-      annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation()
       const store = types.model('MockStore', {
         annotation: AnnotationModel,
         task: TaskModel
@@ -75,7 +75,7 @@ describe('Model > SimpleDropdownTask', function () {
     before(function () {
       const requiredTask = Object.assign({}, simpleDropdownTask, { required: true })
       task = TaskModel.create(requiredTask)
-      annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation()
       const store = types.model('MockStore', {
         annotation: AnnotationModel,
         task: TaskModel

--- a/packages/lib-classifier/src/plugins/tasks/SubjectGroupComparisonTask/components/SubjectGroupComparisonTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SubjectGroupComparisonTask/components/SubjectGroupComparisonTask.spec.js
@@ -11,7 +11,7 @@ describe('SubjectGroupComparisonTask', function () {
     taskKey: 'init',
     type: 'subjectGroupComparison'
   })
-  const annotation = task.defaultAnnotation
+  const annotation = task.defaultAnnotation()
 
   describe('when it renders', function () {
     let wrapper

--- a/packages/lib-classifier/src/plugins/tasks/SubjectGroupComparisonTask/models/SubjectGroupComparisonTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/SubjectGroupComparisonTask/models/SubjectGroupComparisonTask.js
@@ -13,9 +13,9 @@ const SubjectGroupComparison = types.model('SubjectGroupComparison', {
   type: types.literal('subjectGroupComparison')
 })
   .views(self => ({
-    get defaultAnnotation () {
+    defaultAnnotation (id = cuid()) {
       return SubjectGroupComparisonAnnotation.create({
-        id: cuid(),
+        id,
         task: self.taskKey,
         taskType: self.type
       })

--- a/packages/lib-classifier/src/plugins/tasks/SubjectGroupComparisonTask/models/SubjectGroupComparisonTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SubjectGroupComparisonTask/models/SubjectGroupComparisonTask.spec.js
@@ -30,7 +30,7 @@ describe('Model > SubjectGroupComparisonTask', function () {
 
     before(function () {
       task = SubjectGroupComparisonTask.TaskModel.create(subjectGroupTask)
-      annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation()
       const store = types.model('MockStore', {
         annotation: SubjectGroupComparisonTask.AnnotationModel,
         task: SubjectGroupComparisonTask.TaskModel
@@ -58,7 +58,7 @@ describe('Model > SubjectGroupComparisonTask', function () {
     before(function () {
       const requiredTask = Object.assign({}, subjectGroupTask, { required: true })
       task = SubjectGroupComparisonTask.TaskModel.create(requiredTask)
-      annotation = task.defaultAnnotation
+      annotation = task.defaultAnnotation()
       const store = types.model('MockStore', {
         annotation: SubjectGroupComparisonTask.AnnotationModel,
         task: SubjectGroupComparisonTask.TaskModel


### PR DESCRIPTION
## PR Overview

Follows #1855

PR 1855 introduces an ID parameter to most Tasks (Single Choice Task, Text Task, etc). This PR adds the same changes to two newer tasks that didn't yet follow the new updated format:  Simple Dropdown Task and Subject Group Comparison Task.

Test URLs:
- Simple Dropdown Task: https://local.zooniverse.org:8080/?env=production&project=12754&workflow=16106&subjectSet=85771 (custom workflow, designed to work with a Subject Set selector)
- Subject Group Comparison Task: https://local.zooniverse.org:8080/?env=staging&project=1900&workflow=3412 (custom workflow, with additional `workflow.config.subject_viewer = 'subjectGroup'`)

How to Test:
- Accessing either of those URLs on `master` will result in an immediate crash of the web app.
- Accessing either of those URLs on this PR's branch will allow the pages to load correctly. 

### Status

Ready for review.