### PR TITLE
Update app-project to use redirect and notFound

### DIFF
--- a/packages/app-project/pages/projects/[owner]/[project]/about/education.js
+++ b/packages/app-project/pages/projects/[owner]/[project]/about/education.js
@@ -2,9 +2,10 @@ import getDefaultPageProps from "@helpers/getDefaultPageProps"
 export { default } from "@screens/ProjectAboutPage"
 
 export async function getServerSideProps({ params, query, req, res }) {
-  const { props } = await getDefaultPageProps({ params, query, req, res })
+  const { notFound, props } = await getDefaultPageProps({ params, query, req, res })
 
   return {
+    notFound,
     props: {
       pageType: "education",
       ...props

--- a/packages/app-project/pages/projects/[owner]/[project]/about/faq.js
+++ b/packages/app-project/pages/projects/[owner]/[project]/about/faq.js
@@ -2,9 +2,10 @@ import getDefaultPageProps from "@helpers/getDefaultPageProps"
 export { default } from "@screens/ProjectAboutPage"
 
 export async function getServerSideProps({ params, query, req, res }) {
-  const { props } = await getDefaultPageProps({ params, query, req, res })
+  const { notFound, props } = await getDefaultPageProps({ params, query, req, res })
 
   return {
+    notFound,
     props: {
       pageType: "faq",
       ...props

--- a/packages/app-project/pages/projects/[owner]/[project]/about/index.js
+++ b/packages/app-project/pages/projects/[owner]/[project]/about/index.js
@@ -2,16 +2,17 @@ import getDefaultPageProps from '@helpers/getDefaultPageProps'
 export { default } from '@screens/ProjectAboutPage'
 
 export async function getServerSideProps({ params, query, req, res }) {
-  const { props } = await getDefaultPageProps({ params, query, req, res })
+  const { notFound, props } = await getDefaultPageProps({ params, query, req, res })
   const { env } = query
   const { project } = props.initialState
 
   const projectPath = `/projects/${project?.slug}/about/research`
-  const redirect = env ? `${projectPath}?env=${env}` : projectPath
+  const destination = env ? `${projectPath}?env=${env}` : projectPath
 
-  res.statusCode = 301
-  res.setHeader('Location', redirect)
-  res.end()
-
-  return ({ props })
+  return ({
+    redirect: {
+      destination,
+      permanent: true
+    }
+  })
 }

--- a/packages/app-project/pages/projects/[owner]/[project]/about/research.js
+++ b/packages/app-project/pages/projects/[owner]/[project]/about/research.js
@@ -2,9 +2,10 @@ import getDefaultPageProps from '@helpers/getDefaultPageProps'
 export { default } from '@screens/ProjectAboutPage'
 
 export async function getServerSideProps({ params, query, req, res }) {
-  const { props } = await getDefaultPageProps({ params, query, req, res })
+  const { notFound, props } = await getDefaultPageProps({ params, query, req, res })
 
   return {
+    notFound,
     props: {
       ...props,
       pageType: 'science_case'

--- a/packages/app-project/pages/projects/[owner]/[project]/about/results.js
+++ b/packages/app-project/pages/projects/[owner]/[project]/about/results.js
@@ -2,9 +2,10 @@ import getDefaultPageProps from "@helpers/getDefaultPageProps"
 export { default } from "@screens/ProjectAboutPage"
 
 export async function getServerSideProps({ params, query, req, res }) {
-  const { props } = await getDefaultPageProps({ params, query, req, res })
+  const { notFound, props } = await getDefaultPageProps({ params, query, req, res })
 
   return {
+    notFound,
     props: {
       ...props,
       pageType: "results"

--- a/packages/app-project/pages/projects/[owner]/[project]/about/team.js
+++ b/packages/app-project/pages/projects/[owner]/[project]/about/team.js
@@ -3,7 +3,7 @@ import { panoptes } from '@zooniverse/panoptes-js'
 export { default } from '@screens/ProjectAboutPage'
 
 export async function getServerSideProps({ params, query, req, res }) {
-  const { props } = await getDefaultPageProps({ params, query, req, res })
+  const { notFound, props } = await getDefaultPageProps({ params, query, req, res })
   const { project } = props.initialState
 
   const fetchTeam = async () => {
@@ -49,6 +49,7 @@ export async function getServerSideProps({ params, query, req, res }) {
   const teamArray = await fetchTeam()
 
   return {
+    notFound,
     props: {
       pageType: 'team',
       ...props,

--- a/packages/app-project/pages/projects/[owner]/[project]/classify/index.js
+++ b/packages/app-project/pages/projects/[owner]/[project]/classify/index.js
@@ -2,15 +2,18 @@ import getDefaultPageProps from '@helpers/getDefaultPageProps'
 export { default } from '@screens/ClassifyPage'
 
 export async function getServerSideProps({ params, query, req, res }) {
-  const { props } = await getDefaultPageProps({ params, query, req, res })
+  const { notFound, props } = await getDefaultPageProps({ params, query, req, res })
   if (props.workflowID) {
     const { env } = query
     const { project } = props.initialState
     const workflowPath = `/projects/${project?.slug}/classify/workflow/${props.workflowID}`
-    const redirect = env ? `${workflowPath}?env=${env}` : workflowPath
-    res.statusCode = 301
-    res.setHeader('Location', redirect)
-    res.end()
+    const destination = env ? `${workflowPath}?env=${env}` : workflowPath
+    return ({
+      redirect: {
+        destination,
+        permanent: true
+      }
+    })
   }
-  return ({ props })
+  return ({ notFound, props })
 }

--- a/packages/app-project/pages/projects/[owner]/[project]/classify/workflow/[workflowID]/index.js
+++ b/packages/app-project/pages/projects/[owner]/[project]/classify/workflow/[workflowID]/index.js
@@ -2,23 +2,10 @@ import getDefaultPageProps from '@helpers/getDefaultPageProps'
 export { default } from '@screens/ClassifyPage'
 
 export async function getServerSideProps({ params, query, req, res }) {
-  const { props: defaultProps } = await getDefaultPageProps({ params, query, req, res })
-  /*
-    Redirect to the active workflow when a project has a single workflow
-  */
-  if (defaultProps.workflowID && (params.workflowID !== defaultProps.workflowID)) {
-    const { env } = query
-    const { project } = defaultProps.initialState
-    const redirect = env ?
-      `/projects/${project?.slug}/classify/workflow/${defaultProps.workflowID}?env=${env}` :
-      `/projects/${project?.slug}/classify/workflow/${defaultProps.workflowID}`
-    res.statusCode = 301
-    res.setHeader('Location', redirect)
-    res.end()
-  }
+  const { notFound, props: defaultProps } = await getDefaultPageProps({ params, query, req, res })
   const props = {
     ...defaultProps,
     workflowID : params.workflowID
   }
-  return ({ props })
+  return ({ notFound, props })
 }

--- a/packages/app-project/pages/projects/[owner]/[project]/classify/workflow/[workflowID]/subject-set/[subjectSetID]/index.js
+++ b/packages/app-project/pages/projects/[owner]/[project]/classify/workflow/[workflowID]/subject-set/[subjectSetID]/index.js
@@ -2,8 +2,8 @@ import getDefaultPageProps from '@helpers/getDefaultPageProps'
 export { default } from '@screens/ClassifyPage'
 
 export async function getServerSideProps({ params, query, req, res }) {
-  const { props: defaultProps } = await getDefaultPageProps({ params, query, req, res })
+  const { notFound, props: defaultProps } = await getDefaultPageProps({ params, query, req, res })
   const { subjectSetID, workflowID } = params
   const props = { ...defaultProps, subjectSetID, workflowID }
-  return ({ props })
+  return ({ notFound, props })
 }

--- a/packages/app-project/pages/projects/[owner]/[project]/classify/workflow/[workflowID]/subject-set/[subjectSetID]/subject/[subjectID]/index.js
+++ b/packages/app-project/pages/projects/[owner]/[project]/classify/workflow/[workflowID]/subject-set/[subjectSetID]/subject/[subjectID]/index.js
@@ -2,8 +2,8 @@ import getDefaultPageProps from '@helpers/getDefaultPageProps'
 export { default } from '@screens/ClassifyPage'
 
 export async function getServerSideProps({ params, query, req, res }) {
-  const { props: defaultProps } = await getDefaultPageProps({ params, query, req, res })
+  const { notFound, props: defaultProps } = await getDefaultPageProps({ params, query, req, res })
   const { subjectID, subjectSetID, workflowID } = params
   const props = { ...defaultProps, subjectID, subjectSetID, workflowID }
-  return ({ props })
+  return ({ notFound, props })
 }

--- a/packages/app-project/pages/projects/[owner]/[project]/classify/workflow/[workflowID]/subject/[subjectID]/index.js
+++ b/packages/app-project/pages/projects/[owner]/[project]/classify/workflow/[workflowID]/subject/[subjectID]/index.js
@@ -2,8 +2,8 @@ import getDefaultPageProps from '@helpers/getDefaultPageProps'
 export { default } from '@screens/ClassifyPage'
 
 export async function getServerSideProps({ params, query, req, res }) {
-  const { props: defaultProps } = await getDefaultPageProps({ params, query, req, res })
+  const { notFound, props: defaultProps } = await getDefaultPageProps({ params, query, req, res })
   const { subjectID, workflowID } = params
   const props = { ...defaultProps, subjectID, workflowID }
-  return ({ props })
+  return ({ notFound, props })
 }

--- a/packages/app-project/pages/projects/[owner]/[project]/index.js
+++ b/packages/app-project/pages/projects/[owner]/[project]/index.js
@@ -2,7 +2,7 @@ import getDefaultPageProps from '@helpers/getDefaultPageProps'
 export { default } from '@screens/ProjectHomePage'
 
 export async function getServerSideProps({ params, query, req, res }) {
-  const { props } = await getDefaultPageProps({ params, query, req, res })
-  return ({ props })
+  const { notFound, props } = await getDefaultPageProps({ params, query, req, res })
+  return ({ notFound, props })
 }
 

--- a/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.js
+++ b/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.js
@@ -1,23 +1,14 @@
 import getCookie from '@helpers/getCookie'
 import getStaticPageProps from '@helpers/getStaticPageProps'
 
-export default async function getDefaultPageProps({ params, query, req, res }) {
+export default async function getDefaultPageProps({ params, query, req }) {
 
   // cookie is in the next.js context req object
   const mode = getCookie(req, 'mode') || null
   const dismissedAnnouncementBanner = getCookie(req, 'dismissedAnnouncementBanner') || null
 
   const { props: staticProps } = await getStaticPageProps({ params, query })
-  const { project, statusCode, title, workflowID, workflows } = staticProps
-  if (statusCode) {
-    res.statusCode = statusCode
-    return {
-      props: {
-        statusCode,
-        title
-      }
-    }
-  }
+  const { project, notFound, title, workflowID, workflows } = staticProps
   const { headers, connection } = req
   const host = generateHostUrl(headers, connection)
   /*
@@ -35,6 +26,7 @@ export default async function getDefaultPageProps({ params, query, req, res }) {
     host,
     initialState,
     query,
+    title,
     workflows
   }
 
@@ -42,7 +34,7 @@ export default async function getDefaultPageProps({ params, query, req, res }) {
     props.workflowID = workflowID
   }
 
-  return { props }
+  return { notFound, props }
 }
 
 function generateHostUrl(headers, connection) {

--- a/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.js
+++ b/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.js
@@ -26,8 +26,11 @@ export default async function getDefaultPageProps({ params, query, req }) {
     host,
     initialState,
     query,
-    title,
     workflows
+  }
+
+  if (title) {
+    props.title = title
   }
 
   if (workflowID) {

--- a/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.spec.js
+++ b/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.spec.js
@@ -2,7 +2,7 @@ import nock from 'nock'
 
 import getDefaultPageProps from './'
 
-describe('Components > ProjectHomePage > getDefaultPageProps', function () {
+describe('Helpers > getDefaultPageProps', function () {
   const PROJECT = {
     id: '1',
     default_workflow: '1',
@@ -202,8 +202,7 @@ describe('Components > ProjectHomePage > getDefaultPageProps', function () {
     })
 
     describe('with an invalid project slug', function () {
-      let props
-      let res = {}
+      let response
 
       before(async function () {
         const params = {
@@ -221,20 +220,15 @@ describe('Components > ProjectHomePage > getDefaultPageProps', function () {
             host: 'www.zooniverse.org'
           }
         }
-        const response = await getDefaultPageProps({ params, query, req, res })
-        props = response.props
+        response = await getDefaultPageProps({ params, query, req })
       })
 
-      it('should return a 404 response', function () {
-        expect(res.statusCode).to.equal(404)
-      })
-
-      it('should pass the status code to the error page', function () {
-        expect(props.statusCode).to.equal(404)
+      it('should return notFound', function () {
+        expect(response.notFound).to.be.true()
       })
 
       it('should pass an error message to the error page', function () {
-        expect(props.title).to.equal('Project test-owner/test-wrong-project was not found')
+        expect(response.props.title).to.equal('Project test-owner/test-wrong-project was not found')
       })
     })
 
@@ -256,8 +250,7 @@ describe('Components > ProjectHomePage > getDefaultPageProps', function () {
             host: 'www.zooniverse.org'
           }
         }
-        const res = {}
-        const { props } = await getDefaultPageProps({ params, query, req, res })
+        const { props } = await getDefaultPageProps({ params, query, req })
         expect(props.workflows).to.deep.equal([
           {
             completeness: 0.4,
@@ -276,8 +269,7 @@ describe('Components > ProjectHomePage > getDefaultPageProps', function () {
     })
 
     describe('with an invalid workflow ID', function () {
-      let props
-      let res = {}
+      let response
 
       before(async function () {
         const params = {
@@ -296,20 +288,15 @@ describe('Components > ProjectHomePage > getDefaultPageProps', function () {
             host: 'www.zooniverse.org'
           }
         }
-        const response = await getDefaultPageProps({ params, query, req, res })
-        props = response.props
+        response = await getDefaultPageProps({ params, query, req })
       })
 
-      it('should return a 404 response', function () {
-        expect(res.statusCode).to.equal(404)
-      })
-
-      it('should pass the status code to the error page', function () {
-        expect(props.statusCode).to.equal(404)
+      it('should return notFound', function () {
+        expect(response.notFound).to.be.true()
       })
 
       it('should pass an error message to the error page', function () {
-        expect(props.title).to.equal('Workflow 3 was not found')
+        expect(response.props.title).to.equal('Workflow 3 was not found')
       })
     })
   })
@@ -340,8 +327,7 @@ describe('Components > ProjectHomePage > getDefaultPageProps', function () {
             host: 'www.zooniverse.org'
           }
         }
-        const res = {}
-        const { props } = await getDefaultPageProps({ params, query, req, res })
+        const { props } = await getDefaultPageProps({ params, query, req })
         expect(props.workflows).to.deep.equal([
           {
             completeness: 0.4,
@@ -356,8 +342,7 @@ describe('Components > ProjectHomePage > getDefaultPageProps', function () {
     })
 
     describe('with an invalid project slug', function () {
-      let props
-      let res = {}
+      let response
 
       before(async function () {
         const params = {
@@ -375,20 +360,15 @@ describe('Components > ProjectHomePage > getDefaultPageProps', function () {
             host: 'www.zooniverse.org'
           }
         }
-        const response = await getDefaultPageProps({ params, query, req, res })
-        props = response.props
+        response = await getDefaultPageProps({ params, query, req })
       })
 
-      it('should return a 404 response', function () {
-        expect(res.statusCode).to.equal(404)
-      })
-
-      it('should pass the status code to the error page', function () {
-        expect(props.statusCode).to.equal(404)
+      it('should return notFound', function () {
+        expect(response.notFound).to.be.true()
       })
 
       it('should pass an error message to the error page', function () {
-        expect(props.title).to.equal('Project test-owner/test-wrong-project was not found')
+        expect(response.props.title).to.equal('Project test-owner/test-wrong-project was not found')
       })
     })
 
@@ -410,8 +390,7 @@ describe('Components > ProjectHomePage > getDefaultPageProps', function () {
             host: 'www.zooniverse.org'
           }
         }
-        const res = {}
-        const { props } = await getDefaultPageProps({ params, query, req, res })
+        const { props } = await getDefaultPageProps({ params, query, req })
         expect(props.workflows).to.deep.equal([
           {
             completeness: 0.4,
@@ -430,8 +409,7 @@ describe('Components > ProjectHomePage > getDefaultPageProps', function () {
     })
 
     describe('with an invalid workflow ID', function () {
-      let props
-      let res = {}
+      let response
 
       before(async function () {
         const params = {
@@ -450,20 +428,15 @@ describe('Components > ProjectHomePage > getDefaultPageProps', function () {
             host: 'www.zooniverse.org'
           }
         }
-        const response = await getDefaultPageProps({ params, query, req, res })
-        props = response.props
+        response = await getDefaultPageProps({ params, query, req })
       })
 
-      it('should return a 404 response', function () {
-        expect(res.statusCode).to.equal(404)
-      })
-
-      it('should pass the status code to the error page', function () {
-        expect(props.statusCode).to.equal(404)
+      it('should return notFound', function () {
+        expect(response.notFound).to.be.true()
       })
 
       it('should pass an error message to the error page', function () {
-        expect(props.title).to.equal('Workflow 3 was not found')
+        expect(response.props.title).to.equal('Workflow 3 was not found')
       })
     })
   })

--- a/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.spec.js
+++ b/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.spec.js
@@ -208,8 +208,8 @@ describe('Helpers > getStaticPageProps', function () {
         props = response.props
       })
 
-      it('should return a 404 status code', function () {
-        expect(props.statusCode).to.equal(404)
+      it('should return notFound', function () {
+        expect(props.notFound).to.be.true()
       })
 
       it('should return a project error message', function () {
@@ -270,8 +270,8 @@ describe('Helpers > getStaticPageProps', function () {
         props = response.props
       })
 
-      it('should return a 404 status code', function () {
-        expect(props.statusCode).to.equal(404)
+      it('should return notFound', function () {
+        expect(props.notFound).to.be.true()
       })
 
       it('should return a workflow error message', function () {
@@ -335,8 +335,8 @@ describe('Helpers > getStaticPageProps', function () {
         props = response.props
       })
 
-      it('should return a 404 status code', function () {
-        expect(props.statusCode).to.equal(404)
+      it('should return notFound', function () {
+        expect(props.notFound).to.be.true()
       })
 
       it('should return a project error message', function () {
@@ -397,8 +397,8 @@ describe('Helpers > getStaticPageProps', function () {
         props = response.props
       })
 
-      it('should return a 404 status code', function () {
-        expect(props.statusCode).to.equal(404)
+      it('should return notFound', function () {
+        expect(props.notFound).to.be.true()
       })
 
       it('should return a workflow error message', function () {

--- a/packages/app-project/src/helpers/notFoundError/notFoundError.js
+++ b/packages/app-project/src/helpers/notFoundError/notFoundError.js
@@ -1,7 +1,7 @@
 export default function notFoundError(title) {
   return {
     props: {
-      statusCode: 404,
+      notFound: true,
       title
     }
   }

--- a/packages/app-project/src/helpers/notFoundError/notFoundError.spec.js
+++ b/packages/app-project/src/helpers/notFoundError/notFoundError.spec.js
@@ -11,8 +11,8 @@ const ERROR = 'That page does not exist'
       props = response.props
     })
 
-    it('should set a 404 status code', function () {
-      expect(props.statusCode).to.equal(404)
+    it('should set notFound', function () {
+      expect(props.notFound).to.be.true()
     })
 
     it('should set a title for the error page', function () {
@@ -28,8 +28,8 @@ const ERROR = 'That page does not exist'
       props = response.props
     })
 
-    it('should set a 404 status code', function () {
-      expect(props.statusCode).to.equal(404)
+    it('should set notFound', function () {
+      expect(props.notFound).to.be.true()
     })
 
     it('should not set a title for the error page', function () {


### PR DESCRIPTION
Next 10 added `notFound` and `redirect` to the object returned by `getStaticProps` and `getServerSideProps`. This PR adds `notFound` to the `notFoundError` helper, and to the page props helpers. `redirect` is added to routes that previously modified the response to redirect.

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
