### PR TITLE
Project: Cache subject sets across workflows

### DIFF
--- a/packages/app-project/src/helpers/fetchSubjectSets/fetchSubjectSets.js
+++ b/packages/app-project/src/helpers/fetchSubjectSets/fetchSubjectSets.js
@@ -3,6 +3,8 @@ import fetch from 'node-fetch'
 
 import { logToSentry } from '@helpers/logger'
 
+const subjectSetCache = {}
+
 async function fetchSubjectSetData(subjectSetIDs, env) {
   let subject_sets = []
   try {
@@ -19,6 +21,26 @@ async function fetchSubjectSetData(subjectSetIDs, env) {
     logToSentry(error)
   }
   return subject_sets
+}
+
+async function workflowSubjectSets(subjectSetIDs, env) {
+  const workflowSubjectSets = []
+  const setsToFetch = []
+  subjectSetIDs.forEach(id => {
+    if (subjectSetCache[id]) {
+      workflowSubjectSets.push(subjectSetCache[id])
+    } else {
+      setsToFetch.push(id)
+    }
+  })
+  if (setsToFetch.length > 0) {
+    const newSets = await fetchSubjectSetData(setsToFetch, env)
+    newSets.forEach(subjectSet => {
+      workflowSubjectSets.push(subjectSet)
+      subjectSetCache[subjectSet.id] = subjectSet
+    })
+  }
+  return workflowSubjectSets
 }
 
 async function fetchWorkflowCellectStatus(workflow) {
@@ -66,7 +88,7 @@ export default async function fetchSubjectSets(workflow, env) {
   if (subjectSetIDs.length === 0) {
     subjectSetIDs = workflow.links.subject_sets
   }
-  const subjectSets = await fetchSubjectSetData(subjectSetIDs, env)
+  const subjectSets = await workflowSubjectSets(subjectSetIDs, env)
   subjectSets.forEach(subjectSet => {
     subjectSet.availableSubjects = subjectSetCounts[subjectSet.id]
   })


### PR DESCRIPTION
Cache subject sets by ID, in `fetchSubjectSets`, so that we only fetch each set once from Panoptes. For HMS NHS, I'm seeing this speed up `getServerSideProps` from ~8s to ~1.5s.

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
