### PR TITLE
LightCurveViewer: fix "invisible annotations" when returning to Classify page

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -179,14 +179,13 @@ class LightCurveViewer extends Component {
    */
   initBrushes () {
     if (!this.annotationBrushes.length) {
-      this.createAnnotationBrush() // Create the initial brush
-
       // Load any existing brushes from the stores. This is ONLY relevant when
       // the user is re-visiting the Classifier after leaving
       // mid-classification. In most normal cases (i.e. the classifier loads, or
       // a new Subject is loaded), there are 0 existing brushes in the stores
       this.loadBrushesFromAnnotations()
 
+      this.createAnnotationBrush() // Create the "default" brush (i.e. the brush that listens for new input)
       this.updateAnnotationBrushes()  // Draw!
     }
 
@@ -208,16 +207,12 @@ class LightCurveViewer extends Component {
   loadBrushesFromAnnotations () {
     const annotationValues = this.getAnnotationValues()
 
-    console.log('+++ loadBrushesFromAnnotations (A) ', annotationValues)
-
     annotationValues?.forEach(data => {
       const brush = this.createAnnotationBrush()
       brush.minX = data.x - data.width / 2
       brush.maxX = data.x + data.width / 2
       brush.zoomLevelOnCreation = data.zoomLevelOnCreation
     })
-
-    console.log('+++ loadBrushesFromAnnotations (B) ', this.annotationBrushes)
   }
 
   /*

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -330,8 +330,7 @@ class LightCurveViewer extends Component {
   }
 
   getAnnotationValues () {
-    const { annotations, currentTask } = this.props
-    const annotation = annotations.get(currentTask.taskKey)
+    const { annotation } = this.props
     if (annotation && this.isCurrentTaskValidForAnnotation()) return Array.from(annotation.value) || []
     return []
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
@@ -12,30 +12,38 @@ import locationValidator from '../../helpers/locationValidator'
 
 function storeMapper (stores) {
   const {
-    enableAnnotate,
-    enableMove,
-    interactionMode,
-    setOnPan,
-    setOnZoom
-  } = stores.classifierStore.subjectViewer
+    subjectViewer: {
+      enableAnnotate,
+      enableMove,
+      interactionMode,
+      setOnPan,
+      setOnZoom
+    },
+    classifications: {
+      addAnnotation
+    },
+    workflowSteps: {
+      activeStepTasks
+    },
+    subjects: {
+      active: subject
+    },
+  } = stores.classifierStore
 
-  const {
-    addAnnotation
-  } = stores.classifierStore.classifications
-  const annotations = stores.classifierStore.classifications.currentAnnotations
-
-  const {
-    activeStepTasks
-  } = stores.classifierStore.workflowSteps
-
-  const [activeDataVisTask] = activeStepTasks.filter(task => task.type === 'dataVisAnnotation')
+  const [ activeDataVisTask ] = activeStepTasks.filter(task => task?.type === 'dataVisAnnotation')
   const { activeToolIndex } = activeDataVisTask || {}
+
+  let annotation
+  const latest = subject?.stepHistory.latest
+  if (latest) {
+    ([ annotation ] = latest.annotations.filter(annotation => activeDataVisTask && annotation.task === activeDataVisTask.taskKey))
+  }
 
   return {
     activeDataVisTask,
     activeToolIndex,
     addAnnotation,
-    annotations,
+    annotation,  // dataVisAnnotation
     enableAnnotate,
     enableMove,
     interactionMode,
@@ -132,7 +140,7 @@ class LightCurveViewerContainer extends Component {
       activeDataVisTask,
       activeToolIndex,
       addAnnotation,
-      annotations,
+      annotation,  // dataVisAnnotation
       drawFeedbackBrushes,
       enableAnnotate,
       enableMove,
@@ -151,7 +159,7 @@ class LightCurveViewerContainer extends Component {
     return (
       <LightCurveViewer
         addAnnotation={addAnnotation}
-        annotations={annotations}
+        annotation={annotation}
         currentTask={activeDataVisTask}
         dataExtent={this.state.dataExtent}
         dataPoints={this.state.dataPoints}
@@ -171,33 +179,48 @@ class LightCurveViewerContainer extends Component {
 }
 
 LightCurveViewerContainer.defaultProps = {
+  activeDataVisTask: undefined,
+  activeToolIndex: undefined,
   addAnnotation: () => {},
+  annotation: undefined,
   drawFeedbackBrushes: () => {},
+  enableAnnotate: () => {},
+  enableMove: () => {},
+  feedback: false,
   interactionMode: 'annotate',
-  loadingState: asyncStates.initialized,
-  onError: () => true,
-  onReady: () => true,
+  onKeyDown: () => {},
+  setOnPan: () => {},
+  setOnZoom: () => {},
   subject: {
     id: '',
     locations: []
-  }
+  },
+
+  loadingState: asyncStates.initialized,
+  onError: () => true,
+  onReady: () => true,
 }
 
 LightCurveViewerContainer.propTypes = {
+  activeDataVisTask: PropTypes.object,
   activeToolIndex: PropTypes.number,
   addAnnotation: PropTypes.func,
   drawFeedbackBrushes: PropTypes.func,
+  enableAnnotate: PropTypes.func,
+  enableMove: PropTypes.func,
+  feedback: PropTypes.bool,
   interactionMode: PropTypes.oneOf(['annotate', 'move']),
-  loadingState: PropTypes.string,
-  onError: PropTypes.func,
   onKeyDown: PropTypes.func.isRequired,
-  onReady: PropTypes.func,
   setOnPan: PropTypes.func.isRequired,
   setOnZoom: PropTypes.func.isRequired,
   subject: PropTypes.shape({
     id: PropTypes.string,
     locations: PropTypes.arrayOf(locationValidator)
-  })
+  }),
+
+  loadingState: PropTypes.string,
+  onError: PropTypes.func,
+  onReady: PropTypes.func,
 }
 
 @inject(storeMapper)


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`
Fixes: #2553 

This PR fixes the issue where the LightCurveViewer's existing annotations "disappear" (i.e. go invisible, but still exist in the stores so they'd be submitted in the Classification!) when navigating away from the FEM Classify page to another FEM page, then back to the Classify page.

Basically, there's a desync between the UI visuals (D3.js graph) and the data (Mobx store).

- The problem is that...
  - right now, D3.js is the "source of truth" and syncs one-way to the Mobx store (you draw something on D3.js, it tells the stores "this is what's happening")
  - This is fine in most cases, UNLESS you navigate away (to another FEM page) and _return_ to the Classify page, because _returning_ to the Classify page resets the D3.js graph but NOT the MobX stores.
- The planned solution is to draw all the "brushes" (i.e. visible annotations), based on existing MobX store data, _on component load._ (i.e. once when visiting/revisiting the Classify page)
  - This should "close the loop" for syncing the D3.js and the MobX stores, with the D3.js being the source of truth for all cases _except_ on component load, in which case the MobX store is the source of truth for one fleeting moment.

⚠️ ALSO I've done my best to clean up the code to modern FEM standards, but there's still a lot I don't want to touch.

### Testing

Testing URL: [Planet Finders Beta (staging)](https://local.zooniverse.org:3000/projects/nora-dot-test/planet-finders-beta/classify/workflow/3317)
- This is the precursor to [Planet Hunters TESS (production)](https://www.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess)
- It's a Workflow with the LCV Subject Viewer enabled, and exactly 1 Task (dataVisAnnotation, with the tool graph2dRangeX), and specialised JSON-type Subjects.

Testing steps:
- Run `app-project` (not lib-classifier!) and go to the URL
- Open the Classify page
- Make 1 annotation
- Click on the project title to go to the Project home page
- EITHER press the 'Back' button on the browser OR click on the 'Classify' link, to return to the Classify page
- Observe that the 1 annotations you made is still visible
  - (On `master`, you will see 0 annotations instead)
- From here, you need to test two paths:
- PATH A: Submit the classification. The 1 annotation you made should be reflected in the submitted data.
- PATH B: Add another annotation
  - Observe that there are now 2 annotations
  - Submit the classification, and ensure all 2 annotations are reflected in the submitted data.

NOT in the testing scope:
- Workflows with multiple tasks, WFs with NO dataVisAnnotation tasks, etc.

### Status

WIP