### PR TITLE
Rotate rectangle resize

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.js
@@ -33,6 +33,13 @@ function RotateRectangle({
     mark.setCoordinates({ x_left, x_right, y_top, y_bottom, angle })
   }
 
+  function rotateXY({ x, y }, angleInDegrees) {
+    const theta = angleInDegrees * (Math.PI / 180)
+    const xTheta = x * Math.cos(theta) + y * Math.sin(theta)
+    const yTheta = -(x * Math.sin(theta)) + y * Math.cos(theta)
+    return { x: xTheta, y: yTheta }
+  }
+
   return (
     <g onPointerUp={active ? onFinish : undefined}>
       <rect x={x_left} y={y_top} width={width} height={height} />
@@ -72,10 +79,10 @@ function RotateRectangle({
           y={y_top}
           dragMove={(e, d) =>
             onHandleDrag({
-              x_left: x_left + d.x,
-              x_right: x_right,
-              y_top: y_top + d.y,
-              y_bottom: y_bottom,
+              x_left: x_left + rotateXY(d, angle).x,
+              x_right: x_right - rotateXY(d, angle).x,
+              y_top: y_top + rotateXY(d, angle).y,
+              y_bottom: y_bottom - rotateXY(d, angle).y,
               angle: angle
             })
           }
@@ -90,10 +97,10 @@ function RotateRectangle({
           y={y_top}
           dragMove={(e, d) =>
             onHandleDrag({
-              x_left: x_left,
-              x_right: x_right + d.x,
-              y_top: y_top + d.y,
-              y_bottom: y_bottom,
+              x_left: x_left - rotateXY(d, angle).x,
+              x_right: x_right + rotateXY(d, angle).x,
+              y_top: y_top + rotateXY(d, angle).y,
+              y_bottom: y_bottom - rotateXY(d, angle).y,
               angle: angle
             })
           }
@@ -108,10 +115,10 @@ function RotateRectangle({
           y={y_bottom}
           dragMove={(e, d) =>
             onHandleDrag({
-              x_left: x_left,
-              x_right: x_right + d.x,
-              y_top: y_top,
-              y_bottom: y_bottom + d.y,
+              x_left: x_left - rotateXY(d, angle).x,
+              x_right: x_right + rotateXY(d, angle).x,
+              y_top: y_top - rotateXY(d, angle).y,
+              y_bottom: y_bottom + rotateXY(d, angle).y,
               angle: angle
             })
           }
@@ -126,10 +133,10 @@ function RotateRectangle({
           y={y_bottom}
           dragMove={(e, d) =>
             onHandleDrag({
-              x_left: x_left + d.x,
-              x_right: x_right,
-              y_top: y_top,
-              y_bottom: y_bottom + d.y,
+              x_left: x_left + rotateXY(d, angle).x,
+              x_right: x_right - rotateXY(d, angle).x,
+              y_top: y_top - rotateXY(d, angle).y,
+              y_bottom: y_bottom + rotateXY(d, angle).y,
               angle: angle
             })
           }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.js
@@ -64,6 +64,7 @@ function RotateRectangle({
         </g>
       )}
 
+      {/* Original Top Left corner */}
       {active && (
         <DragHandle
           scale={scale}
@@ -80,38 +81,8 @@ function RotateRectangle({
           }
         />
       )}
-      {active && (
-        <DragHandle
-          scale={scale}
-          x={x_right}
-          y={y_bottom}
-          dragMove={(e, d) =>
-            onHandleDrag({
-              x_left: x_left,
-              x_right: x_right + d.x,
-              y_top: y_top,
-              y_bottom: y_bottom + d.y,
-              angle: angle
-            })
-          }
-        />
-      )}
-      {active && (
-        <DragHandle
-          scale={scale}
-          x={x_left}
-          y={y_bottom}
-          dragMove={(e, d) =>
-            onHandleDrag({
-              x_left: x_left + d.x,
-              x_right: x_right,
-              y_top: y_top,
-              y_bottom: y_bottom + d.y,
-              angle: angle
-            })
-          }
-        />
-      )}
+
+      {/* Original Top Right corner */}
       {active && (
         <DragHandle
           scale={scale}
@@ -123,6 +94,42 @@ function RotateRectangle({
               x_right: x_right + d.x,
               y_top: y_top + d.y,
               y_bottom: y_bottom,
+              angle: angle
+            })
+          }
+        />
+      )}
+
+      {/* Original Bottom Right corner */}
+      {active && (
+        <DragHandle
+          scale={scale}
+          x={x_right}
+          y={y_bottom}
+          dragMove={(e, d) =>
+            onHandleDrag({
+              x_left: x_left,
+              x_right: x_right + d.x,
+              y_top: y_top,
+              y_bottom: y_bottom + d.y,
+              angle: angle
+            })
+          }
+        />
+      )}
+
+      {/* Original Bottom Left corner */}
+      {active && (
+        <DragHandle
+          scale={scale}
+          x={x_left}
+          y={y_bottom}
+          dragMove={(e, d) =>
+            onHandleDrag({
+              x_left: x_left + d.x,
+              x_right: x_right,
+              y_top: y_top,
+              y_bottom: y_bottom + d.y,
               angle: angle
             })
           }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateRectangle/RotateRectangle.spec.js
@@ -65,10 +65,10 @@ describe('RotateRectangle tool', function () {
       dragMove({}, { x: 50, y: 20 })
 
       expect(mark.angle).to.equal(0)
-      expect(mark.x_center).to.equal(325)
-      expect(mark.y_center).to.equal(310)
-      expect(mark.width).to.equal(250)
-      expect(mark.height).to.equal(220)
+      expect(mark.x_center).to.equal(300)
+      expect(mark.y_center).to.equal(300)
+      expect(mark.width).to.equal(300)
+      expect(mark.height).to.equal(240)
     })
 
     it('should rotate to 90 degrees when the RotateHandle is moved', function () {
@@ -122,6 +122,45 @@ describe('RotateRectangle tool', function () {
       )
       wrapper.simulate('pointerup')
       expect(onFinish).to.have.been.calledOnce()
+    })
+
+    describe('when rotated 180 degrees', function () {
+      let mark
+      beforeEach(function () {
+        mark = RotateRectangleMark.create({
+          id: 'rotateRectangle2',
+          toolType: 'rotateRectangle',
+          angle: 180,
+          x_center: 300,
+          y_center: 300,
+          width: 200,
+          height: 200
+        })
+      })
+
+      it('should resize when the drag handles are moved', function () {
+        const wrapper = mount(<RotateRectangle active mark={mark} scale={1} />)
+
+        // rectangle is now rotated 180 degrees
+        // test current Top Right handle
+        const dragMove = wrapper
+          .find(DragHandle)
+          .find('[x=400][y=200][dragMove]')
+          .prop('dragMove')
+        expect(mark.angle).to.equal(180)
+        expect(mark.x_center).to.equal(300)
+        expect(mark.y_center).to.equal(300)
+        expect(mark.width).to.equal(200)
+        expect(mark.height).to.equal(200)
+
+        dragMove({}, { x: 50, y: 50 })
+
+        expect(mark.angle).to.equal(180)
+        expect(mark.x_center).to.equal(300)
+        expect(mark.y_center).to.equal(300)
+        expect(mark.width).to.equal(100)
+        expect(mark.height).to.equal(300)
+      })
     })
   })
 })


### PR DESCRIPTION
Package: `lib-classifier`

Closes #2296 

Describe your changes:
Added a new function, `rotateXY`, to include the angle of the rectangle when resizing.
Then using this function on each `DragHandle` (corner) of the rectangle.
See Issue #2296 for a great explanation of this.

With this new update, resizing the rectangle has a mirroring effect where the center will remain and the width/height will resize on both sides of the center point.
Because of this, the `resizing` unit test was updated and a new unit test was created for resizing a rotated rectangle.
