### PR TITLE
Integrate UPP store in project app

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperConnector.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperConnector.js
@@ -14,8 +14,7 @@ function useStore() {
     user,
     ui: {
       mode
-    },
-    yourStats
+    }
   } = store
 
   return ({
@@ -24,7 +23,7 @@ function useStore() {
     project,
     recents,
     user,
-    yourStats
+    yourStats: user.personalization
   })
 }
 

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperConnector.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperConnector.spec.js
@@ -5,7 +5,6 @@ import React from 'react'
 import asyncStates from '@zooniverse/async-states'
 
 import initStore from '@stores/initStore'
-import ClassifierWrapper from './ClassifierWrapper'
 import ClassifierWrapperConnector from './ClassifierWrapperConnector'
 
 describe('Component > ClassifierWrapperConnector', function () {
@@ -59,7 +58,7 @@ describe('Component > ClassifierWrapperConnector', function () {
       })
 
       it('should include your personal stats', function () {
-        expect(wrapper.props().yourStats).to.equal(store.yourStats)
+        expect(wrapper.props().yourStats).to.equal(store.user.personalization)
       })
 
       it('should include the project', function () {

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStatsContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStatsContainer.js
@@ -6,7 +6,7 @@ import YourStats from './YourStats'
 import withRequireUser from '@shared/components/withRequireUser'
 
 function storeMapper (stores) {
-  const { project, yourStats: { counts } } = stores.store
+  const { project, user: { personalization: { counts } } } = stores.store
   return {
     counts,
     projectName: project['display_name']

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react'
 import DailyClassificationsChart from './DailyClassificationsChart'
 
 function storeMapper (stores) {
-  const { project, yourStats: { counts, thisWeek } } = stores.store
+  const { project, user: { personalization: { counts, stats: { thisWeek } } } } = stores.store
   return {
     counts,
     thisWeek,

--- a/packages/app-project/stores/Store.js
+++ b/packages/app-project/stores/Store.js
@@ -6,7 +6,6 @@ import Project from './Project'
 import Recents from './Recents'
 import UI from './UI'
 import User from './User'
-import YourStats from './YourStats'
 
 const Store = types
   .model('Store', {
@@ -14,8 +13,7 @@ const Store = types
     project: types.optional(Project, {}),
     recents: types.optional(Recents, {}),
     ui: types.optional(UI, {}),
-    user: types.optional(User, {}),
-    yourStats: types.optional(YourStats, {})
+    user: types.optional(User, {})
   })
 
   .views(self => ({

--- a/packages/app-project/stores/User.js
+++ b/packages/app-project/stores/User.js
@@ -1,7 +1,7 @@
 import asyncStates from '@zooniverse/async-states'
 import { flow, types } from 'mobx-state-tree'
 import auth from 'panoptes-client/lib/auth'
-
+import UserPersonalization from './UserPersonalization'
 import numberString from './types/numberString'
 
 const User = types
@@ -11,7 +11,8 @@ const User = types
     error: types.maybeNull(types.frozen({})),
     id: types.maybeNull(numberString),
     login: types.maybeNull(types.string),
-    loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.loading)
+    loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.loading),
+    personalization: types.optional(UserPersonalization, {})
   })
 
   .views(self => ({

--- a/packages/app-project/stores/UserPersonalization.js
+++ b/packages/app-project/stores/UserPersonalization.js
@@ -36,7 +36,7 @@ const UserPersonalization = types
       const parentDisposer = autorun(() => {
         const { project, user } = getRoot(self)
         if (project.id && user.id) {
-          if (!self.projectPreferences.id) self.projectPreferences.fetchResource()
+          self.projectPreferences.fetchResource()
           self.stats.fetchDailyCounts()
         }
       })

--- a/packages/app-project/stores/UserPersonalization.js
+++ b/packages/app-project/stores/UserPersonalization.js
@@ -1,0 +1,61 @@
+import { addDisposer, getRoot, types } from 'mobx-state-tree'
+import { autorun } from 'mobx'
+import UserProjectPreferences from './UserProjectPreferences'
+import YourStats from './YourStats'
+
+const UserPersonalization = types
+  .model('UserPersonalization', {
+    projectPreferences: types.optional(UserProjectPreferences, {}),
+    stats: types.optional(YourStats, {}),
+    totalClassificationCount: 0
+  })
+  .volatile(self => ({
+    sessionCount: 0
+  }))
+  .views(self => ({
+    get counts() {
+      const todaysDate = new Date()
+      let today
+      try {
+        const todaysCount = self.stats.thisWeek.length === 7
+          ? self.stats.thisWeek[todaysDate.getDay() - 1].count
+          : 0
+        today = todaysCount + self.sessionCount
+      } catch (error) {
+        today = 0
+      }
+
+      return {
+        today,
+        total: self.totalClassificationCount
+      }
+    }
+  }))
+  .actions(self => {
+    function createParentObserver() {
+      const parentDisposer = autorun(() => {
+        const { project, user } = getRoot(self)
+        if (project.id && user.id) {
+          if (!self.projectPreferences.id) self.projectPreferences.fetchResource()
+          self.stats.fetchDailyCounts()
+        }
+      })
+      addDisposer(self, parentDisposer)
+    }
+    return {
+      afterAttach() {
+        createParentObserver()
+      },
+
+      increment() {
+        self.sessionCount = self.sessionCount + 1
+        self.totalClassificationCount = self.totalClassificationCount + 1
+      },
+
+      setTotalClassificationCount(count) {
+        self.totalClassificationCount = count
+      }
+    }
+  })
+
+export default UserPersonalization

--- a/packages/app-project/stores/UserPersonalization.spec.js
+++ b/packages/app-project/stores/UserPersonalization.spec.js
@@ -1,0 +1,251 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+import auth from 'panoptes-client/lib/auth'
+import nock from 'nock'
+
+import initStore from './initStore'
+import UserPersonalization from './UserPersonalization'
+import { statsClient } from './YourStats'
+
+describe('Stores > UserPersonalization', function () {
+  let rootStore, nockScope
+  const project = {
+    id: '2',
+    display_name: 'Hello',
+    slug: 'test/project'
+  }
+
+  before(function () {
+    sinon.stub(console, 'error')
+    const MOCK_DAILY_COUNTS = [
+      { count: 12, period: '2019-09-29' },
+      { count: 12, period: '2019-09-30' },
+      { count: 13, period: '2019-10-01' },
+      { count: 14, period: '2019-10-02' },
+      { count: 10, period: '2019-10-03' },
+      { count: 11, period: '2019-10-04' },
+      { count: 8, period: '2019-10-05' },
+      { count: 15, period: '2019-10-06' }
+    ]
+    nockScope = nock('https://panoptes-staging.zooniverse.org/api')
+      .persist()
+      .get('/project_preferences')
+      .query(true)
+      .reply(200, {
+        project_preferences: [
+          { activity_count: 23 }
+        ]
+      })
+      .get('/collections')
+      .query(true)
+      .reply(200)
+      .post('/collections')
+      .query(true)
+      .reply(200)
+    rootStore = initStore(true, { project })
+    sinon.spy(rootStore.client.panoptes, 'get')
+    sinon.stub(statsClient, 'request').callsFake(() => Promise.resolve({ statsCount: MOCK_DAILY_COUNTS }))
+  })
+
+  after(function () {
+    console.error.restore()
+    rootStore.client.panoptes.get.restore()
+    statsClient.request.restore()
+    nock.cleanAll()
+  })
+
+  it('should exist', function () {
+    expect(rootStore.user.personalization).to.be.ok()
+  })
+
+  describe('with a project and user', function () {
+    let clock
+
+    before(function () {
+      clock = sinon.useFakeTimers({ now: new Date(2019, 9, 1, 12), toFake: ['Date'] })
+      const user = {
+        id: '123',
+        login: 'test.user'
+      }
+      rootStore.user.set(user)
+    })
+
+    after(function () {
+      clock.restore()
+      rootStore.client.panoptes.get.resetHistory()
+    })
+
+    it('should trigger the child UPP node store to request user preferences', function () {
+      const authorization = 'Bearer '
+      const endpoint = '/project_preferences'
+      const query = {
+        project_id: '2',
+        user_id: '123'
+      }
+      expect(rootStore.client.panoptes.get.withArgs(endpoint, query, { authorization })).to.have.been.calledOnce()
+    })
+
+    it('should trigger the child YourStats node to request user statistics', function () {
+      const query = `{
+        statsCount(
+          eventType: "classification",
+          interval: "1 Day",
+          window: "1 Week",
+          projectId: "2",
+          userId: "123"
+        ){
+          period,
+          count
+        }
+      }`
+      expect(statsClient.request).to.have.been.calledOnceWith(query.replace(/\s+/g, ' '))
+    })
+
+    describe('incrementing your classification count', function () {
+      before(function () {
+        const user = {
+          id: '123',
+          login: 'test.user',
+          personalization: {
+            projectPreferences: {
+              activity_count: 23
+            }
+          }
+        }
+        rootStore = initStore(true, { project, user })
+        rootStore.user.personalization.setTotalClassificationCount(23)
+        rootStore.user.personalization.increment()
+      })
+
+      it('should add 1 to your total count', function () {
+        expect(rootStore.user.personalization.totalClassificationCount).to.equal(24)
+      })
+
+      it('should add 1 to your session count', function () {
+        expect(rootStore.user.personalization.sessionCount).to.equal(1)
+      })
+    })
+  })
+
+  describe('with a project and anonymous user', function () {
+    before(function () {
+      rootStore = initStore(true, { project })
+    })
+
+    it('should not trigger the child UPP store to request user preferences from Panoptes', function () {
+      expect(rootStore.client.panoptes.get).to.have.not.been.called()
+    })
+
+    it('should start counting from 0', function () {
+      expect(rootStore.user.personalization.totalClassificationCount).to.equal(0)
+    })
+
+    describe('incrementing your classification count', function () {
+      before(function () {
+        rootStore.user.personalization.increment()
+      })
+
+      it('should add 1 to your total count', function () {
+        expect(rootStore.user.personalization.totalClassificationCount).to.equal(1)
+      })
+    })
+  })
+
+  describe('when Zooniverse auth is down.', function () {
+    before(function () {
+      rootStore = initStore(true, { project })
+      const user = {
+        id: '123',
+        login: 'test.user'
+      }
+      sinon.stub(auth, 'checkBearerToken').callsFake(() => Promise.reject(new Error('Auth is not available')))
+      rootStore.user.set(user)
+      rootStore.user.personalization.increment()
+    })
+
+    after(function () {
+      auth.checkBearerToken.restore()
+    })
+
+    it('should count session classifications from 0', function () {
+      expect(rootStore.user.personalization.totalClassificationCount).to.equal(1)
+    })
+  })
+
+  describe('on Panoptes API errors', function () {
+    before(function () {
+      rootStore = initStore(true, { project })
+      const user = {
+        id: '123',
+        login: 'test.user'
+      }
+      nockScope
+        .get('/project_preferences')
+        .query(true)
+        .replyWithError('Panoptes is not available')
+      rootStore.user.set(user)
+      rootStore.user.personalization.increment()
+    })
+
+    it('should count session classifications from 0', function () {
+      expect(rootStore.user.personalization.totalClassificationCount).to.equal(1)
+    })
+  })
+
+  describe('counts view', function () {
+    it('should return the expected counts with no data', function () {
+      const personalizationStore = UserPersonalization.create()
+      expect(personalizationStore.counts).to.deep.equal({
+        today: 0,
+        total: 0
+      })
+    })
+
+    describe('total count', function () {
+      it('should get the total count from the store `totalClassificationCount` value', function () {
+        const personalizationStore = UserPersonalization.create()
+        personalizationStore.increment()
+        personalizationStore.increment()
+        personalizationStore.increment()
+        personalizationStore.increment()
+        expect(personalizationStore.counts.total).to.equal(4)
+      })
+    })
+
+    describe('today\'s count', function () {
+      let clock
+
+      before(function () {
+        clock = sinon.useFakeTimers({ now: new Date(2019, 9, 1, 12), toFake: ['Date'] })
+      })
+
+      after(function () {
+        clock.restore()
+      })
+
+      it('should get today\'s count from the store\'s counts for this week', function () {
+        const MOCK_DAILY_COUNTS = [
+          { count: 12, period: '2019-09-30T00:00:00Z' },
+          { count: 13, period: '2019-10-01T00:00:00Z' },
+          { count: 14, period: '2019-10-02T00:00:00Z' },
+          { count: 10, period: '2019-10-03T00:00:00Z' },
+          { count: 11, period: '2019-10-04T00:00:00Z' },
+          { count: 8, period: '2019-10-05T00:00:00Z' },
+          { count: 15, period: '2019-10-06T00:00:00Z' }
+        ]
+        const personalizationStore = UserPersonalization.create({ stats: { thisWeek: MOCK_DAILY_COUNTS } })
+        expect(personalizationStore.counts.today).to.equal(MOCK_DAILY_COUNTS[1].count)
+      })
+
+      it('should be `0` if there are no classifications today', function () {
+        const MOCK_DAILY_COUNTS = [
+          { count: 12, period: '2019-01-03T00:00:00Z' },
+          { count: 13, period: '2019-01-02T00:00:00Z' },
+          { count: 14, period: '2019-01-01T00:00:00Z' }
+        ]
+        const personalizationStore = UserPersonalization.create({ stats: { thisWeek: MOCK_DAILY_COUNTS } })
+        expect(personalizationStore.counts.today).to.equal(0)
+      })
+    })
+  })
+})

--- a/packages/app-project/stores/UserPersonalization.spec.js
+++ b/packages/app-project/stores/UserPersonalization.spec.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai'
 import sinon from 'sinon'
 import auth from 'panoptes-client/lib/auth'
 import nock from 'nock'
@@ -36,7 +35,7 @@ describe('Stores > UserPersonalization', function () {
           { activity_count: 23 }
         ]
       })
-      .get('/collections')
+      .get('/collections') // This is to get the collections store to not make real requests
       .query(true)
       .reply(200)
       .post('/collections')

--- a/packages/app-project/stores/UserProjectPreferences.js
+++ b/packages/app-project/stores/UserProjectPreferences.js
@@ -1,4 +1,7 @@
-import { types } from 'mobx-state-tree'
+import { applySnapshot, flow, getRoot, types } from 'mobx-state-tree'
+import auth from 'panoptes-client/lib/auth'
+import asyncStates from '@zooniverse/async-states'
+import numberString from './types/numberString'
 
 const Preferences = types
   .model('Preferences', {
@@ -11,14 +14,51 @@ const UserProjectPreferences = types
   .model('UserProjectPreferences', {
     activity_count: types.maybe(types.number),
     activity_count_by_workflow: types.maybe(types.frozen()),
+    error: types.maybeNull(types.frozen({})),
+    id: types.maybe(numberString),
     links: types.maybe(
       types.frozen({
         project: types.string,
         user: types.string
       })
     ),
+    loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.initialized),
     preferences: types.maybe(Preferences),
     settings: types.maybe(types.frozen())
+  })
+  .actions(self => {
+    return {
+      fetchResource: flow(function* fetchResource() {
+        const { client, project, user } = getRoot(self)
+        self.loadingState = asyncStates.loading
+        try {
+          const token = yield auth.checkBearerToken()
+          const authorization = `Bearer ${token}`
+          const query = {
+            project_id: project.id,
+            user_id: user.id
+          }
+          // TODO: this should really share the UPP that's being requested by the classifier.
+          const response = yield client.panoptes.get('/project_preferences', query, { authorization })
+          const [preferences] = response.body.project_preferences
+          if (preferences) {
+
+          }
+          if (preferences) {
+            applySnapshot(self, preferences)
+          }
+
+          self.loadingState = asyncStates.success
+          if (preferences.activity_count) {
+            user.personalization.setTotalCount(preferences.activity_count)
+          }
+        } catch (error) {
+          console.error(error)
+          self.error = error
+          self.loadingState = asyncStates.error
+        }
+      })
+    }
   })
 
 export default UserProjectPreferences

--- a/packages/app-project/stores/UserProjectPreferences.js
+++ b/packages/app-project/stores/UserProjectPreferences.js
@@ -38,20 +38,16 @@ const UserProjectPreferences = types
             project_id: project.id,
             user_id: user.id
           }
-          // TODO: this should really share the UPP that's being requested by the classifier.
+
           const response = yield client.panoptes.get('/project_preferences', query, { authorization })
           const [preferences] = response.body.project_preferences
           if (preferences) {
-
-          }
-          if (preferences) {
             applySnapshot(self, preferences)
+            user.personalization.setTotalClassificationCount(preferences.activity_count)
           }
 
           self.loadingState = asyncStates.success
-          if (preferences.activity_count) {
-            user.personalization.setTotalCount(preferences.activity_count)
-          }
+          console.log(self.toJSON())
         } catch (error) {
           console.error(error)
           self.error = error

--- a/packages/app-project/stores/UserProjectPreferences.spec.js
+++ b/packages/app-project/stores/UserProjectPreferences.spec.js
@@ -1,7 +1,156 @@
-import UserProjectPreferences from './UserProjectPreferences'
+import sinon from 'sinon'
+import nock from 'nock'
+import initStore from './initStore'
+import asyncStates from '@zooniverse/async-states'
+import { statsClient } from './YourStats'
+import { expect } from 'chai'
 
-describe('Stores > UserProjectPreferences', function () {
+describe.only('Stores > UserProjectPreferences', function () {
+  let nockScope, rootStore;
+  const project = {
+    id: '2',
+    display_name: 'Hello',
+    slug: 'test/project'
+  }
+  const user = {
+    id: '123'
+  }
+  const upp = {
+    activity_count: 23,
+    activity_count_by_workflow: {},
+    id: '555',
+    links: {
+      project: '2',
+      user: '123'
+    },
+    preferences: {
+      minicourses: undefined,
+      selected_workflow: undefined,
+      tutorials_completed_at: undefined
+    },
+    settings: {}
+  }
+
+  before(function () {
+    sinon.stub(console, 'error')
+    sinon.stub(statsClient, 'request')
+    nockScope = nock('https://panoptes-staging.zooniverse.org/api')
+      .get('/project_preferences')
+      .query(true)
+      .reply(200, {
+        project_preferences: [
+          upp
+        ]
+      })
+      .get('/collections') // This is to prevent the collections store from making real requests
+      .query(true)
+      .reply(200)
+      .post('/collections')
+      .query(true)
+      .reply(200)
+
+    rootStore = initStore(true, {
+      project,
+      user
+    })
+    sinon.spy(rootStore.client.panoptes, 'get')
+  })
+
+  after(function () {
+    console.error.restore()
+    nock.cleanAll()
+    rootStore.client.panoptes.get.restore()
+    statsClient.request.restore()
+    nockScope = null
+    rootStore = null
+  })
+
   it('should exist', function () {
-    expect(UserProjectPreferences).to.be.an('object')
+    expect(rootStore.user.personalization.projectPreferences).to.be.an('object')
+  })
+
+  describe('Action > fetchResource', function () {
+    describe('when there is a resource in the response', function () {
+      it('should request the user project preferences resource', function () {
+        const authorization = 'Bearer '
+        const endpoint = '/project_preferences'
+        const query = {
+          project_id: '2',
+          user_id: '123'
+        }
+        expect(rootStore.client.panoptes.get.withArgs(endpoint, query, { authorization })).to.have.been.calledOnce()
+      })
+
+      it('should store the UPP resource', function () {
+        const storedUPP = Object.assign({}, upp, { error: undefined, loadingState: asyncStates.success })
+        expect(rootStore.user.personalization.projectPreferences).to.deep.equal(storedUPP)
+        expect(rootStore.user.personalization.projectPreferences.loadingState).to.equal(asyncStates.success)
+      })
+
+      it('should set the total classification count on the parent node', function () {
+        expect(rootStore.user.personalization.totalClassificationCount).to.equal(23)
+      })
+    })
+
+    describe('when there are no user project preferences in the response', function () {
+      before(function () {
+        nockScope = nock('https://panoptes-staging.zooniverse.org/api')
+          .get('/project_preferences')
+          .query(true)
+          .reply(200, {
+            project_preferences: []
+          })
+          .get('/collections') // This is to prevent the collections store from making real requests
+          .query(true)
+          .reply(200)
+          .post('/collections')
+          .query(true)
+          .reply(200)
+
+        rootStore = initStore(true, {
+          project,
+          user
+        })
+      })
+
+      after(function () {
+        nockScope = null
+        rootStore = null
+      })
+
+      it('should not apply the UPP resource', function () {
+        expect(rootStore.user.personalization.projectPreferences.loadingState).to.equal(asyncStates.success)
+        expect(rootStore.user.personalization.projectPreferences.id).to.be.undefined()
+      })
+
+      it('should not set the total classification count on the parent node', function () {
+        expect(rootStore.user.personalization.totalClassificationCount).to.equal(0)
+      })
+    })
+
+    describe('when the request errors', function () {
+      before(function () {
+        nockScope = nock('https://panoptes-staging.zooniverse.org/api')
+          .get('/project_preferences')
+          .query(true)
+          .replyWithError('Error!') // Note this is an error on the request object, not the response
+          .get('/collections') // This is to prevent the collections store from making real requests
+          .query(true)
+          .reply(200)
+          .post('/collections')
+          .query(true)
+          .reply(200)
+
+        rootStore = initStore(true, {
+          project,
+          user
+        })
+      })
+
+      it('should store the error', function () {
+        expect(rootStore.user.personalization.projectPreferences.error).to.equal('Error!')
+        expect(rootStore.user.personalization.projectPreferences.loadingState).to.equal(asyncStates.error)
+      })
+    })
   })
 })


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

Package: app-project

Toward #2205 

This has three main parts:

- A refactor of `YourStats` to only handle the stats server request and data
- The addition of `UserPersonalization` to handle the shared bits between `YourStats` and UserProjectPreferences`
- The async fetch and storing of the UPP resource

I initially thought about using MST's [`types.compose`](https://mobx-state-tree.js.org/API/#compose) in `UserPersonalization` of two stores, but eventually to remove the redundancy between the project app and the classifier, the UPP store will have other HTTP requests it is handling for updating the UPP and creating it initially, so it async state needs to be tracked separately from the user stats. 

`UserPersonalization` now handles the merging of the two different stats tracked by the stats service and on the UPP.

A future refactor should include reworking the `YourStats` and `Collections` stores to not automatically make requests when their nodes attached to their parents. It made the tests for separate stores more complicated having to stub or mock for them when the tests in the UPP store have nothing to do with them. (We need to do similar refactors in the classifier stores too).

I chose nock rather than mocking the fetch requests as I find it a bit easier to work with in this case.

The components store connections are also updated and when running the app, the component runs fine while signed out. Testing the signed in user is impossible locally (due to CORS and browser SSL security now), so the full manual QA will happen with the staging deploy. 

@goplayoutside3 asking for review from you since I think you have some flexibility right now still, but let me know if you need to go work on the tile feature and we can ask someone else. Thanks!

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [x] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
