### PR TITLE
[Security] Upgrade trim and node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "nyc": "~15.1.0",
     "snazzy": "~9.0.0"
   },
+  "resolutions": {
+    "**/trim": "~1.0"
+  },
   "scripts": {
     "bootstrap": "./bin/bootstrap.sh",
     "build": "lerna run --parallel build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17626,10 +17626,10 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+trim@0.0.1, trim@~1.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-1.0.1.tgz#68e78f6178ccab9687a610752f4f5e5a7022ee8c"
+  integrity sha512-3JVP2YVqITUisXblCDq/Bi4P9457G/sdEamInkyvCsjbTcXLXIiG7XCb4kGMFWh6JGXesS3TKxOPtrncN/xe8w==
 
 trough@^1.0.0:
   version "1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13292,10 +13292,17 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.5.0, node-fetch@^2.6.1, node-fetch@~2.6.1:
+node-fetch@^2.5.0, node-fetch@^2.6.1:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
   integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@~2.6.1:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
+  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
Upgrade `trim` to 1.0.1 and bump `node-fetch` to 2.6.5

Package:
app-project
lib-react-components

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
