### PR TITLE
ensure datatable UI can use desc sort order at subject-set-search API

### DIFF
--- a/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.js
@@ -59,6 +59,16 @@ export default function SubjectPicker({ baseUrl, subjectSet, workflow }) {
   const customHeaders = indexFields.split(',')
 
   async function fetchSubjectData() {
+    // Resetting the rows is important when fetchSubjectData() occurs as a
+    // result of changing the sort order, when the number of subjects exceeds
+    // PAGE_SIZE. Otherwise, we see a "visual hiccup" where the SubjectPicker
+    // first sorts the OLD set of subjects (say) 1-100, then fetches the new set
+    // of subjects (say) 899-999 (with the opposite sort logic), then sorts the
+    // new set.
+    // See https://github.com/zooniverse/front-end-monorepo/pull/2466#issuecomment-931547044
+    // for details.
+    setRows([])  // TODO: replace this with a more elegant "state = fetching data" so we can show a "Please wait..." status message.
+
     const subjects = await fetchSubjects(subjectSet.id, query, sortField, sortOrder)
     const rows = await fetchRows(subjects, workflow, PAGE_SIZE)
     setRows(rows)

--- a/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.js
@@ -53,6 +53,7 @@ export default function SubjectPicker({ baseUrl, subjectSet, workflow }) {
   const router = useRouter()
   const [ rows, setRows ] = useState([])
   const [ query, setQuery ] = useState('')
+  const [ isFetching, setIsFetching ] = useState(false)
   const [ sortField, setSortField ] = useState('priority')
   const [ sortOrder, setSortOrder ] = useState('asc')
   const { indexFields } = subjectSet.metadata
@@ -67,11 +68,13 @@ export default function SubjectPicker({ baseUrl, subjectSet, workflow }) {
     // new set.
     // See https://github.com/zooniverse/front-end-monorepo/pull/2466#issuecomment-931547044
     // for details.
-    setRows([])  // TODO: replace this with a more elegant "state = fetching data" so we can show a "Please wait..." status message.
+    setIsFetching(true)
+    setRows([])
 
     const subjects = await fetchSubjects(subjectSet.id, query, sortField, sortOrder)
     const rows = await fetchRows(subjects, workflow, PAGE_SIZE)
     setRows(rows)
+    setIsFetching(false)
   }
 
   useEffect(function onChange() {
@@ -165,6 +168,9 @@ export default function SubjectPicker({ baseUrl, subjectSet, workflow }) {
         sortable
         step={PAGE_SIZE}
       />
+      {isFetching && (
+        <Paragraph textAlign="center">{counterpart('SubjectPicker.fetching')}</Paragraph>
+      )}
     </>
   )
 }

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchSubjects.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchSubjects.js
@@ -1,6 +1,6 @@
 const API_HOST = 'https://subject-set-search-api.zooniverse.org/subjects'
-const ASC_SORT = '_sort'
-const DESC_SORT = '_sort_desc'
+const ASCENDING_SORT = '_sort'
+const DESCENDING_SORT = '_sort_desc'
 
 export default async function fetchSubjects(
   subjectSetID,
@@ -8,7 +8,7 @@ export default async function fetchSubjects(
   sortField='priority',
   sortOrder='asc'
 ) {
-  const sortOrderParam = 'asc'.localeCompare(sortOrder) ? ASC_SORT : DESC_SORT
+  const sortOrderParam = 'asc'.localeCompare(sortOrder) ? ASCENDING_SORT : DESCENDING_SORT
   const url = `${API_HOST}/${subjectSetID}.json?${query}&${sortOrderParam}=${sortField}`
   const mode = 'cors'
   const response = await fetch(url, { mode })

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchSubjects.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchSubjects.js
@@ -8,7 +8,7 @@ export default async function fetchSubjects(
   sortField='priority',
   sortOrder='asc'
 ) {
-  const sortOrderParam = 'asc'.localeCompare(sortOrder) ? ASCENDING_SORT : DESCENDING_SORT
+  const sortOrderParam = 'asc'.localeCompare(sortOrder) ? DESCENDING_SORT : ASCENDING_SORT
   const url = `${API_HOST}/${subjectSetID}.json?${query}&${sortOrderParam}=${sortField}`
   const mode = 'cors'
   const response = await fetch(url, { mode })

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchSubjects.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchSubjects.js
@@ -1,11 +1,15 @@
 const API_HOST = 'https://subject-set-search-api.zooniverse.org/subjects'
+const ASC_SORT = '_sort'
+const DESC_SORT = '_sort_desc'
 
 export default async function fetchSubjects(
   subjectSetID,
   query='',
-  sortField='priority'
+  sortField='priority',
+  sortOrder='asc'
 ) {
-  const url = `${API_HOST}/${subjectSetID}.json?${query}&_sort=${sortField}`
+  const sortOrderParam = 'asc'.localeCompare(sortOrder) ? ASC_SORT : DESC_SORT
+  const url = `${API_HOST}/${subjectSetID}.json?${query}&${sortOrderParam}=${sortField}`
   const mode = 'cors'
   const response = await fetch(url, { mode })
   const data = await response.json()

--- a/packages/app-project/src/shared/components/SubjectPicker/locales/en.json
+++ b/packages/app-project/src/shared/components/SubjectPicker/locales/en.json
@@ -5,6 +5,7 @@
     "byline": "Sort the list by clicking column names. You will see subjects sequentially, starting with the one you choose.",
     "alreadySeen": "Already seen",
     "retired": "Retired",
-    "unclassified": "Available"
+    "unclassified": "Available",
+    "fetching": "Please wait..."
   }
 }


### PR DESCRIPTION
subject set search API allows the sort order to be desc via special _sort_desc param, https://docs.datasette.io/en/stable/json_api.html#special-table-arguments

Grommet datatable provides the 'asc' or 'desc' direction key on the callback function https://v2.grommet.io/datatable#onSort - use this in the API call from the UI component to ensure the API can return more than the first 100 rows of data

Package: app-project

Closes - issue detected when testing Engaging Crowd projects subject picker tool

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
