### PR TITLE
CI: build the storybooks

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -1,22 +1,15 @@
-name: CI Tests
+name: Build storybooks
 
 on:
-  pull_request:
-  push:
-    branches:
-      - master
+  pull_request
 
 jobs:
-  build:
+  build_storybooks:
    runs-on: ubuntu-latest
    env:
      APP_ENV: production
      NODE_ENV: production
      PANOPTES_ENV: production
-     CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
-     CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
-     CONTENT_ASSET_PREFIX: 'https://fe-content-pages.zooniverse.org'
-     PROJECT_ASSET_PREFIX: 'https://fe-project.zooniverse.org'
 
    steps:
     # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#using-the-checkout-action
@@ -42,11 +35,4 @@ jobs:
     - run: yarn install --production=false --frozen-lockfile
     - run: yarn workspace @zooniverse/react-components build
     - run: yarn workspace @zooniverse/classifier build
-    - run: yarn workspace @zooniverse/fe-project build
-    - run: yarn workspace @zooniverse/fe-content-pages build
-    - run: PANOPTES_ENV=test yarn test:ci
-    - run: yarn coverage-lcov
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - run: yarn deploy-storybook --dry-run

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -6,10 +6,6 @@ on:
 jobs:
   build_storybooks:
    runs-on: ubuntu-latest
-   env:
-     APP_ENV: production
-     NODE_ENV: production
-     PANOPTES_ENV: production
 
    steps:
     # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#using-the-checkout-action
@@ -32,7 +28,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
 
-    - run: yarn install --production=false --frozen-lockfile
+    - run: yarn install --frozen-lockfile
     - run: yarn workspace @zooniverse/react-components build
     - run: yarn workspace @zooniverse/classifier build
     - run: yarn deploy-storybook --dry-run


### PR DESCRIPTION
Includes the fix for project storybook builds from #2190.

This PR adds a CI workflow which runs `yarn deploy-storybook --dry-run` to check that the storybooks build. I've not made it required, so PRs can still be merged with broken storybooks.

I've also added caching, so that the storybook build should re-use the yarn cache from the test monorepo build, rather than running the full install again. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
