### PR TITLE
Engaging Crowds: test DisabledTaskPopup

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
@@ -65,7 +65,6 @@ export default function TaskArea({
         flex
       >
         <Tab
-          disabled={disabled}
           title={counterpart('TaskArea.task')}
         >
           <Box

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
@@ -12,7 +12,8 @@ import { SubjectFactory, SubjectSetFactory, WorkflowFactory } from '@test/factor
 import mockStore from '@test/mockStore'
 import TaskAreaConnector from './TaskAreaConnector'
 
-import popupText from './components/DisabledTaskPopup/locales/en'
+import DisabledTaskPopupLocale from './components/DisabledTaskPopup/locales/en'
+const { DisabledTaskPopup: popupText } = DisabledTaskPopupLocale
 
 describe('TaskAreaConnector', function () {
 
@@ -51,10 +52,10 @@ describe('TaskAreaConnector', function () {
           wrapper: withStore(store)
         }
       )
-      finishedMessage = screen.queryByText(popupText.DisabledTaskPopup.body)
-      selectButton = screen.queryByText(popupText.DisabledTaskPopup.options.select)
-      nextButton = screen.queryByText(popupText.DisabledTaskPopup.options.next)
-      dismissButton = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
+      finishedMessage = screen.queryByText(popupText.body)
+      selectButton = screen.queryByText(popupText.options.select)
+      nextButton = screen.queryByText(popupText.options.next)
+      dismissButton = screen.queryByText(popupText.options.dismiss)
       inputs = screen.queryAllByRole('radio')
     })
 
@@ -148,10 +149,10 @@ describe('TaskAreaConnector', function () {
             wrapper: withStore(store)
           }
         )
-        finishedMessage = screen.queryByText(popupText.DisabledTaskPopup.body)
-        selectButton = screen.queryByText(popupText.DisabledTaskPopup.options.select)
-        nextButton = screen.queryByText(popupText.DisabledTaskPopup.options.next)
-        dismissButton = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
+        finishedMessage = screen.queryByText(popupText.body)
+        selectButton = screen.queryByText(popupText.options.select)
+        nextButton = screen.queryByText(popupText.options.next)
+        dismissButton = screen.queryByText(popupText.options.dismiss)
         inputs = screen.queryAllByRole('radio')
       })
 
@@ -197,10 +198,10 @@ describe('TaskAreaConnector', function () {
             wrapper: withStore(store)
           }
         )
-        finishedMessage = screen.queryByText(popupText.DisabledTaskPopup.body)
-        selectButton = screen.queryByText(popupText.DisabledTaskPopup.options.select)
-        nextButton = screen.queryByText(popupText.DisabledTaskPopup.options.next)
-        dismissButton = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
+        finishedMessage = screen.queryByText(popupText.body)
+        selectButton = screen.queryByText(popupText.options.select)
+        nextButton = screen.queryByText(popupText.options.next)
+        dismissButton = screen.queryByText(popupText.options.dismiss)
         inputs = screen.queryAllByRole('radio')
       })
 
@@ -244,10 +245,10 @@ describe('TaskAreaConnector', function () {
             wrapper: withStore(store)
           }
         )
