### PR TITLE
Add survey annotation _choiceInProgress property

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/SurveyTaskContainer.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/SurveyTaskContainer.js
@@ -31,6 +31,13 @@ class SurveyTaskContainer extends React.Component {
 
   handleChoice (selectedChoice) {
     const { annotation } = this.props
+    
+    // onCancel, onClickOutside, and onEsc selectedChoice defined as ''
+    if (selectedChoice === '') {
+      annotation.setChoiceInProgress(false)
+    } else {
+      annotation.setChoiceInProgress(true)
+    }
 
     if (annotation?.value?.map(item => item.choice).includes(selectedChoice)) {
       const existingAnnotationValue = annotation?.value?.find(value => value.choice === selectedChoice)
@@ -66,6 +73,7 @@ class SurveyTaskContainer extends React.Component {
     })
 
     annotation.update(value)
+    annotation.setChoiceInProgress(false)
   }
 
   handleReset() {
@@ -118,8 +126,10 @@ SurveyTaskContainer.defaultProps = {
 SurveyTaskContainer.propTypes = {
   autoFocus: PropTypes.bool,
   annotation: PropTypes.shape({
+    setChoiceInProgress: PropTypes.func,
     update: PropTypes.func,
-    value: PropTypes.array
+    value: PropTypes.array,
+    _choiceInProgress: PropTypes.bool
   }).isRequired,
   disabled: PropTypes.bool,
   task: PropTypes.shape({

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/models/SurveyAnnotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/models/SurveyAnnotation.js
@@ -8,11 +8,17 @@ const SurveyChoice = types.model('SurveyChoice', {
 })
 
 const Survey = types.model('Survey', {
-  value: types.optional(types.array(SurveyChoice), [])
+  value: types.optional(types.array(SurveyChoice), []),
+  _choiceInProgress: types.optional(types.boolean, false)
 })
   .views(self => ({
     get isComplete () {
-      return self.value.length > 0
+      return self.value.length > 0 && !self._choiceInProgress
+    }
+  }))
+  .actions(self => ({
+    setChoiceInProgress (boolean) {
+      self._choiceInProgress = boolean
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/models/SurveyAnnotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/models/SurveyAnnotation.spec.js
@@ -22,6 +22,10 @@ describe('Model > SurveyAnnotation', function () {
       expect(surveyAnnotation).to.be.an('object')
     })
 
+    it('should have _choiceInProgress as false', function () {
+      expect(surveyAnnotation._choiceInProgress).to.be.false()
+    })
+
     it('should be complete', function () {
       expect(surveyAnnotation.isComplete).to.be.true()
     })
@@ -105,6 +109,33 @@ describe('Model > SurveyAnnotation', function () {
 
     it('should be complete', function () {
       expect(surveyAnnotation.isComplete).to.be.true()
+    })
+  })
+
+  describe('with _choiceInProgress as true', function () {
+    let surveyAnnotationInProgress
+
+    before(function () {
+      surveyAnnotationInProgress = SurveyAnnotation.create({
+        id: 'survey1',
+        task: 'T0',
+        taskType: 'survey',
+        value: [{
+          answers: {},
+          choice: 'WHISTLE',
+          filters: {}
+        }],
+        _choiceInProgress: true
+      })
+    })
+
+    it('should be incomplete', function () {
+      expect(surveyAnnotationInProgress.isComplete).to.be.false()
+    })
+
+    it('should update _choiceInProgress to false when action inProgress is called with false', function () {
+      surveyAnnotationInProgress.setChoiceInProgress(false)
+      expect(surveyAnnotationInProgress._choiceInProgress).to.be.false()
     })
   })
 


### PR DESCRIPTION
Package:
- lib-classifier

Closes #2086.

Describe your changes:
- add `_choiceInProgress` property to survey annotation, defaults to `false`, when choice identified set to `true`, when choice complete or canceled set to `false`
- add ^ related tests

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
