### PR TITLE
Fix SubjectSetProgressBanner stories

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.js
@@ -1,5 +1,5 @@
 import counterpart from 'counterpart'
-import { bool, func, shape, string } from 'prop-types'
+import { bool, func, number, shape, string } from 'prop-types'
 import React, { Component, useState } from 'react'
 
 import en from './locales/en'
@@ -8,6 +8,11 @@ import ConfirmModal from './components/ConfirmModal'
 
 counterpart.registerTranslations('en', en)
 
+/**
+  A banner which shows progress through a prioritised subject set, showing `subject.metadata.priority` to the volunteer.
+
+  Optionally, it can also show Next and Previous subject navigation buttons for indexed workflows.
+*/
 function SubjectSetProgressBanner({
   checkForProgress = false,
   onNext,
@@ -91,15 +96,26 @@ function SubjectSetProgressBanner({
 }
 
 SubjectSetProgressBanner.propTypes = {
+  /** Check for classification work in progress. */
   checkForProgress: bool,
+  /** Callback to load the next subject (indexed workflows only.) */
   onNext: func,
+  /** Callback to load the previous subject (indexed workflows only.) */
   onPrevious: func,
+  /** The active subject */
   subject: shape({
     alreadySeen: bool,
     finished_workflow: bool,
     id: string,
     retired: bool,
     user_has_finished_workflow: bool
+  }),
+  /** The active workflow */
+  workflow: shape({
+    subjectSet: shape({
+      display_name: string,
+      set_member_subjects_count: number
+    })
   })
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.stories.js
@@ -1,8 +1,7 @@
 import React from 'react'
-import { Provider } from 'mobx-react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Grommet } from 'grommet'
-import Banners from '../../Banners'
+import SubjectSetProgressBanner from './SubjectSetProgressBanner'
 // import readme from '../../README.md'
 import { SubjectFactory, SubjectSetFactory, WorkflowFactory } from '@test/factories'
 import mockStore from '@test/mockStore'
@@ -21,12 +20,14 @@ function buildMocks({ already_seen, metadata = { ['#priority']: 37 }, retired })
   })
   const store = mockStore({ subject: subjectSnapshot, subjectSet: subjectSetSnapshot, workflow: workflowSnapshot })
 
-  return store
+  const subject = store.subjects.active
+  const workflow = store.workflows.resources.get(workflowSnapshot.id)
+  return { subject, workflow }
 }
 
 export default {
   title: 'Banners / Subject Set Progress Banner',
-  component: Banners,
+  component: SubjectSetProgressBanner,
   // parameters: {
   //   docs: {
   //     description: {
@@ -37,18 +38,19 @@ export default {
 }
 
 export function Default({ already_seen, dark, retired }) {
-  const store = buildMocks({ already_seen, retired })
+  const { subject, workflow } = buildMocks({ already_seen, retired })
   return (
     <Grommet
       theme={Object.assign({}, zooTheme, { dark })}
       themeMode={(dark) ? 'dark' : 'light'}
     >
-      <Provider classifierStore={store}>
-        <Box background={{ dark: 'dark-3', light: 'light-3' }} width='large'>
-          <Banners />
-          <img src="https://placekitten.com/800/400" alt='placeholder' />
-        </Box>
-      </Provider>
+      <Box background={{ dark: 'dark-3', light: 'light-3' }} width='large'>
+        <SubjectSetProgressBanner
+          subject={subject}
+          workflow={workflow}
+        />
+        <img src="https://placekitten.com/800/400" alt='placeholder' />
+      </Box>
     </Grommet>
   )
 }
@@ -60,37 +62,39 @@ Default.args = {
 }
 
 export function WithVisiblePriorityMetadata({ already_seen, dark, retired }) {
-  const priority = { priority: 37 }
-  const store = buildMocks({ already_seen, priority, retired })
+  const metadata = { priority: 37 }
+  const { subject, workflow } = buildMocks({ already_seen, metadata, retired })
   return (
     <Grommet
       theme={Object.assign({}, zooTheme, { dark })}
       themeMode={(dark) ? 'dark' : 'light'}
     >
-      <Provider classifierStore={store}>
-        <Box background={{ dark: 'dark-3', light: 'light-3' }} width='large'>
-          <Banners />
-          <img src="https://placekitten.com/800/400" alt='placeholder' />
-        </Box>
-      </Provider>
+      <Box background={{ dark: 'dark-3', light: 'light-3' }} width='large'>
+        <SubjectSetProgressBanner
+          subject={subject}
+          workflow={workflow}
+        />
+        <img src="https://placekitten.com/800/400" alt='placeholder' />
+      </Box>
     </Grommet>
   )
 }
 
 export function WithVisiblePriorityMetadataAndRetired({ already_seen, dark, retired }) {
-  const priority = { priority: 37 }
-  const store = buildMocks({ already_seen, priority, retired })
+  const metadata = { priority: 37 }
+  const { subject, workflow } = buildMocks({ already_seen, metadata, retired })
   return (
     <Grommet
       theme={Object.assign({}, zooTheme, { dark })}
       themeMode={(dark) ? 'dark' : 'light'}
     >
-      <Provider classifierStore={store}>
-        <Box background={{ dark: 'dark-3', light: 'light-3' }} width='large'>
-          <Banners />
-          <img src="https://placekitten.com/800/400" alt='placeholder' />
-        </Box>
-      </Provider>
+      <Box background={{ dark: 'dark-3', light: 'light-3' }} width='large'>
+        <SubjectSetProgressBanner
+          subject={subject}
+          workflow={workflow}
+        />
+        <img src="https://placekitten.com/800/400" alt='placeholder' />
+      </Box>
     </Grommet>
   )
 }
@@ -102,19 +106,20 @@ WithVisiblePriorityMetadataAndRetired.args = {
 }
 
 export function WithVisiblePriorityMetadataAndAlreadySeen({ already_seen, dark, retired }) {
-  const priority = { priority: 37 }
-  const store = buildMocks({ already_seen, priority, retired })
+  const metadata = { priority: 37 }
+  const { subject, workflow } = buildMocks({ already_seen, metadata, retired })
   return (
     <Grommet
       theme={Object.assign({}, zooTheme, { dark })}
       themeMode={(dark) ? 'dark' : 'light'}
     >
-      <Provider classifierStore={store}>
-        <Box background={{ dark: 'dark-3', light: 'light-3' }} width='large'>
-          <Banners />
-          <img src="https://placekitten.com/800/400" alt='placeholder' />
-        </Box>
-      </Provider>
+      <Box background={{ dark: 'dark-3', light: 'light-3' }} width='large'>
+        <SubjectSetProgressBanner
+          subject={subject}
+          workflow={workflow}
+        />
+        <img src="https://placekitten.com/800/400" alt='placeholder' />
+      </Box>
     </Grommet>
   )
 }
@@ -126,18 +131,19 @@ WithVisiblePriorityMetadataAndAlreadySeen.args = {
 }
 
 export function WithRetiredSubject({ already_seen, dark, retired }) {
-  const store = buildMocks({ already_seen, retired })
+  const { subject, workflow } = buildMocks({ already_seen, retired })
   return (
     <Grommet
       theme={Object.assign({}, zooTheme, { dark })}
       themeMode={(dark) ? 'dark' : 'light'}
     >
-      <Provider classifierStore={store}>
-        <Box background={{ dark: 'dark-3', light: 'light-3' }} width='large'>
-          <Banners />
-          <img src="https://placekitten.com/800/400" alt='placeholder' />
-        </Box>
-      </Provider>
+      <Box background={{ dark: 'dark-3', light: 'light-3' }} width='large'>
+        <SubjectSetProgressBanner
+          subject={subject}
+          workflow={workflow}
+        />
+        <img src="https://placekitten.com/800/400" alt='placeholder' />
+      </Box>
     </Grommet>
   )
 }
@@ -149,18 +155,19 @@ WithRetiredSubject.args = {
 }
 
 export function WithAlreadySeenSubject({ already_seen, dark, retired }) {
-  const store = buildMocks({ already_seen, retired })
+  const { subject, workflow } = buildMocks({ already_seen, retired })
   return (
     <Grommet
       theme={Object.assign({}, zooTheme, { dark })}
       themeMode={(dark) ? 'dark' : 'light'}
     >
-      <Provider classifierStore={store}>
-        <Box background={{ dark: 'dark-3', light: 'light-3' }} width='large'>
-          <Banners />
-          <img src="https://placekitten.com/800/400" alt='placeholder' />
-        </Box>
-      </Provider>
+      <Box background={{ dark: 'dark-3', light: 'light-3' }} width='large'>
+        <SubjectSetProgressBanner
+          subject={subject}
+          workflow={workflow}
+        />
+        <img src="https://placekitten.com/800/400" alt='placeholder' />
+      </Box>
     </Grommet>
   )
 }


### PR DESCRIPTION
Remove `Provider`. Render `SubjectSetProgressBanner`, not `Banners`. Wire up story controls to component props.

Since #2402, the stories are broken with
```
MobX Provider: The set of provided stores has changed. See: https://github.com/mobxjs/mobx-react#the-set-of-provided-stores-has-changed-error.
```

The controls should be updating component props, not generating a new MobX store, when they change.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
