### PR TITLE
Render inside the it statement so it doesn't pollute other tests

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
@@ -44,15 +44,15 @@ describe('TaskAreaConnector', function () {
       isThereTaskHelp: false
     },
   }
-  const renderedComponent = render(
-    <Grommet theme={zooTheme}>
-      <Provider classifierStore={mockStore}>
-        <TaskAreaConnector />
-      </Provider>
-    </Grommet>
-  )
 
   it('should render without crashing', function () {
+    const renderedComponent = render(
+      <Grommet theme={zooTheme}>
+        <Provider classifierStore={mockStore}>
+          <TaskAreaConnector />
+        </Provider>
+      </Grommet>
+    )
     expect(renderedComponent).to.be.ok()
   })
 })


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

Package: lib-classifier

My mistake in adding the smoke test the other day when fixing the tutorial. Be sure to only render inside the `it` statement function or inside a `before` or `beforeEach` so it gets cleaned up and doesn't pollute the test jsdom for other tests.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
