### PR TITLE
Add user existence check before UPP refresh in increment action of UserPersonalization store

### DIFF
--- a/packages/app-project/stores/UserPersonalization.js
+++ b/packages/app-project/stores/UserPersonalization.js
@@ -58,7 +58,8 @@ const UserPersonalization = types
         self.sessionCount = self.sessionCount + 1
         self.totalClassificationCount = self.totalClassificationCount + 1
 
-        if (self.sessionCountIsDivisibleByFive) {
+        const { user } = getRoot(self)
+        if (user?.id && self.sessionCountIsDivisibleByFive) {
           self.projectPreferences.refreshResource()
         }
       },

--- a/packages/app-project/stores/UserPersonalization.spec.js
+++ b/packages/app-project/stores/UserPersonalization.spec.js
@@ -123,7 +123,6 @@ describe('Stores > UserPersonalization', function () {
         rootStore.user.personalization.increment()
       })
 
-
       it('should add 1 to your total count', function () {
         expect(rootStore.user.personalization.totalClassificationCount).to.equal(24)
       })
@@ -210,6 +209,25 @@ describe('Stores > UserPersonalization', function () {
 
       it('should add 1 to your total count', function () {
         expect(rootStore.user.personalization.totalClassificationCount).to.equal(1)
+      })
+    })
+
+    describe('incrementing your classification count to 5', function () {
+      before(function () {
+        rootStore.user.personalization.reset()
+        rootStore.user.personalization.increment()
+        rootStore.user.personalization.increment()
+        rootStore.user.personalization.increment()
+        rootStore.user.personalization.increment()
+        rootStore.user.personalization.increment()
+      })
+
+      it('should add 5 to your total count', function () {
+        expect(rootStore.user.personalization.totalClassificationCount).to.equal(5)
+      })
+
+      it('should not trigger the child UPP store to request user preferences from Panoptes', function () {
+        expect(rootStore.client.panoptes.get).to.have.not.been.called()
       })
     })
   })


### PR DESCRIPTION
Package:
- app-project

Closes #2467.

Describe your changes:
- adds test for anonymous user incrementing classifications 5 times, shouldn't trigger UPP store refresh
- add user existence check in increment action of UserPersonalization store before triggering UPP store refresh

Staging project for testing:
- https://local.zooniverse.org:3000/projects/nora-dot-test/planet-finders-beta/classify/workflow/3317?demo=true

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
