### PR TITLE
Fix error where the code attempted to array-desctructure a boolean

### DIFF
--- a/packages/lib-classifier/dev/components/App/App.js
+++ b/packages/lib-classifier/dev/components/App/App.js
@@ -85,7 +85,7 @@ class App extends React.Component {
     }
 
     const { active_workflows } = this.state.project.links
-    const [singleActiveWorkflow] = (active_workflows.length === 1) && active_workflows
+    const [singleActiveWorkflow] = (active_workflows.length === 1) ? active_workflows : []
     const workflowID = this.props.workflowID ?? singleActiveWorkflow
     const mergedThemes = _.merge({}, baseTheme, zooTheme, { dark: this.state.dark })
 


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`

This PR fixes an issue where, upon attempting to view certain projects, the classifier crashes (full crash, white screen) with the error: _Uncaught TypeError: Invalid attempt to destructure non-iterable instance. In order to be iterable, non-array objects must have a [Symbol.iterator]() method._

- This bug was accidentally introduced in #2017 
- Explanation: with the line `const [singleActiveWorkflow] = (active_workflows.length === 1) && active_workflows`, the first condition before the && returns a boolean (when false, I think), and the [singleActiveWorkflow] then tries to _array-destructure_ a _boolean_ value, which makes the JS compiler go BLARP then go home for a nap.
- Fix is straightforward, comes from Jim, and passes for all tests 👍 

### Testing

Setup: localhost, macOS10+Chrome88
Testing method: try to open all the URLs below. If the Classifier loads and doesn't turn into a blank white screen, the test passes.

Projects to test:
- [ ] I Fancy Cats - https://local.zooniverse.org:8080/?env=staging&project=335&workflow=693
- [ ] Survos Testing (p=1900&w=3412) - https://local.zooniverse.org:8080/?env=staging&project=1900&workflow=3412
- [ ] TESS - https://local.zooniverse.org:8080/?env=production&project=7929&workflow=11235
- [ ] Shaun's Transformers - https://local.zooniverse.org:8080/?env=staging&project=1651&workflow=2628

Compare this to `master` (commit 28073be)

### Status

Important bug fix. Ready for review