### PR TITLE
Engaging Crowds: Add URL workflow and subject set to WorkflowMenu

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -43,6 +43,15 @@ function ClassifyPage ({
   // indexed subject sets require a subject
   canClassify = subjectSetFromUrl?.isIndexed ? !!subjectID : canClassify 
 
+  let classifierProps = {}
+  if (canClassify) {
+    classifierProps = {
+      workflowID,
+      subjectSetID,
+      subjectID
+    }
+  }
+
   return (
     <StandardLayout>
 
@@ -64,9 +73,7 @@ function ClassifyPage ({
             <ProjectName />
             <ClassifierWrapper
               onAddToCollection={addToCollection}
-              subjectID={subjectID}
-              subjectSetID={subjectSetID}
-              workflowID={workflowID}
+              {...classifierProps}
             />
             <ThemeModeToggle />
           </Grid>

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -15,7 +15,7 @@ import StandardLayout from '@shared/components/StandardLayout'
 import WorkflowAssignmentModal from './components/WorkflowAssignmentModal'
 import WorkflowMenu from './components/WorkflowMenu'
 
-const ClassifierWrapper = dynamic(() =>
+export const ClassifierWrapper = dynamic(() =>
   import('./components/ClassifierWrapper'), { ssr: false }
 )
 

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -32,7 +32,12 @@ function ClassifyPage ({
     : ['1em', 'auto', '1em']
 
   const [ workflowFromUrl ] = workflows.filter(workflow => workflow.id === workflowID)
-  const canClassify = workflowFromUrl?.grouped ? !!subjectSetID : !!workflowID
+  let subjectSetFromUrl
+  if (workflowFromUrl) {
+    [ subjectSetFromUrl ] = workflowFromUrl.subjectSets.filter(subjectSet => subjectSet.id === subjectSetID)
+  }
+  let canClassify = workflowFromUrl?.grouped ? !!subjectSetID : !!workflowID
+  canClassify = subjectSetFromUrl?.isIndexed ? !!subjectID : canClassify 
 
   return (
     <StandardLayout>
@@ -46,6 +51,8 @@ function ClassifyPage ({
         <Box as='main' fill='horizontal'>
           {!canClassify && (
             <WorkflowMenu
+              subjectSetFromUrl={subjectSetFromUrl}
+              workflowFromUrl={workflowFromUrl}
               workflows={workflows}
             />
           )}

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -33,7 +33,7 @@ function ClassifyPage ({
 
   const [ workflowFromUrl ] = workflows.filter(workflow => workflow.id === workflowID)
   let subjectSetFromUrl
-  if (workflowFromUrl) {
+  if (workflowFromUrl && workflowFromUrl.subjectSets) {
     [ subjectSetFromUrl ] = workflowFromUrl.subjectSets.filter(subjectSet => subjectSet.id === subjectSetID)
   }
   let canClassify = workflowFromUrl?.grouped ? !!subjectSetID : !!workflowID

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -36,7 +36,11 @@ function ClassifyPage ({
   if (workflowFromUrl && workflowFromUrl.subjectSets) {
     [ subjectSetFromUrl ] = workflowFromUrl.subjectSets.filter(subjectSet => subjectSet.id === subjectSetID)
   }
-  let canClassify = workflowFromUrl?.grouped ? !!subjectSetID : !!workflowID
+  // The classifier requires a workflow by default
+  let canClassify = !!workflowID
+  // grouped workflows require a subject set
+  canClassify = workflowFromUrl?.grouped ? !!subjectSetID : canClassify
+  // indexed subject sets require a subject
   canClassify = subjectSetFromUrl?.isIndexed ? !!subjectID : canClassify 
 
   return (

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
@@ -10,6 +10,9 @@ import YourStats from './components/YourStats'
 import ConnectWithProject from '@shared/components/ConnectWithProject'
 import ProjectStatistics from '@shared/components/ProjectStatistics'
 
+// TODO: is there a better way to find the dynamically imported classifier?
+const ClassifierDisplayName = 'ForwardRef(LoadableComponent)'
+
 describe('Component > ClassifyPage', function () {
   let wrapper
 
@@ -84,6 +87,11 @@ describe('Component > ClassifyPage', function () {
       it('should show a workflow menu', function () {
         expect(wrapper.find(WorkflowMenu)).to.have.lengthOf(1)
       })
+
+      it('should not pass the workflow ID to the classifier', function () {
+        const classifier = wrapper.find(ClassifierDisplayName)
+        expect(classifier.prop('workflowID')).to.be.undefined()
+      })
     })
 
     describe('with a subject set', function () {
@@ -99,6 +107,16 @@ describe('Component > ClassifyPage', function () {
 
       it('should not show a workflow menu', function () {
         expect(wrapper.find(WorkflowMenu)).to.have.lengthOf(0)
+      })
+
+      it('should pass the workflow ID to the classifier', function () {
+        const classifier = wrapper.find(ClassifierDisplayName)
+        expect(classifier.prop('workflowID')).to.equal('1234')
+      })
+
+      it('should pass the subject set ID to the classifier', function () {
+        const classifier = wrapper.find(ClassifierDisplayName)
+        expect(classifier.prop('subjectSetID')).to.equal('3456')
       })
     })
 
@@ -129,6 +147,16 @@ describe('Component > ClassifyPage', function () {
         it('should show a workflow menu', function () {
           expect(wrapper.find(WorkflowMenu)).to.have.lengthOf(1)
         })
+
+        it('should not pass the workflow ID to the classifier', function () {
+          const classifier = wrapper.find(ClassifierDisplayName)
+          expect(classifier.prop('workflowID')).to.be.undefined()
+        })
+
+        it('should not pass the subject set ID to the classifier', function () {
+          const classifier = wrapper.find(ClassifierDisplayName)
+          expect(classifier.prop('subjectSetID')).to.be.undefined()
+        })
       })
 
       describe('with a subject', function () {
@@ -147,6 +175,21 @@ describe('Component > ClassifyPage', function () {
 
         it('should not show a workflow menu', function () {
           expect(wrapper.find(WorkflowMenu)).to.have.lengthOf(0)
+        })
+
+        it('should pass the workflow ID to the classifier', function () {
+          const classifier = wrapper.find(ClassifierDisplayName)
+          expect(classifier.prop('workflowID')).to.equal('1234')
+        })
+
+        it('should pass the subject set ID to the classifier', function () {
+          const classifier = wrapper.find(ClassifierDisplayName)
+          expect(classifier.prop('subjectSetID')).to.equal('3456')
+        })
+
+        it('should pass the subject ID to the classifier', function () {
+          const classifier = wrapper.find(ClassifierDisplayName)
+          expect(classifier.prop('subjectID')).to.equal('5678')
         })
       })
     })

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
@@ -101,5 +101,54 @@ describe('Component > ClassifyPage', function () {
         expect(wrapper.find(WorkflowMenu)).to.have.lengthOf(0)
       })
     })
+
+    describe('with an indexed subject set', function () {
+      let workflows = [{
+        id: '1234',
+        grouped: true,
+        subjectSets: [{
+          id: '3456',
+          displayName: 'indexed set',
+          isIndexed: true
+        }]
+      }]
+
+      describe('without a subject', function () {
+        let wrapper
+
+        before(function () {
+          wrapper = shallow(
+            <ClassifyPage
+              subjectSetID='3456'
+              workflowID='1234'
+              workflows={workflows}
+            />
+          )
+        })
+
+        it('should show a workflow menu', function () {
+          expect(wrapper.find(WorkflowMenu)).to.have.lengthOf(1)
+        })
+      })
+
+      describe('with a subject', function () {
+        let wrapper
+
+        before(function () {
+          wrapper = shallow(
+            <ClassifyPage
+              subjectID='5678'
+              subjectSetID='3456'
+              workflowID='1234'
+              workflows={workflows}
+            />
+          )
+        })
+
+        it('should not show a workflow menu', function () {
+          expect(wrapper.find(WorkflowMenu)).to.have.lengthOf(0)
+        })
+      })
+    })
   })
 })

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme'
 import React from 'react'
 
-import { ClassifyPage } from './ClassifyPage'
+import { ClassifyPage, ClassifierWrapper } from './ClassifyPage'
 import FinishedForTheDay from './components/FinishedForTheDay'
 import WorkflowMenu from './components/WorkflowMenu'
 import ThemeModeToggle from '@components/ThemeModeToggle'
@@ -9,9 +9,6 @@ import ProjectName from '@components/ProjectName'
 import YourStats from './components/YourStats'
 import ConnectWithProject from '@shared/components/ConnectWithProject'
 import ProjectStatistics from '@shared/components/ProjectStatistics'
-
-// TODO: is there a better way to find the dynamically imported classifier?
-const ClassifierDisplayName = 'ForwardRef(LoadableComponent)'
 
 describe('Component > ClassifyPage', function () {
   let wrapper
@@ -89,7 +86,7 @@ describe('Component > ClassifyPage', function () {
       })
 
       it('should not pass the workflow ID to the classifier', function () {
-        const classifier = wrapper.find(ClassifierDisplayName)
+        const classifier = wrapper.find(ClassifierWrapper)
         expect(classifier.prop('workflowID')).to.be.undefined()
       })
     })
@@ -110,12 +107,12 @@ describe('Component > ClassifyPage', function () {
       })
 
       it('should pass the workflow ID to the classifier', function () {
-        const classifier = wrapper.find(ClassifierDisplayName)
+        const classifier = wrapper.find(ClassifierWrapper)
         expect(classifier.prop('workflowID')).to.equal('1234')
       })
 
       it('should pass the subject set ID to the classifier', function () {
-        const classifier = wrapper.find(ClassifierDisplayName)
+        const classifier = wrapper.find(ClassifierWrapper)
         expect(classifier.prop('subjectSetID')).to.equal('3456')
       })
     })
@@ -149,12 +146,12 @@ describe('Component > ClassifyPage', function () {
         })
 
         it('should not pass the workflow ID to the classifier', function () {
-          const classifier = wrapper.find(ClassifierDisplayName)
+          const classifier = wrapper.find(ClassifierWrapper)
           expect(classifier.prop('workflowID')).to.be.undefined()
         })
 
         it('should not pass the subject set ID to the classifier', function () {
-          const classifier = wrapper.find(ClassifierDisplayName)
+          const classifier = wrapper.find(ClassifierWrapper)
           expect(classifier.prop('subjectSetID')).to.be.undefined()
         })
       })
@@ -178,17 +175,17 @@ describe('Component > ClassifyPage', function () {
         })
 
         it('should pass the workflow ID to the classifier', function () {
-          const classifier = wrapper.find(ClassifierDisplayName)
+          const classifier = wrapper.find(ClassifierWrapper)
           expect(classifier.prop('workflowID')).to.equal('1234')
         })
 
         it('should pass the subject set ID to the classifier', function () {
-          const classifier = wrapper.find(ClassifierDisplayName)
+          const classifier = wrapper.find(ClassifierWrapper)
           expect(classifier.prop('subjectSetID')).to.equal('3456')
         })
 
         it('should pass the subject ID to the classifier', function () {
-          const classifier = wrapper.find(ClassifierDisplayName)
+          const classifier = wrapper.find(ClassifierWrapper)
           expect(classifier.prop('subjectID')).to.equal('5678')
         })
       })

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/WorkflowMenu.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/WorkflowMenu.js
@@ -12,13 +12,14 @@ import SubjectPicker from '@shared/components/SubjectPicker'
 */
 export default function WorkflowMenu({
   headingBackground = 'brand',
+  subjectSetFromUrl,
   titleColor = 'neutral-6',
   workflowFromUrl,
   workflows
 }) {
   const router = useRouter()
   const { owner, project } = router?.query || {}
-  const [ activeSubjectSet, setActiveSubjectSet ] = useState()
+  const [ activeSubjectSet, setActiveSubjectSet ] = useState(subjectSetFromUrl)
   const [ activeWorkflow, setActiveWorkflow ] = useState(workflowFromUrl)
 
   function onSelectSubjectSet(event, subjectSet) {

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/WorkflowMenu.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/WorkflowMenu.js
@@ -85,6 +85,11 @@ export default function WorkflowMenu({
   )
 }
 
+const subjectSetType = shape({
+  displayName: string,
+  id: string
+})
+
 const workflowType = shape({
   displayName: string,
   id: string
@@ -95,6 +100,10 @@ WorkflowMenu.propTypes = {
     Background colour of the title bar.
   */
   headingBackground: string,
+  /**
+    An optional selected subject set. If present, we can jump straight to subject selection.
+  **/
+  subjectSetFromUrl: subjectSetType,
   /**
     text colour of the title bar.
   */

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/WorkflowMenu.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenu/WorkflowMenu.spec.js
@@ -5,6 +5,7 @@ import WorkflowMenu from './'
 
 import WorkflowSelector from '@shared/components/WorkflowSelector'
 import SubjectSetPicker from '@shared/components/SubjectSetPicker'
+import SubjectPicker from '@shared/components/SubjectPicker'
 
 describe('Component > ClassifyPage > WorkflowMenu', function () {
   describe('without a selected workflow', function () {
@@ -39,6 +40,36 @@ describe('Component > ClassifyPage > WorkflowMenu', function () {
 
     it('should show a subject set picker', function () {
       expect(wrapper.find(SubjectSetPicker)).to.have.lengthOf(1)
+    })
+  })
+
+  describe('with a selected workflow and subject set', function () {
+    let wrapper
+    let workflows = [{
+      id: '1234',
+      grouped: true
+    }]
+    let subjectSet = {
+      id: '345',
+      displayName: 'test set'
+    }
+
+    before(function () {
+      wrapper = shallow(
+        <WorkflowMenu
+          subjectSetFromUrl={subjectSet}
+          workflowFromUrl={workflows[0]}
+          workflows={workflows}
+        />
+      )
+    })
+
+    it('should not show a workflow selector', function () {
+      expect(wrapper.find(WorkflowSelector)).to.have.lengthOf(0)
+    })
+
+    it('should show a subject picker', function () {
+      expect(wrapper.find(SubjectPicker)).to.have.lengthOf(1)
     })
   })
 })

--- a/packages/app-project/src/shared/components/SubjectSetPicker/SubjectSetPicker.js
+++ b/packages/app-project/src/shared/components/SubjectSetPicker/SubjectSetPicker.js
@@ -32,7 +32,15 @@ function BackButton({ onClick }) {
     />
   )
 }
-function SubjectSetPicker ({ baseUrl, onClose, onSelect, workflow }) {
+/**
+  Display a list of subject set cards for a workflow. Each card links to the corresponding subject set ID.
+*/
+function SubjectSetPicker ({
+  baseUrl,
+  onClose = () => true,
+  onSelect = () => true,
+  workflow
+}) {
   const router = useRouter()
   /*
     Vertical spacing for the picker instructions.
@@ -100,9 +108,21 @@ function SubjectSetPicker ({ baseUrl, onClose, onSelect, workflow }) {
 }
 
 SubjectSetPicker.propTypes = {
+  /**
+    Base URL for links eg. `/projects/${owner}/${project}/classify`
+  */
+  baseUrl: string.isRequired,
+  /**
+    Callback to close/cancel the picker without taking action.
+  */
   onClose: func,
-  owner: string.isRequired,
-  project: string.isRequired,
+  /**
+    Callback to call on clicking a subject set card: `onSelect(event, subjectSet)`
+  */
+  onSelect: func,
+  /**
+    The selected workflow.
+  */
   workflow: shape({
     completeness: number,
     default: bool,

--- a/packages/app-project/src/shared/components/SubjectSetPicker/components/SubjectSetCard/SubjectSetCard.js
+++ b/packages/app-project/src/shared/components/SubjectSetPicker/components/SubjectSetCard/SubjectSetCard.js
@@ -5,8 +5,16 @@ import getConfig from 'next/config'
 import { array, number, string } from 'prop-types'
 import React from 'react'
 
-function SubjectSetCard (props) {
-  const { availableSubjects, display_name, id, set_member_subjects_count, subjects } = props
+/**
+  Summary card for a subject set, showing a preview subject, the set name, total subject count and completeness percentage.
+*/
+function SubjectSetCard ({
+  availableSubjects,
+  display_name,
+  id,
+  set_member_subjects_count,
+  subjects = []
+}) {
   const [subject] = subjects
   const { publicRuntimeConfig = {} } = getConfig() || {}
   const assetPrefix = publicRuntimeConfig.assetPrefix || ''
@@ -69,14 +77,26 @@ function SubjectSetCard (props) {
 }
 
 SubjectSetCard.propTypes = {
-  display_name: string.required,
-  id: string.required,
-  set_member_subjects_count: number.required,
+  /**
+   The number of subjects available to be classified.
+  */
+  availableSubjects: number.isRequired,
+  /**
+   Subject set title.
+  */
+  display_name: string.isRequired,
+  /**
+    Subject set ID.
+  */
+  id: string.isRequired,
+  /**
+    Total subject count
+  */
+  set_member_subjects_count: number.isRequired,
+  /**
+   Preview subjects. Used to show a preview image.
+  */
   subjects: array
-}
-
-SubjectSetCard.defaultProps = {
-  subjects: []
 }
 
 export default SubjectSetCard


### PR DESCRIPTION
If workflowID and/or subjectSetID are defined in the Classify page URL, this skips past workflow selection and/or subject set selection when opening the workflow menu.

Something I missed in #2132: if you link directly to a workflow or subject set, then that workflow or set should already be selected in the workflow menu when the Classify page opens.

Test URLs:
Workflow selected, jump straight to subject set selection
http://local.zooniverse.org:3000/projects/bogden/scarlets-and-blues/classify/workflow/17077?env=production&demo=true

Subject set selected, jump straight to subject selection
http://local.zooniverse.org:3000/projects/bogden/scarlets-and-blues/classify/workflow/17077/subject-set/92751?env=production&demo=true

Subject set selected but workflow doesn't use subject selection
http://local.zooniverse.org:3000/projects/bogden/scarlets-and-blues/classify/workflow/16848/subject-set/90488?env=production&demo=true

A workflow that doesn't use the `WorkflowMenu` component
http://local.zooniverse.org:3000/projects/brooke/i-fancy-cats/classify?env=staging&demo=true

I Fancy Cats with a specific subject
http://local.zooniverse.org:3000/projects/brooke/i-fancy-cats/classify/workflow/693/subject/4235?env=staging&demo=true

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
