### PR TITLE
Classifier: Trap scroll wheel events on drawing tools popups

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.js
@@ -54,6 +54,10 @@ function SubTaskPopup(props) {
     }
   }
 
+  function onWheel(event) {
+    event.stopPropagation()
+  }
+
   const defaultPosition = getDefaultPosition(subTaskMarkBounds, MIN_POPUP_HEIGHT, MIN_POPUP_WIDTH)
 
   return (
@@ -62,6 +66,7 @@ function SubTaskPopup(props) {
         active
         closeFn={close}
         headingBackground='transparent'
+        onWheel={onWheel}
         pad={{ bottom: 'medium', left: 'medium', right: 'medium' }}
         plain
         position='top-left'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.spec.js
@@ -28,7 +28,8 @@ describe('SubTaskPopup', function () {
     const fakeEvent = {
       stopPropagation: sinon.stub()
     }
-    const wrapper = shallow(<SubTaskPopup />)
+    const activeMark = { subTaskVisibility: true }
+    const wrapper = shallow(<SubTaskPopup activeMark={activeMark} />)
     wrapper.find(MovableModal).simulate('wheel', fakeEvent)
     expect(fakeEvent.stopPropagation).to.have.been.calledOnce()
   })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.spec.js
@@ -24,6 +24,15 @@ describe('SubTaskPopup', function () {
     expect(wrapper.find(ConfirmModal)).to.have.lengthOf(0)
   })
 
+  it('should trap scroll wheel events', function () {
+    const fakeEvent = {
+      stopPropagation: sinon.stub()
+    }
+    const wrapper = shallow(<SubTaskPopup />)
+    wrapper.find(MovableModal).simulate('wheel', fakeEvent)
+    expect(fakeEvent.stopPropagation).to.have.been.calledOnce()
+  })
+
   describe('with confirm modal', function () {
     let wrapper
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.js
@@ -33,6 +33,10 @@ export default function ConsensusPopup (props) {
 
   line.textOptions.forEach((option, index) => itemProps[index] = { border: false, pad: { horizontal: 'none', vertical: 'xsmall'} })
 
+  function onWheel(event) {
+    event.stopPropagation()
+  }
+
   return (
     <MovableModal
       active={active}
@@ -42,6 +46,7 @@ export default function ConsensusPopup (props) {
         light: 'neutral-6'
       }}
       height={{ min: '250px', max: '350px' }}
+      onWheel={onWheel}
       pad={{ bottom: 'medium', left: 'medium', right: 'medium' }}
       position='top-left'
       plain

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import counterpart from 'counterpart'
+import { array, bool, func, object, shape, string } from 'prop-types'
 import styled from 'styled-components'
 import { Box, List, Paragraph, Text } from 'grommet'
 import { MovableModal } from '@zooniverse/react-components'
@@ -16,18 +17,18 @@ const StyledBox = styled(Box)`
     font-size: 0.8em;
   }
 `
-
-export default function ConsensusPopup (props) {
-  const {
-    active = false,
-    bounds = undefined,
-    closeFn = () => {},
-    line = {
-      consensusText: '',
-      textOptions: []
-    }
-  } = props
-
+/**
+  A popup which shows the previous annotations for a single transcription line.
+*/
+export default function ConsensusPopup ({
+  active = false,
+  bounds = undefined,
+  closeFn = () => {},
+  line = {
+    consensusText: '',
+    textOptions: []
+  }
+}) {
   const itemProps = {}
   const position = getDefaultPosition(bounds, MIN_POPUP_HEIGHT, MIN_POPUP_WIDTH)
 
@@ -81,4 +82,26 @@ export default function ConsensusPopup (props) {
       </StyledBox>
     </MovableModal>
   )
+}
+
+ConsensusPopup.propTypes = {
+  /**
+    Modal active state.
+  */
+  active: bool,
+  /**
+    Bounding rectangle in the browser.
+  */
+  bounds: object,
+  /**
+    Callback for the modal's close button.
+  */
+  closeFn: func,
+  /**
+    Consensus options for the current line.
+  */
+  line:shape({
+    consensusText: string,
+    textOptions: array
+  })
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.spec.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { List, Paragraph, Text } from 'grommet'
 import { shallow } from 'enzyme'
+import sinon from 'sinon'
 import { MovableModal } from '@zooniverse/react-components'
 import ConsensusPopup from './ConsensusPopup'
 import setupMock from './helpers/setupMock'
@@ -26,6 +27,14 @@ describe('TranscribedLines > Component > ConsensusPopup', function () {
 
     it('should render a MovableModal component', function () {
       expect(wrapper.find(MovableModal)).to.have.lengthOf(1)
+    })
+
+    it('should trap scroll wheel events', function () {
+      const fakeEvent = {
+        stopPropagation: sinon.stub()
+      }
+      wrapper.simulate('wheel', fakeEvent)
+      expect(fakeEvent.stopPropagation).to.have.been.calledOnce()
     })
 
     describe('title bar', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.stories.js
@@ -1,17 +1,23 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Grommet } from 'grommet'
 import { withKnobs, number } from '@storybook/addon-knobs'
 import setupMock from './helpers/setupMock'
 import ConsensusPopup from './ConsensusPopup'
 
-const config = {}
 const completedLines = setupMock()
-const stories = storiesOf('Drawing Tools / TranscribedLines/ConsensusPopup', module)
-stories.addDecorator(withKnobs)
 
-function ConsensusPopupStory (props) {
+export default {
+  title: 'Drawing Tools / TranscribedLines/ConsensusPopup',
+  component: ConsensusPopup,
+  parameters: {
+    docs: {
+      inlineStories: false
+    }
+  }
+}
+
+function ConsensusPopupStory(props) {
   const { dark = false, index = 0 } = props
 
   return (
@@ -30,15 +36,19 @@ function ConsensusPopupStory (props) {
   )
 }
 
-stories
-  .add('default', () => (
+export function Default() {
+  return (
     <ConsensusPopupStory
       index={number('Completed lines index', 0, { min: 0, max: 12 })}
     />
-  ), config)
-  .add('dark theme', () => (
+  )
+}
+
+export function DarkTheme() {
+  return (
     <ConsensusPopupStory
       dark
       index={number('Completed lines index', 0, { min: 0, max: 12 })}
     />
-  ), config)
+  )
+}


### PR DESCRIPTION
Cancel event bubbling for scroll wheel events on the subtask popup and the consensus popup. This stops wheel events from bubbling up to the containing SVG image, in the React tree, and triggering wheel zoom in/out.

I've also taken the opportunity to add some documentation to the consensus popup component, and converted its stories to CSF.

Package:
lib-classifier

Closes #1835.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
