### PR TITLE
Update getNavLink helper for about page routing

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/helpers/getNavLinks/getNavLinks.js
+++ b/packages/app-project/src/components/ProjectHeader/helpers/getNavLinks/getNavLinks.js
@@ -2,9 +2,10 @@ import counterpart from 'counterpart'
 
 function getNavLinks (isLoggedIn, baseUrl, defaultWorkflow) {
   const classifyHref = defaultWorkflow ? `${baseUrl}/classify/workflow/${defaultWorkflow}` : `${baseUrl}/classify`
+  const aboutHref = (process.env.PANOPTES_ENV === 'production') ? `https://www.zooniverse.org${baseUrl}/about` : `${baseUrl}/about/research`
   const links = [
     {
-      href: `${baseUrl}/about`,
+      href: aboutHref,
       text: counterpart('ProjectHeader.nav.about')
     },
     {

--- a/packages/app-project/src/components/ProjectHeader/helpers/getNavLinks/getNavLinks.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/helpers/getNavLinks/getNavLinks.spec.js
@@ -1,6 +1,8 @@
 import getNavLinks from './getNavLinks'
 
 const BASE_URL = '/foo/bar'
+const stagingOrigin = 'https://frontend.preview.zooniverse.org'
+const productionOrigin = 'https://www.zooniverse.org'
 
 describe('Helper > getNavLinks', function () {
   describe('when not logged in', function () {
@@ -8,7 +10,7 @@ describe('Helper > getNavLinks', function () {
       const links = getNavLinks(false, BASE_URL)
       expect(links).to.deep.equal([
         {
-          href: `${BASE_URL}/about`,
+          href: `${BASE_URL}/about/research`,
           text: 'About'
         },
         {
@@ -32,7 +34,7 @@ describe('Helper > getNavLinks', function () {
       const links = getNavLinks(true, BASE_URL)
       expect(links).to.deep.equal([
         {
-          href: `${BASE_URL}/about`,
+          href: `${BASE_URL}/about/research`,
           text: 'About'
         },
         {
@@ -60,7 +62,44 @@ describe('Helper > getNavLinks', function () {
       const links = getNavLinks(true, BASE_URL, '1234')
       expect(links).to.deep.equal([
         {
-          href: `${BASE_URL}/about`,
+          href: `${BASE_URL}/about/research`,
+          text: 'About'
+        },
+        {
+          href: `${BASE_URL}/classify/workflow/1234`,
+          text: 'Classify'
+        },
+        {
+          href: `${BASE_URL}/talk`,
+          text: 'Talk'
+        },
+        {
+          href: `${BASE_URL}/collections`,
+          text: 'Collect'
+        },
+        {
+          href: `${BASE_URL}/recents`,
+          text: 'Recents'
+        }
+      ])
+    })
+  })
+
+  describe('when PANOPTES_ENV is production', function () {
+    let previousEnv
+    before(function () {
+      previousEnv = process.env.PANOPTES_ENV
+      process.env.PANOPTES_ENV = 'production'
+    })
+
+    after(function () {
+      process.env.PANOPTES_ENV = previousEnv
+    })
+    it('should return the correct menu links', function () {
+      const links = getNavLinks(true, BASE_URL, '1234')
+      expect(links).to.deep.equal([
+        {
+          href: `${productionOrigin}${BASE_URL}/about`,
           text: 'About'
         },
         {


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: app-project

Describe your changes:
Partly toward #2061. I've updated the `getNavLink` helper to build the href for the about page to use an absolute url to zooniverse.org when in production. I also updated it to route to `/about/research`,  but we'll still  need the redirect as described in #2061 for direct links. When we're ready to launch the about pages, this change to use an absolute url in production in the helper will be reverted.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
