### PR TITLE
Engaging Crowds: ADRs for selecting a subject

### DIFF
--- a/docs/arch/README.md
+++ b/docs/arch/README.md
@@ -36,3 +36,5 @@
 - [ADR 34: Workflow selection](adr-34.md)
 - [ADR 35: Adding undo/redo to workflow steps](adr-35.md)
 - [ADR 36: NextJS App base paths](adr-36.md)
+- [ADR 37: Engaging Crowds: Indexed subject sets](adr-37.md)
+- [ADR 38: Engaging Crowds: Next/previous subjects](adr-38.md)

--- a/docs/arch/adr-37.md
+++ b/docs/arch/adr-37.md
@@ -25,6 +25,11 @@ The subjects table in Panoptes is too large to allow for fast querying, so we al
 
 - All subjects linked to an indexed set are expected to have the same metadata fields. This isn't enforced in the code but mixing subjects with different sets of indexed fields isn't possible.
 
+- Components are limited to showing one page of results from the API at the moment. Page sizes are:
+  - Workflows (20.)
+  - Subject sets (50.)
+  - Subjects (100.)
+
 ## Status
 
 Accepted

--- a/docs/arch/adr-37.md
+++ b/docs/arch/adr-37.md
@@ -1,0 +1,30 @@
+# ADR 37: Engaging Crowds: Indexed subject sets
+
+7 December 2021
+
+## Context
+
+Engaging Crowds allows volunteers to browse and search subject sets, linked to a workflow, in order to pick which subjects they want to work on. We needed a solution that would allow us to search a set, via indexed subject metadata, and present the results to a volunteer.
+
+The subjects table in Panoptes is too large to allow for fast querying, so we also needed to build our own indexing system for indexed sets.
+
+## Decision
+
+- Project owners can flag subject metadata columns as searchable by prefixing the heading with `%` in the manifest eg. these manifest headings `subject_id,image_name_1,%origin,link,%attribution,license,#secret_description` mark `metadata.origin` and `metadata.attribution` as searchable.
+- Subject sets with indexed subjects have `metadata.indexFields` set to a list of indexed fields eg. `indexFields: 'origin,attribution'`.
+- Subject metadata for indexed sets is copied to a separate database running on [Datasette](https://datasette.io). Each set is given its own table, named by subject set ID. Datasette gives us a RESTful API out of the box, allowing us to browse and search subject data as HTML or JSON. See https://subject-set-search-api.zooniverse.org/subjects.
+- From a volunteers point-of-view, the Datasette service is used to find specific subject IDs to work on. Those IDs are then sent to the Panoptes API `/subjects/selection` endpoint, which returns those subjects, in order, for classification.
+
+## Consequences
+
+- Subject metadata has to be synchronised between Panoptes and the Datasette service. At the moment, this is a manual process, which can be run via Jenkins or `lita`. The service has to be rebuilt whenever changes are made to any indexed set.
+
+  Rebuilding all indexed sets whenever one changes might prove costly as the number of indexed sets grows.
+
+- A [new subject selection strategy](https://github.com/zooniverse/front-end-monorepo/blob/80de98c88966c0d6764d8d9ae4a4f0dcca7f4354/packages/lib-classifier/src/store/SubjectStore/helpers/subjectSelectionStrategy/subjectSelectionStrategy.js#L36-L52) has been added to the subjects store. It's invoked when a workflow is grouped and has indexed subject sets.
+
+- All subjects linked to an indexed set are expected to have the same metadata fields. This isn't enforced in the code but mixing subjects with different sets of indexed fields isn't possible.
+
+## Status
+
+Accepted

--- a/docs/arch/adr-38.md
+++ b/docs/arch/adr-38.md
@@ -1,0 +1,30 @@
+# ADR 38: Engaging Crowds: Next/previous subjects
+
+7 December 2021
+
+## Context
+
+Engaging Crowds allows volunteers to browse and search subject sets, linked to a workflow, in order to pick which subjects they want to work on. As part of this, volunteers can browse a subject set, in the classifier, while they decide which subject they wish to work on.
+
+The classifier's subject queue was originally built to support random or sequential subject selection, with subjects being shown to a volunteer in the order they were received from the Panoptes API. Subjects were discarded after being classified. Going backwards through the queue, to view previous subjects, was not possible.
+
+## Decision
+
+- The subject queue was changed from an ordered map, `subjects.resources`, to an array `subjects.queue`. Each item in `subjects.queue` is a subject ID, pointing to a subject in `subjects.resources`. Subjects are shown to the volunteer in array order.
+- Existing workflows continue to use the orignal queueing logic: subjects are shifted off the array after being classified. The active subject is always the first entry in `subjects.queue`.
+- Indexed subject sets, for Engaging Crowds, use a different logic. Subject IDs are never removed from the queue. Volunteers can browse available subjects by moving forwards and backwards through the array, changing the active index.
+
+## Consequences
+
+- The `SubjectStore` model now supports two different models of subject queue, branching on whether `workflow.hasIndexedSubjects` set. It might be better to separate the behaviours into two different models, depending on workflow types.
+- `store.workflows` and `store.subjects` are separate subtrees in the classfier store. If subjects and workflows were contained in the same subtree, we could have different `subjects` models for different types of workflow.
+- Changing the active subject (`subjects.active`) deletes an existing classification and generates a new one. Consequently, next/previous don't work once you've started to classify a subject. We've elected to show a warning if you try to view the next/previous page while working on a subject.
+- Subjects are given arbitary priority numbers by project owners. This makes it difficult/impossible to tell, in the frontend code, when we're looking at the first subject in a set. Ideally, we'd hide the Previous button at the beginning of a set.
+- Subjects are loaded asynchronously in the `SubjectStore`. In practice this means we can't tell when we're at the end of a set, so can't hide the Next button at the end of a set.
+- `subject.queue` holds subjects in ascending priority order. When you reach the end of the set, Done submits a classification but can't load a new subject. Instead, we show a message that you've finished the current subject and should choose something new to work on.
+
+  Since volunteers can pick what they work on, and classify a set in the order of their choosing, completing the last subject is no guarantee that they've completed the entire set.
+
+## Status
+
+Accepted


### PR DESCRIPTION
ADRs for the last two major pieces of Engaging Crowds: browsing subject sets and searching available subjects, and browsing the available subject queue in order to pick a subject to classify.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
