### PR TITLE
Use as prop to render a span when href is defined and disabled is true

### DIFF
--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Changed `LinkList` component to use `fit-content` CSS styling to render correct height in Safari.
 - Modified matchRegex in `ping` of `Markdownz` to avoid creating username-links in typed email addresses.
+- Fixed buttons that could be rendered like disabled buttons, but still functioned as links. Grommet's `Button` allows you to add an `href` prop which will render a link (HTML anchor tag) styled like a button. It, however, accepts all `Button` props including `disabled`, but links can't be disabled. We now prevent this by checking to see if an `href` is defined and if `disabled` is true and instead render a span via the `as` prop. This impacts `PrimaryButton`, `PlainButton`, and `CloseButton` which directly use Grommet's `Button`.
 
 ## [1.1.0] 2021-05-26
 

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Changed `LinkList` component to use `fit-content` CSS styling to render correct height in Safari.
 - Modified matchRegex in `ping` of `Markdownz` to avoid creating username-links in typed email addresses.
-- Fixed buttons that could be rendered like disabled buttons, but still functioned as links. Grommet's `Button` allows you to add an `href` prop which will render a link (HTML anchor tag) styled like a button. It, however, accepts all `Button` props including `disabled`, but links can't be disabled. We now prevent this by checking to see if an `href` is defined and if `disabled` is true and instead render a span via the `as` prop. This impacts `PrimaryButton`, `PlainButton`, and `CloseButton` which directly use Grommet's `Button`.
+- Fixed buttons that could be rendered like disabled buttons, but still functioned as links. Grommet's `Button` allows you to add an `href` prop which will render a link (HTML anchor tag) styled like a button. It, however, accepts all `Button` props including `disabled`, but links can't be disabled. We now prevent this by checking to see if an `href` is defined and if `disabled` is true and instead render a span via the `as` prop. This impacts `PrimaryButton` and `PlainButton` which directly use Grommet's `Button`. For `CloseButton`, we've destructured `href` from the props to make sure it's not passed along because it doesn't make sense to render this component as a link.
 
 ## [1.1.0] 2021-05-26
 

--- a/packages/lib-react-components/src/CloseButton/CloseButton.js
+++ b/packages/lib-react-components/src/CloseButton/CloseButton.js
@@ -27,11 +27,19 @@ const StyledButton = styled(Button)`
   }
 `
 
