### PR TITLE
Add a production test build to CI Tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -10,7 +10,13 @@ jobs:
   build:
    runs-on: ubuntu-latest
    env:
-     CI: true
+     APP_ENV: production
+     NODE_ENV: production
+     PANOPTES_ENV: production
+     CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
+     CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+     CONTENT_ASSET_PREFIX: 'https://fe-content-pages.zooniverse.org'
+     PROJECT_ASSET_PREFIX: 'https://fe-project.zooniverse.org'
 
    steps:
     # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#using-the-checkout-action
@@ -20,10 +26,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.x'
-    - run: yarn install
+    - run: yarn install --production=false
     - run: yarn workspace @zooniverse/react-components build
     - run: yarn workspace @zooniverse/classifier build
-    - run: yarn test:ci
+    - run: yarn workspace @zooniverse/fe-project build
+    - run: yarn workspace @zooniverse/fe-content-pages build
+    - run: PANOPTES_ENV=test yarn test:ci
     - run: yarn coverage-lcov
     - name: Coveralls
       uses: coverallsapp/github-action@master

--- a/README.md
+++ b/README.md
@@ -130,8 +130,12 @@ More information is available in [ADR 12](docs/arch/adr-12.md) and [ADR 17](docs
   - `staging` will use `https://panoptes-staging.zooniverse.org/api`.
 
 The yarn build scripts default to production for libraries if `PANOPTES_ENV` is not specified. The apps are always built to the production API.
-- `NODE_ENV`: sets the environment for library builds.
+- `NODE_ENV`: the [webpack build mode](https://webpack.js.org/configuration/mode/) for libraries and the NextJS apps (production, development or undefined.)
 - `APP_ENV`: sets the [Sentry environment](https://docs.sentry.io/enriching-error-data/environments/?platform=javascript) (development, staging or production) when reporting errors.
+- `CONTENTFUL_ACCESS_TOKEN`: access token for the Contentful API. Should be kept secret.
+- `CONTENTFUL_SPACE_ID`: space ID for Zooniverse About pages in Contentful. Should be kept secret.
+- `CONTENT_ASSET_PREFIX`: [NextJS asset prefix](https://nextjs.org/docs/api-reference/next.config.js/cdn-support-with-asset-prefix) for `app-content-pages`.
+- `PROJECT_ASSET_PREFIX`: [NextJS asset prefix](https://nextjs.org/docs/api-reference/next.config.js/cdn-support-with-asset-prefix) for `app-project`.
 
 ### Docker images
 

--- a/packages/app-content-pages/server/set-logging.spec.js
+++ b/packages/app-content-pages/server/set-logging.spec.js
@@ -8,7 +8,7 @@ describe('Server > setLogging', function () {
   }
   const useSpy = sinon.spy(expressInstance, 'use')
 
-  describe('default behaviour', function () {
+  describe('in development', function () {
     before(function () {
       setLogging = proxyquire('./set-logging', {
         process: {
@@ -29,7 +29,7 @@ describe('Server > setLogging', function () {
     })
   })
 
-  describe('production behaviour', function () {
+  describe('in production', function () {
     before(function () {
       setLogging = proxyquire('./set-logging', {
         process: {

--- a/packages/app-content-pages/server/set-logging.spec.js
+++ b/packages/app-content-pages/server/set-logging.spec.js
@@ -10,7 +10,13 @@ describe('Server > setLogging', function () {
 
   describe('default behaviour', function () {
     before(function () {
-      setLogging = require('./set-logging')
+      setLogging = proxyquire('./set-logging', {
+        process: {
+          env: {
+            NODE_ENV: 'development'
+          }
+        }
+      })
     })
 
     afterEach(function () {

--- a/packages/app-project/server/set-logging.spec.js
+++ b/packages/app-project/server/set-logging.spec.js
@@ -8,9 +8,15 @@ describe('Server > setLogging', function () {
   }
   const useSpy = sinon.spy(expressInstance, 'use')
 
-  describe('default behaviour', function () {
+  describe('in development', function () {
     before(function () {
-      setLogging = require('./set-logging')
+      setLogging = proxyquire('./set-logging', {
+        process: {
+          env: {
+            NODE_ENV: 'development'
+          }
+        }
+      })
     })
 
     afterEach(function () {
@@ -23,7 +29,7 @@ describe('Server > setLogging', function () {
     })
   })
 
-  describe('production behaviour', function () {
+  describe('in production', function () {
     before(function () {
       setLogging = proxyquire('./set-logging', {
         process: {

--- a/packages/app-project/stores/UI.spec.js
+++ b/packages/app-project/stores/UI.spec.js
@@ -62,8 +62,28 @@ describe('Stores > UI', function () {
   })
 
   describe('when using the mode cookie', function () {
+    let originalDocument
     let setModeCookieSpy
     let store
+
+    before(function () {
+      originalDocument = document
+      document = sinon.mock({
+        value_: '',
+
+        get cookie() {
+          return this.value_;
+        },
+
+        set cookie(value) {
+          this.value_ += value + ';';
+        }
+      })
+    })
+
+    after(function () {
+      document = originalDocument
+    })
 
     beforeEach(function () {
       document.cookie = 'mode=; max-age=-99999999;'
@@ -134,19 +154,31 @@ describe('Stores > UI', function () {
   describe('when using the dismissedProjectAnnouncementBanner cookie', function () {
     let rootStore
     let store
-    let originalURL
+    let originalDocument
     let setProjectAnnouncementBannerCookieSpy
 
     before(function () {
-      originalURL = document.URL
+      originalDocument = document
       dom.reconfigure({
         url: `https://localhost/projects/${PROJECT.slug}`
+      })
+      document = sinon.mock({
+        value_: '',
+
+        get cookie() {
+          return this.value_;
+        },
+
+        set cookie(value) {
+          this.value_ += value + ';';
+        }
       })
     })
 
     after(function () {
+      document = originalDocument
       dom.reconfigure({
-        url: originalURL
+        url: originalDocument.URL
       })
     })
 

--- a/packages/lib-react-components/src/helpers/withCustomFormik/withCustomFormik.spec.js
+++ b/packages/lib-react-components/src/helpers/withCustomFormik/withCustomFormik.spec.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { mount, shallow } from 'enzyme'
 import { expect } from 'chai'
+import { Formik } from 'formik'
 import { Box, Button, FormField, Grommet, TextInput } from 'grommet'
 import sinon from 'sinon'
 import zooTheme from '@zooniverse/grommet-theme'
@@ -98,7 +99,7 @@ describe('Higher Order Component > withCustomFormik', function () {
 
       // the form's children prop is a render function
       // ie. a stateless component
-      InnerForm = wrapper.find('Formik').props().children
+      InnerForm = wrapper.find(Formik).props().children
 
       mockForm = shallow(<InnerForm {...mockInnerProps} />)
     })


### PR DESCRIPTION
Set up a copy of the production build environment. Run a full install (to install the build tools.) Run a test build of all the libraries and the NextJS apps. Run the tests with PANOPTES_ENV=test.

#1943 restricts the Jenkins builds to deploys only, so this runs a full build of the monorepo as part of the CI tests for each PR. In theory, this should catch breaking changes in the NextJS apps before we merge to staging.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
