### PR TITLE
Add classifier Sentry logging

### DIFF
--- a/.github/workflows/sentry-staging-releases.yml
+++ b/.github/workflows/sentry-staging-releases.yml
@@ -13,6 +13,7 @@ jobs:
      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
      SENTRY_PROJECT_APP: ${{ secrets.SENTRY_PROJECT_APP }}
      SENTRY_CONTENT_APP: ${{ secrets.SENTRY_CONTENT_APP }}
+     SENTRY_CLASSIFIER: ${{ secrets.SENTRY_CLASSIFIER }}
 
    steps: 
     # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#using-the-checkout-action
@@ -26,7 +27,7 @@ jobs:
         # Create a new Sentry release with the commit SHA as the version.
         # Associate all commits since the last finalised release.
         export VERSION=$(sentry-cli releases propose-version)
-        sentry-cli releases new -p $SENTRY_PROJECT_APP -p $SENTRY_CONTENT_APP $VERSION
+        sentry-cli releases new -p $SENTRY_PROJECT_APP -p $SENTRY_CONTENT_APP -p $SENTRY_CLASSIFIER $VERSION
         sentry-cli releases set-commits --auto $VERSION
         
         # Create new staging deploy for this Sentry release

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "@babel/plugin-transform-runtime": "~7.13.10",
-    "@sentry/browser": "~6.16.1",
+    "@sentry/react": "~6.16.1",
+    "@sentry/tracing": "~6.16.1",
     "@visx/axis": "~1.8.0",
     "@visx/event": "~1.7.0",
     "@visx/glyph": "~1.7.0",

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/react";
+import { Integrations } from "@sentry/tracing";
 import { GraphQLClient } from 'graphql-request'
 import makeInspectable from 'mobx-devtools-mst'
 import { Provider } from 'mobx-react'
@@ -15,6 +17,17 @@ import { unregisterWorkers } from '../../workers'
 import RootStore from '../../store'
 import Layout from './components/Layout'
 import ModalTutorial from './components/ModalTutorial'
