### PR TITLE
Classifier: react to workflow version changes

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -16,7 +16,8 @@ export default function Classifier({
   project,
   subjectID,
   subjectSetID,
-  workflowData,
+  workflowSnapshot,
+  workflowVersion,
   workflowID
 }) {
 
@@ -40,15 +41,19 @@ export default function Classifier({
     }
   }, [subjectID, subjectSetID, workflowID])
 
-  useEffect(function onWorkflowChange() {
+  /*
+    This should run when a project owner edits a workflow, but not when a workflow updates
+    as a result of receiving classifications eg. workflow.completeness.
+    It refreshes the stored workflow then resets any classifications in progress.
+  */
+  useEffect(function onWorkflowVersionChange() {
     const { workflows, subjects } = classifierStore
-    if (workflowData) {
-      const [ workflowSnapshot ] = JSON.parse(workflowData).workflows
+    if (workflowSnapshot) {
       workflows.setResources([workflowSnapshot])
       // TODO: the task area crashes without the following line. Why is that?
       subjects.setActiveSubject(subjects.active?.id)
     }
-  }, [workflowData])
+  }, [workflowVersion])
 
   try {
     return (
@@ -75,5 +80,9 @@ Classifier.propTypes = {
   }).isRequired,
   subjectSetID: PropTypes.string,
   subjectID: PropTypes.string,
+  workflowSnapshot: PropTypes.shape({
+    id: PropTypes.string
+  }),
+  workflowVersion: PropTypes.string,
   workflowID: PropTypes.string.isRequired
 }

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
@@ -149,27 +149,27 @@ export default function ClassifierContainer({
   }, [loaded, authClient])
 
   try {
-    if (!loaded && !workflowData) {
-      return <Paragraph>Loading…</Paragraph>
+    if (loaded && workflowData) {
+      const [ workflowSnapshot ] = JSON.parse(workflowData).workflows
+
+      return (
+        <Provider classifierStore={classifierStore}>
+          <Classifier
+            classifierStore={classifierStore}
+            locale={locale}
+            onError={onError}
+            project={project}
+            subjectSetID={subjectSetID}
+            subjectID={subjectID}
+            workflowSnapshot={workflowSnapshot}
+            workflowVersion={workflowSnapshot?.version}
+            workflowID={workflowSnapshot?.id}
+          />
+        </Provider>
+      )
     }
 
-    const [ workflowSnapshot ] = JSON.parse(workflowData).workflows
-
-    return (
-      <Provider classifierStore={classifierStore}>
-        <Classifier
-          classifierStore={classifierStore}
-          locale={locale}
-          onError={onError}
-          project={project}
-          subjectSetID={subjectSetID}
-          subjectID={subjectID}
-          workflowSnapshot={workflowSnapshot}
-          workflowVersion={workflowSnapshot?.version}
-          workflowID={workflowSnapshot?.id}
-        />
-      </Provider>
-    )
+    return <Paragraph>Loading…</Paragraph>
   } catch (error) {
     const info = {
       package: '@zooniverse/classifier'

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
@@ -149,9 +149,11 @@ export default function ClassifierContainer({
   }, [loaded, authClient])
 
   try {
-    if (!loaded) {
+    if (!loaded && !workflowData) {
       return <Paragraph>Loading…</Paragraph>
     }
+
+    const [ workflowSnapshot ] = JSON.parse(workflowData).workflows
 
     return (
       <Provider classifierStore={classifierStore}>
@@ -162,8 +164,9 @@ export default function ClassifierContainer({
           project={project}
           subjectSetID={subjectSetID}
           subjectID={subjectID}
-          workflowData={workflowData}
-          workflowID={workflowID}
+          workflowSnapshot={workflowSnapshot}
+          workflowVersion={workflowSnapshot?.version}
+          workflowID={workflowSnapshot?.id}
         />
       </Provider>
     )


### PR DESCRIPTION
Replace the classifier's `workflowData` prop with `workflowSnapshot` and `workflowVersion` props. `workflowData` changes when eg. workflow completeness changes, which isn't very useful. This change restricts updates (and re-renders) to cases where `workflow.version` has explicitly changed.

Closes: #2749.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
