### PR TITLE
[Security] Patch outdated dependencies

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4752,13 +4752,6 @@ axe-core@^4.0.1:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.1.tgz#70a7855888e287f7add66002211a423937063eaf"
   integrity sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==
 
-axios@^0.19.0:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
-
 axios@^0.21.0:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
@@ -6534,9 +6527,9 @@ contentful-sdk-core@^6.5.0:
     qs "^6.9.4"
 
 contentful@~8.1.6:
-  version "8.1.6"
-  resolved "https://registry.yarnpkg.com/contentful/-/contentful-8.1.6.tgz#cebfa67de46194f3807cad25f925b8672632dfc1"
-  integrity sha512-Tb4SOdAXrWbe7wVKEk0HjvJ0Rz1H2z3tV4UhfuAGcQq8K1g4xmPwm0w8g1mlrLE63Nd/fb92J2YTt5+ZGpcjsA==
+  version "8.1.7"
+  resolved "https://registry.yarnpkg.com/contentful/-/contentful-8.1.7.tgz#24786d5eb98118368cafd2a7bf718de9a1f99bae"
+  integrity sha512-dFlpRjkrTp+TG6kCjERIgzsBRTfjflRnjosE0uQus7dENrz2nrVEYhFO/T3WrKQfAbTyozKcTpWr5pEZiXpm2A==
   dependencies:
     axios "^0.21.0"
     contentful-resolve-response "^1.3.0"
@@ -7529,7 +7522,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@=3.1.0:
+debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -7819,12 +7812,12 @@ detect-port@^1.3.0:
     address "^1.0.1"
     debug "^2.6.0"
 
-devour-client@~2.0.23:
-  version "2.0.27"
-  resolved "https://registry.yarnpkg.com/devour-client/-/devour-client-2.0.27.tgz#b997118f736149520542a593cf7a8a2f6cf0f118"
-  integrity sha512-opNX+uQG3eaAXimDgPLfRAtaSa6ByjN2djrEQClG2UvI/ts1TUYCaFGCTgjR+ytWxLQsRBFPinpqMUDc5zJQKg==
+devour-client@~2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/devour-client/-/devour-client-2.1.2.tgz#c36cdb702775ff8e866c68af14359597564d039d"
+  integrity sha512-xjId5HSfiBfAt6YfLgBpS8MKTHEB+m7+g96dQeR+JHbwzlXTAczGOoFLxImLx17CjfnBqiu/Ckv6WWcS80Xfag==
   dependencies:
-    axios "^0.19.0"
+    axios "^0.21.0"
     es6-promise ">=3.1.2 <5.0.0"
     lodash "^4.17.15"
     minilog "^3.0.0"
@@ -8885,9 +8878,9 @@ extsprintf@^1.2.0:
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
 fast-copy@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-2.1.0.tgz#99c1b842aee063f8212d6f749080c196a822b293"
-  integrity sha512-j4VxAVJsu9NHveYrIj0+nJxXe2lOlibKTlyy0jH8DBwcuV6QyXTy0zTqZhmMKo7EYvuaUk/BFj/o6NU6grE5ag==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-2.1.1.tgz#f5cbcf2df64215e59b8e43f0b2caabc19848083a"
+  integrity sha512-Qod3DdRgFZ8GUIM6ygeoZYpQ0QLW9cf/FS9KhhjlYggcSZXWAemAw8BOCO5LuYCrR3Uj3qXDVTUzOUwG8C7beQ==
 
 fast-deep-equal@^3.1.1:
   version "3.1.3"
@@ -9203,13 +9196,6 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
-
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
 
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.1"
@@ -16579,11 +16565,11 @@ setprototypeof@1.1.1:
   integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
 
 seven-ten@~3.4.0:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/seven-ten/-/seven-ten-3.4.3.tgz#ed3c23418e528e1f9797b22f7823b3493133d3c7"
-  integrity sha512-HnjISEs3d0EuyQovCwPvreUgNq9n1IGdI7UKqPPqQ7ok6AGrp/lCHKg5K+JNDARowKeNBiVoCDv9K/9nUZ36lg==
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/seven-ten/-/seven-ten-3.4.4.tgz#af31fd7ff34817ea455bb420c031e819e1923a5d"
+  integrity sha512-C2xJgl6a1zuVhASwJZVPIbOX3TH2OhKWUEGA8iqtfej7lqaPTSfQ4PVowKB4POxvtO//4xN7MF9897tvx2RAlQ==
   dependencies:
-    devour-client "~2.0.23"
+    devour-client "~2.1.2"
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"


### PR DESCRIPTION
Bump `contentful` and `seven-ten` to their latest versions. Fixes a security issue with `axios`.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
