### PR TITLE
Use next.js dynamic import to not SSR auth invite banner.

### DIFF
--- a/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationConnector.js
+++ b/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationConnector.js
@@ -1,6 +1,11 @@
+import dynamic from 'next/dynamic'
 import { MobXProviderContext, observer } from 'mobx-react'
 import React from 'react'
-import AuthenticationInvitationContainer from './AuthenticationInvitationContainer'
+
+export const DynamicallyImportedAuthenticationInvitationContainer = dynamic(
+  () => import('./AuthenticationInvitationContainer'),
+  { ssr: false }
+)
 
 function useStores() {
   const stores = React.useContext(MobXProviderContext)
@@ -18,7 +23,7 @@ function AuthenticationInvitationConnector (props) {
   const { isVisible = false } = useStores()
 
   return (
-    <AuthenticationInvitationContainer isVisible={isVisible} />
+    <DynamicallyImportedAuthenticationInvitationContainer isVisible={isVisible} />
   )
 }
 

--- a/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationConnector.spec.js
+++ b/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationConnector.spec.js
@@ -2,8 +2,7 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import sinon from 'sinon'
 
-import AuthenticationInvitationConnector from './AuthenticationInvitationConnector'
-import AuthenticationInvitationContainer from './AuthenticationInvitationContainer'
+import AuthenticationInvitationConnector, { DynamicallyImportedAuthenticationInvitationContainer } from './AuthenticationInvitationConnector'
 
 describe('Component > AuthenticationInvitationConnector', function () {
   let wrapper
@@ -29,7 +28,7 @@ describe('Component > AuthenticationInvitationConnector', function () {
     wrapper = shallow(
       <AuthenticationInvitationConnector />
     )
-    componentWrapper = wrapper.find(AuthenticationInvitationContainer)
+    componentWrapper = wrapper.find(DynamicallyImportedAuthenticationInvitationContainer)
   })
 
   after(function () {
@@ -50,7 +49,7 @@ describe('Component > AuthenticationInvitationConnector', function () {
       wrapper = shallow(
         <AuthenticationInvitationConnector />
       )
-      componentWrapper = wrapper.find(AuthenticationInvitationContainer)
+      componentWrapper = wrapper.find(DynamicallyImportedAuthenticationInvitationContainer)
     })
 
     after(function () {
@@ -66,7 +65,7 @@ describe('Component > AuthenticationInvitationConnector', function () {
     before(function () {
       mockStore.store.user.isLoggedIn = true
       wrapper = shallow(<AuthenticationInvitationConnector />)
-      componentWrapper = wrapper.find(AuthenticationInvitationContainer)
+      componentWrapper = wrapper.find(DynamicallyImportedAuthenticationInvitationContainer)
     })
 
     after(function () {
@@ -82,7 +81,7 @@ describe('Component > AuthenticationInvitationConnector', function () {
     before(function () {
       mockStore.store.user.personalization.sessionCount = 3
       wrapper = shallow(<AuthenticationInvitationConnector />)
-      componentWrapper = wrapper.find(AuthenticationInvitationContainer)
+      componentWrapper = wrapper.find(DynamicallyImportedAuthenticationInvitationContainer)
     })
 
     it('should not be visible', function () {


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

Package: app-project

We don't want the auth banner to render server side, and because it doesn't render until 5 classifications are made, it never actually will, however, the code expects window to be defined, so tell next explicitly to dynamically import it with no SSR. 

Current staging shows a flash of a window is no defined on the initial render: https://frontend.preview.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess/classify/workflow/11235?demo=true

Local project on this branch doesn't: http://localhost:3000/projects/nora-dot-eisner/planet-hunters-tess/classify/workflow/11235?demo=true

And to confirm that the banner still does appear as expected, you can make 5 classifications while demo mode is on (be sure to click it on with the gear icon next to done) and the banner will appear with the correct links for the auth modals. 


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
