### PR TITLE
Classifier: Convert drawing stories to CSF

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -98,7 +98,7 @@ function InteractionLayer ({
       activeTool.deleteMark(activeMark)
       setActiveMark(undefined)
     } else {
-      activeMark.setSubTaskVisibility(true, node)
+      activeMark?.setSubTaskVisibility(true, node)
     }
 
     if (target && pointerId) {

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Ellipse/Ellipse.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Ellipse/Ellipse.stories.js
@@ -1,5 +1,4 @@
 import { withKnobs } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import React, { Component } from 'react'
 import { Box, Grommet } from 'grommet'
@@ -11,6 +10,7 @@ import ClassificationStore from '@store/ClassificationStore'
 import SubjectViewerStore from '@store/SubjectViewerStore'
 import DrawingTask from '@plugins/tasks/DrawingTask/models/DrawingTask'
 import { DrawingTaskFactory, ProjectFactory, SubjectFactory, WorkflowFactory } from '@test/factories'
+import Ellipse from './'
 
 const subject = SubjectFactory.build({
   locations: [
@@ -136,30 +136,36 @@ class DrawingStory extends Component {
   }
 }
 
-storiesOf('Drawing tools / Ellipse', module)
-  .addDecorator(withKnobs)
-  .addParameters({
+export default {
+  title: 'Drawing tools / Ellipse',
+  component: Ellipse,
+  decorators: [withKnobs],
+  parameters: {
     viewport: {
       defaultViewport: 'responsive'
     }
-  })
-  .add('complete', function () {
-    const stores = setupStores({ activeMark: false, subtask: false })
+  }
+}
 
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
-  .add('active', function () {
-    const stores = setupStores({ activeMark: true, subtask: false })
+export function Complete() {
+  const stores = setupStores({ activeMark: false, subtask: false })
 
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
-  .add('active with subtask', function () {
-    const stores = setupStores({ activeMark: true, subtask: true })
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
+  return (
+    <DrawingStory stores={stores} />
+  )
+}
+
+export function Active() {
+  const stores = setupStores({ activeMark: true, subtask: false })
+
+  return (
+    <DrawingStory stores={stores} />
+  )
+}
+
+export function Subtask() {
+  const stores = setupStores({ activeMark: true, subtask: true })
+  return (
+    <DrawingStory stores={stores} />
+  )
+}

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Ellipse/Ellipse.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Ellipse/Ellipse.stories.js
@@ -52,22 +52,28 @@ const subTasksSnapshot = [
   }
 ]
 
+// should think of a better way to do create bounds for the story
+// this is a rough approximation of what the positioning is like now
+const nodeMock = {
+  getBoundingClientRect: () => ({
+    x: 200,
+    y: 200,
+    width: 0,
+    height: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0
+  })
+}
+
 function setupStores({ activeMark, subtask }) {
   if (subtask) {
     drawingTaskSnapshot.tools[0].details = subTasksSnapshot
     drawingTaskSnapshot.subTaskVisibility = true
     // should think of a better way to do this for the story
     // this is a rough approximation of what the positioning is like now
-    drawingTaskSnapshot.subTaskMarkBounds = {
-      x: 200,
-      y: 200,
-      width: 0,
-      height: 0,
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    }
+    drawingTaskSnapshot.subTaskMarkBounds = nodeMock.getBoundingClientRect()
   }
 
   const drawingTask = DrawingTask.create(drawingTaskSnapshot)
@@ -75,6 +81,10 @@ function setupStores({ activeMark, subtask }) {
   const ellipse = drawingTask.activeTool.createMark()
   ellipse.initialPosition({ x: 125, y: 125 })
   ellipse.setCoordinates({ x: 125, y: 125, rx: 50, ry: 20, angle: 2 })
+
+  if (subtask) {
+    ellipse.setSubTaskVisibility(true, nodeMock)
+  }
 
   const mockStores = {
     classifications: ClassificationStore.create(),

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.stories.js
@@ -67,24 +67,14 @@ const nodeMock = {
   })
 }
 
-function setupStores({ activeMark, subtask }) {
-  if (subtask) {
-    drawingTaskSnapshot.tools[0].details = subTasksSnapshot
-    drawingTaskSnapshot.subTaskVisibility = true
-    // should think of a better way to do this for the story
-    // this is a rough approximation of what the positioning is like now
-    drawingTaskSnapshot.subTaskMarkBounds = nodeMock.getBoundingClientRect()
-  }
+function setupStores() {
+  drawingTaskSnapshot.tools[0].details = subTasksSnapshot
 
   const drawingTask = DrawingTask.create(drawingTaskSnapshot)
   drawingTask.setActiveTool(0)
   const line = drawingTask.activeTool.createMark()
   line.initialPosition({ x: 100, y: 100 })
   line.initialDrag({ x: 200, y: 200 })
-
-  if (subtask) {
-    line.setSubTaskVisibility(true, nodeMock)
-  }
 
   const mockStores = {
     classifications: ClassificationStore.create(),
@@ -101,11 +91,25 @@ function setupStores({ activeMark, subtask }) {
   }
 
   mockStores.classifications.createClassification(subject, workflow, project)
-  if (activeMark) {
-    mockStores.workflowSteps.activeStepTasks[0].setActiveMark(line.id)
-  }
 
   return mockStores
+}
+
+const stores = setupStores()
+
+function updateStores({ activeMark, finished, subtask }) {
+  const [ drawingTask ] = stores.workflowSteps.activeStepTasks
+  const [ mark ] = drawingTask.marks
+  if (finished) {
+    drawingTask.setActiveMark(mark.id)
+    mark.finish && mark.finish()
+  }
+  mark.setSubTaskVisibility(subtask, nodeMock)
+  if (activeMark) {
+    drawingTask.setActiveMark(mark.id)
+  } else {
+    drawingTask.setActiveMark(undefined)
+  }
 }
 
 class DrawingStory extends Component {
@@ -157,23 +161,38 @@ export default {
   }
 }
 
-export function Complete() {
-  const stores = setupStores({ activeMark: false, subtask: false })
+export function Complete(args) {
+  updateStores(args)
   return (
     <DrawingStory stores={stores} />
   )
 }
+Complete.args = {
+  activeMark: false,
+  finished: false,
+  subtask: false
+}
 
-export function Active() {
-  const stores = setupStores({ activeMark: true, subtask: false })
+export function Active(args) {
+  updateStores(args)
   return (
     <DrawingStory stores={stores} />
   )
 }
+Active.args = {
+  activeMark: true,
+  finished: false,
+  subtask: false
+}
 
-export function Subtask() {
-  const stores = setupStores({ activeMark: true, subtask: true })
+export function Subtask(args) {
+  updateStores(args)
   return (
     <DrawingStory stores={stores} />
   )
+}
+Subtask.args = {
+  activeMark: true,
+  finished: true,
+  subtask: true
 }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.stories.js
@@ -52,22 +52,28 @@ const subTasksSnapshot = [
   }
 ]
 
+// should think of a better way to do create bounds for the story
+// this is a rough approximation of what the positioning is like now
+const nodeMock = {
+  getBoundingClientRect: () => ({
+    x: 250,
+    y: 250,
+    width: 0,
+    height: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0
+  })
+}
+
 function setupStores({ activeMark, subtask }) {
   if (subtask) {
     drawingTaskSnapshot.tools[0].details = subTasksSnapshot
     drawingTaskSnapshot.subTaskVisibility = true
     // should think of a better way to do this for the story
     // this is a rough approximation of what the positioning is like now
-    drawingTaskSnapshot.subTaskMarkBounds = {
-      x: 250,
-      y: 250,
-      width: 0,
-      height: 0,
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    }
+    drawingTaskSnapshot.subTaskMarkBounds = nodeMock.getBoundingClientRect()
   }
 
   const drawingTask = DrawingTask.create(drawingTaskSnapshot)
@@ -75,6 +81,10 @@ function setupStores({ activeMark, subtask }) {
   const line = drawingTask.activeTool.createMark()
   line.initialPosition({ x: 100, y: 100 })
   line.initialDrag({ x: 200, y: 200 })
+
+  if (subtask) {
+    line.setSubTaskVisibility(true, nodeMock)
+  }
 
   const mockStores = {
     classifications: ClassificationStore.create(),

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.stories.js
@@ -1,5 +1,4 @@
 import { withKnobs } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import React, { Component } from 'react'
 import { Box, Grommet } from 'grommet'
@@ -11,6 +10,7 @@ import ClassificationStore from '@store/ClassificationStore'
 import SubjectViewerStore from '@store/SubjectViewerStore'
 import DrawingTask from '@plugins/tasks/DrawingTask/models/DrawingTask'
 import { DrawingTaskFactory, ProjectFactory, SubjectFactory, WorkflowFactory } from '@test/factories'
+import Line from './'
 
 const subject = SubjectFactory.build({
   locations: [
@@ -136,28 +136,34 @@ class DrawingStory extends Component {
   }
 }
 
-storiesOf('Drawing tools / Line', module)
-  .addDecorator(withKnobs)
-  .addParameters({
+export default {
+  title: 'Drawing tools / Line',
+  component: Line,
+  decorators: [withKnobs],
+  parameters: {
     viewport: {
       defaultViewport: 'responsive'
     }
-  })
-  .add('complete', function () {
-    const stores = setupStores({ activeMark: false, subtask: false })
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
-  .add('active', function () {
-    const stores = setupStores({ activeMark: true, subtask: false })
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
-  .add('active with subtask', function () {
-    const stores = setupStores({ activeMark: true, subtask: true })
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
+  }
+}
+
+export function Complete() {
+  const stores = setupStores({ activeMark: false, subtask: false })
+  return (
+    <DrawingStory stores={stores} />
+  )
+}
+
+export function Active() {
+  const stores = setupStores({ activeMark: true, subtask: false })
+  return (
+    <DrawingStory stores={stores} />
+  )
+}
+
+export function Subtask() {
+  const stores = setupStores({ activeMark: true, subtask: true })
+  return (
+    <DrawingStory stores={stores} />
+  )
+}

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.stories.js
@@ -67,23 +67,13 @@ const nodeMock = {
   })
 }
 
-function setupStores ({ activeMark, subtask }) {
-  if (subtask) {
-    drawingTaskSnapshot.tools[0].details = subTasksSnapshot
-    drawingTaskSnapshot.subTaskVisibility = true
-    // should think of a better way to do this for the story
-    // this is a rough approximation of what the positioning is like now
-    drawingTaskSnapshot.subTaskMarkBounds = nodeMock.getBoundingClientRect()
-  } 
+function setupStores () {
+  drawingTaskSnapshot.tools[0].details = subTasksSnapshot 
 
   const drawingTask = DrawingTask.create(drawingTaskSnapshot)
   drawingTask.setActiveTool(0)
   const point = drawingTask.activeTool.createMark()
   point.move({ x: 100, y: 100 })
-
-  if (subtask) {
-    point.setSubTaskVisibility(true, nodeMock)
-  }
 
   const mockStores = {
     classifications: ClassificationStore.create(),
@@ -100,13 +90,26 @@ function setupStores ({ activeMark, subtask }) {
   }
 
   mockStores.classifications.createClassification(subject, workflow, project)
-  if (activeMark) {
-    mockStores.workflowSteps.activeStepTasks[0].setActiveMark(point.id)
-  }
 
   return mockStores
 }
 
+const stores = setupStores()
+
+function updateStores({ activeMark, finished, subtask }) {
+  const [ drawingTask ] = stores.workflowSteps.activeStepTasks
+  const [ mark ] = drawingTask.marks
+  if (finished) {
+    drawingTask.setActiveMark(mark.id)
+    mark.finish && mark.finish()
+  }
+  mark.setSubTaskVisibility(subtask, nodeMock)
+  if (activeMark) {
+    drawingTask.setActiveMark(mark.id)
+  } else {
+    drawingTask.setActiveMark(undefined)
+  }
+}
 
 class DrawingStory extends Component {
   constructor () {
@@ -157,23 +160,39 @@ export default {
   }
 }
 
-export function Complete() {
-  const stores = setupStores({ activeMark: false, subtask: false})
+export function Complete(args) {
+  updateStores(args)
   return (
     <DrawingStory stores={stores} />
   )
+}
+Complete.args = {
+  activeMark: false,
+  finished: false,
+  subtask: false
 }
 
-export function Active() {
-  const stores = setupStores({ activeMark: true, subtask: false })
+export function Active(args) {
+  updateStores(args)
   return (
     <DrawingStory stores={stores} />
   )
+}
+Active.args = {
+  activeMark: true,
+  finished: false,
+  subtask: false
 }
 
-export function Subtask() {
-  const stores = setupStores({ activeMark: true, subtask: true })
+export function Subtask(args) {
+  updateStores(args)
   return (
     <DrawingStory stores={stores} />
   )
 }
+Subtask.args = {
+  activeMark: true,
+  finished: true,
+  subtask: true
+}
+

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.stories.js
@@ -52,28 +52,38 @@ const subTasksSnapshot = [
   }
 ]
 
+// should think of a better way to do create bounds for the story
+// this is a rough approximation of what the positioning is like now
+const nodeMock = {
+  getBoundingClientRect: () => ({
+    x: 162.5,
+    y: 162.5,
+    width: 0,
+    height: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0
+  })
+}
+
 function setupStores ({ activeMark, subtask }) {
   if (subtask) {
     drawingTaskSnapshot.tools[0].details = subTasksSnapshot
     drawingTaskSnapshot.subTaskVisibility = true
     // should think of a better way to do this for the story
     // this is a rough approximation of what the positioning is like now
-    drawingTaskSnapshot.subTaskMarkBounds = {
-      x: 162.5,
-      y: 162.5,
-      width: 0,
-      height: 0,
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    }
+    drawingTaskSnapshot.subTaskMarkBounds = nodeMock.getBoundingClientRect()
   } 
 
   const drawingTask = DrawingTask.create(drawingTaskSnapshot)
   drawingTask.setActiveTool(0)
   const point = drawingTask.activeTool.createMark()
   point.move({ x: 100, y: 100 })
+
+  if (subtask) {
+    point.setSubTaskVisibility(true, nodeMock)
+  }
 
   const mockStores = {
     classifications: ClassificationStore.create(),

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.stories.js
@@ -1,5 +1,4 @@
 import { withKnobs } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
 import React, { Component } from 'react'
 import { Provider } from 'mobx-react'
 import { Box, Grommet } from 'grommet'
@@ -11,6 +10,7 @@ import ClassificationStore from '@store/ClassificationStore'
 import SubjectViewerStore from '@store/SubjectViewerStore'
 import DrawingTask from '@plugins/tasks/DrawingTask/models/DrawingTask'
 import { DrawingTaskFactory, ProjectFactory, SubjectFactory, WorkflowFactory } from '@test/factories'
+import Point from './'
 
 const subject = SubjectFactory.build({
   locations: [
@@ -135,28 +135,35 @@ class DrawingStory extends Component {
     )
   }
 }
-storiesOf('Drawing tools / Point', module)
-  .addDecorator(withKnobs)
-  .addParameters({
+
+export default {
+  title: 'Drawing tools / Point',
+  component: Point,
+  decorators: [withKnobs],
+  parameters: {
     viewport: {
       defaultViewport: 'responsive'
     }
-  })
-  .add('complete', function () {
-    const stores = setupStores({ activeMark: false, subtask: false})
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
-  .add('active', function () {
-    const stores = setupStores({ activeMark: true, subtask: false })
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
-  .add('active with subtask', function () {
-    const stores = setupStores({ activeMark: true, subtask: true })
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
+  }
+}
+
+export function Complete() {
+  const stores = setupStores({ activeMark: false, subtask: false})
+  return (
+    <DrawingStory stores={stores} />
+  )
+}
+
+export function Active() {
+  const stores = setupStores({ activeMark: true, subtask: false })
+  return (
+    <DrawingStory stores={stores} />
+  )
+}
+
+export function Subtask() {
+  const stores = setupStores({ activeMark: true, subtask: true })
+  return (
+    <DrawingStory stores={stores} />
+  )
+}

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Rectangle/Rectangle.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Rectangle/Rectangle.stories.js
@@ -1,5 +1,4 @@
 import { withKnobs } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import React, { Component } from 'react'
 import { Box, Grommet } from 'grommet'
@@ -11,6 +10,7 @@ import ClassificationStore from '@store/ClassificationStore'
 import SubjectViewerStore from '@store/SubjectViewerStore'
 import DrawingTask from '@plugins/tasks/DrawingTask/models/DrawingTask'
 import { DrawingTaskFactory, ProjectFactory, SubjectFactory, WorkflowFactory } from '@test/factories'
+import Rectangle from './'
 
 const subject = SubjectFactory.build({
   locations: [
@@ -136,30 +136,34 @@ class DrawingStory extends Component {
   }
 }
 
-storiesOf('Drawing tools / Rectangle', module)
-  .addDecorator(withKnobs)
-  .addParameters({
+export default {
+  title: 'Drawing tools / Rectangle',
+  component: Rectangle,
+  decorators: [withKnobs],
+  parameters: {
     viewport: {
       defaultViewport: 'responsive'
     }
-  })
-  .add('complete', function () {
-    const stores = setupStores({ activeMark: false, subtask: false })
+  }
+}
 
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
-  .add('active', function () {
-    const stores = setupStores({ activeMark: true, subtask: false })
+export function Complete() {
+  const stores = setupStores({ activeMark: false, subtask: false})
+  return (
+    <DrawingStory stores={stores} />
+  )
+}
 
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
-  .add('active with subtask', function () {
-    const stores = setupStores({ activeMark: true, subtask: true })
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
+export function Active() {
+  const stores = setupStores({ activeMark: true, subtask: false })
+  return (
+    <DrawingStory stores={stores} />
+  )
+}
+
+export function Subtask() {
+  const stores = setupStores({ activeMark: true, subtask: true })
+  return (
+    <DrawingStory stores={stores} />
+  )
+}

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Rectangle/Rectangle.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Rectangle/Rectangle.stories.js
@@ -67,24 +67,14 @@ const nodeMock = {
   })
 }
 
-function setupStores({ activeMark, subtask }) {
-  if (subtask) {
-    drawingTaskSnapshot.tools[0].details = subTasksSnapshot
-    drawingTaskSnapshot.subTaskVisibility = true
-    // should think of a better way to do this for the story
-    // this is a rough approximation of what the positioning is like now
-    drawingTaskSnapshot.subTaskMarkBounds = nodeMock.getBoundingClientRect()
-  }
+function setupStores() {
+  drawingTaskSnapshot.tools[0].details = subTasksSnapshot
 
   const drawingTask = DrawingTask.create(drawingTaskSnapshot)
   drawingTask.setActiveTool(0)
   const rectangle = drawingTask.activeTool.createMark()
   rectangle.initialPosition({ x: 100, y: 100 })
   rectangle.initialDrag({ x: 150, y: 150 })
-
-  if (subtask) {
-    rectangle.setSubTaskVisibility(true, nodeMock)
-  }
 
   const mockStores = {
     classifications: ClassificationStore.create(),
@@ -101,11 +91,25 @@ function setupStores({ activeMark, subtask }) {
   }
 
   mockStores.classifications.createClassification(subject, workflow, project)
-  if (activeMark) {
-    mockStores.workflowSteps.activeStepTasks[0].setActiveMark(rectangle.id)
-  }
 
   return mockStores
+}
+
+const stores = setupStores()
+
+function updateStores({ activeMark, finished, subtask }) {
+  const [ drawingTask ] = stores.workflowSteps.activeStepTasks
+  const [ mark ] = drawingTask.marks
+  if (finished) {
+    drawingTask.setActiveMark(mark.id)
+    mark.finish && mark.finish()
+  }
+  mark.setSubTaskVisibility(subtask, nodeMock)
+  if (activeMark) {
+    drawingTask.setActiveMark(mark.id)
+  } else {
+    drawingTask.setActiveMark(undefined)
+  }
 }
 
 class DrawingStory extends Component {
@@ -157,23 +161,38 @@ export default {
   }
 }
 
-export function Complete() {
-  const stores = setupStores({ activeMark: false, subtask: false})
+export function Complete(args) {
+  updateStores(args)
   return (
     <DrawingStory stores={stores} />
   )
 }
+Complete.args = {
+  activeMark: false,
+  finished: false,
+  subtask: false
+}
 
-export function Active() {
-  const stores = setupStores({ activeMark: true, subtask: false })
+export function Active(args) {
+  updateStores(args)
   return (
     <DrawingStory stores={stores} />
   )
 }
+Active.args = {
+  activeMark: true,
+  finished: false,
+  subtask: false
+}
 
-export function Subtask() {
-  const stores = setupStores({ activeMark: true, subtask: true })
+export function Subtask(args) {
+  updateStores(args)
   return (
     <DrawingStory stores={stores} />
   )
+}
+Subtask.args = {
+  activeMark: true,
+  finished: true,
+  subtask: true
 }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Rectangle/Rectangle.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Rectangle/Rectangle.stories.js
@@ -52,22 +52,28 @@ const subTasksSnapshot = [
   }
 ]
 
+// should think of a better way to do create bounds for the story
+// this is a rough approximation of what the positioning is like now
+const nodeMock = {
+  getBoundingClientRect: () => ({
+    x: 200,
+    y: 200,
+    width: 0,
+    height: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0
+  })
+}
+
 function setupStores({ activeMark, subtask }) {
   if (subtask) {
     drawingTaskSnapshot.tools[0].details = subTasksSnapshot
     drawingTaskSnapshot.subTaskVisibility = true
     // should think of a better way to do this for the story
     // this is a rough approximation of what the positioning is like now
-    drawingTaskSnapshot.subTaskMarkBounds = {
-      x: 200,
-      y: 200,
-      width: 0,
-      height: 0,
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0
-    }
+    drawingTaskSnapshot.subTaskMarkBounds = nodeMock.getBoundingClientRect()
   }
 
   const drawingTask = DrawingTask.create(drawingTaskSnapshot)
@@ -75,6 +81,10 @@ function setupStores({ activeMark, subtask }) {
   const rectangle = drawingTask.activeTool.createMark()
   rectangle.initialPosition({ x: 100, y: 100 })
   rectangle.initialDrag({ x: 150, y: 150 })
+
+  if (subtask) {
+    rectangle.setSubTaskVisibility(true, nodeMock)
+  }
 
   const mockStores = {
     classifications: ClassificationStore.create(),

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
@@ -138,7 +138,7 @@ export default {
 }
 
 export function Complete() {
-  const stores = setupStores({ activeMark: false, finished: true, subtask: false})
+  const stores = setupStores({ activeMark: false, subtask: false})
   return (
     <DrawingStory stores={stores} />
   )
@@ -152,7 +152,7 @@ export function Active() {
 }
 
 export function Subtask() {
-  const stores = setupStores({ activeMark: true, subtask: true })
+  const stores = setupStores({ activeMark: true, finished: true, subtask: true })
   return (
     <DrawingStory stores={stores} />
   )

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
@@ -138,7 +138,7 @@ export default {
 }
 
 export function Complete() {
-  const stores = setupStores({ activeMark: false, subtask: false})
+  const stores = setupStores({ activeMark: false, finished: true, subtask: false})
   return (
     <DrawingStory stores={stores} />
   )

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
@@ -1,5 +1,4 @@
 import { withKnobs } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import React, { Component } from 'react'
 import { Box, Grommet } from 'grommet'
@@ -11,6 +10,7 @@ import ClassificationStore from '@store/ClassificationStore'
 import SubjectViewerStore from '@store/SubjectViewerStore'
 import DrawingTask from '@plugins/tasks/DrawingTask/models/DrawingTask'
 import { DrawingTaskFactory, ProjectFactory, SubjectFactory, WorkflowFactory } from '@test/factories'
+import TranscriptionLine from './'
 
 const subject = SubjectFactory.build({
   locations: [
@@ -126,29 +126,35 @@ class DrawingStory extends Component {
   }
 }
 
-storiesOf('Drawing Tools / TranscriptionLine', module)
-  .addDecorator(withKnobs)
-  .addParameters({
+export default {
+  title: 'Drawing tools / Transcription Line',
+  component: TranscriptionLine,
+  decorators: [withKnobs],
+  parameters: {
     viewport: {
       defaultViewport: 'responsive'
     }
-  })
-  .add('in drawing task, drawing complete', function () {
-    const stores = setupStores({ activeMark: false, finished: true, subtask: false })
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
-  .add('in drawing task, active', function () {
-    const stores = setupStores({ activeMark: true, subtask: false })
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
-  .add('in drawing task, active, with sub-task', function () {
-    const stores = setupStores({ activeMark: true, subtask: true })
-    return (
-      <DrawingStory stores={stores} />
-    )
-  })
+  }
+}
+
+export function Complete() {
+  const stores = setupStores({ activeMark: false, subtask: false})
+  return (
+    <DrawingStory stores={stores} />
+  )
+}
+
+export function Active() {
+  const stores = setupStores({ activeMark: true, subtask: false })
+  return (
+    <DrawingStory stores={stores} />
+  )
+}
+
+export function Subtask() {
+  const stores = setupStores({ activeMark: true, subtask: true })
+  return (
+    <DrawingStory stores={stores} />
+  )
+}
 

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
@@ -53,18 +53,12 @@ const nodeMock = {
   })
 }
 
-function setupStores({ activeMark, finished, subtask }) {
-  if (subtask) {
-    drawingTaskSnapshot.tools[0].details = subTasksSnapshot
-  }
+function setupStores() {
+  drawingTaskSnapshot.tools[0].details = subTasksSnapshot
 
   const drawingTask = DrawingTask.create(drawingTaskSnapshot)
   drawingTask.setActiveTool(0)
   const transcriptionLine = drawingTask.activeTool.createMark({ x1: 100, y1: 100, x2: 200, y2: 105 })
-  if (subtask) {
-    transcriptionLine.setSubTaskVisibility(true, nodeMock)
-  }
-  if (finished) transcriptionLine.finish()
 
   const mockStores = {
     classifications: ClassificationStore.create(),
@@ -81,11 +75,25 @@ function setupStores({ activeMark, finished, subtask }) {
   }
 
   mockStores.classifications.createClassification(subject, workflow, project)
-  if (activeMark) {
-    mockStores.workflowSteps.activeStepTasks[0].setActiveMark(transcriptionLine.id)
-  }
 
   return mockStores
+}
+
+const stores = setupStores()
+
+function updateStores({ activeMark, finished, subtask }) {
+  const [ drawingTask ] = stores.workflowSteps.activeStepTasks
+  const [ transcriptionLine ] = drawingTask.marks
+  if (finished) {
+    drawingTask.setActiveMark(transcriptionLine.id)
+    transcriptionLine.finish()
+  }
+  transcriptionLine.setSubTaskVisibility(subtask, nodeMock)
+  if (activeMark) {
+    drawingTask.setActiveMark(transcriptionLine.id)
+  } else {
+    drawingTask.setActiveMark(undefined)
+  }
 }
 
 class DrawingStory extends Component {
@@ -129,7 +137,6 @@ class DrawingStory extends Component {
 export default {
   title: 'Drawing tools / Transcription Line',
   component: TranscriptionLine,
-  decorators: [withKnobs],
   parameters: {
     viewport: {
       defaultViewport: 'responsive'
@@ -137,24 +144,39 @@ export default {
   }
 }
 
-export function Complete() {
-  const stores = setupStores({ activeMark: false, subtask: false})
+export function Complete(args) {
+  updateStores(args)
   return (
     <DrawingStory stores={stores} />
   )
 }
+Complete.args = {
+  activeMark: false,
+  finished: false,
+  subtask: false
+}
 
-export function Active() {
-  const stores = setupStores({ activeMark: true, subtask: false })
+export function Active(args) {
+  updateStores(args)
   return (
     <DrawingStory stores={stores} />
   )
 }
+Active.args = {
+  activeMark: true,
+  finished: false,
+  subtask: false
+}
 
-export function Subtask() {
-  const stores = setupStores({ activeMark: true, finished: true, subtask: true })
+export function Subtask(args) {
+  updateStores(args)
   return (
     <DrawingStory stores={stores} />
   )
+}
+Subtask.args = {
+  activeMark: true,
+  finished: true,
+  subtask: true
 }
 


### PR DESCRIPTION
Remove `storiesOf` from the drawing tool stories and replace them with [Component Story Format](https://storybook.js.org/docs/react/api/csf) functions.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
