### PR TITLE
Refactor user collections and recents

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.spec.js
@@ -59,9 +59,6 @@ describe('Component > ClassifyPageContainer', function () {
         toJSON: () => { }, // is this being used in the code somewhere? toJS() should be used instead
         urls: []
       },
-      recents: {
-        recents: []
-      },
       ui: {
         dismissProjectAnnouncementBanner: () => { },
         showAnnouncement: false
@@ -77,7 +74,10 @@ describe('Component > ClassifyPageContainer', function () {
           stats: {
             thisWeek: []
           }
-        }
+        },
+        recents: {
+          recents: []
+        },
       }
     }
 
@@ -159,9 +159,6 @@ describe('Component > ClassifyPageContainer', function () {
           toJSON: () => {}, // is this being used in the code somewhere? toJS() should be used instead
           urls: []
         },
-        recents: {
-          recents: []
-        },
         ui: {
           dismissProjectAnnouncementBanner: () => { },
           showAnnouncement: false
@@ -177,6 +174,9 @@ describe('Component > ClassifyPageContainer', function () {
             stats: {
               thisWeek: []
             }
+          },
+          recents: {
+            recents: []
           }
         }
       }
@@ -213,6 +213,9 @@ describe('Component > ClassifyPageContainer', function () {
                 stats: {
                   thisWeek: []
                 }
+              },
+              recents: {
+                recents: []
               }
             }
           })
@@ -248,7 +251,9 @@ describe('Component > ClassifyPageContainer', function () {
                   thisWeek: []
                 }
               },
-
+              recents: {
+                recents: []
+              }
             } 
           })
 
@@ -283,6 +288,9 @@ describe('Component > ClassifyPageContainer', function () {
               stats: {
                 thisWeek: []
               }
+            },
+            recents: {
+              recents: []
             }
           }})
         const wrapper = mount(
@@ -311,6 +319,9 @@ describe('Component > ClassifyPageContainer', function () {
               stats: {
                 thisWeek: []
               }
+            },
+            recents: {
+              recents: []
             }
           }
         })
