### PR TITLE
Classifier: catch git errors during builds

### DIFF
--- a/packages/lib-classifier/webpack.dev.js
+++ b/packages/lib-classifier/webpack.dev.js
@@ -4,8 +4,13 @@ const path = require('path')
 const webpack = require('webpack')
 
 function gitCommit() {
-  const commitHash = execSync('git describe --always').toString('utf8').trim()
-  return commitHash
+  try {
+    const commitHash = execSync('git describe --always').toString('utf8').trim()
+    return commitHash
+  } catch (error) {
+    console.log(error)
+    return 'Not a git repository.'
+  }
 }
 
 const EnvironmentWebpackPlugin = new webpack.EnvironmentPlugin({

--- a/packages/lib-classifier/webpack.dist.js
+++ b/packages/lib-classifier/webpack.dist.js
@@ -3,8 +3,13 @@ const path = require('path')
 const webpack = require('webpack')
 
 function gitCommit() {
-  const commitHash = execSync('git describe --always').toString('utf8').trim()
-  return commitHash
+  try {
+    const commitHash = execSync('git describe --always').toString('utf8').trim()
+    return commitHash
+  } catch (error) {
+    console.log(error)
+    return 'Not a git repository.'
+  }
 }
 
 const EnvironmentWebpackPlugin = new webpack.EnvironmentPlugin({


### PR DESCRIPTION
`gitCommit()` fails on production Docker builds because `.git` is excluded from the Docker image now. This PR wraps gitCommit() in try/catch. The Jenkins build should pick up the commit ID from the build environment, with `gitCommit()` setting a default value.

Here's an example of a broken build:
https://jenkins.zooniverse.org/job/Zooniverse%20GitHub/job/front-end-monorepo/job/master/1114/console

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
