### PR TITLE
Add unmount to FieldGuideWrapper tests

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideWrapper.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideWrapper.spec.js
@@ -62,6 +62,10 @@ describe('Component > FieldGuideWrapper', function () {
       )
     })
 
+    afterEach(function () {
+      wrapper.unmount()
+    })
+
     it('should display the FieldGuide based on the showModal prop', function () {
       expect(wrapper.find(FieldGuide)).to.have.lengthOf(1)
     })
@@ -102,6 +106,10 @@ describe('Component > FieldGuideWrapper', function () {
           wrappingComponentProps: { theme: zooTheme }
         }
       )
+    })
+
+    afterEach(function () {
+      wrapper.unmount()
     })
 
     it('should render a FieldGuideButton', function () {


### PR DESCRIPTION
Package:
- lib-classifier

Describe your changes:
- adds `wrapper.unmount()` to the two nested test blocks that open the Field Guide modal

Note:
- the Field Guide modal is opened in the noted test blocks, and remained in the testing DOM, causing an issue with react-testing-library tests

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
