### PR TITLE
Fix extra space that Safari renders below footer

### DIFF
--- a/packages/lib-react-components/src/ZooFooter/components/LinkList/LinkList.js
+++ b/packages/lib-react-components/src/ZooFooter/components/LinkList/LinkList.js
@@ -7,7 +7,7 @@ import zipLabelsAndUrls from '../../helpers/zipLabelsAndUrls'
 import SpacedText from '../../../SpacedText'
 
 const StyledBox = styled(Box)`
-  height: 100%;
+  height: fit-content;
   list-style-type: none;
 `
 


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

Package:
lib-react-components

Closes #2216.

Describe your changes:
Changed `LinkList` height property to `fit-content`.
[Mozilla](https://developer.mozilla.org/en-US/docs/Web/CSS/height) docs say Firefox does not support the CSS property `fit-content`, but when run in the latest version of Firefox, the LinkList height is still styled with the property `moz-fit-content`.
Can test by running storybook on all browsers.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
