### PR TITLE
Always hide workflow summaries

### DIFF
--- a/packages/lib-classifier/src/store/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
+++ b/packages/lib-classifier/src/store/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
@@ -3,7 +3,6 @@ import subjectViewers from '@helpers/subjectViewers'
 
 const WorkflowConfiguration = types.model({
   enable_switching_flipbook_and_separate: types.optional(types.boolean, false),
-  hide_classification_summaries: types.optional(types.boolean, true),
   multi_image_mode: types.optional(types.enumeration('multiImageMode', ['flipbook', 'separate']), 'flipbook'),
   persist_annotations: types.optional(types.boolean, true),
   subject_viewer: types.maybe(types.enumeration('subjectViewer', [

--- a/packages/lib-classifier/src/store/Workflow/WorkflowConfiguration/WorkflowConfiguration.spec.js
+++ b/packages/lib-classifier/src/store/Workflow/WorkflowConfiguration/WorkflowConfiguration.spec.js
@@ -16,8 +16,8 @@ describe('Model > Workflow > WorkflowConfiguration', function () {
       expect(model).to.be.ok()
     })
 
-    it('should hide classification summaries', function () {
-      expect(model.hide_classification_summaries).to.be.true()
+    it('should ignore the hide_classification_summaries flag', function () {
+      expect(model.hide_classification_summaries).to.be.undefined()
     })
 
     it('should persist annotations', function () {

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -40,7 +40,6 @@ const WorkflowStepStore = types
         const disableTalk = classification.metadata.subject_flagged
         const lastStep = !step.next
         return lastStep &&
-        workflow.configuration.hide_classification_summaries && // Default in model is to hide
         !disableTalk // &&
         // !completed TODO: implement classification completed validations per task?
       }

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
@@ -344,41 +344,37 @@ describe('Model > WorkflowStepStore', function () {
       expect(rootStore.workflowSteps.shouldWeShowDoneAndTalkButton).to.be.false()
     })
 
-    it('should be true by default', async function () {
-      const project = ProjectFactory.build({}, { activeWorkflowId: workflow.id })
-      const panoptesClientStub = stubPanoptesJs({ workflows: workflow, subjects })
-      const rootStore = await setupStores(panoptesClientStub, project, workflow)
-      rootStore.classifications.createClassification(subject, workflow, project)
-      rootStore.workflowSteps.selectStep('S2')
-      expect(rootStore.workflowSteps.shouldWeShowDoneAndTalkButton).to.be.true()
-    })
+    describe('for any value of hide_classification_summaries', function () {
+      let workflows
 
-    it('should be false if the classification subject has been flagged', async function () {
-      const project = ProjectFactory.build({}, { activeWorkflowId: workflow.id })
-      const panoptesClientStub = stubPanoptesJs({ workflows: workflow, subjects })
-      const rootStore = await setupStores(panoptesClientStub, project, workflow)
-      rootStore.classifications.createClassification(subject, workflow, project)
-      rootStore.classifications.active.metadata.update({ subject_flagged: true })
-      rootStore.workflowSteps.selectStep('S2')
-      expect(rootStore.workflowSteps.shouldWeShowDoneAndTalkButton).to.be.false()
-    })
+      before(function () {
+        workflows = [ workflow, hiddenSummaryWorkflow, showSummaryWorkflow ]
+      })
 
-    it('should be true when hide_classification_summaries is false', async function () {
-      const project = ProjectFactory.build({}, { activeWorkflowId: showSummaryWorkflow.id })
-      const panoptesClientStub = stubPanoptesJs({ workflows: showSummaryWorkflow, subjects })
-      const rootStore = await setupStores(panoptesClientStub, project, showSummaryWorkflow)
-      rootStore.classifications.createClassification(subject, showSummaryWorkflow, project)
-      rootStore.workflowSteps.selectStep('S2')
-      expect(rootStore.workflowSteps.shouldWeShowDoneAndTalkButton).to.be.true()
-    })
+      it('should be true by default', async function () {
+        const awaitWorkflows = workflows.map(async function (testWorkflow) {
+          const project = ProjectFactory.build({}, { activeWorkflowId: testWorkflow.id })
+          const panoptesClientStub = stubPanoptesJs({ workflows: testWorkflow, subjects })
+          const rootStore = await setupStores(panoptesClientStub, project, testWorkflow)
+          rootStore.classifications.createClassification(subject, testWorkflow, project)
+          rootStore.workflowSteps.selectStep('S2')
+          expect(rootStore.workflowSteps.shouldWeShowDoneAndTalkButton).to.be.true()
+        })
+        await Promise.all(awaitWorkflows)
+      })
 
-    it('should be true when hide_classification_summaries is true', async function () {
-      const project = ProjectFactory.build({}, { activeWorkflowId: hiddenSummaryWorkflow.id })
-      const panoptesClientStub = stubPanoptesJs({ workflows: hiddenSummaryWorkflow, subjects })
-      const rootStore = await setupStores(panoptesClientStub, project, hiddenSummaryWorkflow)
-      rootStore.classifications.createClassification(subject, hiddenSummaryWorkflow, project)
-      rootStore.workflowSteps.selectStep('S2')
-      expect(rootStore.workflowSteps.shouldWeShowDoneAndTalkButton).to.be.true()
+      it('should be false if the classification has been flagged', async function () {
+        const awaitWorkflows = workflows.map(async function (testWorkflow) {
+          const project = ProjectFactory.build({}, { activeWorkflowId: testWorkflow.id })
+          const panoptesClientStub = stubPanoptesJs({ workflows: testWorkflow, subjects })
+          const rootStore = await setupStores(panoptesClientStub, project, testWorkflow)
+          rootStore.classifications.createClassification(subject, testWorkflow, project)
+          rootStore.classifications.active.metadata.update({ subject_flagged: true })
+          rootStore.workflowSteps.selectStep('S2')
+          expect(rootStore.workflowSteps.shouldWeShowDoneAndTalkButton).to.be.false()
+        })
+        await Promise.all(awaitWorkflows)
+      })
     })
   })
 

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
@@ -344,7 +344,7 @@ describe('Model > WorkflowStepStore', function () {
       expect(rootStore.workflowSteps.shouldWeShowDoneAndTalkButton).to.be.false()
     })
 
-    it('should default to return true if the workflow is not configured to hide classification summaries', async function () {
+    it('should be true by default', async function () {
       const project = ProjectFactory.build({}, { activeWorkflowId: workflow.id })
       const panoptesClientStub = stubPanoptesJs({ workflows: workflow, subjects })
       const rootStore = await setupStores(panoptesClientStub, project, workflow)
@@ -353,26 +353,26 @@ describe('Model > WorkflowStepStore', function () {
       expect(rootStore.workflowSteps.shouldWeShowDoneAndTalkButton).to.be.true()
     })
 
-    it('should return false if the classification subject has been flagged', async function () {
-      const project = ProjectFactory.build({}, { activeWorkflowId: hiddenSummaryWorkflow.id })
-      const panoptesClientStub = stubPanoptesJs({ workflows: hiddenSummaryWorkflow, subjects })
-      const rootStore = await setupStores(panoptesClientStub, project, hiddenSummaryWorkflow)
-      rootStore.classifications.createClassification(subject, hiddenSummaryWorkflow, project)
+    it('should be false if the classification subject has been flagged', async function () {
+      const project = ProjectFactory.build({}, { activeWorkflowId: workflow.id })
+      const panoptesClientStub = stubPanoptesJs({ workflows: workflow, subjects })
+      const rootStore = await setupStores(panoptesClientStub, project, workflow)
+      rootStore.classifications.createClassification(subject, workflow, project)
       rootStore.classifications.active.metadata.update({ subject_flagged: true })
       rootStore.workflowSteps.selectStep('S2')
       expect(rootStore.workflowSteps.shouldWeShowDoneAndTalkButton).to.be.false()
     })
 
-    it('should return false if configured to show the summary', async function () {
+    it('should be true when hide_classification_summaries is false', async function () {
       const project = ProjectFactory.build({}, { activeWorkflowId: showSummaryWorkflow.id })
       const panoptesClientStub = stubPanoptesJs({ workflows: showSummaryWorkflow, subjects })
       const rootStore = await setupStores(panoptesClientStub, project, showSummaryWorkflow)
       rootStore.classifications.createClassification(subject, showSummaryWorkflow, project)
       rootStore.workflowSteps.selectStep('S2')
-      expect(rootStore.workflowSteps.shouldWeShowDoneAndTalkButton).to.be.false()
+      expect(rootStore.workflowSteps.shouldWeShowDoneAndTalkButton).to.be.true()
     })
 
-    it('should return true if configured to hide the summary', async function () {
+    it('should be true when hide_classification_summaries is true', async function () {
       const project = ProjectFactory.build({}, { activeWorkflowId: hiddenSummaryWorkflow.id })
       const panoptesClientStub = stubPanoptesJs({ workflows: hiddenSummaryWorkflow, subjects })
       const rootStore = await setupStores(panoptesClientStub, project, hiddenSummaryWorkflow)


### PR DESCRIPTION
Remove `hide_classification_summaries` from `workflowSteps.shouldWeShowDoneAndTalk`, so that we always show Done & Talk on the last step of a workflow (except for flagged classifications.)

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
