### PR TITLE
Fix TranscribedLines to show lines for frames beyond 0

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js
@@ -18,7 +18,7 @@ describe('Component > TranscribedLines', function () {
       subjectId: '1234',
       workflowId: '5678'
     })
-    consensusLines = transcriptionReductions.consensusLines
+    consensusLines = transcriptionReductions.consensusLines()
     task = transcriptionModels.TaskModel.create({
       tools: [{
         type: 'transcriptionLine',
@@ -147,7 +147,7 @@ describe('Component > TranscribedLines', function () {
           subjectId: '1234',
           workflowId: '5678'
         })
-        const consensusLines = transcriptionReductions.consensusLines
+        const consensusLines = transcriptionReductions.consensusLines()
         const task = transcriptionModels.TaskModel.create({
           tools: [{
             type: 'transcriptionLine',

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.js
@@ -22,7 +22,7 @@ function useStores () {
     }
   } = stores.classifierStore
 
-  const { consensusLines } = subject.transcriptionReductions || {}
+  const consensusLines = subject.transcriptionReductions?.consensusLines(frame) || []
 
   // We expect there to only be one
   const [transcriptionTask] = findTasksByType('transcription')
@@ -30,7 +30,13 @@ function useStores () {
   const marks = transcriptionTask?.marks
 
   const valid = step?.isValid
-  return { invalid: !valid, transcriptionTask, consensusLines, frame, marks, workflow }
+  return { 
+    invalid: !valid,
+    transcriptionTask,
+    consensusLines,
+    marks,
+    workflow
+  }
 }
 
 function TranscribedLinesConnector ({
@@ -39,7 +45,6 @@ function TranscribedLinesConnector ({
   const { 
     invalid = false,
     transcriptionTask = {},
-    frame = 0,
     consensusLines = [],
     marks = [],
     workflow = {
@@ -47,13 +52,13 @@ function TranscribedLinesConnector ({
     }
   } = useStores()
   const { shownMarks } = transcriptionTask
-  const visibleLinesPerFrame = consensusLines.filter(line => line.frame === frame)
+  console.log('lines', consensusLines)
 
-  if (workflow?.usesTranscriptionTask && shownMarks === SHOWN_MARKS.ALL && visibleLinesPerFrame.length > 0) {
+  if (workflow?.usesTranscriptionTask && shownMarks === SHOWN_MARKS.ALL && consensusLines.length > 0) {
     return (
       <TranscribedLines
         invalidMark={invalid}
-        lines={visibleLinesPerFrame}
+        lines={consensusLines}
         marks={marks}
         scale={scale}
         task={transcriptionTask}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.spec.js
@@ -12,7 +12,7 @@ describe('Component > TranscribedLinesConnector', function () {
     subjects: {
       active: {
         transcriptionReductions: {
-          consensusLines: []
+          consensusLines: () => []
         }
       }
     },
@@ -61,7 +61,7 @@ describe('Component > TranscribedLinesConnector', function () {
     subjects: {
       active: {
         transcriptionReductions: {
-          consensusLines: []
+          consensusLines: () => []
         }
       }
     },
@@ -134,17 +134,27 @@ describe('Component > TranscribedLinesConnector', function () {
       })
       const wrapper = shallow(<TranscribedLinesConnector />)
       expect(wrapper.find(TranscribedLines)).to.have.lengthOf(1)
-      expect(wrapper.find(TranscribedLines).prop('lines')).to.have.lengthOf(transcriptionReductions.consensusLines.length)
+      expect(wrapper.find(TranscribedLines).prop('lines')).to.have.lengthOf(transcriptionReductions.consensusLines(0).length)
     })
 
-    it('should not render TranscribedLines if no lines per frame', function () {
+    it('should render lines per frame', function () {
       mockUseContext = sinon.stub(React, 'useContext').callsFake(() => {
         return {
           classifierStore: Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, { subjectViewer: { frame: 1 } })
         }
       })
       const wrapper = shallow(<TranscribedLinesConnector />)
-      expect(wrapper.find(TranscribedLines)).to.have.lengthOf(0)
+      expect(wrapper.find(TranscribedLines).prop('lines')).to.have.lengthOf(transcriptionReductions.consensusLines(1).length)
+    })
+
+    it('should not render TranscribedLines if no lines per frame', function () {
+      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => {
+        return {
+          classifierStore: Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, { subjectViewer: { frame: 3 } })
+        }
+      })
+      const wrapper = shallow(<TranscribedLinesConnector />)
+      expect(wrapper.find(TranscribedLines)).to.have.lengthOf(transcriptionReductions.consensusLines(3).length)
     })
 
     it('should not render TranscribedLines if showing only user marks', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/helpers/setupMock.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/helpers/setupMock.js
@@ -7,6 +7,6 @@ export default function setupMock () {
     subjectId: '1',
     workflowId: '2'
   })
-  const { consensusLines } = transcriptionReductions
+  const consensusLines = transcriptionReductions.consensusLines()
   return consensusLines.filter(line => line.consensusReached)
 }

--- a/packages/lib-classifier/src/store/TranscriptionReductions/TranscriptionReductions.js
+++ b/packages/lib-classifier/src/store/TranscriptionReductions/TranscriptionReductions.js
@@ -9,7 +9,6 @@ const REDUCER_KEY = 'alice'
 const TranscriptionReductions = types
   .model('TranscriptionReductions', {
     error: types.maybeNull(types.frozen({})),
-    frame: types.optional(types.number, 0),
     loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.initialized),
     reductions: types.array(types.frozen({})),
     subjectId: types.string,
@@ -42,8 +41,7 @@ const TranscriptionReductions = types
     }
 
     function constructLine (reduction, options) {
-      const { minimumViews, threshold } = options
-      const { frame } = self
+      const { frame, minimumViews, threshold } = options
       const consensusText = reduction.consensus_text
       const points = constructCoordinates(reduction)
       const textOptions = constructText(reduction)
@@ -60,8 +58,8 @@ const TranscriptionReductions = types
     }
 
     return {
-      get consensusLines () {
-        const { frame, reductions } = self
+      consensusLines (frame = 0) {
+        const { reductions } = self
         let consensusLines = []
         reductions.forEach(reduction => {
           const { parameters } = reduction.data
@@ -69,7 +67,7 @@ const TranscriptionReductions = types
           const minimumViews = parameters?.minimum_views || DEFAULT_VIEWS_TO_RETIRE
           const currentFrameReductions = reduction.data[`frame${frame}`] || []
           const currentFrameConsensus = currentFrameReductions.map(reduction => {
-            return constructLine(reduction, { minimumViews, threshold })
+            return constructLine(reduction, { frame, minimumViews, threshold })
           })
           consensusLines = consensusLines.concat(currentFrameConsensus)
         })
@@ -107,11 +105,7 @@ const TranscriptionReductions = types
           self.loadingState = asyncStates.error
           self.reductions = []
         }
-      }),
-
-      changeFrame (frame) {
-        self.frame = frame
-      }
+      })
     }
   })
 

--- a/packages/lib-classifier/src/store/TranscriptionReductions/TranscriptionReductions.spec.js
+++ b/packages/lib-classifier/src/store/TranscriptionReductions/TranscriptionReductions.spec.js
@@ -1,3 +1,4 @@
+import { expect } from 'chai'
 import { GraphQLClient } from 'graphql-request'
 import sinon from 'sinon'
 import { reducedEmptySubject, reducedSubject } from './mocks'
@@ -6,7 +7,7 @@ import TranscriptionReductions from './TranscriptionReductions'
 
 describe('Models > TranscriptionReductions', function () {
 
-  describe('with transcribed lines', function () {
+  describe('with reductions', function () {
     const caesarClient = new GraphQLClient('https://caesar-staging.zooniverse.org/graphql')
     let reductionsModel
 
@@ -38,42 +39,28 @@ describe('Models > TranscriptionReductions', function () {
 
     it('should have transcribed lines', function () {
       reductionsModel.reductions.forEach(reduction => expect(reduction.data.transcribed_lines).to.equal(10))
-      expect(reductionsModel.consensusLines).not.to.be.empty()
-    })
-
-    it('should default to frame 0', function () {
-      reductionsModel.consensusLines.forEach(function (consensusLine) {
-        expect(consensusLine.frame).to.equal(0)
-      })
+      expect(reductionsModel.consensusLines(0)).not.to.be.empty()
     })
 
     it('should have points', function () {
-      reductionsModel.consensusLines.forEach(function (consensusLine) {
+      reductionsModel.consensusLines(0).forEach(function (consensusLine) {
         expect(consensusLine.points).to.be.a('array')
         expect(consensusLine.points).not.to.be.empty
       })
     })
 
     it('should have text options', function () {
-      reductionsModel.consensusLines.forEach(function (consensusLine) {
+      reductionsModel.consensusLines(0).forEach(function (consensusLine) {
         expect(consensusLine.textOptions).to.be.a('array')
         expect(consensusLine.textOptions).not.to.be.empty
       })
-    })
-
-    it('should update on frame change', function () {
-      reductionsModel.changeFrame(2)
-      reductionsModel.consensusLines.forEach(function (consensusLine) {
-        expect(consensusLine.frame).to.equal(2)
-      })
-      reductionsModel.changeFrame(0)
     })
 
     describe('transcribed lines', function () {
       let consensusLine
 
       before(async function () {
-        consensusLine = reductionsModel.consensusLines[0]
+        consensusLine = reductionsModel.consensusLines(0)[0]
       })
 
       it('should have consensus text', function () {
@@ -103,10 +90,16 @@ describe('Models > TranscriptionReductions', function () {
         const y = 280.3498840332031
         expect(consensusLine.points[1]).to.deep.equal({ x, y })
       })
+
+      it('should filter by frame', function () {
+        expect(consensusLine.frame).to.equal(0)
+        const frameOneLines = reductionsModel.consensusLines(1)
+        expect(frameOneLines[0].frame).to.equal(1)
+      })
     })
   })
 
-  describe('without transcribed lines', function () {
+  describe('without reductions', function () {
     const caesarClient = new GraphQLClient('https://caesar-staging.zooniverse.org/graphql')
     let reductionsModel
 
@@ -138,7 +131,10 @@ describe('Models > TranscriptionReductions', function () {
 
     it('should not have any transcribed lines', function () {
       reductionsModel.reductions.forEach(reduction => expect(reduction.data.transcribed_lines).to.equal(0))
-      expect(reductionsModel.consensusLines).to.be.empty()
+      expect(reductionsModel.consensusLines(0)).to.be.empty()
+      expect(reductionsModel.consensusLines(1)).to.be.empty()
+      expect(reductionsModel.consensusLines(2)).to.be.empty()
+      expect(reductionsModel.consensusLines(3)).to.be.empty()
     })
   })
 
@@ -200,7 +196,10 @@ describe('Models > TranscriptionReductions', function () {
     })
 
     it('should not have any transcribed lines', function () {
-      expect(reductionsModel.consensusLines).to.be.empty()
+      expect(reductionsModel.consensusLines(0)).to.be.empty()
+      expect(reductionsModel.consensusLines(1)).to.be.empty()
+      expect(reductionsModel.consensusLines(2)).to.be.empty()
+      expect(reductionsModel.consensusLines(3)).to.be.empty()
     })
   })
 })

--- a/packages/lib-classifier/src/store/TranscriptionReductions/mocks/reducedSubject.js
+++ b/packages/lib-classifier/src/store/TranscriptionReductions/mocks/reducedSubject.js
@@ -217,6 +217,7 @@ export default {
       'low_consensus': true
     }
   ],
+  'frame3': [], // Added this just for testing purposes
   'parameters': {
     'min_samples': 'auto',
     'max_eps': null,


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

Package:

Closes #2389 

The issue can be demonstrated by having a look at the transcription task with this subject:

https://frontend.preview.zooniverse.org/projects/blicksam/transcription-task-testing/classify/workflow/13898/subject/55414221

Frame 0 has several marks while frame 1 doesn't show any despite the fact its reduction from caesar confirms there should be one:

<img width="405" alt="Screen Shot 2021-08-24 at 2 46 52 PM" src="https://user-images.githubusercontent.com/5016731/130680118-c9ac3e49-703a-4648-8ae1-2212e5cf9060.png">

The `TranscriptionReductions` store currently stores a frame index and has a `changeFrame` action, but going through the commit history, I haven't found an instance of this actually being used. 

The MultiFrameViewer was only ever connected to the `SubjectViewerStore` and its event handler for frames only updated it there: https://github.com/zooniverse/front-end-monorepo/blame/master/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js#L87

Then `TranscribedLinesContainer` implemented a filter by frame in https://github.com/zooniverse/front-end-monorepo/pull/1722 which would imply that `consensusLines` used to return all of them, but the original model frame and `changeFrame` seems to have been there from the beginning: https://github.com/zooniverse/front-end-monorepo/blame/master/packages/lib-classifier/src/store/TranscriptionReductions/TranscriptionReductions.js

I thought I remembered this working, but maybe it never was wired up correctly.

This updates the `consensusLines` view to take a frame parameter, removes the storing of the frame index from `TranscriptionReductions` effectively making `SubjectViewerStore` authoritative on which frame you're on. 

This can be manually tested using the same subject and test project running the project app at:

https://local.zooniverse.org:3000projects/blicksam/transcription-task-testing/classify/workflow/13898/subject/55414221?env=production

You should now see a mark on frame 1.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
