### PR TITLE
Refactor step.getNextStep to use workflowSteps store

### DIFF
--- a/packages/lib-classifier/src/store/AnnotatedSteps/AnnotatedSteps.spec.js
+++ b/packages/lib-classifier/src/store/AnnotatedSteps/AnnotatedSteps.spec.js
@@ -1,12 +1,4 @@
-import { Factory } from 'rosie'
-import sinon from 'sinon'
-
-import AnnotatedSteps from './'
-
-import RootStore from '@store'
-import { SubjectFactory, WorkflowFactory, ProjectFactory } from '@test/factories'
 import mockStore from '@test/mockStore'
-import stubPanoptesJs from '@test/stubPanoptesJs'
 
 describe('Model > AnnotatedSteps', function () {
   let store

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
@@ -11,6 +11,7 @@ import {
 } from '@test/factories'
 import { Factory } from 'rosie'
 import stubPanoptesJs from '@test/stubPanoptesJs'
+import { expect } from 'chai'
 
 async function setupStores (clientStub, project, workflow) {
   const store = RootStore.create({
@@ -49,11 +50,13 @@ describe('Model > WorkflowStepStore', function () {
       workflow = WorkflowFactory.build({
         steps: [
           ['S1', { taskKeys: ['T1'] }],
-          ['S2', { taskKeys: ['T2'] }]
+          ['S2', { taskKeys: ['T2'] }],
+          ['S3', { taskKeys: ['T3'], next: 'S1' }]
         ],
         tasks: {
           T1: SingleChoiceTaskFactory.build(),
-          T2: MultipleChoiceTaskFactory.build()
+          T2: MultipleChoiceTaskFactory.build(),
+          T3: MultipleChoiceTaskFactory.build()
         }
       })
 
@@ -91,16 +94,8 @@ describe('Model > WorkflowStepStore', function () {
       })
 
       it('should set the next step', function () {
-        STORE_STEPS.forEach((step, stepIndex) => {
-          let nextStep
-          if (STORE_STEPS.length > 0 && stepIndex + 2 <= STORE_STEPS.length) {
-            nextStep = step[stepIndex + 1]
-          }
-          if (nextStep) {
-            expect(step.next).to.equal(nextStep.stepKey)
-          }
-
-          expect(step.next).to.be.undefined()
+        STORE_STEPS.forEach((step, index) => {
+          expect(step.next).to.equal(workflow.steps[index].next)
         })
       })
     })
@@ -123,7 +118,6 @@ describe('Model > WorkflowStepStore', function () {
       const firstStep = workflow.steps[0]
       const firstStepKey = firstStep[0]
       const firstStepSnapshot = firstStep[1]
-      const secondStepKey = workflow.steps[1][0]
       workflowSteps.selectStep()
       const storedStep = workflowSteps.active
 


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

Closes #2102 

Two issues are the cause of #2102:

We have two stores that sort of do the same thing, `WorkflowStepsStore` and `AnnotatedSteps`. The issue with this is that they both sort of control the step behavior, but behave slightly differently and make different assumptions.

`WorkflowStepsStore` assumes the step order is generally the order of the map. `step.next` is only used if the step is configured to recurse. Prior to the refactor to use `AnnotatedSteps`, `step.next` was also set and used when there was single choice branching. This behavior is consistent with the concept laid out in [ADR 5](https://github.com/zooniverse/front-end-monorepo/blob/master/docs/arch/adr-05.md).

`AnnotatedSteps` was built to handle step annotation history, but took over control of the back/next/done behavior of the task step UI. It assumes `step.next` is always defined unless there is a single choice task branching, in which, `answer.next` would take precedence. 

Two issues arise from this: 

- The `Step` model is a child node of both `WorkflowStepsStore` and `AnnotatedSteps`. When a child of `WorkflowStepsStore`, the `answer.next` value of a pre-existing PFE style workflow gets correctly converted from the next task to the next step. When `Step` is a child node of `AnnotatedSteps`, no such conversion occurred and `answer.next` tried to select a PFE style next task rather than a next step. (Note: PR #2104 proses a fix to have all workflow types, whether for PFE or classifier 2.0, to go through the converter and always set `step.next`.)
- The differing assumptions of how the next step is derived has longer term impact on other development, including the workflow lab page, where right now, the plan is to follow the logic laid out in ADR 5. The interim lab editor for the transcription task followed this, and does not set the next step by `step.next`, but instead relies on nested arrays which gets converted to a map in the store to set the order.

This PR proposes an alternative fix to #2104:
- Start to use `workflowSteps.getNextStepKey` again rather than have it be unused cruft and derive the next step by step map order or use `step.next` if defined (only for recursion).
- Use `workflowSteps.active.tasks` for when there is a single choice task branch because the next task key is correctly converted already here, so we don't need to do it again. 

Long term I'd prefer we consolidate this logic more so we don't have two stores doing slightly similar things but behave enough differently to introduce bugs. 

This can be tested with Davy Notebooks:
https://localhost:8080/?env=production&project=9006&workflow=18244&demo=true

The workflow now flows through all of the defined steps as expected. 

And by the testing kitty project, to confirm we don't have a regression with single choice branching and PFE workflow conversion:
https://localhost:8080/

When a choice isn't selected, disable the buttons:
<img width="424" alt="Screen Shot 2021-04-19 at 3 06 11 PM" src="https://user-images.githubusercontent.com/5016731/115298405-0e40ff00-a123-11eb-9f46-8ca6e05a3f9b.png">

When none is selected, end the classification:
<img width="418" alt="Screen Shot 2021-04-19 at 3 06 17 PM" src="https://user-images.githubusercontent.com/5016731/115298460-1dc04800-a123-11eb-8b13-e43aba42f14e.png">

When 1 is selected, go to the next step and task:
<img width="416" alt="Screen Shot 2021-04-19 at 3 06 23 PM" src="https://user-images.githubusercontent.com/5016731/115298514-2c0e6400-a123-11eb-8326-f9fef2ec6fb4.png">

As for the differing assumptions, I'm happy to discuss changes from what we laid out in ADR 5, but this should be a discussion first and if we arrive at a idea to try or a decision, let's document it so it can be communicated across the team so we don't run into issues like this in the future.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
