### PR TITLE
Fix mobx warning about accessing an undefined index in an array

### DIFF
--- a/packages/lib-classifier/src/store/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.js
@@ -156,7 +156,9 @@ const WorkflowStepStore = types
       const { steps } = workflow
       steps.forEach(([ stepKey, step ], index) => {
         let next
-        if (steps[index + 1]) {
+        // checking for there being a next step without accessing it directly
+        // mobx throws errors for undefined indices because you can't observe those
+        if (steps.length > 0 && index + 2 <= steps.length) {
           const [nextStepKey] = steps[index + 1]
           next = nextStepKey
         }

--- a/packages/lib-classifier/src/store/WorkflowStepStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore.spec.js
@@ -90,7 +90,10 @@ describe('Model > WorkflowStepStore', function () {
 
       it('should set the next step', function () {
         STORE_STEPS.forEach((step, stepIndex) => {
-          const nextStep = step[stepIndex + 1]
+          let nextStep
+          if (STORE_STEPS.length > 0 && stepIndex + 2 <= STORE_STEPS.length) {
+            nextStep = step[stepIndex + 1]
+          }
           if (nextStep) {
             expect(step.next).to.equal(nextStep.stepKey)
           }


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

This fixes something I missed while reviewing #1885. The change on the `Workflow` model type for steps caused this warning to start to be thrown: `[mobx.array] Attempt to read an array index (1) that is out of bounds (1). Please check length first. Out of bound indices will not be tracked by MobX`

This only appears with projects actually configured to use steps, so TESS, Stellar Sleuths and any staging test project we've setup as well and in the specs (if you scope to this model's specs, the warning is thrown, but doesn't fail a test either. Not sure if we want to start testing for warnings...)

The issue is that mobx warns about code that is attempting to read an undefined index in an array since undefined values are not observed. This can and has caused bugs for us in the past, so good to address this kind of warning. As far as I can tell, it didn't actually break anything on TESS.

I've fixed this by checking the index against the length rather than directly checking for a defined value at that index in the array. I'm not exactly sure why the type change caused this. Perhaps the initial union type definition did something else under the hood I'm not understanding at the moment (and I don't have the time right now to invest in that). 

Long term, I'd like to see the data actually stored here to actually be a map. That was always the intention. The storing of an array of pairs is a workaround for JSONB storage requirements on Panoptes. Even _later_ long term, directly storing the steps model would be even better. Both require more refactoring time that isn't really afforded to me right before the holidays. So for another day.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
