### PR TITLE
Style PreviousMarks with pointer-events: none

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/PreviousMarks/PreviousMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/PreviousMarks/PreviousMarks.js
@@ -20,11 +20,15 @@ function PreviousMarks (props) {
         {interactionTaskAnnotations.map((annotation) => {
           const annotationValuesPerFrame = annotation.value.filter(value => value.frame === frame)
           return (
-            <DrawingToolMarks
+            <g
               key={annotation.task}
-              marks={annotationValuesPerFrame}
-              scale={scale}
-            />
+              pointerEvents='none'
+            >
+              <DrawingToolMarks
+                marks={annotationValuesPerFrame}
+                scale={scale}
+              />
+            </g>
           )
         })}
       </>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/PreviousMarks/PreviousMarks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/PreviousMarks/PreviousMarks.spec.js
@@ -25,6 +25,12 @@ describe('Component > PreviousMarks', function () {
     expect(wrapper).to.be.ok()
   })
 
+  it('should ignore pointer events on all drawn marks', function () {
+    const wrapper = shallow(<PreviousMarks interactionTaskAnnotations={interactionTaskAnnotations} scale={2} />)
+    const marksGroups = wrapper.find('g')
+    marksGroups.forEach( group => expect(group.prop('pointerEvents')).to.equal('none'))
+  })
+
   it('should pass scale along as a prop to each DrawingToolMarks component', function ()  {
     const wrapper = shallow(<PreviousMarks interactionTaskAnnotations={interactionTaskAnnotations} scale={2} />)
     expect(wrapper.find(DrawingToolMarks).first().props().scale).to.equal(2)
@@ -42,8 +48,8 @@ describe('Component > PreviousMarks', function () {
     it('should render a DrawingToolMarks for each task', function ()  {
       const wrapper = shallow(<PreviousMarks interactionTaskAnnotations={interactionTaskAnnotations} />)
       expect(wrapper.find(DrawingToolMarks)).to.have.lengthOf(2)
-      expect(wrapper.find(DrawingToolMarks).first().key()).to.equal(interactionTaskAnnotations[0].task)
-      expect(wrapper.find(DrawingToolMarks).last().key()).to.equal(interactionTaskAnnotations[1].task)
+      expect(wrapper.find('g').first().key()).to.equal(interactionTaskAnnotations[0].task)
+      expect(wrapper.find('g').last().key()).to.equal(interactionTaskAnnotations[1].task)
     })
 
     it('should pass along the correct number of marks per task by frame', function () {


### PR DESCRIPTION
Disable pointer events for `PreviousMarks`. This fixes the hover styles for marks that can't be selected. It also allows marks to be drawn over.

- Transcription task: https://localhost:8080/?project=11300&env=production
- Multiple drawing tasks: https://localhost:8080/?project=7170&env=production

![Screenshot of a page from Worlds of Wonder, showing point marks drawn on top of a rectangle from a previous step.](https://user-images.githubusercontent.com/59547/105964328-ef7a2180-6079-11eb-94d7-a6087c02384f.png)

Package:
lib-classifier

Closes #2005.
Closes #2003.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
