### PR TITLE
Classifier: Priority subject fixes

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Banners/Banners.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/Banners.spec.js
@@ -111,6 +111,7 @@ describe('Component > Banners', function () {
         id: '1'
       }, {
         grouped: true,
+        prioritized: true,
         subjectSet: '1'
       })
       wrapper = shallow(<Banners stores={stores} />)
@@ -135,6 +136,7 @@ describe('Component > Banners', function () {
         id: '1'
       }, {
         grouped: true,
+        prioritized: true,
         subjectSet: '1'
       })
       wrapper = shallow(<Banners stores={stores} />)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
@@ -107,6 +107,7 @@ describe('TaskAreaConnector', function () {
       const workflowSnapshot = WorkflowFactory.build({
         first_task: 'T0',
         grouped: true,
+        prioritized: true,
         tasks: {
           T0: {
             answers: [{ label: 'yes', next: 'T1' }, { label: 'no', next: 'T2' }],

--- a/packages/lib-classifier/src/store/Subject/Subject.js
+++ b/packages/lib-classifier/src/store/Subject/Subject.js
@@ -81,7 +81,11 @@ const Subject = types
     },
 
     get priority () {
-      return self.metadata['#priority'] ?? self.metadata.priority
+      const priority = self.metadata['#priority'] ?? self.metadata.priority
+      if (priority !== undefined) {
+        return parseFloat(priority)
+      }
+      return undefined
     },
 
     get alreadySeen () {

--- a/packages/lib-classifier/src/store/Subject/Subject.spec.js
+++ b/packages/lib-classifier/src/store/Subject/Subject.spec.js
@@ -74,6 +74,36 @@ describe('Model > Subject', function () {
     })
   })
 
+  describe('Views > priority', function () {
+    it('should be undefined by default', function () {
+      expect(subject.priority).to.be.undefined()
+    })
+
+    it('should be a number', function () {
+      const prioritySnapshot = SubjectFactory.build({
+        metadata: {
+          '#priority': '3'
+        }
+      })
+      const prioritySubject = Subject.create(prioritySnapshot)
+      expect(prioritySubject.priority).to.equal(3)
+    })
+
+    /*
+      This might not be supported by prioritised selection in Panoptes
+      but we've come across subject.metadata.priority on Engaging Crowds subjects.
+    */
+    it('should support visible metadata', function () {
+      const prioritySnapshot = SubjectFactory.build({
+        metadata: {
+          priority: '3'
+        }
+      })
+      const prioritySubject = Subject.create(prioritySnapshot)
+      expect(prioritySubject.priority).to.equal(3)
+    })
+  })
+
   describe('Views > talkURL', function () {
     before(function () {
       subject.projects = ProjectStore.create({})

--- a/packages/lib-classifier/src/store/Workflow/Workflow.js
+++ b/packages/lib-classifier/src/store/Workflow/Workflow.js
@@ -26,6 +26,7 @@ const Workflow = types
     first_task: types.optional(types.string, ''),
     grouped: types.optional(types.boolean, false),
     links: types.frozen({}),
+    prioritized: types.optional(types.boolean, false),
     steps: types.array(WorkflowStep),
     subjectSet: types.safeReference(SubjectSet),
     tasks: types.maybe(types.frozen()),

--- a/packages/lib-classifier/src/store/Workflow/Workflow.spec.js
+++ b/packages/lib-classifier/src/store/Workflow/Workflow.spec.js
@@ -27,6 +27,10 @@ describe('Model > Workflow', function () {
       expect(workflow.grouped).to.be.false()
     })
 
+    it('should not be prioritised', function () {
+      expect(workflow.prioritized).to.be.false()
+    })
+
     it('should not use transcription task', function () {
       expect(workflow.usesTranscriptionTask).to.be.false()
     })
@@ -181,6 +185,7 @@ describe('Model > Workflow', function () {
         id: 'workflow1',
         display_name: 'A test workflow',
         grouped: true,
+        prioritized: true,
         links: {
           subject_sets: subjectSets.map(subjectSet => subjectSet.id)
         },


### PR DESCRIPTION
This fixes a couple of bugs in the workflow and subject models.
- `workflow.prioritized` is always falsy, even for prioritised workflows.
- `subject.priority` is a string, which leads to unexpected results when you try to compare two subjects by priority order.

I've tagged this with Engaging Crowds, but I think we're using prioritised selection outside that project eg. for Davy Notebooks too.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
