### PR TITLE
Markdownz: Image dimensions inside Grommet Grid

### DIFF
--- a/packages/lib-react-components/src/Markdownz/Markdownz.stories.js
+++ b/packages/lib-react-components/src/Markdownz/Markdownz.stories.js
@@ -1,12 +1,13 @@
 import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
-import { Grommet, Box, TableRow } from 'grommet'
+import { Grid, Grommet, Box, TableRow } from 'grommet'
 import styled from 'styled-components'
 import React from 'react'
 
 import Markdownz from './Markdownz'
 import readme from './README.md'
 import markdownExample from '../../.storybook/lib/example.md'
+import markdownInGrid from './markdownGridExample.md'
 
 const TableRowWithBorder = styled(TableRow)`
   border-top: solid thin black;
@@ -60,5 +61,18 @@ storiesOf('Components/Markdownz', module)
           {markdownExample}
         </Markdownz>
       </Box>
+    </Grommet>
+  ), config)
+
+  .add('Grid example', () => (
+    <Grommet theme={zooTheme}>
+      <Grid columns={['small', 'flex']} gap='8%'>
+        <Box>Sidebar Here</Box>
+        <Box>
+          <Markdownz>
+            {markdownInGrid}
+          </Markdownz>
+        </Box>
+      </Grid>
     </Grommet>
   ), config)

--- a/packages/lib-react-components/src/Markdownz/markdownGridExample.md
+++ b/packages/lib-react-components/src/Markdownz/markdownGridExample.md
@@ -1,0 +1,7 @@
+Lorem ipsum etc
+
+![J1003351.36-003340.8_sdss_decals.gif](https://panoptes-uploads.zooniverse.org/production/project_attached_image/7656d42d-4d25-42e1-9014-6b8876a5641f.gif =250x) ![J094402.93+004556.2_sdss_decals.gif](https://panoptes-uploads.zooniverse.org/production/project_attached_image/bb03674a-e03a-455b-9a4d-4aad7d718df1.gif =250x)
+
+Lorem ipsum
+
+*This is an image label*

--- a/packages/lib-react-components/src/Markdownz/markdownGridExample.md
+++ b/packages/lib-react-components/src/Markdownz/markdownGridExample.md
@@ -1,7 +1,10 @@
+# This is a Header #
 Lorem ipsum etc
 
-![J1003351.36-003340.8_sdss_decals.gif](https://panoptes-uploads.zooniverse.org/production/project_attached_image/7656d42d-4d25-42e1-9014-6b8876a5641f.gif =250x) ![J094402.93+004556.2_sdss_decals.gif](https://panoptes-uploads.zooniverse.org/production/project_attached_image/bb03674a-e03a-455b-9a4d-4aad7d718df1.gif =250x)
-
-Lorem ipsum
-
+![J1003351.36-003340.8_sdss_decals.gif](https://panoptes-uploads.zooniverse.org/production/project_attached_image/7656d42d-4d25-42e1-9014-6b8876a5641f.gif =250x) 
+![J094402.93+004556.2_sdss_decals.gif](https://panoptes-uploads.zooniverse.org/production/project_attached_image/bb03674a-e03a-455b-9a4d-4aad7d718df1.gif =250x)
 *This is an image label*
+
+![alt](https://static.zooniverse.org/www.zooniverse.org/assets/home-video.mp4)
+
+![alt](https://panoptes-uploads.zooniverse.org/production/subject_location/1c93591f-5d7e-4129-a6da-a65419b88048.mpga)

--- a/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.js
+++ b/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.js
@@ -8,8 +8,8 @@ import { propTypes, defaultProps } from '../../helpers/mediaPropTypes'
 const DEFAULT_THUMBNAIL_DIMENSION = 999
 
 const StyledBox = styled(Box)`
-  ${props => props.maxHeight && css`max-height: ${props.maxHeight}px;`}
-  ${props => props.maxWidth && css`max-width: ${props.maxWidth}px;`}
+  ${props => props.maxHeight && css`max-height: ${props.maxHeight};`}
+  ${props => props.maxWidth && css`max-width: ${props.maxWidth};`}
 `
 
 const StyledImage = styled(Image)`
@@ -78,10 +78,8 @@ export default class ThumbnailImage extends React.Component {
               <StyledBox
                 animation={loading ? undefined : "fadeIn"}
                 flex={flex}
-                height='100%'
-                maxWidth={width}
-                maxHeight={height}
-                width='100%'
+                maxWidth={stringWidth}
+                maxHeight={stringHeight}
                 {...rest}
               >
                 <StyledImage


### PR DESCRIPTION
Package:
lib-react-components

Closes: #2189

Describe your changes:
- When a `Markdownz` component is rendered inside a Grommet `Grid`, the image container is overlapping text intended to render below the image.

Example PFE:
![pfe](https://user-images.githubusercontent.com/23665803/134980036-e021048e-4bf4-4559-a177-9da24190e744.jpg)

Example FEM:
![fem](https://user-images.githubusercontent.com/23665803/134980403-be9aca26-084d-447e-ac5f-9e96a6a9fcd6.jpg)

- This PR removes the repetitive "px" units that were in `ThumbnailImage` component, and no longer explicitly sets the image container's height and width to 100% so that it does not stretch to the surrounding Grommet `Grid`. 
- The changes can be tested by running `yarn storybook` and viewing the new "Grid Example" in `Markdownz` stories.
- I'm also noting here that the current implementation of `Markdownz` is using outdated `remark` packages. In `remark-react`, react components are mapped to html elements, but the custom function mapped to images is returning `Media` components inside a `<p>`. This means multiple images cannot be rendered inline with each other even if their widths are small enough. Upgrading all remark packages and refactoring to address this behavior is beyond the scope of this PR, so I've opened Issue #2462.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
