### PR TITLE
Classifier: remove @inject from Layout

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.js
@@ -1,30 +1,25 @@
-import { inject, observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { withStores } from '@helpers'
 import getLayout from './helpers/getLayout'
 
-function storeMapper (stores) {
-  const { layout } = stores.classifierStore.subjectViewer
+function storeMapper(classifierStore) {
+  const { layout } = classifierStore.subjectViewer
   return { layout }
 }
 
-@inject(storeMapper)
-@observer
-class Layout extends React.Component {
-  render () {
-    // `getLayout()` will always return the default layout as a fallback
-    const CurrentLayout = getLayout(this.props.layout)
-    return <CurrentLayout />
-  }
+
+function Layout({
+  layout = 'default'
+}) {
+  // `getLayout()` will always return the default layout as a fallback
+  const CurrentLayout = getLayout(layout)
+  return <CurrentLayout />
 }
 
-Layout.wrappedComponent.propTypes = {
+Layout.propTypes = {
   layout: PropTypes.string
 }
 
-Layout.wrappedComponent.defaultProps = {
-  layout: 'default'
-}
-
-export default Layout
+export default withStores(Layout, storeMapper)

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.spec.js
@@ -1,10 +1,11 @@
 import { shallow } from 'enzyme'
 import React from 'react'
 
+import mockStore from '@test/mockStore'
 import Layout from './Layout'
 
 describe('Component > Layout', function () {
   it('should render without crashing', function () {
-    shallow(<Layout.wrappedComponent />)
+    shallow(<Layout store={mockStore()} />)
   })
 })


### PR DESCRIPTION
Remove `@inject` from `Layout` and rewrite it as a functional component.

Package:
lib-classifier

Towards: #2712.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
