### PR TITLE
Classifier drawing tools: simplify SVGContext

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
@@ -6,7 +6,6 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { draggable } from '@plugins/drawingTools/components'
-import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 
 import FrameCarousel from './FrameCarousel'
 import locationValidator from '../../helpers/locationValidator'
@@ -47,7 +46,6 @@ class MultiFrameViewerContainer extends React.Component {
     this.onFrameChange = this.onFrameChange.bind(this)
     this.setOnDrag = this.setOnDrag.bind(this)
 
-    this.imageViewer = React.createRef()
     this.subjectImage = React.createRef()
     
     this.state = {
@@ -105,7 +103,7 @@ class MultiFrameViewerContainer extends React.Component {
 
   async getImageSize () {
     const img = await this.preload()
-    const svg = this.imageViewer.current
+    const svg = this.subjectImage.current
     const { width: clientWidth, height: clientHeight } = svg ? svg.getBoundingClientRect() : {}
     return {
       clientHeight,
@@ -152,7 +150,6 @@ class MultiFrameViewerContainer extends React.Component {
       )
     }
 
-    const svg = this.imageViewer.current
     const enableDrawing = (loadingState === asyncStates.success) && enableInteractionLayer
     const SubjectImage = move ? DraggableImage : 'image'
     const subjectImageProps = {
@@ -161,7 +158,7 @@ class MultiFrameViewerContainer extends React.Component {
       xlinkHref: src,
       ...(move && { dragMove: this.dragMove })
     }
-    
+
     if (loadingState !== asyncStates.initialized) {
       return (
         <Box
@@ -173,33 +170,30 @@ class MultiFrameViewerContainer extends React.Component {
             onFrameChange={this.onFrameChange}
             locations={subject.locations}
           />
-          <SVGContext.Provider value={{ svg }}>
-            <SVGPanZoom
-              img={this.subjectImage.current}
-              maxZoom={5}
-              naturalHeight={naturalHeight}
-              naturalWidth={naturalWidth}
-              setOnDrag={this.setOnDrag}
-              setOnPan={setOnPan}
-              setOnZoom={setOnZoom}
-              src={src}
+          <SVGPanZoom
+            img={this.subjectImage.current}
+            maxZoom={5}
+            naturalHeight={naturalHeight}
+            naturalWidth={naturalWidth}
+            setOnDrag={this.setOnDrag}
+            setOnPan={setOnPan}
+            setOnZoom={setOnZoom}
+            src={src}
+          >
+            <SingleImageViewer
+              enableInteractionLayer={enableDrawing}
+              height={naturalHeight}
+              onKeyDown={onKeyDown}
+              rotate={rotation}
+              width={naturalWidth}
             >
-              <SingleImageViewer
-                enableInteractionLayer={enableDrawing}
-                height={naturalHeight}
-                onKeyDown={onKeyDown}
-                ref={this.imageViewer}
-                rotate={rotation}
-                width={naturalWidth}
-              >
-                <g ref={this.subjectImage}>
-                  <SubjectImage
-                    {...subjectImageProps}
-                  />
-                </g>
-              </SingleImageViewer>
-            </SVGPanZoom>
-          </SVGContext.Provider>
+              <g ref={this.subjectImage}>
+                <SubjectImage
+                  {...subjectImageProps}
+                />
+              </g>
+            </SingleImageViewer>
+          </SVGPanZoom>
         </Box>
       )
     }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
@@ -103,8 +103,8 @@ class MultiFrameViewerContainer extends React.Component {
 
   async getImageSize () {
     const img = await this.preload()
-    const svg = this.subjectImage.current
-    const { width: clientWidth, height: clientHeight } = svg ? svg.getBoundingClientRect() : {}
+    const svgImage = this.subjectImage.current
+    const { width: clientWidth, height: clientHeight } = svgImage ? svgImage.getBoundingClientRect() : {}
     return {
       clientHeight,
       clientWidth,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.spec.js
@@ -78,7 +78,7 @@ describe('Component > MultiFrameViewerContainer', function () {
         />
       )
       imageWrapper = wrapper.find(SingleImageViewer)
-      wrapper.instance().imageViewer = {
+      wrapper.instance().subjectImage = {
         current: {
           clientHeight: 50,
           clientWidth: 100,
@@ -102,7 +102,7 @@ describe('Component > MultiFrameViewerContainer', function () {
     })
 
     it('should record the original image dimensions on load', function () {
-      const svg = wrapper.instance().imageViewer.current
+      const svg = wrapper.instance().subjectImage.current
       const fakeEvent = {
         target: {
           clientHeight: 0,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types'
-import React, { createRef, forwardRef, useContext } from 'react'
+import React, { useRef } from 'react'
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import { Box } from 'grommet'
 import InteractionLayer from '../InteractionLayer'
 import ZoomControlButton from '../ZoomControlButton'
 
-const SingleImageViewer = forwardRef(function SingleImageViewer(props, ref) {
+function SingleImageViewer(props) {
   const {
     children,
     enableInteractionLayer,
@@ -20,8 +20,9 @@ const SingleImageViewer = forwardRef(function SingleImageViewer(props, ref) {
     zooming
   } = props
 
-  const transformLayer = createRef()
-  const { svg } = useContext(SVGContext)
+  const imageViewer = useRef()
+  const transformLayer = useRef()
+  const svg = imageViewer.current
   const transform = `rotate(${rotate} ${width / 2} ${height / 2})`
   const getScreenCTM = () => transformLayer.current.getScreenCTM()
 
@@ -32,7 +33,7 @@ const SingleImageViewer = forwardRef(function SingleImageViewer(props, ref) {
       )}
       <Box animation='fadeIn' overflow='hidden'>
         <svg
-          ref={ref}
+          ref={imageViewer}
           focusable
           onKeyDown={onKeyDown}
           tabIndex={0}
@@ -51,7 +52,7 @@ const SingleImageViewer = forwardRef(function SingleImageViewer(props, ref) {
       </Box>
     </SVGContext.Provider>
   )
-})
+}
 
 SingleImageViewer.propTypes = {
   enableInteractionLayer: PropTypes.bool,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -65,9 +65,9 @@ class SingleImageViewerContainer extends React.Component {
 
   async getImageSize() {
     const img = await this.preload()
-    const svg = this.subjectImage.current
-    const { width: clientWidth, height: clientHeight } = svg
-      ? svg.getBoundingClientRect()
+    const svgImage = this.subjectImage.current
+    const { width: clientWidth, height: clientHeight } = svgImage
+      ? svgImage.getBoundingClientRect()
       : {}
     return {
       clientHeight,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -5,7 +5,6 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { draggable } from '@plugins/drawingTools/components'
-import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 
 import locationValidator from '../../helpers/locationValidator'
 import SingleImageViewer from './SingleImageViewer'
@@ -22,7 +21,6 @@ class SingleImageViewerContainer extends React.Component {
     this.dragMove = this.dragMove.bind(this)
     this.setOnDrag = this.setOnDrag.bind(this)
 
-    this.imageViewer = React.createRef()
     this.subjectImage = React.createRef()
 
     this.state = {
@@ -67,7 +65,7 @@ class SingleImageViewerContainer extends React.Component {
 
   async getImageSize() {
     const img = await this.preload()
-    const svg = this.imageViewer.current
+    const svg = this.subjectImage.current
     const { width: clientWidth, height: clientHeight } = svg
       ? svg.getBoundingClientRect()
       : {}
@@ -120,7 +118,6 @@ class SingleImageViewerContainer extends React.Component {
       return <div>Something went wrong.</div>
     }
 
-    const svg = this.imageViewer.current
     const enableDrawing =
       loadingState === asyncStates.success && enableInteractionLayer
     const SubjectImage = move ? DraggableImage : 'image'
@@ -133,35 +130,32 @@ class SingleImageViewerContainer extends React.Component {
 
     if (loadingState !== asyncStates.initialized) {
       return (
-        <SVGContext.Provider value={{ svg }}>
-          <SVGPanZoom
-            img={this.subjectImage.current}
-            maxZoom={5}
-            naturalHeight={naturalHeight}
-            naturalWidth={naturalWidth}
-            setOnDrag={this.setOnDrag}
-            setOnPan={setOnPan}
-            setOnZoom={setOnZoom}
+        <SVGPanZoom
+          img={this.subjectImage.current}
+          maxZoom={5}
+          naturalHeight={naturalHeight}
+          naturalWidth={naturalWidth}
+          setOnDrag={this.setOnDrag}
+          setOnPan={setOnPan}
+          setOnZoom={setOnZoom}
+          zooming={zooming}
+          src={src}
+        >
+          <SingleImageViewer
+            enableInteractionLayer={enableDrawing}
+            height={naturalHeight}
+            onKeyDown={onKeyDown}
+            rotate={rotation}
+            title={title}
+            width={naturalWidth}
+            zoomControlFn={zoomControlFn}
             zooming={zooming}
-            src={src}
           >
-            <SingleImageViewer
-              enableInteractionLayer={enableDrawing}
-              height={naturalHeight}
-              onKeyDown={onKeyDown}
-              ref={this.imageViewer}
-              rotate={rotation}
-              title={title}
-              width={naturalWidth}
-              zoomControlFn={zoomControlFn}
-              zooming={zooming}
-            >
-              <g ref={this.subjectImage}>
-                <SubjectImage {...subjectImageProps} />
-              </g>
-            </SingleImageViewer>
-          </SVGPanZoom>
-        </SVGContext.Provider>
+            <g ref={this.subjectImage}>
+              <SubjectImage {...subjectImageProps} />
+            </g>
+          </SingleImageViewer>
+        </SVGPanZoom>
       )
     }
     return null

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -76,7 +76,7 @@ describe('Component > SingleImageViewerContainer', function () {
         />
       )
       imageWrapper = wrapper.find(SingleImageViewer)
-      wrapper.instance().imageViewer = {
+      wrapper.instance().subjectImage = {
         current: {
           clientHeight: 50,
           clientWidth: 100,
@@ -96,7 +96,7 @@ describe('Component > SingleImageViewerContainer', function () {
     })
 
     it('should record the original image dimensions on load', function () {
-      const svg = wrapper.instance().imageViewer.current
+      const svg = wrapper.instance().subjectImage.current
       const fakeEvent = {
         target: {
           clientHeight: 0,


### PR DESCRIPTION
Remove the imageViewer ref from SingleImageViewerContainer and MultiFrameViewerContainer. Instead, reference the svg DOM node from SingleImageViewer. Pass that node down to individual drawing components in SVGContext.

~~Remove `getScreenCTM` from the context since any SVG element should have a `getScreenCTM` method.~~ Messing with the transformation matrix breaks tools that use `rotate` transforms, so I've left the context alone.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
