### PR TITLE
Project: ContentBox: remove client-side links

### DIFF
--- a/packages/app-project/src/shared/components/ContentBox/ContentBox.js
+++ b/packages/app-project/src/shared/components/ContentBox/ContentBox.js
@@ -18,7 +18,7 @@ function ContentBox (props) {
     ...rest
   } = props
 
-  const showHeader = title || (linkLabel && linkUrl)
+  const showHeader = title || (linkLabel && linkProps)
 
   return (
     <Box
@@ -53,13 +53,11 @@ function ContentBox (props) {
           )}
 
           {(linkLabel && linkProps) && (
-            <Link {...linkProps} passHref>
-              <Anchor>
-                <SpacedText>
-                  {linkLabel}
-                </SpacedText>
-              </Anchor>
-            </Link>
+            <Anchor {...linkProps}>
+              <SpacedText>
+                {linkLabel}
+              </SpacedText>
+            </Anchor>
           )}
 
         </Box>

--- a/packages/app-project/src/shared/components/ContentBox/ContentBox.spec.js
+++ b/packages/app-project/src/shared/components/ContentBox/ContentBox.spec.js
@@ -1,12 +1,13 @@
 import { shallow } from 'enzyme'
+import { Anchor } from 'grommet'
 import React from 'react'
 
 import { ContentBox } from './ContentBox'
 
-let wrapper
 const Foobar = () => (<div>Foobar</div>)
 
 describe('Component > ContentBox', function () {
+  let wrapper
   before(function () {
     wrapper = shallow(
       <ContentBox theme={{ dark: false }}>
@@ -21,5 +22,32 @@ describe('Component > ContentBox', function () {
 
   it('should render its children', function () {
     expect(wrapper.find(Foobar)).to.have.lengthOf(1)
+  })
+
+  describe('with link props', function () {
+    let wrapper
+
+    before(function () {
+      let linkProps = {
+        href: '/projects/test/project/stats'
+      }
+      wrapper = shallow(
+        <ContentBox
+          theme={{ dark: false }}
+          linkLabel='View more stats'
+          linkProps={linkProps}
+          >
+          <Foobar />
+        </ContentBox>
+      )
+    })
+
+    it('should render a link anchor', function () {
+      expect(wrapper.find(Anchor)).to.have.lengthOf(1)
+    })
+
+    it('should link to the specified href', function () {
+      expect(wrapper.find(Anchor).prop('href')).to.equal('/projects/test/project/stats')
+    })
   })
 })


### PR DESCRIPTION
We aren't linking to any client-side pages from the ContentBox component, so this replaces Link with Anchor, which will load a new page in the browser. It also adds tests and fixes a small typo (linkUrl should be linkProps.)

Further down the line, we may want logic that renders `Link` or `Anchor`, depending on whether the target page is part of the NextJS app.

Package:
app-project

Closes #2012.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
