### PR TITLE
[Security] Projects: remove direct node-fetch dependency

### DIFF
--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -54,7 +54,6 @@
     "newrelic": "~8.7.0",
     "next": "~12.0.4",
     "next-i18next": "~10.0.1",
-    "node-fetch": "~2.6.1",
     "panoptes-client": "~3.3.2",
     "path-match": "~1.2.4",
     "polished": "~3.6.4",

--- a/packages/app-project/src/helpers/fetchSubjectSets/fetchSubjectSets.js
+++ b/packages/app-project/src/helpers/fetchSubjectSets/fetchSubjectSets.js
@@ -1,5 +1,4 @@
 import { panoptes } from '@zooniverse/panoptes-js'
-import fetch from 'node-fetch'
 
 import { logToSentry } from '@helpers/logger'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12391,13 +12391,6 @@ node-fetch@^2.6.1:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@~2.6.1:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
-  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
-  dependencies:
-    whatwg-url "^5.0.0"
-
 node-forge@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.2.1.tgz#82794919071ef2eb5c509293325cec8afd0fd53c"


### PR DESCRIPTION
`fetch` is polyfilled in NextJS, since 9.7, so this removes the direct dependency from the project app.

Package:
app-project

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
