### PR TITLE
Engaging Crowds: Subject picker tool

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowMenu/WorkflowMenu.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowMenu/WorkflowMenu.js
@@ -6,12 +6,14 @@ import { Modal } from '@zooniverse/react-components'
 
 import WorkflowSelector from '@shared/components/WorkflowSelector'
 import SubjectSetPicker from '@shared/components/SubjectSetPicker'
+import SubjectPicker from '@shared/components/SubjectPicker'
 
 import en from './locales/en'
 counterpart.registerTranslations('en', en)
 
 export default function WorkflowMenu({ workflows }) {
   const [ activeWorkflow, setActiveWorkflow ] = useState()
+  const [ activeSubjectSet, setActiveSubjectSet ] = useState()
   const router = useRouter()
   const { owner, project } = router?.query || {}
 
@@ -24,8 +26,26 @@ export default function WorkflowMenu({ workflows }) {
     return true
   }
 
+  function onSelectSubjectSet(event, subjectSet) {
+    const useSubjectSelection = activeWorkflow.id === '16106'
+    if (useSubjectSelection) {
+      event.preventDefault()
+      setActiveSubjectSet(subjectSet)
+      return false
+    }
+    return true
+  }
+
   function onClose() {
     setActiveWorkflow(null)
+  }
+
+  let baseUrl = `/projects/${owner}/${project}/classify`
+  if (activeWorkflow) {
+    baseUrl = `${baseUrl}/workflow/${activeWorkflow.id}`
+  }
+  if (activeSubjectSet) {
+    baseUrl = `${baseUrl}/subject-set/${activeSubjectSet.id}`
   }
 
   return (
@@ -42,12 +62,21 @@ export default function WorkflowMenu({ workflows }) {
         title={activeWorkflow.displayName || counterpart('WorkflowMenu.chooseASubjectSet')}
         titleColor='neutral-6'
       >
-        <SubjectSetPicker
-          onClose={onClose}
-          owner={owner}
-          project={project}
-          workflow={activeWorkflow}
-        />
+        {activeSubjectSet ?
+          <SubjectPicker
+            baseUrl={baseUrl}
+            subjectSet={activeSubjectSet}
+            workflow={activeWorkflow}
+          /> :
+          <SubjectSetPicker
+            baseUrl={baseUrl}
+            onClose={onClose}
+            onSelect={onSelectSubjectSet}
+            owner={owner}
+            project={project}
+            workflow={activeWorkflow}
+          />
+        }
       </Modal>
     }
     </>

--- a/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.js
@@ -121,7 +121,7 @@ export default function SubjectPicker({ baseUrl, subjectSet, workflow }) {
             margin='medium'
             weight='bold'
           >
-            {subjectSet.title}
+            {subjectSet.display_name}
           </SpacedText>
         </Paragraph>
       </StyledBox>
@@ -145,7 +145,7 @@ export default function SubjectPicker({ baseUrl, subjectSet, workflow }) {
 SubjectPicker.defaultProps = {
   subjectSet: {
     id: '15582',
-    title: 'Anti-Slavery Letters: 1800-1839',
+    display_name: 'Anti-Slavery Letters: 1800-1839',
     metadata: {
       indexFields: 'date,title,creators'
     }

--- a/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.js
@@ -1,0 +1,157 @@
+import { Modal, SpacedText } from '@zooniverse/react-components'
+import counterpart from 'counterpart'
+import { debounce } from 'lodash'
+import { useRouter } from 'next/router'
+import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
+import { Box, DataTable, Heading, Paragraph } from 'grommet'
+
+import { columns, fetchRows, fetchSubjects, searchParams } from './helpers'
+import en from './locales/en'
+
+counterpart.registerTranslations('en', en)
+
+/*
+  Grommet is opinionated about line-height and links it to font-size.
+  Reset the heading baselines here so that spacing is measured from
+  the tops and bottoms of the letters (without changing the text size.)
+  https://matthiasott.com/notes/the-thing-with-leading-in-css
+*/
+
+const StyledBox = styled(Box)`
+  min-height: 30px;
+`
+const StyledHeading = styled(Heading)`
+  line-height: 100%;
+`
+
+const SubjectDataTable = styled(DataTable)`
+  button {
+    padding: 0;
+  }
+  th button {
+    color: ${props => props.theme.global.colors['dark-1']};
+    font-weight: bold;
+    text-transform: uppercase;
+  }
+  th svg {
+    stroke: ${props => props.theme.global.colors['dark-1']};
+  }
+`
+
+const PAGE_SIZE = 100
+
+export default function SubjectPicker({ baseUrl, subjectSet, workflow }) {
+  const [ rows, setRows ] = useState([])
+  const [ query, setQuery ] = useState('')
+  const [ sortField, setSortField ] = useState('subject_id')
+  const [ sortOrder, setSortOrder ] = useState('asc')
+  const { indexFields } = subjectSet.metadata
+  const customHeaders = indexFields ? indexFields.split(',') : ['date', 'title', 'creators']
+
+  async function fetchSubjectData() {
+    const subjects = await fetchSubjects('15582', query, sortField, sortOrder, PAGE_SIZE)
+    const rows = await fetchRows(subjects, workflow, PAGE_SIZE)
+    setRows(rows)
+  }
+
+  useEffect(function onChange() {
+    fetchSubjectData()
+  }, [query, sortField, sortOrder])
+
+  function search(data) {
+    const query = searchParams(data)
+    setQuery(query)
+  }
+
+  function sort(data) {
+    const { property: sortField, direction: sortOrder } = data
+    if (sortField === 'status') {
+      return true;
+    }
+    setSortField(sortField)
+    setSortOrder(sortOrder)
+  }
+
+  const background = {
+    header: "accent-2",
+    body: ["white", "light-1"]
+  }
+  const pad = {
+    header: "xsmall",
+    body: "xsmall"
+  }
+
+  /*
+    Vertical spacing for the picker instructions.
+    The theme's named margins are set in multiples of 10px, so set 15px explicitly.
+  */
+  const textMargin = {
+    top: '15px',
+    bottom: 'medium'
+  }
+  return (
+    <>
+      <StyledHeading
+        level={3}
+        margin={{ top: 'xsmall', bottom: 'none' }}
+      >
+        {counterpart('SubjectPicker.heading')}
+      </StyledHeading>
+      <Paragraph
+        margin={textMargin}
+      >
+        {counterpart('SubjectPicker.byline')}
+      </Paragraph>
+      <StyledBox
+        background='brand'
+        fill
+        pad={{
+          top: '5px',
+          bottom: 'none',
+          horizontal: 'none'
+        }}
+      >
+        <Paragraph
+          color="white"
+          margin='none'
+          textAlign='center'
+        >
+          <SpacedText
+            margin='medium'
+            weight='bold'
+          >
+            {subjectSet.title}
+          </SpacedText>
+        </Paragraph>
+      </StyledBox>
+      <SubjectDataTable
+        background={background}
+        columns={columns(customHeaders, baseUrl)}
+        data={rows}
+        fill
+        onSearch={debounce(search, 500)}
+        onSort={sort}
+        pad={pad}
+        pin
+        replace
+        sortable
+        step={PAGE_SIZE}
+      />
+    </>
+  )
+}
+
+SubjectPicker.defaultProps = {
+  subjectSet: {
+    id: '15582',
+    title: 'Anti-Slavery Letters: 1800-1839',
+    metadata: {
+      indexFields: 'date,title,creators'
+    }
+  },
+  workflow: {
+    id: '5329',
+    display_name: 'Transcribe Text (Main Workflow)'
+  }
+}

--- a/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.js
@@ -141,17 +141,3 @@ export default function SubjectPicker({ baseUrl, subjectSet, workflow }) {
     </>
   )
 }
-
-SubjectPicker.defaultProps = {
-  subjectSet: {
-    id: '15582',
-    display_name: 'Anti-Slavery Letters: 1800-1839',
-    metadata: {
-      indexFields: 'date,title,creators'
-    }
-  },
-  workflow: {
-    id: '5329',
-    display_name: 'Transcribe Text (Main Workflow)'
-  }
-}

--- a/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.stories.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.stories.js
@@ -1,0 +1,82 @@
+import zooTheme from '@zooniverse/grommet-theme'
+import { Grommet } from 'grommet'
+import React from 'react'
+
+import SubjectPicker from './SubjectPicker'
+
+function StoryContext (props) {
+  const { children, theme } = props
+
+  return (
+    <Grommet
+      background={{
+        dark: 'dark-1',
+        light: 'light-1'
+      }}
+      theme={theme}
+      themeMode={(theme.dark) ? 'dark' : 'light'}
+    >
+      {children}
+    </Grommet>
+  )
+}
+
+export default {
+  title: 'Project App / Screens / Project Home / Subject Picker',
+  component: SubjectPicker
+}
+
+export function Default(args) {
+  const { dark, ...props } = args
+  return (
+    <StoryContext theme={{ ...zooTheme, dark }}>
+      <SubjectPicker
+        {...props}
+      />
+    </StoryContext>
+  )
+}
+Default.args = {
+  active: true,
+  closeFn: e => true,
+  dark: false,
+  subjectSet: {
+    id: '15582',
+    title: 'Anti-Slavery Letters: 1800-1839',
+    metadata: {
+      indexFields: 'date,title,creators'
+    }
+  },
+  workflow: {
+    id: '5329',
+    display_name: 'Transcribe Text (Main Workflow)'
+  }
+}
+
+export function Tablet(args) {
+  const { dark, ...props } = args
+  return (
+    <StoryContext theme={{ ...zooTheme, dark }}>
+      <SubjectPicker
+        {...props}
+      />
+    </StoryContext>
+  )
+}
+Tablet.parameters = { viewport: { defaultViewport: 'ipad' }}
+Tablet.args = {
+  active: true,
+  closeFn: e => true,
+  dark: false,
+  subjectSet: {
+    id: '15582',
+    title: 'Anti-Slavery Letters: 1800-1839',
+    metadata: {
+      indexFields: 'date,title,creators'
+    }
+  },
+  workflow: {
+    id: '5329',
+    display_name: 'Transcribe Text (Main Workflow)'
+  }
+}

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/checkRetiredStatus.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/checkRetiredStatus.js
@@ -1,20 +1,25 @@
-import { panoptes } from '@zooniverse/panoptes-js'
-const env = 'production'
+import { env, panoptes } from '@zooniverse/panoptes-js'
+import { logToSentry } from '@helpers/logger'
 
 export default async function checkRetiredStatus(subject_ids, workflow, page_size=20) {
-  const workflow_id = workflow.id
+  const workflow_id = '5329'
   const retirementStatuses = {}
-  const response = await panoptes
-    .get('/subject_workflow_statuses', {
-      env,
-      page_size,
-      subject_ids,
-      workflow_id
+  try {
+    const response = await panoptes
+      .get('/subject_workflow_statuses', {
+        env,
+        page_size,
+        subject_ids,
+        workflow_id
+      })
+    const { subject_workflow_statuses } = response.body
+    subject_workflow_statuses.forEach(status => {
+      const inProgress = status.classifications_count > 0 ? 'In progress' : 'Unclassified'
+      retirementStatuses[status.links.subject] = status.retired_at ? 'Retired' : inProgress
     })
-  const { subject_workflow_statuses } = response.body
-  subject_workflow_statuses.forEach(status => {
-    const inProgress = status.classifications_count > 0 ? 'In progress' : 'Unclassified'
-    retirementStatuses[status.links.subject] = status.retired_at ? 'Retired' : inProgress
-  })
+  } catch (error) {
+    console.error(error)
+    logToSentry(error)
+  }
   return retirementStatuses
 }

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/checkRetiredStatus.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/checkRetiredStatus.js
@@ -1,0 +1,20 @@
+import { panoptes } from '@zooniverse/panoptes-js'
+const env = 'production'
+
+export default async function checkRetiredStatus(subject_ids, workflow, page_size=20) {
+  const workflow_id = workflow.id
+  const retirementStatuses = {}
+  const response = await panoptes
+    .get('/subject_workflow_statuses', {
+      env,
+      page_size,
+      subject_ids,
+      workflow_id
+    })
+  const { subject_workflow_statuses } = response.body
+  subject_workflow_statuses.forEach(status => {
+    const inProgress = status.classifications_count > 0 ? 'In progress' : 'Unclassified'
+    retirementStatuses[status.links.subject] = status.retired_at ? 'Retired' : inProgress
+  })
+  return retirementStatuses
+}

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/columns.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/columns.js
@@ -1,0 +1,30 @@
+import NavLink from '@shared/components/NavLink'
+
+function subjectLink({ subject_id }, baseUrl) {
+  const href = `${baseUrl}/subject/${subject_id}`
+  const link = {
+    href,
+    text: subject_id
+  }
+  return <NavLink link={link} />
+}
+
+export default function columns(customHeaders, baseUrl) {
+  const headers = ['subject_id', ...customHeaders, 'status']
+  return headers.map(header => {
+    let render
+    if (header === 'subject_id') {
+      render = datum => subjectLink(datum, baseUrl)
+    }
+    return {
+      align: 'start',
+      header,
+      primary: (header === 'subject_id'),
+      property: header,
+      render,
+      search: customHeaders.includes(header),
+      size: (header === 'status') ? 'xsmall' : 'small',
+      sortable: true
+    }
+  })
+}

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/columns.spec.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/columns.spec.js
@@ -1,0 +1,34 @@
+import columns from './columns'
+
+describe('Components > Subject Picker > helpers > columns', function () {
+  const customHeadings = ['date', 'creator', 'title']
+  const baseUrl = '/projects/owner/project/classify/workflow/123/subject-set/456'
+
+  function testColumn(column) {
+    const searchable = customHeadings.includes(column.header)
+    const primary = column.header === 'subject_id'
+    describe(column.header, function () {
+      it(`should ${primary ? '' : 'not '}be the primary key`, function () {
+        expect(column.primary).to.equal(primary)
+      })
+
+      if (primary) {
+        it('should render a link to the subject', function () {
+          const linkComponent = column.render({ subject_id: '123' }, baseUrl)
+          const { link } = linkComponent.props
+          expect(link.text).to.equal('123')
+          expect(link.href).to.equal(`${baseUrl}/subject/123`)
+        })
+      }
+
+      it(`should ${searchable ? '' : 'not '}be searchable`, function () {
+        expect(column.search).to.equal(searchable)
+      })
+
+      it('should be sortable', function () {
+        expect(column.sortable).to.be.true()
+      })
+    })
+  }
+  columns(customHeadings, baseUrl).forEach(testColumn)
+})

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchRows.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchRows.js
@@ -1,0 +1,15 @@
+import { checkRetiredStatus } from './'
+
+export default async function fetchRows(subjects, workflow, page_size) {
+  const subject_ids = subjects.map(subject => subject.subject_id).join(',')
+  const retirementStatuses = await checkRetiredStatus(subject_ids, workflow, page_size)
+  const rows = subjects.map(subject => {
+    const { id, subject_id, ...fields } = subject
+    return {
+      subject_id,
+      status: retirementStatuses[subject_id],
+      ...fields
+    }
+  })
+  return rows
+}

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchSubjects.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchSubjects.js
@@ -1,0 +1,15 @@
+const API_HOST = 'https://redsea.zooniverse.org/search'
+
+export default async function fetchSubjects(
+  subjectSetID,
+  query='',
+  sortField='subject_id',
+  sortOrder='asc',
+  page_size=20
+) {
+  const url = `${API_HOST}/${subjectSetID}?${query}&limit=${page_size}&sort_field=${sortField}&sort_order=${sortOrder}`
+  const mode = 'cors'
+  const response = await fetch(url, { mode })
+  const results = await response.json()
+  return results
+}

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/index.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/index.js
@@ -1,0 +1,5 @@
+export { default as checkRetiredStatus } from './checkRetiredStatus'
+export { default as columns } from './columns'
+export { default as fetchRows } from './fetchRows'
+export { default as fetchSubjects } from './fetchSubjects'
+export { default as searchParams } from './searchParams'

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/searchParams.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/searchParams.js
@@ -1,0 +1,10 @@
+export default function searchParams(data) {
+  let query = ''
+  Object.entries(data).forEach(([key, value]) => {
+    if (value !== '') {
+      query += `@${key}:${value}*`
+    }
+  })
+  const urlParams = (query !== '') ? `filter_field=${query}` : ''
+  return urlParams
+}

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/searchParams.spec.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/searchParams.spec.js
@@ -1,0 +1,27 @@
+import searchParams from './searchParams'
+
+describe('Components > Subject Picker > helpers > searchParams', function () {
+  describe('with data', function () {
+    it('should generate a filter_field query param', function () {
+      const data = {
+        creators: 'Smith',
+        date: '',
+        title: 'boston'
+      }
+      const query = searchParams(data)
+      expect(query).to.equal('filter_field=@creators:Smith*@title:boston*')
+    })
+  })
+
+  describe('without data', function () {
+    it('should return an empty string', function () {
+      const data = {
+        creators: '',
+        date: '',
+        title: ''
+      }
+      const query = searchParams(data)
+      expect(query).to.equal('')
+    })
+  })
+})

--- a/packages/app-project/src/shared/components/SubjectPicker/index.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/index.js
@@ -1,0 +1,1 @@
+export { default } from './SubjectPicker'

--- a/packages/app-project/src/shared/components/SubjectPicker/locales/en.json
+++ b/packages/app-project/src/shared/components/SubjectPicker/locales/en.json
@@ -1,0 +1,6 @@
+{
+  "SubjectPicker": {
+    "heading": "Choose a subject to get started",
+    "byline": "Sort the list by clicking column names. You will see subjects sequentially, starting with the one you choose."
+  }
+}

--- a/packages/app-project/src/shared/components/SubjectSetPicker/SubjectSetPicker.js
+++ b/packages/app-project/src/shared/components/SubjectSetPicker/SubjectSetPicker.js
@@ -2,9 +2,12 @@ import { PlainButton } from '@zooniverse/react-components'
 import counterpart from 'counterpart'
 import { Anchor, Box, Grid, Heading, Paragraph } from 'grommet'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import { array, bool, func, number, shape, string } from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
+
+import addQueryParams from '@helpers/addQueryParams'
 
 import SubjectSetCard from './components/SubjectSetCard'
 import en from './locales/en'
@@ -29,8 +32,8 @@ function BackButton({ onClick }) {
     />
   )
 }
-function SubjectSetPicker (props) {
-  const { onClose, owner, project, workflow } = props
+function SubjectSetPicker ({ baseUrl, onClose, onSelect, workflow }) {
+  const router = useRouter()
   /*
     Vertical spacing for the picker instructions.
     The theme's named margins are set in multiples of 10px, so set 15px explicitly.
@@ -41,6 +44,13 @@ function SubjectSetPicker (props) {
   }
 
   const columns = Math.floor(window.innerWidth / 240)
+
+  function onClick(event, subjectSet) {
+    if (onSelect) {
+      return onSelect(event, subjectSet)
+    }
+    return true
+  }
 
   return (
     <>
@@ -68,13 +78,16 @@ function SubjectSetPicker (props) {
           pad='medium'
         >
         {workflow?.subjectSets.map(subjectSet => {
+          const href = `${baseUrl}/subject-set/${subjectSet.id}`
           return (
             <Link
               key={subjectSet.id}
-              href={`/projects/${owner}/${project}/classify/workflow/${workflow.id}/subject-set/${subjectSet.id}`}
+              href={addQueryParams(href, router)}
               passHref
             >
-              <Anchor>
+              <Anchor
+                onClick={event => onClick(event, subjectSet)}
+              >
                 <SubjectSetCard {...subjectSet} />
               </Anchor>
             </Link>


### PR DESCRIPTION
Work-in-progress towards allowing volunteers to select which subject they work on, from a sequential set of pages in a prioritised subject set. See #1884 for the designs.

You can test this locally on http://local.zooniverse.org:3000/projects/darkeshard/engaging-the-crowds-2020?env=production
After selecting workflow 16106 (the third workflow) and subject set, you should be shown a list of subjects from https://redsea.zooniverse.org. Clicking on any subject ID will take you to the classifier for the selected workflow and subject set. The subject should be selected in the URL.

There's only one subject set indexed at the moment, which is a set of letters from ASM. You should be able to search and sort that set using the Grommet data table headings.

TODO:
- [ ] Tests.
- [ ] Mock the API for the storybook.

![A screenshot of the subject picker displayed on the home page of Shaun's test project.](https://user-images.githubusercontent.com/59547/112986014-df092480-9158-11eb-89fb-a4c8155d4599.png)


Package:
app-project

Closes #1884.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
