### PR TITLE
Add devcert to deal with SSL in browsers for local dev (particularly Chrome)

### DIFF
--- a/packages/app-project/README.md
+++ b/packages/app-project/README.md
@@ -45,6 +45,8 @@ yarn build
 yarn start
 ```
 
+If you wish to run the app in a production environment with [`devcert`](#running-in-development), then run `yarn start:dev`.
+
 ### Tests
 
 See [Testing](#testing) for more details.

--- a/packages/app-project/README.md
+++ b/packages/app-project/README.md
@@ -13,11 +13,13 @@ This package should be cloned as part of the [front-end-monorepo](https://github
 
 ## Running in development
 
-Starts a development server on port 3000 and a Storybook server on port 9001 by default.
+Starts a development server on port 3000 and a Storybook server on port 9001 by default. The package `devcert` sets up a local certificate authority to generate self-signed SSL certificates for the `local.zooniverse.org` and `localhost.zooniverse.org` sub-domains. When you run this for the first time on Mac OS, you will be prompted for sudo (Read more at: https://github.com/davewasmer/devcert#security-concerns). In addition, you must have one of those sub-domains [setup](https://stackoverflow.com/c/zooniverse/questions/109) to get past CORS errors when authenticating with Panoptes in your hosts file.
+
+Once the local CA is created and you have the hosts file configured, you'll be able to use one of those subdomains to do local development for projects on and be able to authenticate with Panoptes, i.e. at `https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats` or `https://localhost.zooniverse.org:3000/projects/brooke/i-fancy-cats`
 
 ### Docker
 
-- `docker-compose up -d` to run a dev server, in the background, on http://localhost:3000 and the storybook on http://localhost:9001 using `yarn dev` and `yarn storybook` respectively. The `--build` flag can be used to build the container. This builds and runs a local image which matches the Jenkins build except for running behind a proxy.
+- `docker-compose up -d` to run a dev server, in the background, on http://localhost:3000 and the storybook on http://localhost:9001 using `yarn dev` and `yarn storybook` respectively. The `--build` flag can be used to build the container. This builds and runs a local image which matches the Jenkins build except for running behind a proxy. Note: `devcert` is not yet setup for our docker build for local development.
 - `docker-compose down` to stop the dev containers.
 - `docker-compose run --rm project test` to run the tests.
 

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -8,9 +8,10 @@
   "scripts": {
     "build": "PANOPTES_ENV=${PANOPTES_ENV:-production} next build",
     "build-storybook": "build-storybook -s public",
-    "dev": "PANOPTES_ENV=${PANOPTES_ENV:-staging} node server/server.js",
+    "dev": "PANOPTES_ENV=${PANOPTES_ENV:-staging} node server/dev-server.js",
     "lint": "zoo-standard --fix | snazzy",
     "start": "NODE_ENV=${NODE_ENV:-production} node server/server.js",
+    "start:dev": "NODE_ENV=${NODE_ENV:-production} node server/dev-server.js",
     "storybook": "start-storybook -p 9001 -c .storybook -s public",
     "test": "BABEL_ENV=test mocha --config test/.mocharc.json \"./{src,pages,stores}/**/*.spec.js\"",
     "test:ci": "BABEL_ENV=test mocha --config test/.mocharc.json --reporter=min \"./{src,pages,stores}/**/*.spec.js\""

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -76,6 +76,7 @@
     "babel-loader": "~8.2.2",
     "babel-plugin-webpack-alias": "~2.1.2",
     "chai": "~4.3.4",
+    "devcert": "~1.2.0",
     "dirty-chai": "~2.0.1",
     "enzyme": "~3.11.0",
     "enzyme-adapter-react-16": "~1.15.2",

--- a/packages/app-project/server/dev-server.js
+++ b/packages/app-project/server/dev-server.js
@@ -1,9 +1,7 @@
-if (process.env.NEWRELIC_LICENSE_KEY) {
-  require('newrelic')
-}
-
 const express = require('express')
 const next = require('next')
+const devcert = require('devcert')
+const https = require('https')
 
 const setLogging = require('./set-logging')
 const setCacheHeaders = require('./set-cache-headers')
@@ -23,8 +21,14 @@ app.prepare().then(() => {
     return handle(req, res)
   })
 
-  server.listen(port, err => {
-    if (err) throw err
-    console.log(`> Ready on http://localhost:${port}`)
-  })
+  devcert.certificateFor([
+    'local.zooniverse.org',
+    'localhost.zooniverse.org'
+  ]).then(cert => {
+    return https.createServer(cert, server)
+      .listen(port, err => {
+        if (err) throw err
+        console.log(`> Ready on https://local.zooniverse.org:${port} or https://localhost.zooniverse.org:${port}`)
+      })
+  }).catch(error => console.error(error))
 })

