### PR TITLE
Project home page: Remove next/link from Talk button

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/JoinInButton/JoinInButton.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/JoinInButton/JoinInButton.js
@@ -1,6 +1,5 @@
 import counterpart from 'counterpart'
 import { Button } from 'grommet'
-import Link from 'next/link'
 import { object } from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
@@ -13,9 +12,8 @@ function JoinInButton (props) {
   const { linkProps } = props
   const label = counterpart('ZooniverseTalk.button')
   return (
-    <Link {...linkProps} passHref>
-      <StyledButton label={label} />
-    </Link>
+    // if you pass href to Button, you get a link instead of a button.
+    <StyledButton {...linkProps} label={label} />
   )
 }
 


### PR DESCRIPTION
Remove next/link from the "Join in" button, so that it renders an external link to the project's Talk.

Package:
app-project

Closes #2023.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
