### PR TITLE
Classifier: use mark.isComplete for subtask validation

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.js
@@ -47,8 +47,7 @@ function SubTaskPopup(props) {
   }
 
   function close() {
-    const incompleteTask = tasks.some(task => !task.isComplete)
-    if (incompleteTask) {
+    if (!activeMark.isComplete) {
       onOpenConfirm()
     } else {
       setSubTaskVisibility(false)

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
@@ -61,14 +61,11 @@ const BaseMark = types.model('BaseMark', {
     },
 
     get isComplete () {
-      // Return false after the first incomplete task, true otherwise.
-      let isMarkComplete = true
-      self.tasks.forEach(task => {
-        if (isMarkComplete) {
-          isMarkComplete = !task.required || !!self.annotation(task)?.isComplete
-        }
+      const incomplete = self.tasks.some(task => {
+        const taskAnnotation = self.annotation(task)
+        return task.required && !taskAnnotation?.isComplete
       })
-      return isMarkComplete
+      return !incomplete
     },
 
     get isValid () {


### PR DESCRIPTION
Use `mark.isComplete`, not `task.isComplete`, when validating drawing and transcription subtasks. Update `Mark.isComplete` to use `tasks.some`.

Test URLs:
Drawing task: https://localhost:8080/?project=908&workflow=3370
Transcription task: https://localhost:8080/?project=11300&env=production

Package:
lib-classifier

Closes #1986.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
