### PR TITLE
Engaging Crowds: enable indexed subject selection

### DIFF
--- a/packages/lib-classifier/src/store/SubjectSet/SubjectSet.js
+++ b/packages/lib-classifier/src/store/SubjectSet/SubjectSet.js
@@ -5,7 +5,13 @@ const SubjectSet = types
   .model('SubjectSet', {
     display_name: types.string,
     links: types.frozen({}),
+    metadata: types.frozen({}),
     set_member_subjects_count: types.number
   })
+  .views(self => ({
+    get isIndexed () {
+      return self.metadata.indexFields?.length > 0
+    }
+  }))
 
 export default types.compose('SubjectSetResource', Resource, SubjectSet)

--- a/packages/lib-classifier/src/store/SubjectSet/SubjectSet.spec.js
+++ b/packages/lib-classifier/src/store/SubjectSet/SubjectSet.spec.js
@@ -23,4 +23,61 @@ describe('Model > SubjectSet', function () {
   it('should have a subject count', function () {
     expect(model.set_member_subjects_count).to.equal(19)
   })
+
+  describe('isIndexed', function () {
+    let isIndexed
+
+    describe('without metadata', function () {
+      before(function () {
+        const metadataModel = SubjectSet.create({
+          id: '1234',
+          display_name: 'Hello there!',
+          set_member_subjects_count: 19
+        })
+        isIndexed = metadataModel.isIndexed
+      })
+
+      it('should be false', function () {
+        expect(isIndexed).to.be.false()
+      })
+    })
+
+    describe('with metadata', function () {
+      describe('but no indexed fields', function () {
+        before(function () {
+          const metadataModel = SubjectSet.create({
+            id: '1234',
+            display_name: 'Hello there!',
+            metadata: {
+              indexFields: ''
+            },
+            set_member_subjects_count: 19
+          })
+          isIndexed = metadataModel.isIndexed
+        })
+
+        it('should be false', function () {
+          expect(isIndexed).to.be.false()
+        })
+      })
+
+      describe('and indexed fields', function () {
+        before(function () {
+          const metadataModel = SubjectSet.create({
+            id: '1234',
+            display_name: 'Hello there!',
+            metadata: {
+              indexFields: 'Date,Creator'
+            },
+            set_member_subjects_count: 19
+          })
+          isIndexed = metadataModel.isIndexed
+        })
+
+        it('should be true', function () {
+          expect(isIndexed).to.be.true()
+        })
+      })
+    })
+  })
 })

--- a/packages/lib-classifier/src/store/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore.js
@@ -2,6 +2,7 @@ import asyncStates from '@zooniverse/async-states'
 import { autorun } from 'mobx'
 import { addDisposer, addMiddleware, flow, getRoot, isValidReference, onPatch, tryReference, types } from 'mobx-state-tree'
 import { getBearerToken } from './utils'
+import { getIndexedSubjects } from './helpers'
 import { filterByLabel, filters } from '../components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal'
 import ResourceStore from './ResourceStore'
 import Subject from './Subject'
@@ -56,6 +57,17 @@ const SubjectStore = types
       }
 
       return false
+    },
+
+    /** a helper to get the last subject in the queue */
+    get last () {
+      let lastSubject
+
+      if ( self.resources.size > 0 ) {
+        const activeSubjects = Array.from(self.resources.values())
+        lastSubject = activeSubjects[self.resources.size - 1]
+      }
+      return lastSubject
     }
   }))
 
