### PR TITLE
Classifier: Run addMiddleware, onAction and onPatch outside of autorun

### DIFF
--- a/packages/lib-classifier/src/store/ClassificationStore.spec.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.spec.js
@@ -175,7 +175,6 @@ describe('Model > ClassificationStore', function () {
         sinon.stub(rootStore.feedback, 'createRules')
         sinon.stub(rootStore.feedback, 'update')
         sinon.stub(rootStore.feedback, 'reset')
-        sinon.stub(rootStore.classifications, 'reset')
         sinon.stub(helpers, 'isFeedbackActive').callsFake(() => true)
         classifications = rootStore.classifications
         feedback = rootStore.feedback
@@ -202,7 +201,6 @@ describe('Model > ClassificationStore', function () {
         feedback.createRules.restore()
         feedback.update.restore()
         feedback.reset.restore()
-        classifications.reset.restore()
         helpers.isFeedbackActive.restore()
       })
 

--- a/packages/lib-classifier/src/store/FeedbackStore.spec.js
+++ b/packages/lib-classifier/src/store/FeedbackStore.spec.js
@@ -371,7 +371,7 @@ describe('Model > FeedbackStore', function () {
       beforeEach(function () {
         const feedbackStub = FeedbackFactory.build({ rules: rulesStub })
         feedback = FeedbackStore.create(feedbackStub)
-        feedback.onSubjectAdvance(call, next, abort)
+        feedback._onSubjectAdvance(call, next, abort)
       })
 
       after(function () {
@@ -392,7 +392,7 @@ describe('Model > FeedbackStore', function () {
       beforeEach(function () {
         const feedbackStub = FeedbackFactory.build({ rules: rulesStub, showModal: false })
         feedback = FeedbackStore.create(feedbackStub)
-        feedback.onSubjectAdvance(call, next, abort)
+        feedback._onSubjectAdvance(call, next, abort)
       })
 
       after(function () {

--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -74,6 +74,15 @@ const RootStore = types
       }
     }
 
+    function _addMiddleware(call, next, abort) {
+      if (call.name === 'setActiveSubject') {
+        const res = next(call)
+        onSubjectAdvance()
+        return res
+      }
+      return next(call)
+    }
+
     function _onAction(call) {
       if (call.name === 'completeClassification') {
         const annotations = self.classifications.currentAnnotations
@@ -104,25 +113,11 @@ const RootStore = types
 
     // Public actions
     function afterCreate () {
-      createSubjectObserver()
       const subjectAnnotationsDisposer = autorun(_observeWorkInProgress)
       addDisposer(self, subjectAnnotationsDisposer)
+      addMiddleware(self, _addMiddleware)
       onAction(self, _onAction)
       onPatch(self, _onPatch)
-    }
-
-    function createSubjectObserver () {
-      const subjectDisposer = autorun(() => {
-        addMiddleware(self, (call, next, abort) => {
-          if (call.name === 'setActiveSubject') {
-            const res = next(call)
-            onSubjectAdvance()
-            return res
-          }
-          return next(call)
-        })
-      }, { name: 'Root Store Subject Observer autorun' })
-      addDisposer(self, subjectDisposer)
     }
 
     function setOnAddToCollection (callback) {

--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -5,6 +5,7 @@ import {
   addMiddleware,
   getEnv,
   onAction,
+  onPatch,
   tryReference,
   types,
   setLivelynessChecking
@@ -72,6 +73,14 @@ const RootStore = types
       }
     }
 
+    function _onPatch(patch) {
+      // TODO: why are we doing this rather than observe classifications.loadingState for changes?
+      const { path, value } = patch
+      if (path === '/classifications/loadingState' && value === 'posting') {
+        self.subjects.advance()
+      }
+    }
+
     function onSubjectAdvance () {
       const { classifications, feedback, projects, subjects, workflows, workflowSteps } = self
       const subject = tryReference(() => subjects?.active)
@@ -91,6 +100,7 @@ const RootStore = types
       createSubjectObserver()
       const subjectAnnotationsDisposer = autorun(_observeWorkInProgress)
       addDisposer(self, subjectAnnotationsDisposer)
+      onPatch(self, _onPatch)
     }
 
     function createClassificationObserver () {

--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -60,6 +60,7 @@ const RootStore = types
 
   .actions(self => {
     // Private methods
+
     /**
       Add or remove a beforeunload listener whenever self.subjects.active?.stepHistory.checkForProgress changes.
     */
@@ -70,6 +71,13 @@ const RootStore = types
         addEventListener && addEventListener("beforeunload", beforeUnloadListener, {capture: true});
       } else {
         removeEventListener && removeEventListener("beforeunload", beforeUnloadListener, {capture: true});
+      }
+    }
+
+    function _onAction(call) {
+      if (call.name === 'completeClassification') {
+        const annotations = self.classifications.currentAnnotations
+        annotations.forEach(annotation => self.feedback.update(annotation))
       }
     }
 
@@ -96,23 +104,11 @@ const RootStore = types
 
     // Public actions
     function afterCreate () {
-      createClassificationObserver()
       createSubjectObserver()
       const subjectAnnotationsDisposer = autorun(_observeWorkInProgress)
       addDisposer(self, subjectAnnotationsDisposer)
+      onAction(self, _onAction)
       onPatch(self, _onPatch)
-    }
-
-    function createClassificationObserver () {
-      const classificationDisposer = autorun(() => {
-        onAction(self, (call) => {
-          if (call.name === 'completeClassification') {
-            const annotations = self.classifications.currentAnnotations
-            annotations.forEach(annotation => self.feedback.update(annotation))
-          }
-        })
-      }, { name: 'Root Store Classification Observer autorun' })
-      addDisposer(self, classificationDisposer)
     }
 
     function createSubjectObserver () {

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
@@ -1,6 +1,6 @@
 import asyncStates from '@zooniverse/async-states'
 import { autorun } from 'mobx'
-import { addDisposer, addMiddleware, flow, getRoot, isValidReference, onPatch, tryReference, types } from 'mobx-state-tree'
+import { addDisposer, addMiddleware, flow, getRoot, isValidReference, tryReference, types } from 'mobx-state-tree'
 import { getBearerToken } from '@store/utils'
 import { getIndexedSubjects, subjectSelectionStrategy } from './helpers'
 import { filterByLabel, filters } from '../../components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal'
@@ -93,7 +93,6 @@ const SubjectStore = types
     function afterAttach () {
       createWorkflowObserver()
       createClassificationChangeObserver()
-      createClassificationPostObserver()
       createSubjectMiddleware()
     }
 
@@ -107,20 +106,6 @@ const SubjectStore = types
         }
       }, { name: 'SubjectStore Workflow Observer autorun' })
       addDisposer(self, workflowDisposer)
-    }
-
-    function createClassificationPostObserver () {
-      const classificationDisposer = autorun(() => {
-
-        onPatch(getRoot(self), (patch) => {
-          const { path, value } = patch
-          if (path === '/classifications/loadingState' && value === 'posting') {
-            self.available.clear()
-            self.advance()
-          }
-        })
-      }, { name: 'SubjectStore Classification Post Observer autorun' })
-      addDisposer(self, classificationDisposer)
     }
 
     function createClassificationChangeObserver () {

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
@@ -112,8 +112,7 @@ const SubjectStore = types
       const validSubjectReference = isValidReference(() => self.active)
       if (validSubjectReference) {
         const subject = self.active
-        const shouldShowFeedback = root.feedback.isActive && root.feedback.messages.length && !root.feedback.showModal
-        if (!shouldShowFeedback && subject && subject.shouldDiscuss) {
+        if (!root.feedback.shouldShowFeedback && subject && subject.shouldDiscuss) {
           const { url, newTab } = subject.shouldDiscuss
           openTalkPage(url, newTab)
         }

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -2,8 +2,7 @@ import { autorun, toJS } from 'mobx'
 import {
   addDisposer, 
   getRoot, 
-  isValidReference, 
-  onAction,
+  isValidReference,
   tryReference, 
   types 
 } from 'mobx-state-tree'


### PR DESCRIPTION
#2520 revealed a subtle bug in the way that hooks like `onPatch` are being run in the classifier. `onPatch` was called inside an `autorun` listener, which ran every time a new classification was created. A side effect of this was that a new patch listener was created for each subject classified. So the first subject advanced the subject queue by one subject, the second by two subjects, the third by three subjects and so on.

This PR removes `onPatch` from the subjects store and moves it to the root store, where it can observe changes in the `classifications` sub-tree and call actions in the `subjects` sub-tree.

I've also unwrapped `onAction` and `addMiddleware`, which were being run inside `autorun` listeners, and removed some stubs that were needed to pass tests in #2520. In retrospect, I think those stubs were covering up for the bug mentioned above.

With this PR, `onAction`, `onPatch` and `addMiddleWare` are run only once, after the root store is created. The listeners that they create will then run when their respective triggers are triggered.

I've also removed anonymous functions nested inside other functions. Personally, I find anonymous, nested functions hard to read and debug so I've replaced them with named functions in each case.

[Listeners in MobX State Tree](https://mobx-state-tree.js.org/concepts/listeners)

Package:
lib-classifier

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
