### PR TITLE
Update SubjectGroupViewer README (May 2021)

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md
@@ -45,11 +45,29 @@ When the _current task_ on the Classifier is a Subject Group Task - which usuall
 
 **Workflow: Configuration**
 
-To enable the SGV, the Workflow of the project must have its `.configuration` set up.
+To enable the SGV, the Workflow of the project must have its `.configuration` set up. For example, this is for a 5x5 grid with 200x200px cells:
 
-`workflow.configuration = { subject_viewer: 'subjectGroup' }`
+```
+workflow.configuration = {
+  subject_viewer: 'subjectGroup',
+  subject_viewer_config: {
+    cell_width: 200,
+    cell_height: 200,
+    grid_columns: 5,
+    grid_rows: 5,
+  },
+  subject_group: {
+    num_columns: 5,  // This must match grid_columns
+    num_rows: 5,     // This must match grid_rows
+  }
+}
+```
 
-Optionally, the SGV can be further configured to specify a certain grid size. The example here shows how to specify a 4x3 grid, with each cell having a "native size" of 1200px x 1000px. (This will result in a grid with a "native size" of 4800px x 3000px, which will then be squished to fit the available view space of the Classifier.)
+(Note 1: the actual size of the cells will be "squished" to fit the actual visible size of the viewer on the classifier.)
+
+(Note 2: `subject_viewer_config` is used by the frontend UI, while `subject_group` is used by the backend service. There's a small duplication of values here, don't mind it.)
+
+Optionally, the SGV can be further configured with specific styles.
 
 ```
 workflow.configuration = {
@@ -66,8 +84,12 @@ workflow.configuration = {
       focusOutline: '2px dashed rgba(255, 255, 255, 0.5)',
       background: '#000'
     },
-    grid_columns: 4,
-    grid_rows: 3
+    grid_columns: 5,
+    grid_rows: 5
+  },
+  subject_group: {
+    num_columns: 5,
+    num_rows: 5,
   }
 }
 ```
@@ -81,4 +103,12 @@ Some notes on cell_style:
 
 **Subject: Group Subjects**
 
-// TODO
+- Subjects for the SubjectGroupViewer are a special case; a "Group Subject" is a randomised collection of X **single image Subjects** (where X = rows x columns) that the backend packages in to a single "pseudo" Subject.
+- Subject Groups are called from the `/subjects/grouped` Panoptes endpoint (instead of the usual `/subjects/queued` endpoint)
+  - An example request looks like `https://panoptes-staging.zooniverse.org/api/subjects/grouped?workflow_id=3412&num_rows=5&num_columns=5`
+  - Note: `num_rows` and `num_columns` need to match the `workflow.configuration.subject_group` value
+  - Note: as of May 2021, there is a maximum limit of 25 constituent Subjects per Subject Group
+- To the frontend, a Subject Group looks almost EXACTLY like a multi-image Subject, but with extra metadata.
+  - `subject.locations` has X (where X = rows x columns) number of image URLs.
+  - `subject.metadata.#group_subject_ids` is a string of X Subject IDs, consisting of the Subject Group's _constituent Subject's IDs_ joined together with the dash `-` character. e.g. "134859-134722-134823-134642-134700-134888-134853-134685-134843-134619-134864-134697-134637-134624-134832-134805-134623-134788-134828-134643-134610-134795-134756-134676-134714"
+  - `subject.metadata.#subject_group_id` is a number indicating the unique ID of this Subject Group, which is distinct from `subject.id`. Honestly, don't worry about this for now.

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md
@@ -4,7 +4,7 @@ The Subject Group Viewer (SGV) is a variant of the Subject Viewer that's used to
 display Subjects containing an array of sub-Subjects, with each sub-Subject
 shown on a grid.
 
-The Subject Group Viewer was originally created by @shaun.a.noordin on Mar 2020, for the SURVOS project.
+The Subject Group Viewer was originally created by @shaunanoordin on Mar 2020, for the SURVOS project.
 
 ## Features
 
@@ -112,3 +112,10 @@ Some notes on cell_style:
   - `subject.locations` has X (where X = rows x columns) number of image URLs.
   - `subject.metadata.#group_subject_ids` is a string of X Subject IDs, consisting of the Subject Group's _constituent Subject's IDs_ joined together with the dash `-` character. e.g. "134859-134722-134823-134642-134700-134888-134853-134685-134843-134619-134864-134697-134637-134624-134832-134805-134623-134788-134828-134643-134610-134795-134756-134676-134714"
   - `subject.metadata.#subject_group_id` is a number indicating the unique ID of this Subject Group, which is distinct from `subject.id`. Honestly, don't worry about this for now.
