### PR TITLE
Classifier: fix "Reset Image/View" action (fix 2274)

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -42,7 +42,7 @@ function SVGPanZoom({
       enableZoom()
       return disableZoom
     }
-  }, [zooming])
+  }, [zooming, src])
 
   useEffect(
     function onZoomChange() {


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`
Fixes #2274

This PR fixes a bug (introduced in #2241) where the "Reset Image/View" doesn't correctly reset the image, and actually adds a horizontal+vertical pan offset.

- The problem is that the `onZoom()` function of SVGPanZoom stores/remembers the naturalWidth/naturalHeight of the _placeholder image_
- This fix refreshes the `onZoom()` function when the subject image loads and replaces the placeholder image.
- Please see #2274 for more details.

### Testing

Project: any project with a single image viewer
Testing URL: [I Fancy Cats!](https://localhost:8080/)

Testing Steps:
- Open the classifier and wait for subject image to load.
- Subject image should load with a zoom of 1.0, and translation/pan/offset of (0,0) , and a rotation of 0.
- Move the subject image around (drag to pan, or use keyboard arrow keys to pan), zoom in/out, and/or rotate the image.
- Press the "Reset Image/View" button on the Image Toolbar.
- Expectation: subject image should return to a zoom of 1.0, and translation/pan/offset of (0,0) , and a rotation of 0.

### Status

Ready for review! I actually remembered to check the tests before saying that this time, thank goodness.