### PR TITLE
Fix Done & Talk for single answer tasks

### DIFF
--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -130,16 +130,9 @@ const WorkflowStepStore = types
     }
 
     function setSteps (steps) {
-      steps.forEach(([ stepKey, step ], index) => {
-        let next
-        // checking for there being a next step without accessing it directly
-        // mobx throws errors for undefined indices because you can't observe those
-        if (steps.length > 0 && index + 2 <= steps.length) {
-          const [nextStepKey] = steps[index + 1]
-          next = nextStepKey
-        }
-
-        self.steps.put(Object.assign({}, step, { stepKey, next }))
+      steps.forEach(workflowStep => {
+        const [ stepKey, step ] = workflowStep
+        self.steps.put(Object.assign({}, step, { stepKey }))
       })
     }
 

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
@@ -131,7 +131,7 @@ describe('Model > WorkflowStepStore', function () {
       firstStepSnapshot.taskKeys.forEach((taskKey, index) => {
         expect(taskKey).to.equal(storedStep.taskKeys[index])
       })
-      expect(storedStep.next).to.equal(secondStepKey)
+      expect(storedStep.next).to.be.undefined()
     })
   })
 


### PR DESCRIPTION
The workflowSteps store creates or overwrites `step.next` for each workflow step, which then breaks the Done & Talk button for single choice questions. This PR removes that code so that the value of `step.next` is taken from `workflow.steps`, for each step.

Package:
lib-classifier

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
