### PR TITLE
Classifier: set classification.metadata.started_at when a classification is created

### DIFF
--- a/packages/lib-classifier/src/store/Classification/ClassificationMetadata.js
+++ b/packages/lib-classifier/src/store/Classification/ClassificationMetadata.js
@@ -7,7 +7,7 @@ const ClassificationMetadata = types.model('ClassificationMetadata', {
   revision: types.frozen(process.env.COMMIT_ID),
   session: types.maybe(types.string),
   source: types.enumeration(['api', 'sugar']),
-  startedAt: types.optional(types.string, (new Date()).toISOString()),
+  startedAt: types.optional(types.string, ''),
   subjectDimensions: types.array(types.frozen({
     clientHeight: types.integer,
     clientWidth: types.integer,
@@ -33,7 +33,12 @@ const ClassificationMetadata = types.model('ClassificationMetadata', {
   workflowVersion: types.string
 })
   .actions(self => ({
-    update (newMetadata) {
+    afterCreate() {
+      const now = new Date()
+      self.startedAt = now.toISOString()
+    },
+
+    update(newMetadata) {
       Object.keys(newMetadata).forEach(key => {
         self[key] = newMetadata[key]
       })

--- a/packages/lib-classifier/src/store/Classification/ClassificationMetadata.spec.js
+++ b/packages/lib-classifier/src/store/Classification/ClassificationMetadata.spec.js
@@ -1,16 +1,22 @@
 import { getSnapshot } from 'mobx-state-tree'
+import sinon from 'sinon'
 import ClassificationMetadata from './ClassificationMetadata'
 
 describe('Model > ClassificationMetadata', function () {
-  let model
+  let clock, model
 
   before(function () {
+    clock = sinon.useFakeTimers({ now: new Date(2022, 1, 10, 12), toFake: ['Date'] })
     model = ClassificationMetadata.create({
       classifier_version: '2.0',
       source: 'api',
       userLanguage: 'en',
       workflowVersion: '1.0'
     })
+  })
+
+  after(function () {
+    clock.restore()
   })
 
   it('should exist', function () {
@@ -21,7 +27,14 @@ describe('Model > ClassificationMetadata', function () {
   it('should have a classifier version', function () {
     expect(model.classifier_version).to.equal('2.0')
   })
-  
+
+  describe('startedAt', function () {
+    it('should be the current time', function () {
+      const now = new Date(2022, 1, 10, 12)
+      expect(model.startedAt).to.equal(now.toISOString())
+    })
+  })
+
   describe('update', function() {
     let snapshot
 

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -131,9 +131,8 @@ const ClassificationStore = types
         let classificationToSubmit = classification.toSnapshot()
 
         const convertedMetadata = {}
-        Object.entries(classificationToSubmit.metadata).forEach((entry) => {
-          const key = _.snakeCase(entry[0])
-          convertedMetadata[key] = entry[1]
+        Object.entries(classificationToSubmit.metadata).forEach(([key, value]) => {
+          convertedMetadata[_.snakeCase(key)] = value
         })
         classificationToSubmit.metadata = convertedMetadata
 


### PR DESCRIPTION
Add a test for `classificationMetadata.startedAt` and an `afterCreate` hook, which sets the start time after a new classification is created. 

Package:
lib-classifier

Closes #2603.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
