### PR TITLE
Engaging Crowds: fetch multiple queued subjects for Next Available Subject

### DIFF
--- a/packages/lib-classifier/src/store/SubjectStore/AvailableSubjects/AvailableSubjects.js
+++ b/packages/lib-classifier/src/store/SubjectStore/AvailableSubjects/AvailableSubjects.js
@@ -1,0 +1,86 @@
+import { flow, getRoot, getSnapshot, types } from 'mobx-state-tree'
+
+import { getBearerToken } from '@store/utils'
+import Subject from '@store/Subject'
+import SingleImageSubject from '@store/SingleImageSubject'
+import SingleVideoSubject from '@store/SingleVideoSubject'
+import SubjectGroup from '@store/SubjectGroup'
+
+const CACHE_SIZE = 10
+
+/*
+  see https://github.com/mobxjs/mobx-state-tree/issues/514
+  for advice about using references with types.union.
+*/
+
+const SingleSubject = types.union(SingleImageSubject, SingleVideoSubject, Subject)
+function subjectDispatcher (snapshot) {
+  if (snapshot?.metadata?.['#subject_group_id']) {
+    return SubjectGroup
+  }
+  return SingleSubject
+}
+const subjectModels = [ { dispatcher: subjectDispatcher }, SingleSubject, SubjectGroup ]
+const SubjectType = types.union(...subjectModels)
+
+export default types.model('AvailableSubjects', {
+  subjects: types.array(SubjectType)
+})
+
+.actions(self => {
+  async function _fetchAvailableSubjects(workflow) {
+    const apiUrl = '/subjects/queued'
+    const params = {
+      page_size: CACHE_SIZE,
+      workflow_id: workflow.id
+    }
+    if (workflow.grouped) {
+      params.subject_set_id = workflow.subjectSetId
+    }
+
+    return await _fetchSubjects({ apiUrl, params })
+  }
+
+  async function _fetchSubjects({ apiUrl, params }) {
+    const {
+      authClient,
+      client: {
+        panoptes
+      }
+    } = getRoot(self)
+
+    const authorization = await getBearerToken(authClient)
+    const response = await panoptes.get(apiUrl, params, { authorization })
+
+    if (response.body.subjects?.length > 0) {
+      return response.body.subjects
+    }
+    return []
+  }
+
+  function clear() {
+    self.subjects.clear()
+  }
+
+  function * next(workflow) {
+    if (workflow) {
+      try {
+        if (self.subjects.length === 0) {
+          const availableSubjects = yield _fetchAvailableSubjects(workflow)
+          self.subjects.replace(availableSubjects)
+        }
+        if (self.subjects.length > 0) {
+          const newSubject = getSnapshot(self.subjects[0])
+          self.subjects.shift()
+          return newSubject
+        }
+      } catch (error) {
+        console.error(error)
+      }
+    }
+  }
+  return {
+    clear,
+    next: flow(next)
+  }
+})

