### PR TITLE
Create general field guide story

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuide.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuide.stories.js
@@ -1,0 +1,78 @@
+import React from 'react'
+import zooTheme from '@zooniverse/grommet-theme'
+import { Box, Grommet } from 'grommet'
+import { Provider } from 'mobx-react'
+import FieldGuideContainer from './FieldGuideContainer'
+import FieldGuideStore from '@store/FieldGuideStore'
+import {
+  FieldGuideFactory,
+  FieldGuideMediumFactory
+} from '@test/factories'
+// import readme from './README.md'
+
+// TODO: add readme
+const config = {
+  notes: {
+    // markdown: readme
+  }
+}
+
+const medium = FieldGuideMediumFactory.build()
+const fieldGuide = FieldGuideFactory.build({
+  items: [
+    {
+      content: 'All about cats',
+      icon: medium.id,
+      title: 'Cats'
+    },
+    {
+      content: 'All about dogs',
+      title: 'Dogs'
+    }
+  ]
+})
+
+const mockStore = {
+  fieldGuide: FieldGuideStore.create({
+    active: fieldGuide.id,
+    attachedMedia: { [medium.id]: medium },
+    resources: { [fieldGuide.id]: fieldGuide }
+  })
+}
+
+export default {
+  title: 'Help Resources/Field Guide',
+  component: FieldGuideContainer,
+  parameters: {
+    viewport: {
+      defaultViewport: 'responsive'
+    }
+  }
+}
+
+function FieldGuideStoryContext (props) {
+  return (
+    <Provider classifierStore={mockStore}>
+      <Grommet
+        background={{
+          dark: 'dark-1',
+          light: 'light-1'
+        }}
+        full
+        theme={zooTheme}
+        themeMode={(props.darkMode) ? 'dark' : 'light'}
+      >
+        <Box height='60px' width='60px'>
+          <FieldGuideContainer />
+        </Box>
+      </Grommet>
+    </Provider>
+  )
+}
+
+export function General (args) {
+  return <FieldGuideStoryContext {...args} />
+}
+
+General.args = { darkMode: false }
+


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

Describe your changes:
Add stories for the field guide using the new CSF format. Can be previewed by running `yarn storybook` in the `lib-classifier` folder. You might have to scroll the left hand list of stories to find the new one for the field guide. The button should be clickable to launch the field guide on the right hand side of the preview area.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
