### PR TITLE
Link to workflow in assignment prompt

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -77,7 +77,7 @@ function ClassifyPage ({
             />
             <ThemeModeToggle />
           </Grid>
-          <WorkflowAssignmentModal workflowID={workflowID} />
+          <WorkflowAssignmentModal currentWorkflowID={workflowID} />
         </Box>
 
         <Box as='aside' gap='medium' width={{ min: 'none', max: 'xxlarge' }}>

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.js
@@ -1,14 +1,22 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button, Box, CheckBox } from 'grommet'
+import { Button, Box, CheckBox, Text } from 'grommet'
 import { Modal, PrimaryButton, SpacedText } from '@zooniverse/react-components'
-import en from './locales/en'
+import { useRouter } from 'next/router'
 import counterpart from 'counterpart'
+
+import NavLink from '@shared/components/NavLink'
+import en from './locales/en'
 
 counterpart.registerTranslations('en', en)
 
 export default function WorkflowAssignmentModal(props) {
-  const { active = false, closeFn, dismiss, dismissedForSession = false } = props
+  const { active = false, assignedWorkflowID, closeFn, dismiss, dismissedForSession = false } = props
+  const router = useRouter()
+  const { owner, project } = router?.query || {}
+
+  const url = `/projects/${owner}/${project}/classify/workflow/${assignedWorkflowID}`
+
   return (
     <Modal active={active} closeFn={closeFn} title={counterpart('WorkflowAssignmentModal.title')}>
       <Box pad={{ bottom: 'xsmall' }}>{counterpart('WorkflowAssignmentModal.content')}</Box>
@@ -21,7 +29,11 @@ export default function WorkflowAssignmentModal(props) {
       </Box>
       <Box direction='row' gap='xsmall' justify='center'>
         <Button label={counterpart('WorkflowAssignmentModal.cancel')} onClick={() => closeFn()} />
-        <PrimaryButton label={counterpart('WorkflowAssignmentModal.confirm')} />
+        <NavLink
+          StyledAnchor={PrimaryButton}
+          StyledSpacedText={Text}
+          link={{ href: url, text: counterpart('WorkflowAssignmentModal.confirm')}}
+        />
       </Box>
     </Modal>
   )
@@ -29,6 +41,7 @@ export default function WorkflowAssignmentModal(props) {
 
 WorkflowAssignmentModal.propTypes = {
   active: PropTypes.bool,
+  assignedWorkflowID: PropTypes.string.isRequired,
   closeFn: PropTypes.func.isRequired,
   dismiss: PropTypes.func.isRequired,
   dismissedForSession: PropTypes.bool

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.spec.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { Modal, PrimaryButton } from '@zooniverse/react-components'
+import { Modal } from '@zooniverse/react-components'
 import { Button, CheckBox } from 'grommet'
 import sinon from 'sinon'
 import WorkflowAssignmentModal from './WorkflowAssignmentModal'
 import en from './locales/en'
-import { expect } from 'chai'
+import NavLink from '@shared/components/NavLink'
 
 describe('Component > WorkflowAssignmentModal', function () {
   let wrapper, closeFnSpy, dismissSpy
@@ -47,9 +47,9 @@ describe('Component > WorkflowAssignmentModal', function () {
     expect(wrapper.find(Modal).props().title).to.equal(en.WorkflowAssignmentModal.title)
   })
 
-  it('should render a confirmation button', function () {
-    const button = wrapper.find(PrimaryButton)
-    expect(button.props().label).to.equal(en.WorkflowAssignmentModal.confirm)
+  it('should render a confirmation link', function () {
+    const button = wrapper.find(NavLink)
+    expect(button.props().link.text).to.equal(en.WorkflowAssignmentModal.confirm)
   })
 
   it('should render a cancel button', function () {

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.spec.js
@@ -6,16 +6,27 @@ import sinon from 'sinon'
 import WorkflowAssignmentModal from './WorkflowAssignmentModal'
 import en from './locales/en'
 import NavLink from '@shared/components/NavLink'
+import * as nextRouter from 'next/router'
 
 describe('Component > WorkflowAssignmentModal', function () {
   let wrapper, closeFnSpy, dismissSpy
+  const router = {
+    asPath: '/projects/foo/bar',
+    query: {
+      owner: 'foo',
+      project: 'bar'
+    }
+  }
+
   before(function() {
     closeFnSpy = sinon.spy()
     dismissSpy = sinon.spy()
-    wrapper = shallow(<WorkflowAssignmentModal closeFn={closeFnSpy} dismiss={dismissSpy} />)
+    sinon.stub(nextRouter, 'useRouter').callsFake(() => router)
+    wrapper = shallow(<WorkflowAssignmentModal closeFn={closeFnSpy} dismiss={dismissSpy} assignedWorkflowID='1234' />)
   })
 
   after(function () {
+    nextRouter.useRouter.restore()
     closeFnSpy = null
     dismissSpy = null
     wrapper = null
@@ -50,6 +61,7 @@ describe('Component > WorkflowAssignmentModal', function () {
   it('should render a confirmation link', function () {
     const button = wrapper.find(NavLink)
     expect(button.props().link.text).to.equal(en.WorkflowAssignmentModal.confirm)
+    expect(button.props().link.href).to.equal('/projects/foo/bar/classify/workflow/1234')
   })
 
   it('should render a cancel button', function () {

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.stories.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.stories.js
@@ -18,7 +18,10 @@ export default {
 
 export function Default({ dark }) {
   const projectPreferences = {
-    promptAssignment: () => true
+    promptAssignment: () => true,
+    settings: {
+      workflow_id: '1234'
+    }
   }
   return (
     <Grommet

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalConnector.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalConnector.js
@@ -11,20 +11,20 @@ function useStore() {
   }
 }
 
-function WorkflowAssignmentModalConnector({ workflowID, ...rest }) {
+function WorkflowAssignmentModalConnector({ currentWorkflowID, ...rest }) {
   const { projectPreferences } = useStore()
 
   return (
     <WorkflowAssignmentModalContainer
       projectPreferences={projectPreferences}
-      workflowID={workflowID}
+      currentWorkflowID={currentWorkflowID}
       {...rest}
     />
   )
 }
 
 WorkflowAssignmentModalConnector.propTypes = {
-  workflowID: PropTypes.string.isRequired
+  currentWorkflowID: PropTypes.string.isRequired
 }
 
 export default observer(WorkflowAssignmentModalConnector)

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalContainer.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import WorkflowAssignmentModal from './WorkflowAssignmentModal'
 
-function WorkflowAssignmentModalContainer({ projectPreferences, workflowID }) {
+function WorkflowAssignmentModalContainer({ projectPreferences, currentWorkflowID }) {
   const [ active, setActive ] = React.useState(false)
   const [ dismissedForSession, setDismissed ] = React.useState(false)
 
@@ -16,16 +16,17 @@ function WorkflowAssignmentModalContainer({ projectPreferences, workflowID }) {
   }
 
   React.useEffect(() => {
-    if (projectPreferences?.promptAssignment(workflowID)) {
+    if (projectPreferences?.promptAssignment(currentWorkflowID)) {
       if (!dismissedForSession) setActive(true)
     }
 
     return () => setActive(false)
-  }, [projectPreferences, workflowID])
+  }, [projectPreferences, currentWorkflowID])
 
   return (
     <WorkflowAssignmentModal
       active={active}
+      assignedWorkflowID={projectPreferences?.settings?.workflow_id}
       closeFn={closeFn}
       dismiss={onDismiss}
       dismissedForSession={dismissedForSession}
@@ -34,10 +35,10 @@ function WorkflowAssignmentModalContainer({ projectPreferences, workflowID }) {
 }
 
 WorkflowAssignmentModalContainer.propTypes = {
+  currentWorkflowID: PropTypes.string,
   projectPreferences: PropTypes.shape({
     promptAssignment: PropTypes.func
-  }),
-  workflowID: PropTypes.string
+  })
 }
 
 export default WorkflowAssignmentModalContainer


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

Package: app-project

Toward #2205

This updates the modal to use a Next.js Link in place of the button placeholder there previously and correctly link to the assigned workflow id. This can be observed in the storybook story. 


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
