### PR TITLE
Revert "Classifier: try to improve Choice test performance"

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/Choice.js
@@ -46,7 +46,6 @@ export default function Choice (props) {
         dark: 'dark-1',
         light: 'light-1'
       }}
-      data-testid={`choice-${choiceId}`}
       elevation='large'
       flex='grow'
       pad='small'

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/Choice.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/Choice.spec.js
@@ -1,221 +1,156 @@
 import { expect } from 'chai'
 import React from 'react'
 import sinon from 'sinon'
-import { cleanup, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { task as mockTask } from '@plugins/tasks/SurveyTask/mock-data'
 import Choice from './Choice'
 import en from './locales/en'
 
-describe('Component > Choice', function () {
-  describe('default', function () {
-    let choice
-
-    before(function () {
-      render(
-        <Choice
-          choiceId='KD'
-          task={mockTask}
-        />
-      )
-      choice = screen.getByTestId('choice-KD')
-    })
-
-    after(function () {
-      cleanup()
-    })
-
-    it('should render without crashing', function () {
-      expect(choice).to.be.ok()
-    })
+describe.skip('Component > Choice', function () {
+  it('should render without crashing', function () {
+    render(
+      <Choice
+        choiceId='KD'
+        task={mockTask}
+      />
+    )
+    expect(screen).to.be.ok()
   })
 
-  describe('handleDelete callback', function () {
-    let handleDeleteSpy
+  it('should call handleDelete when "Not this" button clicked', function () {
+    const handleDeleteSpy = sinon.spy()
+    render(
+      <Choice
+        choiceId='KD'
+        handleDelete={handleDeleteSpy}
+        task={mockTask}
+      />
+    )
+    userEvent.click(screen.getByText(en.Choice.notThis))
 
-    before(function () {
-      handleDeleteSpy = sinon.spy()
-      render(
-        <Choice
-          choiceId='KD'
-          handleDelete={handleDeleteSpy}
-          task={mockTask}
-        />
-      )
-      const notThis = screen.getByText(en.Choice.notThis)
-      userEvent.click(notThis)
-    })
-
-    after(function () {
-      cleanup()
-    })
-
-    it('should be called when "Not this" button is clicked', function () {
-      expect(handleDeleteSpy).to.have.been.calledOnceWith('KD')
-    })
+    expect(handleDeleteSpy).to.have.been.calledOnceWith('KD')
   })
 
-  describe('onIdentify callback', function () {
-    let onIdentifySpy
+  it('should call onIdentify when "Identify" button clicked', function () {
+    const onIdentifySpy = sinon.spy()
+    render(
+      <Choice
+        choiceId='FR'
+        onIdentify={onIdentifySpy}
+        task={mockTask}
+      />
+    )
+    userEvent.click(screen.getByText(en.Choice.identify))
 
-    before(function () {
-      onIdentifySpy = sinon.spy()
-      render(
-        <Choice
-          choiceId='FR'
-          onIdentify={onIdentifySpy}
-          task={mockTask}
-        />
-      )
-      const identify = screen.getByText(en.Choice.identify) 
-      userEvent.click(identify)
-    })
-
-    after(function () {
-      cleanup()
-    })
-
-    it('should be called when "Identify" button clicked', function () {
-      expect(onIdentifySpy).to.have.been.calledOnce()
-    })
+    expect(onIdentifySpy).to.have.been.calledOnce()
   })
 
-  describe('with choice with images and confusions', function () {
+  describe('with choice with images, confusions, and questions', function () {
     // choice 'KD' (Kudu) includes images, confusions, and questions
-    let carousel, confusedWith
-
-    before(function () {
-      render(
-        <Choice
-          choiceId='KD'
-          task={mockTask}
-        />
-      )
-      carousel = screen.getByTestId('choice-images')
-      confusedWith = screen.getByText('Sometimes confused with')
-    })
-
-    after(function () {
-      cleanup()
-    })
 
     it('should render Carousel', function () {
-      expect(carousel).to.exist()
+      render(
+        <Choice
+          choiceId='KD'
+          task={mockTask}
+        />
+      )
+      expect(screen.getByTestId('choice-images')).to.exist()
     })
 
     it('should render ConfusedWith', function () {
-      expect(confusedWith).to.exist()
-    })
-  })
-
-  describe('with choice with questions', function () {
-    // choice 'KD' (Kudu) includes images, confusions, and questions
-    let question
-
-    before(function () {
       render(
         <Choice
           choiceId='KD'
           task={mockTask}
         />
       )
-      question = screen.getByText('Are there any young present?')
-    })
-
-    after(function () {
-      cleanup()
+      expect(screen.getByText('Sometimes confused with')).to.exist()
     })
 
     it('should render Questions', function () {
-      expect(question).to.exist()
-    })
-  })
-
-  describe('with choice without images, with confusions', function () {
-    // choice 'NTHNGHR' (Nothing here) excludes images, includes confusions
-    let carousel, fire
-
-    before(function () {
-      render(
-        <Choice
-          choiceId='NTHNGHR'
-          task={mockTask}
-        />
-      )
-      carousel = screen.queryByTestId('choice-images')
-      fire = screen.getByText('Fire')
-    })
-
-    after(function () {
-      cleanup()
-    })
-
-    it('should have the first ConfusedWith button as the document active element', function () {
-      expect(fire).to.equal(document.activeElement)
-    })
-
-    it('should not render Carousel', function () {
-      expect(carousel).to.be.null()
-    })
-  })
-
-  describe('with choice without images or confusions, with questions', function () {
-    // choice 'HMN' (Human) excludes images and confusions, includes questions
-    let activeElement, confusedWith, yesAnswer
-
-    before(function () {
       render(
         <Choice
           choiceId='HMN'
           task={mockTask}
         />
       )
-      confusedWith = screen.queryByText('Sometimes confused with')
-      yesAnswer = screen.getByLabelText('Yes')
+      expect(screen.getByText('Are there any young present?')).to.exist()
+    })
+  })
+
+  describe('with choice without images, with confusions', function () {
+    // choice 'NTHNGHR' (Nothing here) excludes images, includes confusions
+
+    it('should not render Carousel', function () {
+      render(
+        <Choice
+          choiceId='NTHNGHR'
+          task={mockTask}
+        />
+      )
+      expect(screen.queryByTestId('choice-images')).to.be.null()
     })
 
-    after(function () {
-      cleanup()
+    it('should have the first ConfusedWith button as the document active element', function () {
+      render(
+        <Choice
+          choiceId='NTHNGHR'
+          task={mockTask}
+        />
+      )
+      expect(screen.getByText('Fire')).to.equal(document.activeElement)
+    })
+  })
+
+  describe('with choice without images or confusions, with questions', function () {
+    // choice 'HMN' (Human) excludes images and confusions, includes questions
+
+    it('should not render ConfusedWith', function () {
+      render(
+        <Choice
+          choiceId='HMN'
+          task={mockTask}
+        />
+      )
+      expect(screen.queryByText('Sometimes confused with')).to.be.null()
     })
 
     it('should have the first Questions input as the document active element', function () {
-      expect(yesAnswer).to.equal(document.activeElement)
-    })
-
-    it('should not render ConfusedWith', function () {
-      expect(confusedWith).to.be.null()
+      render(
+        <Choice
+          choiceId='HMN'
+          task={mockTask}
+        />
+      )
+      expect(screen.getByLabelText('Yes')).to.equal(document.activeElement)
     })
   })
 
   describe('with choice without more than 1 image, confusions, or questions', function () {
     // choice 'FR' (Fire) has 1 image, excludes confusions and questions
-    let activeElement, radioButtons, checkboxes, identify
 
-    before(function () {
+    it('should not render Questions', function () {
       render(
         <Choice
           choiceId='FR'
           task={mockTask}
         />
       )
-      radioButtons = screen.queryAllByRole('radio', { hidden: true })
-      checkboxes = screen.queryAllByRole('checkbox', { hidden: true })
-      identify = screen.getByRole('button', { name: en.Choice.identify }, { hidden: true })
-      const activeElement = document.activeElement
-    })
-
-    after(function () {
-      cleanup()
+      expect(screen.queryAllByRole('radio', { hidden: true })).to.have.lengthOf(0)
+      expect(screen.queryAllByRole('checkbox', { hidden: true })).to.have.lengthOf(0)
     })
 
     it('should have the "Identify" button as the document active element', function () {
-      expect(identify).to.equal(document.activeElement)
-    })
-
-    it('should not render Questions', function () {
-      expect(radioButtons).to.have.lengthOf(0)
-      expect(checkboxes).to.have.lengthOf(0)
+      render(
+        <Choice
+          choiceId='FR'
+          task={mockTask}
+        />
+      )
+      expect(screen.getByRole('button', { name: en.Choice.identify }, { hidden: true })).to.equal(document.activeElement)
     })
   })
 })


### PR DESCRIPTION
Reverts zooniverse/front-end-monorepo#2449

`Choice` component tests are breaking CI for open PRs, so this reverts them back to being skipped.