### PR TITLE
Add mobile app nav item

### DIFF
--- a/packages/app-content-pages/src/shared/components/AboutHeader/AboutHeader.js
+++ b/packages/app-content-pages/src/shared/components/AboutHeader/AboutHeader.js
@@ -28,6 +28,7 @@ function AboutHeader () {
         <NavLink label='Contact Us' href='/about/contact' />
         <NavLink label='FAQ' href='/about/faq' />
         <NavLink label='Highlights Book' href='/about/highlights' />
+        <NavLink label='Mobile App' href='/about/mobile-app' />
         <NavLink label='Donate' href='/about/donate' />
       </Box>
     </Box>

--- a/packages/app-content-pages/src/shared/components/AboutHeader/AboutHeader.spec.js
+++ b/packages/app-content-pages/src/shared/components/AboutHeader/AboutHeader.spec.js
@@ -45,6 +45,10 @@ describe('Component > AboutHeader', function () {
     expect(wrapper.find('[href="/about/highlights"]')).to.have.lengthOf(1)
   })
 
+  it('should have a `Mobile App` link', function () {
+    expect(wrapper.find('[href="/about/mobile-app"]')).to.have.lengthOf(1)
+  })
+
   it('should have a `Donate` link', function () {
     expect(wrapper.find('[href="/about/donate"]')).to.have.lengthOf(1)
   })


### PR DESCRIPTION
Package:
- app-content-pages

Continuation on zooniverse/Panoptes-Front-End/pull/6062

Describe your changes:
- adds Mobile App nav item
- adds related test

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
