### PR TITLE
Add mockStore to classifier task stories

### DIFF
--- a/packages/lib-classifier/src/stories/components/MockTask/MockTask.js
+++ b/packages/lib-classifier/src/stories/components/MockTask/MockTask.js
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react'
 import Tasks from '@components/Classifier/components/TaskArea/components/Tasks'
 import asyncStates from '@zooniverse/async-states'
 import zooTheme from '@zooniverse/grommet-theme'
-import { createStore }  from '@store/helpers'
+import mockStore  from '@test/mockStore'
 import { SubjectFactory, WorkflowFactory } from '@test/factories'
 
 /**
@@ -38,10 +38,8 @@ function addStepToStore(taskSnapshots = {}, isThereTaskHelp = true) {
   Initialise the store state on story load.
 */
 function initStore(tasks) {
-  store = store ?? createStore()
   const workflow = WorkflowFactory.build(Object.assign({}, { tasks }))
-  store.workflows.setResources([workflow])
-  store.workflows.setActive(workflow.id)
+  store = store ?? mockStore({ workflow })
   const mockSubject = {
     id: 'subject',
     metadata: {}


### PR DESCRIPTION
Add `mockStore`, which includes mocked clients for the Panoptes and Caesar APIs, to the classifier task stories. This should fix store errors in these stories, where `getRoot(self).client` is undefined when you change the value of any of a story's controls.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
