### PR TITLE
Classifier: track annotation changes on step change

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/PreviousMarks/PreviousMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/PreviousMarks/PreviousMarks.js
@@ -3,13 +3,16 @@ import PropTypes from 'prop-types'
 import DrawingToolMarks from '../DrawingToolMarks'
 import SHOWN_MARKS from '@helpers/shownMarks'
 
-function PreviousMarks (props) {
-  const {
-    frame = 0,
-    previousAnnotations = [],
-    scale = 1,
-    shownMarks = 'ALL'
-  } = props
+function PreviousMarks ({
+  /** The current active frame in the subject viewer. */
+  frame = 0,
+  /** Annotations from previous marking tasks. Each annotation is an array of marks. */
+  previousAnnotations = [],
+  /** SVG image scale (client size / natural size.)*/
+  scale = 1,
+  /** The show/hide previous marks setting. */
+  shownMarks = 'ALL'
+}) {
   const marksToShow = shownMarks === SHOWN_MARKS.ALL || shownMarks === SHOWN_MARKS.USER
 
   if (previousAnnotations?.length > 0 && marksToShow) {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/NextButton/NextButtonConnector.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/NextButton/NextButtonConnector.js
@@ -9,7 +9,13 @@ function withStores(Component) {
       classifierStore: {
         annotatedSteps: {
           hasNextStep,
+          latest: {
+            annotations
+          },
           next
+        },
+        workflowSteps: {
+          active: step
         }
       }
     } = props.store || useContext(MobXProviderContext)
@@ -18,9 +24,14 @@ function withStores(Component) {
       return null
     }
 
+    function onClick() {
+      step.completeTasks(annotations)
+      next()
+    }
+
     return (
       <Component
-        onClick={next}
+        onClick={onClick}
         {...props}
       />
     )

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/NextButton/NextButtonConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/NextButton/NextButtonConnector.spec.js
@@ -1,5 +1,6 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+import sinon from 'sinon'
 
 import mockStore from '@test/mockStore'
 
@@ -38,12 +39,23 @@ describe('Components > NextButtonConnector', function () {
 
   describe('on click', function () {
     before(function () {
+      const firstStep = classifierStore.workflowSteps.steps.get('S0')
+      firstStep.tasks.forEach(task => {
+        sinon.spy(task, 'complete')
+      })
       const button = wrapper.find(NextButton)
       button.props().onClick()
       wrapper.update()
     })
 
-    it('should create a default annotation for each task if there is not an annotation for that task', function () {
+    after(function () {
+      const firstStep = classifierStore.workflowSteps.steps.get('S0')
+      firstStep.tasks.forEach(task => {
+        task.complete.restore()
+      })
+    })
+
+    it('should create a default annotation for each new task if there is not an annotation for that task', function () {
       const step = classifierStore.workflowSteps.active
       const classification = classifierStore.classifications.active
       step.tasks.forEach((task) => {
@@ -57,6 +69,13 @@ describe('Components > NextButtonConnector', function () {
     it('should select the next step', function () {
       const step = classifierStore.workflowSteps.active
       expect(step.stepKey).to.equal('S1')
+    })
+
+    it('should complete each active task',function () {
+      const firstStep = classifierStore.workflowSteps.steps.get('S0')
+      firstStep.tasks.forEach(task => {
+        expect(task.complete).to.have.been.calledOnce()
+      })
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
@@ -208,6 +208,29 @@ describe('Model > DrawingTask', function () {
     it('should copy marks to the task annotation', function () {
       expect(annotation.value).to.deep.equal([point1, point2, line1])
     })
+
+    describe('on deleting a mark', function () {
+      before(function () {
+        task.tools[1].deleteMark(line1)
+        task.complete(annotation)
+      })
+
+      it('should update the annotation', function () {
+        expect(annotation.value).to.deep.equal([point1, point2])
+      })
+    })
+
+    describe('on creating a mark', function () {
+      let line2
+      before(function () {
+        line2 = task.tools[1].createMark({ id: 'line2' })
+        task.complete(annotation)
+      })
+
+      it('should update the annotation', function () {
+        expect(annotation.value).to.deep.equal([point1, point2, line2])
+      })
+    })
   })
 
   describe('on reset', function () {

--- a/packages/lib-classifier/src/store/AnnotatedSteps/AnnotatedSteps.js
+++ b/packages/lib-classifier/src/store/AnnotatedSteps/AnnotatedSteps.js
@@ -119,11 +119,10 @@ const AnnotatedSteps = types.model('AnnotatedSteps', {
   }
   /** Redo the next step, or add a new step to history if there is no redo. */
   function next() {
-    const { annotations, step, nextStepKey } = self.latest
+    const { nextStepKey } = self.latest
     if (undoManager.canRedo) {
       _redo(nextStepKey)
     } else {
-      step.completeTasks(annotations)
       _beginStep(nextStepKey)
     }
   }

--- a/packages/lib-classifier/src/store/AnnotatedSteps/AnnotatedSteps.spec.js
+++ b/packages/lib-classifier/src/store/AnnotatedSteps/AnnotatedSteps.spec.js
@@ -44,34 +44,18 @@ describe('Model > AnnotatedSteps', function () {
   })
 
   describe('after moving to the second step', function () {
-    let firstStep
-
     before(function () {
       const [ branchingQuestionAnnotation ] = store.annotatedSteps.latest.annotations
       // answer Yes to the branching question.
       branchingQuestionAnnotation.update(0)
-      firstStep = store.annotatedSteps.latest.step
-      firstStep.tasks.forEach(task => {
-        sinon.spy(task, 'complete')
-      })
       store.annotatedSteps.next()
       const [ multipleChoiceAnnotation ] = store.annotatedSteps.latest.annotations
       // answer the T1 question so we can test redo.
       multipleChoiceAnnotation.update([0,1])
     })
 
-    after(function () {
-      firstStep.tasks.forEach(task => {
-        task.complete.restore()
-      })
-    })
-
     it('should have two steps', function () {
       expect(store.annotatedSteps.steps.size).to.equal(2)
-    })
-
-    it('should complete the first step', function () {
-      firstStep.tasks.forEach(task => expect(task.complete).to.have.been.calledOnce())
     })
 
     it('should store the second workflow step', function () {


### PR DESCRIPTION
Testing of #2187 uncovered a drawing bug on master: `PreviousMarks` doesn't update if you go back and change a drawing annotation. If you go back and add a new mark, the new mark isn't rendered. If you go back and delete a mark, the classifier crashes, because `PreviousMarks` now holds a reference to a mark that doesn't exist.

When I refactored the Next button in #2062, I moved `step.completeTasks` into the `next()` action, which is tracked by undo/redo. Now, pressing the Next button always redoes the first value you set for a drawing/transcription annotation, ignoring any new marks and restoring the IDs of any deleted marks. References to deleted  marks crash the store, with an invalid reference error.

This PR fixes that by running `step.completeTasks`, for the active workflow step, outside the `next()` action when we finish a step.
 
Package:
lib-classifier

Closes #2200.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
