### PR TITLE
Fix subtask positioning

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -107,7 +107,7 @@ function InteractionLayer ({
       activeTool.deleteMark(activeMark)
       setActiveMark(undefined)
     } else {
-      activeMark?.setSubTaskVisibility(true, node)
+      if (node) activeMark?.setSubTaskVisibility(true, node)
     }
 
     if (target && pointerId) {


### PR DESCRIPTION
A quick fix for positioning of the subtask popup. Check for the existence of a DOM node before setting the modal's visibility.

Package:
lib-classifier

Closes #1949.

Testing URL: https://localhost:8080/?project=11300&env=production
![A screenshot of the transcription task, showing the popup appearing halfway along the new line.](https://user-images.githubusercontent.com/59547/102527615-43661380-4095-11eb-9c05-4a0536b5a378.png)

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
