### PR TITLE
Classifier: Log dropped classifications to Sentry

### DIFF
--- a/packages/lib-classifier/src/store/utils/ClassificationQueue.js
+++ b/packages/lib-classifier/src/store/utils/ClassificationQueue.js
@@ -35,6 +35,10 @@ class ClassificationQueue {
       if (process.env.NODE_ENV !== 'test') console.info('Queued classifications:', queue.length)
     } catch (error) {
       if (process.env.NODE_ENV !== 'test') console.error('Failed to queue classification:', error)
+      Sentry.withScope((scope) => {
+        scope.setExtra('classification', JSON.stringify(classification))
+        Sentry.captureException(error)
+      })
     }
   }
 


### PR DESCRIPTION
Log dropped classifications to Sentry after an error writing to local storage.

Follow up to #2598. The classifier silently deletes classifications after errors in `ClassificationQueue.store(classification)`. This PR logs those errors to Sentry, so that we can follow up and investigate.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
