### PR TITLE
Project: WorkflowSelectButtons: fix list structure

### DIFF
--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.js
@@ -4,16 +4,26 @@ import WorkflowSelectButton from '../WorkflowSelectButton'
 import en from './locales/en'
 import counterpart from 'counterpart'
 import PropTypes from 'prop-types'
+import { withTheme } from 'styled-components'
 
 counterpart.registerTranslations('en', en)
 
-export default function WorkflowSelectButtons (props) {
-  const {
-    assignedWorkflowID = '',
-    onSelect,
-    workflowAssignmentEnabled = false,
-    workflows = []
-  } = props
+function WorkflowSelectButtons ({
+  assignedWorkflowID = '',
+  gap = 'xsmall',
+  onSelect,
+  workflowAssignmentEnabled = false,
+  theme = {
+    global: {
+      edgeSize: {}
+    }
+  },
+  workflows = []
+}) {
+  const listStyle = {
+    gap: theme.global.edgeSize[gap],
+    listStyle: 'none'
+  }
 
   if (workflowAssignmentEnabled) {
     let assignedWorkflow
@@ -58,13 +68,15 @@ export default function WorkflowSelectButtons (props) {
           <SpacedText>{counterpart('WorkflowSelectButtons.unlocked')}</SpacedText>
           <Box
             as="ul"
-            gap='xsmall'
             pad='none'
-            style={{ listStyle: 'none' }}
+            style={listStyle}
           >
             {filteredWorkflowsByLevel.allowed.map((workflow) => (
               <li key={workflow.id}>
-                <WorkflowSelectButton onSelect={onSelect} workflow={workflow} />
+                <WorkflowSelectButton
+                  onSelect={onSelect}
+                  workflow={workflow}
+                />
               </li>
             ))}
           </Box>
@@ -79,13 +91,16 @@ export default function WorkflowSelectButtons (props) {
           <SpacedText>{counterpart('WorkflowSelectButtons.locked')}</SpacedText>
           <Box
             as="ul"
-            gap='xsmall'
             pad='none'
-            style={{ listStyle: 'none' }}
+            style={listStyle}
           >
             {filteredWorkflowsByLevel.disallowed.map((workflow) => (
               <li key={workflow.id}>
-                <WorkflowSelectButton disabled={true} onSelect={onSelect} workflow={workflow} />
+                <WorkflowSelectButton
+                  disabled={true}
+                  onSelect={onSelect}
+                  workflow={workflow}
+                />
               </li>
             ))}
           </Box>
@@ -100,14 +115,17 @@ export default function WorkflowSelectButtons (props) {
       alignSelf='start'
       as="ul"
       fill='horizontal'
-      gap='xsmall'
       margin={{ top: 'small' }}
       pad='none'
-      style={{ listStyle: 'none' }}
+      style={listStyle}
       width={{ max: 'medium' }}
-    >{workflows.map(workflow => (
+    >
+      {workflows.map(workflow => (
         <li key={workflow.id}>
-          <WorkflowSelectButton onSelect={onSelect} workflow={workflow} />
+          <WorkflowSelectButton
+            onSelect={onSelect}
+            workflow={workflow}
+          />
         </li>
       ))}
     </Box>
@@ -116,6 +134,9 @@ export default function WorkflowSelectButtons (props) {
 
 WorkflowSelectButtons.propTypes = {
   assignedWorkflowID: PropTypes.string,
+  gap: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
   workflows: PropTypes.arrayOf(PropTypes.object)
 }
+
+export default withTheme(WorkflowSelectButtons)


### PR DESCRIPTION
Replace the `gap` prop with CSS gaps in `WorkflowSelectButtons`. Grommet renders gaps as `<div>` elements, but that generates invalid lists, with extra divs between the list items.

Package:
app-project

Closes #2338.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
