### PR TITLE
Classifier: Refactor drawing Tool tests

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
@@ -50,13 +50,6 @@ describe('Model > DrawingTools > Tool', function () {
   })
 
   describe('tool.createTask', function () {
-    before(function () {
-      sinon.stub(console, 'error')
-    })
-
-    after(function () {
-      console.error.restore()
-    })
 
     describe('with valid subtasks', function () {
       let multipleTaskSnapshot
@@ -116,19 +109,36 @@ describe('Model > DrawingTools > Tool', function () {
       })
     })
 
-    it('should error for invalid subtasks', function () {
-      const tasks = [
-        {
-          taskKey: 'drawing',
-          type: 'drawing',
-          question: 'which fruit?',
-          tools: []
-        }
-      ]
-      const tool = Tool.create(toolData)
-      const drawingTaskSnapshot = tasks[0]
-      const drawingTask = tool.createTask(drawingTaskSnapshot)
-      expect(console.error.withArgs('drawing is not a valid drawing subtask')).to.have.been.calledOnce()
+    describe('with invalid subtasks', function () {
+      let consoleStub
+      let tool
+
+      before(function () {
+        consoleStub = sinon.stub(console, 'error')
+        const tasks = [
+          {
+            taskKey: 'drawing',
+            type: 'drawing',
+            question: 'which fruit?',
+            tools: []
+          }
+        ]
+        tool = Tool.create(toolData)
+        const drawingTaskSnapshot = tasks[0]
+        const drawingTask = tool.createTask(drawingTaskSnapshot)
+      })
+
+      after(function () {
+        consoleStub.restore()
+      })
+
+      it('should not create subtasks', function () {
+        expect(tool.tasks).to.be.empty()
+      })
+
+      it('should error', function () {
+        expect(consoleStub.withArgs('drawing is not a valid drawing subtask')).to.have.been.calledOnce()
+      })
     })
   })
 


### PR DESCRIPTION
Use a named stub for `console.error`, so that we don't clobber the console in other tests eg. feedback or the subject viewers. Test that invalid tasks are not added to `tool.tasks`.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
