### PR TITLE
ADR #40: Next.js Internationalization Sub-path Routing

### DIFF
--- a/docs/arch/README.md
+++ b/docs/arch/README.md
@@ -38,3 +38,4 @@
 - [ADR 36: NextJS App base paths](adr-36.md)
 - [ADR 37: Engaging Crowds: Indexed subject sets](adr-37.md)
 - [ADR 38: Engaging Crowds: Next/previous subjects](adr-38.md)
+- [ADR 40: Next.js Internationalized Routing](adr-40.md)

--- a/docs/arch/adr-39.md
+++ b/docs/arch/adr-39.md
@@ -1,0 +1,25 @@
+# ADR 39: Next.js Internationalized Routing
+
+28 December 2021
+
+## Context
+
+Our goal is to internationalize FEM and provide translatable content based on a user's preferred locale. There are two types of translatable strings: static strings (e.g menu items, nav links) and dynamic strings (project-specific content provided by volunteers).
+
+When a user specifies their locale preference, all translatable content should reflect that preference across the Zooniverse platform.
+
+## Decision
+
+In order to synchronize a user's locale preference across Zooniverse, we'll utilize [Next.js Internationalized Sub-path Routing](https://nextjs.org/docs/advanced-features/i18n-routing#sub-path-routing). With the exception of English (the default locale), the user's chosen locale is reflected in a url subpath.
+
+For example, `www.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess` will render content in English because `en` is the default locale. When a user decides to view the same page in French, the url will change to `www.zooniverse.org/projects/fr/nora-dot-eisner/planet-hunters-tess`. As explained in [ADR #36](https://github.com/zooniverse/front-end-monorepo/blob/master/docs/arch/adr-36.md), `/projects` is the base path for `app-project`, so `/fr/` falls after `/projects`. Therefore, the url to view Zooniverse About pages in French will look like `www.zooniverse.org/about/fr/publications`.
+
+## Consequences
+
+When a project is migrated to FEM, not all project pages are rendered with FEM. The project's Home, About, and Classify pages use FEM as a frontend, but Talk, Collections, and Recents pages use PFE as a frontend. Eventually, the latter three pages will be migrated to FEM and use Next.js Internationalized Routing, but for now, navigation requires some extra work by the dev team.
+
+To navigate to FEM from PFE, we could add query params to `ProjectHeader` links in PFE, then Next.js middleware could handle conversion of param —> subpath. To navigate to PFE from FEM, we could also add query params to `ProjectHeader` links in FEM because PFE already accepts language as a custom query param.
+
+## Status
+
+Accepted

--- a/docs/arch/adr-40.md
+++ b/docs/arch/adr-40.md
@@ -18,7 +18,7 @@ For example, `www.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess` w
 
 When a project is migrated to FEM, not all project pages are rendered with FEM. The project's Home, About, and Classify pages use FEM as a frontend, but Talk, Collections, and Recents pages use PFE as a frontend. Eventually, the latter three pages will be migrated to FEM and use Next.js Internationalized Routing, but for now, navigation requires some extra work by the dev team.
 
-To navigate to FEM from PFE, we could add query params to `ProjectHeader` links in PFE, then Next.js middleware could handle conversion of param —> subpath. To navigate to PFE from FEM, we could also add query params to `ProjectHeader` links in FEM because PFE already accepts language as a custom query param.
+To navigate to FEM from PFE, we could add query params to `ProjectHeader` links in PFE (e.g `www.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess/recents?language=fr`), then Next.js middleware could handle conversion of param —> subpath. To navigate to PFE from FEM, we could also add a `language` query params to `ProjectHeader` links in FEM because PFE already accepts language as a custom query param.
 
 ## Status
 

--- a/docs/arch/adr-40.md
+++ b/docs/arch/adr-40.md
@@ -1,4 +1,4 @@
-# ADR 39: Next.js Internationalized Routing
+# ADR 40: Next.js Internationalized Routing
 
 28 December 2021
 


### PR DESCRIPTION
Note: ADR 39 is here https://github.com/zooniverse/front-end-monorepo/pull/2594.

## Package:
app-project
lib-classifier
app-content-pages

## Purpose

This is an ADR outlining the decision to use [Next.js Internationalized Routing](https://nextjs.org/docs/advanced-features/i18n-routing#sub-path-routing) to provide translated content based a user's locale preference.

Backend team, I'm tagging you to keep everyone in the loop about locale being reflected in the url.

The status of this ADR says "accepted" based on the frontend team's discussion on PR #2550 as well as discussion during weekly stand-ups. To see an example of how this internationalization routing strategy works, take a look at PR #2592, which implements Next.js internationalized routing in app-project, lib-classifier, and lib-react-components.

## Review Checklist

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?
