### PR TITLE
Engaging Crowds: Ignore active subjects when selecting a subject

### DIFF
--- a/packages/lib-classifier/src/store/WorkflowStore/WorkflowStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/WorkflowStore.js
@@ -59,6 +59,7 @@ const WorkflowStore = types
     function * selectWorkflow (id = getDefaultWorkflowId(), subjectSetID, subjectID) {
       if (id) {
         const activeWorkflows = self.project?.links?.active_workflows || []
+        const activeSubject = tryReference(() => getRoot(self).subjects.active)
         const projectID = self.project?.id
         if (activeWorkflows.indexOf(id) > -1) {
           const workflow = yield self.getResource(id)
@@ -68,7 +69,7 @@ const WorkflowStore = types
             // wait for the subject set to load before activating the workflow
             const subjectSet = yield selectedWorkflow.selectSubjectSet(subjectSetID)
           }
-          if (subjectID) {
+          if (subjectID && subjectID !== activeSubject?.id) {
             selectedWorkflow.selectSubjects([ subjectID ])
           }
           self.setActive(id)

--- a/packages/lib-classifier/src/store/WorkflowStore/WorkflowStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/WorkflowStore.spec.js
@@ -175,10 +175,12 @@ describe('Model > WorkflowStore', function () {
           version: '0.0'
         })
         const workflowWithSubject = Workflow.create(workflowSnapshot)
+        const subjects = Factory.buildList('subject', 10)
+        const [ firstSubject ] = subjects
         workflowID = workflow.id
         subjectID = '1234'
         const panoptesClientStub = stubPanoptesJs({
-          subjects: Factory.buildList('subject', 10),
+          subjects,
           workflows: [workflowWithSubject]
         })
 
@@ -186,6 +188,8 @@ describe('Model > WorkflowStore', function () {
         rootStore.workflows.reset()
         rootStore.workflows.setResources([workflowWithSubject])
         await rootStore.workflows.selectWorkflow(workflowID, subjectSetID, subjectID)
+        rootStore.subjects.setResources(subjects)
+        rootStore.subjects.setActive(firstSubject.id)
       })
 
       after(function () {
@@ -197,6 +201,13 @@ describe('Model > WorkflowStore', function () {
       })
 
       it('should set the selected subject', function () {
+        expect(rootStore.workflows.active.selectedSubjects).to.deep.equal([ subjectID ])
+      })
+
+      it('should ignore subjects that are already active', async function () {
+        const activeSubjectID = rootStore.subjects.active.id
+        expect(rootStore.workflows.active.selectedSubjects).to.deep.equal([ subjectID ])
+        await rootStore.workflows.selectWorkflow(workflowID, subjectSetID, activeSubjectID)
         expect(rootStore.workflows.active.selectedSubjects).to.deep.equal([ subjectID ])
       })
     })


### PR DESCRIPTION
When selecting a specific subject to classify, ignore the selected subject if it is already active. This fixes a bug where the classifier resets the subject queue, and active classification, if we select the current active subject to work on.

This fixes a subtle bug in Scarlets & Blues, which uses subject IDs in Classify page URLs. If you made some annotations and navigated away from the classifier, to another client-side page (About or Home), then back to Classify with the browser Back button, the subjectID in the URL would trigger the subjects store to reset and reload the subject queue. In the browser you would see your annotations appear briefly, then disappear as the active subject reloads.

This PR checks the `subjectID` parameter (from the URL) against the active subject before selecting a specific subject to work on, when the classifier mounts.

To test it, you'll need to build the classifier and also build the project app then run the project app with `yarn start:dev`, in order to enable client-side page transitions. Go to an S&B subject, annotate it, navigate to About or Home then back to the Classifier. Your annotations should be preserved as long as you don't leave the NextJS app.

https://local.zooniverse.org:3000/projects/bogden/scarlets-and-blues

https://user-images.githubusercontent.com/59547/142910148-9017b9e2-bee9-49a2-b672-a0ab696f2a23.mov




Package:
lib-classifier

Closes #2536.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
