### PR TITLE
Remove /classify as the route for a project's default workflow

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
@@ -1,6 +1,6 @@
 import { inject, observer } from 'mobx-react'
 import { bool, shape, string } from 'prop-types'
-import React, { Component } from 'react'
+import React from 'react'
 import { withRouter } from 'next/router'
 
 import ProjectHeader from './ProjectHeader'
@@ -14,25 +14,21 @@ function storeMapper (stores) {
   }
 }
 
-class ProjectHeaderContainer extends Component {
-  getBaseUrl () {
-    const { owner, project } = this.props.router.query
+function ProjectHeaderContainer ({ className, inBeta, isLoggedIn, projectName, router }) {
+  function getBaseUrl () {
+    const { owner, project } = router.query
     return `/projects/${owner}/${project}`
   }
+  const navLinks = getNavLinks(isLoggedIn, getBaseUrl())
 
-  render () {
-    const { className, inBeta, isLoggedIn, projectName } = this.props
-    const navLinks = getNavLinks(isLoggedIn, this.getBaseUrl())
-
-    return (
-      <ProjectHeader
-        className={className}
-        inBeta={inBeta}
-        navLinks={navLinks}
-        title={projectName}
-      />
-    )
-  }
+  return (
+    <ProjectHeader
+      className={className}
+      inBeta={inBeta}
+      navLinks={navLinks}
+      title={projectName}
+    />
+  )
 }
 
 ProjectHeaderContainer.defaultProps = {
@@ -52,10 +48,7 @@ ProjectHeaderContainer.propTypes = {
   })
 }
 
-@inject(storeMapper)
-@withRouter
-@observer
-class DecoratedProjectHeaderContainer extends ProjectHeaderContainer {}
+const DecoratedProjectHeaderContainer = inject(storeMapper)(withRouter(observer(ProjectHeaderContainer)))
 
 export {
   DecoratedProjectHeaderContainer as default,

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
@@ -10,16 +10,18 @@ function storeMapper (stores) {
   return {
     inBeta: stores.store.project.inBeta,
     isLoggedIn: stores.store.user.isLoggedIn,
-    projectName: stores.store.project.display_name
+    projectName: stores.store.project.display_name,
+    defaultWorkflow: stores.store.project.defaultWorkflow
   }
 }
 
-function ProjectHeaderContainer ({ className, inBeta, isLoggedIn, projectName, router }) {
-  function getBaseUrl () {
-    const { owner, project } = router.query
-    return `/projects/${owner}/${project}`
-  }
-  const navLinks = getNavLinks(isLoggedIn, getBaseUrl())
+function getBaseUrl (router) {
+  const { owner, project } = router.query
+  return `/projects/${owner}/${project}`
+}
+
+function ProjectHeaderContainer ({ className, defaultWorkflow, inBeta, isLoggedIn, projectName, router }) {
+  const navLinks = getNavLinks(isLoggedIn, getBaseUrl(router), defaultWorkflow)
 
   return (
     <ProjectHeader

--- a/packages/app-project/src/components/ProjectHeader/helpers/getNavLinks/getNavLinks.js
+++ b/packages/app-project/src/components/ProjectHeader/helpers/getNavLinks/getNavLinks.js
@@ -1,14 +1,18 @@
 import counterpart from 'counterpart'
 
-function getNavLinks (isLoggedIn, baseUrl) {
+function getNavLinks (isLoggedIn, baseUrl, defaultWorkflow) {
+  const classifyHref = defaultWorkflow ?
+    `/projects/[owner]/[project]/classify/workflow/[workflowID]` :
+    `/projects/[owner]/[project]/classify`
+  const classifyAs = defaultWorkflow ? `${baseUrl}/classify/workflow/${defaultWorkflow}` : `${baseUrl}/classify`
   const links = [
     {
       href: `${baseUrl}/about`,
       text: counterpart('ProjectHeader.nav.about')
     },
     {
-      as: `${baseUrl}/classify`,
-      href: `/projects/[owner]/[project]/classify`,
+      as: classifyAs,
+      href: classifyHref,
       text: counterpart('ProjectHeader.nav.classify')
     },
     {

--- a/packages/app-project/src/components/ProjectHeader/helpers/getNavLinks/getNavLinks.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/helpers/getNavLinks/getNavLinks.spec.js
@@ -56,4 +56,33 @@ describe('Helper > getNavLinks', function () {
       ])
     })
   })
+
+  describe('with a default workflow', function () {
+    it('should return the correct menu links', function () {
+      const links = getNavLinks(true, BASE_URL, '1234')
+      expect(links).to.deep.equal([
+        {
+          href: `${BASE_URL}/about`,
+          text: 'About'
+        },
+        {
+          as: `${BASE_URL}/classify/workflow/1234`,
+          href: '/projects/[owner]/[project]/classify/workflow/[workflowID]',
+          text: 'Classify'
+        },
+        {
+          href: `${BASE_URL}/talk`,
+          text: 'Talk'
+        },
+        {
+          href: `${BASE_URL}/collections`,
+          text: 'Collect'
+        },
+        {
+          href: `${BASE_URL}/recents`,
+          text: 'Recents'
+        }
+      ])
+    })
+  })
 })

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.js
@@ -23,12 +23,8 @@ function WorkflowSelectButton (props) {
   const { owner, project } = router?.query || {}
   const [ showPicker, setShowPicker ] = useState(false)
 
-  const url = (workflow.default)
-    ? `/projects/${owner}/${project}/classify`
-    : `/projects/${owner}/${project}/classify/workflow/${workflow.id}`
-  const href = (workflow.default)
-    ? '/projects/[owner]/[project]/classify'
-    : '/projects/[owner]/[project]/classify/workflow/[workflowID]'
+  const url = `/projects/${owner}/${project}/classify/workflow/${workflow.id}`
+  const href = '/projects/[owner]/[project]/classify/workflow/[workflowID]'
 
   const as = addQueryParams(url, router)
   const completeness = parseInt(workflow.completeness * 100, 10)

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.spec.js
@@ -36,14 +36,14 @@ describe('Component > WorkflowSelectButton', function () {
   })
 
   describe('when used with a default workflow', function () {
-    it('should be a link pointing to `/classify`', function () {
+    it('should be a link pointing to `/classify/workflow/:workflow_id`', function () {
       const wrapper = shallow(
           <WorkflowSelectButton workflow={{
           ...WORKFLOW,
           default: true
         }} />
       ).find(WorkflowLink)
-      expect(wrapper.prop('as')).to.equal(`${router.asPath}/classify`)
+      expect(wrapper.prop('as')).to.equal(`${router.asPath}/classify/workflow/${WORKFLOW.id}`)
     })
   })
 

--- a/packages/app-project/stores/Project.js
+++ b/packages/app-project/stores/Project.js
@@ -44,8 +44,7 @@ const Project = types
       if (activeWorkflows.length === 1) {
         [singleActiveWorkflow] = self.links['active_workflows']
       }
-      const defaultWorkflow = self.configuration['default_workflow']
-      return singleActiveWorkflow || defaultWorkflow
+      return singleActiveWorkflow
     },
 
     get displayName () {

--- a/packages/app-project/stores/Project.spec.js
+++ b/packages/app-project/stores/Project.spec.js
@@ -205,13 +205,12 @@ describe('Stores > Project', function () {
         project = rootStore.project
       })
 
-      it('should be the configured workflow', function () {
-        expect(project.defaultWorkflow).to.exist()
-        expect(project.defaultWorkflow).to.equal(project.configuration.default_workflow)
+      it('should be undefined', function () {
+        expect(project.defaultWorkflow).to.be.undefined()
       })
     })
 
-    describe('with neither', function () {
+    describe('with no active workflows', function () {
       let project
 
       before(function () {

--- a/packages/lib-classifier/src/store/Project/Project.js
+++ b/packages/lib-classifier/src/store/Project/Project.js
@@ -16,8 +16,7 @@ const Project = types
       if (activeWorkflows.length === 1) {
         [singleActiveWorkflow] = self.links['active_workflows']
       }
-      const defaultWorkflow = self.configuration['default_workflow']
-      return singleActiveWorkflow || defaultWorkflow
+      return singleActiveWorkflow
     }
   }))
 

--- a/packages/lib-classifier/src/store/Project/Project.spec.js
+++ b/packages/lib-classifier/src/store/Project/Project.spec.js
@@ -60,7 +60,7 @@ describe('Model > Project', function () {
       })
     })
 
-    describe('with a default workflow', function () {
+    describe('with multiple active workflows', function () {
       let project
 
       before(function () {
@@ -75,9 +75,8 @@ describe('Model > Project', function () {
         })
       })
 
-      it('should be the configured workflow', function () {
-        expect(project.defaultWorkflow).to.exist()
-        expect(project.defaultWorkflow).to.equal(project.configuration.default_workflow)
+      it('should be undefined', function () {
+        expect(project.defaultWorkflow).to.be.undefined()
       })
     })
 


### PR DESCRIPTION
This PR removes `/classify` as the route for a project's default workflow. If a project has a single active workflow, then `/classify` will set that as the `workflowID` prop for the classifier. If a project has multiple workflows, then you are expected to select a workflow by specifying it in the URL: `/classify/workflow/:workflow_id`. In the second case, `/classify` no longer selects the default workflow for you.

One side effect of this change is that navigation links and workflow links on the project homepage now link to workflows by ID, even for projects that have only one workflow.

Package:
app-project
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
