### PR TITLE
Engaging Crowds: Subject set selection fixes

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -1,9 +1,8 @@
 import { Box, Grid } from 'grommet'
 import dynamic from 'next/dynamic'
-import { useRouter } from 'next/router'
 import { arrayOf, func, shape, string } from 'prop-types'
 import React, { useState } from 'react'
-import { Modal, withResponsiveContext } from '@zooniverse/react-components'
+import { withResponsiveContext } from '@zooniverse/react-components'
 
 import ThemeModeToggle from '@components/ThemeModeToggle'
 import ProjectName from '@components/ProjectName'
@@ -14,8 +13,7 @@ import RecentSubjects from './components/RecentSubjects'
 import YourStats from './components/YourStats'
 import StandardLayout from '@shared/components/StandardLayout'
 
-import WorkflowSelector from '@shared/components/WorkflowSelector'
-import SubjectSetPicker from '@shared/components/SubjectSetPicker'
+import WorkflowMenu from './components/WorkflowMenu'
 
 const ClassifierWrapper = dynamic(() =>
   import('./components/ClassifierWrapper'), { ssr: false }
@@ -29,22 +27,6 @@ function ClassifyPage (props) {
 
   const [ workflowFromUrl ] = workflows.filter(workflow => workflow.id === workflowID)
   const canClassify = workflowFromUrl?.grouped ? !!subjectSetID : !!workflowID
-  const router = useRouter()
-  const { owner, project } = router?.query || {}
-  const [ activeWorkflow, setActiveWorkflow ] = useState(workflowFromUrl)
-
-  function onSelectWorkflow(event, workflow) {
-    if (workflow.grouped) {
-      event.preventDefault()
-      setActiveWorkflow(workflow)
-      return false
-    }
-    return true
-  }
-
-  function onClose() {
-    setActiveWorkflow(null)
-  }
 
   return (
     <StandardLayout>
@@ -57,26 +39,9 @@ function ClassifyPage (props) {
 
         <Box as='main' fill='horizontal'>
           {!canClassify && (
-            <Modal
-              active
-              closeFn={onClose}
-              headingBackground='brand'
-              title={activeWorkflow ? (activeWorkflow.displayName || 'Choose a subject set') : 'Choose a workflow'}
-              titleColor='neutral-6'
-            >
-              {!activeWorkflow ?
-                <WorkflowSelector
-                  onSelect={onSelectWorkflow}
-                  workflows={workflows}
-                /> :
-                <SubjectSetPicker
-                  onClose={onClose}
-                  owner={owner}
-                  project={project}
-                  workflow={activeWorkflow}
-                />
-              }
-            </Modal>
+            <WorkflowMenu
+              workflows={workflows}
+            />
           )}
           <Grid columns={responsiveColumns} gap='small'>
             <ProjectName />

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
@@ -3,13 +3,12 @@ import React from 'react'
 
 import { ClassifyPage } from './ClassifyPage'
 import FinishedForTheDay from './components/FinishedForTheDay'
+import WorkflowMenu from './components/WorkflowMenu'
 import ThemeModeToggle from '@components/ThemeModeToggle'
 import ProjectName from '@components/ProjectName'
 import YourStats from './components/YourStats'
 import ConnectWithProject from '@shared/components/ConnectWithProject'
 import ProjectStatistics from '@shared/components/ProjectStatistics'
-import WorkflowSelector from '@shared/components/WorkflowSelector'
-import SubjectSetPicker from '@shared/components/SubjectSetPicker'
 
 describe('Component > ClassifyPage', function () {
   let wrapper
@@ -54,7 +53,7 @@ describe('Component > ClassifyPage', function () {
     })
 
     it('should show a workflow selector', function () {
-      expect(wrapper.find(WorkflowSelector)).to.have.lengthOf(1)
+      expect(wrapper.find(WorkflowMenu)).to.have.lengthOf(1)
     })
   })
 
@@ -66,7 +65,7 @@ describe('Component > ClassifyPage', function () {
     })
 
     it('should not show a workflow selector', function () {
-      expect(wrapper.find(WorkflowSelector)).to.have.lengthOf(0)
+      expect(wrapper.find(WorkflowMenu)).to.have.lengthOf(0)
     })
   })
 
@@ -82,12 +81,8 @@ describe('Component > ClassifyPage', function () {
         wrapper = shallow(<ClassifyPage workflowID='1234' workflows={workflows} />)
       })
 
-      it('should not show a workflow selector', function () {
-        expect(wrapper.find(WorkflowSelector)).to.have.lengthOf(0)
-      })
-
-      it('should show a subject set picker', function () {
-        expect(wrapper.find(SubjectSetPicker)).to.have.lengthOf(1)
+      it('should show a workflow menu', function () {
+        expect(wrapper.find(WorkflowMenu)).to.have.lengthOf(1)
       })
     })
 
@@ -102,8 +97,8 @@ describe('Component > ClassifyPage', function () {
         wrapper = shallow(<ClassifyPage subjectSetID='3456' workflowID='1234' workflows={workflows} />)
       })
 
-      it('should not show a workflow selector', function () {
-        expect(wrapper.find(WorkflowSelector)).to.have.lengthOf(0)
+      it('should not show a workflow menu', function () {
+        expect(wrapper.find(WorkflowMenu)).to.have.lengthOf(0)
       })
     })
   })

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/WorkflowMenu.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/WorkflowMenu.js
@@ -1,0 +1,80 @@
+import { useRouter } from 'next/router'
+import { arrayOf, shape, string } from 'prop-types'
+import React, { useState } from 'react'
+import { Modal } from '@zooniverse/react-components'
+
+import WorkflowSelector from '@shared/components/WorkflowSelector'
+import SubjectSetPicker from '@shared/components/SubjectSetPicker'
+
+/**
+  A popup menu which allows you to choose a workflow and optional subject set from the classify page.
+*/
+export default function WorkflowMenu({
+  headingBackground = 'brand',
+  titleColor = 'neutral-6',
+  workflowFromUrl,
+  workflows
+}) {
+  const router = useRouter()
+  const { owner, project } = router?.query || {}
+  const [ activeWorkflow, setActiveWorkflow ] = useState(workflowFromUrl)
+
+  function onSelectWorkflow(event, workflow) {
+    if (workflow.grouped) {
+      event.preventDefault()
+      setActiveWorkflow(workflow)
+      return false
+    }
+    return true
+  }
+
+  function onClose() {
+    setActiveWorkflow(null)
+  }
+
+  return (
+    <Modal
+      active
+      headingBackground={headingBackground}
+      title={activeWorkflow ? (activeWorkflow.displayName || 'Choose a subject set') : 'Choose a workflow'}
+      titleColor={titleColor}
+    >
+      {!activeWorkflow ?
+        <WorkflowSelector
+          onSelect={onSelectWorkflow}
+          workflows={workflows}
+        /> :
+        <SubjectSetPicker
+          onClose={onClose}
+          owner={owner}
+          project={project}
+          workflow={activeWorkflow}
+        />
+      }
+    </Modal>
+  )
+}
+
+const workflowType = shape({
+  displayName: string,
+  id: string
+})
+
+WorkflowMenu.propTypes = {
+  /**
+    Background colour of the title bar.
+  */
+  headingBackground: string,
+  /**
+    text colour of the title bar.
+  */
+  titleColor: string,
+  /**
+    An optional selected workflow. If present, we jump straight to subject set selecton.
+  */
+  workflowFromUrl: workflowType,
+  /**
+    A list of workflows to use for the menu.
+  */
+  workflows: arrayOf(workflowType)
+}

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/WorkflowMenu.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/WorkflowMenu.spec.js
@@ -1,0 +1,44 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import WorkflowMenu from './'
+
+import WorkflowSelector from '@shared/components/WorkflowSelector'
+import SubjectSetPicker from '@shared/components/SubjectSetPicker'
+
+describe('Component > ClassifyPage > WorkflowMenu', function () {
+  describe('without a selected workflow', function () {
+    let wrapper
+    let workflows = [{
+      id: '1234',
+    }]
+
+    before(function () {
+      wrapper = shallow(<WorkflowMenu workflows={workflows} />)
+    })
+
+    it('should show a workflow selector', function () {
+      expect(wrapper.find(WorkflowSelector)).to.have.lengthOf(1)
+    })
+  })
+
+  describe('with a selected workflow', function () {
+    let wrapper
+    let workflows = [{
+      id: '1234',
+      grouped: true
+    }]
+
+    before(function () {
+      wrapper = shallow(<WorkflowMenu workflowFromUrl={workflows[0]} workflows={workflows} />)
+    })
+
+    it('should not show a workflow selector', function () {
+      expect(wrapper.find(WorkflowSelector)).to.have.lengthOf(0)
+    })
+
+    it('should show a subject set picker', function () {
+      expect(wrapper.find(SubjectSetPicker)).to.have.lengthOf(1)
+    })
+  })
+})

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/WorkflowMenu.stories.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/WorkflowMenu.stories.js
@@ -88,10 +88,14 @@ export default {
   }
 }
 
