### PR TITLE
Refactor UPP data-fetching

### DIFF
--- a/packages/app-project/stores/User/UserPersonalization/UserPersonalization.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserPersonalization.js
@@ -64,7 +64,7 @@ const UserPersonalization = types
 
         const { user } = getRoot(self)
         if (user?.id && self.sessionCountIsDivisibleByFive) {
-          self.projectPreferences.refreshResource()
+          self.projectPreferences.refreshSettings()
         }
       },
 

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
@@ -45,27 +45,19 @@ const UserProjectPreferences = types
 
   }))
   .actions(self => {
-    const _fetch = flow(function * _fetch() {
+    async function _fetch() {
       const { client, project, user } = getRoot(self)
-      self.setLoadingState(asyncStates.loading)
-      try {
-        const token = yield auth.checkBearerToken()
-        const authorization = `Bearer ${token}`
-        const query = {
-          project_id: project.id,
-          user_id: user.id
-        }
-
-        const response = yield client.panoptes.get('/project_preferences', query, { authorization })
-        const [preferences] = response.body.project_preferences
-        if (preferences) {
-          self.setResource(preferences)
-        }
-        self.setLoadingState(asyncStates.success)
-      } catch (error) {
-        self.handleError(error)
+      const token = await auth.checkBearerToken()
+      const authorization = `Bearer ${token}`
+      const query = {
+        project_id: project.id,
+        user_id: user.id
       }
-    })
+
+      const response = await client.panoptes.get('/project_preferences', query, { authorization })
+      const [preferences] = response.body.project_preferences
+      return preferences
+    }
 
     return {
       reset() {
@@ -97,13 +89,29 @@ const UserProjectPreferences = types
       },
 
       fetchResource: flow(function* fetchResource() {
-        if (!self.id) {
-          yield _fetch()
+        try {
+          if (!self.id) {
+            self.setLoadingState(asyncStates.loading)
+            const preferences = yield _fetch()
+            if (preferences) {
+              self.setResource(preferences)
+            }
+            self.setLoadingState(asyncStates.success)
+          }
+        } catch (error) {
+          self.handleError(error)
         }
       }),
 
       refreshResource: flow(function * refreshResource() {
-        yield _fetch()
+        try {
+          const preferences = yield _fetch()
+          if (preferences) {
+            self.preferences = preferences.preferences
+          }
+        } catch (error) {
+          self.handleError(error)
+        }
       })
     }
   })

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
@@ -2,6 +2,7 @@ import { applySnapshot, flow, getRoot, types } from 'mobx-state-tree'
 import auth from 'panoptes-client/lib/auth'
 import asyncStates from '@zooniverse/async-states'
 
+import { logToSentry } from '@helpers/logger'
 import numberString from '@stores/types/numberString'
 
 const Preferences = types
@@ -83,12 +84,6 @@ const UserProjectPreferences = types
         applySnapshot(self, resource)
       },
 
-      handleError(error) {
-        console.error(error)
-        self.error = error
-        self.setLoadingState(asyncStates.error)
-      },
-
       setLoadingState(state) {
         self.loadingState = state
       },
@@ -104,7 +99,10 @@ const UserProjectPreferences = types
             self.setLoadingState(asyncStates.success)
           }
         } catch (error) {
-          self.handleError(error)
+          console.error(error)
+          logToSentry(error)
+          self.error = error
+          self.setLoadingState(asyncStates.error)
         }
       }),
 
