### PR TITLE
Fix initStore args

### DIFF
--- a/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.js
+++ b/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.js
@@ -7,12 +7,13 @@ export default async function getDefaultPageProps({ params, query, req, res }) {
   // cookie is in the next.js context req object
   const mode = getCookie(req, 'mode') || null
   const dismissedAnnouncementBanner = getCookie(req, 'dismissedAnnouncementBanner') || null
-  const store = initStore({
+  const snapshot = {
     ui: {
       dismissedAnnouncementBanner,
       mode
     }
-  })
+  }
+  const store = initStore(true, snapshot)
 
   if (params.owner && params.project) {
     const { owner, project } = params

--- a/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.js
+++ b/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.js
@@ -13,7 +13,8 @@ export default async function getDefaultPageProps({ params, query, req, res }) {
       mode
     }
   }
-  const store = initStore(true, snapshot)
+  const isServer = true
+  const store = initStore(isServer, snapshot)
 
   if (params.owner && params.project) {
     const { owner, project } = params


### PR DESCRIPTION
The first argument passed to initStore should be the boolean flag `isServer`. This PR calls `initStore(true, snapshot)`, rather than `initStore(snapshot)`.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
