### PR TITLE
Engaging Crowds: Add annotation._inProgress

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/index.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/index.spec.js
@@ -1,0 +1,57 @@
+import taskRegistry from './'
+
+describe('Task models', function () {
+  const taskTypes = Object.keys(taskRegistry.register)
+  taskTypes.forEach(function (taskType) {
+    let task
+    describe(taskType, function () {
+      before(function () {
+        const taskSnapshot = {
+          answers: [],
+          instruction: `${taskType} instructions`,
+          options: [ '1', '2', '3', '4' ],
+          question: `${taskType} question`,
+          taskKey: 'init',
+          type: taskType
+        }
+        const { TaskModel } = taskRegistry.get(taskType)
+        task = TaskModel.create(taskSnapshot)
+      })
+
+      it('should exist', function () {
+        expect(task).to.be.ok()
+      })
+
+      describe('annotations', function () {
+        let annotation
+
+        before(function () {
+          annotation = task.createAnnotation()
+        })
+
+        it('should exist', function () {
+          expect(annotation).to.be.ok()
+        })
+
+        it('should store the task key', function () {
+          expect(annotation.task).to.equal(task.taskKey)
+        })
+
+        it('should store the task type', function () {
+          expect(annotation.taskType).to.equal(taskType)
+        })
+
+        it('should not be in progress', function () {
+          expect(annotation._inProgress).to.be.false()
+        })
+
+        describe('on update', function () {
+          it('should be marked in progress', function () {
+            annotation.update(annotation.value)
+            expect(annotation._inProgress).to.be.true()
+          })
+        })
+      })
+    })
+  })
+})

--- a/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Annotation.js
@@ -18,6 +18,9 @@ const Annotation = types.model('Annotation', {
     delete newSnapshot.id
     return newSnapshot
   })
+  .volatile(self => ({
+    _inProgress: false
+  }))
   .views(self => ({
     get isComplete () {
       return true
@@ -30,6 +33,7 @@ const Annotation = types.model('Annotation', {
   .actions(self => ({
     update (value) {
       self.value = value
+      self._inProgress = true
     }
   }))
 


### PR DESCRIPTION
Add the `annotation._inProgress` flag, which is false by default, but true once an annotation has been updated by the classifier.
Add some generic tests which create and update an annotation for each registered task type.

For Engaging Crowds, we'd like to be able to detect when a volunteer has begun to work on a subject, so that we can warn them before clearing their classification when changing to a new subject. `annotation._inProgress` here should hopefully provide a flag that we can use to detect when classification work has begun.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
