### PR TITLE
Project: test null project properties

### DIFF
--- a/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.js
+++ b/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.js
@@ -17,10 +17,10 @@ export default async function getStaticPageProps({ params, query }) {
   if (params.owner && params.project) {
     const projectSlug = `${params.owner}/${params.project}`
     const project = await fetchProjectData(projectSlug, { env })
-    if (!project.id) {
+    applySnapshot(store.project, project)
+    if (!store.project.id) {
       return notFoundError(`Project ${params.owner}/${params.project} was not found`)
     }
-    applySnapshot(store.project, project)
   }
 
   // snapshots don't include computed values, so cache the default workflow ID.

--- a/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.spec.js
+++ b/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.spec.js
@@ -7,6 +7,7 @@ describe('Helpers > getStaticPageProps', function () {
     id: '1',
     default_workflow: '1',
     primary_language: 'en',
+    researcher_quote: null,
     slug: 'test-owner/test-project',
     links: {
       active_workflows: ['1']


### PR DESCRIPTION
Add `researcher_quote:null` to the mock project in tests, so that we can test the project model with an invalid snapshot (see #2053.)
Check for a 404 response after creating the project model, so that `getStaticPageProps` returns early if the project model fails.

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
