### PR TITLE
Refactor glyph assignment

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/README.md
@@ -77,7 +77,9 @@ The JSON file can take two different shapes depending on if the data is a single
 
 #### Series Data
 
-The `seriesData` property should be an array of objects where at minimum an x and y coordinate is required. An optional `x_error` and/or `y_error` number can be specified if error bars need to be displayed for that single data point. Each series supports a set of options under `seriesOptions` and at minimum a string `label` is required for each series. An optional string `color` for can defined using either a variable name from the colors available in from the [zooniverse theme object](https://github.com/zooniverse/front-end-monorepo/tree/master/packages/lib-grommet-theme) or a hex value. If a color is not provided, a color from the zooniverse theme will be chosen and applied for each series. 
+The `seriesData` property should be an array of objects where at minimum an x and y coordinate is required. An optional `x_error` and/or `y_error` number can be specified if error bars need to be displayed for that single data point. 
+
+Each series supports a set of options under `seriesOptions` and at minimum a string `label` is required for each series. An optional string `color` for can defined using either a variable name from the colors available in from the [zooniverse theme object](https://github.com/zooniverse/front-end-monorepo/tree/master/packages/lib-grommet-theme) or a hex value. If a color is not provided, a color from the zooniverse theme will be chosen and applied for each series. An optional `glyph` shape can be defined for the data series. This must be a string and must correspond to the following options: `'circle'`, `'cross'`, `'diamond'`, `'square'`, `'star'`, `'triangle'`, `'wye'`. If a glyph shape is not defined in the series options, then a fallback is automatically chosen based on the array order of the data series.
 
 The single series JSON shape is a very, very basic data object consisting of an array of numbers for each axis. The multiple series shape can also be used for a single series and is required if you need to use error bars:
 
@@ -119,6 +121,7 @@ The multiple series JSON shape is an array of objects consisting of `seriesData`
       ],
       "seriesOptions": {
         "color": "accent-1",
+        "glyph": "circle",
         "label": "Filter 1"
       }
     }, {
@@ -134,6 +137,7 @@ The multiple series JSON shape is an array of objects consisting of `seriesData`
       ],
       "seriesOptions": {
         "color": "#98b6a7",
+        "glyph": "cross",
         "label": "Filter 2"
       }
     }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
@@ -147,7 +147,7 @@ function ScatterPlot (props) {
           })
 
           const errorBarColor = lighten(0.25, glyphColor)