--- a/packages/lib-classifier/src/store/SubjectStore/AvailableSubjects/index.js
+++ b/packages/lib-classifier/src/store/SubjectStore/AvailableSubjects/index.js
@@ -1,0 +1,1 @@
+export { default } from './AvailableSubjects'

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
@@ -205,7 +205,7 @@ const SubjectStore = types
 
       if (workflow) {
         try {
-          self.reset()
+          self.resources.clear()
           const newSubject = yield self.available.next(workflow)
           if (newSubject) {
             self.append([newSubject])
@@ -240,6 +240,7 @@ const SubjectStore = types
 
     function reset () {
       self.resources.clear()
+      self.available.clear()
     }
 
     function setOnReset(callback) {

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
@@ -101,7 +101,10 @@ const SubjectStore = types
       const classificationDisposer = autorun(() => {
         onPatch(getRoot(self), (patch) => {
           const { path, value } = patch
-          if (path === '/classifications/loadingState' && value === 'posting') self.advance()
+          if (path === '/classifications/loadingState' && value === 'posting') {
+            self.clearAvailable()
+            self.advance()
+          }
         })
       }, { name: 'SubjectStore Classification Observer autorun' })
       addDisposer(self, classificationDisposer)
@@ -198,6 +201,10 @@ const SubjectStore = types
       }
     }
 
+    function clearAvailable() {
+      self.availableSubjects.clear()
+    }
+
     function clearQueue() {
       self.onReset()
       self.reset()
@@ -262,6 +269,7 @@ const SubjectStore = types
       advance,
       afterAttach,
       append,
+      clearAvailable,
       clearQueue,
       nextAvailable: flow(nextAvailable),
       populateQueue: flow(populateQueue),

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.spec.js
@@ -211,11 +211,33 @@ describe('Model > SubjectStore', function () {
       })
     })
 
+    describe('clear available', function () {
+      let subjects
+
+      beforeEach(async function () {
+        const queuedSubjectSnapshots = Factory.buildList('subject', 10)
+        const selectedSubjectSnapshots = Factory.buildList('subject', 10)
+        const subjectMocks = {
+          ['/subjects/grouped']: [],
+          ['/subjects/queued']: queuedSubjectSnapshots,
+          ['/subjects/selection']: selectedSubjectSnapshots
+        }
+        subjects = mockSubjectStore(subjectMocks)
+        await subjects.nextAvailable()
+      })
+
+      it('should clear available subjects', function () {
+        expect(subjects.availableSubjects.length).to.equal(9)
+        subjects.clearAvailable()
+        expect(subjects.availableSubjects).to.be.empty()
+      })
+    })
+
     describe('next available',function () {
       let subjects
       let subjectIDs
 
-      before(function () {
+      beforeEach(async function () {
         const queuedSubjectSnapshots = Factory.buildList('subject', 10)
         const selectedSubjectSnapshots = Factory.buildList('subject', 10)
         const subjectMocks = {
@@ -225,16 +247,15 @@ describe('Model > SubjectStore', function () {
         }
         subjectIDs = queuedSubjectSnapshots.map(subject => subject.id)
         subjects = mockSubjectStore(subjectMocks)
-        subjects.nextAvailable()
+        await subjects.nextAvailable()
       })
 
       it('should select the first queued subject', function () {
-        expect(subjects.resources.size).to.equal(10)
         expect(subjects.active.id).to.equal(subjectIDs[0])
       })
 
-      it('should cycle through queued subjects', function () {
-        subjects.nextAvailable()
+      it('should cycle through queued subjects', async function () {
+        await subjects.nextAvailable()
         expect(subjects.active.id).to.equal(subjectIDs[1])
       })
     })

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.spec.js
@@ -216,20 +216,26 @@ describe('Model > SubjectStore', function () {
       let subjectIDs
 
       before(function () {
-        const subjectSnapshots = Factory.buildList('subject', 5)
+        const queuedSubjectSnapshots = Factory.buildList('subject', 10)
+        const selectedSubjectSnapshots = Factory.buildList('subject', 10)
         const subjectMocks = {
           ['/subjects/grouped']: [],
-          ['/subjects/queued']: subjectSnapshots.slice(0,1),
-          ['/subjects/selection']: subjectSnapshots.slice(0)
+          ['/subjects/queued']: queuedSubjectSnapshots,
+          ['/subjects/selection']: selectedSubjectSnapshots
         }
-        subjectIDs = subjectSnapshots.map(subject => subject.id)
+        subjectIDs = queuedSubjectSnapshots.map(subject => subject.id)
         subjects = mockSubjectStore(subjectMocks)
         subjects.nextAvailable()
       })
 
-      it('should select the next queued subject', function () {
-        expect(subjects.resources.size).to.equal(1)
-        expect(Array.from(subjects.resources.keys())).to.deep.equal(subjectIDs.slice(0,1))
+      it('should select the first queued subject', function () {
+        expect(subjects.resources.size).to.equal(10)
+        expect(subjects.active.id).to.equal(subjectIDs[0])
+      })
+
+      it('should cycle through queued subjects', function () {
+        subjects.nextAvailable()
+        expect(subjects.active.id).to.equal(subjectIDs[1])
       })
     })
 

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.spec.js
@@ -227,9 +227,9 @@ describe('Model > SubjectStore', function () {
       })
 
       it('should clear available subjects', function () {
-        expect(subjects.availableSubjects.length).to.equal(9)
+        expect(subjects.available.subjects.length).to.equal(9)
         subjects.clearAvailable()
-        expect(subjects.availableSubjects).to.be.empty()
+        expect(subjects.available.subjects).to.be.empty()
       })
     })
 


### PR DESCRIPTION
On pressing 'Next Available Subject', fetch 10 queued, unclassified subjects. Cycle through those 10 subjects each time the button is pressed again. When a new available subject is selected, use it to seed a new, ordered queue from the `/api/subjects/selection` endpoint. Clear the stored, available subjects when a classification is submitted.

Test URL:
https://localhost:8080/?project=12268&workflow=17076&subjectSet=96235&subject=63413209&env=production&demo=true&finished=true
Press 'Next Available Subject' a few times to try cycling through a selection of unclassified pages.

Alternatively, build the libraries and try it out with a logged-in volunteer at
http://local.zooniverse.org:3000/projects/bogden/scarlets-and-blues/classify/workflow/17076/subject-set/96235/subject/63413209?env=production&demo=true&finished=true

NB. Subject set 96235 isn't properly set up for prioritised selection, so the queued endpoint is falling back to random selection. When you press Next Available Subject, you'll see pages come back in a random order.

TODO:
- [x] Tests
- [x] Reset `subjects.available.subjects` when you submit a classification.

Package:
lib-classifier

Closes #2299.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
