### PR TITLE
Classifier: Refresh workflows with SWR (stale-while-revalidate)

### DIFF
--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -40,6 +40,7 @@
     "react-i18next": "~11.15.1",
     "react-player": "~2.7.0",
     "react-resize-detector": "~7.0.0",
+    "swr": "~1.1.2",
     "valid-url": "~1.0.9"
   },
   "peerDependencies": {

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
@@ -130,25 +130,9 @@ const SubjectStore = types
     }
 
     function afterAttach () {
-      createWorkflowObserver()
-      createClassificationChangeObserver()
+      addDisposer(self, autorun(_onWorkflowChange))
+      addDisposer(self, autorun(_onClassificationChange))
       addMiddleware(self, _addMiddleware)
-    }
-
-    function createWorkflowObserver () {
-      const workflowDisposer = autorun(
-        _onWorkflowChange,
-        { name: 'SubjectStore Workflow Observer autorun' }
-      )
-      addDisposer(self, workflowDisposer)
-    }
-
-    function createClassificationChangeObserver () {
-      const classificationDisposer = autorun(
-        _onClassificationChange,
-        { name: 'SubjectStore Classification Change Observer autorun' }
-      )
-      addDisposer(self, classificationDisposer)
     }
 
     async function _fetchPreviousSubjects(workflow, priority) {

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -74,19 +74,16 @@ const WorkflowStepStore = types
     }
   }))
   .actions(self => {
-    function afterAttach () {
-      createWorkflowObserver()
+    function _onWorkflowChange() {
+      const workflow = tryReference(() => getRoot(self).workflows?.active)
+      if (workflow) {
+        self.reset()
+        setStepsAndTasks(workflow)
+      }
     }
 
-    function createWorkflowObserver () {
-      const workflowDisposer = autorun(() => {
-        const workflow = tryReference(() => getRoot(self).workflows?.active)
-        if (workflow) {
-          self.reset()
-          setStepsAndTasks(workflow)
-        }
-      }, { name: 'WorkflowStepStore Workflow Observer autorun' })
-      addDisposer(self, workflowDisposer)
+    function afterAttach () {
+      addDisposer(self, autorun(_onWorkflowChange))
     }
 
     function getNextStepKey () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16075,6 +16075,11 @@ svg-loaders-react@~2.0.1:
   resolved "https://registry.yarnpkg.com/svg-loaders-react/-/svg-loaders-react-2.0.1.tgz#67b50783b1dd0f9bb845a7248e46290ba828fc06"
   integrity sha512-7oOA29mMLPuGNZ5UkyprH/4RysYy6F19/P8cr5mbrWJeNseH01ih5YpynNFhgpvUaQ8h6vStMS8wd3IFELcFYA==
 
+swr@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.1.2.tgz#9f3de2541931fccf03c48f322f1fc935a7551612"
+  integrity sha512-UsM0eo5T+kRPyWFZtWRx2XR5qzohs/LS4lDC0GCyLpCYFmsfTk28UCVDbOE9+KtoXY4FnwHYiF+ZYEU3hnJ1lQ==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"


### PR DESCRIPTION
Add the [`useSWR`](https://swr.vercel.app/) hook to the root `Classifier` and an `onWorkflowChange` effect which updates the store when workflow data changes in Panoptes.

Package:
lib-classifier

Closes #2668.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
