### PR TITLE
Drawing tools: add actions to handle events during mark creation

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -7,7 +7,7 @@ import DrawingToolMarks from './components/DrawingToolMarks'
 import TranscribedLines from './components/TranscribedLines'
 import SubTaskPopup from './components/SubTaskPopup'
 
-const StyledRect = styled('rect')`
+const DrawingCanvas = styled('rect')`
   ${props => props.disabled ?
     css`cursor: not-allowed;` :
     css`cursor: crosshair;`
@@ -67,6 +67,8 @@ function InteractionLayer ({
   }
 
   function onPointerDown (event) {
+    const { target, pointerId } = event
+    target.setPointerCapture(pointerId)
     if (disabled || move) {
       return true
     }
@@ -87,8 +89,6 @@ function InteractionLayer ({
 
   function onPointerMove (event) {
     if (creating) {
-      const { target, pointerId } = event
-      target.setPointerCapture(pointerId)
       activeMark.initialDrag(convertEvent(event))
     }
   }
@@ -109,22 +109,28 @@ function InteractionLayer ({
     }
   }
 
+  function onPointerUp(event) {
+    if (creating) {
+      onFinish(event)
+    }
+  }
+
   function inactivateMark () {
     setActiveMark(undefined)
   }
 
   return (
-    <g
-      onPointerMove={onPointerMove}
-      touch-action='none'
-    >
-      <StyledRect
+    <g>
+      <DrawingCanvas
         disabled={disabled || move}
         pointerEvents={move ? 'none' : 'all'}
         width={width}
         height={height}
         fill='transparent'
         onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        touch-action='none'
       />
       <TranscribedLines
         scale={scale}
@@ -172,4 +178,4 @@ InteractionLayer.defaultProps = {
 }
 
 export default InteractionLayer
-export { StyledRect }
+export { DrawingCanvas }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -89,7 +89,7 @@ function InteractionLayer ({
 
   function onPointerMove (event) {
     if (creating) {
-      activeMark.initialDrag(convertEvent(event))
+      activeTool.handlePointerMove && activeTool.handlePointerMove(convertEvent(event), activeMark)
     }
   }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -1,6 +1,6 @@
 import cuid from 'cuid'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect } from 'react'
 import styled, { css } from 'styled-components'
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import DrawingToolMarks from './components/DrawingToolMarks'
@@ -29,6 +29,12 @@ function InteractionLayer ({
 }) {
   const [ creating, setCreating ] = React.useState(false)
   const { svg, getScreenCTM } = React.useContext(SVGContext)
+
+  useEffect(function onDeleteMark() {
+    if (creating && !activeMark) {
+      setCreating(false)
+    }
+  }, [activeMark])
 
   function convertEvent (event) {
     const type = event.type

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -79,7 +79,7 @@ function InteractionLayer ({
 
     if (creating) {
       activeTool.handlePointerDown && activeTool.handlePointerDown(convertEvent(event), activeMark)
-      if (activeMark.finished) setCreating(false)
+      if (activeMark.finished) onFinish(event)
       return true
     }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -67,11 +67,11 @@ function InteractionLayer ({
   }
 
   function onPointerDown (event) {
-    const { target, pointerId } = event
-    target.setPointerCapture(pointerId)
     if (disabled || move) {
       return true
     }
+    const { target, pointerId } = event
+    target.setPointerCapture(pointerId)
 
     if (!activeTool.type) {
       return false;

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -78,7 +78,7 @@ function InteractionLayer ({
     }
 
     if (creating) {
-      const activeMark = activeTool.handlePointerDown && activeTool.handlePointerDown(convertEvent(event))
+      activeTool.handlePointerDown && activeTool.handlePointerDown(convertEvent(event), activeMark)
       if (activeMark.finished) setCreating(false)
       return true
     }
@@ -111,7 +111,8 @@ function InteractionLayer ({
 
   function onPointerUp(event) {
     if (creating) {
-      onFinish(event)
+      activeTool.handlePointerUp && activeTool.handlePointerUp(convertEvent(event), activeMark)
+      if (activeMark.finished) onFinish(event)
     }
   }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -3,7 +3,7 @@ import React from 'react'
 import sinon from 'sinon'
 
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
-import InteractionLayer, { StyledRect } from './InteractionLayer'
+import InteractionLayer, { DrawingCanvas } from './InteractionLayer'
 import TranscribedLines from './components/TranscribedLines'
 import SubTaskPopup from './components/SubTaskPopup'
 import DrawingTask from '@plugins/tasks/DrawingTask'
@@ -94,7 +94,7 @@ describe('Component > InteractionLayer', function () {
     })
 
     it('should render a transparent rect', function () {
-      const rect = wrapper.find(StyledRect)
+      const rect = wrapper.find(DrawingCanvas)
       expect(rect.exists()).to.be.true()
       expect(rect.prop('fill')).to.equal('transparent')
     })
@@ -126,7 +126,7 @@ describe('Component > InteractionLayer', function () {
             releasePointerCapture: sinon.stub()
           }
         }
-        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+        wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
         expect(activeTool.createMark).to.have.been.calledOnce()
       })
 
@@ -139,7 +139,7 @@ describe('Component > InteractionLayer', function () {
             releasePointerCapture: sinon.stub()
           }
         }
-        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+        wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
         const createMarkArgs = activeTool.createMark.args[0][0]
         expect(createMarkArgs.frame).to.equal(2)
       })
@@ -153,7 +153,7 @@ describe('Component > InteractionLayer', function () {
             releasePointerCapture: sinon.stub()
           }
         }
-        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+        wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
         expect(mockMark.initialPosition).to.have.been.calledOnce()
       })
 
@@ -166,12 +166,12 @@ describe('Component > InteractionLayer', function () {
             releasePointerCapture: sinon.stub()
           }
         }
-        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
-        wrapper.simulate('pointermove', fakeEvent)
+        wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
+        wrapper.find(DrawingCanvas).simulate('pointermove', fakeEvent)
         expect(mockMark.initialDrag).to.have.been.calledOnce()
       })
 
-      it('should capture the pointer on pointer down + move', function () {
+      it('should capture the pointer on pointer down', function () {
         const fakeEvent = {
           pointerId: 'fakePointer',
           type: 'pointer',
@@ -180,7 +180,7 @@ describe('Component > InteractionLayer', function () {
             releasePointerCapture: sinon.stub()
           }
         }
-        wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+        wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
         wrapper.simulate('pointermove', fakeEvent)
         expect(fakeEvent.target.setPointerCapture.withArgs('fakePointer')).to.have.been.calledOnce()
       })
@@ -223,8 +223,8 @@ describe('Component > InteractionLayer', function () {
               releasePointerCapture: sinon.stub()
             }
           }
-          wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
-          wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+          wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
+          wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
           expect(activeTool.handlePointerDown).to.have.been.calledOnce()
         })
       })
@@ -284,7 +284,7 @@ describe('Component > InteractionLayer', function () {
           releasePointerCapture: sinon.stub()
         }
       }
-      wrapper.find(StyledRect).simulate('pointerdown', fakeEvent)
+      wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
       expect(activeTool.createMark).to.have.not.been.called()
     })
   })

--- a/packages/lib-classifier/src/plugins/drawingTools/README.md
+++ b/packages/lib-classifier/src/plugins/drawingTools/README.md
@@ -41,6 +41,7 @@ All tools should extend the Tool model by implementing the following:
 - _type_: a string uniquely identifying this type of tool.
 - _createMark(snapshot)_: an action which creates a new mark from the supplied snapshot, then stores it in `self.marks`.
 - _handlePointerDown(event, mark)_: handle pointer down events when creating `mark`. `event.x` and `event.y` contain the pointer coordinates on the SVG canvas. Implement this action to handle custom mark validation for marks that require complex gestures to create.
+- _handlePointerMove(event, mark)_: handle pointer move events when creating `mark`. `event.x` and `event.y` contain the pointer coordinates on the SVG canvas. Implement this action to handle custom mark validation for marks that require complex gestures to create.
 - _handlePointerUp(event, mark)_: handle pointer up events when creating `mark`. `event.x` and `event.y` contain the pointer coordinates on the SVG canvas. Implement this action to handle custom mark validation for marks that require complex gestures to create.
 
 ## Mark models

--- a/packages/lib-classifier/src/plugins/drawingTools/README.md
+++ b/packages/lib-classifier/src/plugins/drawingTools/README.md
@@ -40,6 +40,8 @@ All tools should extend the Tool model by implementing the following:
 - _marks_: a map of mark types for this particular tool eg. `types.map(Line)` for the Line tool.
 - _type_: a string uniquely identifying this type of tool.
 - _createMark(snapshot)_: an action which creates a new mark from the supplied snapshot, then stores it in `self.marks`.
+- _handlePointerDown(event, mark)_: handle pointer down events when creating `mark`. `event.x` and `event.y` contain the pointer coordinates on the SVG canvas. Implement this action to handle custom mark validation for marks that require complex gestures to create.
+- _handlePointerUp(event, mark)_: handle pointer up events when creating `mark`. `event.x` and `event.y` contain the pointer coordinates on the SVG canvas. Implement this action to handle custom mark validation for marks that require complex gestures to create.
 
 ## Mark models
 

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/TranscriptionLine/TranscriptionLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/TranscriptionLine/TranscriptionLine.js
@@ -10,9 +10,6 @@ const TranscriptionLineModel = types
     x2: types.maybe(types.number),
     y2: types.maybe(types.number)
   })
-  .volatile(self => ({
-    finished: false
-  }))
   .views(self => ({
     get coords () {
       return {
@@ -46,10 +43,6 @@ const TranscriptionLineModel = types
     }
   }))
   .actions(self => {
-    function finish () {
-      self.finished = true
-    }
-
     function initialDrag ({ x, y }) {
       self.x2 = x
       self.y2 = y
@@ -77,7 +70,6 @@ const TranscriptionLineModel = types
     }
 
     return {
-      finish,
       initialDrag,
       initialPosition,
       move,

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool.js
@@ -7,12 +7,13 @@ const TranscriptionLineTool = types.model('TranscriptionLine', {
   type: types.literal('transcriptionLine')
 })
   .actions(self => {
-    function handlePointerDown (mark) {
-      const allMarks = Array.from(self.marks.values())
-      const mostRecent = allMarks[allMarks.length - 1]
-      mostRecent.initialDrag(mark)
-      mostRecent.finish()
-      return mostRecent
+    function handlePointerDown (event, mark) {
+      mark.initialDrag(event)
+      mark.finish()
+    }
+
+    function handlePointerUp (event, mark) {
+      return
     }
 
     function createMark (mark) {
@@ -23,7 +24,8 @@ const TranscriptionLineTool = types.model('TranscriptionLine', {
 
     return {
       createMark,
-      handlePointerDown
+      handlePointerDown,
+      handlePointerUp
     }
   })
 

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool.js
@@ -12,6 +12,10 @@ const TranscriptionLineTool = types.model('TranscriptionLine', {
       mark.finish()
     }
 
+    function handlePointerMove (event, mark) {
+      return
+    }
+
     function handlePointerUp (event, mark) {
       return
     }
@@ -25,6 +29,7 @@ const TranscriptionLineTool = types.model('TranscriptionLine', {
     return {
       createMark,
       handlePointerDown,
+      handlePointerMove,
       handlePointerUp
     }
   })

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool.spec.js
@@ -11,8 +11,11 @@ const toolData = {
 describe('Model > TranscriptionLineTool', function () {
   let tool
 
-  it('should exist', function () {
+  beforeEach(function () {
     tool = TranscriptionLineTool.create(toolData)
+  })
+
+  it('should exist', function () {
     expect(tool).to.exist()
     expect(tool).to.be.an('object')
   })
@@ -29,9 +32,9 @@ describe('Model > TranscriptionLineTool', function () {
 
     describe('handlePointerDown', function () {
       it('should finish the previous mark', function () {
-        const secondMark = { x: 10, y: 10 }
-        tool.handlePointerDown(secondMark)
-        let mark = tool.marks.values().next().value
+        const pointerEvent = { x: 10, y: 10 }
+        const mark = tool.createMark({ x: 0, y: 0 })
+        tool.handlePointerDown(pointerEvent, mark)
         expect(tool.marks.size).to.equal(1)
         expect(mark.finished).to.be.true()
       })

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
@@ -42,6 +42,7 @@ const BaseMark = types.model('BaseMark', {
     return newSnapshot
   })
   .volatile(self => ({
+    finished: false,
     // we may be able to move this to be local component state
     subTaskMarkBounds: undefined,
     subTaskVisibility: false
@@ -87,6 +88,10 @@ const BaseMark = types.model('BaseMark', {
     }
   }))
   .actions(self => {
+    function finish () {
+      self.finished = true
+    }
+
     function setSubTaskVisibility (visible, drawingMarkNode, previousAnnotationValues) {
       if(self.tasks.length > 0) {
         self.subTaskVisibility = visible
@@ -104,6 +109,7 @@ const BaseMark = types.model('BaseMark', {
     }
 
     return {
+      finish,
       setSubTaskVisibility
     }
   })

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
@@ -66,6 +66,10 @@ const Tool = types.model('Tool', {
       self.marks.delete(mark.id)
     }
 
+    function handlePointerUp (event, mark) {
+      mark.finish()
+    }
+
     function reset () {
       self.marks.clear()
     }
@@ -74,6 +78,7 @@ const Tool = types.model('Tool', {
       createMark,
       createTask,
       deleteMark,
+      handlePointerUp,
       reset
     }
   })

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
@@ -66,6 +66,10 @@ const Tool = types.model('Tool', {
       self.marks.delete(mark.id)
     }
 
+    function handlePointerMove(event, mark) {
+      mark.initialDrag(event)
+    }
+
     function handlePointerUp (event, mark) {
       mark.finish()
     }
@@ -78,6 +82,7 @@ const Tool = types.model('Tool', {
       createMark,
       createTask,
       deleteMark,
+      handlePointerMove,
       handlePointerUp,
       reset
     }


### PR DESCRIPTION
This extends #1921 to fix #1919 by adding `tool.handlePointerMove(event, mark)` and `tool.handlePointerUp(event, mark)` to the tool model. The pointer is captured on mark creation, and pointer events are handled by the drawing surface until the new mark is finished (https://github.com/zooniverse/front-end-monorepo/issues/1919#issuecomment-737989521). `handlePointerMove` and `handlePointerUp` are called during mark creation and allow tools to implement custom validation of marks. By default, a mark is dragged on pointer move and finished on pointer up, but the transcription line tool overrides these to wait for a second pointer down, which finishes the line. Ellipses might also implement this, to allow for two swipes to create both axes of an ellipse.

I've tested this on browserstack, on a Pixel 4 running Android 11, and it seems to work. I think this needs more thorough testing than #1921, so I've opened it as a separate PR. If you only have time to review a small PR, I'd recommend looking at #1921 first.

Package:
lib-classifier

Closes #1919.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
