### PR TITLE
Reset cpu requests to ensure the HPA pod scaling is correct

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -45,7 +45,7 @@ spec:
           resources:
             requests:
               memory: "500Mi"
-              cpu: "100m"
+              cpu: "250m"
             limits:
               memory: "1000Mi"
               cpu: "1000m"
@@ -137,7 +137,7 @@ spec:
           resources:
             requests:
               memory: "200Mi"
-              cpu: "100m"
+              cpu: "250m"
             limits:
               memory: "500Mi"
               cpu: "1000m"

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -35,7 +35,7 @@ spec:
           resources:
             requests:
               memory: "250Mi"
-              cpu: "10m"
+              cpu: "100m"
             limits:
               memory: "500Mi"
               cpu: "1000m"
@@ -119,7 +119,7 @@ spec:
           resources:
             requests:
               memory: "250Mi"
-              cpu: "10m"
+              cpu: "100m"
             limits:
               memory: "500Mi"
               cpu: "1000m"


### PR DESCRIPTION
this PR reinstates the CPU request values in #2261 as they are used for the horizontal pod autoscaler metrics. Making these CPU requests too low means the autoscaler will kick in and run more pods for each app service. 

As such this PR reinstates the values back to previous to reinstate the original scaling behaviour.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
