### PR TITLE
Fix liveness probe paths

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -49,14 +49,22 @@ spec:
             limits:
               memory: "1000Mi"
               cpu: "1000m"
+          startupProbe:
+            httpGet:
+              path: /projects/Index
+              port: 3000
+            failureThreshold: 6
           livenessProbe:
             httpGet:
-              path: /Index
+              path: /projects/Index
               port: 3000
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /Index
+              path: /projects/Index
               port: 3000
+            initialDelaySeconds: 20
+            timeoutSeconds: 10
           ports:
             - containerPort: 3000
           env:
@@ -141,14 +149,22 @@ spec:
             limits:
               memory: "500Mi"
               cpu: "1000m"
+          startupProbe:
+            httpGet:
+              path: /about/Index
+              port: 3000
+            failureThreshold: 6
           livenessProbe:
             httpGet:
-              path: /Index
+              path: /about/Index
               port: 3000
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /Index
+              path: /about/Index
               port: 3000
+            initialDelaySeconds: 20
+            timeoutSeconds: 10
           ports:
             - containerPort: 3000
           env:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -39,14 +39,22 @@ spec:
             limits:
               memory: "500Mi"
               cpu: "1000m"
+          startupProbe:
+            httpGet:
+              path: /projects/Index
+              port: 3000
+            failureThreshold: 6
           livenessProbe:
             httpGet:
-              path: /Index
+              path: /projects/Index
               port: 3000
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /Index
+              path: /projects/Index
               port: 3000
+            initialDelaySeconds: 20
+            timeoutSeconds: 10
           ports:
             - containerPort: 3000
           env:
@@ -123,14 +131,22 @@ spec:
             limits:
               memory: "500Mi"
               cpu: "1000m"
+          startupProbe:
+            httpGet:
+              path: /about/Index
+              port: 3000
+            failureThreshold: 6
           livenessProbe:
             httpGet:
-              path: /Index
+              path: /about/Index
               port: 3000
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /Index
+              path: /about/Index
               port: 3000
+            initialDelaySeconds: 20
+            timeoutSeconds: 10
           ports:
             - containerPort: 3000
           env:


### PR DESCRIPTION
Add `/projects` and `/about` prefixes to the liveness probes. Extend timeouts to 10s and allow for retries.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
