### PR TITLE
Classifier: check classification and step before rendering Tasks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.js
@@ -16,7 +16,9 @@ function withStores(Component) {
   function TasksConnector(props) {
     const { classifierStore } = useContext(MobXProviderContext)
     const {
-      annotatedSteps,
+      annotatedSteps: {
+        latest
+      },
       classifications: {
         active: classification,
         demoMode
@@ -32,7 +34,13 @@ function withStores(Component) {
         isThereTaskHelp
       }
     } = classifierStore
-    const isComplete = annotatedSteps.latest?.isComplete
+
+    let isComplete
+    // wait for the step and the classification before calculating isComplete from annotations.
+    if (step && classification) {
+      isComplete = step.isComplete(latest.annotations)
+    }
+
     return (
       <Component
         classification={classification}
@@ -73,7 +81,7 @@ class Tasks extends React.Component {
       step
     } = this.props
     const ready = subjectReadyState === asyncStates.success
-    if (classification && step.tasks.length > 0) {
+    if (classification && step) {
       // setting the wrapping box of the task component to a basis of 246px feels hacky,
       // but gets the area to be the same 453px height (or very close) as the subject area
       // and keeps the task nav buttons at the the bottom area
@@ -126,7 +134,8 @@ Tasks.defaultProps = {
   isComplete: false,
   isThereTaskHelp: false,
   loadingState: asyncStates.initialized,
-  ready: false
+  ready: false,
+  step: undefined
 }
 
 export default withStores(Tasks)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
@@ -83,8 +83,13 @@ describe('Tasks', function () {
             />
           )
         })
+
         it('should render without crashing', function () {
           expect(wrapper).to.be.ok()
+        })
+
+        it('should render null', function () {
+          expect(wrapper.type()).to.be.null()
         })
       })
 
@@ -100,8 +105,13 @@ describe('Tasks', function () {
             />
           )
         })
+
         it('should render without crashing', function () {
           expect(wrapper).to.be.ok()
+        })
+
+        it('should render null', function () {
+          expect(wrapper.type()).to.be.null()
         })
       })
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
@@ -71,6 +71,40 @@ describe('Tasks', function () {
         expect(wrapper.type()).to.be.null()
       })
 
+      describe('without an active step', function () {
+        let wrapper
+
+        before(function () {
+          wrapper = shallow(
+            <Tasks
+              loadingState={asyncStates.success}
+              ready
+              classification={classification}
+            />
+          )
+        })
+        it('should render without crashing', function () {
+          expect(wrapper).to.be.ok()
+        })
+      })
+
+      describe('without an active classification', function () {
+        let wrapper
+
+        before(function () {
+          wrapper = shallow(
+            <Tasks
+              loadingState={asyncStates.success}
+              ready
+              step={step}
+            />
+          )
+        })
+        it('should render without crashing', function () {
+          expect(wrapper).to.be.ok()
+        })
+      })
+
       it('should render a task component if the workflow is loaded', function () {
         const wrapper = shallow(
           <Tasks


### PR DESCRIPTION
Package:
lib-classifier

Closes #2154.

The `Tasks` component will crash the classifier if it renders while `workflowSteps.active` or `classifications.active` are undefined. That condition can be triggered by changing the active workflow while the classifier is mounted (#2154.)

This PR fixes that bug by checking for `classification` and `step` before calculating the `isComplete` prop. ~~It also adds a default value for the `step` prop, so that `step.tasks` doesn't crash the classifier.~~ The `Tasks` component also waits until `classification` and `step` are defined, before rendering.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
