### PR TITLE
Classifier: Clarify getNextStep

### DIFF
--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -93,17 +93,18 @@ const WorkflowStepStore = types
     function getNextStepKey () {
       const validStepReference = isValidReference(() => self.active)
       const stepKeys = self.steps.keys()
+      const stepKeysArray = Array.from(stepKeys)
+      const [ firstStep ] = stepKeysArray
       if (validStepReference) {
         if (!!self.active.next) {
           return self.active.next
         } else {
-          const stepKeysArray = Array.from(stepKeys)
           const currentStepIndex = stepKeysArray.indexOf(self.active.stepKey)
           return stepKeysArray[currentStepIndex + 1]
         }
       }
 
-      return stepKeys.next().value
+      return firstStep
     }
 
     function resetSteps () {


### PR DESCRIPTION
Rewrite `WorkflowSteps.getNextStep` to make it clear that it returns the first step by default.

Following conversation in #2392 about how confusing it can be to read `resources.values().next().value`, this replaces `steps.keys().next().value` in `getNextStep` to make it clear that the first step is returned by default.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