-function CloseButton ({ closeFn, color, ...rest }) {
+function CloseButton ({ as, closeFn, color, disabled, href, ...rest }) {
+  // Dunno why anyone would do this to do this button
+  // But let's keep them from doing something that
+  // shouldn't be done
+  const renderAs = as || href && disabled && 'span'
+
   return (
     <StyledButton
       a11yTitle={counterpart('CloseButton.close')}
+      as={renderAs}
+      disabled={disabled}
       icon={<CloseIcon color={color} size='15px' />}
+      href={href}
       onClick={closeFn}
       {...rest}
     />

--- a/packages/lib-react-components/src/CloseButton/CloseButton.js
+++ b/packages/lib-react-components/src/CloseButton/CloseButton.js
@@ -28,18 +28,13 @@ const StyledButton = styled(Button)`
 `
 
 function CloseButton ({ as, closeFn, color, disabled, href, ...rest }) {
-  // Dunno why anyone would do this to do this button
-  // But let's keep them from doing something that
-  // shouldn't be done
-  const renderAs = as || href && disabled && 'span'
+  // We've destructured href from the props to make sure it's NOT passed along
 
   return (
     <StyledButton
       a11yTitle={counterpart('CloseButton.close')}
-      as={renderAs}
       disabled={disabled}
       icon={<CloseIcon color={color} size='15px' />}
-      href={href}
       onClick={closeFn}
       {...rest}
     />

--- a/packages/lib-react-components/src/CloseButton/CloseButton.spec.js
+++ b/packages/lib-react-components/src/CloseButton/CloseButton.spec.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import sinon from 'sinon'
 import CloseButton from './CloseButton'
+import { expect } from 'chai'
 
 describe('<CloseButton />', function () {
   let wrapper
@@ -16,6 +17,11 @@ describe('<CloseButton />', function () {
   it('calls on the closeFn prop on click', function () {
     wrapper.simulate('click')
     expect(wrapper.props().onClick).to.have.been.calledOnce()
+  })
+
+  it('should not pass along a href prop', function () {
+    wrapper.setProps({ href: 'www.google.com' })
+    expect(wrapper.props().href).to.be.undefined()
   })
 
   describe('with a color prop', function () {

--- a/packages/lib-react-components/src/CloseButton/README.md
+++ b/packages/lib-react-components/src/CloseButton/README.md
@@ -1,6 +1,6 @@
 # CloseButton
 
-A styled Grommet `Button` component that displays a close icon. Has the same API as [Grommet's `Button`](https://v2.grommet.io/button).
+A styled Grommet `Button` component that displays a close icon. Has the same API as [Grommet's `Button`](https://v2.grommet.io/button) except we've disallowed the `href` prop for this component.
 
 ## props
 

--- a/packages/lib-react-components/src/PlainButton/PlainButton.js
+++ b/packages/lib-react-components/src/PlainButton/PlainButton.js
@@ -13,11 +13,25 @@ export const StyledPlainButton = styled(Button)`
 `
 
 function PlainButton (props) {
-  const { className, onClick, labelSize, text, color, ...rest } = props
+  const {
+    as,
+    className,
+    disabled,
+    href,
+    onClick,
+    labelSize,
+    text,
+    color,
+    ...rest
+  } = props
+  const renderAs = as || href && disabled && 'span'
 
   return (
     <StyledPlainButton
+      as={renderAs}
       className={className}
+      disabled={disabled}
+      href={href}
       gap='xxsmall'
       label={(
         <SpacedText

--- a/packages/lib-react-components/src/PlainButton/PlainButton.js
+++ b/packages/lib-react-components/src/PlainButton/PlainButton.js
@@ -10,6 +10,10 @@ export const StyledPlainButton = styled(Button)`
   &:enabled:hover {
     text-decoration: underline;
   }
+
+  &:disabled {
+    cursor: not-allowed;
+  }
 `
 
 function PlainButton (props) {

--- a/packages/lib-react-components/src/PlainButton/PlainButton.js
+++ b/packages/lib-react-components/src/PlainButton/PlainButton.js
@@ -50,6 +50,7 @@ function PlainButton (props) {
 
 PlainButton.defaultProps = {
   className: '',
+  href: '',
   labelSize: 'medium',
   onClick: () => {},
   text: '',
@@ -80,3 +81,4 @@ PlainButton.propTypes = {
 }
 
 export default withTheme(PlainButton)
+export { PlainButton }

--- a/packages/lib-react-components/src/PlainButton/PlainButton.spec.js
+++ b/packages/lib-react-components/src/PlainButton/PlainButton.spec.js
@@ -1,14 +1,25 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import PlainButton from './PlainButton'
+import { PlainButton } from './PlainButton'
+import { expect } from 'chai'
+import { Grommet } from 'grommet'
 
 describe('<PlainButton />', function () {
   let wrapper
   before(function () {
-    wrapper = shallow(<PlainButton text='Click me' />)
+    wrapper = shallow(<PlainButton text='Click me' />, { wrappingComponent: <Grommet /> })
   })
 
   it('renders without crashing', function () {
     expect(wrapper).to.be.ok()
+  })
+
+  it('should render a plain Grommet Button', function () {
+    expect(wrapper.props().plain).to.be.true()
+  })
+
+  it('should render a span when the button is disabled and href is defined', function () {
+    wrapper.setProps({ disabled: true, href: 'www.google.com' })
+    expect(wrapper.props().as).to.equal('span')
   })
 })

--- a/packages/lib-react-components/src/PlainButton/PlainButton.stories.js
+++ b/packages/lib-react-components/src/PlainButton/PlainButton.stories.js
@@ -59,7 +59,7 @@ storiesOf('Components/PlainButton', module)
 
   .add('Disabled', () => (
     <Grommet theme={zooTheme}>
-      <PlainButton disabled text={text('Text', 'Click me')} />
+      <PlainButton href={text('href', '')} disabled text={text('Text', 'Click me')} />
     </Grommet>
   ), config)
 

--- a/packages/lib-react-components/src/PrimaryButton/PrimaryButton.js
+++ b/packages/lib-react-components/src/PrimaryButton/PrimaryButton.js
@@ -15,15 +15,19 @@ const themeMap = {
 }
 
 function PrimaryButton (props) {
-  const { color, label, ...rest } = props
+  const { as, color, disabled, href, label, ...rest } = props
   const theme = themeMap[color] || themeMap['gold']
   const wrappedLabel = React.isValidElement(label)
     ? label
     : <Text children={label} size='medium' />
+  const renderAs = as || href && disabled && 'span'
 
   return (
     <ThemeContext.Extend value={theme}>
       <Button
+        as={renderAs}
+        disabled={disabled}
+        href={href}
         label={wrappedLabel}
         primary
         {...rest}

--- a/packages/lib-react-components/src/PrimaryButton/PrimaryButton.js
+++ b/packages/lib-react-components/src/PrimaryButton/PrimaryButton.js
@@ -42,7 +42,9 @@ PrimaryButton.propTypes = {
 }
 
 PrimaryButton.defaultProps = {
-  color: 'gold'
+  color: 'gold',
+  disabled: false,
+  href: ''
 }
 
 export default PrimaryButton

--- a/packages/lib-react-components/src/PrimaryButton/PrimaryButton.spec.js
+++ b/packages/lib-react-components/src/PrimaryButton/PrimaryButton.spec.js
@@ -1,5 +1,6 @@
+import { expect } from 'chai'
 import { shallow, render } from 'enzyme'
-import { Grommet } from 'grommet'
+import { Grommet, Button } from 'grommet'
 import React from 'react'
 
 import PrimaryButton from './PrimaryButton'
@@ -27,13 +28,23 @@ describe('Component > PrimaryButton', function () {
     }
 
     const wrapper = shallow(
-      <Grommet>
-        <PrimaryButton label={LABEL} {...TEST_PROPS} />
-      </Grommet>
+        <PrimaryButton label={LABEL} {...TEST_PROPS} />, {
+        wrappingComponent: <Grommet />
+      }
     )
 
-    const primaryButton = wrapper.find(PrimaryButton).dive()
-    const grommetButton = primaryButton.dive().dive().dive()
-    expect(grommetButton.props()).to.deep.include(TEST_PROPS)
+    expect(wrapper.find(Button).props()).to.deep.include(TEST_PROPS)
+  })
+
+  describe('when href is defined and disabled is true', function () {
+    it('should render as a span', function () {
+      const wrapper = render(
+        <Grommet>
+          <PrimaryButton disabled href='www.google.com' label={LABEL} />
+        </Grommet>
+      )
+
+      expect(wrapper.children()[0].name).to.equal('span')
+    })
   })
 })

--- a/packages/lib-react-components/src/PrimaryButton/PrimaryButton.stories.js
+++ b/packages/lib-react-components/src/PrimaryButton/PrimaryButton.stories.js
@@ -39,6 +39,7 @@ storiesOf('Components/PrimaryButton', module)
           color={select('Color', colors, colors[1])}
           disabled={boolean('Disabled', false)}
           label={text('Label', 'Click me')}
+          href={text('href', '')}
           onClick={() => { }}
         />
       </Box>
@@ -59,6 +60,7 @@ storiesOf('Components/PrimaryButton', module)
           color={select('Color', colors, colors[1])}
           disabled={boolean('Disabled', false)}
           label={text('Label', 'Click me')}
+          href={text('href', '')}
           onClick={() => { }}
         />
       </Box>


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

Package: lib-react-components

Toward #2249.

Grommet's `Button` allows us to specify an `href` which will then render an anchor tag that is styled as a button. This is convenient and is definitely used in our code base, however, all other `Button` props are still accepted including `disabled`. This is a problem because links cannot be disabled via attribute. What happens is with this combination you have a link styled like a disabled button, but is still functional. There is a method to pseudo-disable a link, but it's better to just render text rather than do that. 

At first, I thought I'd create a new component for our shared components library that was a span styled like a button, but remembering Grommet's `as` prop that all their components support, we can more succinctly do that in the button components themselves. 

This adds a conditional where if `href` is defined and `disabled` is true to render a span instead of an anchor for the `PrimaryButton` and `PlainButton` components in the shared component library. I've destructured `href` out of the props to pass along for `CloseButton` so this shouldn't be possible for that one. The stories and tests are updated as well.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
