### PR TITLE
ZRC: Add Readme docs to React Components stories

### DIFF
--- a/packages/lib-react-components/src/AdminCheckbox/AdminCheckbox.stories.js
+++ b/packages/lib-react-components/src/AdminCheckbox/AdminCheckbox.stories.js
@@ -15,7 +15,7 @@ const config = {
   }
 }
 
-storiesOf('ZooFooter/AdminCheckbox', module)
+storiesOf('AdminCheckbox', module)
   .addDecorator(withActions('change #admin-checkbox'))
 
   .add('Light theme (default)', () => (

--- a/packages/lib-react-components/src/AdminCheckbox/AdminCheckbox.stories.js
+++ b/packages/lib-react-components/src/AdminCheckbox/AdminCheckbox.stories.js
@@ -8,8 +8,10 @@ import AdminCheckbox from './AdminCheckbox'
 import readme from './README.md'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/CloseButton/CloseButton.stories.js
+++ b/packages/lib-react-components/src/CloseButton/CloseButton.stories.js
@@ -8,8 +8,10 @@ import CloseButton from './CloseButton'
 import readme from './README.md'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/FavouritesButton/FavouritesButton.stories.js
+++ b/packages/lib-react-components/src/FavouritesButton/FavouritesButton.stories.js
@@ -8,8 +8,10 @@ import readme from './README.md'
 import FavouritesButton from './'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/GoldButton/GoldButton.stories.js
+++ b/packages/lib-react-components/src/GoldButton/GoldButton.stories.js
@@ -10,8 +10,10 @@ import readme from './README.md'
 import { backgrounds } from '../../.storybook/lib/'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/Media/Media.stories.js
+++ b/packages/lib-react-components/src/Media/Media.stories.js
@@ -9,8 +9,10 @@ import readme from './README.md'
 import ZooniverseLogo from '../ZooniverseLogo'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/MetaToolsButton/MetaToolsButton.stories.js
+++ b/packages/lib-react-components/src/MetaToolsButton/MetaToolsButton.stories.js
@@ -9,8 +9,10 @@ import readme from './README.md'
 import MetaToolsButton from './'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/Modal/Modal.stories.js
+++ b/packages/lib-react-components/src/Modal/Modal.stories.js
@@ -11,8 +11,10 @@ import readme from './README.md'
 const EXAMPLE_STRING = 'Leo mollis dictum id dis maecenas consectetur metus elementum vivamus nisl, suscipit tristique lectus nulla mus etiam nisi facilisis magnis, scelerisque ligula montes luctus cursus nibh vulputate parturient risus.'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/MovableModal/MovableModal.stories.js
+++ b/packages/lib-react-components/src/MovableModal/MovableModal.stories.js
@@ -12,8 +12,10 @@ import readme from './README.md'
 const EXAMPLE_STRING = 'Leo mollis dictum id dis maecenas consectetur metus elementum vivamus nisl, suscipit tristique lectus nulla mus etiam nisi facilisis magnis, scelerisque ligula montes luctus cursus nibh vulputate parturient risus.'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/PlainButton/PlainButton.stories.js
+++ b/packages/lib-react-components/src/PlainButton/PlainButton.stories.js
@@ -10,8 +10,10 @@ import PlainButton from './PlainButton'
 import readme from './README.md'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/PrimaryButton/PrimaryButton.stories.js
+++ b/packages/lib-react-components/src/PrimaryButton/PrimaryButton.stories.js
@@ -10,8 +10,10 @@ import readme from './README.md'
 import PrimaryButton from './PrimaryButton'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/SpacedHeading/SpacedHeading.stories.js
+++ b/packages/lib-react-components/src/SpacedHeading/SpacedHeading.stories.js
@@ -8,8 +8,10 @@ import readme from './README.md'
 import SpacedHeading from './SpacedHeading'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/SpacedText/SpacedText.stories.js
+++ b/packages/lib-react-components/src/SpacedText/SpacedText.stories.js
@@ -8,8 +8,10 @@ import readme from './README.md'
 import SpacedText from './SpacedText'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/Tabs/Tabs.stories.js
+++ b/packages/lib-react-components/src/Tabs/Tabs.stories.js
@@ -8,8 +8,10 @@ import Tab from '../Tab'
 import readme from './README.md'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/Tooltip/Tooltip.stories.js
+++ b/packages/lib-react-components/src/Tooltip/Tooltip.stories.js
@@ -9,8 +9,10 @@ import readme from './README.md'
 import Tooltip from './Tooltip'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/Tooltip/Tooltip.stories.js
+++ b/packages/lib-react-components/src/Tooltip/Tooltip.stories.js
@@ -1,37 +1,44 @@
-import { withActions } from '@storybook/addon-actions'
-import { withKnobs, text, boolean } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Button, Grommet } from 'grommet'
 import React from 'react'
 
 import readme from './README.md'
-import Tooltip from './Tooltip'
+import { default as TooltipComponent } from './Tooltip'
 
-const config = {
-  docs: {
-    description: {
-      component: readme
+export default {
+  title: 'Tooltip',
+  component: TooltipComponent,
+  args: {
+    dark: false,
+    tooltipText: 'A helpful tip'
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: readme
+      }
     }
   }
 }
 
-storiesOf('Tooltip', module)
-  .addDecorator(withKnobs)
-  .addDecorator(withActions('click button'))
-  .add('default', () => (
+export function Tooltip({ dark, tooltipText }) {
+  return (
     <TooltipStoryExample
-      dark={boolean('Dark theme', false)}
+      dark={dark}
       height='500px'
-      tooltipText={text('Tooltip text', 'A helpful tip')}
+      tooltipText={tooltipText}
     />
-  ), config)
-  .add('rotated position when close to viewport edge', () => (
+  )
+}
+
+export function RotatedWhenCloseToTheViewportEdge({ dark, tooltipText }) {
+  return (
     <TooltipStoryExample
-      dark={boolean('Dark theme', false)}
-      tooltipText={text('Tooltip text', 'A helpful tip')}
+      dark={dark}
+      tooltipText={tooltipText}
     />
-  ), config)
+  )
+}
 
 function TooltipStoryExample (props) {
   const { dark, height, tooltipText } = props
@@ -45,11 +52,11 @@ function TooltipStoryExample (props) {
       themeMode={(dark) ? 'dark' : 'light'}
     >
       <Box align='center' height={height} justify='center' pad='medium'>
-        <Tooltip
+        <TooltipComponent
           label={tooltipText}
         >
           <Button label='Focus me' onClick={() => { }} />
-        </Tooltip>
+        </TooltipComponent>
       </Box>
     </Grommet>
   )

--- a/packages/lib-react-components/src/Tooltip/components/Label/Label.stories.js
+++ b/packages/lib-react-components/src/Tooltip/components/Label/Label.stories.js
@@ -1,29 +1,28 @@
-import { withActions } from '@storybook/addon-actions'
-import { withKnobs, text, boolean, select } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Button, Grommet } from 'grommet'
 import React from 'react'
 
-// import readme from './README.md'
-import Label from './Label'
+import { default as LabelComponent } from './Label'
 
-const config = {
-  // notes: {
-  //   markdown: readme
-  // }
+export default {
+  title: 'Tooltip/Label',
+  component: LabelComponent,
+  args: {
+    arrow: true,
+    dark: false,
+    label: 'Hello'
+  }
 }
 
-storiesOf('Tooltip/Label', module)
-  .addDecorator(withKnobs)
-  .addDecorator(withActions('click button'))
-  .add('default', () => (
+export function Label({ arrow, dark, label }){
+  return (
     <LabelStoryExample
-      arrow={boolean('Arrow', true)}
-      dark={boolean('Dark theme', false)}
-      label={text('Label text', 'Hello')}
+      arrow={arrow}
+      dark={dark}
+      label={label}
     />
-  ), config)
+  )
+}
 
 function LabelStoryExample(props) {
   const { arrow, dark, label } = props
@@ -37,7 +36,7 @@ function LabelStoryExample(props) {
       themeMode={(dark) ? 'dark' : 'light'}
     >
       <Box align='center' height='medium' justify='center' pad='medium'>
-        <Label arrow={arrow} label={label} />
+        <LabelComponent arrow={arrow} label={label} />
       </Box>
     </Grommet>
   )

--- a/packages/lib-react-components/src/Tooltip/components/Triangle/Triangle.stories.js
+++ b/packages/lib-react-components/src/Tooltip/components/Triangle/Triangle.stories.js
@@ -1,31 +1,35 @@
-import { withActions } from '@storybook/addon-actions'
-import { withKnobs, text, boolean, select } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Button, Grommet } from 'grommet'
 import React from 'react'
 
-// import readme from './README.md'
-import Triangle from './Triangle'
+import { default as TriangleComponent } from './Triangle'
 
-const config = {
-  // notes: {
-  //   markdown: readme
-  // }
+export default {
+  title: 'Tooltip/Triangle',
+  component: TriangleComponent,
+  args: {
+    dark: false,
+    height: '500px'
+  },
+  argTypes: {
+    pointDirection: {
+      control: {
+        type: 'select',
+        options: ['up', 'down', 'left', 'right']
+      }
+    }
+  }
 }
 
-const pointDirections = ['up', 'down', 'left', 'right']
-
-storiesOf('Triangle', module)
-  .addDecorator(withKnobs)
-  .addDecorator(withActions('click button'))
-  .add('default', () => (
+export function Triangle({ dark, height, pointDirection }){
+  return (
     <TriangleStoryExample
-      dark={boolean('Dark theme', false)}
-      height='500px'
-      pointDirection={select('Point Direction', pointDirections)}
+      dark={dark}
+      height={height}
+      pointDirection={pointDirection}
     />
-  ), config)
+  )
+}
 
 function TriangleStoryExample(props) {
   const { dark, pointDirection } = props
@@ -39,7 +43,7 @@ function TriangleStoryExample(props) {
       themeMode={(dark) ? 'dark' : 'light'}
     >
       <Box align='center' height='medium' justify='center' pad='medium'>
-        <Triangle pointDirection={pointDirection} />
+        <TriangleComponent pointDirection={pointDirection} />
       </Box>
     </Grommet>
   )

--- a/packages/lib-react-components/src/ZooFooter/ZooFooter.stories.js
+++ b/packages/lib-react-components/src/ZooFooter/ZooFooter.stories.js
@@ -10,8 +10,10 @@ import readme from './README.md'
 import AdminCheckbox from '../AdminCheckbox'
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.stories.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.stories.js
@@ -11,8 +11,10 @@ const signIn = action('Sign in button clicked')
 const signOut = action('Sign out button clicked')
 
 const config = {
-  notes: {
-    markdown: readme
+  docs: {
+    description: {
+      component: readme
+    }
   }
 }
 


### PR DESCRIPTION
Storybook v6 deprecated `addon-notes` in favour of the Docs page for each component story. This PR replaces the `notes` parameter with the `docs` parameter for all the ZRC stories. This should add each component's Readme to its Docs page in the storybook.
![Screenshot of the Favourites Button story, showing the component's Readme on its Docs page.](https://user-images.githubusercontent.com/59547/104301314-68e11400-54bf-11eb-8f6e-6313c2a572e8.png)

Package:
lib-react-components

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
