### PR TITLE
Refactor workflow promotion prompt

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalConnector.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalConnector.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { MobXProviderContext, observer } from 'mobx-react'
 import WorkflowAssignmentModalContainer from './WorkflowAssignmentModalContainer'
 
-function useStore(store) {
+function useStore (store) {
   const stores = useContext(MobXProviderContext)
   if (!store) {
     store = stores.store
@@ -11,15 +11,13 @@ function useStore(store) {
 
   return {
     assignedWorkflowID: store.user.personalization.projectPreferences.settings?.workflow_id,
-    loadingState: store.user.personalization.projectPreferences.loadingState,
     promptAssignment: store.user.personalization.projectPreferences.promptAssignment
   }
 }
 
-function WorkflowAssignmentModalConnector({ currentWorkflowID, store, ...rest }) {
+function WorkflowAssignmentModalConnector ({ currentWorkflowID, store, ...rest }) {
   const {
     assignedWorkflowID = '',
-    loadingState,
     promptAssignment
   } = useStore(store)
 
@@ -27,7 +25,6 @@ function WorkflowAssignmentModalConnector({ currentWorkflowID, store, ...rest })
     <WorkflowAssignmentModalContainer
       assignedWorkflowID={assignedWorkflowID}
       currentWorkflowID={currentWorkflowID}
-      loadingState={loadingState}
       promptAssignment={promptAssignment}
       {...rest}
     />

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalConnector.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalConnector.spec.js
@@ -47,10 +47,6 @@ describe('Component > WorkflowAssignmentModalConnector', function () {
       expect(wrapper.props().assignedWorkflowID).to.deep.equal(mockStore.store.user.personalization.projectPreferences.settings.workflow_id)
     })
 
-    it('should inject the user project preferences loading state', function () {
-      expect(wrapper.props().loadingState).to.deep.equal(mockStore.store.user.personalization.projectPreferences.loadingState)
-    })
-
     it('should inject the user project preferences promptAssignment function', function () {
       expect(wrapper.props().promptAssignment).to.equal(mockStore.store.user.personalization.projectPreferences.promptAssignment)
     })

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalContainer.js
@@ -1,24 +1,22 @@
 import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import WorkflowAssignmentModal from './WorkflowAssignmentModal'
-import asyncStates from '@zooniverse/async-states'
 
-function WorkflowAssignmentModalContainer(props) {
+function WorkflowAssignmentModalContainer (props) {
   const {
     assignedWorkflowID = '',
     currentWorkflowID = '',
-    loadingState = asyncStates.initialized,
     promptAssignment = () => { }
   } = props
   const [ active, setActive ] = useState(false)
   const [ dismissedForSession, setDismissed ] = useState(false)
 
   // TODO: integrate session storage
-  function onDismiss(event) {
+  function onDismiss (event) {
     setDismissed(event.target.checked)
   }
 
-  function closeFn() {
+  function closeFn () {
     setActive(false)
   }
 
@@ -28,7 +26,7 @@ function WorkflowAssignmentModalContainer(props) {
     }
 
     return () => setActive(false)
-  }, [loadingState, currentWorkflowID])
+  }, [assignedWorkflowID, currentWorkflowID])
 
   if (assignedWorkflowID) {
     return (
@@ -49,7 +47,6 @@ WorkflowAssignmentModalContainer.propTypes = {
   assignedWorkflowID: PropTypes.string,
   currentWorkflowID: PropTypes.string,
   promptAssignment: PropTypes.func
-
 }
 
 export default WorkflowAssignmentModalContainer

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalContainer.spec.js
@@ -4,7 +4,6 @@ import WorkflowAssignmentModalContainer from './WorkflowAssignmentModalContainer
 import WorkflowAssignmentModal from './WorkflowAssignmentModal'
 import { Grommet } from 'grommet'
 import zooTheme from '@zooniverse/grommet-theme'
-import asyncStates from '@zooniverse/async-states'
 
 describe('Component > WorkflowAssignmentModalContainer', function() {
   let wrapper
@@ -43,7 +42,7 @@ describe('Component > WorkflowAssignmentModalContainer', function() {
         wrappingComponentProps: { theme: zooTheme }
       })
       expect(wrapper.find(WorkflowAssignmentModal)).to.have.lengthOf(0)
-      wrapper.setProps({ assignedWorkflowID: '555', loadingState: asyncStates.success, currentWorkflowID: '', promptAssignment })
+      wrapper.setProps({ assignedWorkflowID: '555', currentWorkflowID: '', promptAssignment })
       wrapper.update()
       expect(wrapper.find(WorkflowAssignmentModal).props().active).to.be.false()
     })
@@ -53,15 +52,14 @@ describe('Component > WorkflowAssignmentModalContainer', function() {
     describe('when the currently selected workflow is the same as the assigned workflow', function () {
       it('should not display the modal', function () {
         wrapper = mount(
-          <WorkflowAssignmentModalContainer loadingState={asyncStates.initialized} />, {
+          <WorkflowAssignmentModalContainer />, {
           wrappingComponent: Grommet,
           wrappingComponentProps: { theme: zooTheme }
         })
         expect(wrapper.find(WorkflowAssignmentModal)).to.have.lengthOf(0)
         const promptAssignment = sinon.stub().callsFake(() => false)
         const assignedWorkflowID = '555'
-        const loadingState = asyncStates.success
-        wrapper.setProps({ assignedWorkflowID, currentWorkflowID: '555', loadingState, promptAssignment })
+        wrapper.setProps({ assignedWorkflowID, currentWorkflowID: '555', promptAssignment })
         wrapper.update()
         expect(wrapper.find(WorkflowAssignmentModal).props().active).to.be.false()
       })
@@ -70,15 +68,14 @@ describe('Component > WorkflowAssignmentModalContainer', function() {
     describe('when the currently selected workflow is not the same as the assigned workflow', function () {
       it('should display the modal', function () {
         wrapper = mount(
-          <WorkflowAssignmentModalContainer loadingState={asyncStates.initialized} />, {
+          <WorkflowAssignmentModalContainer />, {
           wrappingComponent: Grommet,
           wrappingComponentProps: { theme: zooTheme }
         })
         expect(wrapper.find(WorkflowAssignmentModal)).to.have.lengthOf(0)
         const promptAssignment = sinon.stub().callsFake(() => true)
         const assignedWorkflowID = '555'
-        const loadingState = asyncStates.success
-        wrapper.setProps({ assignedWorkflowID, loadingState, promptAssignment, currentWorkflowID: '123' })
+        wrapper.setProps({ assignedWorkflowID, promptAssignment, currentWorkflowID: '123' })
         wrapper.update()
         expect(wrapper.find(WorkflowAssignmentModal).props().active).to.be.true()
       })
@@ -92,9 +89,7 @@ describe('Component > WorkflowAssignmentModalContainer', function() {
           wrappingComponentProps: { theme: zooTheme }
         })
         expect(wrapper.find(WorkflowAssignmentModal).props().active).to.be.false()
-        const loadingState = asyncStates.success
         wrapper.find(WorkflowAssignmentModal).props().dismiss({ target: { checked: true }})
-        wrapper.setProps({ loadingState })
         wrapper.update()
         expect(wrapper.find(WorkflowAssignmentModal).props().active).to.be.false()
       })
@@ -104,12 +99,10 @@ describe('Component > WorkflowAssignmentModalContainer', function() {
       it('should remove the modal', function () {
         const promptAssignment = sinon.stub().callsFake(() => true)
         const assignedWorkflowID = '555'
-        const loadingState = asyncStates.success
         wrapper = mount(
           <WorkflowAssignmentModalContainer
             assignedWorkflowID={assignedWorkflowID}
             currentWorkflowID='123'
-            loadingState={loadingState}
             promptAssignment={promptAssignment}
           />, {
             wrappingComponent: Grommet,


### PR DESCRIPTION
Package:
- app-project

Closes #2522.

Describe your changes:
- temporary solution until further refactoring can be done, see #2515 and #2431 for additional context
- refactors the WorkflowAssignmentModal to update if the UPP.settings.workflow_id (workflow promoted to) changes, prompting user to try workflow promoted to
- this doesn't restore the prompting every 5 classifications, but prompts if a user has been promoted

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
