### PR TITLE
Drawing tools models cleanup

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/TranscriptionLine/TranscriptionLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/TranscriptionLine/TranscriptionLine.js
@@ -42,40 +42,33 @@ const TranscriptionLineModel = types
       return TranscriptionLineComponent
     }
   }))
-  .actions((self) => {
-    function initialDrag({ x, y }) {
+  .actions((self) => ({
+    initialDrag({ x, y }) {
       self.x2 = x
       self.y2 = y
-    }
+    },
 
-    function initialPosition({ x, y }) {
+    initialPosition({ x, y }) {
       self.x1 = x
       self.y1 = y
       self.x2 = x
       self.y2 = y
-    }
+    },
 
-    function move({ x, y }) {
+    move({ x, y }) {
       self.x1 += x
       self.x2 += x
       self.y1 += y
       self.y2 += y
-    }
+    },
 
-    function setCoordinates({ x1, y1, x2, y2 }) {
+    setCoordinates({ x1, y1, x2, y2 }) {
       self.x1 = x1
       self.y1 = y1
       self.x2 = x2
       self.y2 = y2
     }
-
-    return {
-      initialDrag,
-      initialPosition,
-      move,
-      setCoordinates
-    }
-  })
+  }))
 
 const TranscriptionLine = types.compose(
   'TranscriptionLine',

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/TranscriptionLine/TranscriptionLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/TranscriptionLine/TranscriptionLine.js
@@ -10,59 +10,59 @@ const TranscriptionLineModel = types
     x2: types.maybe(types.number),
     y2: types.maybe(types.number)
   })
