### PR TITLE
Fix OpenGraph preview URLs

### DIFF
--- a/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.js
+++ b/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.js
@@ -1,6 +1,13 @@
 import getCookie from '@helpers/getCookie'
 import getStaticPageProps from '@helpers/getStaticPageProps'
 
+const environment = process.env.APP_ENV
+
+const HOSTS = {
+  production: 'https://www.zooniverse.org',
+  staging: 'https://frontend.preview.zooniverse.org'
+}
+
 export default async function getDefaultPageProps({ params, query, req }) {
 
   // cookie is in the next.js context req object
@@ -9,8 +16,7 @@ export default async function getDefaultPageProps({ params, query, req }) {
 
   const { props: staticProps } = await getStaticPageProps({ params, query })
   const { project, notFound, title, workflowID, workflows } = staticProps
-  const { headers, connection } = req
-  const host = generateHostUrl(headers, connection)
+  const host = HOSTS[environment] || 'https://localhost:3000'
   /*
     snapshot for store hydration in the browser
   */
@@ -38,9 +44,4 @@ export default async function getDefaultPageProps({ params, query, req }) {
   }
 
   return { notFound, props }
-}
-
-function generateHostUrl(headers, connection) {
-  const protocol = connection.encrypted ? 'https' : 'http'
-  return `${protocol}://${headers.host}`
 }


### PR DESCRIPTION
Define our production and staging hosts in the code. Default `pageProps.host` to `https://localhost:3000` if the deploy environment is undefined.

Try it out with `APP_ENV=staging yarn build && yarn start` or `APP_ENV=production yarn build && yarn start`.

Package:
app-project

Closes #2487.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
