### PR TITLE
Engaging Crowds: hide Next and Prev buttons behind indexedSubjectSetNextPrevButton experimental flag

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Banners/Banners.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/Banners.js
@@ -18,8 +18,6 @@ function useStores(stores) {
   }
 }
 
-const environment = process.env.APP_ENV
-
 function Banners({ stores }) {
   const { annotatedSteps, project, subject, subjects, workflow } = useStores(stores)
   const subjectNumber = subject?.priority ?? -1
@@ -29,10 +27,10 @@ function Banners({ stores }) {
   // Next/Prev buttons are only enabled when Project has the experimental tool enabled AND the Subject Set is indexed.
   const enableIndexedSubjectSetNextPrevButtons =
     project?.experimental_tools?.includes('indexedSubjectSetNextPrevButtons')
-  const onPrevious = enableIndexedSubjectSetNextPrevButtons && subjects.previousIndexed
-  const onNext = enableIndexedSubjectSetNextPrevButtons && subjects.nextIndexed
+  const onPrevious = subjects.previousIndexed
+  const onNext = subjects.nextIndexed
 
-  if (environment !== 'production' && hasIndexedSubjects && subjectNumber > -1) {
+  if (enableIndexedSubjectSetNextPrevButtons && hasIndexedSubjects && subjectNumber > -1) {
     return (
       <SubjectSetProgressBanner
         checkForProgress={annotatedSteps.checkForProgress}


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`
Project: Engaging Crowds

This PR modifies the behaviour of the Subject Set Progress banner:

- Prior to this PR, the Subject Set Progress banner will show the "Next" and "Previous" navigation buttons as long as the subject is part of an indexed Subject Set. (i.e. the set is indexed on the Subject Set Search API)
- With this PR, the "Next" and "Previous" navigation buttons will only show when the subject is part of an indexed Subject Set, **and** the `indexedSubjectSetNextPrevButton` **experimental tool is enabled on the project level.**

_Example Scarlets & Blues subject (which is part of an indexed Subject Set) WITHOUT the experimental tool enabled_
![image](https://user-images.githubusercontent.com/13952701/138350895-d709065f-4b1b-4287-b6c2-391382095e1c.png)

_Same thing, but WITH the experimental tool_
![image](https://user-images.githubusercontent.com/13952701/138351165-7d364fc6-d70e-4db5-964c-35eb7558225b.png)

Context: turns out, the next/prev buttons shouldn't be enabled for _every_ Engaging Crowds projects that has indexed subject sets. This experimental_tool flag allows more granular control over when the Next/Prev button appears.

### Testing

- Test URL: [Scarlets & Blues](https://local.zooniverse.org:8080/?env=production&project=12268&workflow=18504&subjectSet=98218&subject=68962003)
  - Scarlet & Blues is one of the few projects with Indexed Subject Sets, so our pool of test projects is very small.
- How to test:
  - See https://github.com/zooniverse/Panoptes-Front-End/pull/6034 for the complementary PFE PR that allows admins to add/remove this new experimental tool flag.
  - Login as admin, then go to https://pr-6034.pfe-preview.zooniverse.org/admin/project_status/bogden/scarlets-and-blues?env=production
  - Add or remove the `indexedSubjectSetNextPrevButton` experimental tool to the Scarlets & Blues project. ❗⚠️ WARNING: this is a production project!
  - Observe the changes on the test URL

### Status

Ready for review