### PR TITLE
Project app: Add set_member_subjects to API mocks for page props

### DIFF
--- a/packages/app-project/src/helpers/fetchWorkflowsHelper/fetchWorkflowsHelper.spec.js
+++ b/packages/app-project/src/helpers/fetchWorkflowsHelper/fetchWorkflowsHelper.spec.js
@@ -48,9 +48,25 @@ describe('Helpers > fetchWorkflowsHelper', function () {
     return {
       id,
       display_name: `test set ${id}`,
-      set_member_subjects_count: 10
+      set_member_subjects_count: 10,
+      subjects: mockSetSubjects
     }
   }
+
+  const mockSetSubjects = [
+    {
+      "id":"47696316",
+      "metadata":{"Filename":"ultraman-x.png"},
+      "locations":[
+        {"image/png":"https://panoptes-uploads.zooniverse.org/production/subject_location/78964ce7-72db-4607-b493-63626738cf4e.png"}
+      ],
+      "zooniverse_id":null,
+      "external_id":null,
+      "created_at":"2020-07-09T20:47:07.128Z",
+      "updated_at":"2020-07-09T20:47:07.128Z",
+      "href":"/subjects/47696316",
+      "links":{"project":"12754","collections":[],"subject_sets":["85771"],"set_member_subjects":["80512512"]}}
+  ]
 
   before(function () {
     const cellect = nock('https://cellect.zooniverse.org')
@@ -60,6 +76,25 @@ describe('Helpers > fetchWorkflowsHelper', function () {
     .get('/workflows/2/status')
     .reply(200, {
       groups: availableSubjects
+    })
+
+    const panoptes = nock('https://panoptes-staging.zooniverse.org/api')
+    .persist()
+    .get('/subject_sets')
+    .query(true)
+    .reply(200, {
+      subject_sets: [
+        subjectSet('1'),
+        subjectSet('2'),
+        subjectSet('3')
+      ]
+    })
+    .get('/set_member_subjects')
+    .query(query => query.include === 'subject')
+    .reply(200, {
+      linked: {
+        subjects: mockSetSubjects
+      }
     })
   })
 
@@ -78,15 +113,6 @@ describe('Helpers > fetchWorkflowsHelper', function () {
       .query(true)
       .reply(200, {
         workflows: WORKFLOWS.slice(0, 1)
-      })
-      .get('/subject_sets')
-      .query(query => query.id === '1,2,3')
-      .reply(200, {
-        subject_sets: [
-          subjectSet('1'),
-          subjectSet('2'),
-          subjectSet('3')
-        ]
       })
 
     const result = await fetchWorkflowsHelper('en', ['1'])
@@ -114,15 +140,6 @@ describe('Helpers > fetchWorkflowsHelper', function () {
       .query(true)
       .reply(200, {
         workflows: WORKFLOWS
-      })
-      .get('/subject_sets')
-      .query(true)
-      .reply(200, {
-        subject_sets: [
-          subjectSet('1'),
-          subjectSet('2'),
-          subjectSet('3')
-        ]
       })
 
     const result = await fetchWorkflowsHelper('en', ['1', '2'])
@@ -162,15 +179,6 @@ describe('Helpers > fetchWorkflowsHelper', function () {
         .query(true)
         .reply(200, {
           workflows: WORKFLOWS
-        })
-        .get('/subject_sets')
-        .query(true)
-        .reply(200, {
-          subject_sets: [
-            subjectSet('1'),
-            subjectSet('2'),
-            subjectSet('3')
-          ]
         })
 
       const result = await fetchWorkflowsHelper('en', ['1', '2'], '2')
@@ -232,15 +240,6 @@ describe('Helpers > fetchWorkflowsHelper', function () {
         .query(true)
         .reply(200, {
           workflows: WORKFLOWS
-        })
-        .get('/subject_sets')
-        .query(true)
-        .reply(200, {
-          subject_sets: [
-            subjectSet('1'),
-            subjectSet('2'),
-            subjectSet('3')
-          ]
         })
 
       try {

--- a/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.spec.js
+++ b/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.spec.js
@@ -65,9 +65,25 @@ describe('Components > ProjectHomePage > getDefaultPageProps', function () {
     return {
       id,
       display_name: `test set ${id}`,
-      set_member_subjects_count: 10
+      set_member_subjects_count: 10,
+      subjects: mockSetSubjects
     }
   }
+
+  const mockSetSubjects = [
+    {
+      "id":"47696316",
+      "metadata":{"Filename":"ultraman-x.png"},
+      "locations":[
+        {"image/png":"https://panoptes-uploads.zooniverse.org/production/subject_location/78964ce7-72db-4607-b493-63626738cf4e.png"}
+      ],
+      "zooniverse_id":null,
+      "external_id":null,
+      "created_at":"2020-07-09T20:47:07.128Z",
+      "updated_at":"2020-07-09T20:47:07.128Z",
+      "href":"/subjects/47696316",
+      "links":{"project":"12754","collections":[],"subject_sets":["85771"],"set_member_subjects":["80512512"]}}
+  ]
 
   function mockAPI(panoptesHost) {
     const cellect = nock('https://cellect.zooniverse.org')
@@ -119,6 +135,13 @@ describe('Components > ProjectHomePage > getDefaultPageProps', function () {
           subjectSet('2'),
           subjectSet('3')
         ]
+      })
+      .get('/set_member_subjects')
+      .query(query => query.include === 'subject')
+      .reply(200, {
+        linked: {
+          subjects: mockSetSubjects
+        }
       })
       .get('/workflows')
       .query(query => query.id === '1')

--- a/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.spec.js
+++ b/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.spec.js
@@ -66,9 +66,25 @@ describe('Helpers > getStaticPageProps', function () {
     return {
       id,
       display_name: `test set ${id}`,
-      set_member_subjects_count: 10
+      set_member_subjects_count: 10,
+      subjects: mockSetSubjects
     }
   }
+
+  const mockSetSubjects = [
+    {
+      "id":"47696316",
+      "metadata":{"Filename":"ultraman-x.png"},
+      "locations":[
+        {"image/png":"https://panoptes-uploads.zooniverse.org/production/subject_location/78964ce7-72db-4607-b493-63626738cf4e.png"}
+      ],
+      "zooniverse_id":null,
+      "external_id":null,
+      "created_at":"2020-07-09T20:47:07.128Z",
+      "updated_at":"2020-07-09T20:47:07.128Z",
+      "href":"/subjects/47696316",
+      "links":{"project":"12754","collections":[],"subject_sets":["85771"],"set_member_subjects":["80512512"]}}
+  ]
 
   function mockAPI(panoptesHost) {
     const cellect = nock('https://cellect.zooniverse.org')
@@ -120,6 +136,13 @@ describe('Helpers > getStaticPageProps', function () {
           subjectSet('2'),
           subjectSet('3')
         ]
+      })
+      .get('/set_member_subjects')
+      .query(query => query.include === 'subject')
+      .reply(200, {
+        linked: {
+          subjects: mockSetSubjects
+        }
       })
       .get('/workflows')
       .query(query => query.id === '1')

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsContainer.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsContainer.spec.js
@@ -1,13 +1,42 @@
 import { shallow } from 'enzyme'
+import nock from 'nock'
 import React from 'react'
 
 import RecentSubjectsContainer from './RecentSubjectsContainer'
 
-let wrapper
-
 describe('Component > RecentSubjectsContainer', function () {
+  let wrapper
+
+  const TALK_URL = 'https://talk-staging.zooniverse.org'
+  const PANOPTES_URL = 'https://panoptes-staging.zooniverse.org/api'
+
+  const MOCK_COMMENTS = [
+    { focus_id: '1' },
+    { focus_id: '2' },
+    { focus_id: '3' }
+  ]
+
+  const MOCK_SUBJECTS = [
+    { id: '1' },
+    { id: '2' },
+    { id: '3' }
+  ]
+
   before(function () {
+    process.env.TALK_HOST = TALK_URL
+    nock(TALK_URL)
+      .get('/comments')
+      .query(true)
+      .reply(200, { comments: MOCK_COMMENTS })
+    nock(PANOPTES_URL)
+      .get('/subjects')
+      .query(true)
+      .reply(200, { subjects: MOCK_SUBJECTS })
     wrapper = shallow(<RecentSubjectsContainer.wrappedComponent />)
+  })
+
+  after(function () {
+    delete process.env.TALK_HOST
   })
 
   it('should render without crashing', function () {


### PR DESCRIPTION
Add `set_member_subjects` to the API mocks for page props. Add a mock subject to mock subject sets, to check that the API response is being added to page props as expected.

Package:
app-project

Closes #2090.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
