### PR TITLE
Classifier: add image placeholder for Multi Frame Viewer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewer.stories.js
@@ -10,6 +10,7 @@ import ImageToolbar from '../../../ImageToolbar'
 import SubjectViewerStore from '@store/SubjectViewerStore'
 import readme from './README.md'
 import backgrounds from '../../../../../../../.storybook/lib/backgrounds'
+import asyncStates from '@zooniverse/async-states'
 
 const config = {
   notes: {
@@ -88,6 +89,7 @@ storiesOf('Subject Viewers / MultiFrameViewer', module)
       <ViewerContext subject={subjectWithMore} theme={zooTheme} themeMode='light'>
         <Box>
           <DecoratedMultiFrameViewerContainer
+            loadingState={asyncStates.success}
             enableInteractionLayer={false}
             subject={subjectWithMore}
           />
@@ -101,6 +103,7 @@ storiesOf('Subject Viewers / MultiFrameViewer', module)
       <ViewerContext subject={subjectWithMore} theme={darkZooTheme} themeMode='dark'>
         <Box>
           <DecoratedMultiFrameViewerContainer
+            loadingState={asyncStates.success}
             enableInteractionLayer={false}
             subject={subjectWithMore}
           />
@@ -113,6 +116,7 @@ storiesOf('Subject Viewers / MultiFrameViewer', module)
       <ViewerContext mode='light' subject={subjectWithMore} theme={zooTheme}>
         <Box direction='row'>
           <DecoratedMultiFrameViewerContainer
+            loadingState={asyncStates.success}
             enableInteractionLayer={false}
             subject={subjectWithMore}
           />
@@ -126,6 +130,7 @@ storiesOf('Subject Viewers / MultiFrameViewer', module)
       <ViewerContext mode='light' subject={subjectWithLess} theme={zooTheme}>
         <Box direction='row'>
           <DecoratedMultiFrameViewerContainer
+            loadingState={asyncStates.success}
             enableInteractionLayer={false}
             subject={subjectWithLess}
           />

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
@@ -140,20 +140,16 @@ class MultiFrameViewerContainer extends React.Component {
       subject
     } = this.props
     const { img } = this.state
-    const { naturalHeight, naturalWidth, src } = img
+    
+    // If image hasn't been fully retrieved, use a placeholder
+    const src = img?.src || 'https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png'  // Use this instead of https://www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png to save on network calls
+    const naturalWidth = img?.naturalWidth || 800
+    const naturalHeight = img?.naturalHeight || 600
 
     if (loadingState === asyncStates.error) {
       return (
         <div>Something went wrong.</div>
       )
-    }
-
-    if (!src) {
-      return null
-    }
-
-    if (!naturalWidth) {
-      return null
     }
 
     const svg = this.imageViewer.current
@@ -166,45 +162,48 @@ class MultiFrameViewerContainer extends React.Component {
       ...(move && { dragMove: this.dragMove })
     }
     
-    return (
-      <Box
-        direction='row'
-        fill='horizontal'
-      >
-        <FrameCarousel
-          frame={frame}
-          onFrameChange={this.onFrameChange}
-          locations={subject.locations}
-        />
-        <SVGContext.Provider value={{ svg }}>
-          <SVGPanZoom
-            img={this.subjectImage.current}
-            maxZoom={5}
-            naturalHeight={naturalHeight}
-            naturalWidth={naturalWidth}
-            setOnDrag={this.setOnDrag}
-            setOnPan={setOnPan}
-            setOnZoom={setOnZoom}
-            src={src}
-          >
-            <SingleImageViewer
-              enableInteractionLayer={enableDrawing}
-              height={naturalHeight}
-              onKeyDown={onKeyDown}
-              ref={this.imageViewer}
-              rotate={rotation}
-              width={naturalWidth}
+    if (loadingState !== asyncStates.initialized) {
+      return (
+        <Box
+          direction='row'
+          fill='horizontal'
+        >
+          <FrameCarousel
+            frame={frame}
+            onFrameChange={this.onFrameChange}
+            locations={subject.locations}
+          />
+          <SVGContext.Provider value={{ svg }}>
+            <SVGPanZoom
+              img={this.subjectImage.current}
+              maxZoom={5}
+              naturalHeight={naturalHeight}
+              naturalWidth={naturalWidth}
+              setOnDrag={this.setOnDrag}
+              setOnPan={setOnPan}
+              setOnZoom={setOnZoom}
+              src={src}
             >
-              <g ref={this.subjectImage}>
-                <SubjectImage
-                  {...subjectImageProps}
-                />
-              </g>
-            </SingleImageViewer>
-          </SVGPanZoom>
-        </SVGContext.Provider>
-      </Box>
-    )
+              <SingleImageViewer
+                enableInteractionLayer={enableDrawing}
+                height={naturalHeight}
+                onKeyDown={onKeyDown}
+                ref={this.imageViewer}
+                rotate={rotation}
+                width={naturalWidth}
+              >
+                <g ref={this.subjectImage}>
+                  <SubjectImage
+                    {...subjectImageProps}
+                  />
+                </g>
+              </SingleImageViewer>
+            </SVGPanZoom>
+          </SVGContext.Provider>
+        </Box>
+      )
+    }
+    return null
   }
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.spec.js
@@ -5,6 +5,7 @@ import React from 'react'
 import { DraggableImage, MultiFrameViewerContainer } from './MultiFrameViewerContainer'
 import FrameCarousel from './FrameCarousel'
 import SingleImageViewer from '../SingleImageViewer/SingleImageViewer'
+import asyncStates from '@zooniverse/async-states'
 
 describe('Component > MultiFrameViewerContainer', function () {
   let wrapper
@@ -70,6 +71,7 @@ describe('Component > MultiFrameViewerContainer', function () {
       wrapper = shallow(
         <MultiFrameViewerContainer
           ImageObject={ValidImage}
+          loadingState={asyncStates.success}
           subject={subject}
           onError={onError}
           onReady={onReady}
@@ -162,6 +164,7 @@ describe('Component > MultiFrameViewerContainer', function () {
       wrapper = shallow(
         <MultiFrameViewerContainer
           ImageObject={InvalidImage}
+          loadingState={asyncStates.success}
           subject={subject}
           onError={onError}
           onReady={onReady}


### PR DESCRIPTION
## PR Overview

packages: code change in `lib-classifier`, but can only be tested on `app-project`
Fixes #2221
Follows #2241 

This PR is a follow up to 2241, which adds an image placeholder for the Single Image Viewer, to solve the issue of drawing components not fully working when the Classifier page is _re-visited after navigating away from it._

- The problem context and solution is the same, **just on different viewers.**
- This PR addresses the issue where the Davy Notebooks projects is STILL encountering the issue "solved" by 2241, since D-Notes (as the cool kids call it) is using an MF Viewer not an SI Viewer.

### Testing

BE SURE TO TEST THIS ON DAVY NOTEBOOKS

1. Bootstrap everything
2. Open the Classify Page of Davy Notebooks: http://localhost:3000/projects/humphrydavy/davy-notebooks-project/classify?env=production (this WF should be using Multi-Frame Viewer)
3. Draw some Transcription Lines, annotate some text, etc.
4. Navigate to the Project home page
5. Return to the Classify page by clicking on the 'Classify' link on the project nav
  - Expected: the Transcription Lines should _look_ correct. (Without this PR, the scale of the drag handles shift wildly since it defaults to a scale of 1.0 instead of calculating the size relative to the browser window)
  - Expected: you should be able to modify existing Transcription Lines by dragging their start/end handles
  - Expected: you should be able to delete existing T-Lines and draw new T-Lines.

### Status

WIP. TODO:

- update tests.
- update Stories.
- check that everything still works with multi-image subjects (while testing today, I've only seen D-Notes subjects with only 1 image.)

Tagging @snblickhan so she has eyes on this for D-Notes.