### PR TITLE
Classifier: Remove mocks from global test setup

### DIFF
--- a/packages/lib-classifier/src/helpers/useStores/useStores.spec.js
+++ b/packages/lib-classifier/src/helpers/useStores/useStores.spec.js
@@ -8,9 +8,10 @@ import useStores from '.'
 describe('Helpers > useStores', function () {
   describe('without storeMapper', function () {
     let current
-    const store = mockStore()
+    let store
 
     before(function () {
+      store = mockStore()
       const wrapper = props => (
         <Provider classifierStore={store}>
           {props.children}
@@ -27,7 +28,7 @@ describe('Helpers > useStores', function () {
 
   describe('with storeMapper', function () {
     let current
-    const store = mockStore()
+    let store
     function storeMapper(store) {
       const {
         workflows: {
@@ -38,6 +39,7 @@ describe('Helpers > useStores', function () {
     }
 
     before(function () {
+      store = mockStore()
       const wrapper = props => (
         <Provider classifierStore={store}>
           {props.children}

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.spec.js
@@ -51,11 +51,13 @@ describe('Model > SubjectStore', function () {
   describe('Actions', function() {
     describe('advance', function () {
       describe('with a full queue', function () {
-        const subjects = mockSubjectStore(longListSubjects)
+        let subjects
         let previousSubjectID
         let initialSize
 
-        before(function () {
+        before(async function () {
+          subjects = mockSubjectStore(longListSubjects)
+          await when(() => subjects.resources.size > 9)
           previousSubjectID = subjects.active && subjects.active.id
           initialSize = subjects.resources.size
           subjects.advance()
@@ -82,7 +84,11 @@ describe('Model > SubjectStore', function () {
 
       describe('with less than three subjects in the queue', function () {
         describe('when the initial response has ten subjects', function () {
-          const subjects = mockSubjectStore(longListSubjects)
+          let subjects
+
+          before(function () {
+            subjects = mockSubjectStore(longListSubjects)
+          })
 
           it('should request more subjects', function () {
             while (subjects.resources.size > MINIMUM_QUEUE_SIZE) {
@@ -95,7 +101,11 @@ describe('Model > SubjectStore', function () {
         })
 
         describe('when the initial response has less than three subjects', function () {
-          const subjects = mockSubjectStore(shortListSubjects)
+          let subjects
+
+          before(function () {
+            subjects = mockSubjectStore(shortListSubjects)
+          })
 
           it('should request more subjects', function () {
             // Once for initialization and again since less than three subjects in initial response
@@ -104,7 +114,11 @@ describe('Model > SubjectStore', function () {
         })
 
         describe('when the initial response has no subjects', function () {
-          const subjects = mockSubjectStore([])
+          let subjects
+
+          before(function () {
+            subjects = mockSubjectStore([])
+          })
 
           it('should request more subjects', function () {
             // Once for initialization
@@ -119,9 +133,10 @@ describe('Model > SubjectStore', function () {
       })
 
       describe('after emptying the queue', function () {
-        const subjects = mockSubjectStore(longListSubjects)
+        let subjects
 
         beforeEach(function () {
+          subjects = mockSubjectStore(longListSubjects)
           while (subjects.resources.size > 0) {
             subjects.advance()
           }
@@ -135,9 +150,10 @@ describe('Model > SubjectStore', function () {
     })
 
     describe('append', function () {
-      const subjects = mockSubjectStore([])
+      let subjects
 
       before(function () {
+        subjects = mockSubjectStore([])
         subjects.append(longListSubjects)
       })
 


### PR DESCRIPTION
Move mocks for the `useStore` and `SubjectStore` tests into before() blocks, so that they aren't run during global setup for all tests.

When you run tests on master, you'll see the following messages printed before the tests run:
```
Fetching more subjects
Fetching more subjects
Fetching more subjects
```
Those messages are caused by some mocks that are run globally for all tests. This PR moves those mocks into `before` blocks for the tests that use them.


Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
