### PR TITLE
React Components: storybook structure

### DIFF
--- a/packages/lib-react-components/src/AdminCheckbox/AdminCheckbox.stories.js
+++ b/packages/lib-react-components/src/AdminCheckbox/AdminCheckbox.stories.js
@@ -15,7 +15,7 @@ const config = {
   }
 }
 
-storiesOf('AdminCheckbox', module)
+storiesOf('Components/AdminCheckbox', module)
   .addDecorator(withActions('change #admin-checkbox'))
 
   .add('Light theme (default)', () => (

--- a/packages/lib-react-components/src/CloseButton/CloseButton.stories.js
+++ b/packages/lib-react-components/src/CloseButton/CloseButton.stories.js
@@ -17,7 +17,7 @@ const config = {
 
 const darkZooTheme = { ...zooTheme, dark: true }
 
-storiesOf('CloseButton', module)
+storiesOf('Components/CloseButton', module)
   .addDecorator(withActions('click button'))
 
   .add('Light theme (default)', () => (

--- a/packages/lib-react-components/src/FavouritesButton/FavouritesButton.stories.js
+++ b/packages/lib-react-components/src/FavouritesButton/FavouritesButton.stories.js
@@ -23,7 +23,7 @@ const CAT = {
   ]
 }
 
-storiesOf('Favourites Button', module)
+storiesOf('Components/Favourites Button', module)
   .addDecorator(withKnobs)
   .add('plain', () => (
     <Grommet theme={{ ...zooTheme, dark: boolean('Dark theme', false) }}>

--- a/packages/lib-react-components/src/GoldButton/GoldButton.stories.js
+++ b/packages/lib-react-components/src/GoldButton/GoldButton.stories.js
@@ -20,7 +20,7 @@ const config = {
 const darkTheme = Object.assign({}, zooTheme, { dark: true })
 const darkThemeConfig = Object.assign({}, config, { backgrounds: backgrounds.darkDefault })
 
-storiesOf('GoldButton', module)
+storiesOf('Components/GoldButton', module)
   .addDecorator(withActions('click button'))
   .addDecorator(withKnobs)
 

--- a/packages/lib-react-components/src/Markdownz/Markdownz.stories.js
+++ b/packages/lib-react-components/src/Markdownz/Markdownz.stories.js
@@ -21,7 +21,7 @@ const config = {
   }
 }
 
-storiesOf('Markdownz', module)
+storiesOf('Components/Markdownz', module)
 
   .add('Light theme (default)', () => (
     <Grommet theme={zooTheme}>

--- a/packages/lib-react-components/src/Media/Media.stories.js
+++ b/packages/lib-react-components/src/Media/Media.stories.js
@@ -20,7 +20,7 @@ const AUDIO_URL = 'https://panoptes-uploads.zooniverse.org/production/subject_lo
 const IMAGE_URL = 'https://panoptes-uploads.zooniverse.org/production/subject_location/66094a64-8823-4314-8ef4-1ee228e49470.jpeg'
 const VIDEO_URL = 'https://static.zooniverse.org/www.zooniverse.org/assets/home-video.mp4'
 
-storiesOf('Media', module)
+storiesOf('Components/Media', module)
   .addDecorator(withKnobs)
 
   .add('Image', () => (

--- a/packages/lib-react-components/src/MetaToolsButton/MetaToolsButton.stories.js
+++ b/packages/lib-react-components/src/MetaToolsButton/MetaToolsButton.stories.js
@@ -16,7 +16,7 @@ const config = {
   }
 }
 
-storiesOf('MetaToolsButton', module)
+storiesOf('Components/MetaToolsButton', module)
   .addDecorator(withKnobs)
   .add('plain', () => (
     <Grommet theme={{ ...zooTheme, dark: boolean('Dark theme', false) }}>

--- a/packages/lib-react-components/src/Modal/Modal.stories.js
+++ b/packages/lib-react-components/src/Modal/Modal.stories.js
@@ -11,7 +11,7 @@ const { colors } = zooTheme.global
 
 
 export default {
-  title: 'Modal',
+  title: 'Components/Modal',
   component: ModalComponent,
   args: {
     active: true,

--- a/packages/lib-react-components/src/MovableModal/MovableModal.stories.js
+++ b/packages/lib-react-components/src/MovableModal/MovableModal.stories.js
@@ -35,7 +35,7 @@ const layerPositions = [
   "top-left",
   "top-right"
 ]
-storiesOf('MovableModal', module)
+storiesOf('Components/MovableModal', module)
   .addDecorator(withKnobs)
 
   .add('Light theme (default)', () => (

--- a/packages/lib-react-components/src/PlainButton/PlainButton.stories.js
+++ b/packages/lib-react-components/src/PlainButton/PlainButton.stories.js
@@ -17,7 +17,7 @@ const config = {
   }
 }
 
-storiesOf('PlainButton', module)
+storiesOf('Components/PlainButton', module)
   .addDecorator(withActions('click button'))
   .addDecorator(withKnobs)
 

--- a/packages/lib-react-components/src/PrimaryButton/PrimaryButton.stories.js
+++ b/packages/lib-react-components/src/PrimaryButton/PrimaryButton.stories.js
@@ -21,7 +21,7 @@ const darkTheme = Object.assign({}, zooTheme, { dark: true })
 const darkThemeConfig = Object.assign({}, config, { backgrounds: backgrounds.darkDefault })
 const colors = ['blue', 'gold', 'green', 'teal']
 
-storiesOf('PrimaryButton', module)
+storiesOf('Components/PrimaryButton', module)
   .addDecorator(withActions('click button'))
   .addDecorator(withKnobs)
 

--- a/packages/lib-react-components/src/SpacedHeading/SpacedHeading.stories.js
+++ b/packages/lib-react-components/src/SpacedHeading/SpacedHeading.stories.js
@@ -15,7 +15,7 @@ const config = {
   }
 }
 
-storiesOf('SpacedHeading', module)
+storiesOf('Components/SpacedHeading', module)
   .addDecorator(withKnobs)
 
   .add('default', () => (

--- a/packages/lib-react-components/src/SpacedText/SpacedText.stories.js
+++ b/packages/lib-react-components/src/SpacedText/SpacedText.stories.js
@@ -15,7 +15,7 @@ const config = {
   }
 }
 
-storiesOf('SpacedText', module)
+storiesOf('Components/SpacedText', module)
   .addDecorator(withKnobs)
 
   .add('default', () => (

--- a/packages/lib-react-components/src/Tabs/Tabs.stories.js
+++ b/packages/lib-react-components/src/Tabs/Tabs.stories.js
@@ -17,7 +17,7 @@ const config = {
 
 const darkZooTheme = { ...zooTheme, dark: true }
 
-storiesOf('Tabs', module)
+storiesOf('Components/Tabs', module)
 
   .add('Light theme (default)', () => (
     <Grommet

--- a/packages/lib-react-components/src/Tooltip/Tooltip.stories.js
+++ b/packages/lib-react-components/src/Tooltip/Tooltip.stories.js
@@ -6,7 +6,7 @@ import readme from './README.md'
 import { default as TooltipComponent } from './Tooltip'
 
 export default {
-  title: 'Tooltip',
+  title: 'Components/Tooltip',
   component: TooltipComponent,
   args: {
     dark: false,

--- a/packages/lib-react-components/src/Tooltip/components/Label/Label.stories.js
+++ b/packages/lib-react-components/src/Tooltip/components/Label/Label.stories.js
@@ -5,7 +5,7 @@ import React from 'react'
 import { default as LabelComponent } from './Label'
 
 export default {
-  title: 'Tooltip/Label',
+  title: 'Components/Tooltip/Label',
   component: LabelComponent,
   args: {
     arrow: true,

--- a/packages/lib-react-components/src/Tooltip/components/Triangle/Triangle.stories.js
+++ b/packages/lib-react-components/src/Tooltip/components/Triangle/Triangle.stories.js
@@ -5,7 +5,7 @@ import React from 'react'
 import { default as TriangleComponent } from './Triangle'
 
 export default {
-  title: 'Tooltip/Triangle',
+  title: 'Components/Tooltip/Triangle',
   component: TriangleComponent,
   args: {
     dark: false,

--- a/packages/lib-react-components/src/ZooFooter/ZooFooter.stories.js
+++ b/packages/lib-react-components/src/ZooFooter/ZooFooter.stories.js
@@ -17,7 +17,7 @@ const config = {
   }
 }
 
-storiesOf('ZooFooter', module)
+storiesOf('Components/ZooFooter', module)
 
   .add('Light theme (default)', () => (
     <Grommet

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.stories.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.stories.js
@@ -18,7 +18,7 @@ const config = {
   }
 }
 
-storiesOf('ZooHeader', module)
+storiesOf('Components/ZooHeader', module)
 
   .add('Signed out', () => (
     <Grommet theme={zooTheme} full>


### PR DESCRIPTION
Add a top-level Components category to the ZRC storybook. ~~Move the admin checkbox back under ZooFooter stories. Move the close button under Modal stories.~~

Follows on from #1969, where we noted that the sidebar structure for the ZRC storybook is a little confusing.

Package:
lib-react-components

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [x] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
