### PR TITLE
Fix UserPersonalisation on Sundays

### DIFF
--- a/packages/app-project/stores/Store.spec.js
+++ b/packages/app-project/stores/Store.spec.js
@@ -81,14 +81,13 @@ describe('Stores > Store', function () {
             stats: {
               loadingState: asyncStates.success,
               thisWeek: [
-                { count: 12, period: '2019-09-29' },
-                { count: 12, period: '2019-09-30' },
-                { count: 13, period: '2019-10-01' },
-                { count: 14, period: '2019-10-02' },
-                { count: 10, period: '2019-10-03' },
-                { count: 11, period: '2019-10-04' },
-                { count: 8, period: '2019-10-05' },
-                { count: 15, period: '2019-10-06' }
+                { count: 12, dayNumber: 1, period: '2019-09-29' },
+                { count: 12, dayNumber: 2, period: '2019-09-30' },
+                { count: 13, dayNumber: 3, period: '2019-10-01' },
+                { count: 14, dayNumber: 4, period: '2019-10-02' },
+                { count: 10, dayNumber: 5, period: '2019-10-03' },
+                { count: 11, dayNumber: 6, period: '2019-10-04' },
+                { count: 8, dayNumber: 0, period: '2019-10-05' }
               ]
             },
             totalClassificationCount: 8

--- a/packages/app-project/stores/User/UserPersonalization/UserPersonalization.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserPersonalization.js
@@ -16,15 +16,16 @@ const UserPersonalization = types
   .views(self => ({
     get counts() {
       const todaysDate = new Date()
-      let today
+      let todaysCount = 0
       try {
-        const todaysCount = self.stats.thisWeek.length === 7
-          ? self.stats.thisWeek[todaysDate.getDay() - 1].count
-          : 0
-        today = todaysCount + self.sessionCount
+        if (self.stats.thisWeek.length === 7) {
+          const todaysStats = self.stats.thisWeek.find(stat => stat.dayNumber === todaysDate.getDay())
+          todaysCount = todaysStats.count
+        }
       } catch (error) {
-        today = 0
+        todaysCount = 0
       }
+      const today = todaysCount + self.sessionCount
 
       return {
         today,

--- a/packages/app-project/stores/User/UserPersonalization/UserPersonalization.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserPersonalization.spec.js
@@ -307,13 +307,13 @@ describe('Stores > UserPersonalization', function () {
 
       it('should get today\'s count from the store\'s counts for this week', function () {
         const MOCK_DAILY_COUNTS = [
-          { count: 12, period: '2019-09-30T00:00:00Z' },
-          { count: 13, period: '2019-10-01T00:00:00Z' },
-          { count: 14, period: '2019-10-02T00:00:00Z' },
-          { count: 10, period: '2019-10-03T00:00:00Z' },
-          { count: 11, period: '2019-10-04T00:00:00Z' },
-          { count: 8, period: '2019-10-05T00:00:00Z' },
-          { count: 15, period: '2019-10-06T00:00:00Z' }
+          { count: 12, dayNumber: 1, period: '2019-09-30T00:00:00Z' },
+          { count: 13, dayNumber: 2, period: '2019-10-01T00:00:00Z' },
+          { count: 14, dayNumber: 3, period: '2019-10-02T00:00:00Z' },
+          { count: 10, dayNumber: 4, period: '2019-10-03T00:00:00Z' },
+          { count: 11, dayNumber: 5, period: '2019-10-04T00:00:00Z' },
+          { count: 8, dayNumber: 6, period: '2019-10-05T00:00:00Z' },
+          { count: 15, dayNumber: 0, period: '2019-10-06T00:00:00Z' }
         ]
         const personalizationStore = UserPersonalization.create({ stats: { thisWeek: MOCK_DAILY_COUNTS } })
         expect(personalizationStore.counts.today).to.equal(MOCK_DAILY_COUNTS[1].count)
@@ -321,9 +321,9 @@ describe('Stores > UserPersonalization', function () {
 
       it('should be `0` if there are no classifications today', function () {
         const MOCK_DAILY_COUNTS = [
-          { count: 12, period: '2019-01-03T00:00:00Z' },
-          { count: 13, period: '2019-01-02T00:00:00Z' },
-          { count: 14, period: '2019-01-01T00:00:00Z' }
+          { count: 12, dayNumber: 2, period: '2019-01-03T00:00:00Z' },
+          { count: 13, dayNumber: 1, period: '2019-01-02T00:00:00Z' },
+          { count: 14, dayNumber: 0, period: '2019-01-01T00:00:00Z' }
         ]
         const personalizationStore = UserPersonalization.create({ stats: { thisWeek: MOCK_DAILY_COUNTS } })
         expect(personalizationStore.counts.today).to.equal(0)
@@ -334,13 +334,13 @@ describe('Stores > UserPersonalization', function () {
   describe('on reset', function () {
     it('should reset project preferences, stats, and counts', function () {
       const MOCK_DAILY_COUNTS = [
-        { count: 12, period: '2019-09-30T00:00:00Z' },
-        { count: 13, period: '2019-10-01T00:00:00Z' },
-        { count: 14, period: '2019-10-02T00:00:00Z' },
-        { count: 10, period: '2019-10-03T00:00:00Z' },
-        { count: 11, period: '2019-10-04T00:00:00Z' },
-        { count: 8, period: '2019-10-05T00:00:00Z' },
-        { count: 15, period: '2019-10-06T00:00:00Z' }
+        { count: 12, dayNumber: 1, period: '2019-09-30T00:00:00Z' },
+        { count: 13, dayNumber: 2, period: '2019-10-01T00:00:00Z' },
+        { count: 14, dayNumber: 3, period: '2019-10-02T00:00:00Z' },
+        { count: 10, dayNumber: 4, period: '2019-10-03T00:00:00Z' },
+        { count: 11, dayNumber: 5, period: '2019-10-04T00:00:00Z' },
+        { count: 8, dayNumber: 6, period: '2019-10-05T00:00:00Z' },
+        { count: 15, dayNumber: 0, period: '2019-10-06T00:00:00Z' }
       ]
       const personalizationStore = UserPersonalization.create({
         projectPreferences: {

--- a/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
+++ b/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
@@ -22,6 +22,7 @@ function firstDayOfWeek (dateObject, firstDayOfWeekIndex) {
 const Count = types
   .model('Count', {
     count: types.number,
+    dayNumber: types.number,
     period: types.string
   })
 
@@ -46,8 +47,10 @@ const YourStats = types
         weekDay.setUTCDate(newDate)
         const period = weekDay.toISOString().substring(0, 10)
         const { count } = dailyCounts.find(count => count.period.startsWith(period)) || { count: 0, period }
+        const dayNumber = weekDay.getDay()
         weeklyStats.push({
           count,
+          dayNumber,
           period
         })
       }

--- a/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.spec.js
@@ -96,11 +96,19 @@ describe('Stores > YourStats', function () {
       })
 
       it('should start on Monday', function () {
-        expect(rootStore.user.personalization.stats.thisWeek[0]).to.deep.equal({ count: 12, period: '2019-09-30' })
+        expect(rootStore.user.personalization.stats.thisWeek[0]).to.deep.equal({
+          count: 12,
+          dayNumber: 1,
+          period: '2019-09-30'
+        })
       })
 
       it('should end on Sunday', function () {
-        expect(rootStore.user.personalization.stats.thisWeek[6]).to.deep.equal({ count: 15, period: '2019-10-06' })
+        expect(rootStore.user.personalization.stats.thisWeek[6]).to.deep.equal({
+          count: 15,
+          dayNumber: 0,
+          period: '2019-10-06'
+        })
       })
     })
   })
@@ -108,14 +116,13 @@ describe('Stores > YourStats', function () {
   describe('on reset', function () {
     it('should reset weekly stats and loading state', function () {
       const MOCK_DAILY_COUNTS = [
-        { count: 12, period: '2019-09-29' },
-        { count: 12, period: '2019-09-30' },
-        { count: 13, period: '2019-10-01' },
-        { count: 14, period: '2019-10-02' },
-        { count: 10, period: '2019-10-03' },
-        { count: 11, period: '2019-10-04' },
-        { count: 8, period: '2019-10-05' },
-        { count: 15, period: '2019-10-06' }
+        { count: 12, dayNumber: 1, period: '2019-09-29' },
+        { count: 12, dayNumber: 2, period: '2019-09-30' },
+        { count: 13, dayNumber: 3, period: '2019-10-01' },
+        { count: 14, dayNumber: 4, period: '2019-10-02' },
+        { count: 10, dayNumber: 5, period: '2019-10-03' },
+        { count: 11, dayNumber: 6, period: '2019-10-04' },
+        { count: 8, dayNumber: 0, period: '2019-10-05' },
       ]
       const yourStatsStore = YourStats.create({
         loadingState: asyncStates.success,


### PR DESCRIPTION
Daily classifications break on Sundays, when `today.getDay()` is 0. This removes the array index from daily stats. Instead, it adds the day number to daily counts, and uses that to find today's count.

Talk thread here: https://www.zooniverse.org/projects/bogden/scarlets-and-blues/talk/4757/2211561

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
