### PR TITLE
Add survey task model

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/index.js
@@ -1,0 +1,9 @@
+// import component
+import { default as TaskModel } from './models/SurveyTask'
+import { default as AnnotationModel } from './models/SurveyAnnotation'
+
+export default {
+  // TaskComponent,
+  TaskModel,
+  AnnotationModel
+}

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/models/SurveyAnnotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/models/SurveyAnnotation.spec.js
@@ -121,6 +121,7 @@ describe('Model > SurveyAnnotation', function () {
     })
 
     it('should have a default value', function () {
+      expect(surveyAnnotation.value).to.be.an('array')
       expect(surveyAnnotation.value).to.have.lengthOf(0)
     })
 

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/models/SurveyTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/models/SurveyTask.js
@@ -1,0 +1,33 @@
+import cuid from 'cuid'
+import { types } from 'mobx-state-tree'
+import Task from '../../models/Task'
+import SurveyAnnotation from './SurveyAnnotation'
+
+const Survey = types.model('Survey', {
+  annotation: types.safeReference(SurveyAnnotation),
+  characteristics: types.frozen({}),
+  characteristicsOrder: types.array(types.string),
+  choices: types.frozen({}),
+  choicesOrder: types.array(types.string),
+  exclusions: types.array(types.string),
+  help: types.optional(types.string, ''),
+  images: types.frozen({}),
+  inclusions: types.array(types.string),
+  questions: types.frozen({}),
+  questionsMap: types.frozen({}),
+  questionsOrder: types.array(types.string),
+  type: types.literal('survey')
+})
+  .views(self => ({
+    defaultAnnotation (id = cuid()) {
+      return SurveyAnnotation.create({
+        id,
+        task: self.taskKey,
+        taskType: self.type
+      })
+    }
+  }))
+
+const SurveyTask = types.compose('SurveyTask', Task, Survey)
+
+export default SurveyTask

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/models/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/models/SurveyTask.spec.js
@@ -1,0 +1,497 @@
+import { types } from 'mobx-state-tree'
+import SurveyTask from '@plugins/tasks/SurveyTask'
+
+const surveyTask = {
+  characteristics: {
+    'LIKE': {
+      'label': 'Like',
+      'valuesOrder': [
+        'CATDOG',
+        'COWHORSE',
+        'ANTELOPEDEER',
+        'PRIMATE',
+        'WEASEL',
+        'BIRD',
+        'OTHER'
+      ],
+      'values': {
+        'CATDOG': {
+          'label': 'cat/dog',
+          'image': 'cat-dog-icon.svg'
+        },
+        'COWHORSE': {
+          'label': 'cow/horse',
+          'image': 'cow-horse-icon.svg'
+        },
+        'ANTELOPEDEER': {
+          'label': 'antelope/deer',
+          'image': 'ante-deer-icon.svg'
+        },
+        'PRIMATE': {
+          'label': 'primate',
+          'image': 'primate-icon.svg'
+        },
+        'WEASEL': {
+          'label': 'weasel',
+          'image': 'weasel-icon.svg'
+        },
+        'BIRD': {
+          'label': 'bird',
+          'image': 'bird-icon.svg'
+        },
+        'OTHER': {
+          'label': 'other',
+          'image': 'nothing-icon.svg'
+        }
+      }
+    },
+    'PATTERN': {
+      'label': 'Pattern',
+      'valuesOrder': [
+        'SOLID',
+        'STRIPES',
+        'BANDS',
+        'SPOTS'
+      ],
+      'values': {
+        'SOLID': {
+          'label': 'solid',
+          'image': 'solid-icon.svg'
+        },
+        'STRIPES': {
+          'label': 'stripes',
+          'image': 'stripes-icon.svg'
+        },
+        'BANDS': {
+          'label': 'bands',
+          'image': 'banding-icon.svg'
+        },
+        'SPOTS': {
+          'label': 'spots',
+          'image': 'spots-icon.svg'
+        }
+      }
+    },
+    'COLOR': {
+      'label': 'color',
+      'valuesOrder': [
+        'TANYELLOW',
+        'RED',
+        'BROWN',
+        'WHITE',
+        'GRAY',
+        'BLACK'
+      ],
+      'values': {
+        'TANYELLOW': {
+          'label': 'tan/yellow',
+          'image': 'tan-yellow.svg'
+        },
+        'RED': {
+          'label': 'red',
+          'image': 'red.svg'
+        },
+        'BROWN': {
+          'label': 'brown',
+          'image': 'brown.svg'
+        },
+        'WHITE': {
+          'label': 'white',
+          'image': 'white.svg'
+        },
+        'GRAY': {
+          'label': 'gray',
+          'image': 'gray.svg'
+        },
+        'BLACK': {
+          'label': 'black',
+          'image': 'black.svg'
+        }
+      }
+    }
+  },
+  characteristicsOrder: [
+    'COLOR',
+    'LIKE',
+    'PATTERN'
+  ],
+  choices: {
+    'AARDVARK': {
+      'label': 'Aardvark',
+      'description': 'Not as awesome as a pangolin, but surprisingly big.',
+      'noQuestions': false,
+      'images': [
+        'aardvark-1.jpg',
+        'aardvark-2.jpg',
+        'aardvark-3.jpg'
+      ],
+      'characteristics': {
+        'LIKE': [
+          'WEASEL',
+          'OTHER'
+        ],
+        'PATTERN': [
+          'SOLID'
+        ],
+        'COLOR': [
+          'RED',
+          'BROWN',
+          'GRAY'
+        ]
+      },
+      'confusionsOrder': [
+        'FIRE'
+      ],
+      'confusions': {
+        'FIRE': `You probably shouldn't be getting these confused.`
+      }
+    },
+    'BABOON': {
+      'label': 'Baboon',
+      'description': 'AKA the creatures that break into your house and destroy everything.',
+      'noQuestions': false,
+      'images': [
+        'baboon-1.jpg',
+        'baboon-2.jpg',
+        'baboon-3.jpg'
+      ],
+      'characteristics': {
+        'LIKE': [
+          'CATDOG',
+          'PRIMATE',
+          'OTHER'
+        ],
+        'PATTERN': [
+          'SOLID'
+        ],
+        'COLOR': [
+          'TANYELLOW',
+          'BROWN',
+          'GRAY'
+        ]
+      },
+      'confusionsOrder': [],
+      'confusions': {}
+    },
+    'FIRE': {
+      'label': 'Fire',
+      'description': `It's a fire. Pretty sure you know what this looks like.`,
+      'noQuestions': true,
+      'images': [
+        'fire-1.jpg'
+      ],
+      'characteristics': {
+        'LIKE': [],
+        'PATTERN': [],
+        'COLOR': []
+      },
+      'confusionsOrder': [],
+      'confusions': {}
+    }
+  },
+  choicesOrder: [
+    'AARDVARK',
+    'BABOON',
+    'FIRE'
+  ],
+  exclusions: [''],
+  images: {},
+  inclusions: [''],
+  questions: {
+    'HOWMANY': {
+      'label': 'How many?',
+      'multiple': false,
+      'required': true,
+      'answersOrder': [
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+        '6',
+        '7',
+        '8',
+        '9',
+        '10',
+        '1150',
+        '51'
+      ],
+      'answers': {
+        '1': {
+          'label': '1'
+        },
+        '2': {
+          'label': ' 2'
+        },
+        '3': {
+          'label': ' 3'
+        },
+        '4': {
+          'label': ' 4'
+        },
+        '5': {
+          'label': ' 5'
+        },
+        '6': {
+          'label': ' 6'
+        },
+        '7': {
+          'label': ' 7'
+        },
+        '8': {
+          'label': ' 8'
+        },
+        '9': {
+          'label': ' 9'
+        },
+        '10': {
+          'label': ' 10'
+        },
+        '51': {
+          'label': ' 51+'
+        },
+        '1150': {
+          'label': ' 11-50'
+        }
+      }
+    },
+    'WHATBEHAVIORSDOYOUSEE': {
+      'label': 'What behaviors do you see?',
+      'multiple': true,
+      'required': true,
+      'answersOrder': [
+        'RESTING',
+        'STANDING',
+        'MOVING',
+        'EATING',
+        'INTERACTING'
+      ],
+      'answers': {
+        'RESTING': {
+          'label': 'Resting'
+        },
+        'STANDING': {
+          'label': ' Standing'
+        },
+        'MOVING': {
+          'label': ' Moving'
+        },
+        'EATING': {
+          'label': ' Eating'
+        },
+        'INTERACTING': {
+          'label': ' Interacting'
+        }
+      }
+    },
+    'ARETHEREANYYOUNGPRESENT': {
+      'label': 'Are there any young present?',
+      'multiple': false,
+      'required': false,
+      'answersOrder': [
+        'YES',
+        'NO'
+      ],
+      'answers': {
+        'YES': {
+          'label': 'Yes'
+        },
+        'NO': {
+          'label': ' No'
+        }
+      }
+    },
+    'DOYOUSEEANYHORNS': {
+      'label': 'Do you see any horns?',
+      'multiple': false,
+      'required': false,
+      'answersOrder': [
+        'YES',
+        'NO'
+      ],
+      'answers': {
+        'YES': {
+          'label': 'Yes'
+        },
+        'NO': {
+          'label': ' No'
+        }
+      }
+    },
+    'DONTCARE': {
+      'label': `Don't care?`,
+      'multiple': false,
+      'required': true,
+      'answersOrder': [
+        'YES',
+        'NO'
+      ],
+      'answers': {
+        'YES': {
+          'label': 'Yes'
+        },
+        'NO': {
+          'label': ' No'
+        }
+      }
+    },
+    'CLICKWOWIFTHISISANAWESOMEPHOTO': {
+      'label': `Click 'WOW!' if this is an awesome photo`,
+      'multiple': false,
+      'required': false,
+      'answersOrder': [
+        'WOW'
+      ],
+      'answers': {
+        'WOW': {
+          'label': 'WOW!'
+        }
+      }
+    }
+  },
+  questionsMap: {
+    'AARDVARK': [
+      'HOWMANY',
+      'WHATBEHAVIORSDOYOUSEE',
+      'ARETHEREANYYOUNGPRESENT',
+      'CLICKWOWIFTHISISANAWESOMEPHOTO'
+    ],
+    'BABOON': [
+      'HOWMANY',
+      'WHATBEHAVIORSDOYOUSEE',
+      'ARETHEREANYYOUNGPRESENT',
+      'CLICKWOWIFTHISISANAWESOMEPHOTO'
+    ]
+
+  },
+  questionsOrder: [
+    'HOWMANY',
+    'WHATBEHAVIORSDOYOUSEE',
+    'ARETHEREANYYOUNGPRESENT',
+    'CLICKWOWIFTHISISANAWESOMEPHOTO'
+  ],
+  required: '',
+  taskKey: 'T0',
+  type: 'survey'
+}
+
+const surveyAnnotation = [
+  {
+    'choice': 'AARDVARK',
+    'answers': {
+      'HOWMANY': '1',
+      'WHATBEHAVIORSDOYOUSEE': [
+        'INTERACTING'
+      ],
+      'ARETHEREANYYOUNGPRESENT': 'NO',
+      'CLICKWOWIFTHISISANAWESOMEPHOTO': 'WOW'
+    },
+    'filters': {
+      'COLOR': 'RED'
+    }
+  }
+]
+
+describe('Model > SurveyTask', function () {
+  it('should exist', function () {
+    const surveyTaskInstance = SurveyTask.TaskModel.create(surveyTask)
+    expect(surveyTaskInstance).to.be.ok()
+    expect(surveyTaskInstance).to.be.an('object')
+    expect(surveyTaskInstance.type).to.equal('survey')
+  })
+
+  it('should error for invalid tasks', function () {
+    let errorThrown = false
+    try {
+      SurveyTask.TaskModel.create({})
+    } catch (e) {
+      errorThrown = true
+    }
+    expect(errorThrown).to.be.true()
+  })
+
+  describe('Views > defaultAnnotation', function () {
+    let task
+
+    before(function () {
+      task = SurveyTask.TaskModel.create(surveyTask)
+    })
+
+    it('should be a valid annotation', function () {
+      const annotation = task.defaultAnnotation()
+      expect(annotation.id).to.be.ok()
+      expect(annotation.task).to.equal('T0')
+      expect(annotation.taskType).to.equal('survey')
+    })
+
+    it('should generate unique annotations', function () {
+      const firstAnnotation = task.defaultAnnotation()
+      const secondAnnotation = task.defaultAnnotation()
+      expect(firstAnnotation.id).to.not.equal(secondAnnotation.id)
+    })
+  })
+
+  describe('with an annotation', function () {
+    let annotation
+    let task
+
+    before(function () {
+      task = SurveyTask.TaskModel.create(surveyTask)
+      annotation = task.defaultAnnotation()
+      const store = types
+        .model('MockStore', {
+          annotation: SurveyTask.AnnotationModel,
+          task: SurveyTask.TaskModel
+        })
+        .create({
+          annotation,
+          task
+        })
+      task.setAnnotation(annotation)
+    })
+
+    it('should start up with an empty array', function () {
+      expect(annotation.value).to.be.an('array')
+      expect(annotation.value).to.have.lengthOf(0)
+
+    })
+
+    it('should update annotations', function () {
+      annotation.update(surveyAnnotation)
+      expect(task.annotation.value).to.deep.equal(surveyAnnotation)
+    })
+  })
+
+  describe('when required', function () {
+    let annotation
+    let task
+
+    before(function () {
+      const requiredTask = Object.assign({}, surveyTask, { required: 'true' })
+      task = SurveyTask.TaskModel.create(requiredTask)
+      annotation = task.defaultAnnotation()
+      const store = types.model('MockStore', {
+        annotation: SurveyTask.AnnotationModel,
+        task: SurveyTask.TaskModel
+      })
+        .create({
+          annotation,
+          task
+        })
+      task.setAnnotation(annotation)
+    })
+
+    describe('with an incomplete annotation', function () {
+      it('should be incomplete', function () {
+        expect(task.isComplete).to.be.false()
+      })
+    })
+
+    describe('with a complete annotation', function () {
+      it('should be complete', function () {
+        annotation.update(surveyAnnotation)
+        expect(task.isComplete).to.be.true()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Package: lib-classifier

Closes #1900.

Describe your changes:
- adds survey task model tests
- adds survey task model (basic)

Notes:
- subsequent PR incoming to refactor survey task and survey task annotation to utilize `types.refinement`

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
