### PR TITLE
Fix focus on new transcription line subtask

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -100,8 +100,8 @@ function InteractionLayer ({
   }
 
   function onFinish (event = {}, node) {
+    if (event.preventDefault) event.preventDefault()
     const { target, pointerId } = event
-
     setCreating(false)
     if (activeMark && !activeMark.isValid) {
       activeTool.deleteMark(activeMark)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -13,6 +13,7 @@ describe('Component > InteractionLayer', function () {
   let wrapper
   let activeTool
   const mockMark = {
+    finish: sinon.stub(),
     initialDrag: sinon.stub(),
     initialPosition: sinon.stub(),
     setCoordinates: sinon.stub(),
@@ -107,114 +108,58 @@ describe('Component > InteractionLayer', function () {
       expect(wrapper.find(SubTaskPopup)).to.have.lengthOf(1)
     })
 
-    describe('on pointer events', function () {
-      let mockedContext
-      before(function () {
-        mockedContext = sinon.stub(React, 'useContext').callsFake(() => { return { svg, getScreenCTM } })
-      })
+    describe('pointer events', function () {
+      describe('onPointerDown', function () {
+        let mockedContext
+        before(function () {
+          mockedContext = sinon.stub(React, 'useContext').callsFake(() => { return { svg, getScreenCTM } })
+        })
 
-      after(function () {
-        mockedContext.restore()
-      })
+        after(function () {
+          mockedContext.restore()
+        })
 
-      it('should create a mark on pointer down', function () {
-        const fakeEvent = {
-          pointerId: 'fakePointer',
-          type: 'pointerdown',
-          target: {
-            setPointerCapture: sinon.stub(),
-            releasePointerCapture: sinon.stub()
+        it('should create a mark', function () {
+          const fakeEvent = {
+            pointerId: 'fakePointer',
+            type: 'pointerdown',
+            target: {
+              setPointerCapture: sinon.stub(),
+              releasePointerCapture: sinon.stub()
+            }
           }
-        }
-        wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
-        expect(activeTool.createMark).to.have.been.calledOnce()
-      })
+          wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
+          expect(activeTool.createMark).to.have.been.calledOnce()
+        })
 
-      it('should create a mark with current frame', function () {
-        const fakeEvent = {
-          pointerId: 'fakePointer',
-          type: 'pointerdown',
-          target: {
-            setPointerCapture: sinon.stub(),
-            releasePointerCapture: sinon.stub()
+        it('should create a mark with current frame', function () {
+          const fakeEvent = {
+            pointerId: 'fakePointer',
+            type: 'pointerdown',
+            target: {
+              setPointerCapture: sinon.stub(),
+              releasePointerCapture: sinon.stub()
+            }
           }
-        }
-        wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
-        const createMarkArgs = activeTool.createMark.args[0][0]
-        expect(createMarkArgs.frame).to.equal(2)
-      })
+          wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
+          const createMarkArgs = activeTool.createMark.args[0][0]
+          expect(createMarkArgs.frame).to.equal(2)
+        })
 
-      it('should place a new mark on pointer down', function () {
-        const fakeEvent = {
-          pointerId: 'fakePointer',
-          type: 'pointerdown',
-          target: {
-            setPointerCapture: sinon.stub(),
-            releasePointerCapture: sinon.stub()
+        it('should place a new mark', function () {
+          const fakeEvent = {
+            pointerId: 'fakePointer',
+            type: 'pointerdown',
+            target: {
+              setPointerCapture: sinon.stub(),
+              releasePointerCapture: sinon.stub()
+            }
           }
-        }
-        wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
-        expect(mockMark.initialPosition).to.have.been.calledOnce()
-      })
+          wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
+          expect(mockMark.initialPosition).to.have.been.calledOnce()
+        })
 
-      it('should drag the new mark on pointer down + move', function () {
-        const fakeEvent = {
-          pointerId: 'fakePointer',
-          type: 'pointer',
-          target: {
-            setPointerCapture: sinon.stub(),
-            releasePointerCapture: sinon.stub()
-          }
-        }
-        wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
-        wrapper.find(DrawingCanvas).simulate('pointermove', fakeEvent)
-        expect(mockMark.initialDrag).to.have.been.calledOnce()
-      })
-
-      it('should capture the pointer on pointer down', function () {
-        const fakeEvent = {
-          pointerId: 'fakePointer',
-          type: 'pointer',
-          target: {
-            setPointerCapture: sinon.stub(),
-            releasePointerCapture: sinon.stub()
-          }
-        }
-        wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
-        wrapper.simulate('pointermove', fakeEvent)
-        expect(fakeEvent.target.setPointerCapture.withArgs('fakePointer')).to.have.been.calledOnce()
-      })
-
-      describe('onPointerDown with a TranscriptionLine mark already in progress', function () {
-        it('should call the handlePointerDown function', function () {
-          const mockDrawingTask = DrawingTask.TaskModel.create({
-            activeToolIndex: 0,
-            instruction: 'draw a mark',
-            taskKey: 'T0',
-            tools: [
-              {
-                marks: {},
-                max: 2,
-                toolComponent: TranscriptionLine,
-                type: 'transcriptionLine'
-              }
-            ],
-            type: 'drawing'
-          })
-          activeTool = mockDrawingTask.activeTool
-          sinon.stub(activeTool, 'createMark').callsFake(() => mockMark)
-          sinon.stub(activeTool, 'handlePointerDown').callsFake(() => mockMark)
-
-          wrapper = shallow(
-            <InteractionLayer
-              activeMark={mockMark}
-              activeTool={activeTool}
-              frame={2}
-              height={400}
-              width={600}
-            />
-          )
-
+        it('should drag the new mark on pointer down + move', function () {
           const fakeEvent = {
             pointerId: 'fakePointer',
             type: 'pointer',
@@ -224,9 +169,108 @@ describe('Component > InteractionLayer', function () {
             }
           }
           wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
-          wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
-          expect(activeTool.handlePointerDown).to.have.been.calledOnce()
+          wrapper.find(DrawingCanvas).simulate('pointermove', fakeEvent)
+          expect(mockMark.initialDrag).to.have.been.calledOnce()
         })
+
+        it('should capture the pointer', function () {
+          const fakeEvent = {
+            pointerId: 'fakePointer',
+            type: 'pointer',
+            target: {
+              setPointerCapture: sinon.stub(),
+              releasePointerCapture: sinon.stub()
+            }
+          }
+          wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
+          wrapper.simulate('pointermove', fakeEvent)
+          expect(fakeEvent.target.setPointerCapture.withArgs('fakePointer')).to.have.been.calledOnce()
+        })
+
+        describe('with a TranscriptionLine mark already in progress', function () {
+          it('should call the handlePointerDown function once', function () {
+            const mockDrawingTask = DrawingTask.TaskModel.create({
+              activeToolIndex: 0,
+              instruction: 'draw a mark',
+              taskKey: 'T0',
+              tools: [
+                {
+                  marks: {},
+                  max: 2,
+                  toolComponent: TranscriptionLine,
+                  type: 'transcriptionLine'
+                }
+              ],
+              type: 'drawing'
+            })
+            activeTool = mockDrawingTask.activeTool
+            sinon.stub(activeTool, 'createMark').callsFake(() => mockMark)
+            sinon.stub(activeTool, 'handlePointerDown').callsFake(() => mockMark)
+
+            wrapper = shallow(
+              <InteractionLayer
+                activeMark={mockMark}
+                activeTool={activeTool}
+                frame={2}
+                height={400}
+                width={600}
+              />
+            )
+
+            const fakeEvent = {
+              pointerId: 'fakePointer',
+              type: 'pointer',
+              target: {
+                setPointerCapture: sinon.stub(),
+                releasePointerCapture: sinon.stub()
+              }
+            }
+            wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
+            wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
+            expect(activeTool.handlePointerDown).to.have.been.calledOnce()
+          })
+        })
+      })
+    })
+
+    describe('onPointerUp', function () {
+      let mockedContext
+      before(function () {
+        mockedContext = sinon.stub(React, 'useContext').callsFake(() => { return { svg, getScreenCTM } })
+      })
+
+      after(function () {
+        mockedContext.restore()
+      })
+
+      it('should set the mark to finished', function () {
+        const fakeEvent = {
+          pointerId: 'fakePointer',
+          type: 'pointer',
+          target: {
+            setPointerCapture: sinon.stub(),
+            releasePointerCapture: sinon.stub()
+          }
+        }
+        wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
+        wrapper.find(DrawingCanvas).simulate('pointerup', fakeEvent)
+        expect(mockMark.finish).to.have.been.calledOnce()
+      })
+
+      it('should release the pointer', function () {
+        const fakeEvent = {
+          pointerId: 'fakePointer',
+          type: 'pointer',
+          target: {
+            setPointerCapture: sinon.stub(),
+            releasePointerCapture: sinon.stub()
+          }
+        }
+        const finishedMark = Object.assign({}, mockMark, { finished: true })
+        wrapper.setProps({ activeMark: finishedMark })
+        wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
+        wrapper.find(DrawingCanvas).simulate('pointerup', fakeEvent)
+        expect(fakeEvent.target.releasePointerCapture.withArgs('fakePointer')).to.have.been.calledOnce()
       })
     })
   })


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

Toward #1978

> Cursor should automatically move to the text box after the second underline dot is placed, so you can just start typing — really annoying to have to click into the box every time.

I've added an `event.preventDefault()` when the real event is defined for the `onFinish` call. I suspect that the pointer up event is happening after the subtask opens and shifting the focus back to the SVG. I don't have high confidence in this because the onFinish handler is doing more than handling an event, given it can be undefined sometimes, and the specs were missing for pointer up events. I added a couple of specs to make sure and it doesn't seem like I'm breaking anything, but a good manual check should happen.

Before, no focus on the text area:
<img width="549" alt="Screen Shot 2021-03-23 at 4 38 36 PM" src="https://user-images.githubusercontent.com/5016731/112226394-1c6f2e80-8bfc-11eb-859b-2cd13dd2e55f.png">

After, focus on the text area:
<img width="547" alt="Screen Shot 2021-03-23 at 4 39 08 PM" src="https://user-images.githubusercontent.com/5016731/112226434-2d1fa480-8bfc-11eb-99e8-7a7e40ae32f2.png">

Testable with: https://localhost:8080/?project=1764&workflow=3392

Be sure to create a new mark to test this out. The previous mark subtask with the suggestions text input properly received focus previously.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
