### PR TITLE
Use standard anchor for about page link for now

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.js
@@ -41,9 +41,17 @@ const StyledAnchor = styled(Anchor)`
 function Nav({
   navLinks = []
 }) {
+  const aboutNavLink = navLinks.shift()
   return (
     <Box aria-label={counterpart('ProjectNav.ariaLabel')} as='nav'>
       <Box as='ul' direction='row'>
+        <Box as='li' pad={{ left: 'medium' }}>
+          <StyledAnchor
+            color='white'
+            href={aboutNavLink.href}
+            label={<StyledSpacedText children={aboutNavLink.text} weight='bold' />}
+          />
+        </Box>
         {navLinks.map(navLink => (
           <Box as='li' key={navLink.href} pad={{ left: 'medium' }}>
             <NavLink

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/Introduction.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/Introduction.js
@@ -43,6 +43,7 @@ function Introduction (props) {
         gap='xsmall'
         icon={<Next color='light-5' size='12px' />}
         href={link.href}
+        label={link.text}
         reverse
       />
     </Box>

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/Introduction.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/Introduction.js
@@ -39,12 +39,11 @@ function Introduction (props) {
       <StyledParagraph margin={{ bottom: 'small', top: 'none' }} size='xxlarge'>
         {description}
       </StyledParagraph>
-      <NavLink
+      <StyledAnchor
         gap='xsmall'
         icon={<Next color='light-5' size='12px' />}
-        link={link}
+        href={link.href}
         reverse
-        StyledAnchor={StyledAnchor}
       />
     </Box>
   )

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/Introduction.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/Introduction.js
@@ -43,7 +43,7 @@ function Introduction (props) {
         gap='xsmall'
         icon={<Next color='light-5' size='12px' />}
         href={link.href}
-        label={link.text}
+        label={<SpacedText>{link.text}</SpacedText>}
         reverse
       />
     </Box>

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/Introduction.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/Introduction.spec.js
@@ -1,5 +1,7 @@
+import { expect } from 'chai'
 import { render } from 'enzyme'
 import React from 'react'
+import en from './locales/en'
 
 import Introduction from './Introduction'
 
@@ -33,6 +35,8 @@ describe('Component > Hero > Introduction', function () {
   })
 
   it('should render a link to the about page', function () {
-    expect(wrapper.find(`a[href="${LINK_PROPS.href}"]`)).to.have.lengthOf(1)
+    const link = wrapper.find(`a[href="${LINK_PROPS.href}"]`)
+    expect(link).to.have.lengthOf(1)
+    expect(link.text()).to.contain(en.Introduction.link)
   })
 })

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/IntroductionContainer.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/IntroductionContainer.js
@@ -17,8 +17,9 @@ class IntroductionContainer extends Component {
   getLinkProps () {
     const { router } = this.props
     const { owner, project } = router?.query || {}
+    const href = (process.env.PANOPTES_ENV === 'production') ? `https://www.zooniverse.org/projects/${owner}/${project}/about` : `/projects/${owner}/${project}/about/research`
     return {
-      href: `/projects/${owner}/${project}/about`
+      href
     }
   }
 

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/IntroductionContainer.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/IntroductionContainer.spec.js
@@ -4,9 +4,6 @@ import React from 'react'
 import { IntroductionContainer } from './IntroductionContainer'
 import Introduction from './Introduction'
 
-let wrapper
-let componentWrapper
-
 const DESCRIPTION = 'Ligula vestibulum id natoque mus cursus sociis varius risus nunc'
 const ROUTER = {
   asPath: '/projects/foo/bar',
@@ -18,6 +15,8 @@ const ROUTER = {
 const TITLE = 'Cum semper tristique'
 
 describe('Component > Hero > IntroductionContainer', function () {
+  let wrapper
+  let componentWrapper
   before(function () {
     wrapper = shallow(<IntroductionContainer
       description={DESCRIPTION}
@@ -38,8 +37,32 @@ describe('Component > Hero > IntroductionContainer', function () {
   it('should pass down the expected props to the `Introduction` component', function () {
     expect(componentWrapper.prop('description')).to.equal(DESCRIPTION)
     expect(componentWrapper.prop('linkProps')).to.deep.equal({
-      href: '/projects/foo/bar/about'
+      href: '/projects/foo/bar/about/research'
     })
     expect(componentWrapper.prop('title')).to.equal(TITLE)
+  })
+
+  describe('when the PANOPTES_ENV is production', function () {
+    let previousEnv
+    before(function () {
+      previousEnv = process.env.PANOPTES_ENV
+      process.env.PANOPTES_ENV = 'production'
+      wrapper = shallow(<IntroductionContainer
+        description={DESCRIPTION}
+        router={ROUTER}
+        title={TITLE}
+      />)
+      componentWrapper = wrapper.find(Introduction)
+    })
+
+    after(function () {
+      process.env.PANOPTES_ENV = previousEnv
+    })
+
+    it('should pass the expect href prop', function () {
+      expect(componentWrapper.prop('linkProps')).to.deep.equal({
+        href: 'https://www.zooniverse.org/projects/foo/bar/about'
+      })
+    })
   })
 })


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: app-project

This is a quick fix to get the project navbar about link to route to the existing PFE page as we would expect. This should function like the social media links on the homepage which also use a standard anchor. #2065 works on frontend.preview but not on prod deploy. Let's get this fixed for now and circle back. 


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
