### PR TITLE
Classifier: Fix Finished modal button alignment

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/DisabledTaskPopup/DisabledTaskPopup.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/DisabledTaskPopup/DisabledTaskPopup.js
@@ -58,6 +58,7 @@ export default function DisabledTaskPopup({
         text={counterpart('DisabledTaskPopup.options.select')}
       />
       <PrimaryButton
+        alignSelf="center"
         color='teal'
         label={counterpart('DisabledTaskPopup.options.next')}
         onClick={nextAvailable}


### PR DESCRIPTION
Add a missing `alignSelf="center"` to the 'Next available subject' button.

![The Next available subject button harmoniously filling the available space, with equal margins to either side.](https://user-images.githubusercontent.com/59547/127887085-e5b255c4-b839-4c50-aeeb-c0e9c9111e65.png)
https://local.zooniverse.org:8080/?project=12268&workflow=17076&subjectSet=96235&subject=63413209&env=production&demo=true&finished=true

Package:
lib-classifier

Closes #2327.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