+
+const environment = process.env.APP_ENV
+const release = process.env.COMMIT_ID
+Sentry.init({
+  dsn: "https://4426b5dca74d4d559c69ffce572f2aae@o274434.ingest.sentry.io/6144023",
+  environment,
+  integrations: [new Integrations.BrowserTracing()],
+  release,
+  tracesSampleRate: 0.01,
+})
+
 // import { isBackgroundSyncAvailable } from '../../helpers/featureDetection'
 function caesarClient (env) {
   switch (env) {

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -84,7 +84,7 @@ function useStore({ authClient, client, initialState }) {
   return _store
 }
 
-function Classifier({
+export default function Classifier({
   authClient,
   onAddToCollection = () => true,
   onCompleteClassification = () => true,
@@ -144,14 +144,19 @@ function Classifier({
     userProjectPreferences.checkForUser()
   }, [authClient])
 
-  return (
-    <Provider classifierStore={classifierStore}>
-        <>
-          <Layout />
-          <ModalTutorial />
-        </>
-    </Provider>
-  )
+  try {
+    return (
+      <Provider classifierStore={classifierStore}>
+          <Sentry.ErrorBoundary fallback={ErrorFallback}>
+            <Layout />
+            <ModalTutorial />
+          </Sentry.ErrorBoundary>
+      </Provider>
+    )
+  } catch (error) {
+    Sentry.captureException(error)
+    return <p>An error occurred. {error.message}</p>
+  }
 }
 
 Classifier.propTypes = {
@@ -181,5 +186,3 @@ function ErrorFallback({ error, componentStack, resetError }) {
     </>
   )
 }
-
-export default Sentry.withErrorBoundary(Classifier, { fallback: ErrorFallback })

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -19,15 +19,19 @@ import RootStore from '../../store'
 import Layout from './components/Layout'
 import ModalTutorial from './components/ModalTutorial'
 
+const dsn = process.env.SENTRY_CLASSIFIER_DSN
 const environment = process.env.APP_ENV
 const release = process.env.COMMIT_ID
-Sentry.init({
-  dsn: "https://4426b5dca74d4d559c69ffce572f2aae@o274434.ingest.sentry.io/6144023",
-  environment,
-  integrations: [new Integrations.BrowserTracing()],
-  release,
-  tracesSampleRate: 0.01,
-})
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    environment,
+    integrations: [new Integrations.BrowserTracing()],
+    release,
+    tracesSampleRate: 0.01,
+  })
+}
 
 // import { isBackgroundSyncAvailable } from '../../helpers/featureDetection'
 function caesarClient (env) {

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/react";
 import { Integrations } from "@sentry/tracing";
 import { GraphQLClient } from 'graphql-request'
+import { Button, Paragraph } from 'grommet'
 import makeInspectable from 'mobx-devtools-mst'
 import { Provider } from 'mobx-react'
 import PropTypes from 'prop-types'
@@ -79,7 +80,7 @@ function useStore({ authClient, client, initialState }) {
   return _store
 }
 
-export default function Classifier({
+function Classifier({
   authClient,
   onAddToCollection = () => true,
   onCompleteClassification = () => true,
@@ -139,22 +140,14 @@ export default function Classifier({
     userProjectPreferences.checkForUser()
   }, [authClient])
 
-  try {
-    return (
-      <Provider classifierStore={classifierStore}>
-          <>
-            <Layout />
-            <ModalTutorial />
-          </>
-      </Provider>
-    )
-  } catch (error) {
-    const info = {
-      package: '@zooniverse/classifier'
-    }
-    onError(error, info);
-  }
-  return null
+  return (
+    <Provider classifierStore={classifierStore}>
+        <>
+          <Layout />
+          <ModalTutorial />
+        </>
+    </Provider>
+  )
 }
 
 Classifier.propTypes = {
@@ -170,3 +163,19 @@ Classifier.propTypes = {
   }).isRequired,
   theme: PropTypes.object
 }
+
+function ErrorFallback({ error, componentStack, resetError }) {
+  return (
+    <>
+      <Paragraph>An error has occurred.</Paragraph>
+      <Paragraph>{ error.message }</Paragraph>
+      <Button
+        label="Restart"
+        onClick={resetError}
+      />
+      <pre>{componentStack}</pre>
+    </>
+  )
+}
+
+export default Sentry.withErrorBoundary(Classifier, { fallback: ErrorFallback })

--- a/packages/lib-classifier/src/store/utils/ClassificationQueue.js
+++ b/packages/lib-classifier/src/store/utils/ClassificationQueue.js
@@ -2,7 +2,7 @@
 // and/or the loading of Google's Workbox fails to load.
 // Also for browsers that do not support Background Sync API
 
-import * as Sentry from '@sentry/browser'
+import * as Sentry from '@sentry/react'
 import { panoptes } from '@zooniverse/panoptes-js'
 import { getBearerToken } from './'
 

--- a/packages/lib-classifier/webpack.dev.js
+++ b/packages/lib-classifier/webpack.dev.js
@@ -14,6 +14,7 @@ function gitCommit() {
 }
 
 const EnvironmentWebpackPlugin = new webpack.EnvironmentPlugin({
+  APP_ENV: 'development',
   COMMIT_ID: gitCommit(),
   DEBUG: false,
   NODE_ENV: 'development',

--- a/packages/lib-classifier/webpack.dist.js
+++ b/packages/lib-classifier/webpack.dist.js
@@ -17,7 +17,8 @@ const EnvironmentWebpackPlugin = new webpack.EnvironmentPlugin({
   COMMIT_ID: gitCommit(),
   DEBUG: false,
   NODE_ENV: 'production',
-  PANOPTES_ENV: 'production'
+  PANOPTES_ENV: 'production',
+  SENTRY_CLASSIFIER_DSN: 'https://4426b5dca74d4d559c69ffce572f2aae@o274434.ingest.sentry.io/6144023'
 })
 
 module.exports = {

--- a/packages/lib-classifier/webpack.dist.js
+++ b/packages/lib-classifier/webpack.dist.js
@@ -13,6 +13,7 @@ function gitCommit() {
 }
 
 const EnvironmentWebpackPlugin = new webpack.EnvironmentPlugin({
+  APP_ENV: 'development',
   COMMIT_ID: gitCommit(),
   DEBUG: false,
   NODE_ENV: 'production',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,7 +2730,7 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.0.9.tgz#1168db664faab4c3bb82c76124b393970e80bf89"
   integrity sha512-yk9Xj/3bUxyz3azMXW8qigLqXWEr2R0h9G7PVnnmjNQdlZLN+aESqCTnVN7ubtYUIQfW32/v8+AXsbpL1ryI1A==
 
-"@sentry/browser@~6.16.1":
+"@sentry/browser@6.16.1", "@sentry/browser@~6.16.1":
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.16.1.tgz#4270ab0fbd1de425e339b3e7a364feb09f470a87"
   integrity sha512-F2I5RL7RTLQF9CccMrqt73GRdK3FdqaChED3RulGQX5lH6U3exHGFxwyZxSrY4x6FedfBFYlfXWWCJXpLnFkow==
@@ -2784,7 +2784,19 @@
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/tracing@6.16.1":
+"@sentry/react@~6.16.1":
+  version "6.16.1"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-6.16.1.tgz#d4930c4b23bcd307306a0549d20964d98caed38c"
+  integrity sha512-n8fOEKbym4kBi946q3AWXBNy1UKTmABj/hE2nAJbTWhi5IwdM7WBG6QCT2yq7oTHLuTxQrAwgKQc+A6zFTyVHg==
+  dependencies:
+    "@sentry/browser" "6.16.1"
+    "@sentry/minimal" "6.16.1"
+    "@sentry/types" "6.16.1"
+    "@sentry/utils" "6.16.1"
+    hoist-non-react-statics "^3.3.2"
+    tslib "^1.9.3"
+
+"@sentry/tracing@6.16.1", "@sentry/tracing@~6.16.1":
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.16.1.tgz#32fba3e07748e9a955055afd559a65996acb7d71"
   integrity sha512-MPSbqXX59P+OEeST+U2V/8Hu/8QjpTUxTNeNyTHWIbbchdcMMjDbXTS3etCgajZR6Ro+DHElOz5cdSxH6IBGlA==
@@ -10516,7 +10528,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.2.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.2.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==


### PR DESCRIPTION
This adds a Sentry logger specifically for the classifier component. Sentry logging is enabled for production builds, via the `SENTRY_CLASSIFIER_DSN` environment variable.
The corresponding Sentry project is https://sentry.io/organizations/zooniverse-27/issues/?project=6144023.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
