### PR TITLE
Classifier: Refactor drawing task annotations

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -21,14 +21,15 @@ const DrawingCanvas = styled('rect')`
 function InteractionLayer({
   activeMark,
   activeTool,
-  activeToolIndex,
-  disabled,
-  frame,
+  activeToolIndex = 0,
+  annotation,
+  disabled = false,
+  frame = 0,
   height,
-  marks,
+  marks = [],
   move,
-  setActiveMark,
-  scale,
+  setActiveMark = () => {},
+  scale = 1,
   width,
   played,
   duration
@@ -96,6 +97,8 @@ function InteractionLayer({
     mark.setSubTaskVisibility(false)
     // Add a time value for tools that care about time. For most tools, this value is ignored.
     mark.setVideoTime(timeStamp, duration)
+    const markIDs = marks.map(mark => mark.id)
+    annotation.update([ ...markIDs, mark.id ])
   }
 
   function onPointerDown(event) {
@@ -185,6 +188,11 @@ InteractionLayer.propTypes = {
   activeMark: PropTypes.object,
   activeTool: PropTypes.object.isRequired,
   activeToolIndex: PropTypes.number,
+  annotation: PropTypes.shape({
+    task: PropTypes.string,
+    taskType: PropTypes.string,
+    value: PropTypes.array
+  }).isRequired,
   frame: PropTypes.number,
   marks: PropTypes.array,
   setActiveMark: PropTypes.func,
@@ -192,16 +200,6 @@ InteractionLayer.propTypes = {
   disabled: PropTypes.bool,
   scale: PropTypes.number,
   width: PropTypes.number.isRequired
-}
-
-InteractionLayer.defaultProps = {
-  activeMark: undefined,
-  activeToolIndex: 0,
-  frame: 0,
-  marks: [],
-  setActiveMark: () => {},
-  disabled: false,
-  scale: 1
 }
 
 export default InteractionLayer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -46,6 +46,7 @@ describe('Component > InteractionLayer', function () {
         ],
         type: 'drawing'
       })
+      const annotation = mockDrawingTask.createAnnotation()
       const setActiveMarkStub = sinon.stub().callsFake(() => mockMark)
       activeTool = mockDrawingTask.activeTool
       sinon.stub(activeTool, 'createMark').callsFake(() => mockMark)
@@ -53,6 +54,7 @@ describe('Component > InteractionLayer', function () {
         <InteractionLayer
           activeMark={mockMark}
           activeTool={activeTool}
+          annotation={annotation}
           frame={2}
           setActiveMark={setActiveMarkStub}
           height={400}
@@ -175,6 +177,7 @@ describe('Component > InteractionLayer', function () {
               type: 'drawing'
             })
             activeTool = mockDrawingTask.activeTool
+            const annotation = mockDrawingTask.createAnnotation()
             sinon.stub(activeTool, 'createMark').callsFake(() => mockMark)
             sinon
               .stub(activeTool, 'handlePointerDown')
@@ -184,6 +187,7 @@ describe('Component > InteractionLayer', function () {
               <InteractionLayer
                 activeMark={mockMark}
                 activeTool={activeTool}
+                annotation={annotation}
                 frame={2}
                 height={400}
                 width={600}
@@ -250,6 +254,7 @@ describe('Component > InteractionLayer', function () {
             type: 'drawing'
           })
           activeTool = mockDrawingTask.activeTool
+          const annotation = mockDrawingTask.createAnnotation()
           const setActiveMarkStub = sinon.stub()
           sinon.stub(activeTool, 'createMark').callsFake(() => mockMark)
           sinon.stub(activeTool, 'deleteMark').callsFake(() => {})
@@ -261,6 +266,7 @@ describe('Component > InteractionLayer', function () {
             <InteractionLayer
               activeMark={mockMark}
               activeTool={activeTool}
+              annotation={annotation}
               frame={2}
               height={400}
               setActiveMark={setActiveMarkStub}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -1,15 +1,15 @@
-import { inject, observer } from 'mobx-react'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React from 'react'
 
 import InteractionLayer from './InteractionLayer'
 import PreviousMarks from './components/PreviousMarks'
 import SHOWN_MARKS from '@helpers/shownMarks'
+import { withStores } from '@helpers'
 
-function storeMapper(stores) {
-  const activeStepAnnotations = stores.classifierStore.annotatedSteps.latest?.annotations
-  const { activeStepTasks } = stores.classifierStore.workflowSteps
-  const { frame, move } = stores.classifierStore.subjectViewer
+function storeMapper(classifierStore) {
+  const activeStepAnnotations = classifierStore.annotatedSteps.latest?.annotations
+  const { activeStepTasks } = classifierStore.workflowSteps
+  const { frame, move } = classifierStore.subjectViewer
 
   const [activeInteractionTask] = activeStepTasks.filter(
     (task) => task.type === 'drawing' || task.type === 'transcription'
@@ -18,114 +18,102 @@ function storeMapper(stores) {
     annotation => annotation.taskType === 'drawing' || annotation.taskType === 'transcription'
   )
 
+  const {
+    activeMark,
+    activeTool,
+    activeToolIndex,
+    hidingIndex,
+    marks,
+    setActiveMark,
+    shownMarks,
+    taskKey
+  } = activeInteractionTask || {}
+
+  const disabled = activeTool?.disabled
+
   return {
-    activeInteractionTask,
+    activeMark,
+    activeTool,
+    activeToolIndex,
     annotation,
     frame,
-    move
+    hidingIndex,
+    marks,
+    move,
+    setActiveMark,
+    shownMarks,
+    taskKey
   }
 }
 
-@inject(storeMapper)
-@observer
-class InteractionLayerContainer extends Component {
-  render() {
-    const {
-      activeInteractionTask,
-      annotation,
-      frame,
-      height,
-      move,
-      scale,
-      width,
-      played,
-      duration
-    } = this.props
+export function InteractionLayerContainer({
+  activeMark,
+  activeTool,
+  activeToolIndex,
+  annotation,
+  disabled = false,
+  frame = 0,
+  height,
+  hidingIndex,
+  marks = [],
+  move = false,
+  scale = 1,
+  setActiveMark = () => {},
+  shownMarks = SHOWN_MARKS.ALL,
+  taskKey = '',
+  width,
+  played,
+  duration
+}) {
 
-    const {
-      activeMark,
-      activeTool,
-      activeToolIndex,
-      hidingIndex,
-      marks,
-      setActiveMark,
-      shownMarks,
-      taskKey
-    } = activeInteractionTask
+  const newMarks =
+    shownMarks === SHOWN_MARKS.NONE ? marks.slice(hidingIndex) : marks
+  const visibleMarksPerFrame = newMarks?.filter(
+    (mark) => mark.frame === frame
+  )
 
-    const newMarks =
-      shownMarks === SHOWN_MARKS.NONE ? marks.slice(hidingIndex) : marks
-    const visibleMarksPerFrame = newMarks?.filter(
-      (mark) => mark.frame === frame
-    )
-
-    return (
-      <>
-        {activeInteractionTask && activeTool && (
-          <InteractionLayer
-            activeMark={activeMark}
-            activeTool={activeTool}
-            activeToolIndex={activeToolIndex}
-            annotation={annotation}
-            disabled={activeTool.disabled}
-            frame={frame}
-            height={height}
-            key={taskKey}
-            marks={visibleMarksPerFrame}
-            move={move}
-            scale={scale}
-            played={played}
-            duration={duration}
-            setActiveMark={setActiveMark}
-            width={width}
-          />
-        )}
-        <PreviousMarks scale={scale} />
-      </>
-    )
-  }
+  return (
+    <>
+      {activeTool && (
+        <InteractionLayer
+          activeMark={activeMark}
+          activeTool={activeTool}
+          activeToolIndex={activeToolIndex}
+          annotation={annotation}
+          disabled={disabled}
+          frame={frame}
+          height={height}
+          key={taskKey}
+          marks={visibleMarksPerFrame}
+          move={move}
+          scale={scale}
+          played={played}
+          duration={duration}
+          setActiveMark={setActiveMark}
+          width={width}
+        />
+      )}
+      <PreviousMarks scale={scale} />
+    </>
+  )
 }
 
-InteractionLayerContainer.wrappedComponent.propTypes = {
-  activeInteractionTask: PropTypes.shape({
-    activeMark: PropTypes.object,
-    activeTool: PropTypes.shape({
-      disabled: PropTypes.bool
-    }),
-    marks: PropTypes.array,
-    setActiveMark: PropTypes.func,
-    shownMarks: PropTypes.string,
-    taskKey: PropTypes.string
-  }),
+InteractionLayerContainer.propTypes = {
+  activeMark: PropTypes.object,
+  activeTool: PropTypes.object,
   disabled: PropTypes.bool,
+  duration: PropTypes.number,
   frame: PropTypes.number,
   height: PropTypes.number.isRequired,
   interactionTaskAnnotations: PropTypes.array,
+  marks: PropTypes.array,
   move: PropTypes.bool,
-  scale: PropTypes.number,
   played: PropTypes.number,
-  duration: PropTypes.number,
+  scale: PropTypes.number,
+  setActiveMark: PropTypes.func,
+  shownMarks: PropTypes.string,
+  taskKey: PropTypes.string,
   width: PropTypes.number.isRequired
 }
 
-InteractionLayerContainer.wrappedComponent.defaultProps = {
-  activeInteractionTask: {
-    activeMark: undefined,
-    activeTool: {
-      disabled: false
-    },
-    marks: [],
-    setActiveMark: () => {},
-    shownMarks: SHOWN_MARKS.ALL,
-    taskKey: ''
-  },
-  disabled: false,
-  frame: 0,
-  interactionTaskAnnotations: [],
-  move: false,
-  scale: 1,
-  played: undefined, // used for tracking video progress from 0 - 1. if undefined, subject is not a video
-  duration: undefined // total length of video. if undefined, subject is not a video
-}
-
-export default InteractionLayerContainer
+export default withStores(InteractionLayerContainer, storeMapper)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -7,15 +7,20 @@ import PreviousMarks from './components/PreviousMarks'
 import SHOWN_MARKS from '@helpers/shownMarks'
 
 function storeMapper(stores) {
+  const activeStepAnnotations = stores.classifierStore.annotatedSteps.latest?.annotations
   const { activeStepTasks } = stores.classifierStore.workflowSteps
   const { frame, move } = stores.classifierStore.subjectViewer
 
   const [activeInteractionTask] = activeStepTasks.filter(
     (task) => task.type === 'drawing' || task.type === 'transcription'
   )
+  const annotation = activeStepAnnotations.find(
+    annotation => annotation.taskType === 'drawing' || annotation.taskType === 'transcription'
+  )
 
   return {
     activeInteractionTask,
+    annotation,
     frame,
     move
   }
@@ -27,6 +32,7 @@ class InteractionLayerContainer extends Component {
   render() {
     const {
       activeInteractionTask,
+      annotation,
       frame,
       height,
       move,
@@ -60,6 +66,7 @@ class InteractionLayerContainer extends Component {
             activeMark={activeMark}
             activeTool={activeTool}
             activeToolIndex={activeToolIndex}
+            annotation={annotation}
             disabled={activeTool.disabled}
             frame={frame}
             height={height}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.spec.js
@@ -1,6 +1,6 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import InteractionLayerContainer from './InteractionLayerContainer'
+import { InteractionLayerContainer } from './InteractionLayerContainer'
 import InteractionLayer from './InteractionLayer'
 import PreviousMarks from './components/PreviousMarks'
 import SHOWN_MARKS from '@helpers/shownMarks'
@@ -31,10 +31,27 @@ describe('Component > InteractionLayerContainer', function () {
   }
 
   it('should render without crashing', function () {
+    const {
+      activeMark,
+      activeTool,
+      activeToolIndex,
+      hidingIndex,
+      marks,
+      setActiveMark,
+      shownMarks,
+      taskKey
+    } = drawingTask
     const wrapper = shallow(
-      <InteractionLayerContainer.wrappedComponent
-        activeInteractionTask={drawingTask}
+      <InteractionLayerContainer
+        activeMark={activeMark}
+        activeTool={activeTool}
+        activeToolIndex={activeToolIndex}
         height={height}
+        hidingIndex={hidingIndex}
+        marks={marks}
+        setActiveMark={setActiveMark}
+        shownMarks={shownMarks}
+        taskKey={taskKey}
         width={width}
       />
     )
@@ -42,10 +59,27 @@ describe('Component > InteractionLayerContainer', function () {
   })
 
   it('should render PreviousMarks',  function () {
+    const {
+      activeMark,
+      activeTool,
+      activeToolIndex,
+      hidingIndex,
+      marks,
+      setActiveMark,
+      shownMarks,
+      taskKey
+    } = drawingTask
     const wrapper = shallow(
-      <InteractionLayerContainer.wrappedComponent
-        activeInteractionTask={drawingTask}
+      <InteractionLayerContainer
+        activeMark={activeMark}
+        activeTool={activeTool}
+        activeToolIndex={activeToolIndex}
         height={height}
+        hidingIndex={hidingIndex}
+        marks={marks}
+        setActiveMark={setActiveMark}
+        shownMarks={shownMarks}
+        taskKey={taskKey}
         width={width}
       />
     )
@@ -56,10 +90,27 @@ describe('Component > InteractionLayerContainer', function () {
     let wrapper
 
     before(function () {
+      const {
+        activeMark,
+        activeTool,
+        activeToolIndex,
+        hidingIndex,
+        marks,
+        setActiveMark,
+        shownMarks,
+        taskKey
+      } = drawingTask
       wrapper = shallow(
-        <InteractionLayerContainer.wrappedComponent
-          activeInteractionTask={drawingTask}
+        <InteractionLayerContainer
+          activeMark={activeMark}
+          activeTool={activeTool}
+          activeToolIndex={activeToolIndex}
           height={height}
+          hidingIndex={hidingIndex}
+          marks={marks}
+          setActiveMark={setActiveMark}
+          shownMarks={shownMarks}
+          taskKey={taskKey}
           width={width}
         />
       )
@@ -88,11 +139,28 @@ describe('Component > InteractionLayerContainer', function () {
     }
 
     before(function () {
+      const {
+        activeMark,
+        activeTool,
+        activeToolIndex,
+        hidingIndex,
+        marks,
+        setActiveMark,
+        shownMarks,
+        taskKey
+      } = transcriptionTask
       wrapper = shallow(
-        <InteractionLayerContainer.wrappedComponent
+        <InteractionLayerContainer
+          activeMark={activeMark}
+          activeTool={activeTool}
+          activeToolIndex={activeToolIndex}
           height={height}
+          hidingIndex={hidingIndex}
+          marks={marks}
+          setActiveMark={setActiveMark}
+          shownMarks={shownMarks}
+          taskKey={taskKey}
           width={width}
-          activeInteractionTask={transcriptionTask}
         />
       )
     })
@@ -135,13 +203,29 @@ describe('Component > InteractionLayerContainer', function () {
         ]
       }
       const activeTranscriptionTask = Object.assign({}, activeTask, transcriptionTask)
-
+      const {
+        activeMark,
+        activeTool,
+        activeToolIndex,
+        hidingIndex,
+        marks,
+        setActiveMark,
+        shownMarks,
+        taskKey
+      } = activeTranscriptionTask
       const wrapper = shallow(
-        <InteractionLayerContainer.wrappedComponent
-          height={height}
-          width={width}
+        <InteractionLayerContainer
+          activeMark={activeMark}
+          activeTool={activeTool}
+          activeToolIndex={activeToolIndex}
           frame={0}
-          activeInteractionTask={activeTranscriptionTask}
+          height={height}
+          hidingIndex={hidingIndex}
+          marks={marks}
+          setActiveMark={setActiveMark}
+          shownMarks={shownMarks}
+          taskKey={taskKey}
+          width={width}
         />
       )
 
@@ -162,12 +246,28 @@ describe('Component > InteractionLayerContainer', function () {
           marks: [{ x: 0, y: 0, frame: 0 }, { x: 5, y: 5, frame: 0 }]
         }
         const hidingMarksInteractionTask = Object.assign({}, transcriptionTask, hidingTask)
+        const {
+          activeMark,
+          activeTool,
+          activeToolIndex,
+          hidingIndex,
+          marks,
+          setActiveMark,
+          shownMarks,
+          taskKey
+        } = hidingMarksInteractionTask
         wrapper = shallow(
-          <InteractionLayerContainer.wrappedComponent
+          <InteractionLayerContainer
+            activeMark={activeMark}
+            activeTool={activeTool}
+            activeToolIndex={activeToolIndex}
             height={height}
+            hidingIndex={hidingIndex}
+            marks={marks}
+            setActiveMark={setActiveMark}
+            shownMarks={shownMarks}
+            taskKey={taskKey}
             width={width}
-            activeInteractionTask={hidingMarksInteractionTask}
-            interactionTaskAnnotations={drawingAnnotations}
           />
         )
       })
@@ -183,17 +283,33 @@ describe('Component > InteractionLayerContainer', function () {
         const userHidingTask = Object.assign({}, hidingTask)
         userHidingTask.shownMarks = SHOWN_MARKS.USER
         const hidingUserMarksInteractionTask = Object.assign({}, transcriptionTask, userHidingTask)
+        const {
+          activeMark,
+          activeTool,
+          activeToolIndex,
+          hidingIndex,
+          marks,
+          setActiveMark,
+          shownMarks,
+          taskKey
+        } = hidingUserMarksInteractionTask
         wrapper = shallow(
-          <InteractionLayerContainer.wrappedComponent
+          <InteractionLayerContainer
+            activeMark={activeMark}
+            activeTool={activeTool}
+            activeToolIndex={activeToolIndex}
             height={height}
+            hidingIndex={hidingIndex}
+            marks={marks}
+            setActiveMark={setActiveMark}
+            shownMarks={shownMarks}
+            taskKey={taskKey}
             width={width}
-            activeInteractionTask={hidingUserMarksInteractionTask}
-            interactionTaskAnnotations={drawingAnnotations}
           />
         )
 
-        const marks = wrapper.find(InteractionLayer).props().marks
-        expect(marks).to.have.lengthOf(2)
+        const filteredMarks = wrapper.find(InteractionLayer).props().marks
+        expect(filteredMarks).to.have.lengthOf(2)
       })
     })
   })

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.js
@@ -74,7 +74,6 @@ export const Drawing = types.model('Drawing', {
     }
 
     function complete(annotation) {
-      annotation.update(self.marks)
       self.subTaskVisibility = false
     }
 

--- a/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/DrawingTask/models/DrawingTask.spec.js
@@ -278,17 +278,21 @@ describe('Model > DrawingTask', function () {
       point1 = task.tools[0].createMark({ id: 'point1' })
       point2 = task.tools[0].createMark({ id: 'point2' })
       line1 = task.tools[1].createMark({ id: 'line1' })
+      annotation.update(task.marks)
       task.complete(annotation)
     })
 
-    it('should copy marks to the task annotation', function () {
-      expect(annotation.value).to.deep.equal([point1, point2, line1])
+    it('should reset the subtask visiblity', function () {
+      expect(task.subTaskVisibility).to.be.false()
     })
 
     describe('on deleting a mark', function () {
       before(function () {
         task.tools[1].deleteMark(line1)
-        task.complete(annotation)
+      })
+
+      it('should remove the mark', function () {
+        expect(task.marks).to.deep.equal([point1, point2])
       })
 
       it('should update the annotation', function () {
@@ -300,11 +304,10 @@ describe('Model > DrawingTask', function () {
       let line2
       before(function () {
         line2 = task.tools[1].createMark({ id: 'line2' })
-        task.complete(annotation)
       })
 
-      it('should update the annotation', function () {
-        expect(annotation.value).to.deep.equal([point1, point2, line2])
+      it('should add a new mark', function () {
+        expect(task.marks).to.deep.equal([point1, point2, line2])
       })
     })
   })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/TranscriptionTask/models/TranscriptionTask.spec.js
@@ -163,8 +163,8 @@ describe('Model > TranscriptionTask', function () {
       task.complete(annotation)
     })
 
-    it('should copy marks to the task annotation', function () {
-      expect(annotation.value).to.deep.equal([transcriptionLine])
+    it('should reset the subtask visiblity', function () {
+      expect(task.subTaskVisibility).to.be.false()
     })
   })
 


### PR DESCRIPTION
Pass the active drawing task annotation down to the `InteractionLayer` components as a prop. Update the annotation incrementally, when a new mark is created, rather than waiting until drawing is complete for the current step.

Here's a test project with a couple of drawing steps, including some subtasks.
https://localhost:8080/?project=908&workflow=3370

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
