### PR TITLE
Projects: Localise the project model

### DIFF
--- a/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.js
+++ b/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.js
@@ -16,20 +16,20 @@ export default async function getDefaultPageProps({ params, query, req, res }) {
   }
   const isServer = true
   const store = initStore(isServer, snapshot)
+  const { env, language } = query
 
   if (params.owner && params.project) {
     const { owner, project } = params
     const projectSlug = `${owner}/${project}`
-    const { env } = query
-    await store.project.fetch(projectSlug, { env })
+    await store.project.fetch(projectSlug, { env, language })
   }
 
   const { project, ui } = getSnapshot(store)
   const { headers, connection } = req
-  const { env } = query
-  const language = project.primary_language
   const { active_workflows, default_workflow } = project.links
-  const workflows = await fetchWorkflowsHelper(language, active_workflows, default_workflow, env)
+  const { primary_language } = project
+  const workflowLanguage = language ?? primary_language
+  const workflows = await fetchWorkflowsHelper(workflowLanguage, active_workflows, default_workflow, env)
   const props = {
     host: generateHostUrl(headers, connection),
     initialState: {


### PR DESCRIPTION
Add an optional `language` query param to projects. Localise the project model by fetching translation strings when a project loads.

I'm leaving this as draft for the time being, because it will conflict with the changes to page props in #1964 and it still needs tests.

PH-TESS in English: http://local.zooniverse.org:3000/projects/nora-dot-eisner/planet-hunters-tess?env=production
PH-TESS in French: http://local.zooniverse.org:3000/projects/nora-dot-eisner/planet-hunters-tess?env=production&language=fr

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
