### PR TITLE
Add modal for workflow assignment

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/WorkflowAssignmentModal/WorkflowAssignmentModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/WorkflowAssignmentModal/WorkflowAssignmentModal.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button, Box } from 'grommet'
+import { Modal, PrimaryButton } from '@zooniverse/react-components'
+import en from './locales/en'
+import counterpart from 'counterpart'
+
+counterpart.registerTranslations('en', en)
+
+export default function WorkflowAssignmentModal({ active = false }) {
+  return (
+    <Modal active={active} closeFn={() => {}}>
+      <Box pad={{ bottom: 'xsmall' }}>{counterpart('WorkflowAssignmentModal.content')}</Box>
+      <Box direction='row' gap='xsmall' justify='center'>
+        <Button label={counterpart('WorkflowAssignmentModal.cancel')} />
+        <PrimaryButton label={counterpart('WorkflowAssignmentModal.confirm')} />
+      </Box>
+    </Modal>
+  )
+}
+
+WorkflowAssignmentModal.propTypes = {
+  active: PropTypes.bool
+}

--- a/packages/lib-classifier/src/components/Classifier/components/WorkflowAssignmentModal/WorkflowAssignmentModal.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/WorkflowAssignmentModal/WorkflowAssignmentModal.spec.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { Modal, PrimaryButton } from '@zooniverse/react-components'
+import { Button } from 'grommet'
+import WorkflowAssignmentModal from './WorkflowAssignmentModal'
+import en from './locales/en'
+
+describe('Component > WorkflowAssignmentModal', function () {
+  let wrapper
+  before(function() {
+    wrapper = shallow(<WorkflowAssignmentModal />)
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok()
+  })
+
+  it('should render a Modal', function () {
+    expect(wrapper.find(Modal)).to.have.lengthOf(1)
+  })
+
+  it('should render rendering messaging', function () {
+    expect(wrapper.contains(en.WorkflowAssignmentModal.content)).to.be.true()
+  })
+
+  it('should render a confirmation button', function () {
+    const button = wrapper.find(PrimaryButton)
+    expect(button.props().label).to.equal(en.WorkflowAssignmentModal.confirm)
+  })
+
+  it('should render a cancel button', function () {
+    const button = wrapper.find(Button)
+    expect(button.props().label).to.equal(en.WorkflowAssignmentModal.cancel)
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/WorkflowAssignmentModal/WorkflowAssignmentModal.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/WorkflowAssignmentModal/WorkflowAssignmentModal.stories.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import WorkflowAssignmentModal from './WorkflowAssignmentModal'
+import zooTheme from '@zooniverse/grommet-theme'
+import { Grommet } from 'grommet'
+
+export default {
+  title: 'Workflow Assignment / Assignment Modal',
+  component: WorkflowAssignmentModal,
+  args: {
+    active: true,
+    dark: false
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'responsive'
+    }
+  }
+}
+
+export function Default({ dark, active }) {
+  return (
+    <Grommet
+      background={{
+        dark: 'dark-1',
+        light: 'light-1'
+      }}
+      theme={zooTheme}
+      themeMode={(dark) ? 'dark' : 'light'}
+    >
+      <WorkflowAssignmentModal active={active} />
+    </Grommet>
+  )
+}

--- a/packages/lib-classifier/src/components/Classifier/components/WorkflowAssignmentModal/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/WorkflowAssignmentModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './WorkflowAssignmentModal'

--- a/packages/lib-classifier/src/components/Classifier/components/WorkflowAssignmentModal/locales/en.json
+++ b/packages/lib-classifier/src/components/Classifier/components/WorkflowAssignmentModal/locales/en.json
@@ -1,0 +1,8 @@
+{
+  "WorkflowAssignmentModal": {
+    "cancel": "No, thanks",
+    "confirm": "Take me to the next workflow!",
+    "content":  "Congratulations! Because you're doing so well, you can now access another workflow. If you prefer to stay with the current workflow, you can choose to stay.",
+    "sessionOptOut": "Don't show this again this session"
+  }
+}


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team. If PR is related to design, please request review from `@beckyrother` in addition._ 

Package: lib-classifier

Toward #2143

Describe your changes:
Implements just the modal UI for workflow assignment. There's no functionality implemented to view this in context of the classifier. However, there is a story: http://localhost:6006/?path=/story/workflow-assignment-assignment-modal--default

Run `yarn storybook` in the lib-classifier folder to have a look.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
