### PR TITLE
Remove absolute link used for project about pages

### DIFF
--- a/packages/app-project/src/shared/components/NavLink/NavLink.js
+++ b/packages/app-project/src/shared/components/NavLink/NavLink.js
@@ -18,9 +18,6 @@ function NavLink ({
 }) {
   const { href, text } = link
   const isCurrentPage = router?.asPath === addQueryParams(href, router)
-  const { owner, project } = router ? router.query : {}
-  const isPFELink = href.startsWith(`/projects/${owner}/${project}/about`)
-  const isProductionAPI = process.env.PANOPTES_ENV === 'production'
 
   const label = <StyledSpacedText children={text} color={color} weight={weight} />
 
@@ -28,11 +25,6 @@ function NavLink ({
     return (
       <StyledAnchor color={color} label={label} {...anchorProps} />
     )
-  }
-  
-  if (isPFELink && isProductionAPI) {
-    const PFEHref = addQueryParams(`https://www.zooniverse.org${href}`, router)
-    return <StyledAnchor color={color} label={label} href={PFEHref} {...anchorProps} />
   }
 
   if (disabled) {

--- a/packages/app-project/src/shared/components/NavLink/NavLink.spec.js
+++ b/packages/app-project/src/shared/components/NavLink/NavLink.spec.js
@@ -29,10 +29,6 @@ describe('Component > NavLink', function () {
     text: 'Foobar'
   }
 
-  const PFE_LINK = {
-    href: '/projects/foo/bar/about/research',
-    text: 'Foobar'
-  }
   describe('default behaviour', function () {
     let wrapper
 
@@ -82,31 +78,6 @@ describe('Component > NavLink', function () {
     })
 
     it('should not have a link', function () {
-      const link = wrapper.find(Link)
-      expect(link).to.be.empty()
-    })
-  })
-
-  describe('production PFE links', function () {
-    let wrapper
-    let panoptesEnv
-
-    before(function () {
-      panoptesEnv = process.env.PANOPTES_ENV
-      process.env.PANOPTES_ENV = 'production'
-      wrapper = shallow(<NavLink router={ROUTER_ON_OTHER_PAGE} link={PFE_LINK} />)
-    })
-
-    after(function () {
-      process.env.PANOPTES_ENV = panoptesEnv
-    })
-
-    it('should use a link anchor', function () {
-      const link = wrapper.find(Anchor)
-      expect(link.prop('href')).to.equal(`https://www.zooniverse.org${PFE_LINK.href}`)
-    })
-
-    it('should not use client-side links', function () {
       const link = wrapper.find(Link)
       expect(link).to.be.empty()
     })


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

Package: app-project

Final step in launching the project about pages. This should be done after two other issues / PRs are done:

- Migrating the Frontdoor rules to to NGINX http-frontend: https://github.com/zooniverse/operations/issues/523
- Adding about pages to redirect on PFE router: https://github.com/zooniverse/Panoptes-Front-End/pull/6014 


# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