-  .views(self => ({
-    get coords () {
+  .views((self) => ({
+    get coords() {
       return {
         x: self.x1,
         y: self.y1
       }
     },
 
-    deleteButtonPosition (scale) {
+    deleteButtonPosition(scale) {
       const BUFFER = 16
-      const x = self.x1 + (BUFFER / scale)
+      const x = self.x1 + BUFFER / scale
       const y = self.y1
       return { x, y }
     },
 
-    get isValid () {
+    get isValid() {
       return self.x1 !== self.x2 || self.y1 !== self.y2
     },
 
-    get length () {
+    get length() {
       const { x1, y1, x2, y2 } = self
       return Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2))
     },
 
-    get tool () {
+    get tool() {
       return getParentOfType(self, TranscriptionLineTool)
     },
 
-    get toolComponent () {
+    get toolComponent() {
       return TranscriptionLineComponent
     }
   }))
-  .actions(self => {
-    function initialDrag ({ x, y }) {
+  .actions((self) => {
+    function initialDrag({ x, y }) {
       self.x2 = x
       self.y2 = y
     }
 
-    function initialPosition ({ x, y }) {
+    function initialPosition({ x, y }) {
       self.x1 = x
       self.y1 = y
       self.x2 = x
       self.y2 = y
     }
 
-    function move ({ x, y }) {
+    function move({ x, y }) {
       self.x1 += x
       self.x2 += x
       self.y1 += y
       self.y2 += y
     }
 
-    function setCoordinates ({ x1, y1, x2, y2 }) {
+    function setCoordinates({ x1, y1, x2, y2 }) {
       self.x1 = x1
       self.y1 = y1
       self.x2 = x2
@@ -77,6 +77,10 @@ const TranscriptionLineModel = types
     }
   })
 
-const TranscriptionLine = types.compose('TranscriptionLine', Mark, TranscriptionLineModel)
+const TranscriptionLine = types.compose(
+  'TranscriptionLine',
+  Mark,
+  TranscriptionLineModel
+)
 
 export default TranscriptionLine

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool.js
@@ -2,36 +2,36 @@ import { types } from 'mobx-state-tree'
 import { Tool } from '@plugins/drawingTools/models/tools'
 import { TranscriptionLine } from '@plugins/drawingTools/models/marks'
 
-const TranscriptionLineTool = types.model('TranscriptionLine', {
-  marks: types.map(TranscriptionLine),
-  type: types.literal('transcriptionLine')
-})
-  .actions(self => {
-    function handlePointerDown (event, mark) {
+const TranscriptionLineTool = types
+  .model('TranscriptionLine', {
+    marks: types.map(TranscriptionLine),
+    type: types.literal('transcriptionLine')
+  })
+  .actions((self) => ({
+    handlePointerDown(event, mark) {
       mark.initialDrag(event)
       mark.finish()
-    }
+    },
 
-    function handlePointerMove (event, mark) {
+    handlePointerMove(event, mark) {
       return
-    }
+    },
 
-    function handlePointerUp (event, mark) {
+    handlePointerUp(event, mark) {
       return
-    }
+    },
 
-    function createMark (mark) {
-      const newMark = TranscriptionLine.create(Object.assign({}, mark, { toolType: self.type }))
+    createMark(mark) {
+      const newMark = TranscriptionLine.create(
+        Object.assign({}, mark, { toolType: self.type })
+      )
       self.marks.put(newMark)
       return newMark
     }
+  }))
 
-    return {
-      createMark,
-      handlePointerDown,
-      handlePointerMove,
-      handlePointerUp
-    }
-  })
-
-export default types.compose('TranscriptionLineTool', Tool, TranscriptionLineTool)
+export default types.compose(
+  'TranscriptionLineTool',
+  Tool,
+  TranscriptionLineTool
+)

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Circle/Circle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Circle/Circle.js
@@ -52,34 +52,27 @@ const CircleModel = types
       return self.y_center
     }
   }))
-  .actions((self) => {
-    function initialDrag({ x, y }) {
+  .actions((self) => ({
+    initialDrag({ x, y }) {
       self.r = self.getDistance(self.x_center, self.y_center, x, y)
-    }
+    },
 
-    function initialPosition({ x, y }) {
+    initialPosition({ x, y }) {
       self.x_center = x
       self.y_center = y
-    }
+    },
 
-    function move({ x, y }) {
+    move({ x, y }) {
       self.x_center += x
       self.y_center += y
-    }
+    },
 
-    function setCoordinates({ x, y, r }) {
+    setCoordinates({ x, y, r }) {
       self.x_center = x
       self.y_center = y
       self.r = r
     }
-
-    return {
-      initialDrag,
-      initialPosition,
-      move,
-      setCoordinates
-    }
-  })
+  }))
 
 const Circle = types.compose('Circle', Mark, CircleModel)
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Ellipse/Ellipse.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Ellipse/Ellipse.js
@@ -16,47 +16,46 @@ const EllipseModel = types
     ry: types.optional(types.number, 0),
     angle: types.optional(types.number, 0)
   })
-  .views(self => ({
-    get coords () {
+  .views((self) => ({
+    get coords() {
       return {
         x: self.x_center,
         y: self.y_center
       }
     },
 
-    deleteButtonPosition (scale) {
+    deleteButtonPosition(scale) {
       const theta = DELETE_BUTTON_ANGLE * (Math.PI / 180)
       const dx = ((self.rx + BUFFER) / scale) * Math.cos(theta)
       const dy = ((self.ry + BUFFER) / scale) * Math.sin(theta)
       return {
         x: dx,
         y: dy
-      };
+      }
     },
 
-    get isValid () {
+    get isValid() {
       return self.rx - MINIMUM_RADIUS > 0
     },
 
-    get tool () {
+    get tool() {
       return getParentOfType(self, EllipseTool)
     },
 
-    get toolComponent () {
+    get toolComponent() {
       return EllipseComponent
     },
-    
-    get x () {
+
+    get x() {
       return self.x_center
     },
 
-    get y () {
+    get y() {
       return self.y_center
     }
   }))
-  .actions(self => {
-
-    function initialDrag ({ x, y }) {
+  .actions((self) => {
+    function initialDrag({ x, y }) {
       const rx = self.getDistance(self.x, self.y, x, y)
       const angle = self.getAngle(self.x, self.y, x, y)
       self.rx = rx
@@ -64,17 +63,17 @@ const EllipseModel = types
       self.angle = angle
     }
 
-    function initialPosition ({ x, y }) {
+    function initialPosition({ x, y }) {
       self.x_center = x
       self.y_center = y
     }
 
-    function move ({ x, y }) {
+    function move({ x, y }) {
       self.x_center += x
       self.y_center += y
     }
 
-    function setCoordinates ({ x, y, rx, ry, angle }) {
+    function setCoordinates({ x, y, rx, ry, angle }) {
       self.x_center = x
       self.y_center = y
       self.rx = rx

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Ellipse/Ellipse.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Ellipse/Ellipse.js
@@ -54,40 +54,33 @@ const EllipseModel = types
       return self.y_center
     }
   }))
-  .actions((self) => {
-    function initialDrag({ x, y }) {
+  .actions((self) => ({
+    initialDrag({ x, y }) {
       const rx = self.getDistance(self.x, self.y, x, y)
       const angle = self.getAngle(self.x, self.y, x, y)
       self.rx = rx
       self.ry = rx * 0.0001
       self.angle = angle
-    }
+    },
 
-    function initialPosition({ x, y }) {
+    initialPosition({ x, y }) {
       self.x_center = x
       self.y_center = y
-    }
+    },
 
-    function move({ x, y }) {
+    move({ x, y }) {
       self.x_center += x
       self.y_center += y
-    }
+    },
 
-    function setCoordinates({ x, y, rx, ry, angle }) {
+    setCoordinates({ x, y, rx, ry, angle }) {
       self.x_center = x
       self.y_center = y
       self.rx = rx
       self.ry = ry
       self.angle = angle
     }
-
-    return {
-      initialDrag,
-      initialPosition,
-      move,
-      setCoordinates
-    }
-  })
+  }))
 
 const Ellipse = types.compose('Ellipse', Mark, EllipseModel)
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
@@ -97,12 +97,12 @@ const BaseMark = types
       return undefined
     }
   }))
-  .actions((self) => {
-    function finish() {
+  .actions((self) => ({
+    finish() {
       self.finished = true
-    }
+    },
 
-    function setPreviousAnnotations(previousAnnotationValues) {
+    setPreviousAnnotations(previousAnnotationValues) {
       if (previousAnnotationValues?.length > 0) {
         previousAnnotationValues.forEach((previousAnnotationValue) => {
           self.subTaskPreviousAnnotationValues.put(previousAnnotationValue)
@@ -110,23 +110,16 @@ const BaseMark = types
       } else {
         self.subTaskPreviousAnnotationValues.clear()
       }
-    }
+    },
 
-    function setSubTaskVisibility(visibility, markBounds) {
+    setSubTaskVisibility(visibility, markBounds) {
       if (self.tasks.length > 0) {
         self.subTaskVisibility = visibility
         self.subTaskMarkBounds = markBounds
       }
-    }
+    },
 
-    function setVideoTime(displayTime) {}
-
-    return {
-      finish,
-      setPreviousAnnotations,
-      setSubTaskVisibility,
-      setVideoTime
-    }
-  })
+    setVideoTime(displayTime) {}
+  }))
 
 export default types.compose('Mark', AnnotationsStore, BaseMark)

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Point/Point.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Point/Point.js
@@ -41,34 +41,27 @@ const PointModel = types
       return PointComponent
     }
   }))
-  .actions((self) => {
-    function initialDrag({ x, y }) {
+  .actions((self) => ({
+    initialDrag({ x, y }) {
       self.x = x
       self.y = y
-    }
+    },
 
-    function initialPosition({ x, y }) {
+    initialPosition({ x, y }) {
       self.x = x
       self.y = y
-    }
+    },
 
-    function move({ x, y }) {
+    move({ x, y }) {
       self.x += x
       self.y += y
-    }
+    },
 
-    function setCoordinates({ x, y }) {
+    setCoordinates({ x, y }) {
       self.x = x
       self.y = y
     }
-
-    return {
-      initialDrag,
-      initialPosition,
-      move,
-      setCoordinates
-    }
-  })
+  }))
 
 const Point = types.compose('Point', Mark, PointModel)
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Rectangle/Rectangle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Rectangle/Rectangle.js
@@ -47,8 +47,8 @@ const RectangleModel = types
       return RectangleComponent
     }
   }))
-  .actions((self) => {
-    function initialDrag({ x, y }) {
+  .actions((self) => ({
+    initialDrag({ x, y }) {
       const x_left = x < self.x_center ? x : self.x_center - self.width / 2
       const x_right = x > self.x_center ? x : self.x_center + self.width / 2
       const y_top = y < self.y_center ? y : self.y_center - self.height / 2
@@ -58,34 +58,27 @@ const RectangleModel = types
       self.height = y_bottom - y_top
       self.x_center = (x_left + x_right) / 2
       self.y_center = (y_top + y_bottom) / 2
-    }
+    },
 
-    function initialPosition({ x, y }) {
+    initialPosition({ x, y }) {
       self.x_center = x
       self.y_center = y
       self.width = 0
       self.height = 0
-    }
+    },
 
-    function move({ x, y }) {
+    move({ x, y }) {
       self.x_center += x
       self.y_center += y
-    }
+    },
 
-    function setCoordinates({ x_left, x_right, y_top, y_bottom }) {
+    setCoordinates({ x_left, x_right, y_top, y_bottom }) {
       self.x_center = (x_left + x_right) / 2
       self.y_center = (y_top + y_bottom) / 2
       self.width = Math.abs(x_right - x_left)
       self.height = Math.abs(y_bottom - y_top)
     }
-
-    return {
-      initialDrag,
-      initialPosition,
-      move,
-      setCoordinates
-    }
-  })
+  }))
 
 const Rectangle = types.compose('Rectangle', Mark, RectangleModel)
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/RotateRectangle/RotateRectangle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/RotateRectangle/RotateRectangle.js
@@ -25,19 +25,15 @@ const RotateRectangleModel = types
       return self.y_center
     }
   }))
-  .actions((self) => {
-    function setCoordinates({ x_left, x_right, y_top, y_bottom, angle }) {
+  .actions((self) => ({
+    setCoordinates({ x_left, x_right, y_top, y_bottom, angle }) {
       self.x_center = (x_left + x_right) / 2
       self.y_center = (y_top + y_bottom) / 2
       self.width = Math.abs(x_right - x_left)
       self.height = Math.abs(y_bottom - y_top)
       self.angle = angle
     }
-
-    return {
-      setCoordinates
-    }
-  })
+  }))
 
 const RotateRectangle = types.compose(
   'RotateRectangle',

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/TemporalPoint/TemporalPoint.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/TemporalPoint/TemporalPoint.js
@@ -23,16 +23,12 @@ const TemporalPointModel = types
       return self.displayTime
     }
   }))
-  .actions((self) => {
-    function setVideoTime(displayTime, duration) {
+  .actions((self) => ({
+    setVideoTime(displayTime, duration) {
       self.displayTime = displayTime
       self.displayTimeStamp = formatTimeStamp(displayTime, duration)
     }
-
-    return {
-      setVideoTime
-    }
-  })
+  }))
 
 const TemporalPoint = types.compose('TemporalPoint', Point, TemporalPointModel)
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/TemporalRotateRectangle/TemporalRotateRectangle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/TemporalRotateRectangle/TemporalRotateRectangle.js
@@ -23,16 +23,12 @@ const TemporalRotateRectangleModel = types
       return self.displayTime
     }
   }))
-  .actions((self) => {
-    function setVideoTime(displayTime, duration) {
+  .actions((self) => ({
+    setVideoTime(displayTime, duration) {
       self.displayTime = displayTime
       self.displayTimeStamp = formatTimeStamp(displayTime, duration)
     }
-
-    return {
-      setVideoTime
-    }
-  })
+  }))
 
 const TemporalRotateRectangle = types.compose(
   'TemporalRotateRectangle',

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/CircleTool/CircleTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/CircleTool/CircleTool.js
@@ -7,18 +7,14 @@ const CircleTool = types
     marks: types.map(Circle),
     type: types.literal('circle')
   })
-  .actions((self) => {
-    function createMark(mark) {
+  .actions((self) => ({
+    createMark(mark) {
       const newMark = Circle.create(
         Object.assign({}, mark, { toolType: self.type })
       )
       self.marks.put(newMark)
       return newMark
     }
-
-    return {
-      createMark
-    }
-  })
+  }))
 
 export default types.compose('CircleTool', Tool, CircleTool)

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/EllipseTool/EllipseTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/EllipseTool/EllipseTool.js
@@ -2,13 +2,16 @@ import { types } from 'mobx-state-tree'
 import Tool from '../Tool'
 import { Ellipse } from '../../marks'
 
-const EllipseTool = types.model('Ellipse', {
-  marks: types.map(Ellipse),
-  type: types.literal('ellipse')
-})
-  .actions(self => {
-    function createMark (mark) {
-      const newMark = Ellipse.create(Object.assign({}, mark, { toolType: self.type }))
+const EllipseTool = types
+  .model('Ellipse', {
+    marks: types.map(Ellipse),
+    type: types.literal('ellipse')
+  })
+  .actions((self) => {
+    function createMark(mark) {
+      const newMark = Ellipse.create(
+        Object.assign({}, mark, { toolType: self.type })
+      )
       self.marks.put(newMark)
       return newMark
     }

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/EllipseTool/EllipseTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/EllipseTool/EllipseTool.js
@@ -7,18 +7,14 @@ const EllipseTool = types
     marks: types.map(Ellipse),
     type: types.literal('ellipse')
   })
-  .actions((self) => {
-    function createMark(mark) {
+  .actions((self) => ({
+    createMark(mark) {
       const newMark = Ellipse.create(
         Object.assign({}, mark, { toolType: self.type })
       )
       self.marks.put(newMark)
       return newMark
     }
-
-    return {
-      createMark
-    }
-  })
+  }))
 
 export default types.compose('EllipseTool', Tool, EllipseTool)

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/PointTool/PointTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/PointTool/PointTool.js
@@ -8,18 +8,14 @@ const PointTool = types
     size: types.optional(types.enumeration(['large', 'small']), 'large'),
     type: types.literal('point')
   })
-  .actions((self) => {
-    function createMark(mark) {
+  .actions((self) => ({
+    createMark(mark) {
       const newMark = Point.create(
         Object.assign({}, mark, { toolType: self.type })
       )
       self.marks.put(newMark)
       return newMark
     }
-
-    return {
-      createMark
-    }
-  })
+  }))
 
 export default types.compose('PointTool', Tool, PointTool)

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/PointTool/PointTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/PointTool/PointTool.js
@@ -2,14 +2,17 @@ import { types } from 'mobx-state-tree'
 import Tool from '../Tool'
 import { Point } from '../../marks'
 
-const PointTool = types.model('Point', {
-  marks: types.map(Point),
-  size: types.optional(types.enumeration(['large', 'small']), 'large'),
-  type: types.literal('point')
-})
-  .actions(self => {
-    function createMark (mark) {
-      const newMark = Point.create(Object.assign({}, mark, { toolType: self.type }))
+const PointTool = types
+  .model('Point', {
+    marks: types.map(Point),
+    size: types.optional(types.enumeration(['large', 'small']), 'large'),
+    type: types.literal('point')
+  })
+  .actions((self) => {
+    function createMark(mark) {
+      const newMark = Point.create(
+        Object.assign({}, mark, { toolType: self.type })
+      )
       self.marks.put(newMark)
       return newMark
     }

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/RectangleTool/RectangleTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/RectangleTool/RectangleTool.js
@@ -7,18 +7,14 @@ const RectangleTool = types
     marks: types.map(Rectangle),
     type: types.literal('rectangle')
   })
-  .actions((self) => {
-    function createMark(mark) {
+  .actions((self) => ({
+    createMark(mark) {
       const newMark = Rectangle.create(
         Object.assign({}, mark, { toolType: self.type })
       )
       self.marks.put(newMark)
       return newMark
     }
-
-    return {
-      createMark
-    }
-  })
+  }))
 
 export default types.compose('RectangleTool', Tool, RectangleTool)

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/RotateRectangleTool/RotateRectangleTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/RotateRectangleTool/RotateRectangleTool.js
@@ -7,19 +7,15 @@ const RotateRectangleTool = types
     marks: types.map(RotateRectangle),
     type: types.literal('rotateRectangle')
   })
-  .actions((self) => {
-    function createMark(mark) {
+  .actions((self) => ({
+    createMark(mark) {
       const newMark = RotateRectangle.create(
         Object.assign({}, mark, { toolType: self.type })
       )
       self.marks.put(newMark)
       return newMark
     }
-
-    return {
-      createMark
-    }
-  })
+  }))
 
 export default types.compose(
   'RotateRectangleTool',

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/TemporalPointTool/TemporalPointTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/TemporalPointTool/TemporalPointTool.js
@@ -7,18 +7,14 @@ const TemporalPointTool = types
     marks: types.map(TemporalPoint),
     type: types.literal('temporalPoint')
   })
-  .actions((self) => {
-    function createMark(mark) {
+  .actions((self) => ({
+    createMark(mark) {
       const newMark = TemporalPoint.create(
         Object.assign({}, mark, { toolType: self.type })
       )
       self.marks.put(newMark)
       return newMark
     }
-
-    return {
-      createMark
-    }
-  })
+  }))
 
 export default types.compose('TemporalPointTool', PointTool, TemporalPointTool)

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/TemporalRotateRectangleTool/TemporalRotateRectangleTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/TemporalRotateRectangleTool/TemporalRotateRectangleTool.js
@@ -7,19 +7,15 @@ const TemporalRotateRectangleTool = types
     marks: types.map(TemporalRotateRectangle),
     type: types.literal('temporalRotateRectangle')
   })
-  .actions((self) => {
-    function createMark(mark) {
+  .actions((self) => ({
+    createMark(mark) {
       const newMark = TemporalRotateRectangle.create(
         Object.assign({}, mark, { toolType: self.type })
       )
       self.marks.put(newMark)
       return newMark
     }
-
-    return {
-      createMark
-    }
-  })
+  }))
 
 export default types.compose(
   'TemporalRotateRectangleTool',

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
@@ -58,41 +58,41 @@ const Tool = types
       return allMarksValid
     }
   }))
-  .actions((self) => {
-    function createMark(mark) {
+  .actions((self) => ({
+    createMark(mark) {
       const newMark = Mark.create(
         Object.assign({}, mark, { toolType: self.type })
       )
       self.marks.put(newMark)
       return newMark
-    }
+    },
 
-    function createTask(snapshot) {
+    createTask(snapshot) {
       try {
         self.tasks.push(snapshot)
         return self.tasks[self.tasks.length - 1]
       } catch (e) {
         console.error(`${snapshot.taskKey} is not a valid drawing subtask`)
       }
-    }
+    },
 
-    function deleteMark(mark) {
+    deleteMark(mark) {
       self.marks.delete(mark.id)
-    }
+    },
 
-    function handlePointerMove(event, mark) {
+    handlePointerMove(event, mark) {
       mark.initialDrag(event)
-    }
+    },
 
-    function handlePointerUp(event, mark) {
+    handlePointerUp(event, mark) {
       mark.finish()
-    }
+    },
 
-    function reset() {
+    reset() {
       self.marks.clear()
-    }
+    },
 
-    function validate() {
+    validate() {
       // if the needed validation action needs to vary,
       // then this can be moved to the tools that should delete on invalid mark
       // transcription line, ellipse
@@ -102,16 +102,6 @@ const Tool = types
         }
       })
     }
-
-    return {
-      createMark,
-      createTask,
-      deleteMark,
-      handlePointerMove,
-      handlePointerUp,
-      reset,
-      validate
-    }
-  })
+  }))
 
 export default Tool


### PR DESCRIPTION
Package: `lib-classifier`

Describe your changes:
mobx actions previously `explicitly` returned functions.
![image](https://user-images.githubusercontent.com/9533007/141368446-8ff4d693-6c81-4052-85fd-a48e7fed87b5.png)


This PR refactored all the drawing tools model actions to `implicitly` return functions.
This approach allows for less code, is easier to read and is a modern clean style.
![image](https://user-images.githubusercontent.com/9533007/141368547-f1c8f1cc-8925-49a6-9cad-6745a83bc3b3.png)


This PR does not change any functionality.
