### PR TITLE
Add top-level storybook script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "deploy-storybook": "storybook-to-ghpages --packages packages",
     "panic": "./bin/panic-button.sh",
     "panic-button": "./bin/panic-button.sh",
+    "storybook": "lerna run --parallel storybook",
     "test": "lerna run --parallel test",
     "test:ci": "nyc lerna run --parallel test:ci"
   },

--- a/packages/app-content-pages/docker-compose.yml
+++ b/packages/app-content-pages/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     command: ["dev"]
     ports:
       - "3000:3000"
-      - "9001:9001"
+      - "9002:9001"
     volumes:
       - ./pages:/usr/src/packages/app-content-pages/pages
       - ./src:/usr/src/packages/app-content-pages/src

--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -10,7 +10,7 @@
     "dev": "PANOPTES_ENV=${PANOPTES_ENV:-production} node server/server.js",
     "lint": "zoo-standard --fix | snazzy",
     "start": "NODE_ENV=${NODE_ENV:-production} node server/server.js",
-    "storybook": "start-storybook -p 9001 -c .storybook",
+    "storybook": "start-storybook -p 9002 -c .storybook",
     "test": "BABEL_ENV=test mocha",
     "test:ci": "BABEL_ENV=test mocha --reporter=min"
   },

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -10,6 +10,7 @@
     "build:storybook": "build-storybook",
     "lint": "zoo-standard --fix {.storybook,src,stories,test}/**/*.{js,jsx} | snazzy",
     "start": "start-storybook -p 6006",
+    "storybook": "start-storybook -p 6007",
     "test": "mocha",
     "test:ci": "mocha --reporter=min"
   },


### PR DESCRIPTION
Add a top-level storybook script, so that `yarn storybook` builds and starts all four storybooks on different ports.

I found this useful while testing out #1913.

Package:
app-content-pages
app-project
lib-classifier
lib-react-components

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