-          const GlyphComponent = getDataSeriesSymbol(seriesIndex)
+          const GlyphComponent = getDataSeriesSymbol({ seriesOptions: series?.seriesOptions, seriesIndex })
 
           return series.seriesData.map((point, pointIndex) => {
             let xErrorBarPoints, yErrorBarPoints

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.spec.js
@@ -19,12 +19,11 @@ import {
 } from '../../helpers/mockData'
 import { left, top } from '../../helpers/utils'
 
-const { variableStar } = lightCurveMockData
-const { data, dataPoints } = randomSingleSeriesData
-
-const defaultColors = Object.values(zooTheme.global.colors.drawingTools)
-
 describe('Component > ScatterPlot', function () {
+  const { variableStar } = lightCurveMockData
+  const { data, dataPoints } = randomSingleSeriesData
+
+  const defaultColors = Object.values(zooTheme.global.colors.drawingTools)
   describe('render', function () {
     let wrapper, chart
     before(function () {
@@ -124,7 +123,7 @@ describe('Component > ScatterPlot', function () {
           transformMatrix={transformMatrix}
         />
       )
-      glyphs = wrapper.find(glyphComponents[0])
+      glyphs = wrapper.find(glyphComponents.circle)
     })
 
     it('should render a number of glyph components equal to the number of data points', function () {
@@ -152,7 +151,7 @@ describe('Component > ScatterPlot', function () {
           transformMatrix={transformMatrix}
         />
       )
-      renderedSeriesGlyphs = glyphComponents.filter((component) => {
+      renderedSeriesGlyphs = Object.values(glyphComponents).filter((component) => {
         const components = wrapper.find(component)
         return components.length > 0
       })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/HighlightSeriesCheckBoxes/HighlightSeriesCheckBoxes.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/HighlightSeriesCheckBoxes/HighlightSeriesCheckBoxes.spec.js
@@ -94,8 +94,8 @@ describe('Component > HighlightSeriesCheckBoxes', function () {
       />
     )
 
-    const seriesOneGlyph = getDataSeriesSymbol(0)
-    const seriesTwoGlyph = getDataSeriesSymbol(1)
+    const seriesOneGlyph = getDataSeriesSymbol({ seriesIndex: 0 })
+    const seriesTwoGlyph = getDataSeriesSymbol({ seriesIndex: 1 })
     const firstGlyph = wrapper.find(seriesOneGlyph)
     const secondGlyph = wrapper.find(seriesTwoGlyph)
     expect(firstGlyph).to.have.lengthOf(1)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/Label/Label.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/Label/Label.js
@@ -24,7 +24,7 @@ const StyledLabel = styled.span`
 
 function Label (props) {
   const { colors, label, seriesIndex, seriesOptions, highlighted } = props
-  const Glyph = getDataSeriesSymbol(seriesIndex)
+  const Glyph = getDataSeriesSymbol({ seriesOptions, seriesIndex })
   const color = getDataSeriesColor({
     defaultColors: Object.values(colors.drawingTools),
     highlighted,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/Label/Label.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/components/Controls/components/Label/Label.spec.js
@@ -46,8 +46,8 @@ describe('Controls > Components > Label', function ()  {
         seriesOptions={seriesOneOptions}
       />
     )
-    const seriesOneGlyph = getDataSeriesSymbol(0)
-    const seriesTwoGlyph = getDataSeriesSymbol(1)
+    const seriesOneGlyph = getDataSeriesSymbol({ seriesIndex: 0 })
+    const seriesTwoGlyph = getDataSeriesSymbol({ seriesIndex: 1 })
     expect(wrapper.find(seriesOneGlyph)).to.have.lengthOf(1)
     expect(wrapper.find(seriesTwoGlyph)).to.have.lengthOf(0)
     wrapper.setProps({ seriesIndex: 1, seriesOptions: seriesTwoOptions })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getDataSeriesSymbol/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getDataSeriesSymbol/README.md
@@ -3,3 +3,10 @@
 This is a helper utility function used by the data as a subject viewers `ScatterPlotViewer` and the `VariableStarViewer` to help determine which SVG glyph to render the data points as. Which symbol that is rendered is determined by the data series index from the subject JSON.
 
 There are seven glyphs available used from the [`visx/glyph`](https://airbnb.io/visx/docs/glyph) library.
+
+## Parameters
+
+The function takes an object which includes:
+
+- `seriesOptions` _(object)_ A `glyph` property can be defined on the series options' object and must map to a string value of the supported Glyphs. This can be: `'circle'`, `'cross'`, `'diamond'`, `'square'`, `'star'`, `'triangle'`, `'wye'`
+- `seriesIndex` _(number)_ A number corresponding to the array index number of the series. This is the fallback method of selecting a glyph if one is not defined in the series options.

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getDataSeriesSymbol/getDataSeriesSymbol.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getDataSeriesSymbol/getDataSeriesSymbol.js
@@ -1,8 +1,14 @@
 import glyphComponents from './glyphComponents'
 
-export default function getDataSeriesSymbol(seriesIndex) {
+export default function getDataSeriesSymbol({
+  seriesOptions: seriesOptions = {},
+  seriesIndex: seriesIndex = 0
+}) {
   if (seriesIndex === undefined || seriesIndex === null) {
     throw new TypeError('seriesIndex cannot be null or undefined')
   }
-  return glyphComponents[seriesIndex]
+  const glyphNames = Object.keys(glyphComponents)
+  const glyphNameBySeriesIndex = glyphNames[seriesIndex]
+  const glyphToRender = glyphComponents[seriesOptions.glyph] || glyphComponents[glyphNameBySeriesIndex]
+  return glyphToRender
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getDataSeriesSymbol/getDataSeriesSymbol.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getDataSeriesSymbol/getDataSeriesSymbol.spec.js
@@ -1,3 +1,4 @@
+import { expect } from 'chai'
 import getDataSeriesSymbol from './getDataSeriesSymbol'
 import glyphComponents from './glyphComponents'
 
@@ -16,8 +17,19 @@ describe('Helper > getDataSeriesSymbol', function () {
 
   it('should return a glyph in order of index', function () {
     [1, 2, 3, 4, 5, 6, 7].forEach((arrayItem, index) => {
-      const glyph = getDataSeriesSymbol(index)
-      expect(glyph).to.equal(glyphComponents[index])
+      const glyph = getDataSeriesSymbol({ seriesIndex: index })
+      const glyphName = Object.keys(glyphComponents)[index]
+      const expectedGlyph = glyphComponents[glyphName]
+      expect(glyph).to.equal(expectedGlyph)
+    })
+  })
+
+  it('should return a glyph if defined in the series options', function () {
+    const glyphNames = Object.keys(glyphComponents)
+
+    glyphNames.forEach((name) => {
+      const glyph = getDataSeriesSymbol({ seriesOptions: { glyph: name } })
+      expect(glyph).to.equal(glyphComponents[name])
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getDataSeriesSymbol/glyphComponents.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getDataSeriesSymbol/glyphComponents.js
@@ -8,14 +8,14 @@ import {
   GlyphWye
 } from '@visx/glyph'
 
-const glyphComponents = [
-  GlyphCircle,
-  GlyphCross,
-  GlyphDiamond,
-  GlyphSquare,
-  GlyphStar,
-  GlyphTriangle,
-  GlyphWye
-]
+const glyphComponents = {
+  circle: GlyphCircle,
+  cross: GlyphCross,
+  diamond: GlyphDiamond,
+  square: GlyphSquare,
+  star: GlyphStar,
+  triangle: GlyphTriangle,
+  wye: GlyphWye
+}
 
 export default glyphComponents


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

Package: lib-classifier

Toward #1851

This refactors how a glyph symbol is assigned to a data series. A glyph is now assignable by way of the series option object or falls back to the order of the data series array. This can be manually tested by running the storybook and having a look at the `VariableStarViewer` story. The first data series should be a red circle and the second a blue cross. 


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