+
+**Associated Task: Subject Group Comparison Task**
+
+- The Subject Group _Viewer_ is STRONGLY ASSOCIATED with the Subject Group _Comparison Task._
+- The SGComparisonTask allows users to CLICK ON cells in the grid to "select" them. (i.e. to pick the cells that look different from the others)
+- Without this Task, the viewer is just a fancy way of seeing multiple images in a grid.
+- Please see `src/plugins/tasks/SubjectGroupComparisonTask/README.md` for more details.

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md
@@ -101,17 +101,11 @@ Some notes on cell_style:
 - A cell can also be in the "has keyboard focus" state. This is visually represented by 'focusOutline'.
 - 'background' indicates the colour to fill the cell with when, e.g. the image doesn't fill the cell's available visible space.
 
-**New Subject "type": Subject Groups**
+**Associated Subject "type": Subject Groups**
 
+- The Subject Group _Viewer_ is STRONGLY ASSOCIATED with the Subject Group "type" of Subject.
 - Subjects for the SubjectGroupViewer are a special case; a "Group Subject" is a randomised collection of X **single image Subjects** (where X = rows x columns) that the backend packages in to a single "pseudo" Subject.
-- Subject Groups are called from the `/subjects/grouped` Panoptes endpoint (instead of the usual `/subjects/queued` endpoint)
-  - An example request looks like `https://panoptes-staging.zooniverse.org/api/subjects/grouped?workflow_id=3412&num_rows=5&num_columns=5`
-  - Note: `num_rows` and `num_columns` need to match the `workflow.configuration.subject_group` value
-  - Note: as of May 2021, there is a maximum limit of 25 constituent Subjects per Subject Group
-- To the frontend, a Subject Group looks almost EXACTLY like a multi-image Subject, but with extra metadata.
-  - `subject.locations` has X (where X = rows x columns) number of image URLs.
-  - `subject.metadata.#group_subject_ids` is a string of X Subject IDs, consisting of the Subject Group's _constituent Subject's IDs_ joined together with the dash `-` character. e.g. "134859-134722-134823-134642-134700-134888-134853-134685-134843-134619-134864-134697-134637-134624-134832-134805-134623-134788-134828-134643-134610-134795-134756-134676-134714"
-  - `subject.metadata.#subject_group_id` is a number indicating the unique ID of this Subject Group, which is distinct from `subject.id`. Honestly, don't worry about this for now.
+- Please see `src/store/SubjectGroup/README.md` for more details.
 
 **Associated Task: Subject Group Comparison Task**
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md
@@ -101,7 +101,7 @@ Some notes on cell_style:
 - A cell can also be in the "has keyboard focus" state. This is visually represented by 'focusOutline'.
 - 'background' indicates the colour to fill the cell with when, e.g. the image doesn't fill the cell's available visible space.
 
-**Subject: Group Subjects**
+**New Subject "type": Subject Groups**
 
 - Subjects for the SubjectGroupViewer are a special case; a "Group Subject" is a randomised collection of X **single image Subjects** (where X = rows x columns) that the backend packages in to a single "pseudo" Subject.
 - Subject Groups are called from the `/subjects/grouped` Panoptes endpoint (instead of the usual `/subjects/queued` endpoint)

--- a/packages/lib-classifier/src/plugins/tasks/SubjectGroupComparisonTask/README.md
+++ b/packages/lib-classifier/src/plugins/tasks/SubjectGroupComparisonTask/README.md
@@ -4,8 +4,8 @@ This Task allows users to select cells on the Subject Group Viewer's grid.
 Selecting cells is a way for volunteers to say that, "hey, these images look
 different from other images on the grid!"
 
-- This task is STRONGLY associated with the Subject Group Viewer.
-  - Please see `src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md` for more details.
+- This task is STRONGLY ASSOCIATED with the Subject Group Viewer. Please see `src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md` for more details.
+- This task is STRONGLY ASSOCIATED with the Subject Group "type" of Subjects. Please see `src/store/SubjectGroup/README.md` for more details.
 
 The Subject Group Comparison Task was originally created by @shaunanoordin on Mar 2020, for the SURVOS project.
 
