### PR TITLE
Add a warning for unsaved work from the transcription task

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
@@ -1,5 +1,5 @@
 import counterpart from 'counterpart'
-import { arrayOf, bool, number, object, shape, string } from 'prop-types'
+import { array, arrayOf, bool, number, object, shape, string } from 'prop-types'
 import React from 'react'
 import styled, { css, withTheme } from 'styled-components'
 import { TranscriptionLine } from '@plugins/drawingTools/components'
@@ -42,7 +42,7 @@ class TranscribedLines extends React.Component {
   }
 
   createMark (line, node) {
-    const { frame } = this.props
+    const { annotation, frame } = this.props
     const { activeTool, activeToolIndex, setActiveMark } = this.props.task
 
     if (activeTool) {
@@ -65,6 +65,8 @@ class TranscribedLines extends React.Component {
       })
       mark.setPreviousAnnotations(previousAnnotationValuesForEachMark)
       mark.finish()
+      const value = annotation.value.slice()
+      annotation.update([ ...value, mark.id ])
     }
   }
 
@@ -208,6 +210,11 @@ class TranscribedLines extends React.Component {
 }
 
 TranscribedLines.propTypes = {
+  annotation: shape({
+    task: string,
+    taskType: string,
+    value: array
+  }),
   frame: number.isRequired,
   invalidMark: bool,
   lines: arrayOf(shape({

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js
@@ -37,7 +37,19 @@ describe('Component > TranscribedLines', function () {
   })
 
   it('should render without crashing', function () {
-    wrapper = shallow(<TranscribedLines frame={0} lines={consensusLines} task={task} marks={task.marks} />)
+    const annotation = {
+      taskKey: 'T1',
+      taskType: 'transcription',
+      update: sinon.stub(),
+      value: []
+    }
+    wrapper = shallow(<TranscribedLines
+      annotation={annotation}
+      frame={0}
+      lines={consensusLines}
+      task={task}
+      marks={task.marks}
+    />)
     expect(wrapper).to.be.ok()
   })
 
@@ -98,7 +110,18 @@ describe('Component > TranscribedLines', function () {
         type: 'transcription'
       })
       task.setActiveTool(0)
-      wrapper = shallow(<TranscribedLines frame={0} lines={consensusLines} marks={task.marks} task={task} />)
+      const annotation = {
+        taskKey: 'T1',
+        taskType: 'transcription',
+        value: []
+      }
+      wrapper = shallow(<TranscribedLines
+        annotation={annotation}
+        frame={0}
+        lines={consensusLines}
+        marks={task.marks}
+        task={task}
+      />)
       lines = wrapper.find(TranscriptionLine).find({ state: 'transcribed' })
     })
 
@@ -194,7 +217,19 @@ describe('Component > TranscribedLines', function () {
       before(function () {
         task.reset()
         consensusLines = transcriptionReductions.consensusLines(0)
-        wrapper = shallow(<TranscribedLines frame={0} lines={consensusLines} marks={task.marks} task={task} />)
+        const annotation = {
+          taskKey: 'T1',
+          taskType: 'transcription',
+          update: sinon.stub(),
+          value: []
+        }
+        wrapper = shallow(<TranscribedLines
+          annotation={annotation}
+          frame={0}
+          lines={consensusLines}
+          marks={task.marks}
+          task={task}
+        />)
         lines = wrapper.find(TranscriptionLine).find({ state: 'transcribed' })
       })
 
@@ -255,7 +290,19 @@ describe('Component > TranscribedLines', function () {
       beforeEach(function () {
         task.reset()
         consensusLines = transcriptionReductions.consensusLines(0)
-        wrapper = shallow(<TranscribedLines frame={0} lines={consensusLines} marks={task.marks} task={task} />)
+        const annotation = {
+          taskKey: 'T1',
+          taskType: 'transcription',
+          update: sinon.stub(),
+          value: []
+        }
+        wrapper = shallow(<TranscribedLines
+          annotation={annotation}
+          frame={0}
+          lines={consensusLines}
+          marks={task.marks}
+          task={task}
+        />)
         lines = wrapper.find(TranscriptionLine).find({ state: 'transcribed' })
       })
 
@@ -315,7 +362,19 @@ describe('Component > TranscribedLines', function () {
       beforeEach(function () {
         task.reset()
         consensusLines = transcriptionReductions.consensusLines(0)
-        wrapper = shallow(<TranscribedLines frame={0} lines={consensusLines} marks={task.marks} task={task} />)
+        const annotation = {
+          taskKey: 'T1',
+          taskType: 'transcription',
+          update: sinon.stub(),
+          value: []
+        }
+        wrapper = shallow(<TranscribedLines
+          annotation={annotation}
+          frame={0}
+          lines={consensusLines}
+          marks={task.marks}
+          task={task}
+        />)
         lines = wrapper.find(TranscriptionLine).find({ state: 'transcribed' })
       })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.js
@@ -23,14 +23,20 @@ function storeMapper(store) {
   } = store
 
   const consensusLines = subject.transcriptionReductions?.consensusLines(frame)
+  const activeStepAnnotations = subject.stepHistory.latest.annotations
 
   // We expect there to only be one
   const [transcriptionTask] = findTasksByType('transcription')
   // We want to observe the marks array for changes, so pass that as a separate prop.
   const marks = transcriptionTask?.marks
+  // find the corresponding annotation
+  const annotation = activeStepAnnotations.find(
+    annotation => annotation.task === transcriptionTask?.taskKey
+  )
 
   const valid = step?.isValid
   return {
+    annotation,
     frame,
     invalid: !valid,
     transcriptionTask,
@@ -45,6 +51,7 @@ const defaultWorkflow = {
 }
 
 function TranscribedLinesContainer ({
+  annotation,
   frame,
   invalid = false,
   transcriptionTask = {},
@@ -58,6 +65,7 @@ function TranscribedLinesContainer ({
   if (workflow?.usesTranscriptionTask && shownMarks === SHOWN_MARKS.ALL && consensusLines.length > 0) {
     return (
       <TranscribedLines
+        annotation={annotation}
         frame={frame}
         invalidMark={invalid}
         lines={consensusLines}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { MobXProviderContext, observer } from 'mobx-react'
 import SHOWN_MARKS from '@helpers/shownMarks'
+
+import { withStores } from '@helpers'
 import TranscribedLines from './TranscribedLines'
 
-function useStores () {
-  const stores = React.useContext(MobXProviderContext)
+function storeMapper(store) {
   const {
     subjects: {
       active: subject
@@ -20,9 +20,9 @@ function useStores () {
       active: step,
       findTasksByType
     }
-  } = stores.classifierStore
+  } = store
 
-  const consensusLines = subject.transcriptionReductions?.consensusLines(frame) || []
+  const consensusLines = subject.transcriptionReductions?.consensusLines(frame)
 
   // We expect there to only be one
   const [transcriptionTask] = findTasksByType('transcription')
@@ -40,19 +40,19 @@ function useStores () {
   }
 }
 
-function TranscribedLinesConnector ({
-  scale = 1
+const defaultWorkflow = {
+  usesTranscriptionTask: false
+}
+
+function TranscribedLinesContainer ({
+  frame,
+  invalid = false,
+  transcriptionTask = {},
+  consensusLines = [],
+  marks = [],
+  scale = 1,
+  workflow = defaultWorkflow
 }) {
-  const {
-    frame,
-    invalid = false,
-    transcriptionTask = {},
-    consensusLines = [],
-    marks = [],
-    workflow = {
-      usesTranscriptionTask: false
-    }
-  } = useStores()
   const { shownMarks } = transcriptionTask
 
   if (workflow?.usesTranscriptionTask && shownMarks === SHOWN_MARKS.ALL && consensusLines.length > 0) {
@@ -71,8 +71,8 @@ function TranscribedLinesConnector ({
   return null
 }
 
-TranscribedLinesConnector.propTypes = {
+TranscribedLinesContainer.propTypes = {
   scale: PropTypes.number
 }
 
-export default observer(TranscribedLinesConnector)
+export default withStores(TranscribedLinesContainer, storeMapper)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.spec.js
@@ -7,7 +7,6 @@ import TranscribedLinesConnector from './TranscribedLinesConnector'
 import TranscribedLines from './TranscribedLines'
 
 describe('Component > TranscribedLinesConnector', function () {
-  let mockUseContext
   const mockStoresWithTranscriptionTask = {
     subjects: {
       active: {
@@ -87,73 +86,45 @@ describe('Component > TranscribedLinesConnector', function () {
     }
   }
 
-  afterEach(function () {
-    mockUseContext.restore()
-  })
-
   it('should render without crashing', function () {
-    mockUseContext = sinon.stub(React, 'useContext').callsFake(() => {
-      return {
-        classifierStore: mockStoresWithTranscriptionTask
-      }
-    })
-    const wrapper = shallow(<TranscribedLinesConnector />)
+    const store = mockStoresWithTranscriptionTask
+    const wrapper = shallow(<TranscribedLinesConnector store={store} />)
     expect(wrapper).to.be.ok()
   })
 
   describe('when the workflow does not have a transcription task', function () {
     it('should not render TranscribedLines', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => {
-        return {
-          classifierStore: mockStoresWithoutTranscriptionTask
-        }
-      })
-      const wrapper = shallow(<TranscribedLinesConnector />)
+      const store = mockStoresWithoutTranscriptionTask
+      const wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
       expect(wrapper.find(TranscribedLines)).to.have.lengthOf(0)
     })
   })
 
   describe('when the subject does not have consensus lines', function () {
     it('should not render TranscribedLines', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => {
-        return {
-          classifierStore: mockStoresWithTranscriptionTask
-        }
-      })
-      const wrapper = shallow(<TranscribedLinesConnector />)
+      const store= mockStoresWithTranscriptionTask
+      const wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
       expect(wrapper.find(TranscribedLines)).to.have.lengthOf(0)
     })
   })
 
   describe('when the workflow does have a transcription task and subject does have consensus lines', function () {
     it('should render TranscribedLines', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => {
-        return {
-          classifierStore: mockStoresWithTranscriptionTaskAndConsensusLines
-        }
-      })
-      const wrapper = shallow(<TranscribedLinesConnector />)
+      const store = mockStoresWithTranscriptionTaskAndConsensusLines
+      const wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
       expect(wrapper.find(TranscribedLines)).to.have.lengthOf(1)
       expect(wrapper.find(TranscribedLines).prop('lines')).to.have.lengthOf(transcriptionReductions.consensusLines(0).length)
     })
 
     it('should render lines per frame', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => {
-        return {
-          classifierStore: Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, { subjectViewer: { frame: 1 } })
-        }
-      })
-      const wrapper = shallow(<TranscribedLinesConnector />)
+      const store = Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, { subjectViewer: { frame: 1 } })
+      const wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
       expect(wrapper.find(TranscribedLines).prop('lines')).to.have.lengthOf(transcriptionReductions.consensusLines(1).length)
     })
 
     it('should not render TranscribedLines if no lines per frame', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => {
-        return {
-          classifierStore: Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, { subjectViewer: { frame: 3 } })
-        }
-      })
-      const wrapper = shallow(<TranscribedLinesConnector />)
+      const store = Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, { subjectViewer: { frame: 3 } })
+      const wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
       expect(wrapper.find(TranscribedLines)).to.have.lengthOf(transcriptionReductions.consensusLines(3).length)
     })
 
@@ -174,12 +145,8 @@ describe('Component > TranscribedLinesConnector', function () {
           }
         }
       }
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => {
-        return {
-          classifierStore: Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, taskShowingOnlyUserMarks)
-        }
-      })
-      const wrapper = shallow(<TranscribedLinesConnector />)
+      const store = Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, taskShowingOnlyUserMarks)
+      const wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
       expect(wrapper.find(TranscribedLines)).to.have.lengthOf(0)
     })
 
@@ -200,49 +167,36 @@ describe('Component > TranscribedLinesConnector', function () {
           }
         }
       }
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => {
-        return {
-          classifierStore: Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, taskHidingAllMarks)
-        }
-      })
-      const wrapper = shallow(<TranscribedLinesConnector />)
+      const store = Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, taskHidingAllMarks)
+      const wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
       expect(wrapper.find(TranscribedLines)).to.have.lengthOf(0)
     })
 
     it('should pass along if the step\'s tasks are in an invalid state', function () {
       let wrapper
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => {
-        return {
-          classifierStore: mockStoresWithTranscriptionTaskAndConsensusLines
-        }
-      })
-      wrapper = shallow(<TranscribedLinesConnector />)
+      let store = mockStoresWithTranscriptionTaskAndConsensusLines
+      wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
       expect(wrapper.props().invalidMark).to.be.false()
-      mockUseContext.restore()
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => {
-        return {
-          classifierStore: Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, { 
-            workflowSteps: { 
-              active:  {
-                isValid: false
-              },
-              activeStepTasks: [
-                {
-                  shownMarks: 'ALL',
-                  type: 'transcription'
-                }
-              ],
-              findTasksByType: () => {
-                return [{
-                  shownMarks: 'ALL',
-                  type: 'transcription'
-                }]
-              }
+      store = Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, { 
+        workflowSteps: { 
+          active:  {
+            isValid: false
+          },
+          activeStepTasks: [
+            {
+              shownMarks: 'ALL',
+              type: 'transcription'
             }
-          })
+          ],
+          findTasksByType: () => {
+            return [{
+              shownMarks: 'ALL',
+              type: 'transcription'
+            }]
+          }
         }
       })
-      wrapper = shallow(<TranscribedLinesConnector />)
+      wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
       expect(wrapper.props().invalidMark).to.be.true()
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.spec.js
@@ -1,5 +1,4 @@
 import { shallow } from 'enzyme'
-import sinon from 'sinon'
 import React from 'react'
 import TranscriptionReductions from '@store/SubjectStore/Subject/TranscriptionReductions'
 import { reducedSubject } from '@store/SubjectStore/Subject/TranscriptionReductions/mocks'
@@ -7,9 +6,15 @@ import TranscribedLinesConnector from './TranscribedLinesConnector'
 import TranscribedLines from './TranscribedLines'
 
 describe('Component > TranscribedLinesConnector', function () {
+  const stepHistory = {
+    latest: {
+      annotations: []
+    }
+  }
   const mockStoresWithTranscriptionTask = {
     subjects: {
       active: {
+        stepHistory,
         transcriptionReductions: {
           consensusLines: () => []
         }
@@ -51,6 +56,7 @@ describe('Component > TranscribedLinesConnector', function () {
   const mockStoresWithTranscriptionTaskAndConsensusLines = Object.assign({}, mockStoresWithTranscriptionTask, {
     subjects: {
       active: {
+        stepHistory,
         transcriptionReductions: transcriptionReductions
       }
     }
@@ -59,6 +65,7 @@ describe('Component > TranscribedLinesConnector', function () {
   const mockStoresWithoutTranscriptionTask = {
     subjects: {
       active: {
+        stepHistory,
         transcriptionReductions: {
           consensusLines: () => []
         }


### PR DESCRIPTION
- refactor `TranscribedLinesConnector` to use the `withStores` helper.
- add the current annotation to `TranscribedLines` as a prop.
- update the active annotation when we create a new transcription line from an existing line.

This PR adds `annotation.update()` to previously transcribed lines, which enables them to use the work-in-progress flag introduced in #2411 and #2415. It will also set them up to refresh auth tokens on update (#2563), which will allow volunteers to stay logged in when working on long pages.


Try it out on a test subject with many previously transcribed lines. If you edit a few lines, then reload the page, you should be warned that your work will be lost.

https://localhost:8080/?project=11300&subject=55414217&env=production&demo=true
<img width="1243" alt="Screenshot of a partially transcribed page, warning that unsaved work will be lost if you leave the page." src="https://user-images.githubusercontent.com/59547/143228889-c5dd1472-38a4-475a-9b67-41d10bdb276e.png">

Package:
lib-classifier

Closes #2564.


# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
