### PR TITLE
Fix: Next and Previous button should only appear when onNext and onPrevious is defined

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.js
@@ -10,8 +10,8 @@ counterpart.registerTranslations('en', en)
 
 function SubjectSetProgressBanner({
   checkForProgress = () => { return false },
-  onNext = () => {},
-  onPrevious = () => {},
+  onNext,
+  onPrevious,
   subject,
   workflow
 }) {


### PR DESCRIPTION
## PR Overview

Package: lib-classifier

#2470 introduced a bug which causes the "Next" and "Previous" button to ALWAYS appear on the Subject Set Progress Banner, regardless of whether or not it has indexed Subjects.

This was caused by `Banner.onNext` and `Banner.onPrevious` being ALWAYS defined, in turn due to `SubjectSetProgressBanner.onNext/onPrev` now being wrapped in tryToGoNext/Previous. This PR fixes that by adding existence checks for the appropriate functions.

### Status

Testing in progress.