### PR TITLE
Classifier: Ensure new tutorials are fetching on workflow change

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
@@ -42,6 +42,10 @@ export default function TaskArea({
     setDisabled(false)
   }
 
+  useEffect(function onWorkflowChange() {
+    setActiveIndex(0)
+  }, [workflow])
+
   function onTabClick(newIndex) {
     if (newIndex === 1) setActiveTutorial(tutorial)
     if (newIndex === 0) setActiveTutorial()

--- a/packages/lib-classifier/src/store/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore.js
@@ -117,7 +117,7 @@ const TutorialStore = types
     function createWorkflowObserver () {
       const workflowDisposer = autorun(() => {
         const workflow = tryReference(() => getRoot(self).workflows.active)
-        if (!self.loaded && workflow) {
+        if (workflow) {
           self.reset()
           self.resetSeen()
           self.fetchTutorials()
@@ -199,11 +199,11 @@ const TutorialStore = types
       }
     }
 
-    function setActiveTutorial (id, stepIndex) {
-      if (!id) {
+    function setActiveTutorial (tutorial, stepIndex) {
+      if (!tutorial) {
         self.resetActiveTutorial()
       } else {
-        self.active = id
+        self.active = tutorial
         self.setTutorialStep(stepIndex)
         self.setSeenTime()
       }


### PR DESCRIPTION
## Package:
lib-classifier

## Bug Fix
Closes #2675 

Bug overview: When classifying "Workflow One" in the classifier, if a user navigates to "Workflow Two" of the same project through it's home page or by clicking Classify in the nav bar (which prompts WorkflowSelector modal), the tutorial belonging to "Workflow One" sticks around instead of loading the tutorial for "Workflow Two".

## Describe your changes:
I found that `fetchTutorials()` in `TutorialStore` wasn't being called when `WorkflowSelector` modal is used to switch to another workflow. The call was prevented by checking for `self.loading` in `TutorialStore`. I removed that check and added a `useEffect` hook that listens for a new workflow in `TaskArea`. Setting TaskArea's tabs to first display the "Task" tab allows the "Tutorial" tab to load the new corresponding tutorial.

### Things to Test:
Use the `WorkflowSelector` on a project's homepage. Use the `WorkflowSelector` modal that shows when navigating to /owner/project/classify. I used Shaun's test project: https://local.zooniverse.org:3000/projects/darkeshard/test-project-2022/classify

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
- [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
- [ ] Is this ready for production deployment?