@@ -21,7 +21,9 @@ Simple Dropdown task data structure, example:
 }
 ```
 
-That's all! Most of the work is done by the `workflow.configuration` set for the Subject Group _Viewer._
+That's all! The Task Area only has a question, and nothing else.
+
+Most of the classification interactivity resides in the Subject Group Viewer. As such, most of the setup work is done by the `workflow.configuration` set for the Subject Group Viewer.
 
 Subject Group Comparison Task annotation (classification) data structure, example:
 

--- a/packages/lib-classifier/src/plugins/tasks/SubjectGroupComparisonTask/README.md
+++ b/packages/lib-classifier/src/plugins/tasks/SubjectGroupComparisonTask/README.md
@@ -1,0 +1,48 @@
+# Subject Group Comparison Task
+
+This Task allows users to select cells on the Subject Group Viewer's grid.
+Selecting cells is a way for volunteers to say that, "hey, these images look
+different from other images on the grid!"
+
+- This task is STRONGLY associated with the Subject Group Viewer.
+  - Please see `src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md` for more details.
+
+The Subject Group Comparison Task was originally created by @shaunanoordin on Mar 2020, for the SURVOS project.
+
+## Data Models
+
+Simple Dropdown task data structure, example:
+
+```
+"T0":{
+  help: "",
+  question: "Please select the cells that look weird.",
+  type: "subjectGroupComparison",
+}
+```
+
+That's all! Most of the work is done by the `workflow.configuration` set for the Subject Group _Viewer._
+
+Subject Group Comparison Task annotation (classification) data structure, example:
+
+```
+{
+  "task": "T0",
+  "value": [
+    {index: 6, subject: "134853"},
+    {index: 12, subject: "134637"},
+    {index: 18, subject: "134828"},
+  ]
+}
+```
+
+The value is an _array of selected cells._ A single selected cell contains two values: the index of the cell on the grid (e.g. say you have a 3x3 grid. The top-left cell is index 0 ; the top-middle cell is index 1 ; the bottom-right cell is index 8), and the ID of the constituent Subject that the cell represents.
+
+NOTE: if no cell was selected (as is the case when initially rendered), the annotation value is an empty array.
+
+```
+{
+  "task":"T0",
+  "value": [],  // No value selected
+}
+```

--- a/packages/lib-classifier/src/plugins/tasks/SubjectGroupComparisonTask/README.md
+++ b/packages/lib-classifier/src/plugins/tasks/SubjectGroupComparisonTask/README.md
@@ -11,7 +11,7 @@ The Subject Group Comparison Task was originally created by @shaunanoordin on Ma
 
 ## Data Models
 
-Simple Dropdown task data structure, example:
+Subject Group Comparison Task data structure, example:
 
 ```
 "T0":{

--- a/packages/lib-classifier/src/store/SubjectGroup/README.md
+++ b/packages/lib-classifier/src/store/SubjectGroup/README.md
@@ -1,0 +1,14 @@
+# Subject Group
+
+Subjects for the SubjectGroupViewer are a special case; a "Group Subject" is a randomised collection of X **single image Subjects** (where X = rows x columns) that the backend packages in to a single "pseudo" Subject.
+
+- Subject Groups are called from the `/subjects/grouped` Panoptes endpoint (instead of the usual `/subjects/queued` endpoint)
+  - An example request looks like `https://panoptes-staging.zooniverse.org/api/subjects/grouped?workflow_id=3412&num_rows=5&num_columns=5`
+  - Note: `num_rows` and `num_columns` need to match the `workflow.configuration.subject_group` value. (See SubjectGroupViewer for info on how the `workflow.configuration` should be set up.)
+  - Note: as of May 2021, there is a maximum limit of 25 constituent Subjects per Subject Group
+- To the frontend, a Subject Group looks almost EXACTLY like a multi-image Subject, but with extra metadata.
+  - `subject.locations` has X (where X = rows x columns) number of image URLs.
+  - `subject.metadata.#group_subject_ids` is a string of X Subject IDs, consisting of the Subject Group's _constituent Subject's IDs_ joined together with the dash `-` character. e.g. "134859-134722-134823-134642-134700-134888-134853-134685-134843-134619-134864-134697-134637-134624-134832-134805-134623-134788-134828-134643-134610-134795-134756-134676-134714"
+  - `subject.metadata.#subject_group_id` is a number indicating the unique ID of this Subject Group, which is distinct from `subject.id`. Honestly, don't worry about this for now.
+- Subject Groups are STRONGLY ASSOCIATED with the Subject Group Viewer. Please see `src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/README.md` for more details.
+- Subject Groups are STRONGLY ASSSOCIATED with the Subject Group Comparison Task. Please see `src/plugins/tasks/SubjectGroupComparisonTask/README.md` for more details.


### PR DESCRIPTION
## PR Overview

This is a documentation update for the Subject Group Viewer system

- A better example of the workflow configuration was added. The previous documentation was missing the "subject_group.num_columns" and "subject_group.num_rows" field that's now essential for the new /subjects/grouped endpoint
- The "Subject Groups" used by the viewer has been expanded upon.

### Status

Ready for review.