### PR TITLE
Fix About page redirects

### DIFF
--- a/packages/app-project/pages/[owner]/[project]/about/index.js
+++ b/packages/app-project/pages/[owner]/[project]/about/index.js
@@ -6,7 +6,7 @@ export async function getServerSideProps({ params, query, req, res }) {
   const { env } = query
   const { project } = props.initialState
 
-  const projectPath = `/projects/${project?.slug}/about/research`
+  const projectPath = `/${project?.slug}/about/research`
   const destination = env ? `${projectPath}?env=${env}` : projectPath
 
   return ({


### PR DESCRIPTION
Now that the project app has `basePath` set, the Research page path is `/:owner:/:project:/about/research`.

Package:
app-project

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
