### PR TITLE
Remove the storing of client size in classification metadata

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
@@ -105,11 +105,8 @@ class MultiFrameViewerContainer extends React.Component {
 
   async getImageSize () {
     const img = await this.preload()
-    const svg = this.imageViewer.current
-    const { width: clientWidth, height: clientHeight } = svg ? svg.getBoundingClientRect() : {}
+
     return {
-      clientHeight,
-      clientWidth,
       naturalHeight: img.naturalHeight,
       naturalWidth: img.naturalWidth
     }
@@ -118,8 +115,8 @@ class MultiFrameViewerContainer extends React.Component {
   async onLoad () {
     const { onError, onReady } = this.props
     try {
-      const { clientHeight, clientWidth, naturalHeight, naturalWidth } = await this.getImageSize()
-      const target = { clientHeight, clientWidth, naturalHeight, naturalWidth }
+      const { naturalHeight, naturalWidth } = await this.getImageSize()
+      const target = { naturalHeight, naturalWidth }
       onReady({ target })
     } catch (error) {
       console.error(error)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.spec.js
@@ -78,8 +78,6 @@ describe('Component > MultiFrameViewerContainer', function () {
       imageWrapper = wrapper.find(SingleImageViewer)
       wrapper.instance().imageViewer = {
         current: {
-          clientHeight: 50,
-          clientWidth: 100,
           addEventListener: sinon.stub(),
           getBoundingClientRect: sinon.stub().callsFake(() => ({ width: 100, height: 50 })),
           removeEventListener: sinon.stub()
@@ -102,15 +100,10 @@ describe('Component > MultiFrameViewerContainer', function () {
     it('should record the original image dimensions on load', function () {
       const svg = wrapper.instance().imageViewer.current
       const fakeEvent = {
-        target: {
-          clientHeight: 0,
-          clientWidth: 0
-        }
+        target: {}
       }
       const expectedEvent = {
         target: {
-          clientHeight: svg.clientHeight,
-          clientWidth: svg.clientWidth,
           naturalHeight: height,
           naturalWidth: width
         }
@@ -170,8 +163,6 @@ describe('Component > MultiFrameViewerContainer', function () {
       imageWrapper = wrapper.find(SingleImageViewer)
       wrapper.instance().imageViewer = {
         current: {
-          clientHeight: 50,
-          clientWidth: 100,
           addEventListener: sinon.stub(),
           getBoundingClientRect: sinon.stub().callsFake(() => ({ width: 100, height: 50 })),
           removeEventListener: sinon.stub()
@@ -194,10 +185,7 @@ describe('Component > MultiFrameViewerContainer', function () {
 
     it('should log an error from an invalid image', function () {
       const fakeEvent = {
-        target: {
-          clientHeight: 0,
-          clientWidth: 0
-        }
+        target: {}
       }
       expect(onError.withArgs(HTMLImgError)).to.have.been.calledOnce()
     })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -67,11 +67,8 @@ class SingleImageViewerContainer extends React.Component {
 
   async getImageSize () {
     const img = await this.preload()
-    const svg = this.imageViewer.current
-    const { width: clientWidth, height: clientHeight } = svg ? svg.getBoundingClientRect() : {}
+
     return {
-      clientHeight,
-      clientWidth,
       naturalHeight: img.naturalHeight,
       naturalWidth: img.naturalWidth
     }
@@ -80,8 +77,8 @@ class SingleImageViewerContainer extends React.Component {
   async onLoad () {
     const { onError, onReady } = this.props
     try {
-      const { clientHeight, clientWidth, naturalHeight, naturalWidth } = await this.getImageSize()
-      const target = { clientHeight, clientWidth, naturalHeight, naturalWidth }
+      const { naturalHeight, naturalWidth } = await this.getImageSize()
+      const target = { naturalHeight, naturalWidth }
       onReady({ target })
     } catch (error) {
       console.error(error)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -76,8 +76,6 @@ describe('Component > SingleImageViewerContainer', function () {
       imageWrapper = wrapper.find(SingleImageViewer)
       wrapper.instance().imageViewer = {
         current: {
-          clientHeight: 50,
-          clientWidth: 100,
           addEventListener: sinon.stub(),
           getBoundingClientRect: sinon.stub().callsFake(() => ({ width: 100, height: 50 })),
           removeEventListener: sinon.stub()
@@ -96,15 +94,10 @@ describe('Component > SingleImageViewerContainer', function () {
     it('should record the original image dimensions on load', function () {
       const svg = wrapper.instance().imageViewer.current
       const fakeEvent = {
-        target: {
-          clientHeight: 0,
-          clientWidth: 0
-        }
+        target: {}
       }
       const expectedEvent = {
         target: {
-          clientHeight: svg.clientHeight,
-          clientWidth: svg.clientWidth,
           naturalHeight: height,
           naturalWidth: width
         }
@@ -164,8 +157,6 @@ describe('Component > SingleImageViewerContainer', function () {
       imageWrapper = wrapper.find(SingleImageViewer)
       wrapper.instance().imageViewer = {
         current: {
-          clientHeight: 50,
-          clientWidth: 100,
           addEventListener: sinon.stub(),
           getBoundingClientRect: sinon.stub().callsFake(() => ({ width: 100, height: 50 })),
           removeEventListener: sinon.stub()
@@ -188,10 +179,7 @@ describe('Component > SingleImageViewerContainer', function () {
 
     it('should log an error from an invalid image', function () {
       const fakeEvent = {
-        target: {
-          clientHeight: 0,
-          clientWidth: 0
-        }
+        target: {}
       }
       expect(onError.withArgs(HTMLImgError)).to.have.been.calledOnce()
     })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
@@ -50,15 +50,15 @@ class SingleVideoViewerContainer extends React.Component {
     const { onError, onReady } = this.props
     try {
       const {
-        clientHeight,
         clientWidth,
         naturalHeight,
         naturalWidth
       } = await this.getVideoSize()
-      const target = { clientHeight, clientWidth, naturalWidth, naturalHeight }
+      const target = { naturalWidth, naturalHeight }
       this.setState({
-        naturalWidth: naturalWidth,
-        naturalHeight: naturalHeight
+        clientWidth,
+        naturalWidth,
+        naturalHeight
       })
       onReady({ target })
     } catch (error) {
@@ -69,16 +69,11 @@ class SingleVideoViewerContainer extends React.Component {
   async getVideoSize() {
     const vid = await this.preload()
     const svg = this.videoViewer.current
-    const { width: clientWidth, height: clientHeight } = svg
+    const { width: clientWidth } = svg
       ? svg.getBoundingClientRect()
       : {}
 
-    this.setState({
-      clientWidth: clientWidth
-    })
-
     return {
-      clientHeight,
       clientWidth,
       naturalHeight: vid.videoHeight,
       naturalWidth: vid.videoWidth

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/SubjectGroupViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/SubjectGroupViewerContainer.js
@@ -151,15 +151,12 @@ class SubjectGroupViewerContainer extends React.Component {
 
   getGridSize () {
     const svg = this.groupViewer.current || {}
-    const { width: clientWidth, height: clientHeight } = svg.getBoundingClientRect && svg.getBoundingClientRect() || {}
     const { gridRows, gridColumns, cellWidth, cellHeight } = this.props
     
     const gridWidth = gridColumns * cellWidth
     const gridHeight = gridRows * cellHeight
     
     return {
-      clientHeight,
-      clientWidth,
       gridHeight,
       gridWidth,
     }
@@ -169,8 +166,8 @@ class SubjectGroupViewerContainer extends React.Component {
     const { onError, onReady } = this.props
     try {
       await this.preload()
-      const { clientHeight, clientWidth, gridHeight: naturalHeight, gridWidth: naturalWidth } = this.getGridSize()
-      const target = { clientHeight, clientWidth, naturalHeight, naturalWidth }
+      const { gridHeight: naturalHeight, gridWidth: naturalWidth } = this.getGridSize()
+      const target = { naturalHeight, naturalWidth }
       onReady({ target })
     } catch (error) {
       console.error(error)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/SubjectGroupViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/SubjectGroupViewerContainer.spec.js
@@ -93,8 +93,6 @@ describe('Component > SubjectGroupViewerContainer', function () {
       groupWrapper = wrapper.find(SubjectGroupViewer)
       wrapper.instance().groupViewer = {
         current: {
-          clientHeight: 50,
-          clientWidth: 100,
           addEventListener: sinon.stub(),
           getBoundingClientRect: sinon.stub().callsFake(() => ({ width: 100, height: 50 })),
           removeEventListener: sinon.stub()
@@ -148,8 +146,6 @@ describe('Component > SubjectGroupViewerContainer', function () {
       groupWrapper = wrapper.find(SubjectGroupViewer)
       wrapper.instance().groupViewer = {
         current: {
-          clientHeight: 50,
-          clientWidth: 100,
           addEventListener: sinon.stub(),
           getBoundingClientRect: sinon.stub().callsFake(() => ({ width: 100, height: 50 })),
           removeEventListener: sinon.stub()
@@ -172,10 +168,7 @@ describe('Component > SubjectGroupViewerContainer', function () {
 
     it('should log an error from an invalid image', function () {
       const fakeEvent = {
-        target: {
-          clientHeight: 0,
-          clientWidth: 0
-        }
+        target: {}
       }
       expect(onError.withArgs(HTMLImgError)).to.have.been.calledOnce()
     })

--- a/packages/lib-classifier/src/store/Classification/ClassificationMetadata.js
+++ b/packages/lib-classifier/src/store/Classification/ClassificationMetadata.js
@@ -8,8 +8,6 @@ const ClassificationMetadata = types.model('ClassificationMetadata', {
   source: types.enumeration(['api', 'sugar']),
   startedAt: types.optional(types.string, (new Date()).toISOString()),
   subjectDimensions: types.array(types.frozen({
-    clientHeight: types.integer,
-    clientWidth: types.integer,
     naturalHeight: types.integer,
     naturalWidth: types.integer
   })),

--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -115,8 +115,6 @@ describe('Model > ClassificationStore', function () {
           fieldGuide: {},
           subjectViewer: {
             dimensions: [{
-              clientHeight: 100,
-              clientWidth: 300,
               naturalHeight: 200,
               naturalWidth: 600
             }]

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -7,8 +7,6 @@ const SubjectViewer = types
   .model('SubjectViewer', {
     annotate: types.optional(types.boolean, true),
     dimensions: types.array(types.frozen({
-      clientHeight: types.integer,
-      clientWidth: types.integer,
       naturalHeight: types.integer,
       naturalWidth: types.integer
     })),
@@ -90,12 +88,10 @@ const SubjectViewer = types
       onSubjectReady (event) {
         const { target = {} } = event || {}
         const {
-          clientHeight = 0,
-          clientWidth = 0,
           naturalHeight = 0,
           naturalWidth = 0
         } = target
-        self.dimensions.push({ clientHeight, clientWidth, naturalHeight, naturalWidth })
+        self.dimensions.push({ naturalHeight, naturalWidth })
         self.rotation = 0
         self.loadingState = asyncStates.success
       },

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.spec.js
@@ -88,7 +88,7 @@ describe('Model > SubjectViewerStore', function () {
       subjectViewerStub = {
         loadingState: asyncStates.success,
         dimensions: [
-          { clientHeight: 200, clientWidth: 200, naturalHeight: 200, naturalWidth: 200 }
+          { naturalHeight: 200, naturalWidth: 200 }
         ]
       }
       subjectViewerStore = SubjectViewerStore.create(subjectViewerStub)


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

For #2118. 

The experimentally removes the recording of the client width and client height across the subject viewers. Reasoning is in #2118 and long term it will make working with pan/zoom features easier. There are a couple of instances where `clientWidth` is still used left in because it's being used in a zoom scale calculation. I'll address these when I attempt the `VisXZoom` swap. 

Tests pass, but I'd like some help with double checking manually that this didn't break anything:

- `SingleImageViewer` and drawing checked with the kitty test project: https://localhost:8080
- `MultiFrameViewer` and transcription: https://localhost:8080/?project=11300&env=production&demo=true

@shaunanoordin could you check the `SubjectGroupViewer`? @ErikOstlund could you check the `SingleVideoViewer`? @eatyourgreens any concerns with EG projects?

We should also double check with PH TESS.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
