### PR TITLE
Classifier: toggle show/hide for transcribed lines

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
@@ -1,6 +1,6 @@
 import counterpart from 'counterpart'
 import { array, arrayOf, bool, number, object, shape, string } from 'prop-types'
-import React from 'react'
+import React, { useState } from 'react'
 import styled, { css, withTheme } from 'styled-components'
 import { TranscriptionLine } from '@plugins/drawingTools/components'
 import { Tooltip } from '@zooniverse/react-components'
@@ -23,27 +23,68 @@ export const ConsensusLine = styled('g')`
   }
 `
 
-class TranscribedLines extends React.Component {
-  constructor () {
-    super()
+const defaultLine = {
+  consensusText: '',
+  textOptions: []
+}
+const defaultTheme = {
+  global: {
+    colors: {}
+  }
+}
 
-    this.state = {
-      bounds: {},
-      line: {
-        consensusText: '',
-        textOptions: []
-      },
-      show: false
-    }
+function onClick(event, callback, line) {
+  const node = event.target
+  callback(line, node)
+}
 
-    this.createMark = this.createMark.bind(this)
-    this.close = this.close.bind(this)
-    this.showConsensus = this.showConsensus.bind(this)
+function onKeyDown(event, callback, line) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    const node = event.target
+    event.preventDefault()
+    callback(line, node)
+  }
+}
+
+function TranscribedLines({
+  /** the transcription task annotation */
+  annotation,
+  /** current frame, for multiple image subjects. */
+  frame = 0,
+  invalidMark = false,
+  /** Aggregated transcribed lines from Caesar. */
+  lines = [],
+  /** Marks drawn by the current user. */
+  marks = [],
+  /** SVG image scale (client width / natural width.) */
+  scale = 1,
+  /** the active transcription task */
+  task = {},
+  /** Grommet theme */
+  theme = defaultTheme,
+  /** Show/hide previously transcribed lines. */
+  visible = true
+}) {
+  const [ bounds, setBounds ] = useState({})
+  const [ line, setLine ] = useState(defaultLine)
+  const [ show, setShow ] = useState(false)
+
+  if (!visible) {
+    return null
   }
 
-  createMark (line, node) {
-    const { annotation, frame } = this.props
-    const { activeTool, activeToolIndex, setActiveMark } = this.props.task
+  const invalidTranscriptionTask = Object.keys(task).length === 0
+  const completedLines = lines.filter(line => line.consensusReached)
+  const transcribedLines = lines.filter(line => !line.consensusReached)
+  const fills = {
+    transcribed: 'drawing-pink',
+    complete: 'light-5'
+  }
+
+  const focusColor = theme.global.colors[theme.global.colors.focus]
+
+  function createMark(line, node) {
+    const { activeTool, activeToolIndex, setActiveMark } = task
 
     if (activeTool) {
       const [{ x: x1, y: y1 }, { x: x2, y: y2 }] = line.points
@@ -70,147 +111,108 @@ class TranscribedLines extends React.Component {
     }
   }
 
-  showConsensus (line, node) {
+  function showConsensus(line, node) {
     const bounds = node?.getBoundingClientRect() || {}
-    this.setState({
-      bounds,
-      line,
-      show: true
-    })
+    setBounds(bounds)
+    setLine(line)
+    setShow(true)
   }
 
-  onClick (event, callback, line) {
-    const node = event.target
-    callback(line, node)
+  function close() {
+    setBounds({})
+    setLine(defaultLine)
+    setShow(false)
   }
 
-  onKeyDown (event, callback, line) {
-    if (event.key === 'Enter' || event.key === ' ') {
-      const node = event.target
-      event.preventDefault()
-      callback(line, node)
-    }
-  }
-
-  close () {
-    this.setState({
-      bounds: {},
-      line: {
-        consensusText: '',
-        textOptions: []
-      },
-      show: false
-    })
-  }
-
-  render () {
-    const { invalidMark, lines, marks, scale, task, theme, visible } = this.props
-    const { bounds, line, show } = this.state
-    const invalidTranscriptionTask = Object.keys(task).length === 0
-    const completedLines = lines.filter(line => line.consensusReached)
-    const transcribedLines = lines.filter(line => !line.consensusReached)
-
-    const fills = {
-      transcribed: 'drawing-pink',
-      complete: 'light-5'
-    }
-
-    const focusColor = theme.global.colors[theme.global.colors.focus]
-
-    if (!visible) {
-      return null
-    }
-
-    return (
-      <g>
-        {completedLines
-          .map((line, index) => {
-            const [{ x: x1, y: y1 }, { x: x2, y: y2 }] = line.points
-            const length = Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2))
-            const mark = { length, x1, y1, x2, y2 }
-            const id = `complete-${index}`
-            const disabled = invalidMark
-            let lineProps = {}
-            if (!disabled) {
-              lineProps.onClick = event => this.onClick(event, this.showConsensus, line)
-              lineProps.onKeyDown = event => this.onKeyDown(event, this.showConsensus, line)
-            }
-            return (
-              <Tooltip
-                id={id}
-                key={line.id}
-                icon={<TooltipIcon fill={fills.complete} />}
-                label={counterpart('TranscribedLines.complete')}
+  return (
+    <g>
+      {completedLines
+        .map((line, index) => {
+          const [{ x: x1, y: y1 }, { x: x2, y: y2 }] = line.points
+          const length = Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2))
+          const mark = { length, x1, y1, x2, y2 }
+          const id = `complete-${index}`
+          const disabled = invalidMark
+          let lineProps = {}
+          if (!disabled) {
+            lineProps.onClick = event => onClick(event, showConsensus, line)
+            lineProps.onKeyDown = event => onKeyDown(event, showConsensus, line)
+          }
+          return (
+            <Tooltip
+              id={id}
+              key={line.id}
+              icon={<TooltipIcon fill={fills.complete} />}
+              label={counterpart('TranscribedLines.complete')}
+            >
+              <ConsensusLine
+                role='button'
+                aria-disabled={disabled.toString()}
+                aria-describedby={id}
+                aria-label={line.consensusText}
+                focusColor={focusColor}
+                tabIndex={disabled ? -1 : 0}
+                {...lineProps}
               >
-                <ConsensusLine
-                  role='button'
-                  aria-disabled={disabled.toString()}
-                  aria-describedby={id}
-                  aria-label={line.consensusText}
-                  focusColor={focusColor}
-                  tabIndex={disabled ? -1 : 0}
-                  {...lineProps}
-                >
-                  <TranscriptionLine
-                    state='complete'
-                    mark={mark}
-                    scale={scale}
-                  />
-                </ConsensusLine>
-              </Tooltip>
-            )
-          })
-        }
-        {transcribedLines
-          .map((line, index) => {
-            const [ existingMark ] = marks.filter(mark => mark.id === line.id)
-            const disabled = invalidTranscriptionTask || invalidMark || !!existingMark
-            const [{ x: x1, y: y1 }, { x: x2, y: y2 }] = line.points
-            const length = Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2))
-            const mark = { length, x1, y1, x2, y2 }
-            const id = `transcribed-${index}`
+                <TranscriptionLine
+                  state='complete'
+                  mark={mark}
+                  scale={scale}
+                />
+              </ConsensusLine>
+            </Tooltip>
+          )
+        })
+      }
+      {transcribedLines
+        .map((line, index) => {
+          const [ existingMark ] = marks.filter(mark => mark.id === line.id)
+          const disabled = invalidTranscriptionTask || invalidMark || !!existingMark
+          const [{ x: x1, y: y1 }, { x: x2, y: y2 }] = line.points
+          const length = Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2))
+          const mark = { length, x1, y1, x2, y2 }
+          const id = `transcribed-${index}`
 
-            const lineProps = {}
-            if (!disabled) {
-              lineProps.onClick = event => this.onClick(event, this.createMark, line)
-              lineProps.onKeyDown = event => this.onKeyDown(event, this.createMark, line)
-            }
+          const lineProps = {}
+          if (!disabled) {
+            lineProps.onClick = event => onClick(event, createMark, line)
+            lineProps.onKeyDown = event => onKeyDown(event, createMark, line)
+          }
 
-            return (
-              <Tooltip
-                id={id}
-                key={line.id}
-                icon={<TooltipIcon fill={fills.transcribed} />}
-                label={counterpart('TranscribedLines.transcribed')}
+          return (
+            <Tooltip
+              id={id}
+              key={line.id}
+              icon={<TooltipIcon fill={fills.transcribed} />}
+              label={counterpart('TranscribedLines.transcribed')}
+            >
+              <ConsensusLine
+                role='button'
+                aria-describedby={id}
+                aria-disabled={disabled.toString()}
+                aria-label={line.consensusText}
+                focusColor={focusColor}
+                tabIndex={disabled ? -1 : 0}
+                {...lineProps}
               >
-                <ConsensusLine
-                  role='button'
-                  aria-describedby={id}
-                  aria-disabled={disabled.toString()}
-                  aria-label={line.consensusText}
-                  focusColor={focusColor}
-                  tabIndex={disabled ? -1 : 0}
-                  {...lineProps}
-                >
-                  <TranscriptionLine
-                    state='transcribed'
-                    mark={mark}
-                    scale={scale}
-                  />
-                </ConsensusLine>
-              </Tooltip>
-            )
-          })
-        }
-        <ConsensusPopup
-          active={show}
-          closeFn={this.close}
-          line={line}
-          bounds={bounds}
-        />
-      </g>
-    )
-  }
+                <TranscriptionLine
+                  state='transcribed'
+                  mark={mark}
+                  scale={scale}
+                />
+              </ConsensusLine>
+            </Tooltip>
+          )
+        })
+      }
+      <ConsensusPopup
+        active={show}
+        closeFn={close}
+        line={line}
+        bounds={bounds}
+      />
+    </g>
+  )
 }
 
 TranscribedLines.propTypes = {
@@ -239,20 +241,6 @@ TranscribedLines.propTypes = {
     })
   }),
   visible: bool
