### PR TITLE
Engaging Crowds: Fallback to workflow.links when Cellect fails

### DIFF
--- a/packages/app-project/src/helpers/fetchSubjectSets/fetchSubjectSets.js
+++ b/packages/app-project/src/helpers/fetchSubjectSets/fetchSubjectSets.js
@@ -55,7 +55,10 @@ async function fetchPreviewImage (subjectSet, env) {
 
 export default async function fetchSubjectSets(workflow, env) {
   const subjectSetCounts = await fetchWorkflowCellectStatus(workflow)
-  const subjectSetIDs = Object.keys(subjectSetCounts)
+  let subjectSetIDs = Object.keys(subjectSetCounts)
+  if (subjectSetIDs.length === 0) {
+    subjectSetIDs = workflow.links.subject_sets
+  }
   const subjectSets = await fetchSubjectSetData(subjectSetIDs, env)
   subjectSets.forEach(subjectSet => {
     subjectSet.availableSubjects = subjectSetCounts[subjectSet.id]


### PR DESCRIPTION
Requests to cellect.zooniverse.org intermittently timeout or fail with an empty response. When that happens, no subject sets are fetched for a workflow and subject set selection is broken. This PR falls back to using `workflow.links.subject_sets` if Cellect fails.

![Screenshot of the subject set picker, asking you to select a subject set but there are no subject sets displayed.](https://user-images.githubusercontent.com/59547/116579060-ebc09a00-a909-11eb-9846-472e0c66552b.png)

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
