### PR TITLE
Engaging Crowds: Mark subjects as seen on subjects.advance()

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
@@ -16,9 +16,11 @@ counterpart.registerTranslations('en', en)
 The tabbed tasks area of the classifier, with tabs for the tutorial and active tasks.
 */
 export default function TaskArea({
+  alreadySeen,
   className,
   disableTutorialTab = true,
   setActiveTutorial = () => true,
+  retired,
   subject,
   tutorial = null,
   workflow = {
@@ -32,9 +34,9 @@ export default function TaskArea({
   useEffect(function onSubjectChange() {
     // TODO: remove this once testing is complete.
     const URLParams = queryString.parse(window?.location?.search)
-    const finished = (subject && URLParams?.finished) || subject?.retired || subject?.alreadySeen
+    const finished = (subject && URLParams?.finished) || retired || alreadySeen
     setDisabled(finished && workflow.hasIndexedSubjects)
-  }, [subject])
+  }, [alreadySeen, subject, retired])
 
   function enableTasks() {
     setDisabled(false)

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.js
@@ -18,8 +18,10 @@ function storeMapper(store) {
   } = store
 
   return {
+    alreadySeen: subject?.alreadySeen,
     disableTutorialTab,
     setActiveTutorial,
+    retired: subject?.retired,
     subject,
     tutorial,
     workflow

--- a/packages/lib-classifier/src/store/SubjectStore/Subject/Subject.js
+++ b/packages/lib-classifier/src/store/SubjectStore/Subject/Subject.js
@@ -96,6 +96,7 @@ const Subject = types
   }))
 
   .actions(self => {
+
     function afterAttach () {
       fetchTranscriptionReductions()
     }
@@ -121,6 +122,10 @@ const Subject = types
       rootStore.onAddToCollection(self.id)
     }
 
+    function markAsSeen() {
+      self.already_seen = true
+    }
+
     function openInTalk (newTab = false) {
       self.shouldDiscuss = {
         newTab,
@@ -138,6 +143,7 @@ const Subject = types
       afterAttach,
       beforeDestroy,
       addToCollection,
+      markAsSeen,
       openInTalk,
       toggleFavorite
     }

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
@@ -188,8 +188,10 @@ const SubjectStore = types
 
     function advance() {
       const workflow = tryReference(() => getRoot(self).workflows.active)
+      const activeSubject = tryReference(() => self.active)
 
       if (workflow?.hasIndexedSubjects) {
+        activeSubject?.markAsSeen()
         self.nextIndexed()
       } else {
         self.shift()

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.spec.js
@@ -380,9 +380,11 @@ describe('Model > SubjectStore', function () {
       })
       for (let priority = 1; priority <= 10; priority++) {
         const snapshot = {
+          already_seen: false,
           metadata: {
             '#priority': priority
-          }
+          },
+          retired: false
         }
         subjects.push(SubjectFactory.build(snapshot))
       }
@@ -446,6 +448,13 @@ describe('Model > SubjectStore', function () {
         store.subjects.setResources(subjects)
         store.subjects.setActive(subjects[0].id)
         store.subjects.advance()
+      })
+
+      it('should mark the previous active subject as seen', function () {
+        let activeSubject = store.subjects.active
+        const previousSubject = store.subjects.resources.get(subjects[0].id)
+        expect(previousSubject.already_seen).to.be.true()
+        expect(activeSubject.already_seen).to.be.false()
       })
 
       it('should preserve the previous active subject', function () {


### PR DESCRIPTION
- Add `subject.markAsSeen()`, which sets `subject.already_seen` to true.
- Update the task area to react to changes in `subject.retired` and `subject.alreadySeen`.
- Call `subjects.active.markAsSeen()` after submitting a classification but before advancing the subject queue for indexed workflows. 

These changes submit the classification, for an unseen subject, with `classification.metadata.subject_selection_state.already_seen: false` then update the store state so that this subject displays as finished.
<img width="1241" alt="Screenshot of the last subject in a Scarlets & Blues subject set, showing a red Finished banner and a Finished popup blocking the task area." src="https://user-images.githubusercontent.com/59547/143910396-dd8893ca-d68a-4a9c-a16e-818f7560a239.png">

Try it out, in demo mode, on the last subject in a Scarlets & Blues subject set.
https://localhost:8080/?project=bogden/scarlets-and-blues&workflow=18505&subjectSet=98881&subject=69734532&demo=true&env=production


Package:
lib-classifier

Closes #2569.


# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
