### PR TITLE
Remove dev dependencies and src from Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:14-alpine as builder
 
 ARG COMMIT_ID
 ENV COMMIT_ID=$COMMIT_ID
@@ -59,3 +59,59 @@ RUN yarn workspace @zooniverse/fe-content-pages build
 RUN echo $COMMIT_ID > /usr/src/packages/app-project/public/commit_id.txt
 
 RUN yarn workspace @zooniverse/fe-project build
+
+
+
+FROM node:14-alpine as runner
+
+ARG COMMIT_ID
+ENV COMMIT_ID=$COMMIT_ID
+
+ARG PANOPTES_ENV=production
+ENV PANOPTES_ENV=$PANOPTES_ENV
+
+ARG NODE_ENV=production
+ENV NODE_ENV=$NODE_ENV
+
+ARG APP_ENV=production
+ENV APP_ENV=$APP_ENV
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+ARG CONTENTFUL_ACCESS_TOKEN
+
+ARG CONTENTFUL_SPACE_ID
+
+ARG CONTENT_ASSET_PREFIX
+ENV CONTENT_ASSET_PREFIX=$CONTENT_ASSET_PREFIX
+
+ARG SENTRY_CONTENT_DSN
+ENV SENTRY_CONTENT_DSN=$SENTRY_CONTENT_DSN
+
+ARG SENTRY_PROJECT_DSN
+ENV SENTRY_PROJECT_DSN=$SENTRY_PROJECT_DSN
+
+ARG PROJECT_ASSET_PREFIX
+ENV PROJECT_ASSET_PREFIX=$PROJECT_ASSET_PREFIX
+
+RUN mkdir -p /usr/src
+
+WORKDIR /usr/src/
+
+ADD package.json /usr/src/
+
+ADD yarn.lock /usr/src/
+
+COPY .yarn /usr/src/.yarn
+
+ADD .yarnrc /usr/src/
+
+COPY --from=builder /usr/src/packages ./packages
+
+RUN yarn install --production --frozen-lockfile --ignore-scripts --prefer-offline
+
+RUN rm -rf /usr/src/packages/lib-react-components/src
+RUN rm -rf /usr/src/packages/lib-classifier/src
+RUN rm -rf /usr/src/packages/app-content-pages/src
+RUN rm -rf /usr/src/packages/app-project/src
+RUN rm -rf /usr/src/packages/app-project/stores

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ docker-compose build
 
 `docker-compose down` stops the running container.
 
-`docker-compose run --rm bash` runs an interactive shell on the Docker image.
+`docker-compose run --rm shell` runs an interactive shell on the Docker image.
 
 Development environments for individual packages can be run from the package directories. For example:
 ```sh


### PR DESCRIPTION
Add a second stage to the Docker build. The second stage takes the packages built by the first stage and builds a new image from them. The new image has a production install of `node_modules` (no dev dependencies) and deletes source code from the built packages. Removing dev dependencies shaves ~500MB off the final image size.

The build is loosely based on [the NextJS Docker example](https://nextjs.org/docs/deployment#docker-image), adapted for our monorepo.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
