### PR TITLE
Engaging Crowds: add confirmation dialog for Next/Prev navigation

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Banners/Banners.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/Banners.js
@@ -10,7 +10,7 @@ import UserHasFinishedWorkflowBanner from './components/UserHasFinishedWorkflowB
 function useStores(stores) {
   const { classifierStore } = stores ?? React.useContext(MobXProviderContext)
   return {
-    annotations: classifierStore.annotations,
+    annotatedSteps: classifierStore.annotatedSteps,
     subject: classifierStore.subjects.active,
     subjects: classifierStore.subjects,
     workflow: classifierStore.workflows.active
@@ -20,14 +20,14 @@ function useStores(stores) {
 const environment = process.env.APP_ENV
 
 function Banners({ stores }) {
-  const { annotations, subject, subjects, workflow } = useStores(stores)
+  const { annotatedSteps, subject, subjects, workflow } = useStores(stores)
   const subjectNumber = subject?.priority ?? -1
   const hasIndexedSubjects = workflow?.hasIndexedSubjects
   const hasGroupedOrderedSubjects = workflow?.grouped && workflow?.prioritized
   if (environment !== 'production' && hasIndexedSubjects && subjectNumber > -1) {
     return (
       <SubjectSetProgressBanner
-        annotations={annotations}
+        checkForProgress={annotatedSteps.checkForProgress}
         onNext={subjects.nextIndexed}
         onPrevious={subjects.previousIndexed}
         subject={subject}

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/Banners.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/Banners.js
@@ -10,6 +10,7 @@ import UserHasFinishedWorkflowBanner from './components/UserHasFinishedWorkflowB
 function useStores(stores) {
   const { classifierStore } = stores ?? React.useContext(MobXProviderContext)
   return {
+    annotations: classifierStore.annotations,
     subject: classifierStore.subjects.active,
     subjects: classifierStore.subjects,
     workflow: classifierStore.workflows.active
@@ -19,13 +20,14 @@ function useStores(stores) {
 const environment = process.env.APP_ENV
 
 function Banners({ stores }) {
-  const { subject, subjects, workflow } = useStores(stores)
+  const { annotations, subject, subjects, workflow } = useStores(stores)
   const subjectNumber = subject?.priority ?? -1
   const hasIndexedSubjects = workflow?.hasIndexedSubjects
   const hasGroupedOrderedSubjects = workflow?.grouped && workflow?.prioritized
   if (environment !== 'production' && hasIndexedSubjects && subjectNumber > -1) {
     return (
       <SubjectSetProgressBanner
+        annotations={annotations}
         onNext={subjects.nextIndexed}
         onPrevious={subjects.previousIndexed}
         subject={subject}

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.js
@@ -7,7 +7,7 @@ import Banner from '../Banner'
 
 counterpart.registerTranslations('en', en)
 
-function SubjectSetProgressBanner({ annotations, onNext, onPrevious, subject, workflow }) {
+function SubjectSetProgressBanner({ checkForProgress, onNext, onPrevious, subject, workflow }) {
   const setName = workflow?.subjectSet?.display_name || ''
   const subjectTotal = workflow?.subjectSet.set_member_subjects_count
   const background = (subject?.alreadySeen || subject?.retired) ? 'status-critical' : 'status-ok'
@@ -24,7 +24,7 @@ function SubjectSetProgressBanner({ annotations, onNext, onPrevious, subject, wo
   const bannerText = statusText ? `${progressText} (${statusText})` : progressText
 
   const tryToGoNext = () => {
-    console.log('+++ annotations : ', annotations)
+    console.log('+++ checkForProgress : ', checkForProgress())
     onNext()
   }
 
@@ -48,7 +48,7 @@ function SubjectSetProgressBanner({ annotations, onNext, onPrevious, subject, wo
 }
 
 SubjectSetProgressBanner.propTypes = {
-  // annotations: ???,  // TODO: what is the propTypes for a shape? object?
+  checkForProgress: func,
   onNext: func,
   onPrevious: func,
   subject: shape({

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.js
@@ -7,7 +7,7 @@ import Banner from '../Banner'
 
 counterpart.registerTranslations('en', en)
 
-function SubjectSetProgressBanner({ onNext, onPrevious, subject, workflow }) {
+function SubjectSetProgressBanner({ annotations, onNext, onPrevious, subject, workflow }) {
   const setName = workflow?.subjectSet?.display_name || ''
   const subjectTotal = workflow?.subjectSet.set_member_subjects_count
   const background = (subject?.alreadySeen || subject?.retired) ? 'status-critical' : 'status-ok'
@@ -23,20 +23,32 @@ function SubjectSetProgressBanner({ onNext, onPrevious, subject, workflow }) {
 
   const bannerText = statusText ? `${progressText} (${statusText})` : progressText
 
+  const tryToGoNext = () => {
+    console.log('+++ annotations : ', annotations)
+    onNext()
+  }
+
+  const tryToGoPrevious = () => {
+    onPrevious()
+  }
+
   return (
-    <Banner
-      background={background}
-      bannerText={bannerText}
-      color={color}
-      onNext={onNext}
-      onPrevious={onPrevious}
-      show
-      tooltipText={tooltipText}
-    />
+    <>
+      <Banner
+        background={background}
+        bannerText={bannerText}
+        color={color}
+        onNext={tryToGoNext}
+        onPrevious={tryToGoPrevious}
+        show
+        tooltipText={tooltipText}
+      />
+    </>
   )
 }
 
 SubjectSetProgressBanner.propTypes = {
+  // annotations: ???,  // TODO: what is the propTypes for a shape? object?
   onNext: func,
   onPrevious: func,
   subject: shape({

--- a/packages/lib-classifier/src/store/AnnotatedSteps/AnnotatedSteps.js
+++ b/packages/lib-classifier/src/store/AnnotatedSteps/AnnotatedSteps.js
@@ -133,11 +133,19 @@ const AnnotatedSteps = types.model('AnnotatedSteps', {
     })
   }
 
+  /** Checks if the user has started making any annotations. Returns boolean */
+  function checkForProgress() {
+    // TODO
+    return Math.random() <= 0.5
+  }
+
+
   return {
     back,
     finish,
     next,
-    start
+    start,
+    checkForProgress
   }
 })
 


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`
Project: Engaging Crowds

Context: Engaging Crowds introduces the ability for users to _select individual Subjects_ in an _indexed, organised Subject Set._ (e.g. Subject Set = a book, Subject = pages, in order) This feature also allows a user to go to the Previous or Next Subject in the indexed set (similar to reading a book). However, there's a possibility that a user might inadvertently move to the Prev/Next Subject while they're still working on the current Subject, not realising they might lose any work in progress.

The intent of this PR is to add a confirmation dialog, prompting users "Are you sure you want to navigate to the Next/Previous Subject?" IF they've already started annotating the current Subject.

Components:
- [ ] Add a mechanism in the annotations (AnnotatedSteps, actually) to check if any there is ANY annotation with their `._inProgress` value set to true.
- [ ] Connect that "checkForProgress" mechanism up to the `SubjectProgressBanner` (which contains the Next/Prev nav buttons, and only displays for grouped WFs with indexed Subject Sets)
- [ ] Modify the Next/Prev nav button logic to check the "checkForProgress" mechanism
- [ ] Add the "Are you SURE??" modal

Intended Behaviour:
- Applicable only for grouped WFs with indexed Subject Sets which allow single Subject selection
- On the Classifier, with a Subject selected:
  - If user has NOT started making any annotations (current step, previous step, or next step, whatever), clicking the Next or Previous nav button should take the user to the next/previous Subject immediately.
  - If user HAS started making any notations, clicking the Next or Previous nav button should open the "Are you sure?" modal
    - If user says yes, the modal closes and then navigation happens as intended.
    - If user says no, the modal closes with no further action.

### Testing

Currently testing on an EC project that has Indexed Subject Sets and Individual Subject Selection enabled, i.e. Scarlet and Blues. Please be aware that this is a rather unique setup with several external dependencies, so describing the full process of replicating that project + external dependencies for "standalone testing" is beyond the scope of this PR.

Basically, just click this link to test, and hope it's still alive when you're reading this: https://frontend.preview.zooniverse.org/projects/bogden/scarlets-and-blues/classify/workflow/18505/subject-set/98217/subject/68961909?env=production

### Status

WIP