### PR TITLE
Engaging Crowds: track classifier subject changes in the page URL

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -53,7 +53,7 @@ export default function ClassifierWrapper({
       const newSubjectRoute = `${baseURL}/workflow/${workflowID}/subject-set/${subjectSetID}/subject/${subject.id}`
       const href = addQueryParams(newSubjectRoute, router)
       const as = href
-      router.push(href, as, { shallow: true })
+      router.replace(href, as, { shallow: true })
     }
   }
 

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -1,8 +1,10 @@
 import Classifier from '@zooniverse/classifier'
+import { useRouter } from 'next/router'
 import auth from 'panoptes-client/lib/auth'
 import { func, string, shape } from 'prop-types'
 import asyncStates from '@zooniverse/async-states'
 
+import addQueryParams from '@helpers/addQueryParams'
 import { logToSentry } from '@helpers/logger'
 import ErrorMessage from './components/ErrorMessage'
 import Loader from '@shared/components/Loader'
@@ -29,6 +31,7 @@ export default function ClassifierWrapper({
   workflowID,
   yourStats
 }) {
+  const router = useRouter()
   function onCompleteClassification(classification, subject) {
     yourStats.increment()
     recents.add({
@@ -41,6 +44,17 @@ export default function ClassifierWrapper({
   function onError(error, errorInfo={}) {
     logToSentry(error, errorInfo)
     console.error('Classifier error', error)
+  }
+
+  function onSubjectChange(subject) {
+    const { query } = router
+    const baseURL = `/${query.owner}/${query.project}/classify`
+    if (query.subjectID && subject.id !== query.subjectID) {
+      const newSubjectRoute = `${baseURL}/workflow/${workflowID}/subject-set/${subjectSetID}/subject/${subject.id}`
+      const href = addQueryParams(newSubjectRoute, router)
+      const as = href
+      router.push(href, as, { shallow: true })
+    }
   }
 
   function onToggleFavourite(subjectId, isFavourite) {
@@ -74,6 +88,7 @@ export default function ClassifierWrapper({
           onAddToCollection={onAddToCollection}
           onCompleteClassification={onCompleteClassification}
           onError={onError}
+          onSubjectChange={onSubjectChange}
           onSubjectReset={onSubjectReset}
           onToggleFavourite={onToggleFavourite}
           project={project}

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -71,6 +71,7 @@ export default function Classifier({
   onAddToCollection = () => true,
   onCompleteClassification = () => true,
   onError = () => true,
+  onSubjectChange = () => true,
   onSubjectReset = () => true,
   onToggleFavourite = () => true,
   project,
@@ -103,6 +104,7 @@ export default function Classifier({
   useEffect(function onMount() {
     classifierStore.setOnAddToCollection(onAddToCollection)
     classifications.setOnComplete(onCompleteClassification)
+    classifierStore.setOnSubjectChange(onSubjectChange)
     subjects.setOnReset(onSubjectReset)
     classifierStore.setOnToggleFavourite(onToggleFavourite)
   }, [])

--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -1,4 +1,5 @@
 import { configure } from 'mobx'
+import { getSnapshot } from 'mobx-state-tree'
 import {
   addMiddleware,
   getEnv,
@@ -43,6 +44,7 @@ const RootStore = types
   .volatile(self => {
     return {
       onAddToCollection: () => true,
+      onSubjectChange: () => true,
       onToggleFavourite: () => true
     }
   })
@@ -84,6 +86,7 @@ const RootStore = types
         classifications.reset()
         classifications.createClassification(subject, workflow, project)
         feedback.onNewSubject()
+        self.onSubjectChange(getSnapshot(subject))
       }
     }
 
@@ -98,6 +101,10 @@ const RootStore = types
       self.onAddToCollection = callback
     }
 
+    function setOnSubjectChange (callback) {
+      self.onSubjectChange = callback
+    }
+
     function setOnToggleFavourite (callback) {
       self.onToggleFavourite = callback
     }
@@ -105,6 +112,7 @@ const RootStore = types
     return {
       afterCreate,
       setOnAddToCollection,
+      setOnSubjectChange,
       setOnToggleFavourite
     }
   })


### PR DESCRIPTION
Add an `onSubjectChange` prop to the classifier, which passes a snapshot of the active subject to the containing page. The `ClassifierWrapper` component listens for subject changes and performs a shallow update of the page location, if we're on a page that uses the `subjectID` parameter.

As a result, if we go to Talk and back, or if we refresh the page, the page should always reload the active subject ID.

Package:
app-project
lib-classifier

Closes #2537.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