@@ -115,7 +113,7 @@ const UserProjectPreferences = types
             self.settings = preferences.settings
           }
         } catch (error) {
-          self.handleError(error)
+          console.error(error)
         }
       })
     }

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
@@ -34,12 +34,15 @@ const UserProjectPreferences = types
     settings: types.maybe(Settings)
   })
   .views(self => ({
+    get assignedWorkflowID() {
+      return self.settings?.workflow_id
+    },
+
     promptAssignment(currentWorkflowID) {
       const project = getRoot(self).project
-      const assignedWorkflowID = self.settings?.workflow_id
 
-      if (assignedWorkflowID && currentWorkflowID && assignedWorkflowID !== currentWorkflowID) {
-        return project.workflowIsActive(assignedWorkflowID)
+      if (self.assignedWorkflowID && currentWorkflowID && self.assignedWorkflowID !== currentWorkflowID) {
+        return project.workflowIsActive(self.assignedWorkflowID)
       }
 
       return false

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
@@ -11,6 +11,11 @@ const Preferences = types
     tutorials_completed_at: types.maybe(types.frozen())
   })
 
+const Settings = types
+  .model('Settings', {
+    workflow_id: types.maybe(types.string)
+  })
+
 const UserProjectPreferences = types
   .model('UserProjectPreferences', {
     activity_count: types.maybe(types.number),
@@ -25,7 +30,7 @@ const UserProjectPreferences = types
     ),
     loadingState: types.optional(types.enumeration('state', asyncStates.values), asyncStates.initialized),
     preferences: types.maybe(Preferences),
-    settings: types.maybe(types.frozen())
+    settings: types.maybe(Settings)
   })
   .views(self => ({
     promptAssignment(currentWorkflowID) {
@@ -103,11 +108,11 @@ const UserProjectPreferences = types
         }
       }),
 
-      refreshResource: flow(function * refreshResource() {
+      refreshSettings: flow(function * refreshSettings() {
         try {
           const preferences = yield _fetch()
           if (preferences) {
-            self.preferences = preferences.preferences
+            self.settings = preferences.settings
           }
         } catch (error) {
           self.handleError(error)

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
@@ -1,5 +1,6 @@
 import asyncStates from '@zooniverse/async-states'
 import sinon from 'sinon'
+import { when } from 'mobx'
 import nock from 'nock'
 
 import initStore from '@stores/initStore'
@@ -7,7 +8,6 @@ import { statsClient } from '../YourStats'
 import UserProjectPreferences from './UserProjectPreferences'
 
 describe('Stores > UserProjectPreferences', function () {
-  let nockScope, rootStore
   const project = {
     id: '2',
     display_name: 'Hello',
@@ -56,48 +56,52 @@ describe('Stores > UserProjectPreferences', function () {
     user_id: '123'
   }
 
-  before(function () {
-    sinon.stub(console, 'error')
-    sinon.stub(statsClient, 'request')
-    nockScope = nock('https://panoptes-staging.zooniverse.org/api')
-      .get('/collections') // This is to prevent the collections store from making real requests
-      .query(true)
-      .reply(200)
-      .post('/collections')
-      .query(true)
-      .reply(200)
-    rootStore = initStore(true, {
-      project,
-      user
-    })
-    sinon.spy(rootStore.client.panoptes, 'get')
-  })
+  function preferencesAreReady(preferences) {
+    return function preferencesAreLoaded() {
+      const { loadingState } = preferences
+      const { error, success } = asyncStates
+      return (loadingState === success) || (loadingState === error)
+    }
+  }
 
-  beforeEach(function () {
-    rootStore.client.panoptes.get.resetHistory()
+  before(function () {
+    sinon.stub(statsClient, 'request')
   })
 
   after(function () {
-    nock.cleanAll()
     statsClient.request.restore()
-    rootStore.client.panoptes.get.restore()
-    console.error.restore()
-    rootStore = null
   })
 
-  it('should exist', function () {
-    expect(UserProjectPreferences).to.be.an('object')
-  })
+  describe('with a snapshot', function () {
+    let rootStore
 
-  it('should not request for the resource if a snapshot has been applied', function () {
-    expect(rootStore.client.panoptes.get.withArgs(endpoint, query, { authorization })).to.not.have.been.called()
+    before(function () {
+      rootStore = initStore(true, {
+        project,
+        user
+      })
+      sinon.spy(rootStore.client.panoptes, 'get')
+    })
+
+    after(function () {
+      rootStore.client.panoptes.get.restore()
+    })
+
+    it('should exist', function () {
+      expect(UserProjectPreferences).to.be.an('object')
+    })
+
+    it('should not request for the resource if a snapshot has been applied', function () {
+      expect(rootStore.client.panoptes.get.withArgs(endpoint, query, { authorization })).to.not.have.been.called()
+    })
   })
 
   describe('fetching the resource', function () {
     describe('when there is a resource in the response', function () {
-      let nockScope
+      let rootStore
+
       before(function () {
-        nockScope = nock('https://panoptes-staging.zooniverse.org/api')
+        nock('https://panoptes-staging.zooniverse.org/api')
           .persist()
           .get('/project_preferences')
           .query(true)
@@ -106,37 +110,38 @@ describe('Stores > UserProjectPreferences', function () {
               upp
             ]
           })
-          .get('/collections') // This is to prevent the collections store from making real requests
-          .query(true)
-          .reply(200)
-          .post('/collections')
-          .query(true)
-          .reply(200)
 
-        // resetting for a clean test from the prior upper scope
-        rootStore.user.personalization.projectPreferences.reset()
+        rootStore = initStore(true, {
+          project,
+          user
+        })
+        sinon.spy(rootStore.client.panoptes, 'get')
       })
 
       after(function () {
-        rootStore.user.personalization.projectPreferences.reset()
         nock.cleanAll()
-        nockScope = null
       })
 
       it('should request the user project preferences resource', async function () {
+        const { projectPreferences } = rootStore.user.personalization
+        projectPreferences.reset()
         expect(rootStore.client.panoptes.get).to.not.have.been.called()
-        expect(rootStore.user.personalization.projectPreferences.loadingState).to.equal(asyncStates.initialized)
-        await rootStore.user.personalization.projectPreferences.fetchResource()
+        expect(projectPreferences.loadingState).to.equal(asyncStates.initialized)
+        projectPreferences.fetchResource()
+        await when(preferencesAreReady(projectPreferences))
         expect(rootStore.client.panoptes.get.withArgs(endpoint, query, { authorization })).to.have.been.calledOnce()
-        expect(rootStore.user.personalization.projectPreferences.loadingState).to.equal(asyncStates.success)
-        rootStore.user.personalization.projectPreferences.reset()
+        expect(projectPreferences.loadingState).to.equal(asyncStates.success)
+        projectPreferences.reset()
       })
 
       it('should store the UPP resource', async function () {
-        expect(rootStore.user.personalization.projectPreferences).to.deep.equal(initialState)
-        await rootStore.user.personalization.projectPreferences.fetchResource()
+        const { projectPreferences } = rootStore.user.personalization
+        projectPreferences.reset()
+        expect(projectPreferences).to.deep.equal(initialState)
+        projectPreferences.fetchResource()
+        await when(preferencesAreReady(projectPreferences))
         const storedUPP = Object.assign({}, upp, { error: undefined, loadingState: asyncStates.success })
-        expect(rootStore.user.personalization.projectPreferences).to.deep.equal(storedUPP)
+        expect(projectPreferences).to.deep.equal(storedUPP)
       })
 
       it('should set the total classification count on the parent node', function () {
@@ -145,34 +150,34 @@ describe('Stores > UserProjectPreferences', function () {
     })
 
     describe('when there are no user project preferences in the response', function () {
-      let nockScope
+      let rootStore
+
       before(function () {
-        nockScope = nock('https://panoptes-staging.zooniverse.org/api')
+        nock('https://panoptes-staging.zooniverse.org/api')
           .persist()
           .get('/project_preferences')
           .query(true)
           .reply(200, {
             project_preferences: []
           })
-          .get('/collections') // This is to prevent the collections store from making real requests
-          .query(true)
-          .reply(200)
-          .post('/collections')
-          .query(true)
-          .reply(200)
+
+        rootStore = initStore(true, {
+          project,
+          user
+        })
       })
 
       after(function () {
         nock.cleanAll()
-        rootStore.user.personalization.projectPreferences.reset()
-        nockScope = null
       })
 
       it('should not apply the UPP resource', async function () {
-        expect(rootStore.user.personalization.projectPreferences.loadingState).to.equal(asyncStates.initialized)
+        const { projectPreferences } = rootStore.user.personalization
+        projectPreferences.reset()
+        expect(projectPreferences.loadingState).to.equal(asyncStates.initialized)
         await rootStore.user.personalization.projectPreferences.fetchResource()
-        expect(rootStore.user.personalization.projectPreferences.loadingState).to.equal(asyncStates.success)
-        expect(rootStore.user.personalization.projectPreferences.id).to.be.undefined()
+        expect(projectPreferences.loadingState).to.equal(asyncStates.success)
+        expect(projectPreferences.id).to.be.undefined()
       })
 
       it('should not set the total classification count on the parent node', function () {
@@ -181,89 +186,75 @@ describe('Stores > UserProjectPreferences', function () {
     })
 
     describe('when the request errors', function () {
-      let nockScope
+      let rootStore
+
       before(function () {
-        nockScope = nock('https://panoptes-staging.zooniverse.org/api')
+        nock('https://panoptes-staging.zooniverse.org/api')
           .persist()
           .get('/project_preferences')
           .query(true)
           .replyWithError('Error!')
-          .get('/collections') // This is to prevent the collections store from making real requests
-          .query(true)
-          .reply(200)
-          .post('/collections')
-          .query(true)
-          .reply(200)
 
+        rootStore = initStore(true, {
+          project,
+          user
+        })
       })
 
       after(function () {
-        rootStore.user.personalization.projectPreferences.reset()
         nock.cleanAll()
-        nockScope = null
       })
 
       it('should store the error', async function () {
-        expect(rootStore.user.personalization.projectPreferences.loadingState).to.equal(asyncStates.initialized)
-        expect(rootStore.user.personalization.projectPreferences.error).to.be.undefined()
-        await rootStore.user.personalization.projectPreferences.fetchResource()
-        expect(rootStore.user.personalization.projectPreferences.error.message).to.equal('Error!')
-        expect(rootStore.user.personalization.projectPreferences.loadingState).to.equal(asyncStates.error)
+        const { projectPreferences } = rootStore.user.personalization
+        projectPreferences.reset()
+        expect(projectPreferences.loadingState).to.equal(asyncStates.initialized)
+        expect(projectPreferences.error).to.be.undefined()
+        projectPreferences.fetchResource()
+        await when(preferencesAreReady(projectPreferences))
+        expect(projectPreferences.error.message).to.equal('Error!')
+        expect(projectPreferences.loadingState).to.equal(asyncStates.error)
       })
     })
 
     describe('when the response errors', function () {
-      let nockScope
+      let rootStore
+
       before(function () {
-        nockScope = nock('https://panoptes-staging.zooniverse.org/api')
+        sinon.stub(console, 'error')
+        nock('https://panoptes-staging.zooniverse.org/api')
           .persist()
           .get('/project_preferences')
           .query(true)
           .reply(401, {
             project_preferences: []
           })
-          .get('/collections') // This is to prevent the collections store from making real requests
-          .query(true)
-          .reply(200)
-          .post('/collections')
-          .query(true)
-          .reply(200)
 
-        rootStore.user.personalization.projectPreferences.reset()
+        rootStore = initStore(true, {
+          project,
+          user
+        })
       })
 
       after(function () {
-        nockScope = null
+        nock.cleanAll()
+        console.error.restore()
       })
 
       it('should store the error', async function () {
-        expect(rootStore.user.personalization.projectPreferences.loadingState).to.equal(asyncStates.initialized)
-        expect(rootStore.user.personalization.projectPreferences.error).to.be.undefined()
-        await rootStore.user.personalization.projectPreferences.fetchResource()
-        expect(rootStore.user.personalization.projectPreferences.error.message).to.equal('Unauthorized')
-        expect(rootStore.user.personalization.projectPreferences.loadingState).to.equal(asyncStates.error)
+        const { projectPreferences } = rootStore.user.personalization
+        projectPreferences.reset()
+        expect(projectPreferences.loadingState).to.equal(asyncStates.initialized)
+        expect(projectPreferences.error).to.be.undefined()
+        projectPreferences.fetchResource()
+        await when(preferencesAreReady(projectPreferences))
+        expect(projectPreferences.error.message).to.equal('Unauthorized')
+        expect(projectPreferences.loadingState).to.equal(asyncStates.error)
       })
     })
   })
 
   describe('Views > promptAssignment', function () {
-    let nockScope
-
-    before(function () {
-      nockScope = nock('https://panoptes-staging.zooniverse.org/api')
-        .get('/collections') // This is to prevent the collections store from making real requests
-        .query(true)
-        .reply(200)
-        .post('/collections')
-        .query(true)
-        .reply(200)
-    })
-
-    after(function () {
-      nockScope = null
-      nock.cleanAll()
-    })
-
     describe('when a workflow is not currently selected', function () {
       let rootStore
       const user = {
@@ -292,16 +283,14 @@ describe('Stores > UserProjectPreferences', function () {
         })
       })
 
-      after(function () {
-        rootStore = null
-      })
-
       it('should not prompt the user', function () {
         expect(rootStore.user.personalization.projectPreferences.promptAssignment()).to.be.false()
       })
     })
 
     describe('when the assigned workflow is not active', function () {
+      let rootStore
+
       before(function () {
         const project = {
           id: '2',
@@ -318,11 +307,13 @@ describe('Stores > UserProjectPreferences', function () {
 
       it('should not prompt the user', function () {
         expect(rootStore.user.personalization.projectPreferences.promptAssignment('123')).to.be.false()
-        expect(rootStore.project.links.active_workflows.includes('555')).to.be.false()
+        expect(rootStore.project.workflowIsActive('555')).to.be.false()
       })
     })
 
     describe('when the assigned workflow is the same as the current workflow', function () {
+      let rootStore
+
       before(function () {
         const project = {
           id: '2',
@@ -339,11 +330,13 @@ describe('Stores > UserProjectPreferences', function () {
 
       it('should not prompt the user', function () {
         expect(rootStore.user.personalization.projectPreferences.promptAssignment('555')).to.be.false()
-        expect(rootStore.project.links.active_workflows.includes('555')).to.be.true()
+        expect(rootStore.project.workflowIsActive('555')).to.be.true()
       })
     })
 
     describe('when the assigned workflow is not the same as the current workflow', function () {
+      let rootStore
+
       before(function () {
         const project = {
           id: '2',
@@ -360,8 +353,8 @@ describe('Stores > UserProjectPreferences', function () {
 
       it('should prompt the user', function () {
         expect(rootStore.user.personalization.projectPreferences.promptAssignment('123')).to.be.false()
-        expect(rootStore.project.links.active_workflows.includes('123')).to.be.true()
-        expect(rootStore.project.links.active_workflows.includes('555')).to.be.true()
+        expect(rootStore.project.workflowIsActive('123')).to.be.true()
+        expect(rootStore.project.workflowIsActive('555')).to.be.true()
       })
     })
   })

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
@@ -285,8 +285,9 @@ describe('Stores > UserProjectPreferences', function () {
       })
 
       it('should not prompt the user', function () {
-        expect(rootStore.user.personalization.projectPreferences.settings.workflow_id).to.equal('555')
-        expect(rootStore.user.personalization.projectPreferences.promptAssignment()).to.be.false()
+        const { projectPreferences } = rootStore.user.personalization
+        expect(projectPreferences.assignedWorkflowID).to.equal('555')
+        expect(projectPreferences.promptAssignment()).to.be.false()
       })
     })
 
@@ -308,8 +309,9 @@ describe('Stores > UserProjectPreferences', function () {
       })
 
       it('should not prompt the user', function () {
-        expect(rootStore.user.personalization.projectPreferences.settings.workflow_id).to.equal('555')
-        expect(rootStore.user.personalization.projectPreferences.promptAssignment('123')).to.be.false()
+        const { projectPreferences } = rootStore.user.personalization
+        expect(projectPreferences.assignedWorkflowID).to.equal('555')
+        expect(projectPreferences.promptAssignment('123')).to.be.false()
         expect(rootStore.project.workflowIsActive('555')).to.be.false()
       })
     })
@@ -332,8 +334,9 @@ describe('Stores > UserProjectPreferences', function () {
       })
 
       it('should not prompt the user', function () {
-        expect(rootStore.user.personalization.projectPreferences.settings.workflow_id).to.equal('555')
-        expect(rootStore.user.personalization.projectPreferences.promptAssignment('555')).to.be.false()
+        const { projectPreferences } = rootStore.user.personalization
+        expect(projectPreferences.assignedWorkflowID).to.equal('555')
+        expect(projectPreferences.promptAssignment('555')).to.be.false()
         expect(rootStore.project.workflowIsActive('555')).to.be.true()
       })
     })
@@ -356,8 +359,9 @@ describe('Stores > UserProjectPreferences', function () {
       })
 
       it('should prompt the user', function () {
-        expect(rootStore.user.personalization.projectPreferences.settings.workflow_id).to.equal('555')
-        expect(rootStore.user.personalization.projectPreferences.promptAssignment('123')).to.be.true()
+        const { projectPreferences } = rootStore.user.personalization
+        expect(projectPreferences.assignedWorkflowID).to.equal('555')
+        expect(projectPreferences.promptAssignment('123')).to.be.true()
         expect(rootStore.project.workflowIsActive('123')).to.be.true()
         expect(rootStore.project.workflowIsActive('555')).to.be.true()
       })

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
@@ -255,19 +255,20 @@ describe('Stores > UserProjectPreferences', function () {
   })
 
   describe('Views > promptAssignment', function () {
-    describe('when a workflow is not currently selected', function () {
-      let rootStore
-      const user = {
-        id: '5',
-        personalization: {
-          projectPreferences: {
-            id: '10',
-            settings: {
-              workflow_id: '555'
-            }
+    const user = {
+      id: '5',
+      personalization: {
+        projectPreferences: {
+          id: '10',
+          settings: {
+            workflow_id: '555'
           }
         }
       }
+    }
+
+    describe('when a workflow is not currently selected', function () {
+      let rootStore
 
       before(function () {
         const project = {
@@ -284,6 +285,7 @@ describe('Stores > UserProjectPreferences', function () {
       })
 
       it('should not prompt the user', function () {
+        expect(rootStore.user.personalization.projectPreferences.settings.workflow_id).to.equal('555')
         expect(rootStore.user.personalization.projectPreferences.promptAssignment()).to.be.false()
       })
     })
@@ -306,6 +308,7 @@ describe('Stores > UserProjectPreferences', function () {
       })
 
       it('should not prompt the user', function () {
+        expect(rootStore.user.personalization.projectPreferences.settings.workflow_id).to.equal('555')
         expect(rootStore.user.personalization.projectPreferences.promptAssignment('123')).to.be.false()
         expect(rootStore.project.workflowIsActive('555')).to.be.false()
       })
@@ -329,6 +332,7 @@ describe('Stores > UserProjectPreferences', function () {
       })
 
       it('should not prompt the user', function () {
+        expect(rootStore.user.personalization.projectPreferences.settings.workflow_id).to.equal('555')
         expect(rootStore.user.personalization.projectPreferences.promptAssignment('555')).to.be.false()
         expect(rootStore.project.workflowIsActive('555')).to.be.true()
       })
@@ -352,7 +356,8 @@ describe('Stores > UserProjectPreferences', function () {
       })
 
       it('should prompt the user', function () {
-        expect(rootStore.user.personalization.projectPreferences.promptAssignment('123')).to.be.false()
+        expect(rootStore.user.personalization.projectPreferences.settings.workflow_id).to.equal('555')
+        expect(rootStore.user.personalization.projectPreferences.promptAssignment('123')).to.be.true()
         expect(rootStore.project.workflowIsActive('123')).to.be.true()
         expect(rootStore.project.workflowIsActive('555')).to.be.true()
       })


### PR DESCRIPTION
Fetch the full UPP resource when the stored user changes. When refreshing the UPP resource, fetch data in the background and only refresh stored settings, so as to avoid overwriting the stored classification count.

#2349 introduced a couple of undesired side effects for all projects:
- every 5 classifications, the user's `activity_count` is refreshed from Panoptes. `activity_count` is updated every 5 minutes, so this can lead to weird behaviour where your classification count, on the Classify page, can go up, then down, then up again.
- every 5 classifications, the classifier is replaced by a loading icon and reloads, including clearing the stored subject queue and refreshing it from Panoptes.

This PR should fix both those effects, by silently requesting UPP (every 5 classifications) and only refreshing `UPP.settings`.

Package:
app-project

Closes #2501.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
