### PR TITLE
Transcription task: Allow one transcription line for each previously transcribed line

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
@@ -38,7 +38,7 @@ class TranscribedLines extends React.Component {
     this.showConsensus = this.showConsensus.bind(this)
   }
 
-  createMark (line) {
+  createMark (line, node) {
     const { activeTool, activeToolIndex, marks, setActiveMark } = this.props.task
 
     if (activeTool) {
@@ -62,15 +62,16 @@ class TranscribedLines extends React.Component {
       })
       mark.setPreviousAnnotations(previousAnnotationValuesForEachMark)
       if (mark.finished) {
-        mark.setSubTaskVisibility(true)
+        const markBounds = node?.getBoundingClientRect()
+        mark.setSubTaskVisibility(true, markBounds)
       } else {
         mark.finish()
       }
     }
   }
 
-  showConsensus (line, ref) {
-    const bounds = ref?.current?.getBoundingClientRect() || {}
+  showConsensus (line, node) {
+    const bounds = node?.getBoundingClientRect() || {}
     this.setState({
       bounds,
       line,
@@ -78,14 +79,14 @@ class TranscribedLines extends React.Component {
     })
   }
 
-  onClick (callback, line, ref) {
-    callback(line, ref)
+  onClick (callback, line, node) {
+    callback(line, node)
   }
 
-  onKeyDown (event, callback, line, ref) {
+  onKeyDown (event, callback, line, node) {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
-      callback(line, ref)
+      callback(line, node)
     }
   }
 
@@ -135,8 +136,8 @@ class TranscribedLines extends React.Component {
                   aria-describedby={id}
                   aria-label={line.consensusText}
                   focusColor={focusColor}
-                  onClick={() => this.onClick(this.showConsensus, line, ref)}
-                  onKeyDown={event => this.onKeyDown(event, this.showConsensus, line, ref)}
+                  onClick={() => this.onClick(this.showConsensus, line, ref?.current)}
+                  onKeyDown={event => this.onKeyDown(event, this.showConsensus, line, ref?.current)}
                   tabIndex={0}
                 >
                   <TranscriptionLine
@@ -166,8 +167,8 @@ class TranscribedLines extends React.Component {
 
             const lineProps = {}
             if (!disabled) {
-              lineProps.onClick = event => this.createMark(line)
-              lineProps.onKeyDown = event => this.onKeyDown(event, this.createMark, line)
+              lineProps.onClick = event => this.createMark(line, event.target)
+              lineProps.onKeyDown = event => this.onKeyDown(event, this.createMark, line, event.target)
             }
 
             return (

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
@@ -61,7 +61,11 @@ class TranscribedLines extends React.Component {
         previousAnnotationValuesForEachMark.push(previousAnnotationValuesForThisMark)
       })
       mark.setPreviousAnnotations(previousAnnotationValuesForEachMark)
-      mark.finish()
+      if (mark.finished) {
+        mark.setSubTaskVisibility(true)
+      } else {
+        mark.finish()
+      }
     }
   }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js
@@ -129,19 +129,21 @@ describe('Component > TranscribedLines', function () {
         const lineState = consensusComponent.find(TranscriptionLine).prop('state')
         if (lineState === 'transcribed') {
           expect(createMarkSpy).to.not.have.been.called()
-          consensusComponent.simulate('click')
+          const fakeNode = {
+            getBoundingClientRect: sinon.stub()
+          }
+          consensusComponent.simulate('click', { target: fakeNode })
           const [createMarkArgs] = createMarkSpy.args
-          const expectedRefForMark = createMarkArgs[1]
-          expect(expectedRefForMark).to.equal(returnRefs[index])
           createMarkSpy.resetHistory()
+          expect(createMarkArgs[1]).to.equal(fakeNode)
         }
         if (lineState === 'complete') {
           expect(showConsensusStub).to.not.have.been.called()
           consensusComponent.simulate('click')
           const [completeArgs] = showConsensusStub.args
           const expectedRefForMark = completeArgs[1]
-          expect(expectedRefForMark).to.equal(returnRefs[index])
           showConsensusStub.resetHistory()
+          expect(expectedRefForMark).to.equal(returnRefs[index].current)
         }
       })
     })
@@ -151,20 +153,23 @@ describe('Component > TranscribedLines', function () {
       consensusComponents.forEach((consensusComponent, index) => {
         const lineState = consensusComponent.find(TranscriptionLine).prop('state')
         if (lineState === 'transcribed') {
+          const fakeNode = {
+            getBoundingClientRect: sinon.stub()
+          }
+          eventMock.target = fakeNode
           expect(createMarkSpy).to.not.have.been.called()
           consensusComponent.simulate('keydown', eventMock)
           const [createMarkArgs] = createMarkSpy.args
-          const expectedRefForMark = createMarkArgs[1]
-          expect(expectedRefForMark).to.equal(returnRefs[index])
           createMarkSpy.resetHistory()
+          expect(createMarkArgs[1]).to.equal(fakeNode)
         }
         if (lineState === 'complete') {
           expect(showConsensusStub).to.not.have.been.called()
           consensusComponent.simulate('keydown', eventMock)
           const [completeArgs] = showConsensusStub.args
           const expectedRefForMark = completeArgs[1]
-          expect(expectedRefForMark).to.equal(returnRefs[index])
           showConsensusStub.resetHistory()
+          expect(expectedRefForMark).to.equal(returnRefs[index].current)
         }
       })
     })
@@ -174,20 +179,23 @@ describe('Component > TranscribedLines', function () {
       consensusComponents.forEach((consensusComponent, index) => {
         const lineState = consensusComponent.find(TranscriptionLine).prop('state')
         if (lineState === 'transcribed') {
+          const fakeNode = {
+            getBoundingClientRect: sinon.stub()
+          }
+          eventMock.target = fakeNode
           expect(createMarkSpy).to.not.have.been.called()
           consensusComponent.simulate('keydown', eventMock)
           const [createMarkArgs] = createMarkSpy.args
-          const expectedRefForMark = createMarkArgs[1]
-          expect(expectedRefForMark).to.equal(returnRefs[index])
           createMarkSpy.resetHistory()
+          expect(createMarkArgs[1]).to.equal(fakeNode)
         }
         if (lineState === 'complete') {
           expect(showConsensusStub).to.not.have.been.called()
           consensusComponent.simulate('keydown', eventMock)
           const [completeArgs] = showConsensusStub.args
           const expectedRefForMark = completeArgs[1]
-          expect(expectedRefForMark).to.equal(returnRefs[index])
           showConsensusStub.resetHistory()
+          expect(expectedRefForMark).to.equal(returnRefs[index].current)
         }
       })
     })
@@ -257,7 +265,7 @@ describe('Component > TranscribedLines', function () {
         expect(task.marks.length).to.equal(0)
         lines.forEach((line, index) => {
           expect(task.activeMark).to.be.undefined()
-          wrapper.find({ 'aria-describedby': `transcribed-${index}` }).simulate('click')
+          wrapper.find({ 'aria-describedby': `transcribed-${index}` }).simulate('click', { target: null })
           expect(task.activeMark.x1).to.equal(transcribedLines[index].points[0].x)
           expect(task.activeMark.y1).to.equal(transcribedLines[index].points[0].y)
           expect(task.activeMark.x2).to.equal(transcribedLines[index].points[1].x)
@@ -268,7 +276,7 @@ describe('Component > TranscribedLines', function () {
       })
 
       it('should create only one mark per transcribed line', function () {
-        const eventMock = { key: 'Enter', preventDefault: sinon.spy() }
+        const eventMock = { key: 'Enter', preventDefault: sinon.spy(), target: null }
         const transcribedLines = consensusLines.filter(line => !line.consensusReached)
         expect(task.marks.length).to.equal(transcribedLines.length)
         lines.forEach((line, index) => {
@@ -290,7 +298,7 @@ describe('Component > TranscribedLines', function () {
       })
 
       it('should create new marks', function () {
-        const eventMock = { key: 'Enter', preventDefault: sinon.spy() }
+        const eventMock = { key: 'Enter', preventDefault: sinon.spy(), target: null }
         const transcribedLines = consensusLines.filter(line => !line.consensusReached)
         expect(task.marks.length).to.equal(0)
         lines.forEach((line, index) => {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js
@@ -256,6 +256,8 @@ describe('Component > TranscribedLines', function () {
     })
 
     describe('on click', function () {
+      const eventMock = { preventDefault: sinon.spy(), target: null }
+
       before(function () {
         task.reset()
       })
@@ -265,7 +267,7 @@ describe('Component > TranscribedLines', function () {
         expect(task.marks.length).to.equal(0)
         lines.forEach((line, index) => {
           expect(task.activeMark).to.be.undefined()
-          wrapper.find({ 'aria-describedby': `transcribed-${index}` }).simulate('click', { target: null })
+          wrapper.find({ 'aria-describedby': `transcribed-${index}` }).simulate('click', eventMock)
           expect(task.activeMark.x1).to.equal(transcribedLines[index].points[0].x)
           expect(task.activeMark.y1).to.equal(transcribedLines[index].points[0].y)
           expect(task.activeMark.x2).to.equal(transcribedLines[index].points[1].x)
@@ -276,12 +278,11 @@ describe('Component > TranscribedLines', function () {
       })
 
       it('should create only one mark per transcribed line', function () {
-        const eventMock = { key: 'Enter', preventDefault: sinon.spy(), target: null }
         const transcribedLines = consensusLines.filter(line => !line.consensusReached)
         expect(task.marks.length).to.equal(transcribedLines.length)
         lines.forEach((line, index) => {
           expect(task.activeMark).to.be.undefined()
-          wrapper.find({ 'aria-describedby': `transcribed-${index}` }).simulate('keydown', eventMock)
+          wrapper.find({ 'aria-describedby': `transcribed-${index}` }).simulate('click', eventMock)
           expect(task.activeMark.x1).to.equal(transcribedLines[index].points[0].x)
           expect(task.activeMark.y1).to.equal(transcribedLines[index].points[0].y)
           expect(task.activeMark.x2).to.equal(transcribedLines[index].points[1].x)
@@ -293,12 +294,13 @@ describe('Component > TranscribedLines', function () {
     })
 
     describe('on Enter', function () {
+      const eventMock = { key: 'Enter', preventDefault: sinon.spy(), target: null }
+
       before(function () {
         task.reset()
       })
 
       it('should create new marks', function () {
-        const eventMock = { key: 'Enter', preventDefault: sinon.spy(), target: null }
         const transcribedLines = consensusLines.filter(line => !line.consensusReached)
         expect(task.marks.length).to.equal(0)
         lines.forEach((line, index) => {
@@ -314,7 +316,6 @@ describe('Component > TranscribedLines', function () {
       })
 
       it('should create only one mark per transcribed line', function () {
-        const eventMock = { key: 'Enter', preventDefault: sinon.spy() }
         const transcribedLines = consensusLines.filter(line => !line.consensusReached)
         expect(task.marks.length).to.equal(transcribedLines.length)
         lines.forEach((line, index) => {
@@ -331,12 +332,13 @@ describe('Component > TranscribedLines', function () {
     })
 
     describe('on Space', function () {
+      const eventMock = { key: ' ', preventDefault: sinon.spy(), target: null }
+
       before(function () {
         task.reset()
       })
 
       it('should create a new mark', function () {
-        const eventMock = { key: ' ', preventDefault: sinon.spy() }
         const transcribedLines = consensusLines.filter(line => !line.consensusReached)
         expect(task.marks.length).to.equal(0)
         lines.forEach((line, index) => {
@@ -352,7 +354,6 @@ describe('Component > TranscribedLines', function () {
       })
 
       it('should create only one mark per transcribed line', function () {
-        const eventMock = { key: 'Enter', preventDefault: sinon.spy() }
         const transcribedLines = consensusLines.filter(line => !line.consensusReached)
         expect(task.marks.length).to.equal(transcribedLines.length)
         lines.forEach((line, index) => {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesContainer.js
@@ -21,7 +21,9 @@ function useStores () {
 
 function TranscribedLinesContainer (props) {
   const { 
-    transcriptionTask = {},
+    transcriptionTask = {
+      marks: []
+    },
     frame = 0,
     consensusLines = [], 
     workflow = {
@@ -38,6 +40,7 @@ function TranscribedLinesContainer (props) {
     return (
       <TranscribedLines
         lines={visibleLinesPerFrame}
+        marks={transcriptionTask.marks}
         scale={scale}
         task={transcriptionTask}
       />

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesContainer.js
@@ -15,24 +15,25 @@ function useStores () {
 
   // We expect there to only be one
   const [transcriptionTask] = stores.classifierStore.workflowSteps.findTasksByType('transcription')
+  // We want to observe the marks array for changes, so pass that as a separate prop.
+  const marks = transcriptionTask?.marks
 
-  return { transcriptionTask, consensusLines, frame, workflow }
+  return { transcriptionTask, consensusLines, frame, marks, workflow }
 }
 
-function TranscribedLinesContainer (props) {
+function TranscribedLinesContainer ({
+  scale = 1
+}) {
   const { 
-    transcriptionTask = {
-      marks: []
-    },
+    transcriptionTask = {},
     frame = 0,
-    consensusLines = [], 
+    consensusLines = [],
+    marks = [],
     workflow = {
       usesTranscriptionTask: false
     }
   } = useStores()
-  const {
-    scale = 1
-  } = props
+
   const { shownMarks } = transcriptionTask
   const visibleLinesPerFrame = consensusLines.filter(line => line.frame === frame)
 
@@ -40,7 +41,7 @@ function TranscribedLinesContainer (props) {
     return (
       <TranscribedLines
         lines={visibleLinesPerFrame}
-        marks={transcriptionTask.marks}
+        marks={marks}
         scale={scale}
         task={transcriptionTask}
       />


### PR DESCRIPTION
This an experimental change, to suggest some possible fixes for #2082.

Give each transcription line a fixed ID, when it is created from a previous line. Observe transcription task marks for changes. Re-use an existing transcription line, rather than creating a new line, when a magenta line is clicked.

Optionally: disable or even hide magenta lines when they have a linked transcription line with the same line ID.

See #1836 for discussion of whether magenta lines should still be interactive after creating a green line.

Package:
lib-classifier

Closes #2082.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
