### PR TITLE
Remove hardcoded cancel value from MovableModal

### DIFF
--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update Modal spacing to reflect the Zooniverse design system.
 - Allow the colour of the Modal close button to be changed based on the ModalHeading text colour.
 - Removed hardcoded margin-top from MetaToolsButton. Leave spacing to the consuming library.
+- Removed the hardcoded cancel string for MovableModal applied to Rnd.
 
 ## [1.0.2] 2020-07-15
 - Patch fix previous version with correctly built package

--- a/packages/lib-react-components/src/MovableModal/MovableModal.js
+++ b/packages/lib-react-components/src/MovableModal/MovableModal.js
@@ -13,6 +13,7 @@ function MovableModal (props) {
     overflow,
     pad,
     rndProps: {
+      cancel,
       minHeight,
       minWidth,
       position,
@@ -26,7 +27,7 @@ function MovableModal (props) {
   // Change handleComponent prop to resizeHandleComponent when react-rnd gets upgraded
   return (
     <Rnd
-      cancel='.subtaskpopup-element-that-ignores-drag-actions'
+      cancel={cancel}
       enableResizing={{
         bottom: true,
         bottomLeft: false,
@@ -99,6 +100,7 @@ MovableModal.propTypes = {
   overflow: PropTypes.oneOfType([ PropTypes.object, PropTypes.string ]),
   pad: PropTypes.oneOfType([ PropTypes.object, PropTypes.string ]),
   rndProps: PropTypes.shape({
+    cancel: PropTypes.string,
     minHeight: PropTypes.number,
     minWidth: PropTypes.number,
     position: PropTypes.shape({


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-react-components

Describe your changes:
It looks like I accidentally left a hardcoded value for `cancel` on the `Rnd` component when I ported it to the shared component library. This PR fixes it so that its value is defined from props.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
