### PR TITLE
Classifier: Refactor the beforeunload warning

### DIFF
--- a/packages/lib-classifier/src/store/SubjectStore/Subject/StepHistory/locales/en.json
+++ b/packages/lib-classifier/src/store/SubjectStore/Subject/StepHistory/locales/en.json
@@ -1,5 +1,5 @@
 {
-  "RootStore": {
+  "StepHistory": {
     "unloadWarning": "You have unsaved work. Are you sure you want to leave?"
   }
 }


### PR DESCRIPTION
Move the `onbeforeunload` warning from `RootStore` down to `StepHistory`, where it observes `checkForProgress` for changes. Add a reset on `stepHistory.finish()`, so that the warning is removed when we press Done or Done & Talk.

Package:
lib-classifier

Closes #2561.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
