### PR TITLE
Classifier: Set step.next for transcription tasks

### DIFF
--- a/packages/lib-classifier/src/store/Workflow/Workflow.js
+++ b/packages/lib-classifier/src/store/Workflow/Workflow.js
@@ -35,9 +35,6 @@ const Workflow = types
     /** convert Panoptes workflows to use steps, if necessary. */
     function convertPanoptesWorkflows(snapshot) {
       const workflowHasSteps = (snapshot.steps?.length > 0 && Object.keys(snapshot.tasks).length > 0)
-      if (workflowHasSteps) {
-        return snapshot
-      }
       const newSnapshot = Object.assign({}, snapshot)
       const { steps, tasks } = convertWorkflowToUseSteps(newSnapshot)
       return { ...newSnapshot, steps, tasks }

--- a/packages/lib-classifier/src/store/helpers/convertWorkflowToUseSteps/convertWorkflowToUseSteps.js
+++ b/packages/lib-classifier/src/store/helpers/convertWorkflowToUseSteps/convertWorkflowToUseSteps.js
@@ -23,14 +23,14 @@ function getStepKeyFromTaskKey(steps, taskKey) {
   return taskStepKey
 }
 
-function getTaskKeysIncludedInComboTasks (tasks) {
+function getTaskKeysIncludedInComboTasks(tasks) {
   let taskKeys
   const comboTasks = Object.values(tasks).filter(task => task?.type === 'combo')
   taskKeys = comboTasks.map(combo => combo.tasks)
   return taskKeys.flat()
 }
 
-function isThereBranching (task) {
+function isThereBranching(task) {
   return task?.answers?.some((answer, index) => {
     if (task.answers.length > index + 1) {
       return answer.next !== task.answers[index + 1].next
@@ -43,16 +43,16 @@ function taskExists(taskKey, tasks) {
   return Object.keys(tasks).includes(taskKey)
 }
 
-export default function convertWorkflowToUseSteps ({ first_task, steps = [], tasks }) {
-  steps = steps.slice()
+function createStepsFromTasks(first_task, tasks) {
+  const steps = []
   const taskKeys = Object.keys(tasks)
 
   const taskKeysIncludedInComboTasks = getTaskKeysIncludedInComboTasks(tasks)
-  const taskKeysToConvertToSteps = steps.length ? [] : difference(taskKeys, taskKeysIncludedInComboTasks)
+  const taskKeysToConvertToSteps = difference(taskKeys, taskKeysIncludedInComboTasks)
 
   const firstTask = tasks[first_task]
 
-  if (steps.length === 0 && first_task) {
+  if (first_task) {
     let firstStep = {
       next: firstTask.next, // temporarily set next to task key, convert to step key once steps created
       stepKey: 'S0',
@@ -96,6 +96,12 @@ export default function convertWorkflowToUseSteps ({ first_task, steps = [], tas
       steps.push([stepKey, stepSnapshot])
     }
   })
+
+  return steps
+}
+
+export default function convertWorkflowToUseSteps({ first_task, steps = [], tasks }) {
+  steps = steps.length > 0 ? steps : createStepsFromTasks(first_task, tasks)
 
   // convert step.next from task key to step key
   steps.forEach(([stepKey, step]) => {

--- a/packages/lib-classifier/src/store/helpers/convertWorkflowToUseSteps/convertWorkflowToUseSteps.spec.js
+++ b/packages/lib-classifier/src/store/helpers/convertWorkflowToUseSteps/convertWorkflowToUseSteps.spec.js
@@ -274,7 +274,67 @@ describe('Helpers > convertWorkflowToUseSteps', function () {
           T4: DrawingTaskFactory.build({ taskKey: 'T4' })
         }
       }
-    }
+    },
+    // workflow with steps
+    {
+      name: 'workflow with steps',
+      input: {
+        first_task: 'T0',
+        steps: [
+          ['S0', {
+            stepKey: 'S0',
+            taskKeys: ['T0']
+          }],
+          ['S1', {
+            stepKey: 'S1',
+            taskKeys: ['T1']
+          }],
+          ['S2', {
+            stepKey: 'S2',
+            taskKeys: ['T2']
+          }]
+        ],
+        tasks: {
+          T0: SingleChoiceTaskFactory.build({
+            taskKey: 'T0',
+            answers: [
+              { label: 'Yes', next: 'T1' },
+              { label: 'No', next: 'T1' }
+            ]
+          }),
+          T1: DrawingTaskFactory.build({ taskKey: 'T1', next: 'T2' }),
+          T2: MultipleChoiceTaskFactory.build({ taskKey: 'T2' })
+        }
+      },
+      output: {
+        steps: [
+          ['S0', {
+            stepKey: 'S0',
+            taskKeys: ['T0']
+          }],
+          ['S1', {
+            next: 'S2',
+            stepKey: 'S1',
+            taskKeys: ['T1']
+          }],
+          ['S2', {
+            stepKey: 'S2',
+            taskKeys: ['T2']
+          }]
+        ],
+        tasks: {
+          T0: SingleChoiceTaskFactory.build({
+            taskKey: 'T0',
+            answers: [
+              { label: 'Yes', next: 'S1' },
+              { label: 'No', next: 'S1' }
+            ]
+          }),
+          T1: DrawingTaskFactory.build({ taskKey: 'T1', next: 'T2' }),
+          T2: MultipleChoiceTaskFactory.build({ taskKey: 'T2' })
+        }
+      }
+    },
   ]
 
   function runTestCase(testCase) {


### PR DESCRIPTION
Transcription workflows have steps defined, so they bypass `convertWorkflowToUseSteps`. However, the Next Task selector in the project builder still sets `task.next` to a task key for each task and single choice answer. This PR runs `convertWorkflowToUseSteps` on all incoming workflow snapshots. It checks `step.next` for each step, and tries to set it from `task.next` if it doesn't exist.

https://localhost:8080/?env=production&project=9006&workflow=18244&demo=true

Package:
lib-classifier

Closes #2102.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
