### PR TITLE
Add dark theme styling to Project About pages

### DIFF
--- a/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
@@ -44,7 +44,7 @@ function ProjectAboutPage ({
 
   return (
     <StandardLayout inBeta={inBeta}>
-      <Grid columns={['xxsmall', 'flex', 'xxsmall']} gap='xxsmall'>
+      <Grid columns={screenSize === 'small' ? ['auto'] : ['xsmall', 'flex', 'xsmall']}>
         <Box />
         <Box
           background={{ dark: 'dark-3', light: 'neutral-6' }}
@@ -55,7 +55,6 @@ function ProjectAboutPage ({
             side: 'vertical'
           }}
           height={{ min: '98vh' }}
-          // margin={{ left: 'large', right: 'large' }}
           width={{ min: 'fill-available', max: 'xxlarge' }}
           pad='large'
           alignSelf='center'
@@ -110,7 +109,7 @@ function ProjectAboutPage ({
             </Box>
           </Grid>
         </Box>
-        <Box justify='start' margin={{ top: 'small' }}>
+        <Box justify='start' margin={screenSize === 'small' ? { vertical: 'medium' } : { top: 'medium' }}>
           <ThemeModeToggle />
         </Box>
       </Grid>

--- a/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
@@ -44,7 +44,7 @@ function ProjectAboutPage ({
 
   return (
     <StandardLayout inBeta={inBeta}>
-      {/* <ThemeModeToggle /> */}
+      <ThemeModeToggle />
       <Box
         background={{ dark: 'dark-3', light: 'neutral-6' }}
         border={{
@@ -92,7 +92,7 @@ function ProjectAboutPage ({
                     margin={{ bottom: '14px' }}
                     children={`${projectDisplayName} TEAM`}
                     weight='bold'
-                    color='black'
+                    color={{ light: 'black' }}
                   />
                   {teamArray.length && (
                     <Box as='ul' margin='none' pad='none'>

--- a/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
@@ -34,7 +34,7 @@ function ProjectAboutPage ({
   projectDisplayName,
   screenSize,
   teamArray,
-  theme: { dark }
+  theme: { dark = false }
 }) {
   const { content, title } = aboutPageData
 

--- a/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
@@ -44,71 +44,76 @@ function ProjectAboutPage ({
 
   return (
     <StandardLayout inBeta={inBeta}>
-      <ThemeModeToggle />
-      <Box
-        background={{ dark: 'dark-3', light: 'neutral-6' }}
-        border={{
-          color: { light: 'light-3' },
-          size: '1px',
-          style: 'solid',
-          side: 'vertical'
-        }}
-        height={{ min: '98vh' }}
-        margin={{ left: 'large', right: 'large' }}
-        width={{ min: 'fill-available', max: 'xxlarge' }}
-        pad='large'
-        alignSelf='center'
-        elevation={dark ? 'xlarge' : 'none'}
-        flex
-      >
-        <Grid
-          columns={screenSize === 'small' ? ['auto'] : ['small', 'flex']}
-          gap={screenSize === 'small' ? '' : '8%'}
+      <Grid columns={['xxsmall', 'flex', 'xxsmall']} gap='xxsmall'>
+        <Box />
+        <Box
+          background={{ dark: 'dark-3', light: 'neutral-6' }}
+          border={{
+            color: { light: 'light-3' },
+            size: '1px',
+            style: 'solid',
+            side: 'vertical'
+          }}
+          height={{ min: '98vh' }}
+          // margin={{ left: 'large', right: 'large' }}
+          width={{ min: 'fill-available', max: 'xxlarge' }}
+          pad='large'
+          alignSelf='center'
+          elevation={dark ? 'xlarge' : 'none'}
+          flex
         >
-          {screenSize !== 'small' ? (
-            <Box>
-              <SidebarHeading children='About' />
-              <AboutSidebar aboutNavLinks={aboutNavLinks} />
-            </Box>
-          ) : (
-            <AboutDropdownNav aboutNavLinks={aboutNavLinks} />
-          )}
-          <Box>
-            <PageHeading
-              children={pageTitle}
-              level='2'
-              weight='normal'
-              size='40px'
-              margin={{ bottom: '30px' }}
-            />
-            {isTeamPage ? (
-              <Grid
-                columns={screenSize === 'small' ? ['auto'] : ['flex', 'small']}
-                gap={screenSize === 'small' ? '' : '8%'}
-              >
-                <AboutMarkdownz content={content} />
-                <Box>
-                  <SpacedText
-                    margin={{ bottom: '14px' }}
-                    children={`${projectDisplayName} TEAM`}
-                    weight='bold'
-                    color={{ light: 'black' }}
-                  />
-                  {teamArray.length && (
-                    <Box as='ul' margin='none' pad='none'>
-                      {teamArray.map(user => (
-                        <TeamMember key={user.id} user={user} />
-                      ))}
-                    </Box>
-                  )}
-                </Box>
-              </Grid>
+          <Grid
+            columns={screenSize === 'small' ? ['auto'] : ['small', 'flex']}
+            gap={screenSize === 'small' ? '' : '8%'}
+          >
+            {screenSize !== 'small' ? (
+              <Box>
+                <SidebarHeading children='About' />
+                <AboutSidebar aboutNavLinks={aboutNavLinks} />
+              </Box>
             ) : (
-              <AboutMarkdownz content={content} />
+              <AboutDropdownNav aboutNavLinks={aboutNavLinks} />
             )}
-          </Box>
-        </Grid>
-      </Box>
+            <Box>
+              <PageHeading
+                children={pageTitle}
+                level='2'
+                weight='normal'
+                size='40px'
+                margin={{ bottom: '30px' }}
+              />
+              {isTeamPage ? (
+                <Grid
+                  columns={screenSize === 'small' ? ['auto'] : ['flex', 'small']}
+                  gap={screenSize === 'small' ? '' : '8%'}
+                >
+                  <AboutMarkdownz content={content} />
+                  <Box>
+                    <SpacedText
+                      margin={{ bottom: '14px' }}
+                      children={`${projectDisplayName} TEAM`}
+                      weight='bold'
+                      color={{ light: 'black' }}
+                    />
+                    {teamArray.length && (
+                      <Box as='ul' margin='none' pad='none'>
+                        {teamArray.map(user => (
+                          <TeamMember key={user.id} user={user} />
+                        ))}
+                      </Box>
+                    )}
+                  </Box>
+                </Grid>
+              ) : (
+                <AboutMarkdownz content={content} />
+              )}
+            </Box>
+          </Grid>
+        </Box>
+        <Box justify='start' margin={{ top: 'small' }}>
+          <ThemeModeToggle />
+        </Box>
+      </Grid>
     </StandardLayout>
   )
 }

--- a/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
@@ -4,9 +4,6 @@ import styled, { withTheme } from 'styled-components'
 import counterpart from 'counterpart'
 import en from './locales/en'
 
-counterpart.registerTranslations('en', en)
-
-/** Components */
 import StandardLayout from '@shared/components/StandardLayout'
 import {
   SpacedHeading,
@@ -17,6 +14,9 @@ import AboutSidebar from './components/AboutSidebar'
 import AboutDropdownNav from './components/AboutDropdownNav'
 import TeamMember from './components/TeamMember'
 import AboutMarkdownz from './components/AboutMarkdownz/AboutMarkdownz'
+import ThemeModeToggle from '@components/ThemeModeToggle'
+
+counterpart.registerTranslations('en', en)
 
 export const PageHeading = styled(Heading)`
   font-weight: normal;
@@ -26,13 +26,14 @@ const SidebarHeading = styled(SpacedHeading)`
   padding: 5px 20px;
 `
 
-function ProjectAboutPage({
+function ProjectAboutPage ({
   aboutNavLinks,
   aboutPageData,
   inBeta,
   projectDisplayName,
   screenSize,
-  teamArray
+  teamArray,
+  theme: { dark = true }
 }) {
   const { content, title } = aboutPageData
 
@@ -42,10 +43,11 @@ function ProjectAboutPage({
 
   return (
     <StandardLayout inBeta={inBeta}>
+      {/* <ThemeModeToggle /> */}
       <Box
-        background="neutral-6"
+        background={{ dark: 'dark-3', light: 'neutral-6' }}
         border={{
-          color: 'light-3',
+          color: { light: 'light-3' },
           size: '1px',
           style: 'solid',
           side: 'vertical'
@@ -53,8 +55,9 @@ function ProjectAboutPage({
         height={{ min: '98vh' }}
         margin={{ left: 'large', right: 'large' }}
         width={{ min: 'fill-available', max: 'xxlarge' }}
-        pad="large"
-        alignSelf="center"
+        pad='large'
+        alignSelf='center'
+        elevation={dark ? 'xlarge' : 'none'}
         flex
       >
         <Grid
@@ -63,7 +66,7 @@ function ProjectAboutPage({
         >
           {screenSize !== 'small' ? (
             <Box>
-              <SidebarHeading children="About" />
+              <SidebarHeading children='About' />
               <AboutSidebar aboutNavLinks={aboutNavLinks} />
             </Box>
           ) : (
@@ -72,9 +75,9 @@ function ProjectAboutPage({
           <Box>
             <PageHeading
               children={pageTitle}
-              level="2"
-              weight="normal"
-              size="40px"
+              level='2'
+              weight='normal'
+              size='40px'
               margin={{ bottom: '30px' }}
             />
             {isTeamPage ? (
@@ -87,11 +90,11 @@ function ProjectAboutPage({
                   <SpacedText
                     margin={{ bottom: '14px' }}
                     children={`${projectDisplayName} TEAM`}
-                    weight="bold"
-                    color="black"
+                    weight='bold'
+                    color='black'
                   />
                   {teamArray.length && (
-                    <Box as="ul" margin="none" pad="none">
+                    <Box as='ul' margin='none' pad='none'>
                       {teamArray.map(user => (
                         <TeamMember key={user.id} user={user} />
                       ))}

--- a/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
@@ -4,6 +4,7 @@ import styled, { withTheme } from 'styled-components'
 import counterpart from 'counterpart'
 import en from './locales/en'
 
+/** Components */
 import StandardLayout from '@shared/components/StandardLayout'
 import {
   SpacedHeading,
@@ -33,7 +34,7 @@ function ProjectAboutPage ({
   projectDisplayName,
   screenSize,
   teamArray,
-  theme: { dark = true }
+  theme: { dark }
 }) {
   const { content, title } = aboutPageData
 

--- a/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
@@ -49,10 +49,13 @@ function ProjectAboutPage ({
         <Box
           background={{ dark: 'dark-3', light: 'neutral-6' }}
           border={{
-            color: { light: 'light-3' },
-            size: '1px',
-            style: 'solid',
-            side: 'vertical'
+            light: {
+              color: 'light-3',
+              size: '1px',
+              style: 'solid',
+              side: 'vertical'
+            },
+            dark: 'none'
           }}
           height={{ min: '98vh' }}
           width={{ min: 'fill-available', max: 'xxlarge' }}
@@ -92,7 +95,7 @@ function ProjectAboutPage ({
                       margin={{ bottom: '14px' }}
                       children={`${projectDisplayName} TEAM`}
                       weight='bold'
-                      color={{ light: 'black' }}
+                      color={{ light: 'black', dark: '' }}
                     />
                     {teamArray.length && (
                       <Box as='ul' margin='none' pad='none'>

--- a/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.spec.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.spec.js
@@ -18,6 +18,7 @@ describe('Component > ProjectAboutPage', () => {
         <ProjectAboutPage
           aboutNavLinks={['research', 'team']}
           aboutPageData={aboutPageData}
+          theme={{ dark: false }}
         />
       )
     })
@@ -53,6 +54,7 @@ describe('Component > ProjectAboutPage', () => {
             { id: 1, display_name: 'name', role: 'owner' }
 
           ]}
+          theme={{ dark: false }}
         />
       )
     })

--- a/packages/app-project/src/screens/ProjectAboutPage/components/AboutDropdownNav.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/components/AboutDropdownNav.js
@@ -14,7 +14,7 @@ export const AboutDropContent = ({ aboutNavLinks, router }) => {
   const baseUrl = `/projects/${owner}/${project}/about`
   
   return (
-    <Nav gap="xsmall" background="white">
+    <Nav gap='xsmall' background={{ dark: 'dark-3', light: 'neutral-6' }}>
       <AboutNavLink
         link={{ href: `${baseUrl}/research`, text: 'research' }}
         router={router}
@@ -62,15 +62,15 @@ const AboutDropdownNav = ({ aboutNavLinks, router }) => {
   return (
     <DropButton
       isOpen={isOpen}
-      alignSelf="center"
+      alignSelf='center'
       dropContent={
         <AboutDropContent aboutNavLinks={aboutNavLinks} router={router} />
       }
       onClose={handleOpen}
       onOpen={handleOpen}
     >
-      <Box align="center" direction="row" gap="xsmall" justify="center">
-        <SpacedText weight="bold" color="black">
+      <Box align='center' direction='row' gap='xsmall' justify='center'>
+        <SpacedText weight='bold' color={{ light: 'black' }}>
           About
         </SpacedText>
         <FormDown />

--- a/packages/app-project/src/screens/ProjectAboutPage/components/AboutDropdownNav.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/components/AboutDropdownNav.js
@@ -14,7 +14,7 @@ export const AboutDropContent = ({ aboutNavLinks, router }) => {
   const baseUrl = `/projects/${owner}/${project}/about`
   
   return (
-    <Nav gap='xsmall' background={{ dark: 'dark-3', light: 'neutral-6' }}>
+    <Nav gap='xsmall' background={{ dark: 'dark-5', light: 'neutral-6' }}>
       <AboutNavLink
         link={{ href: `${baseUrl}/research`, text: 'research' }}
         router={router}
@@ -70,7 +70,7 @@ const AboutDropdownNav = ({ aboutNavLinks, router }) => {
       onOpen={handleOpen}
     >
       <Box align='center' direction='row' gap='xsmall' justify='center'>
-        <SpacedText weight='bold' color={{ light: 'black' }}>
+        <SpacedText weight='bold' color={{ light: 'black', dark: '' }}>
           About
         </SpacedText>
         <FormDown />

--- a/packages/app-project/src/screens/ProjectAboutPage/components/AboutMarkdownz/theme.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/components/AboutMarkdownz/theme.js
@@ -24,7 +24,7 @@ const theme = {
   },
   paragraph: {
     extend: props => css`
-      color: ${props.theme.global.colors.black};
+      color: ${props.theme.dark ? props.theme.global.colors['neutral-6'] : props.theme.global.colors.black};
       line-height: 1.5;
       margin: 0 0 14px 0;
     `

--- a/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink.js
@@ -28,7 +28,7 @@ const AboutNavLink = ({ router, link }) => {
     >
       <NavLink
         link={link}
-        color={isCurrentPage ? 'neutral-1' : { dark: 'neutral-6', light: 'dark-5' }}
+        color={{ dark: 'neutral-6', light: 'dark-3' }}
         weight={isCurrentPage ? 'bold' : 'normal'}
         StyledAnchor={StyledAnchor}
       />

--- a/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink.js
@@ -23,7 +23,7 @@ const AboutNavLink = ({ router, link }) => {
 
   return (
     <Box
-      background={isCurrentPage ? 'accent-1' : { light: 'neutral-6' }}
+      background={isCurrentPage ? 'accent-1' : { light: 'neutral-6', dark: '' }}
       pad={{ horizontal: '20px', vertical: '5px' }}
     >
       <NavLink

--- a/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink.js
@@ -23,12 +23,12 @@ const AboutNavLink = ({ router, link }) => {
 
   return (
     <Box
-      background={isCurrentPage ? 'accent-1' : 'neutral-6'}
+      background={isCurrentPage ? 'accent-1' : { light: 'neutral-6' }}
       pad={{ horizontal: '20px', vertical: '5px' }}
     >
       <NavLink
         link={link}
-        color={isCurrentPage ? 'neutral-1' : 'dark-5'}
+        color={isCurrentPage ? 'neutral-1' : { dark: 'neutral-6', light: 'dark-5' }}
         weight={isCurrentPage ? 'bold' : 'normal'}
         StyledAnchor={StyledAnchor}
       />

--- a/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink.spec.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink.spec.js
@@ -25,12 +25,12 @@ describe('Component > AboutNavLink', function () {
 
     it('should display non-active background color', function () {
       const container = wrapper.find(Box)
-      expect(container.props().background).to.equal('neutral-6')
+      expect(container.props().background.light).to.equal('neutral-6')
     })
 
     it('should display non-active font color', function () {
       const navLink = wrapper.find(NavLink)
-      expect(navLink.props().color).to.equal('dark-5')
+      expect(navLink.props().color.light).to.equal('dark-5')
     })
 
     it('should display regular font weight', function () {

--- a/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink.spec.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink.spec.js
@@ -28,11 +28,6 @@ describe('Component > AboutNavLink', function () {
       expect(container.props().background.light).to.equal('neutral-6')
     })
 
-    it('should display non-active font color', function () {
-      const navLink = wrapper.find(NavLink)
-      expect(navLink.props().color.light).to.equal('dark-5')
-    })
-
     it('should display regular font weight', function () {
       const navLink = wrapper.find(NavLink)
       expect(navLink.props().weight).to.equal('normal')
@@ -55,11 +50,6 @@ describe('Component > AboutNavLink', function () {
     it('should display active background color', function () {
       const container = wrapper.find(Box)
       expect(container.props().background).to.equal('accent-1')
-    })
-
-    it('should display active font color', function () {
-      const navLink = wrapper.find(NavLink)
-      expect(navLink.props().color).to.equal('neutral-1')
     })
 
     it('should display bold font weight', function () {

--- a/packages/app-project/src/screens/ProjectAboutPage/components/TeamMember.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/components/TeamMember.js
@@ -81,7 +81,7 @@ const TeamMember = ({ user, router }) => {
         )}
       </StyledAvatar>
       <Box flex direction='column'>
-        <StyledDisplayName color={{ light: 'neutral-7' }}>{user.display_name}</StyledDisplayName>
+        <StyledDisplayName color={{ light: 'neutral-7', dark: '' }}>{user.display_name}</StyledDisplayName>
         <StyledUsername
           link={{ href: `${baseUrl}/${user.login}`, text: `@${user.login}` }}
         />

--- a/packages/app-project/src/screens/ProjectAboutPage/components/TeamMember.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/components/TeamMember.js
@@ -26,7 +26,9 @@ export const StyledDisplayName = styled(Box)`
   word-wrap: break-word;
   ${props =>
     css`
-      color: ${props.theme.global.colors['black']};
+      color: ${props.theme.dark
+          ? props.theme.global.colors['neutral-6']
+          : props.theme.global.colors.black};
     `}
 `
 
@@ -51,7 +53,7 @@ export const StyledRole = styled(Box)`
   margin-top: 5px;
   ${props =>
     css`
-      color: ${props.theme.global.colors['black']};
+      color: ${props.theme.global.colors.black};
     `}
 `
 
@@ -66,27 +68,27 @@ const TeamMember = ({ user, router }) => {
   const placeholderAvatar = `${assetPrefix}/simple-avatar.png`
 
   return (
-    <StyledTeamMember as="li">
+    <StyledTeamMember as='li'>
       <StyledAvatar>
         {!user.avatar_src ? (
           <Image 
-            alt="Placeholder Avatar"
-            fit="cover" 
+            alt='Placeholder Avatar'
+            fit='cover' 
             src={placeholderAvatar} 
           />
         ) : (
-          <Image alt={user.display_name} fit="cover" src={user.avatar_src} />
+          <Image alt={user.display_name} fit='cover' src={user.avatar_src} />
         )}
       </StyledAvatar>
-      <Box flex direction="column">
-        <StyledDisplayName>{user.display_name}</StyledDisplayName>
+      <Box flex direction='column'>
+        <StyledDisplayName color={{ light: 'neutral-7' }}>{user.display_name}</StyledDisplayName>
         <StyledUsername
           link={{ href: `${baseUrl}/${user.login}`, text: `@${user.login}` }}
         />
         {user?.roles?.map(role => (
           <StyledRole
             key={role}
-            round="xxsmall"
+            round='xxsmall'
             background={role === 'owner' ? 'neutral-2' : 'accent-1'}
           >
             {role === 'scientist' ? 'researcher' : role}


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

Package:
app-project

Describe your changes:
I added the `ThemeModeToggle` to all Project About pages along with appropriate styling for dark theme.

There are some linter corrections included for double-quotes vs single-quotes.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
