### PR TITLE
Engaging Crowds: Refactor subject set completeness

### DIFF
--- a/packages/app-project/src/helpers/fetchSubjectSets/fetchSubjectSets.js
+++ b/packages/app-project/src/helpers/fetchSubjectSets/fetchSubjectSets.js
@@ -90,7 +90,9 @@ export default async function fetchSubjectSets(workflow, env) {
   }
   const subjectSets = await workflowSubjectSets(subjectSetIDs, env)
   subjectSets.forEach(subjectSet => {
-    subjectSet.availableSubjects = subjectSetCounts[subjectSet.id]
+    const availableSubjects = subjectSetCounts[subjectSet.id]
+    const totalSubjects = subjectSet.set_member_subjects_count
+    subjectSet.completeness = 1 - (availableSubjects / totalSubjects)
   })
   return subjectSets
 }

--- a/packages/app-project/src/helpers/fetchSubjectSets/fetchSubjectSets.js
+++ b/packages/app-project/src/helpers/fetchSubjectSets/fetchSubjectSets.js
@@ -28,7 +28,8 @@ async function workflowSubjectSets(subjectSetIDs, env) {
   const setsToFetch = []
   subjectSetIDs.forEach(id => {
     if (subjectSetCache[id]) {
-      workflowSubjectSets.push(subjectSetCache[id])
+      const workflowSubjectSet = Object.assign({}, subjectSetCache[id])
+      workflowSubjectSets.push(workflowSubjectSet)
     } else {
       setsToFetch.push(id)
     }

--- a/packages/app-project/src/helpers/fetchWorkflowsHelper/fetchWorkflowsHelper.spec.js
+++ b/packages/app-project/src/helpers/fetchWorkflowsHelper/fetchWorkflowsHelper.spec.js
@@ -45,6 +45,12 @@ describe('Helpers > fetchWorkflowsHelper', function () {
       3: 10
   }
 
+  const completeness = {
+    1: 0.6,
+    2: 0,
+    3: 0
+  }
+
   function subjectSet(id) {
     return {
       id,
@@ -161,9 +167,9 @@ describe('Helpers > fetchWorkflowsHelper', function () {
         id: '2',
         displayName: 'Bar',
         subjectSets: [
-          Object.assign(subjectSet('1'), { availableSubjects: availableSubjects[1]}),
-          Object.assign(subjectSet('2'), { availableSubjects: availableSubjects[2]}),
-          Object.assign(subjectSet('3'), { availableSubjects: availableSubjects[3]})
+          Object.assign(subjectSet('1'), { completeness: completeness[1] }),
+          Object.assign(subjectSet('2'), { completeness: completeness[2] }),
+          Object.assign(subjectSet('3'), { completeness: completeness[3] })
         ]
       }
     ])
@@ -200,9 +206,9 @@ describe('Helpers > fetchWorkflowsHelper', function () {
           id: '2',
           displayName: 'Bar',
           subjectSets: [
-            Object.assign(subjectSet('1'), { availableSubjects: availableSubjects[1]}),
-            Object.assign(subjectSet('2'), { availableSubjects: availableSubjects[2]}),
-            Object.assign(subjectSet('3'), { availableSubjects: availableSubjects[3]})
+            Object.assign(subjectSet('1'), { completeness: completeness[1] }),
+            Object.assign(subjectSet('2'), { completeness: completeness[2] }),
+            Object.assign(subjectSet('3'), { completeness: completeness[3] })
           ]
         }
       ])
@@ -276,9 +282,9 @@ describe('Helpers > fetchWorkflowsHelper', function () {
           id: '2',
           displayName: 'Bar',
           subjectSets: [
-            Object.assign(subjectSet('1'), { availableSubjects: availableSubjects[1] }),
-            Object.assign(subjectSet('2'), { availableSubjects: availableSubjects[2] }),
-            Object.assign(subjectSet('3'), { availableSubjects: availableSubjects[3] })
+            Object.assign(subjectSet('1'), { completeness: completeness[1] }),
+            Object.assign(subjectSet('2'), { completeness: completeness[2] }),
+            Object.assign(subjectSet('3'), { completeness: completeness[3] })
           ]
         },
         {

--- a/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.spec.js
+++ b/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.spec.js
@@ -61,6 +61,12 @@ describe('Helpers > getDefaultPageProps', function () {
       3: 10
   }
 
+  const completeness = {
+    1: 0.6,
+    2: 0,
+    3: 0
+  }
+
   function subjectSet(id) {
     return {
       id,
@@ -260,9 +266,9 @@ describe('Helpers > getDefaultPageProps', function () {
             id: '2',
             displayName: 'Bar',
             subjectSets: [
-              Object.assign(subjectSet('1'), { availableSubjects: availableSubjects[1]}),
-              Object.assign(subjectSet('2'), { availableSubjects: availableSubjects[2]}),
-              Object.assign(subjectSet('3'), { availableSubjects: availableSubjects[3]})
+              Object.assign(subjectSet('1'), { completeness: completeness[1] }),
+              Object.assign(subjectSet('2'), { completeness: completeness[2] }),
+              Object.assign(subjectSet('3'), { completeness: completeness[3] })
             ]
           }
         ])
@@ -400,9 +406,9 @@ describe('Helpers > getDefaultPageProps', function () {
             id: '2',
             displayName: 'Bar',
             subjectSets: [
-              Object.assign(subjectSet('1'), { availableSubjects: availableSubjects[1]}),
-              Object.assign(subjectSet('2'), { availableSubjects: availableSubjects[2]}),
-              Object.assign(subjectSet('3'), { availableSubjects: availableSubjects[3]})
+              Object.assign(subjectSet('1'), { completeness: completeness[1] }),
+              Object.assign(subjectSet('2'), { completeness: completeness[2] }),
+              Object.assign(subjectSet('3'), { completeness: completeness[3] })
             ]
           }
         ])

--- a/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.spec.js
+++ b/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.spec.js
@@ -62,6 +62,12 @@ describe('Helpers > getStaticPageProps', function () {
       3: 10
   }
 
+  const completeness = {
+    1: 0.6,
+    2: 0,
+    3: 0
+  }
+
   function subjectSet(id) {
     return {
       id,
@@ -246,9 +252,9 @@ describe('Helpers > getStaticPageProps', function () {
             id: '2',
             displayName: 'Bar',
             subjectSets: [
-              Object.assign(subjectSet('1'), { availableSubjects: availableSubjects[1]}),
-              Object.assign(subjectSet('2'), { availableSubjects: availableSubjects[2]}),
-              Object.assign(subjectSet('3'), { availableSubjects: availableSubjects[3]})
+              Object.assign(subjectSet('1'), { completeness: completeness[1] }),
+              Object.assign(subjectSet('2'), { completeness: completeness[2] }),
+              Object.assign(subjectSet('3'), { completeness: completeness[3] })
             ]
           }
         ])
@@ -373,9 +379,9 @@ describe('Helpers > getStaticPageProps', function () {
             id: '2',
             displayName: 'Bar',
             subjectSets: [
-              Object.assign(subjectSet('1'), { availableSubjects: availableSubjects[1]}),
-              Object.assign(subjectSet('2'), { availableSubjects: availableSubjects[2]}),
-              Object.assign(subjectSet('3'), { availableSubjects: availableSubjects[3]})
+              Object.assign(subjectSet('1'), { completeness: completeness[1] }),
+              Object.assign(subjectSet('2'), { completeness: completeness[2] }),
+              Object.assign(subjectSet('3'), { completeness: completeness[3] })
             ]
           }
         ])

--- a/packages/app-project/src/shared/components/SubjectSetPicker/components/SubjectSetCard/SubjectSetCard.js
+++ b/packages/app-project/src/shared/components/SubjectSetPicker/components/SubjectSetCard/SubjectSetCard.js
@@ -9,7 +9,7 @@ import React from 'react'
   Summary card for a subject set, showing a preview subject, the set name, total subject count and completeness percentage.
 */
 function SubjectSetCard ({
-  availableSubjects,
+  completeness,
   display_name,
   id,
   set_member_subjects_count,
@@ -21,7 +21,6 @@ function SubjectSetCard ({
   const placeholderUrl = `${assetPrefix}/subject-placeholder.png`
   const subjectURLs = subject ? subject.locations.map(location => Object.values(location)[0]) : []
   const alt = subject ? `Subject ${subject.id}` : 'Loading'
-  const completeness = 1 - (availableSubjects / set_member_subjects_count)
   const percentComplete = parseInt(100 * completeness)
 
   return (

--- a/packages/app-project/src/shared/components/SubjectSetPicker/helpers/mockWorkflow.js
+++ b/packages/app-project/src/shared/components/SubjectSetPicker/helpers/mockWorkflow.js
@@ -3,6 +3,7 @@
 const subjectSets = [
   {
     "id":"85771",
+    completeness: 0.64,
     "display_name":"Ultraman Series",
     "set_member_subjects_count":6,
     "metadata":{},
@@ -29,6 +30,7 @@ const subjectSets = [
     ]
   },{
     "id":"85772",
+    completeness: 0,
     "display_name":"Transformers Series",
     "set_member_subjects_count":4,
     "metadata":{},
@@ -56,6 +58,7 @@ const subjectSets = [
     ]
   },{
     "id":"85773",
+    completeness: 1,
     "display_name":"Overwatch Series",
     "set_member_subjects_count":9,
     "metadata":{},


### PR DESCRIPTION
Replace `subjectSet.availableSubjects` with `subjectSet.completeness`, which is a number between 0 and 1. `subjectSet.completeness` is calculated after we fetch the grouped subject counts from Cellect.

Subject sets are copied, not referenced, from the subject set cache in order to fix #2283.

Package:
app-project

Closes #2283.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
