### PR TITLE
Remove mouse wheel zoom from SVGPanZoom

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -24,23 +24,17 @@ function SVGPanZoom ({
 
   const [ zoom, setZoom ] = useState(1)
   const [ viewBox, setViewBox ] = useState(defaultViewBox)
-  
-  function preventDefault (e) {
-    e.preventDefault()
-  }
 
   function enableZoom () {
     setOnDrag(onDrag)
     setOnPan(onPan)
     setOnZoom(onZoom)
-    scrollContainer.current.addEventListener('wheel', preventDefault)
   }
 
   function disableZoom () {
     setOnDrag(() => true)
     setOnPan(() => true)
     setOnZoom(() => true)
-    scrollContainer.current.removeEventListener('wheel', preventDefault)
   }
 
   useEffect(() => {
@@ -117,22 +111,12 @@ function SVGPanZoom ({
     }
   }
 
-  function onWheel (event) {
-    const { deltaY } = event
-    if (deltaY < 0) {
-      onZoom('zoomout', -1)
-    } else {
-      onZoom('zoomin', 1)
-    }
-  }
-
   const { x, y, width, height } = scaledViewBox(zoom)
   const scale = imageScale(img)
 
   return (
     <div
       ref={scrollContainer}
-      onWheel={onWheel}
       style={{ width: '100%' }}
     >
       {cloneElement(children, { scale, viewBox: `${x} ${y} ${width} ${height}` })}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
@@ -110,26 +110,6 @@ describe('Components > SVGPanZoom', function () {
     expect(viewBox).to.equal('0 10 400 200')
   })
 
-  it('should should zoom out on wheel scroll up', function () {
-    let fakeEvent = { deltaY: 10, preventDefault: sinon.stub(), stopPropagation: sinon.stub() }
-    wrapper.simulate('wheel', fakeEvent)
-    let viewBox = wrapper.find('svg').prop('viewBox')
-    expect(viewBox).to.equal('18.5 9.5 363 181')
-    fakeEvent = { deltaY: -10, preventDefault: sinon.stub(), stopPropagation: sinon.stub() }
-    wrapper.simulate('wheel', fakeEvent)
-    viewBox = wrapper.find('svg').prop('viewBox')
-    expect(viewBox).to.equal('0 0 400 200')
-  })
-
-  it('should should zoom in on wheel scroll down', function () {
-    let viewBox = wrapper.find('svg').prop('viewBox')
-    expect(viewBox).to.equal('0 0 400 200')
-    const fakeEvent = { deltaY: 10, preventDefault: sinon.stub(), stopPropagation: sinon.stub() }
-    wrapper.simulate('wheel', fakeEvent)
-    viewBox = wrapper.find('svg').prop('viewBox')
-    expect(viewBox).to.equal('18.5 9.5 363 181')
-  })
-
   it('should reset pan with new src', function () {
     onPan(-1, 0)
     wrapper.update()


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

For #2075 and #1978.

Describe your changes:
Removes the `onWheel` event from `SVGPanZoom`. A suggested refactor is in #2075 for the future. It should be noted that this is not a regression as the wheel event is new to the classifier here and a project hasn't launched with it yet. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