-}
-
-TranscribedLines.defaultProps = {
-  invalidMark: false,
-  lines: [],
-  marks: [],
-  scale: 1,
-  task: {},
-  theme: {
-    global: {
-      colors: {}
-    }
-  },
-  visible: true
 }
 
 export default withTheme(TranscribedLines)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
@@ -104,7 +104,7 @@ class TranscribedLines extends React.Component {
   }
 
   render () {
-    const { invalidMark, lines, marks, scale, task, theme } = this.props
+    const { invalidMark, lines, marks, scale, task, theme, visible } = this.props
     const { bounds, line, show } = this.state
     const invalidTranscriptionTask = Object.keys(task).length === 0
     const completedLines = lines.filter(line => line.consensusReached)
@@ -116,6 +116,10 @@ class TranscribedLines extends React.Component {
     }
 
     const focusColor = theme.global.colors[theme.global.colors.focus]
+
+    if (!visible) {
+      return null
+    }
 
     return (
       <g>
@@ -233,7 +237,8 @@ TranscribedLines.propTypes = {
     global: shape({
       colors: object
     })
-  })
+  }),
+  visible: bool
 }
 
 TranscribedLines.defaultProps = {
@@ -246,7 +251,8 @@ TranscribedLines.defaultProps = {
     global: {
       colors: {}
     }
-  }
+  },
+  visible: true
 }
 
 export default withTheme(TranscribedLines)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js