@@ -359,9 +370,6 @@ describe('Component > ClassifyPageContainer', function () {
           toJSON: () => { }, // is this being used in the code somewhere? toJS() should be used instead
           urls: []
         },
-        recents: {
-          recents: []
-        },
         ui: {
           dismissProjectAnnouncementBanner: () => { },
           showAnnouncement: false
@@ -377,6 +385,9 @@ describe('Component > ClassifyPageContainer', function () {
             stats: {
               thisWeek: []
             }
+          },
+          recents: {
+            recents: []
           }
         }
       }

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperConnector.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperConnector.js
@@ -12,9 +12,7 @@ function useStore(store) {
   }
   const {
     appLoadingState,
-    collections,
     project,
-    recents,
     user,
     ui: {
       mode
@@ -23,10 +21,10 @@ function useStore(store) {
 
   return {
     appLoadingState,
-    collections,
+    collections : user.collections,
     mode,
     project,
-    recents,
+    recents: user.recents,
     user,
     yourStats: user.personalization
   }

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperConnector.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperConnector.spec.js
@@ -22,11 +22,11 @@ describe('Component > ClassifierWrapperConnector', function () {
 
     describe('classifier wrapper props', function () {
       it('should include collections', function () {
-        expect(wrapper.props().collections).to.equal(store.collections)
+        expect(wrapper.props().collections).to.equal(store.user.collections)
       })
 
       it('should include recents', function () {
-        expect(wrapper.props().recents).to.equal(store.recents)
+        expect(wrapper.props().recents).to.equal(store.user.recents)
       })
 
       it('should include your personal stats', function () {

--- a/packages/app-project/src/screens/ClassifyPage/components/RecentSubjects/RecentSubjectsConnector.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/RecentSubjects/RecentSubjectsConnector.js
@@ -7,11 +7,11 @@ import RecentSubjects from './RecentSubjects'
 function storeMapper (store) {
   const {
     project,
-    recents: {
-      recents
-    },
     user: {
-      isLoggedIn
+      isLoggedIn,
+      recents : {
+        recents
+      }
     }
   } = store
 

--- a/packages/app-project/src/shared/components/CollectionsModal/CollectionsModalContainer.js
+++ b/packages/app-project/src/shared/components/CollectionsModal/CollectionsModalContainer.js
@@ -8,7 +8,7 @@ import CreateCollection from './components/CreateCollection'
 
 function storeMapper (stores) {
   const store = stores.store || {}
-  const collectionsStore = store.collections || {}
+  const collectionsStore = store.user?.collections || {}
   const {
     addSubjects,
     collections,

--- a/packages/app-project/stores/Store.js
+++ b/packages/app-project/stores/Store.js
@@ -3,17 +3,13 @@ import { addDisposer, addMiddleware, getEnv, onAction, types } from 'mobx-state-
 import { autorun } from 'mobx'
 import { logToSentry } from '../src/helpers/logger'
 
-import Collections from './Collections'
 import Project from './Project'
-import Recents from './Recents'
 import UI from './UI'
 import User from './User'
 
 const Store = types
   .model('Store', {
-    collections: types.optional(Collections, {}),
     project: types.optional(Project, {}),
-    recents: types.optional(Recents, {}),
     ui: types.optional(UI, {}),
     user: types.optional(User, {})
   })

--- a/packages/app-project/stores/User/Collections/Collections.js
+++ b/packages/app-project/stores/User/Collections/Collections.js
@@ -25,21 +25,6 @@ const Collections = types
   .actions(self => {
     let client
 
-    function createProjectObserver () {
-      const projectDisposer = autorun(() => {
-        const project = getRoot(self).project
-        const user = getRoot(self).user
-        if (project.id && user.id) {
-          self.fetchFavourites()
-          self.searchCollections({
-            favorite: false,
-            current_user_roles: 'owner,collaborator,contributor'
-          })
-        }
-      })
-      addDisposer(self, projectDisposer)
-    }
-
     const fetchCollections = flow(function * fetchCollections (query) {
       try {
         self.loadingState = asyncStates.loading
@@ -92,7 +77,6 @@ const Collections = types
     return {
       afterAttach () {
         client = getRoot(self).client
-        createProjectObserver()
       },
 
       createCollection: flow(function * createCollection (

--- a/packages/app-project/stores/User/Collections/index.js
+++ b/packages/app-project/stores/User/Collections/index.js
@@ -1,0 +1,1 @@
+export { default } from './Collections'

--- a/packages/app-project/stores/User/Recents/Recents.js
+++ b/packages/app-project/stores/User/Recents/Recents.js
@@ -32,21 +32,7 @@ const Recents = types
   })
 
   .actions(self => {
-    function createProjectObserver () {
-      const projectDisposer = autorun(() => {
-        const { project, user } = getRoot(self)
-        if (project.id && user.id) {
-          self.fetch()
-        }
-      })
-      addDisposer(self, projectDisposer)
-    }
-
     return {
-      afterAttach () {
-        createProjectObserver()
-      },
-
       fetch: flow(function * fetch () {
         const { client, project, user } = getRoot(self)
         self.loadingState = asyncStates.loading

--- a/packages/app-project/stores/User/Recents/Recents.spec.js
+++ b/packages/app-project/stores/User/Recents/Recents.spec.js
@@ -3,8 +3,8 @@ import sinon from 'sinon'
 import { getSnapshot } from 'mobx-state-tree'
 import auth from 'panoptes-client/lib/auth'
 
-import initStore from './initStore'
-import { statsClient } from './User/UserPersonalization/YourStats'
+import initStore from '@stores/initStore'
+import { statsClient } from '../UserPersonalization/YourStats'
 
 describe('Stores > Recents', function () {
   let rootStore
@@ -32,7 +32,7 @@ describe('Stores > Recents', function () {
       }
     }
     rootStore = initStore(true, { project })
-    recentsStore = rootStore.recents
+    recentsStore = rootStore.user.recents
     sinon.stub(rootStore.client.panoptes, 'get').callsFake(() => Promise.resolve(mockResponse))
     sinon.stub(statsClient, 'request').callsFake(() => Promise.resolve(null))
   })
@@ -53,13 +53,13 @@ describe('Stores > Recents', function () {
         id: '123',
         login: 'test.user'
       }
-      sinon.stub(rootStore.collections, 'fetchFavourites')
+      sinon.stub(rootStore.user.collections, 'fetchFavourites')
       rootStore.user.set(user)
     })
 
     after(function () {
       rootStore.client.panoptes.get.resetHistory()
-      rootStore.collections.fetchFavourites.restore()
+      rootStore.user.collections.fetchFavourites.restore()
     })
 
     it('should request recent subjects from Panoptes', function () {
@@ -107,7 +107,7 @@ describe('Stores > Recents', function () {
   describe('with a project and anonymous user', function () {
     before(function () {
       rootStore = initStore(true, { project })
-      recentsStore = rootStore.recents
+      recentsStore = rootStore.user.recents
     })
 
     it('should not request recent subjects from Panoptes', function () {
@@ -151,20 +151,20 @@ describe('Stores > Recents', function () {
 
     before(function () {
       rootStore = initStore(true, { project })
-      recentsStore = rootStore.recents
+      recentsStore = rootStore.user.recents
       const user = {
         id: '123',
         login: 'test.user'
       }
       sinon.stub(auth, 'checkBearerToken').callsFake(() => Promise.reject(new Error('Auth is not available')))
-      sinon.stub(rootStore.collections, 'fetchFavourites')
+      sinon.stub(rootStore.user.collections, 'fetchFavourites')
       rootStore.user.set(user)
       recentsStore.add(mockRecent)
     })
 
     after(function () {
       auth.checkBearerToken.restore()
-      rootStore.collections.fetchFavourites.restore()
+      rootStore.user.collections.fetchFavourites.restore()
     })
 
     it('should record subjects classified this session', function () {
@@ -187,19 +187,19 @@ describe('Stores > Recents', function () {
 
     before(function () {
       rootStore = initStore(true, { project })
-      recentsStore = rootStore.recents
+      recentsStore = rootStore.user.recents
       const user = {
         id: '123',
         login: 'test.user'
       }
       rootStore.client.panoptes.get.callsFake(() => Promise.reject(new Error('Panoptes is not available')))
-      sinon.stub(rootStore.collections, 'fetchFavourites')
+      sinon.stub(rootStore.user.collections, 'fetchFavourites')
       rootStore.user.set(user)
       recentsStore.add(mockRecent)
     })
 
     after(function () {
-      rootStore.collections.fetchFavourites.restore()
+      rootStore.user.collections.fetchFavourites.restore()
     })
 
     it('should record subjects classified this session', function () {

--- a/packages/app-project/stores/User/Recents/index.js
+++ b/packages/app-project/stores/User/Recents/index.js
@@ -1,0 +1,1 @@
+export { default } from './Recents'

--- a/packages/app-project/stores/User/User.js
+++ b/packages/app-project/stores/User/User.js
@@ -1,6 +1,9 @@
 import asyncStates from '@zooniverse/async-states'
 import { flow, types } from 'mobx-state-tree'
 import auth from 'panoptes-client/lib/auth'
+
+import Collections from './Collections'
+import Recents from './Recents'
 import UserPersonalization from './UserPersonalization'
 
 import numberString from '@stores/types/numberString'
@@ -8,12 +11,14 @@ import numberString from '@stores/types/numberString'
 const User = types
   .model('User', {
     avatar_src: types.maybeNull(types.string),
+    collections: types.optional(Collections, {}),
     display_name: types.maybeNull(types.string),
     error: types.maybeNull(types.frozen({})),
     id: types.maybeNull(numberString),
     login: types.maybeNull(types.string),
     loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.initialized),
-    personalization: types.optional(UserPersonalization, {})
+    personalization: types.optional(UserPersonalization, {}),
+    recents: types.optional(Recents, {})
   })
 
   .views(self => ({
@@ -52,6 +57,12 @@ const User = types
       self.id = user.id
       self.display_name = user.display_name
       self.login = user.login
+      self.recents.fetch()
+      self.collections.fetchFavourites()
+      self.collections.searchCollections({
+        favorite: false,
+        current_user_roles: 'owner,collaborator,contributor'
+      })
     }
   }))
 


### PR DESCRIPTION
Recents and Collections only make sense in the context of a user. This refactors `store.collections` and `store.recents` as `store.user.collections` and `store.user.recents`.

Package:
app-project


# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