-export function Default({ dark, workflows }) {
+export function Default({ dark, headingBackground, titleColor, workflows }) {
   return (
     <StoryContext theme={{ ...zooTheme, dark }}>
-      <WorkflowMenu workflows={workflows} />
+      <WorkflowMenu
+        headingBackground={headingBackground}
+        titleColor={titleColor}
+        workflows={workflows}
+      />
     </StoryContext>
   )
 }

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/WorkflowMenu.stories.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/WorkflowMenu.stories.js
@@ -1,0 +1,97 @@
+import asyncStates from '@zooniverse/async-states'
+import zooTheme from '@zooniverse/grommet-theme'
+import { Grommet } from 'grommet'
+import { Provider } from 'mobx-react'
+import { mockWorkflow as mockGroupedWorkflow } from '@shared/components/SubjectSetPicker/helpers'
+import WorkflowMenu from './WorkflowMenu'
+
+const store = {
+  project: {
+    background: {
+      src: 'https://panoptes-uploads.zooniverse.org/production/project_background/260e68fd-d3ec-4a94-bb32-43ff91d5579a.jpeg'
+    },
+    description: 'Learn about and help document the wonders of nesting Western Bluebirds.',
+    display_name: 'Nest Quest Go: Western Bluebirds',
+    slug: 'brbcornell/nest-quest-go-western-bluebirds',
+    workflow_description: `Choose your own adventure! There are many ways to engage with this project:  
+      1) "Nest Site": Smartphone-friendly, helps us understand where Western Bluebirds build their nests.  
+      2) "Location": Smartphone-friendly, series of questions on the geographic location of the nest.  
+      3) "Nest Attempt: Smartphone-friendly, for data-entry lovers to record nest attempt data on cards.  
+      4) "Comments": For transcription lovers, we ask you to transcribe all the written comments on the cards.`
+  },
+  user: {
+    loadingState: asyncStates.success
+  }
+}
+
+const WORKFLOWS = [
+  {
+    completeness: 0.65,
+    default: false,
+    displayName: 'The Family and the Fishing Net',
+    id: '12345'
+  },
+  {
+    completeness: 0,
+    default: false,
+    displayName: 'Games Without Frontiers',
+    id: '7890'
+  },
+  {
+    completeness: 0.99,
+    default: false,
+    displayName: 'Shock The Monkey',
+    id: '5678'
+  }
+]
+
+function StoryContext (props) {
+  const { children, theme } = props
+
+  return (
+    <Grommet
+      background={{
+        dark: 'dark-1',
+        light: 'light-1'
+      }}
+      theme={theme}
+      themeMode={(theme.dark) ? 'dark' : 'light'}
+    >
+      <Provider store={store}>
+        {children}
+      </Provider>
+    </Grommet>
+  )
+}
+
+export default {
+  title: 'Project App / Screens / Classify / Workflow Menu',
+  component: WorkflowMenu,
+  args: {
+    dark: false,
+    headingBackground: zooTheme.global.colors.brand,
+    titleColor: zooTheme.global.colors['neutral-6'],
+    workflows: [ ...WORKFLOWS, mockGroupedWorkflow ]
+  },
+  argTypes: {
+    headingBackground: {
+      control: 'color'
+    },
+    titleColor: {
+      control: 'color'
+    }
+  },
+  parameters: {
+    docs: {
+      inlineStories: false
+    }
+  }
+}
+
+export function Default({ dark, workflows }) {
+  return (
+    <StoryContext theme={{ ...zooTheme, dark }}>
+      <WorkflowMenu workflows={workflows} />
+    </StoryContext>
+  )
+}

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/index.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/index.js
@@ -1,0 +1,1 @@
+export { default } from './WorkflowMenu'

--- a/packages/app-project/src/shared/components/SubjectSetPicker/locales/en.json
+++ b/packages/app-project/src/shared/components/SubjectSetPicker/locales/en.json
@@ -1,6 +1,6 @@
 {
   "SubjectSetPicker": {
-    "back": "Back to workflow",
+    "back": "Back to workflow choice",
     "heading": "Choose where to start",
     "byline": "Choose a subject set to start transcribing."
   }

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.js
@@ -26,12 +26,15 @@ function WorkflowSelectButton (props) {
 
   const as = addQueryParams(url, router)
   const completeness = parseInt(workflow.completeness * 100, 10)
+  const buttonLabel = workflow.grouped ?
+    `${workflow.displayName} - ${counterpart('WorkflowSelectButton.setSelection')}` :
+    workflow.displayName
   const label = (
     <span>
       <SpacedText size='10px'>
         {counterpart('WorkflowSelectButton.complete', { completeness })}
       </SpacedText><br />
-      {workflow.displayName}
+      {buttonLabel}
     </span>
   )
 

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.spec.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.spec.js
@@ -36,6 +36,12 @@ describe('Component > WorkflowSelectButton', function () {
     expect(wrapper).to.be.ok()
   })
 
+  it('should not add "set selection" to the label', function () {
+    const wrapper = shallow(<WorkflowSelectButton onSelect={onSelect} workflow={WORKFLOW} />)
+    const label = shallow(wrapper.find(Button).prop('label'))
+    expect(label.text()).to.satisfy(label => label.endsWith('Workflow name'))
+  })
+
   describe('when used with a default workflow', function () {
     it('should be a link pointing to `/classify/workflow/:workflow_id`', function () {
       const wrapper = shallow(
@@ -56,14 +62,24 @@ describe('Component > WorkflowSelectButton', function () {
   })
 
   describe('with a grouped workflow', function () {
-    it('should call onSelect when clicked', function () {
+    let wrapper
+
+    before(function () {
       const groupedWorkflow = {
         ...WORKFLOW,
         grouped: true
       }
-      const wrapper = shallow(<WorkflowSelectButton onSelect={onSelect} workflow={groupedWorkflow} />)
+      wrapper = shallow(<WorkflowSelectButton onSelect={onSelect} workflow={groupedWorkflow} />)
+    })
+
+    it('should call onSelect when clicked', function () {
       wrapper.find(Button).simulate('click', { preventDefault: () => false })
       expect(onSelect).to.have.been.calledOnce()
+    })
+
+    it('should add "set selection" to the label', function () {
+      const label = shallow(wrapper.find(Button).prop('label'))
+      expect(label.text()).to.satisfy(label => label.endsWith('Workflow name - set selection'))
     })
   })
 })

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButton/locales/en.json
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButton/locales/en.json
@@ -1,5 +1,6 @@
 {
   "WorkflowSelectButton": {
-    "complete": "%(completeness)s%% complete"
+    "complete": "%(completeness)s%% complete",
+    "setSelection": "set selection"
   }
 }


### PR DESCRIPTION
This PR reorganises the code for workflow selection on the Classify page, including some small fixes for bugs.
- The popup workflow selector is moved into its own `WorkflowMenu` component, with tests and stories. (@srallen the code here shows an example of documenting functional component props with CSF.)
- the close button should be removed from the workflow popup now.
- the wording on the subject set selector should now say 'Back to workflow choice.'
- workflow buttons should now say 'set selection.'

Closes #1998.

![Screenshot of the workflow menu, with no close button and improved wording.](https://user-images.githubusercontent.com/59547/106152020-e457ec00-6174-11eb-9e3f-fc5eda1a84fa.png)

![Screenshot of the subject set selector, with no close button and improved wording.](https://user-images.githubusercontent.com/59547/106131579-c67d8d80-615a-11eb-8e2e-e1fcd272d8c5.png)

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
