### PR TITLE
Add disabled functionality to survey task ChoiceButton and FilterStatus

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/Chooser.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/Chooser.js
@@ -36,6 +36,7 @@ export default function Chooser (props) {
       <StyledHorizontalRule />
       <Choices
         autoFocus={autoFocus}
+        disabled={disabled}
         filteredChoiceIds={filteredChoiceIds}
         handleDelete={handleDelete}
         onChoose={onChoose}

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/Chooser.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/Chooser.js
@@ -29,6 +29,7 @@ export default function Chooser (props) {
   return (
     <Box>
       <FilterStatus
+        disabled={disabled}
         filters={filters}
         handleFilter={handleFilter}
         task={task}

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.js
@@ -30,17 +30,18 @@ const StyledLabel = styled(SpacedText)`
 `
 
 export default function FilterStatus (props) {
-  const { 
+  const {
+    disabled,
     filters,
     handleFilter,
     task
   } = props
-  const { 
+  const {
     characteristics,
     characteristicsOrder,
     images
   } = task
-  
+
   const filterStatusRef = useRef()
 
   const selectedCharacteristicIds = Object.keys(filters)
@@ -55,6 +56,7 @@ export default function FilterStatus (props) {
     >
       <StyledDropButton
         backgroundColor={selectedCharacteristicIds.length > 0}
+        disabled={disabled}
         dropAlign={{
           left: 'left',
           top: 'bottom'
@@ -75,7 +77,7 @@ export default function FilterStatus (props) {
         gap='none'
         icon={<FilterIcon />}
         label={
-          <StyledLabel 
+          <StyledLabel
             color='neutral-1'
           >
             {counterpart('CharacteristicsFilter.filter')}
@@ -87,7 +89,7 @@ export default function FilterStatus (props) {
         const selectedValueId = filters?.[characteristicId] || ''
         const value = characteristic.values?.[selectedValueId] || {}
         const valueImageSrc = images?.[value.image] || ''
-        
+
         return (
           <FilterButton
             key={selectedValueId}
@@ -105,11 +107,13 @@ export default function FilterStatus (props) {
 }
 
 FilterStatus.defaultProps = {
+  disabled: false,
   filters: {},
   handleFilter: () => {}
 }
 
 FilterStatus.propTypes = {
+  disabled: PropTypes.bool,
   filters: PropTypes.objectOf(PropTypes.string),
   handleFilter: PropTypes.func,
   task: PropTypes.shape({

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.spec.js
@@ -43,7 +43,22 @@ describe('Component > FilterStatus', function () {
     expect(wrapper.find(FilterButton)).to.have.lengthOf(0)
   })
 
-  describe('with drop content', function () {
+  describe('when disabled, on click', function () {
+    before(function () {
+      wrapper.setProps({ disabled: true })
+      wrapper.find(DropButton).at(0).simulate('click')
+    })
+
+    after(function () {
+      wrapper.setProps({ disabled: false })
+    })
+
+    it('should not show Characteristics on click', function () {
+      expect(wrapper.find(Characteristics)).to.have.lengthOf(0)
+    })
+  })
+
+  describe('on click', function () {
     before(function () {
       wrapper.find(DropButton).at(0).simulate('click')
     })

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.stories.js
@@ -30,12 +30,14 @@ export default {
 
 const Template = ({
   dark,
+  disabled,
   task
 }) => (
   <StoryContext
     theme={{ ...zooTheme, dark }}
   >
     <FilterStatus
+      disabled={disabled}
       task={task}
     />
   </StoryContext>
@@ -44,5 +46,6 @@ const Template = ({
 export const Default = Template.bind({})
 Default.args = {
   dark: false,
+  disabled: false,
   task: mockTask
 }

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/Choices/Choices.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/Choices/Choices.js
@@ -22,6 +22,7 @@ const StyledGrid = styled.div`
 export function Choices (props) {
   const {
     autoFocus,
+    disabled,
     filteredChoiceIds,
     handleDelete,
     onChoose,
@@ -92,6 +93,7 @@ export function Choices (props) {
             key={choiceId}
             choiceId={choiceId}
             choiceLabel={choice.label}
+            disabled={disabled}
             hasFocus={hasFocus}
             onChoose={onChoose}
             onKeyDown={handleKeyDown}
@@ -108,6 +110,7 @@ export function Choices (props) {
 
 Choices.defaultProps = {
   autoFocus: false,
+  disabled: false,
   filteredChoiceIds: [],
   handleDelete: () => {},
   onChoose: () => {},
@@ -122,6 +125,7 @@ Choices.defaultProps = {
 
 Choices.propTypes = {
   autoFocus: PropTypes.bool,
+  disabled: PropTypes.bool,
   filteredChoiceIds: PropTypes.arrayOf(
     PropTypes.string
   ),

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/Choices/Choices.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/Choices/Choices.stories.js
@@ -38,12 +38,13 @@ export default {
   component: Choices
 }
 
-const Template = ({ autoFocus, dark, filteredChoiceIds, task }) => (
+const Template = ({ autoFocus, dark, disabled, filteredChoiceIds, task }) => (
   <StoryContext
     theme={{ ...zooTheme, dark }}
   >
     <Choices
       autoFocus={autoFocus}
+      disabled={disabled}
       filteredChoiceIds={filteredChoiceIds}
       onChoose={() => console.log('button clicked')}
       task={task}
@@ -55,6 +56,7 @@ export const LessThirtyMoreTwenty = Template.bind({})
 LessThirtyMoreTwenty.args = {
   autoFocus: true,
   dark: false,
+  disabled: false,
   filteredChoiceIds,
   task: mockTask
 }
@@ -63,6 +65,7 @@ export const LessTwentyMoreFive = Template.bind({})
 LessTwentyMoreFive.args = {
   autoFocus: true,
   dark: false,
+  disabled: false,
   filteredChoiceIds: Array.from(filteredChoiceIds).splice(0, 10),
   task: mockTask
 }
@@ -71,6 +74,7 @@ export const LessThanSix = Template.bind({})
 LessThanSix.args = {
   autoFocus: true,
   dark: false,
+  disabled: false,
   filteredChoiceIds: Array.from(filteredChoiceIds).splice(0, 4),
   task: mockTask
 }

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/Choices/components/ChoiceButton.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/Choices/components/ChoiceButton.js
@@ -19,7 +19,7 @@ const StyledChoiceButton = styled(Button)`
   padding: 5px;
   text-align: start;
 
-  &:focus, &:hover {
+  &:focus, &:enabled:hover {
     background-color: ${props => props.theme.global.colors['accent-1']};
   }
 `
@@ -30,6 +30,7 @@ export function ChoiceButton (props) {
   const {
     choiceId,
     choiceLabel,
+    disabled,
     hasFocus,
     onKeyDown,
     onChoose,
@@ -60,6 +61,7 @@ export function ChoiceButton (props) {
   return (
     <StyledChoiceButton
       ref={choiceButton}
+      disabled={disabled}
       label={
         <Box
           direction='row'
@@ -96,6 +98,7 @@ export function ChoiceButton (props) {
 ChoiceButton.defaultProps = {
   choiceId: '',
   choiceLabel: '',
+  disabled: false,
   hasFocus: false,
   onChoose: () => {},
   onKeyDown: () => {},
@@ -114,6 +117,7 @@ ChoiceButton.defaultProps = {
 ChoiceButton.propTypes = {
   choiceId: PropTypes.string,
   choiceLabel: PropTypes.string,
+  disabled: PropTypes.bool,
   hasFocus: PropTypes.bool,
   onChoose: PropTypes.func,
   onKeyDown: PropTypes.func,

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/Choices/components/ChoiceButton.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/Choices/components/ChoiceButton.spec.js
@@ -38,6 +38,7 @@ describe('Component > ChoiceButton', function () {
   it('should call onChoose on click of the button', function () {
     wrapper.simulate('click')
     expect(onChooseSpy).to.have.been.calledOnceWith('cat-1')
+    onChooseSpy.resetHistory()
   })
 
   it('should call onKeyDown on keyDown of the button', function () {
@@ -48,6 +49,18 @@ describe('Component > ChoiceButton', function () {
 
   it('should not render a thumbnail', function () {
     expect(wrapper.find(Media)).to.have.lengthOf(0)
+  })
+
+  describe('when disabled', function () {
+    before(function () {
+      wrapper.setProps({ disabled: true })
+    })
+
+    it('should not be clickable', function () {
+      wrapper.simulate('click')
+      expect(onChooseSpy).to.not.have.been.called()
+      onChooseSpy.resetHistory()
+    })
   })
 
   describe('when there is a small thumbnail', function () {

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/Choices/components/ChoiceButton.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/Choices/components/ChoiceButton.stories.js
@@ -32,6 +32,7 @@ const Template = ({
   choiceId,
   choiceLabel,
   dark,
+  disabled,
   hasFocus,
   selected,
   src,
@@ -44,6 +45,7 @@ const Template = ({
     <ChoiceButton
       choiceId={choiceId}
       choiceLabel={choiceLabel}
+      disabled={disabled}
       hasFocus={hasFocus}
       onChoose={() => console.log(choiceId)}
       onKeyDown={({ key }) => console.log(choiceId, key)}
@@ -60,6 +62,7 @@ Default.args = {
   choiceId: 'AARDVARK',
   choiceLabel: 'Aardvark',
   dark: false,
+  disabled: false,
   hasFocus: false,
   selected: false,
   src: '',
@@ -72,6 +75,7 @@ LongLabel.args = {
   choiceId: 'LONG',
   choiceLabel: 'Long label is really long label',
   dark: false,
+  disabled: false,
   hasFocus: false,
   selected: false,
   src: '',
@@ -84,6 +88,7 @@ SmallThumbnail.args = {
   choiceId: 'CRCL',
   choiceLabel: 'Caracal',
   dark: false,
+  disabled: false,
   hasFocus: false,
   selected: false,
   src: CARACAL_SRC,
@@ -96,6 +101,7 @@ MediumThumbnail.args = {
   choiceId: 'CRCL',
   choiceLabel: 'Caracal',
   dark: false,
+  disabled: false,
   hasFocus: false,
   selected: false,
   src: CARACAL_SRC,
@@ -108,6 +114,7 @@ LargeThumbnail.args = {
   choiceId: 'CRCL',
   choiceLabel: 'Caracal',
   dark: false,
+  disabled: false,
   hasFocus: false,
   selected: false,
   src: CARACAL_SRC,


### PR DESCRIPTION
Package:
- lib-classifier

Towards #1991.

Staging:
- recommend related Storybook components, easy to toggle `disabled` true/false, unlike...
- project - https://local.zooniverse.org:8080/?project=1634&workflow=2434

Describe your changes:
- add disabled property to ChoiceButton component
- add disabled property to DropButton in FilterStatus component

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
