### PR TITLE
Add deselect functionality to survey task question radio input

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/Questions.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/Questions.js
@@ -17,6 +17,11 @@ export default function Questions (props) {
   function handleAnswer (questionAnswer, questionId) {
     const newAnswers = Object.assign({}, answers, { [questionId]: questionAnswer })
 
+    // if questionAnswer is an empty string (cleared radio input) or an empty array (cleared checkbox inputs) then questionAnswer length is 0
+    if (questionAnswer.length === 0) {
+      delete newAnswers[questionId]
+    }
+
     setAnswers(newAnswers)
   }
 

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/components/CheckBoxInputs/components/CheckBoxInput.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/components/CheckBoxInputs/components/CheckBoxInput.spec.js
@@ -56,9 +56,9 @@ describe('Component > CheckBoxInput', function () {
     it('should call handleCheckBoxChange with checked and value', function () {
       expect(handleCheckBoxChangeSpy).to.not.have.been.called()
 
-      wrapper.find('input').simulate('change', { target: { checked: false, value: 'TNG' } })
+      wrapper.find('input').simulate('change', { target: { checked: true, value: 'TNG' } })
 
-      expect(handleCheckBoxChangeSpy).to.have.been.calledWith(false, 'TNG')
+      expect(handleCheckBoxChangeSpy).to.have.been.calledWith(true, 'TNG')
 
       handleCheckBoxChangeSpy.resetHistory()
     })

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/components/RadioInputs/RadioInputs.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/components/RadioInputs/RadioInputs.js
@@ -1,4 +1,4 @@
-import { RadioButtonGroup } from 'grommet'
+import { Box } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -12,24 +12,33 @@ export default function RadioInputs (props) {
     questionId
   } = props
 
+  function handleRadioChange (value) {
+    if (questionAnswer === value) {
+      handleAnswer('', questionId)
+    } else {
+      handleAnswer(value, questionId)
+    }
+  }
+
   return (
-    <RadioButtonGroup
+    <Box
       direction='row'
-      name={questionId}
-      onChange={({ target }) => handleAnswer(target.value, questionId)}
-      options={options}
-      value={questionAnswer}
       wrap
     >
-      {(option, { checked, hover }) => {
+      {options.map(option => {
+        const isChecked = questionAnswer === option.value
+
         return (
           <RadioInput
-            checked={checked}
-            label={option.label}
+            key={option.value}
+            handleRadioChange={handleRadioChange}
+            isChecked={isChecked}
+            option={option}
+            questionId={questionId}
           />
         )
-      }}
-    </RadioButtonGroup>
+      })}
+    </Box>
   )
 }
 

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/components/RadioInputs/RadioInputs.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/components/RadioInputs/RadioInputs.spec.js
@@ -46,7 +46,7 @@ describe('Component > RadioInputs', function () {
       expect(inputs.find({ option: { label: 'Yes', value: 'S' } }).props().isChecked).to.be.true()
     })
 
-    it('should render not chosen RadioInputs as unchecked', function () {
+    it('should render unchosen RadioInputs as unchecked', function () {
       expect(inputs.find({ option: { label: ' No', value: 'N' } }).props().isChecked).to.be.false()
     })
   })

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/components/RadioInputs/RadioInputs.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/components/RadioInputs/RadioInputs.spec.js
@@ -1,14 +1,14 @@
 import { shallow } from 'enzyme'
-import { RadioButtonGroup } from 'grommet'
 import React from 'react'
 import sinon from 'sinon'
 
 import { task as mockTask } from '@plugins/tasks/SurveyTask/mock-data'
 import RadioInputs from './RadioInputs'
+import RadioInput from './components/RadioInput'
 
 describe('Component > RadioInputs', function () {
   let wrapper, handleAnswerSpy
-  const questionId = 'HWMN'
+  const questionId = 'RTHRNNGPRSNT'
   const question = mockTask.questions[questionId]
   const options = question.answersOrder.map(answerId => ({
     label: question.answers[answerId].label,
@@ -30,21 +30,24 @@ describe('Component > RadioInputs', function () {
     expect(wrapper).to.be.ok()
   })
 
-  it('should render a RadioButtonGroup', function () {
-    expect(wrapper.find(RadioButtonGroup)).to.have.lengthOf(1)
+  it('should render 2 RadioInput components', function () {
+    expect(wrapper.find(RadioInput)).to.have.lengthOf(options.length)
   })
 
-  it('should call handleAnswer with new answer on RadioButtonGroup change', function () {
-    expect(handleAnswerSpy).to.not.have.been.called()
+  describe('with defined answer', function () {
+    let inputs
 
-    wrapper.find(RadioButtonGroup).simulate('change', { target: { value: '3' } })
-    expect(handleAnswerSpy).to.have.been.calledWith('3', 'HWMN')
+    before(function () {
+      wrapper.setProps({ questionAnswer: 'S' })
+      inputs = wrapper.find(RadioInput)
+    })
 
-    handleAnswerSpy.resetHistory()
-  })
+    it('should render chosen RadioInput as checked', function () {
+      expect(inputs.find({ option: { label: 'Yes', value: 'S' } }).props().isChecked).to.be.true()
+    })
 
-  it('should render the chosen value', function () {
-    wrapper.setProps({ questionAnswer: '9' })
-    expect(wrapper.find(RadioButtonGroup).props().value).to.equal('9')
+    it('should render not chosen RadioInputs as unchecked', function () {
+      expect(inputs.find({ option: { label: ' No', value: 'N' } }).props().isChecked).to.be.false()
+    })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/components/RadioInputs/RadioInputs.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/components/RadioInputs/RadioInputs.stories.js
@@ -39,12 +39,13 @@ export default {
   component: RadioInputs
 }
 
-const Template = ({ dark, options, questionId }) => (
+const Template = ({ dark, options, questionAnswer, questionId }) => (
   <StoryContext
     theme={{ ...zooTheme, dark }}
   >
     <RadioInputs
       options={options}
+      questionAnswer={questionAnswer}
       questionId={questionId}
     />
   </StoryContext>
@@ -54,5 +55,6 @@ export const Default = Template.bind({})
 Default.args = {
   dark: false,
   options,
+  questionAnswer: '9',
   questionId
 }

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/components/RadioInputs/components/RadioInput.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/components/RadioInputs/components/RadioInput.js
@@ -1,39 +1,82 @@
 import { Box, Text } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
+import styled from 'styled-components'
+
+export const StyledBox = styled(Box)`
+  cursor: pointer;
+  
+  > span {
+    cursor: pointer;
+  }
+  
+  > input {
+    cursor: pointer;
+    opacity: 0.01;
+    position: absolute;
+  }
+`
 
 export default function RadioInput (props) {
   const {
-    checked,
-    label
+    handleRadioChange,
+    isChecked,
+    option,
+    questionId
   } = props
 
-  const backgroundColor = checked ? 'accent-2' : 'neutral-6'
+  const backgroundColor = isChecked ? 'accent-2' : 'neutral-6'
 
   return (
-    <Box
-      align='center'
-      background={{ color: backgroundColor }}
-      height='40px'
-      justify='center'
-      margin={{ bottom: 'xsmall' }}
-      round='full'
-      width='40px'
-    >
-      <Text
-        color='dark-1'
-        weight={checked ? 'bold' : 'normal'}
+    <label>
+      <StyledBox
+        align='center'
+        background={{ color: backgroundColor }}
+        height='40px'
+        justify='center'
+        margin={{
+          bottom: 'xsmall',
+          right: 'xsmall'
+        }}
+        pad={{ horizontal: 'xsmall' }}
+        round='full'
+        width={{ min: '40px' }}
       >
-        {label}
-      </Text>
-    </Box>
+        <input
+          name={questionId}
+          value={option.value}
+          type='radio'
+          checked={isChecked}
+          onChange={({ target }) => (handleRadioChange(target.value))}
+          onClick={({ target }) => (handleRadioChange(target.value))}
+        />
+        <Text
+          color='dark-1'
+          weight={isChecked ? 'bold' : 'normal'}
+        >
+          {option.label}
+        </Text>
+      </StyledBox>
+    </label>
   )
 }
 
 RadioInput.defaultProps = {
-  checked: false
+  handleRadioChange: () => {},
+  isChecked: false,
+  option: {
+    label: '',
+    value: ''
+  },
+  questionId: ''
 }
 
 RadioInput.propTypes = {
-  checked: PropTypes.bool
+  handleRadioChange: PropTypes.func,
+  isChecked: PropTypes.bool,
+  option: PropTypes.shape({
+    label: PropTypes.string,
+    value: PropTypes.string
+  }),
+  questionId: PropTypes.string
 }

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/components/RadioInputs/components/RadioInput.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/Questions/components/RadioInputs/components/RadioInput.spec.js
@@ -1,17 +1,23 @@
 import { shallow } from 'enzyme'
-import { Box, Text } from 'grommet'
+import { Text } from 'grommet'
 import React from 'react'
+import sinon from 'sinon'
 
-import RadioInput from './RadioInput'
+import RadioInput, { StyledBox } from './RadioInput'
 
 describe('Component > RadioInput', function () {
-  let wrapper
+  let wrapper, handleRadioChangeSpy
 
   before(function () {
+    handleRadioChangeSpy = sinon.spy()
     wrapper = shallow(
       <RadioInput
-        check={false}
-        label='True'
+        handleRadioChange={handleRadioChangeSpy}
+        option={{
+          label: 'Yes',
+          value: 'S'
+        }}
+        questionId='RTHRNNGPRSNT'
       />
     )
   })
@@ -21,11 +27,11 @@ describe('Component > RadioInput', function () {
   })
 
   it('should render the label', function () {
-    expect(wrapper.find(Text).text()).to.equal('True')
+    expect(wrapper.find(Text).text()).to.equal('Yes')
   })
 
   it('should have a background color neutral-6', function () {
-    expect(wrapper.find(Box).props().background.color).to.equal('neutral-6')
+    expect(wrapper.find(StyledBox).props().background.color).to.equal('neutral-6')
   })
 
   it('should have text weight normal', function () {
@@ -34,15 +40,39 @@ describe('Component > RadioInput', function () {
 
   describe('when checked', function () {
     before(function () {
-      wrapper.setProps({ checked: true })
+      wrapper.setProps({ isChecked: true })
     })
 
     it('should have a background color of accent-2', function () {
-      expect(wrapper.find(Box).props().background.color).to.equal('accent-2')
+      expect(wrapper.find(StyledBox).props().background.color).to.equal('accent-2')
     })
 
     it('should have text weight bold', function () {
       expect(wrapper.find(Text).props().weight).to.equal('bold')
+    })
+  })
+
+  describe('onChange', function () {
+    it('should call handleRadioChange with checked and value', function () {
+      expect(handleRadioChangeSpy).to.not.have.been.called()
+
+      wrapper.find('input').simulate('change', { target: { checked: true, value: 'S' } })
+
+      expect(handleRadioChangeSpy).to.have.been.calledWith('S')
+
+      handleRadioChangeSpy.resetHistory()
+    })
+  })
+
+  describe('onClick', function () {
+    it('should call handleRadioChange with checked and value', function () {
+      expect(handleRadioChangeSpy).to.not.have.been.called()
+
+      wrapper.find('input').simulate('click', { target: { checked: true, value: 'S' } })
+
+      expect(handleRadioChangeSpy).to.have.been.calledWith('S')
+
+      handleRadioChangeSpy.resetHistory()
     })
   })
 })


### PR DESCRIPTION
Package:
- lib-classifier

Towards #1991.

Describe your changes:
- refactor RadioInputs and RadioInput to support `onClick`, in subsequent PR `onKeyDown`
- refactor Questions `handleAnswer` to delete unanswered question
- fix related tests, edit RadioInputs story

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [x] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