@@ -481,7 +481,8 @@ describe('Component > TranscribedLines', function () {
         popup = wrapper.find(ConsensusPopup)
         expect(popup.props().active).to.be.true()
         expect(popup.props().line).to.deep.equal(completeLines[index])
-        wrapper.instance().close()
+        const closeFn = popup.props().closeFn
+        closeFn()
         popup = wrapper.find(ConsensusPopup)
         expect(popup.props().active).to.be.false()
         expect(popup.props().line).to.deep.equal({
@@ -505,7 +506,8 @@ describe('Component > TranscribedLines', function () {
         expect(eventMock.preventDefault).to.have.been.calledOnce()
         expect(popup.props().active).to.be.true()
         expect(popup.props().line).to.deep.equal(completeLines[index])
-        wrapper.instance().close()
+        const closeFn = popup.props().closeFn
+        closeFn()
         popup = wrapper.find(ConsensusPopup)
         expect(popup.props().active).to.be.false()
         expect(popup.props().line).to.deep.equal({
@@ -530,7 +532,8 @@ describe('Component > TranscribedLines', function () {
         expect(eventMock.preventDefault).to.have.been.calledOnce()
         expect(popup.props().active).to.be.true()
         expect(popup.props().line).to.deep.equal(completeLines[index])
-        wrapper.instance().close()
+        const closeFn = popup.props().closeFn
+        closeFn()
         popup = wrapper.find(ConsensusPopup)
         expect(popup.props().active).to.be.false()
         expect(popup.props().line).to.deep.equal({

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.js
@@ -1,5 +1,3 @@
-import React from 'react'
-import PropTypes from 'prop-types'
 import SHOWN_MARKS from '@helpers/shownMarks'
 
 import { withStores } from '@helpers'
@@ -22,65 +20,33 @@ function storeMapper(store) {
     }
   } = store
 
-  const consensusLines = subject.transcriptionReductions?.consensusLines(frame)
+  const lines = subject.transcriptionReductions?.consensusLines(frame)
   const activeStepAnnotations = subject.stepHistory.latest.annotations
 
   // We expect there to only be one
-  const [transcriptionTask] = findTasksByType('transcription')
+  const [task] = findTasksByType('transcription')
   // We want to observe the marks array for changes, so pass that as a separate prop.
-  const marks = transcriptionTask?.marks
+  const marks = task?.marks
   // find the corresponding annotation
   const annotation = activeStepAnnotations.find(
-    annotation => annotation.task === transcriptionTask?.taskKey
+    annotation => annotation.task === task?.taskKey
   )
 
   const valid = step?.isValid
+  const visible = workflow?.usesTranscriptionTask &&
+    task?.shownMarks === SHOWN_MARKS.ALL &&
+    lines.length > 0
+
   return {
     annotation,
     frame,
-    invalid: !valid,
-    transcriptionTask,
-    consensusLines,
+    invalidMark: !valid,
+    lines,
     marks,
+    task,
+    visible,
     workflow
   }
 }
 
-const defaultWorkflow = {
-  usesTranscriptionTask: false
-}
-
-function TranscribedLinesContainer ({
-  annotation,
-  frame,
-  invalid = false,
-  transcriptionTask = {},
-  consensusLines = [],
-  marks = [],
-  scale = 1,
-  workflow = defaultWorkflow
-}) {
-  const { shownMarks } = transcriptionTask
-
-  if (workflow?.usesTranscriptionTask && shownMarks === SHOWN_MARKS.ALL && consensusLines.length > 0) {
-    return (
-      <TranscribedLines
-        annotation={annotation}
-        frame={frame}
-        invalidMark={invalid}
-        lines={consensusLines}
-        marks={marks}
-        scale={scale}
-        task={transcriptionTask}
-      />
-    )
-  }
-
-  return null
-}
-
-TranscribedLinesContainer.propTypes = {
-  scale: PropTypes.number
-}
-
-export default withStores(TranscribedLinesContainer, storeMapper)
+export default withStores(TranscribedLines, storeMapper)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLinesConnector.spec.js
@@ -100,42 +100,42 @@ describe('Component > TranscribedLinesConnector', function () {
   })
 
   describe('when the workflow does not have a transcription task', function () {
-    it('should not render TranscribedLines', function () {
+    it('should hide TranscribedLines', function () {
       const store = mockStoresWithoutTranscriptionTask
-      const wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
-      expect(wrapper.find(TranscribedLines)).to.have.lengthOf(0)
+      const wrapper = shallow(<TranscribedLinesConnector store={store} />).find(TranscribedLines)
+      expect(wrapper.prop('visible')).to.be.false()
     })
   })
 
   describe('when the subject does not have consensus lines', function () {
-    it('should not render TranscribedLines', function () {
+    it('should hide TranscribedLines', function () {
       const store= mockStoresWithTranscriptionTask
-      const wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
-      expect(wrapper.find(TranscribedLines)).to.have.lengthOf(0)
+      const wrapper = shallow(<TranscribedLinesConnector store={store} />).find(TranscribedLines)
+      expect(wrapper.prop('visible')).to.be.false()
     })
   })
 
   describe('when the workflow does have a transcription task and subject does have consensus lines', function () {
-    it('should render TranscribedLines', function () {
+    it('should show TranscribedLines', function () {
       const store = mockStoresWithTranscriptionTaskAndConsensusLines
-      const wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
-      expect(wrapper.find(TranscribedLines)).to.have.lengthOf(1)
-      expect(wrapper.find(TranscribedLines).prop('lines')).to.have.lengthOf(transcriptionReductions.consensusLines(0).length)
+      const wrapper = shallow(<TranscribedLinesConnector store={store} />).find(TranscribedLines)
+      expect(wrapper.prop('visible')).to.be.true()
+      expect(wrapper.prop('lines')).to.have.lengthOf(transcriptionReductions.consensusLines(0).length)
     })
 
     it('should render lines per frame', function () {
       const store = Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, { subjectViewer: { frame: 1 } })
-      const wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
-      expect(wrapper.find(TranscribedLines).prop('lines')).to.have.lengthOf(transcriptionReductions.consensusLines(1).length)
+      const wrapper = shallow(<TranscribedLinesConnector store={store} />).find(TranscribedLines)
+      expect(wrapper.prop('lines')).to.have.lengthOf(transcriptionReductions.consensusLines(1).length)
     })
 
-    it('should not render TranscribedLines if no lines per frame', function () {
+    it('should hide TranscribedLines if no lines per frame', function () {
       const store = Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, { subjectViewer: { frame: 3 } })
-      const wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
-      expect(wrapper.find(TranscribedLines)).to.have.lengthOf(transcriptionReductions.consensusLines(3).length)
+      const wrapper = shallow(<TranscribedLinesConnector store={store} />).find(TranscribedLines)
+      expect(wrapper.prop('visible')).to.be.false()
     })
 
-    it('should not render TranscribedLines if showing only user marks', function () {
+    it('should hide TranscribedLines if showing only user marks', function () {
       const taskShowingOnlyUserMarks = {
         workflowSteps: {
           activeStepTasks: [
@@ -153,11 +153,11 @@ describe('Component > TranscribedLinesConnector', function () {
         }
       }
       const store = Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, taskShowingOnlyUserMarks)
-      const wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
-      expect(wrapper.find(TranscribedLines)).to.have.lengthOf(0)
+      const wrapper = shallow(<TranscribedLinesConnector store={store} />).find(TranscribedLines)
+      expect(wrapper.prop('visible')).to.be.false()
     })
 
-    it('should not render TranscribedLines if hiding all marks', function () {
+    it('should hide TranscribedLines if hiding all marks', function () {
       const taskHidingAllMarks = {
         workflowSteps: {
           activeStepTasks: [
@@ -175,8 +175,8 @@ describe('Component > TranscribedLinesConnector', function () {
         }
       }
       const store = Object.assign({}, mockStoresWithTranscriptionTaskAndConsensusLines, taskHidingAllMarks)
-      const wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
-      expect(wrapper.find(TranscribedLines)).to.have.lengthOf(0)
+      const wrapper = shallow(<TranscribedLinesConnector store={store} />).find(TranscribedLines)
+      expect(wrapper.prop('visible')).to.be.false()
     })
 
     it('should pass along if the step\'s tasks are in an invalid state', function () {
@@ -203,7 +203,7 @@ describe('Component > TranscribedLinesConnector', function () {
           }
         }
       })
-      wrapper = shallow(<TranscribedLinesConnector store={store} />).dive()
+      wrapper = shallow(<TranscribedLinesConnector store={store} />).find(TranscribedLines)
       expect(wrapper.props().invalidMark).to.be.true()
     })
   })


### PR DESCRIPTION
Add a `visible` prop to `TranscribedLines`, which hides transcribed lines except when `shownMarks` is set to `ALL`. Refactor `TranscribedLinesConnector` to use the same prop names as `TranscribedLines`.

I've also refactored `TranscribedLines` from a class component to a functional component.

Try it out on the Davy Notebooks Project:
https://local.zooniverse.org:8080/?env=production&project=humphrydavy/davy-notebooks-project&workflow=20178&demo=true

Package:
lib-classifier

Closes #2595.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
