### PR TITLE
Add ResizeObserver message to ignoreErrors option

### DIFF
--- a/packages/app-content-pages/src/helpers/logger/initializeSentry.js
+++ b/packages/app-content-pages/src/helpers/logger/initializeSentry.js
@@ -4,12 +4,15 @@ export default function initializeSentry () {
   const dsn = process.env.SENTRY_CONTENT_DSN
   const release = process.env.COMMIT_ID
   const environment = process.env.APP_ENV
-
+  const ignoreErrors = [
+    'ResizeObserver loop limit exceeded' // Ignore benign error: https://github.com/WICG/resize-observer/issues/38
+  ]
   if (dsn) {
     Sentry.init({
       dsn,
       release,
-      environment
+      environment,
+      ignoreErrors
     })
   }
 

--- a/packages/app-project/src/helpers/logger/initializeSentry.js
+++ b/packages/app-project/src/helpers/logger/initializeSentry.js
@@ -4,13 +4,17 @@ export default function initializeSentry () {
   const dsn = process.env.SENTRY_PROJECT_DSN
   const environment = process.env.APP_ENV
   const release = process.env.COMMIT_ID
+  const ignoreErrors = [
+    'ResizeObserver loop limit exceeded' // Ignore benign error: https://github.com/WICG/resize-observer/issues/38
+  ]
   console.log('Initialising Sentry:', dsn, environment, release)
 
   if (dsn) {
     Sentry.init({
       dsn,
       environment,
-      release
+      release,
+      ignoreErrors
     })
   }
 


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: app-projects,  app-content-pages

I've set Sentry to ignore the ResizeObserver error message. This is benign according to the spec authors and there's an open issue to change it to be a warning. See: https://github.com/WICG/resize-observer/issues/38

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