--- a/packages/app-project/server/server.js
+++ b/packages/app-project/server/server.js
@@ -32,8 +32,7 @@ app.prepare().then(() => {
     return https.createServer(cert, server)
       .listen(port, err => {
         if (err) throw err
-        console.log(`> Ready on https://localhost:${port}`)
+        console.log(`> Ready on https://local.zooniverse.org:${port} or https://localhost.zooniverse.org:${port}`)
       })
   }).catch(error => console.error(error))
-
 })

--- a/packages/app-project/server/server.js
+++ b/packages/app-project/server/server.js
@@ -4,6 +4,8 @@ if (process.env.NEWRELIC_LICENSE_KEY) {
 
 const express = require('express')
 const next = require('next')
+const devcert = require('devcert')
+const https = require('https')
 
 const setLogging = require('./set-logging')
 const setCacheHeaders = require('./set-cache-headers')
@@ -23,8 +25,15 @@ app.prepare().then(() => {
     return handle(req, res)
   })
 
-  server.listen(port, err => {
-    if (err) throw err
-    console.log(`> Ready on http://localhost:${port}`)
-  })
+  devcert.certificateFor([
+    'local.zooniverse.org',
+    'localhost.zooniverse.org'
+  ]).then(cert => {
+    return https.createServer(cert, server)
+      .listen(port, err => {
+        if (err) throw err
+        console.log(`> Ready on https://localhost:${port}`)
+      })
+  }).catch(error => console.error(error))
+
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4110,6 +4110,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/configstore@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/configstore/-/configstore-2.1.1.tgz#cd1e8553633ad3185c3f2f239ecff5d2643e92b6"
+  integrity sha1-zR6FU2M60xhcPy8jns/10mQ+krY=
+
 "@types/d3-color@^1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-1.4.1.tgz#0d9746c84dfef28807b2989eed4f37b2575e1f33"
@@ -4156,6 +4161,11 @@
   resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-1.1.1.tgz#6cf3a4242c3bbac00440dfb8ba7884f16bedfcbf"
   integrity sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw==
 
+"@types/debug@^0.0.30":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.30.tgz#dc1e40f7af3b9c815013a7860e6252f6352a84df"
+  integrity sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==
+
 "@types/eslint-scope@^3.7.0":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.0.tgz#4792816e31119ebd506902a482caec4951fabd86"
@@ -4187,6 +4197,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.48.tgz#18dc8091b285df90db2f25aa7d906cfc394b7f74"
   integrity sha512-LfZwXoGUDo0C3me81HXgkBg5CTQYb6xzEl+fNmbO4JdRiSKQ8A0GD1OBBvKAIsbCUgoyAty7m99GqqMQe784ew==
 
+"@types/get-port@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@types/get-port/-/get-port-3.2.0.tgz#f9e0a11443cc21336470185eae3dfba4495d29bc"
+  integrity sha512-TiNg8R1kjDde5Pub9F9vCwZA/BNW9HeXP5b9j7Qucqncy/McfPZ6xze/EyBdXS5FhMIGN6Fx3vg75l5KHy3V1Q==
+
 "@types/glob-base@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@types/glob-base/-/glob-base-0.3.0.tgz#a581d688347e10e50dd7c17d6f2880a10354319d"
@@ -4196,6 +4211,14 @@
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
   integrity sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
+"@types/glob@^5.0.34":
+  version "5.0.37"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-5.0.37.tgz#d0982abc88f9aebbd62099d3d70440cbcea692de"
+  integrity sha512-ATA/xrS7CZ3A2WCPVY4eKdNpybq56zqlTirnHhhyOztZM/lPxJzusOBI3BsaXbu6FrUluqzvMlI4sZ6BDYMlMg==
   dependencies:
     "@types/minimatch" "*"
     "@types/node" "*"
@@ -4280,6 +4303,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.167.tgz#ce7d78553e3c886d4ea643c37ec7edc20f16765e"
   integrity sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw==
 
+"@types/lodash@^4.14.92":
+  version "4.14.171"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.171.tgz#f01b3a5fe3499e34b622c362a46a609fdb23573b"
+  integrity sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==
+
 "@types/long@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
@@ -4316,6 +4344,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
+"@types/mkdirp@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"
+  integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node-fetch@^2.5.7":
   version "2.5.10"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz#9b4d4a0425562f9fcea70b12cb3fcdd946ca8132"
@@ -4348,6 +4383,11 @@
   version "14.14.42"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.42.tgz#20271ce899f35eb6cd525f500bfa8f4c9e27ecd6"
   integrity sha512-88QoObqn9WYIUMRzOx92GmSHmU3JCyukC2ulEv8tFjUG9VeV2FQ/cA7VQ1gi+rB/+gBMVvzVFcTnz8RdMDVIWw==
+
+"@types/node@^8.5.7":
+  version "8.10.66"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.66.tgz#dd035d409df322acc83dff62a602f12a5783bbb3"
+  integrity sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -4411,6 +4451,14 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
+"@types/rimraf@^2.0.2":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-2.0.5.tgz#368fb04d59630b727fc05a74d2ca557f64a8ef98"
+  integrity sha512-YyP+VfeaqAyFmXoTh3HChxOQMyjByRMsHU7kc5KOJkSlXudhMhQIALbYV7rHh/l8d2lX3VUQzprrcAgWdRuU8g==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
+
 "@types/source-list-map@*":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
@@ -4432,6 +4480,11 @@
   integrity sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==
   dependencies:
     "@types/node" "*"
+
+"@types/tmp@^0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.33.tgz#1073c4bc824754ae3d10cfab88ab0237ba964e4d"
+  integrity sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=
 
 "@types/uglify-js@*":
   version "3.11.1"
@@ -5164,7 +5217,7 @@ ansi-colors@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
-ansi-escapes@^3.2.0:
+ansi-escapes@^3.1.0, ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
@@ -5254,6 +5307,11 @@ append-transform@^2.0.0:
   integrity sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==
   dependencies:
     default-require-extensions "^3.0.0"
+
+application-config-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/application-config-path/-/application-config-path-0.1.0.tgz#193c5f0a86541a4c66fba1e2dc38583362ea5e8f"
+  integrity sha1-GTxfCoZUGkxm+6Hi3DhYM2LqXo8=
 
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
@@ -6998,6 +7056,11 @@ comma-separated-tokens@^1.0.0, comma-separated-tokens@^1.0.1:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
+command-exists@^1.2.4:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
+  integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
+
 commander@2, commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -7503,7 +7566,7 @@ cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cross-spawn@^6.0.0:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -8323,6 +8386,34 @@ detect-port@^1.3.0:
     address "^1.0.1"
     debug "^2.6.0"
 
+devcert@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/devcert/-/devcert-1.2.0.tgz#7fb0fa2ca4c73baf3a3053973e80ebc5899fb20d"
+  integrity sha512-Tca9LUcmDegqTxlnQLTxVARS3MqYT+eWJfskXykefknT9jPoSJEA+t5BkDq5C5Tz+gVmAWmOH5vvKMfLJO/UhQ==
+  dependencies:
+    "@types/configstore" "^2.1.1"
+    "@types/debug" "^0.0.30"
+    "@types/get-port" "^3.2.0"
+    "@types/glob" "^5.0.34"
+    "@types/lodash" "^4.14.92"
+    "@types/mkdirp" "^0.5.2"
+    "@types/node" "^8.5.7"
+    "@types/rimraf" "^2.0.2"
+    "@types/tmp" "^0.0.33"
+    application-config-path "^0.1.0"
+    command-exists "^1.2.4"
+    debug "^3.1.0"
+    eol "^0.9.1"
+    get-port "^3.2.0"
+    glob "^7.1.2"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    password-prompt "^1.0.4"
+    rimraf "^2.6.2"
+    sudo-prompt "^8.2.0"
+    tmp "^0.0.33"
+    tslib "^1.10.0"
+
 dezalgo@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
@@ -8886,6 +8977,11 @@ enzyme@~3.11.0:
     raf "^3.4.1"
     rst-selector-parser "^2.2.3"
     string.prototype.trim "^1.2.1"
+
+eol@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/eol/-/eol-0.9.1.tgz#f701912f504074be35c6117a5c4ade49cd547acd"
+  integrity sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==
 
 err-code@^1.0.0:
   version "1.1.2"
@@ -14617,19 +14713,19 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
-panoptes-client@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/panoptes-client/-/panoptes-client-3.3.2.tgz#aefaf42d01b3e490b02258d44fb0df0374f21c74"
-  integrity sha512-fb6Tah+M8QTZ/cSU6BE8/1+hatS1AVmj29iZj7hAdprvhenfcJcyj/C4eLEbbEmzXS7ZeOVJ3ESUY5KngAfivg==
+panoptes-client@~3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/panoptes-client/-/panoptes-client-3.2.1.tgz#d6dc2b3fff211b837e56a1a2a23f1ad6731dae6d"
+  integrity sha512-O4HmQS0iJVKKf4qfxJgG7IH0lYZyjfVW6T/o7+XBiJvg9j63nv5EreSemW7h7YtnloyoQ34zogL2xMCnLIbN3A==
   dependencies:
     json-api-client "~5.0.0"
     local-storage "^1.4.2"
     sugar-client "^1.0.1"
 
-panoptes-client@~3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/panoptes-client/-/panoptes-client-3.2.1.tgz#d6dc2b3fff211b837e56a1a2a23f1ad6731dae6d"
-  integrity sha512-O4HmQS0iJVKKf4qfxJgG7IH0lYZyjfVW6T/o7+XBiJvg9j63nv5EreSemW7h7YtnloyoQ34zogL2xMCnLIbN3A==
+panoptes-client@~3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/panoptes-client/-/panoptes-client-3.3.2.tgz#aefaf42d01b3e490b02258d44fb0df0374f21c74"
+  integrity sha512-fb6Tah+M8QTZ/cSU6BE8/1+hatS1AVmj29iZj7hAdprvhenfcJcyj/C4eLEbbEmzXS7ZeOVJ3ESUY5KngAfivg==
   dependencies:
     json-api-client "~5.0.0"
     local-storage "^1.4.2"
@@ -14807,6 +14903,14 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+password-prompt@^1.0.4:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/password-prompt/-/password-prompt-1.1.2.tgz#85b2f93896c5bd9e9f2d6ff0627fa5af3dc00923"
+  integrity sha512-bpuBhROdrhuN3E7G/koAju0WjVw9/uQOG5Co5mokNj0MiOSBVZS1JTwM4zl55hu0WFmIEFvO9cU9sJQiBIYeIA==
+  dependencies:
+    ansi-escapes "^3.1.0"
+    cross-spawn "^6.0.5"
 
 path-browserify@0.0.1:
   version "0.0.1"
@@ -17885,6 +17989,11 @@ stylis@3.5.4:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
+sudo-prompt@^8.2.0:
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/sudo-prompt/-/sudo-prompt-8.2.5.tgz#cc5ef3769a134bb94b24a631cc09628d4d53603e"
+  integrity sha512-rlBo3HU/1zAJUrkY6jNxDOC9eVYliG6nS4JA8u8KAshITd07tafMc/Br7xQwCSseXwJ2iCcHCE8SNWX3q8Z+kw==
+
 sugar-client@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sugar-client/-/sugar-client-1.0.1.tgz#cd1873fbf2a7dac9a6f29aca1eada1af7513cf9f"
@@ -18415,7 +18524,7 @@ tslib@1.10.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
-tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

Package: project-app

Toward the workflow assignment effort...

This adds [devcert](https://github.com/davewasmer/devcert#readme) to the project app which creates a local certificate authority to generate self-signed SSL certificates (more info on how this works: https://github.com/davewasmer/devcert#how-it-works). Currently, we can get around Chrome's security warnings about SSL by using `http://localhost` and typing in `thisisunsafe`, but we still cannot sign in to Panoptes because of CORS errors. Adding this will enable us to use `https://local.zooniverse.org:3000` and `https://localhost.zooniverse.org:3000` which will get auth to work with Panoptes.

Note that the first time this is run on Mac OS X, you will get prompted for sudo:

> macOS and Linux: the certificate authority's credentials are written to files that are only readable by the root user (i.e. chown 0 ca-cert.crt and chmod 600 ca-cert.crt). When devcert itself needs these, it shells out to sudo invocations to read / write the credentials.

(More on this here: https://github.com/davewasmer/devcert#security-concerns)

Firefox still shows SSL cert warnings and you can still get around using certain configuration settings to get around it. We can [configure it to allow Firefox to trust](https://github.com/davewasmer/devcert#skipcertutil) the locally installed certificate authority. Let me know if anyone wants this done and it can be looked into.

Also note, this does not setup the CA for docker or for the classifier library. This can be done in additional follow up PRs. This right now just gets me in a place to continue workflow assignment feature development. 

To test, run `yarn bootstrap`, go to the project app, run `yarn dev`, enter your sudo password when prompted. You should see a new success message of `Ready on https://local.zooniverse.org:3000 or https://localhost.zooniverse.org:3000` then browse to one of those (depending on which of those local sub-domains you have setup). Now go to a staging project:

https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats

or 

https://localhost.zooniverse.org:3000/projects/brooke/i-fancy-cats

And try authentication with a staging user. You should now be able to authenticate.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [x] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
