### PR TITLE
Engaging Crowds: Show the subject set name for grouped workflows

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.js
@@ -8,6 +8,7 @@ import Banner from '../Banner'
 counterpart.registerTranslations('en', en)
 
 function SubjectSetProgressBanner({ subject, workflow }) {
+  const setName = workflow?.subjectSet.display_name
   const subjectTotal = workflow?.subjectSet.set_member_subjects_count
   const background = (subject?.alreadySeen || subject?.retired) ? 'status-critical' : 'status-ok'
   const color = (subject?.alreadySeen || subject?.retired) ? 'neutral-6' : 'neutral-7'
@@ -15,6 +16,7 @@ function SubjectSetProgressBanner({ subject, workflow }) {
   statusText = subject?.retired ? `${counterpart('SubjectSetProgressBanner.finished')}` : statusText
   const progressText = counterpart('SubjectSetProgressBanner.bannerText', {
     number: subject?.priority,
+    setName,
     total: subjectTotal
   })
   const tooltipText = counterpart('SubjectSetProgressBanner.tooltipText')

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.js
@@ -8,7 +8,7 @@ import Banner from '../Banner'
 counterpart.registerTranslations('en', en)
 
 function SubjectSetProgressBanner({ subject, workflow }) {
-  const setName = workflow?.subjectSet.display_name
+  const setName = workflow?.subjectSet?.display_name || ''
   const subjectTotal = workflow?.subjectSet.set_member_subjects_count
   const background = (subject?.alreadySeen || subject?.retired) ? 'status-critical' : 'status-ok'
   const color = (subject?.alreadySeen || subject?.retired) ? 'neutral-6' : 'neutral-7'

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.spec.js
@@ -19,26 +19,22 @@ describe('Component > SubjectSetProgressBanner', function () {
 
     it('should indicate your position within the subject set', function () {
       const component = render(<Default />)
-      const bannerText = 'Subject 37/56'
+      const bannerText = 'Hello there!: Subject 37/56'
       expect(component.getByText(bannerText)).to.exist()
     })
 
     describe('when the subject is already seen', function () {
       it('should show the Already Seen banner', function () {
-        // Unsure why RTL isn't picking up the updated args from the story
-        // so explicitly setting already_seen to true here
-        const component = render(<WithAlreadySeenSubject already_seen />)
-        const bannerText = 'Subject 37/56 (Already seen)'
+        const component = render(<WithAlreadySeenSubject {...WithAlreadySeenSubject.args} />)
+        const bannerText = 'Hello there!: Subject 37/56 (Already seen)'
         expect(component.getByText(bannerText)).to.exist()
       })
     })
 
     describe('when the subject is retired', function () {
       it('should show the Finished banner', function () {
-        // Unsure why RTL isn't picking up the updated args from the story
-        // so explicitly setting retired to true here
-        const component = render(<WithRetiredSubject retired />)
-        const bannerText = 'Subject 37/56 (Finished)'
+        const component = render(<WithRetiredSubject {...WithRetiredSubject.args} />)
+        const bannerText = 'Hello there!: Subject 37/56 (Finished)'
         expect(component.getByText(bannerText)).to.exist()
       })
     })
@@ -52,22 +48,30 @@ describe('Component > SubjectSetProgressBanner', function () {
 
     it('should indicate your position within the subject set', function () {
       const component = render(<WithVisiblePriorityMetadata />)
-      const bannerText = 'Subject 37/56'
+      const bannerText = 'Hello there!: Subject 37/56'
       expect(component.getByText(bannerText)).to.exist()
     })
 
     describe('when the subject is already seen', function () {
       it('should show the Already Seen banner', function () {
-        const component = render(<WithVisiblePriorityMetadataAndAlreadySeen already_seen />)
-        const bannerText = 'Subject 37/56 (Already seen)'
+        const component = render(
+          <WithVisiblePriorityMetadataAndAlreadySeen
+            {...WithVisiblePriorityMetadataAndAlreadySeen.args}
+          />
+        )
+        const bannerText = 'Hello there!: Subject 37/56 (Already seen)'
         expect(component.getByText(bannerText)).to.exist()
       })
     })
 
     describe('when the subject is retired', function () {
       it('should show the Finished banner', function () {
-        const component = render(<WithVisiblePriorityMetadataAndRetired retired />)
-        const bannerText = 'Subject 37/56 (Finished)'
+        const component = render(
+          <WithVisiblePriorityMetadataAndRetired
+            {...WithVisiblePriorityMetadataAndRetired.args}
+          />
+        )
+        const bannerText = 'Hello there!: Subject 37/56 (Finished)'
         expect(component.getByText(bannerText)).to.exist()
       })
     })

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/locales/en.json
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/locales/en.json
@@ -1,7 +1,7 @@
 {
   "SubjectSetProgressBanner": {
     "alreadySeen": "Already seen",
-    "bannerText": "Subject %(number)s/%(total)s",
+    "bannerText": "%(setName)s: Subject %(number)s/%(total)s",
     "finished": "Finished",
     "tooltipText": "This project allows volunteers to view subjects in sequential order. The number shows you the subject’s position within the total group."
   }


### PR DESCRIPTION
Add the subject set display name to the the `SubjectSetProgressBanner` for grouped workflows, so that we can see which subject set we are working on.

Try this out on HMS NHS:
https://localhost:8080/?project=11429&workflow=18619&subjectSet=82738&env=production&demo=true
![Screenshot of an HMS NHS subject. The subject banner says: 1826-27 (DSH/1): Subject 51/101 (Finished).](https://user-images.githubusercontent.com/59547/130437492-80722f5e-7b2a-4767-9ee4-f45e971afc56.png)

Package:
lib-classifier

Towards #2278.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
