### PR TITLE
Update url-parse to 1.5.1

### DIFF
--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -49,7 +49,7 @@
     "snazzy": "^8.0.0",
     "styled-components": "~5.1.1",
     "superagent": "~5.1.1",
-    "url-parse": "~1.5.0",
+    "url-parse": "~1.5.1",
     "validator": "~10.11.0"
   },
   "devDependencies": {

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -60,7 +60,7 @@
     "react-dom": "~16.13.0",
     "styled-components": "~5.1.1",
     "svg-loaders-react": "~2.0.1",
-    "url-parse": "~1.5.0",
+    "url-parse": "~1.5.1",
     "validator": "~11.0.0"
   },
   "devDependencies": {

--- a/packages/lib-panoptes-js/package.json
+++ b/packages/lib-panoptes-js/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "superagent": "~5.1.0",
-    "url-parse": "~1.5.0"
+    "url-parse": "~1.5.1"
   },
   "devDependencies": {
     "@zooniverse/standard": "~1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18244,18 +18244,10 @@ url-loader@^4.1.1:
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
 
-url-parse@^1.4.3, url-parse@^1.5.1:
+url-parse@^1.4.3, url-parse@^1.5.1, url-parse@~1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
   integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==
-  dependencies:
-    querystringify "^2.1.1"
-    requires-port "^1.0.0"
-
-url-parse@~1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.0.tgz#90aba6c902aeb2d80eac17b91131c27665d5d828"
-  integrity sha512-9iT6N4s93SMfzunOyDPe4vo4nLcSu1yq0IQK1gURmjm8tQNlM6loiuCRrKG1hHGXfB2EWd6H4cGi7tGdaygMFw==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"


### PR DESCRIPTION
Package:
- app-content-pages
- app-project
- lib-panoptes-js

Fixes login issue from `url-parse` v1.5.0 which duplicated part of pathname with sign-in / register.

Describe your changes:
- update `package.json`s for packages noted above, `yarn.lock` for `url-parse` v1.5.1

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
