### PR TITLE
Classifer: Edit component mappings in FieldGuideItem to not override Markdownz images

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItem/FieldGuideItem.js
@@ -42,7 +42,6 @@ const markdownComponents = {
   h4: (nodeProps) => <SpacedHeading level='4'>{nodeProps.children}</SpacedHeading>,
   h5: (nodeProps) => <SpacedHeading level='5'>{nodeProps.children}</SpacedHeading>,
   h6: (nodeProps) => <SpacedHeading level='6'>{nodeProps.children}</SpacedHeading>,
-  img: (nodeProps) => <Media alt={nodeProps.alt} src={nodeProps.src} />,
   p: (nodeProps) => <Paragraph margin={{ bottom: 'none', top: 'xxsmall' }}>{nodeProps.children}</Paragraph>
 }
 


### PR DESCRIPTION
## Package:
lib-classifier

## Issue
Closes #2507.

## Describe your changes:
Removed img from `componentMappings` in FieldGuideItem. The custom `componentMappings` was overriding the backwards compatibility built into Markdownz for custom image dimensions.

In PR #2463, img height constraints were removed in FieldGuideItem, so this mapping was left over and no longer necessary. Markdownz should handle image dimensions of FieldGuideItems instead.

## Testing
- To test, add custom image dimensions to the markdown image source of a field guide time:
- Example test project: https://local.zooniverse.org:8080/?project=1928&workflow=3458
- Image string for the purple image below contains "=80x" and correctly renders
![bt21](https://user-images.githubusercontent.com/23665803/139339440-878883b5-e03a-473c-a2f5-a232b07bde0f.jpg)

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