-        finishedMessage = screen.queryByText(popupText.DisabledTaskPopup.body)
-        selectButton = screen.queryByText(popupText.DisabledTaskPopup.options.select)
-        nextButton = screen.queryByText(popupText.DisabledTaskPopup.options.next)
-        dismissButton = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
+        finishedMessage = screen.queryByText(popupText.body)
+        selectButton = screen.queryByText(popupText.options.select)
+        nextButton = screen.queryByText(popupText.options.next)
+        dismissButton = screen.queryByText(popupText.options.dismiss)
         inputs = screen.queryAllByRole('radio')
       })
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
@@ -76,7 +76,17 @@ describe('TaskAreaConnector', function () {
         }
       })
       const workflowSnapshot = WorkflowFactory.build({
+        first_task: 'T0',
         grouped: true,
+        tasks: {
+          T0: {
+            answers: [{ label: 'yes', next: 'T1' }, { label: 'no', next: 'T2' }],
+            question: 'Is there a cat?',
+            required: false,
+            taskKey: 'T0',
+            type: 'single'
+          }
+        },
         links: {
           subject_sets: [subjectSetSnapshot.id] 
         }
@@ -127,6 +137,14 @@ describe('TaskAreaConnector', function () {
         const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.dismiss)
         expect(button).to.be.ok()
       })
+
+      it('should disable the active task', function () {
+        const inputs = renderedComponent.queryAllByRole('radio')
+        expect(inputs).to.not.be.empty()
+        inputs.forEach(input => {
+          expect(input.disabled).to.be.true()
+        })
+      })
     })
 
     describe('with an already seen subject', function () {
@@ -164,6 +182,14 @@ describe('TaskAreaConnector', function () {
         const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.dismiss)
         expect(button).to.be.ok()
       })
+
+      it('should disable the active task', function () {
+        const inputs = renderedComponent.queryAllByRole('radio')
+        expect(inputs).to.not.be.empty()
+        inputs.forEach(input => {
+          expect(input.disabled).to.be.true()
+        })
+      })
     })
 
     describe('with an unfinished subject', function () {
@@ -198,6 +224,14 @@ describe('TaskAreaConnector', function () {
       it('should not show a button to dismiss the popup', function () {
         const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.dismiss)
         expect(button).to.be.null()
+      })
+
+      it('should not disable the active task', function () {
+        const inputs = renderedComponent.queryAllByRole('radio')
+        expect(inputs).to.not.be.empty()
+        inputs.forEach(input => {
+          expect(input.disabled).to.be.false()
+        })
       })
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
@@ -36,12 +36,11 @@ describe('TaskAreaConnector', function () {
   }
 
   describe('without indexed subjects', function () {
-    let renderedComponent
 
     beforeEach(function () {
       const store = mockStore()
     
-      renderedComponent = render(
+      render(
         <TaskAreaConnector />,
         {
           wrapper: withStore(store)
@@ -49,12 +48,8 @@ describe('TaskAreaConnector', function () {
       )
     })
 
-    it('should render without crashing', function () {
-      expect(renderedComponent).to.be.ok()
-    })
-
     it('should render the active task', function () {
-      const inputs = renderedComponent.queryAllByRole('radio')
+      const inputs = screen.queryAllByRole('radio')
       expect(inputs).to.not.be.empty()
       inputs.forEach(input => {
         expect(input.disabled).to.be.false()
@@ -62,22 +57,22 @@ describe('TaskAreaConnector', function () {
     })
 
     it('should not show a message that the subject is finished', function () {
-      const para = renderedComponent.queryByText(popupText.DisabledTaskPopup.body)
+      const para = screen.queryByText(popupText.DisabledTaskPopup.body)
       expect(para).to.be.null()
     })
 
     it('should not show a button to choose a new subject', function () {
-      const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.select)
+      const button = screen.queryByText(popupText.DisabledTaskPopup.options.select)
       expect(button).to.be.null()
     })
 
     it('should not show a button to choose the next available subject', function () {
-      const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.next)
+      const button = screen.queryByText(popupText.DisabledTaskPopup.options.next)
       expect(button).to.be.null()
     })
 
     it('should not show a button to dismiss the popup', function () {
-      const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.dismiss)
+      const button = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
       expect(button).to.be.null()
     })
   })
@@ -131,14 +126,13 @@ describe('TaskAreaConnector', function () {
     }
 
     describe('with a retired subject', function () {
-      let renderedComponent
 
       beforeEach(async function () {
         const subject = SubjectFactory.build({
           retired: true
         })
         const store = await buildStore(subject)
-        renderedComponent = render(
+        render(
           <TaskAreaConnector />,
           {
             wrapper: withStore(store)
@@ -147,27 +141,27 @@ describe('TaskAreaConnector', function () {
       })
 
       it('should show a message that the subject is finished', function () {
-        const para = renderedComponent.queryByText(popupText.DisabledTaskPopup.body)
+        const para = screen.queryByText(popupText.DisabledTaskPopup.body)
         expect(para).to.be.ok()
       })
 
       it('should show a button to choose a new subject', function () {
-        const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.select)
+        const button = screen.queryByText(popupText.DisabledTaskPopup.options.select)
         expect(button).to.be.ok()
       })
 
       it('should show a button to choose the next available subject', function () {
-        const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.next)
+        const button = screen.queryByText(popupText.DisabledTaskPopup.options.next)
         expect(button).to.be.ok()
       })
 
       it('should show a button to dismiss the popup', function () {
-        const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.dismiss)
+        const button = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
         expect(button).to.be.ok()
       })
 
       it('should disable the active task', function () {
-        const inputs = renderedComponent.queryAllByRole('radio')
+        const inputs = screen.queryAllByRole('radio')
         expect(inputs).to.not.be.empty()
         inputs.forEach(input => {
           expect(input.disabled).to.be.true()
@@ -176,14 +170,13 @@ describe('TaskAreaConnector', function () {
     })
 
     describe('with an already seen subject', function () {
-      let renderedComponent
 
       beforeEach(async function () {
         const subject = SubjectFactory.build({
           already_seen: true
         })
         const store = await buildStore(subject)
-        renderedComponent = render(
+        render(
           <TaskAreaConnector />,
           {
             wrapper: withStore(store)
@@ -192,27 +185,27 @@ describe('TaskAreaConnector', function () {
       })
 
       it('should show a message that the subject is finished', function () {
-        const para = renderedComponent.queryByText(popupText.DisabledTaskPopup.body)
+        const para = screen.queryByText(popupText.DisabledTaskPopup.body)
         expect(para).to.be.ok()
       })
 
       it('should show a button to choose a new subject', function () {
-        const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.select)
+        const button = screen.queryByText(popupText.DisabledTaskPopup.options.select)
         expect(button).to.be.ok()
       })
 
       it('should show a button to choose the next available subject', function () {
-        const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.next)
+        const button = screen.queryByText(popupText.DisabledTaskPopup.options.next)
         expect(button).to.be.ok()
       })
 
       it('should show a button to dismiss the popup', function () {
-        const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.dismiss)
+        const button = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
         expect(button).to.be.ok()
       })
 
       it('should disable the active task', function () {
-        const inputs = renderedComponent.queryAllByRole('radio')
+        const inputs = screen.queryAllByRole('radio')
         expect(inputs).to.not.be.empty()
         inputs.forEach(input => {
           expect(input.disabled).to.be.true()
@@ -221,12 +214,11 @@ describe('TaskAreaConnector', function () {
     })
 
     describe('with an unfinished subject', function () {
-      let renderedComponent
 
       beforeEach(async function () {
         const subject = SubjectFactory.build()
         const store = await buildStore(subject)
-        renderedComponent = render(
+        render(
           <TaskAreaConnector />,
           {
             wrapper: withStore(store)
@@ -235,27 +227,27 @@ describe('TaskAreaConnector', function () {
       })
 
       it('should not show a message that the subject is finished', function () {
-        const para = renderedComponent.queryByText(popupText.DisabledTaskPopup.body)
+        const para = screen.queryByText(popupText.DisabledTaskPopup.body)
         expect(para).to.be.null()
       })
 
       it('should not show a button to choose a new subject', function () {
-        const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.select)
+        const button = screen.queryByText(popupText.DisabledTaskPopup.options.select)
         expect(button).to.be.null()
       })
 
       it('should not show a button to choose the next available subject', function () {
-        const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.next)
+        const button = screen.queryByText(popupText.DisabledTaskPopup.options.next)
         expect(button).to.be.null()
       })
 
       it('should not show a button to dismiss the popup', function () {
-        const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.dismiss)
+        const button = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
         expect(button).to.be.null()
       })
 
       it('should not disable the active task', function () {
-        const inputs = renderedComponent.queryAllByRole('radio')
+        const inputs = screen.queryAllByRole('radio')
         expect(inputs).to.not.be.empty()
         inputs.forEach(input => {
           expect(input.disabled).to.be.false()

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
@@ -38,7 +38,7 @@ describe('TaskAreaConnector', function () {
   describe('without indexed subjects', function () {
     let renderedComponent
 
-    before(function () {
+    beforeEach(function () {
       const store = mockStore()
     
       renderedComponent = render(
@@ -51,6 +51,34 @@ describe('TaskAreaConnector', function () {
 
     it('should render without crashing', function () {
       expect(renderedComponent).to.be.ok()
+    })
+
+    it('should render the active task', function () {
+      const inputs = renderedComponent.queryAllByRole('radio')
+      expect(inputs).to.not.be.empty()
+      inputs.forEach(input => {
+        expect(input.disabled).to.be.false()
+      })
+    })
+
+    it('should not show a message that the subject is finished', function () {
+      const para = renderedComponent.queryByText(popupText.DisabledTaskPopup.body)
+      expect(para).to.be.null()
+    })
+
+    it('should not show a button to choose a new subject', function () {
+      const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.select)
+      expect(button).to.be.null()
+    })
+
+    it('should not show a button to choose the next available subject', function () {
+      const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.next)
+      expect(button).to.be.null()
+    })
+
+    it('should not show a button to dismiss the popup', function () {
+      const button = renderedComponent.queryByText(popupText.DisabledTaskPopup.options.dismiss)
+      expect(button).to.be.null()
     })
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
@@ -36,8 +36,13 @@ describe('TaskAreaConnector', function () {
   }
 
   describe('without indexed subjects', function () {
+    let finishedMessage
+    let selectButton
+    let nextButton
+    let dismissButton
+    let inputs
 
-    beforeEach(function () {
+    before(function () {
       const store = mockStore()
     
       render(
@@ -46,10 +51,14 @@ describe('TaskAreaConnector', function () {
           wrapper: withStore(store)
         }
       )
+      finishedMessage = screen.queryByText(popupText.DisabledTaskPopup.body)
+      selectButton = screen.queryByText(popupText.DisabledTaskPopup.options.select)
+      nextButton = screen.queryByText(popupText.DisabledTaskPopup.options.next)
+      dismissButton = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
+      inputs = screen.queryAllByRole('radio')
     })
 
     it('should render the active task', function () {
-      const inputs = screen.queryAllByRole('radio')
       expect(inputs).to.not.be.empty()
       inputs.forEach(input => {
         expect(input.disabled).to.be.false()
@@ -57,23 +66,19 @@ describe('TaskAreaConnector', function () {
     })
 
     it('should not show a message that the subject is finished', function () {
-      const para = screen.queryByText(popupText.DisabledTaskPopup.body)
-      expect(para).to.be.null()
+      expect(finishedMessage).to.be.null()
     })
 
     it('should not show a button to choose a new subject', function () {
-      const button = screen.queryByText(popupText.DisabledTaskPopup.options.select)
-      expect(button).to.be.null()
+      expect(selectButton).to.be.null()
     })
 
     it('should not show a button to choose the next available subject', function () {
-      const button = screen.queryByText(popupText.DisabledTaskPopup.options.next)
-      expect(button).to.be.null()
+      expect(nextButton).to.be.null()
     })
 
     it('should not show a button to dismiss the popup', function () {
-      const button = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
-      expect(button).to.be.null()
+      expect(dismissButton).to.be.null()
     })
   })
 
@@ -126,8 +131,13 @@ describe('TaskAreaConnector', function () {
     }
 
     describe('with a retired subject', function () {
+      let finishedMessage
+      let selectButton
+      let nextButton
+      let dismissButton
+      let inputs
 
-      beforeEach(async function () {
+      before(async function () {
         const subject = SubjectFactory.build({
           retired: true
         })
@@ -138,30 +148,30 @@ describe('TaskAreaConnector', function () {
             wrapper: withStore(store)
           }
         )
+        finishedMessage = screen.queryByText(popupText.DisabledTaskPopup.body)
+        selectButton = screen.queryByText(popupText.DisabledTaskPopup.options.select)
+        nextButton = screen.queryByText(popupText.DisabledTaskPopup.options.next)
+        dismissButton = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
+        inputs = screen.queryAllByRole('radio')
       })
 
       it('should show a message that the subject is finished', function () {
-        const para = screen.queryByText(popupText.DisabledTaskPopup.body)
-        expect(para).to.be.ok()
+        expect(finishedMessage).to.be.ok()
       })
 
       it('should show a button to choose a new subject', function () {
-        const button = screen.queryByText(popupText.DisabledTaskPopup.options.select)
-        expect(button).to.be.ok()
+        expect(selectButton).to.be.ok()
       })
 
       it('should show a button to choose the next available subject', function () {
-        const button = screen.queryByText(popupText.DisabledTaskPopup.options.next)
-        expect(button).to.be.ok()
+        expect(nextButton).to.be.ok()
       })
 
       it('should show a button to dismiss the popup', function () {
-        const button = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
-        expect(button).to.be.ok()
+        expect(dismissButton).to.be.ok()
       })
 
       it('should disable the active task', function () {
-        const inputs = screen.queryAllByRole('radio')
         expect(inputs).to.not.be.empty()
         inputs.forEach(input => {
           expect(input.disabled).to.be.true()
@@ -170,8 +180,13 @@ describe('TaskAreaConnector', function () {
     })
 
     describe('with an already seen subject', function () {
+      let finishedMessage
+      let selectButton
+      let nextButton
+      let dismissButton
+      let inputs
 
-      beforeEach(async function () {
+      before(async function () {
         const subject = SubjectFactory.build({
           already_seen: true
         })
@@ -182,30 +197,30 @@ describe('TaskAreaConnector', function () {
             wrapper: withStore(store)
           }
         )
+        finishedMessage = screen.queryByText(popupText.DisabledTaskPopup.body)
+        selectButton = screen.queryByText(popupText.DisabledTaskPopup.options.select)
+        nextButton = screen.queryByText(popupText.DisabledTaskPopup.options.next)
+        dismissButton = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
+        inputs = screen.queryAllByRole('radio')
       })
 
       it('should show a message that the subject is finished', function () {
-        const para = screen.queryByText(popupText.DisabledTaskPopup.body)
-        expect(para).to.be.ok()
+        expect(finishedMessage).to.be.ok()
       })
 
       it('should show a button to choose a new subject', function () {
-        const button = screen.queryByText(popupText.DisabledTaskPopup.options.select)
-        expect(button).to.be.ok()
+        expect(selectButton).to.be.ok()
       })
 
       it('should show a button to choose the next available subject', function () {
-        const button = screen.queryByText(popupText.DisabledTaskPopup.options.next)
-        expect(button).to.be.ok()
+        expect(nextButton).to.be.ok()
       })
 
       it('should show a button to dismiss the popup', function () {
-        const button = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
-        expect(button).to.be.ok()
+        expect(dismissButton).to.be.ok()
       })
 
       it('should disable the active task', function () {
-        const inputs = screen.queryAllByRole('radio')
         expect(inputs).to.not.be.empty()
         inputs.forEach(input => {
           expect(input.disabled).to.be.true()
@@ -214,8 +229,13 @@ describe('TaskAreaConnector', function () {
     })
 
     describe('with an unfinished subject', function () {
+      let finishedMessage
+      let selectButton
+      let nextButton
+      let dismissButton
+      let inputs
 
-      beforeEach(async function () {
+      before(async function () {
         const subject = SubjectFactory.build()
         const store = await buildStore(subject)
         render(
@@ -224,30 +244,30 @@ describe('TaskAreaConnector', function () {
             wrapper: withStore(store)
           }
         )
+        finishedMessage = screen.queryByText(popupText.DisabledTaskPopup.body)
+        selectButton = screen.queryByText(popupText.DisabledTaskPopup.options.select)
+        nextButton = screen.queryByText(popupText.DisabledTaskPopup.options.next)
+        dismissButton = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
+        inputs = screen.queryAllByRole('radio')
       })
 
       it('should not show a message that the subject is finished', function () {
-        const para = screen.queryByText(popupText.DisabledTaskPopup.body)
-        expect(para).to.be.null()
+        expect(finishedMessage).to.be.null()
       })
 
       it('should not show a button to choose a new subject', function () {
-        const button = screen.queryByText(popupText.DisabledTaskPopup.options.select)
-        expect(button).to.be.null()
+        expect(selectButton).to.be.null()
       })
 
       it('should not show a button to choose the next available subject', function () {
-        const button = screen.queryByText(popupText.DisabledTaskPopup.options.next)
-        expect(button).to.be.null()
+        expect(nextButton).to.be.null()
       })
 
       it('should not show a button to dismiss the popup', function () {
-        const button = screen.queryByText(popupText.DisabledTaskPopup.options.dismiss)
-        expect(button).to.be.null()
+        expect(dismissButton).to.be.null()
       })
 
       it('should not disable the active task', function () {
-        const inputs = screen.queryAllByRole('radio')
         expect(inputs).to.not.be.empty()
         inputs.forEach(input => {
           expect(input.disabled).to.be.false()

--- a/packages/lib-classifier/test/mockStore/mockStore.js
+++ b/packages/lib-classifier/test/mockStore/mockStore.js
@@ -14,7 +14,6 @@ export default function mockStore({
   subjectSet,
   workflow = branchingWorkflow
 } = {}) {
-  const projectSnapshot = project || ProjectFactory.build()
 
   const subjectSnapshot = subject || SubjectFactory.build({
     metadata: {}
@@ -24,10 +23,16 @@ export default function mockStore({
 
   const workflowSnapshot = workflow || WorkflowFactory.build()
 
+  const projectSnapshot = ProjectFactory.build({}, {
+    activeWorkflowId: workflowSnapshot.id
+  })
+
+  const subjects = [ subjectSnapshot, ...Factory.buildList('subject', 9)]
+
   const { panoptes } = stubPanoptesJs({
     field_guides: [],
     projects: [projectSnapshot],
-    subjects: Factory.buildList('subject', 10),
+    subjects,
     tutorials: [],
     workflows: [workflowSnapshot]
   })


### PR DESCRIPTION
Mock a grouped workflow, with an indexed subject set, for the TaskArea tests. Render the task area with and without an indexed workflow, and with and without finished subjects, and test that the popup renders correctly for indexed, finished subjects.

I've set the tests up to run when `store.subjects` is ready (copying a technique from the UPP store tests) and test whether the popup text and buttons are shown. I've also added tests to check whether the task inputs are disabled. I haven't added any tests to check what happens when the popup buttons are pressed.

Package:
lib-classifier

Closes #2297.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
