### PR TITLE
Added videoViewer ref back to svg element

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
@@ -27,6 +27,7 @@ class SingleVideoViewerContainer extends React.Component {
   constructor() {
     super()
 
+    this.videoViewer = React.createRef()
     this.transformLayer = React.createRef()
 
     this.state = {
@@ -226,19 +227,17 @@ class SingleVideoViewerContainer extends React.Component {
             <Box animation='fadeIn' overflow='hidden'>
               <SVGContext.Provider value={{ canvas }}>
                 <svg
+                  ref={this.videoViewer}
                   focusable
                   onKeyDown={onKeyDown}
                   tabIndex={0}
                   viewBox={`0 0 ${naturalWidth} ${naturalHeight}`}
-                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns='http://www.w3.org/2000/svg'
                 >
                   {/* {title?.id && title?.text && (
                   <title id={title.id}>{title.text}</title>
                 )} */}
-                  <g
-                    ref={this.transformLayer}
-                    transform={transform}
-                  >
+                  <g ref={this.transformLayer} transform={transform}>
                     {enableInteractionLayer && (
                       <InteractionLayer
                         scale={scale}


### PR DESCRIPTION
Package: `lib-classifier`

## Describe your changes:
During the refactor from #2277, the `videoViewer ref` in `SingleVideoViewerContainer.js` was removed.
With the `videoViewer ref` removed, videos were not loading properly and users would see the 'Something went wrong' message.

The `videoViewer ref` is still needed in this file to calculate the video dimensions.
With this `ref` now in place, video dimensions are properly being calculated and loaded!

All unit tests are passing and UI is behaving as expected.

## Testing
In the front-end-monorepo folder, run yarn bootstrap to build the packages. Then cd packages/lib-classifier and run yarn dev.
Project URL: [https://localhost:8080/?env=production&project=13789&workflow=16843](https://localhost:8080/?env=production&project=13789&workflow=16843)
