### PR TITLE
Classifier: improvements to the Finished popup

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
@@ -32,7 +32,7 @@ export default function TaskArea({
   useEffect(function onSubjectChange() {
     // TODO: remove this once testing is complete.
     const URLParams = queryString.parse(window?.location?.search)
-    const finished = (subject && URLParams?.finished) || subject?.retired || subject?.already_seen
+    const finished = (subject && URLParams?.finished) || subject?.retired || subject?.alreadySeen
     setDisabled(finished && workflow.hasIndexedSubjects)
   }, [subject])
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/DisabledTaskPopup/DisabledTaskPopup.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/DisabledTaskPopup/DisabledTaskPopup.js
@@ -30,14 +30,22 @@ export default function DisabledTaskPopup({
   const [ active, setActive ] = useState(isOpen)
 
   useEffect(function onLoaded() {
-    if (isOpen) {
-      setActive(true)
-    }
+    setActive(isOpen)
   }, [isOpen])
 
   function closeModal() {
     setActive(false)
     onClose()
+  }
+
+  function onReset() {
+    setActive(false)
+    reset()
+  }
+
+  function onNext() {
+    setActive(false)
+    nextAvailable()
   }
 
   return (
@@ -54,14 +62,14 @@ export default function DisabledTaskPopup({
       </Paragraph>
       <PlainButton
         alignSelf="center"
-        onClick={reset}
+        onClick={onReset}
         text={counterpart('DisabledTaskPopup.options.select')}
       />
       <PrimaryButton
         alignSelf="center"
         color='teal'
         label={counterpart('DisabledTaskPopup.options.next')}
-        onClick={nextAvailable}
+        onClick={onNext}
         margin="xsmall"
       />
       <PlainButton

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/DisabledTaskPopup/DisabledTaskPopup.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/DisabledTaskPopup/DisabledTaskPopup.spec.js
@@ -69,6 +69,11 @@ describe('TaskArea > DisabledTaskPopup', function () {
       it('should call the reset callback', function () {
         expect(reset).to.have.been.calledOnce()
       })
+
+      it('should close the modal', function () {
+        const modal = wrapper.find(Modal)
+        expect(modal.prop('active')).to.be.false()
+      })
     })
 
     describe('Next Available button',function () {
@@ -85,6 +90,11 @@ describe('TaskArea > DisabledTaskPopup', function () {
 
       it('should call the nextAvailable callback', function () {
         expect(nextAvailable).to.have.been.calledOnce()
+      })
+
+      it('should close the modal', function () {
+        const modal = wrapper.find(Modal)
+        expect(modal.prop('active')).to.be.false()
       })
     })
 


### PR DESCRIPTION
Some small improvements to the popup that disables the task area for finished subjects.
- check `subject.alreadySeen` instead of `subject.already_seen`.
- close the popup when Next Available is pressed.
- close the popup when Select a Subject is pressed.
- close the popup when `isOpen` is false.

This fixes a few small bugs that @mrniaboc found while testing.

https://local.zooniverse.org:8080/?project=12268&workflow=18504&subjectSet=96699&subject=64213748&env=production&demo=true

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
