### PR TITLE
Refactor SurveyTask Choice render, from Drop, to Stack

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/SurveyTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/SurveyTask.js
@@ -1,4 +1,4 @@
-import { Box, Drop } from 'grommet'
+import { Stack } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -20,17 +20,13 @@ function SurveyTask (props) {
     task
   } = props
 
-  const choiceTargetRef = React.useRef()
-
   function handleCancel () {
     handleAnswers({})
     handleChoice('')
   }
 
   return (
-    <Box
-      ref={choiceTargetRef}
-    >
+    <Stack fill>
       <Chooser
         autoFocus={autoFocus}
         disabled={disabled}
@@ -40,28 +36,18 @@ function SurveyTask (props) {
         selectedChoiceIds={selectedChoiceIds}
         task={task}
       />
-      {choiceTargetRef.current && selectedChoice && (
-        <Drop
-          align={{
-            top: 'top'
-          }}
-          onClickOutside={() => handleCancel()}
-          onEsc={() => handleCancel()}
-          stretch='align'
-          target={choiceTargetRef.current}
-        >
-          <Choice
-            answers={answers}
-            choiceId={selectedChoice}
-            handleAnswers={handleAnswers}
-            handleChoice={handleChoice}
-            onCancel={() => handleCancel()}
-            onIdentify={handleIdentify}
-            task={task}
-          />
-        </Drop>
+      {selectedChoice && (
+        <Choice
+          answers={answers}
+          choiceId={selectedChoice}
+          handleAnswers={handleAnswers}
+          handleChoice={handleChoice}
+          onCancel={() => handleCancel()}
+          onIdentify={handleIdentify}
+          task={task}
+        />
       )}
-    </Box>
+    </Stack>
   )
 }
 

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/SurveyTask.spec.js
@@ -1,8 +1,5 @@
-import { mount, shallow } from 'enzyme'
-import { Drop, Grommet } from 'grommet'
+import { shallow } from 'enzyme'
 import React from 'react'
-import sinon from 'sinon'
-import zooTheme from '@zooniverse/grommet-theme'
 import { default as Task } from '@plugins/tasks/SurveyTask'
 import Choice from './components/Choice'
 import Chooser from './components/Chooser'
@@ -31,26 +28,13 @@ describe('SurveyTask', function () {
     expect(wrapper.find(Chooser)).to.have.lengthOf(1)
   })
 
+  it('should not render a Choice component', function () {
+    expect(wrapper.find(Choice)).to.have.lengthOf(0)
+  })
+
   describe('with selectedChoice', function () {
     before(function () {
-      sinon.stub(React, 'useRef').callsFake(() => { return { current: document.createElement('div') } })
-      wrapper = mount(
-        <SurveyTask
-          selectedChoice='HPPPTMS'
-          task={task}
-        />, {
-          wrappingComponent: Grommet,
-          wrappingComponentProps: { theme: zooTheme }
-        }
-      )
-    })
-
-    after(function () {
-      React.useRef.restore()
-    })
-
-    it('should render a Drop component', function () {
-      expect(wrapper.find(Drop)).to.have.lengthOf(1)
+      wrapper.setProps({ selectedChoice: 'HPPPTMS' })
     })
 
     it('should render a Choice component with selectedChoice', function () {

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/Choice.js
@@ -35,6 +35,8 @@ export default function Choice (props) {
 
   return (
     <Box
+      background='light-1'
+      elevation='large'
       flex='grow'
       pad='small'
     >


### PR DESCRIPTION
Package:
- lib-classifier

Closes #2242.

Staging:
- https://local.zooniverse.org:8080/?project=1634&workflow=2434

Describe your changes:
- remove Grommet Drop component
- adds Grommet Stack component
- updates SurveyTask tests accordingly

Notes:
- subsequent PR incoming to disable Done or equivalent (only visible if choice content is small, like Fire)
- subsequent PR to fix focus to first input
- subsequent PR to fix dark theme

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