@@ -157,10 +169,6 @@ const SubjectStore = types
       if (workflow) {
         self.loadingState = asyncStates.loading
         const params = { workflow_id: workflow.id }
-
-        if (workflow.grouped) {
-          params.subject_set_id = workflow.subjectSetId
-        }
         
         if (workflow.configuration.subject_viewer === 'subjectGroup') {
           apiUrl = '/subjects/grouped'
@@ -168,11 +176,21 @@ const SubjectStore = types
           params.num_columns = workflow.configuration.subject_viewer_config?.grid_columns || 1
         }
 
+        if (workflow.hasIndexedSubjects && !subjectIDs) {
+          const priority = self.last ? self.last.priority : -1
+          subjectIDs = yield getIndexedSubjects(workflow, priority)
+        }
+
         if (subjectIDs) {
           apiUrl = '/subjects/selection'
           params.ids = subjectIDs
         }
 
+        if (workflow.grouped && !params.ids) {
+          params.subject_set_id = workflow.subjectSetId
+        }
+
+        console.log({ apiUrl, params })
         try {
           const { authClient } = getRoot(self)
           const authorization = yield getBearerToken(authClient)

--- a/packages/lib-classifier/src/store/Workflow/Workflow.js
+++ b/packages/lib-classifier/src/store/Workflow/Workflow.js
@@ -44,6 +44,11 @@ const Workflow = types
     selectedSubjects: undefined
   }))
   .views(self => ({
+    get hasIndexedSubjects () {
+      const activeSet = tryReference(() => self.subjectSet)
+      return self.grouped && !!activeSet?.isIndexed
+    },
+
     get subjectSetId () {
       const activeSet = tryReference(() => self.subjectSet)
       return activeSet?.id

--- a/packages/lib-classifier/src/store/helpers/getIndexedSubjects/getIndexedSubjects.js
+++ b/packages/lib-classifier/src/store/helpers/getIndexedSubjects/getIndexedSubjects.js
@@ -1,5 +1,4 @@
-export default async function getIndexedSubjects(workflow, priority = -1) {
-  const { subjectSetId } = workflow
+export default async function getIndexedSubjects(subjectSetId, priority = -1) {
   const subjectSetURL = `https://subject-set-search-api.zooniverse.org/subjects/${subjectSetId}.json`
   const query = `priority__gt=${priority}&_sort=priority`
   const mode = 'cors'

--- a/packages/lib-classifier/src/store/helpers/getIndexedSubjects/getIndexedSubjects.js
+++ b/packages/lib-classifier/src/store/helpers/getIndexedSubjects/getIndexedSubjects.js
@@ -1,0 +1,11 @@
+export default async function getIndexedSubjects(workflow, priority = -1) {
+  const { subjectSetId } = workflow
+  const subjectSetURL = `https://subject-set-search-api.zooniverse.org/subjects/${subjectSetId}.json`
+  const query = `priority__gt=${priority}&_sort=priority`
+  const mode = 'cors'
+  const response = await fetch(`${subjectSetURL}?${query}`, { mode })
+  const { columns, rows } = await response.json()
+  const subjectIDColumn = columns.indexOf('subject_id')
+  const subjectIds = rows.map(row => row[subjectIDColumn]).slice(0,10)
+  return subjectIds.join(',')
+}

--- a/packages/lib-classifier/src/store/helpers/getIndexedSubjects/getIndexedSubjects.spec.js
+++ b/packages/lib-classifier/src/store/helpers/getIndexedSubjects/getIndexedSubjects.spec.js
@@ -1,0 +1,50 @@
+import nock from 'nock'
+
+import getIndexedSubjects from './getIndexedSubjects'
+
+describe('Store > Helpers > getIndexedSubjects', function () {
+  let subjectIDs
+
+  before(async function () {
+    nock('https://subject-set-search-api.zooniverse.org')
+    .get('/subjects/2.json')
+    .query(query => query.priority__gt === '-1')
+    .reply(200, {
+      columns: ['subject_id', 'priority'],
+      rows: [
+        ['12345', '1'],
+        ['34567', '2'],
+        ['56789', '3']
+      ]
+    })
+    .get('/subjects/2.json')
+    .query(query => query.priority__gt === '1')
+    .reply(200, {
+      columns: ['subject_id', 'priority'],
+      rows: [
+        ['34567', '2'],
+        ['56789', '3']
+      ]
+    })
+  })
+
+  describe('with a subject priority', function () {
+    before(async function () {
+      subjectIDs = await getIndexedSubjects('2', 1)
+    })
+
+    it('should return the next subjects from the set', function () {
+      expect(subjectIDs).to.equal('34567,56789')
+    })
+  })
+
+  describe('without a subject priority', function () {
+    before(async function () {
+      subjectIDs = await getIndexedSubjects('2')
+    })
+
+    it('should return the first subjects from the set', function () {
+      expect(subjectIDs).to.equal('12345,34567,56789')
+    })
+  })
+})

--- a/packages/lib-classifier/src/store/helpers/getIndexedSubjects/index.js
+++ b/packages/lib-classifier/src/store/helpers/getIndexedSubjects/index.js
@@ -1,0 +1,1 @@
+export { default } from './getIndexedSubjects'

--- a/packages/lib-classifier/src/store/helpers/index.js
+++ b/packages/lib-classifier/src/store/helpers/index.js
@@ -1,2 +1,3 @@
 export { default as convertWorkflowToUseSteps } from './convertWorkflowToUseSteps'
 export { default as createStore } from './createStore'
+export { default as getIndexedSubjects } from './getIndexedSubjects'

--- a/packages/lib-classifier/src/store/helpers/index.js
+++ b/packages/lib-classifier/src/store/helpers/index.js
@@ -1,3 +1,4 @@
 export { default as convertWorkflowToUseSteps } from './convertWorkflowToUseSteps'
 export { default as createStore } from './createStore'
 export { default as getIndexedSubjects } from './getIndexedSubjects'
+export { default as subjectSelectionStrategy } from './subjectSelectionStrategy'

--- a/packages/lib-classifier/src/store/helpers/subjectSelectionStrategy/index.js
+++ b/packages/lib-classifier/src/store/helpers/subjectSelectionStrategy/index.js
@@ -1,0 +1,1 @@
+export { default } from './subjectSelectionStrategy'

--- a/packages/lib-classifier/src/store/helpers/subjectSelectionStrategy/subjectSelectionStrategy.js
+++ b/packages/lib-classifier/src/store/helpers/subjectSelectionStrategy/subjectSelectionStrategy.js
@@ -1,0 +1,73 @@
+import { getIndexedSubjects } from '@store/helpers'
+
+export default async function subjectSelectionStrategy(workflow, subjectIDs, priority = -1) {
+  const workflow_id = workflow.id
+
+  /** Fetch specific subjects for any workflow */
+  if (subjectIDs) {
+    const apiUrl = '/subjects/selection'
+    const ids = subjectIDs.join(',')
+    const params = {
+      ids,
+      workflow_id
+    }
+    return {
+      apiUrl,
+      params
+    }
+  }
+
+  /** Fetch subject groups for workflows that use the subject group viewer */
+  if (workflow.configuration.subject_viewer === 'subjectGroup') {
+    const apiUrl = '/subjects/grouped'
+    const num_rows = workflow.configuration.subject_viewer_config?.grid_rows || 1
+    const num_columns = workflow.configuration.subject_viewer_config?.grid_columns || 1
+    const params = {
+      num_columns,
+      num_rows,
+      workflow_id
+    }
+    return {
+      apiUrl,
+      params
+    }
+  }
+
+  /** fetch ordered subjects for indexed subject sets */
+  if (workflow.hasIndexedSubjects) {
+    const apiUrl = '/subjects/selection'
+    const ids = await getIndexedSubjects(workflow.subjectSetId, priority)
+    const params = {
+      ids,
+      workflow_id
+    }
+    return {
+      apiUrl,
+      params
+    }
+  }
+
+  /** Random grouped selection for grouped workflows */
+  if (workflow.grouped) {
+    const apiUrl = '/subjects/queued'
+    const subject_set_id = workflow.subjectSetId
+    const params = {
+      subject_set_id,
+      workflow_id
+    }
+    return {
+      apiUrl,
+      params
+    }
+  }
+
+  /** default random queued selection */
+  const apiUrl = '/subjects/queued'
+  const params = {
+    workflow_id
+  }
+  return {
+    apiUrl,
+    params
+  }
+}

--- a/packages/lib-classifier/src/store/helpers/subjectSelectionStrategy/subjectSelectionStrategy.js
+++ b/packages/lib-classifier/src/store/helpers/subjectSelectionStrategy/subjectSelectionStrategy.js
@@ -36,7 +36,10 @@ export default async function subjectSelectionStrategy(workflow, subjectIDs, pri
   /** fetch ordered subjects for indexed subject sets */
   if (workflow.hasIndexedSubjects) {
     const apiUrl = '/subjects/selection'
-    const ids = await getIndexedSubjects(workflow.subjectSetId, priority)
+    let ids = await getIndexedSubjects(workflow.subjectSetId, priority)
+    if (ids === '') {
+      ids = await getIndexedSubjects(workflow.subjectSetId)
+    }
     const params = {
       ids,
       workflow_id

--- a/packages/lib-classifier/src/store/helpers/subjectSelectionStrategy/subjectSelectionStrategy.spec.js
+++ b/packages/lib-classifier/src/store/helpers/subjectSelectionStrategy/subjectSelectionStrategy.spec.js
@@ -1,0 +1,181 @@
+import nock from 'nock'
+
+import subjectSelectionStrategy from './subjectSelectionStrategy'
+import { WorkflowFactory } from '@test/factories'
+
+describe('Store > Helpers > subjectSelectionStrategy', function () {
+  describe('default random selection', function () {
+    let strategy
+
+    before(async function () {
+      const workflow = WorkflowFactory.build({
+        id: '12345'
+      })
+      strategy = await subjectSelectionStrategy(workflow)
+    })
+
+    it(`should use the /subjects/queued endpoint`, function () {
+      expect(strategy.apiUrl).to.equal('/subjects/queued')
+    })
+
+    it('should only pass the workflow ID as the query', function () {
+      expect(strategy.params).to.deep.equal({
+        workflow_id: '12345'
+      })
+    })
+  })
+
+  describe('grouped random selection', function () {
+    let strategy
+
+    before(async function () {
+      const workflow = WorkflowFactory.build({
+        id: '12345',
+        grouped: true,
+        subjectSetId: '2'
+      })
+      strategy = await subjectSelectionStrategy(workflow)
+    })
+
+    it(`should use the /subjects/queued endpoint`, function () {
+      expect(strategy.apiUrl).to.equal('/subjects/queued')
+    })
+
+    it('should query by workflow and subject set', function () {
+      expect(strategy.params).to.deep.equal({
+        subject_set_id: '2',
+        workflow_id: '12345'
+      })
+    })
+  })
+
+  describe('specific subjects', function () {
+    let strategy
+
+    before(async function () {
+      const workflow = WorkflowFactory.build({
+        id: '12345',
+        grouped: true,
+        subjectSetId: '2'
+      })
+      const subjectIDs = ['3456', '4567', '8910']
+      strategy = await subjectSelectionStrategy(workflow, subjectIDs)
+    })
+
+    it(`should use the /subjects/selection endpoint`, function () {
+      expect(strategy.apiUrl).to.equal('/subjects/selection')
+    })
+
+    it('should query by workflow and subject ID', function () {
+      expect(strategy.params).to.deep.equal({
+        ids: '3456,4567,8910',
+        workflow_id: '12345'
+      })
+    })
+  })
+
+  describe('subject groups', function () {
+    let strategy
+
+    before(async function () {
+      const workflow = WorkflowFactory.build({
+        id: '12345',
+        configuration: {
+          subject_viewer: 'subjectGroup',
+          subject_viewer_config: {
+            grid_rows: 3,
+            grid_columns: 4
+          }
+        }
+      })
+      strategy = await subjectSelectionStrategy(workflow)
+    })
+
+    it(`should use the /subjects/grouped endpoint`, function () {
+      expect(strategy.apiUrl).to.equal('/subjects/grouped')
+    })
+
+    it('should query by workflow and group viewer dimensions', function () {
+      expect(strategy.params).to.deep.equal({
+        num_columns: 4,
+        num_rows: 3,
+        workflow_id: '12345'
+      })
+    })
+  })
+
+  describe('indexed subject selection', function () {
+    let strategy
+
+    before(async function () {
+      nock('https://subject-set-search-api.zooniverse.org')
+      .get('/subjects/2.json')
+      .query(query => query.priority__gt === '-1')
+      .reply(200, {
+        columns: ['subject_id', 'priority'],
+        rows: [
+          ['12345', '1'],
+          ['34567', '2'],
+          ['56789', '3']
+        ]
+      })
+      .get('/subjects/2.json')
+      .query(query => query.priority__gt === '2')
+      .reply(200, {
+        columns: ['subject_id', 'priority'],
+        rows: [
+          ['56789', '3']
+        ]
+      })
+    })
+
+    describe('with a subject priority', function () {
+      before(async function () {
+        const workflow = WorkflowFactory.build({
+          id: '12345',
+          grouped: true,
+          prioritized: true,
+          hasIndexedSubjects: true,
+          subjectSetId: '2'
+        })
+        let subjectIDs
+        strategy = await subjectSelectionStrategy(workflow, subjectIDs, '2')
+      })
+
+      it(`should use the /subjects/selection endpoint`, function () {
+        expect(strategy.apiUrl).to.equal('/subjects/selection')
+      })
+
+      it('should query by workflow and subjects greater than the specified priority', function () {
+        expect(strategy.params).to.deep.equal({
+          ids: '56789',
+          workflow_id: '12345'
+        })
+      })
+    })
+
+    describe('without a subject priority', function () {
+      before(async function () {
+        const workflow = WorkflowFactory.build({
+          id: '12345',
+          grouped: true,
+          prioritized: true,
+          hasIndexedSubjects: true,
+          subjectSetId: '2'
+        })
+        strategy = await subjectSelectionStrategy(workflow)
+      })
+
+      it(`should use the /subjects/selection endpoint`, function () {
+        expect(strategy.apiUrl).to.equal('/subjects/selection')
+      })
+
+      it('should query by workflow and all subjects', function () {
+        expect(strategy.params).to.deep.equal({
+          ids: '12345,34567,56789',
+          workflow_id: '12345'
+        })
+      })
+    })
+  })
+})

--- a/packages/lib-classifier/test/factories/SubjectSetFactory.js
+++ b/packages/lib-classifier/test/factories/SubjectSetFactory.js
@@ -3,5 +3,6 @@ import { Factory } from 'rosie'
 export default Factory.define('subject_set')
   .sequence('id', (id) => { return id.toString() })
   .attr('display_name', 'Hello there!')
+  .attr('metadata', {})
   .attr('set_member_subjects_count', 56)
   .attr('links', {})


### PR DESCRIPTION
Get indexed subject selection working for Engaging Crowds projects. Indexed selection shows you every subject from an indexed set in order. ~~Setting this to draft because I think `subjects.populateQueue()` might still need some refactoring.~~ The logic for subject selection was getting messy, so I've moved the selection strategy into its own helper function. I think that will fix `422: Unprocessable entity` errors, which have been happening when subjects were requested with an invalid query. `subjectSelectionStrategy` should only return valid query parameters for each API endpoint.

Test URLs:
https://localhost:8080/?demo=true&project=12268&workflow=17077&subjectSet=92752&env=production
Load subject set 92752 and classify every subject from the first one(priority 129) to the last.

https://localhost:8080/?demo=true&project=12268&workflow=17077&subjectSet=92752&subject=58047423&env=production
Load subject set 92752 and classify every subject from a specified subject (priority 136) to the last.

In demo mode, you can skip quickly through that set by selecting 'Blank page' for every page.

https://localhost:8080?demo=true
Should continue to load I Fancy Cats with random subject selection.

Package:
lib-classifier

Closes #1876.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
