### PR TITLE
Classifier: use DOMPointReadOnly for drawing

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -63,7 +63,7 @@ function InteractionLayer({
   function createPoint(event) {
     const { clientX, clientY } = event
     // SVG 2 uses DOMPoint
-    if (document.DOMPointReadOnly) {
+    if (window.DOMPointReadOnly) {
       return new DOMPointReadOnly(clientX, clientY)
     }
     // SVG 1.1 uses SVGPoint

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -34,7 +34,7 @@ function InteractionLayer({
   duration
 }) {
   const [creating, setCreating] = useState(false)
-  const svg = useRef()
+  const canvas = useRef()
 
   useEffect(
     function onDeleteMark() {
@@ -66,13 +66,6 @@ function InteractionLayer({
     if (window.DOMPointReadOnly) {
       return new DOMPointReadOnly(clientX, clientY)
     }
-    // SVG 1.1 uses SVGPoint
-    if (svg.current?.createSVGPoint) {
-      const svgPoint = svg.current.createSVGPoint()
-      svgPoint.x = clientX
-      svgPoint.y = clientY
-      return svgPoint
-    }
     // jsdom doesn't support SVG
     return {
       x: clientX,
@@ -83,7 +76,7 @@ function InteractionLayer({
   function getEventOffset(event) {
     const svgPoint = createPoint(event)
     const svgEventOffset = svgPoint.matrixTransform ?
-      svgPoint.matrixTransform(svg.current?.getScreenCTM().inverse()) :
+      svgPoint.matrixTransform(canvas.current?.getScreenCTM().inverse()) :
       svgPoint
     return svgEventOffset
   }
@@ -157,11 +150,9 @@ function InteractionLayer({
   }
 
   return (
-    <svg
-      ref={svg}
-      xmlns="http://www.w3.org/2000/svg"
-    >
+    <>
       <DrawingCanvas
+        ref={canvas}
         disabled={disabled || move}
         pointerEvents={move ? 'none' : 'all'}
         width={width}
@@ -185,8 +176,8 @@ function InteractionLayer({
           scale={scale}
           played={played}
         />
-      )}
-    </svg>
+    )}
+    </>
   )
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -24,33 +24,6 @@ describe('Component > InteractionLayer', function () {
     setSubTaskVisibility: sinon.stub(),
     setVideoTime: sinon.stub()
   }
-  const mockSVGPoint = {
-    x: 100,
-    y: 200,
-    matrixTransform: sinon.stub().callsFake(() => ({
-      x: 100,
-      y: 200
-    }))
-  }
-  const mockScreenCTM = {
-    a: 1,
-    b: 1,
-    c: 1,
-    d: 1,
-    e: 1,
-    f: 1,
-    inverse: () => ({
-      a: 1,
-      b: 1,
-      c: 1,
-      d: 1,
-      e: 1,
-      f: 1
-    })
-  }
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-  svg.createSVGPoint = () => mockSVGPoint
-  const getScreenCTM = () => mockScreenCTM
 
   describe('when enabled', function () {
     beforeEach(function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -2,7 +2,6 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import sinon from 'sinon'
 
-import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import InteractionLayer, { DrawingCanvas } from './InteractionLayer'
 import TranscribedLines from './components/TranscribedLines'
 import SubTaskPopup from './components/SubTaskPopup'
@@ -116,17 +115,6 @@ describe('Component > InteractionLayer', function () {
 
     describe('pointer events', function () {
       describe('onPointerDown', function () {
-        let mockedContext
-        before(function () {
-          mockedContext = sinon.stub(React, 'useContext').callsFake(() => {
-            return { svg, getScreenCTM }
-          })
-        })
-
-        after(function () {
-          mockedContext.restore()
-        })
-
         it('should create a mark', function () {
           const fakeEvent = {
             pointerId: 'fakePointer',
@@ -246,17 +234,6 @@ describe('Component > InteractionLayer', function () {
     })
 
     describe('onPointerUp', function () {
-      let mockedContext
-      before(function () {
-        mockedContext = sinon.stub(React, 'useContext').callsFake(() => {
-          return { svg, getScreenCTM }
-        })
-      })
-
-      after(function () {
-        mockedContext.restore()
-      })
-
       describe('when the mark is valid', function () {
         it('should set the mark to finished', function () {
           const fakeEvent = {
@@ -368,11 +345,7 @@ describe('Component > InteractionLayer', function () {
           disabled
           height={400}
           width={600}
-        />,
-        {
-          wrappingComponent: SVGContext.Provider,
-          wrappingComponentProps: { value: { svg, getScreenCTM } }
-        }
+        />
       )
     })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
@@ -17,7 +17,7 @@ function DrawingToolMarks({
   scale = 1,
   played
 }) {
-  const { svg } = useContext(SVGContext)
+  const { canvas } = useContext(SVGContext)
 
   return marks.map((mark, index) => {
     /*
@@ -30,7 +30,7 @@ function DrawingToolMarks({
 
     function isInBounds(markElement) {
       const object = markElement.getBoundingClientRect()
-      const bounds = svg.getBoundingClientRect()
+      const bounds = canvas.getBoundingClientRect()
       const notBeyondLeft = object.left + object.width > bounds.left
       const notBeyondRight = object.left < bounds.left + bounds.width
       const notBeyondTop = object.top + object.height > bounds.top

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
@@ -8,15 +8,15 @@ import DrawingToolMarks from './DrawingToolMarks'
 
 describe('Components > DrawingToolMarks', function () {
   let mockContext
-  let svg
+  let canvas
   let line
   let point
   let marks
 
   beforeEach(function () {
-    svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    canvas = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
     const svgBounds = { left: 0, top: 0, right: 2000, bottom: 1000, width: 2000, height: 1000 }
-    sinon.stub(svg, 'getBoundingClientRect').callsFake(() => svgBounds)
+    sinon.stub(canvas, 'getBoundingClientRect').callsFake(() => svgBounds)
     const lineTool = LineTool.create({
       help: '',
       label: 'Draw a line',
@@ -30,7 +30,7 @@ describe('Components > DrawingToolMarks', function () {
     line = lineTool.createMark({ id: 'line1' })
     point = pointTool.createMark({ id: 'point1' })
     marks = [ line, point ]
-    mockContext = { svg }
+    mockContext = { canvas }
   })
 
   it('should render without crashing', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -20,34 +20,36 @@ function SingleImageViewer(props) {
     zooming
   } = props
 
-  const imageViewer = useRef()
   const transformLayer = useRef()
-  const svg = imageViewer.current
+  const svg = transformLayer.current
   const transform = `rotate(${rotate} ${width / 2} ${height / 2})`
-  const getScreenCTM = () => transformLayer.current.getScreenCTM()
 
   return (
-    <SVGContext.Provider value={{ svg, getScreenCTM }}>
+    <SVGContext.Provider value={{ svg }}>
       {zoomControlFn && (
         <ZoomControlButton onClick={zoomControlFn} zooming={zooming} />
       )}
       <Box animation='fadeIn' overflow='hidden'>
         <svg
-          ref={imageViewer}
           focusable
           onKeyDown={onKeyDown}
           tabIndex={0}
           viewBox={viewBox}
+          xmlns="http://www.w3.org/2000/svg"
         >
           {title?.id && title?.text && (
             <title id={title.id}>{title.text}</title>
           )}
-          <g ref={transformLayer} transform={transform}>
+          <svg
+            ref={transformLayer}
+            transform={transform}
+            xmlns="http://www.w3.org/2000/svg"
+          >
             {children}
             {enableInteractionLayer && (
               <InteractionLayer scale={scale} height={height} width={width} />
             )}
-          </g>
+          </svg>
         </svg>
       </Box>
     </SVGContext.Provider>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -21,11 +21,11 @@ function SingleImageViewer(props) {
   } = props
 
   const transformLayer = useRef()
-  const svg = transformLayer.current
+  const canvas = transformLayer.current
   const transform = `rotate(${rotate} ${width / 2} ${height / 2})`
 
   return (
-    <SVGContext.Provider value={{ svg }}>
+    <SVGContext.Provider value={{ canvas }}>
       {zoomControlFn && (
         <ZoomControlButton onClick={zoomControlFn} zooming={zooming} />
       )}
@@ -40,16 +40,15 @@ function SingleImageViewer(props) {
           {title?.id && title?.text && (
             <title id={title.id}>{title.text}</title>
           )}
-          <svg
+          <g
             ref={transformLayer}
             transform={transform}
-            xmlns="http://www.w3.org/2000/svg"
           >
             {children}
             {enableInteractionLayer && (
               <InteractionLayer scale={scale} height={height} width={width} />
             )}
-          </svg>
+          </g>
         </svg>
       </Box>
     </SVGContext.Provider>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.spec.js
@@ -16,7 +16,7 @@ describe('Component > SingleImageViewer', function () {
   })
 
   it('should be upright', function () {
-    const transform = wrapper.find('svg').find('g').prop('transform')
+    const transform = wrapper.find('svg[transform]').prop('transform')
     expect(transform).to.have.string('rotate(0 50 100)')
   })
 
@@ -26,7 +26,7 @@ describe('Component > SingleImageViewer', function () {
     })
 
     it('should be rotated', function () {
-      const transform = wrapper.find('svg').find('g').prop('transform')
+      const transform = wrapper.find('svg[transform]').prop('transform')
       expect(transform).to.have.string('rotate(-90 50 100)')
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.spec.js
@@ -16,7 +16,7 @@ describe('Component > SingleImageViewer', function () {
   })
 
   it('should be upright', function () {
-    const transform = wrapper.find('svg[transform]').prop('transform')
+    const transform = wrapper.find('g[transform]').prop('transform')
     expect(transform).to.have.string('rotate(0 50 100)')
   })
 
@@ -26,7 +26,7 @@ describe('Component > SingleImageViewer', function () {
     })
 
     it('should be rotated', function () {
-      const transform = wrapper.find('svg[transform]').prop('transform')
+      const transform = wrapper.find('g[transform]').prop('transform')
       expect(transform).to.have.string('rotate(-90 50 100)')
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
@@ -201,7 +201,7 @@ class SingleVideoViewerContainer extends React.Component {
     //   return null
     // }
 
-    const svg = this.transformLayer.current
+    const canvas = this.transformLayer.current
     const transform = ``
     const scale = clientWidth / naturalWidth
 
@@ -224,7 +224,7 @@ class SingleVideoViewerContainer extends React.Component {
           {/* Drawing Layer */}
           <DrawingLayer>
             <Box animation='fadeIn' overflow='hidden'>
-              <SVGContext.Provider value={{ svg }}>
+              <SVGContext.Provider value={{ canvas }}>
                 <svg
                   focusable
                   onKeyDown={onKeyDown}
@@ -235,10 +235,9 @@ class SingleVideoViewerContainer extends React.Component {
                   {/* {title?.id && title?.text && (
                   <title id={title.id}>{title.text}</title>
                 )} */}
-                  <svg
+                  <g
                     ref={this.transformLayer}
                     transform={transform}
-                    xmlns="http://www.w3.org/2000/svg"
                   >
                     {enableInteractionLayer && (
                       <InteractionLayer
@@ -249,7 +248,7 @@ class SingleVideoViewerContainer extends React.Component {
                         height={naturalHeight}
                       />
                     )}
-                  </svg>
+                  </g>
                 </svg>
               </SVGContext.Provider>
             </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
@@ -27,7 +27,7 @@ class SingleVideoViewerContainer extends React.Component {
   constructor() {
     super()
 
-    this.videoViewer = React.createRef()
+    this.transformLayer = React.createRef()
 
     this.state = {
       vid: '',
@@ -201,10 +201,8 @@ class SingleVideoViewerContainer extends React.Component {
     //   return null
     // }
 
-    const transformLayer = React.createRef()
-    const svg = this.videoViewer.current
+    const svg = this.transformLayer.current
     const transform = ``
-    const getScreenCTM = () => transformLayer.current.getScreenCTM()
     const scale = clientWidth / naturalWidth
 
     const enableDrawing =
@@ -226,18 +224,22 @@ class SingleVideoViewerContainer extends React.Component {
           {/* Drawing Layer */}
           <DrawingLayer>
             <Box animation='fadeIn' overflow='hidden'>
-              <SVGContext.Provider value={{ svg, getScreenCTM }}>
+              <SVGContext.Provider value={{ svg }}>
                 <svg
-                  ref={this.videoViewer}
                   focusable
                   onKeyDown={onKeyDown}
                   tabIndex={0}
                   viewBox={`0 0 ${naturalWidth} ${naturalHeight}`}
+                  xmlns="http://www.w3.org/2000/svg"
                 >
                   {/* {title?.id && title?.text && (
                   <title id={title.id}>{title.text}</title>
                 )} */}
-                  <g ref={transformLayer} transform={transform}>
+                  <svg
+                    ref={this.transformLayer}
+                    transform={transform}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
                     {enableInteractionLayer && (
                       <InteractionLayer
                         scale={scale}
@@ -247,7 +249,7 @@ class SingleVideoViewerContainer extends React.Component {
                         height={naturalHeight}
                       />
                     )}
-                  </g>
+                  </svg>
                 </svg>
               </SVGContext.Provider>
             </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/SubjectGroupViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/SubjectGroupViewer.js
@@ -78,13 +78,13 @@ const SubjectGroupViewer = forwardRef(function SubjectGroupViewer(props, ref) {
   } = props
 
   const transformLayer = useRef()
-  const svg = transformLayer.current
+  const canvas = transformLayer.current
   const annotatedValues = annotation?.value || []
     
   const annotationMode = interactionMode === 'annotate' && isCurrentTaskValidForAnnotation
   
   return (
-    <SVGContext.Provider value={{ svg }}>
+    <SVGContext.Provider value={{ canvas }}>
       <Container
         gridMaxWidth={gridMaxWidth}
         gridMaxHeight={gridMaxHeight}
@@ -99,9 +99,8 @@ const SubjectGroupViewer = forwardRef(function SubjectGroupViewer(props, ref) {
           gridMaxHeight={gridMaxHeight}
           xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
+          <g
             ref={transformLayer}
-            xmlns="http://www.w3.org/2000/svg"
           >
             {images.map((image, index) => (
               <SGVGridCell
@@ -128,7 +127,7 @@ const SubjectGroupViewer = forwardRef(function SubjectGroupViewer(props, ref) {
                 cellAnnotated={annotatedValues.includes(index)}
               />
             ))}
-          </svg>
+          </g>
         </SVG>
       </Container>
     </SVGContext.Provider>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/SubjectGroupViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/SubjectGroupViewer.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { forwardRef, useContext, useRef } from 'react'
+import React, { forwardRef, useRef } from 'react'
 import styled, { css } from 'styled-components'
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import SGVGridCell from './components/SGVGridCell'
@@ -78,14 +78,13 @@ const SubjectGroupViewer = forwardRef(function SubjectGroupViewer(props, ref) {
   } = props
 
   const transformLayer = useRef()
-  const { svg } = useContext(SVGContext)
-  const getScreenCTM = () => transformLayer.current.getScreenCTM()
+  const svg = transformLayer.current
   const annotatedValues = annotation?.value || []
     
   const annotationMode = interactionMode === 'annotate' && isCurrentTaskValidForAnnotation
   
   return (
-    <SVGContext.Provider value={{ svg, getScreenCTM }}>
+    <SVGContext.Provider value={{ svg }}>
       <Container
         gridMaxWidth={gridMaxWidth}
         gridMaxHeight={gridMaxHeight}
@@ -98,9 +97,11 @@ const SubjectGroupViewer = forwardRef(function SubjectGroupViewer(props, ref) {
           viewBox={`0 0 ${width} ${height}`}
           gridMaxWidth={gridMaxWidth}
           gridMaxHeight={gridMaxHeight}
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <g
+          <svg
             ref={transformLayer}
+            xmlns="http://www.w3.org/2000/svg"
           >
             {images.map((image, index) => (
               <SGVGridCell
@@ -127,7 +128,7 @@ const SubjectGroupViewer = forwardRef(function SubjectGroupViewer(props, ref) {
                 cellAnnotated={annotatedValues.includes(index)}
               />
             ))}
-          </g>
+          </svg>
         </SVG>
       </Container>
     </SVGContext.Provider>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/SubjectGroupViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/SubjectGroupViewerContainer.js
@@ -6,7 +6,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Paragraph } from 'grommet'
 
-import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import SubjectGroupViewer from './SubjectGroupViewer'
 import locationValidator from '../../helpers/locationValidator'
 import withKeyZoom from '../../../withKeyZoom'
@@ -266,7 +265,6 @@ class SubjectGroupViewerContainer extends React.Component {
       
     } = this.props
     const { images, panX, panY, zoom } = this.state
-    const svg = this.groupViewer.current
     
     const gridWidth = gridColumns * cellWidth
     const gridHeight = gridRows * cellHeight
@@ -288,38 +286,36 @@ class SubjectGroupViewerContainer extends React.Component {
     }
     
     return (
-      <SVGContext.Provider value={{ svg }}>
-        <div ref={this.scrollContainer}>
-          <SubjectGroupViewer
-            ref={this.groupViewer}
-            
-            images={images}
-            subjectIds={subject.subjectIds}
-            
-            dragMove={this.dragMove}
-            onKeyDown={onKeyDown}
-            
-            cellWidth={cellWidth}
-            cellHeight={cellHeight}
-            cellStyle={cellStyle}
-            gridRows={gridRows}
-            gridColumns={gridColumns}
-            gridMaxWidth={gridMaxWidth}
-            gridMaxHeight={gridMaxHeight}
-            
-            width={gridWidth}
-            height={gridHeight}
-            
-            panX={panX}
-            panY={panY}
-            zoom={zoom}
-    
-            annotation={annotation}
-            interactionMode={interactionMode}
-            isCurrentTaskValidForAnnotation={isCurrentTaskValidForAnnotation}
-          />
-        </div>
-      </SVGContext.Provider>
+      <div ref={this.scrollContainer}>
+        <SubjectGroupViewer
+          ref={this.groupViewer}
+          
+          images={images}
+          subjectIds={subject.subjectIds}
+          
+          dragMove={this.dragMove}
+          onKeyDown={onKeyDown}
+          
+          cellWidth={cellWidth}
+          cellHeight={cellHeight}
+          cellStyle={cellStyle}
+          gridRows={gridRows}
+          gridColumns={gridColumns}
+          gridMaxWidth={gridMaxWidth}
+          gridMaxHeight={gridMaxHeight}
+          
+          width={gridWidth}
+          height={gridHeight}
+          
+          panX={panX}
+          panY={panY}
+          zoom={zoom}
+  
+          annotation={annotation}
+          interactionMode={interactionMode}
+          isCurrentTaskValidForAnnotation={isCurrentTaskValidForAnnotation}
+        />
+      </div>
     )
   }
 }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -38,13 +38,34 @@ function draggable (WrappedComponent) {
       return this.wrappedComponent.current.getBoundingClientRect()
     }
 
+    createPoint(event) {
+      const { clientX, clientY } = event
+      // SVG 2 uses DOMPoint
+      if (document.DOMPointReadOnly) {
+        return new DOMPointReadOnly(clientX, clientY)
+      }
+      // SVG 1.1 uses SVGPoint
+      const { svg } = this.context
+      if (svg.createSVGPoint) {
+        const svgPoint = svg.createSVGPoint()
+        svgPoint.x = clientX
+        svgPoint.y = clientY
+        return svgPoint
+      }
+      // jsdom doesn't support SVG
+      return {
+        x: clientX,
+        y: clientY
+      }
+    }
+
     getEventOffset (event) {
       const { clientX, clientY } = event
       const { svg } = this.context
-      const svgPoint = svg.createSVGPoint()
-      svgPoint.x = clientX
-      svgPoint.y = clientY
-      const svgEventOffset = svgPoint.matrixTransform(svg.getScreenCTM().inverse())
+      const svgPoint = this.createPoint(event)
+      const svgEventOffset = svgPoint.matrixTransform ?
+        svgPoint.matrixTransform(svg.getScreenCTM().inverse()) :
+        svgPoint
       return svgEventOffset
     }
 

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -40,11 +40,11 @@ function draggable (WrappedComponent) {
 
     getEventOffset (event) {
       const { clientX, clientY } = event
-      const { svg, getScreenCTM } = this.context
+      const { svg } = this.context
       const svgPoint = svg.createSVGPoint()
       svgPoint.x = clientX
       svgPoint.y = clientY
-      const svgEventOffset = svgPoint.matrixTransform(getScreenCTM().inverse())
+      const svgEventOffset = svgPoint.matrixTransform(svg.getScreenCTM().inverse())
       return svgEventOffset
     }
 

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -44,14 +44,6 @@ function draggable (WrappedComponent) {
       if (window.DOMPointReadOnly) {
         return new DOMPointReadOnly(clientX, clientY)
       }
-      // SVG 1.1 uses SVGPoint
-      const { svg } = this.context
-      if (svg.createSVGPoint) {
-        const svgPoint = svg.createSVGPoint()
-        svgPoint.x = clientX
-        svgPoint.y = clientY
-        return svgPoint
-      }
       // jsdom doesn't support SVG
       return {
         x: clientX,
@@ -61,10 +53,10 @@ function draggable (WrappedComponent) {
 
     getEventOffset (event) {
       const { clientX, clientY } = event
-      const { svg } = this.context
+      const { canvas } = this.context
       const svgPoint = this.createPoint(event)
       const svgEventOffset = svgPoint.matrixTransform ?
-        svgPoint.matrixTransform(svg.getScreenCTM().inverse()) :
+        svgPoint.matrixTransform(canvas.getScreenCTM().inverse()) :
         svgPoint
       return svgEventOffset
     }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -41,7 +41,7 @@ function draggable (WrappedComponent) {
     createPoint(event) {
       const { clientX, clientY } = event
       // SVG 2 uses DOMPoint
-      if (document.DOMPointReadOnly) {
+      if (window.DOMPointReadOnly) {
         return new DOMPointReadOnly(clientX, clientY)
       }
       // SVG 1.1 uses SVGPoint

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.spec.js
@@ -25,12 +25,11 @@ describe('draggable', function () {
       inverse: sinon.stub()
     }))
   }
-  const getScreenCTM = sinon.stub().callsFake(() => ({ inverse: sinon.stub() }))
   let wrapper
 
   before(function () {
     wrapper = mount(
-      <SVGContext.Provider value={{ svg: mockSVG, getScreenCTM }}>
+      <SVGContext.Provider value={{ svg: mockSVG }}>
         <svg>
           <Draggable
             dragStart={onStart}


### PR DESCRIPTION
Remove `SVGContext` from `InteractionLayer`. Use `DOMPointReadOnly`, if supported, instead of `SVGPoint`, which allows us to remove the passed SVG element from context. I've also renamed the passed element from `svg` to `canvas`, and this is passed down in order to perform matrix transformations on dragged tools etc.

Follows up on the changes in #2255.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
