### PR TITLE
Classifier: Clean up step annotations history

### DIFF
--- a/packages/lib-classifier/src/store/AnnotatedSteps/AnnotatedSteps.js
+++ b/packages/lib-classifier/src/store/AnnotatedSteps/AnnotatedSteps.js
@@ -49,8 +49,8 @@ const AnnotatedSteps = types.model('AnnotatedSteps', {
 
   /** Create a new history entry from the current active step. **/
   function _beginStep(stepKey) {
-    _selectStep(stepKey)
     const { workflowSteps } = getRoot(self)
+    workflowSteps.selectStep(stepKey)
     const step = tryReference(() => workflowSteps.active)
     if (self.classification && step) {
       let annotations
@@ -62,7 +62,6 @@ const AnnotatedSteps = types.model('AnnotatedSteps', {
         step,
         annotations
       }
-      console.log(`Adding ${historyStep.step.stepKey} to history`)
       self.steps.put(historyStep)
     }
   }
@@ -79,9 +78,7 @@ const AnnotatedSteps = types.model('AnnotatedSteps', {
   function _redo(stepKey) {
     undoManager.redo()
     const storedStepKey = self.latest.step.stepKey
-    console.log(`redo ${storedStepKey}`)
     if (stepKey !== storedStepKey) {
-      console.log(`replace ${storedStepKey} with ${stepKey}`)
       _replace(stepKey)
     }
   }
@@ -96,11 +93,6 @@ const AnnotatedSteps = types.model('AnnotatedSteps', {
     self.steps.clear()
     undoManager.clear()
   }
-  /** select a new active workflow step */
-  function _selectStep(stepKey) {
-    const { workflowSteps } = getRoot(self)
-    workflowSteps.selectStep(stepKey)
-  }
   /** Undo the current step and select the previous step. */
   function back(persistAnnotations = true) {
     if (undoManager.canUndo) {
@@ -108,8 +100,6 @@ const AnnotatedSteps = types.model('AnnotatedSteps', {
       if (!persistAnnotations) {
         self.clearRedo()
       }
-      const { step } = self.latest
-      _selectStep(step.stepKey)
     }
   }
   /** Clear the redo history and delete orphaned annotations. */


### PR DESCRIPTION
Follow-up from #2064.

This removes the logs that I added in order to debug task navigation for looping, recursive workflows. It also removes a redundant `_selectStep` call since the undo manager manages `workflowSteps.active` for us: there's no need to manually set it after an undo.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
