### PR TITLE
Add hydrated state to ClassifierContainer

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -30,6 +30,7 @@ function ClassifyPage({
   workflowFromUrl,
   workflows = []
 }) {
+  const cachePanoptesData = workflowFromUrl?.prioritized
   const responsiveColumns = (screenSize === 'small')
     ? ['auto']
     : ['1em', 'auto', '1em']
@@ -49,13 +50,13 @@ function ClassifyPage({
   let classifierProps = {}
   if (canClassify) {
     classifierProps = {
-      cachePanoptesData: workflowFromUrl?.prioritized,
       workflowID,
       subjectSetID,
       subjectID
     }
   }
 
+  console.log({ cachePanoptesData })
   return (
     <StandardLayout>
 
@@ -76,6 +77,7 @@ function ClassifyPage({
           <Grid columns={responsiveColumns} gap='small'>
             <ProjectName />
             <ClassifierWrapper
+              cachePanoptesData={cachePanoptesData}
               onAddToCollection={addToCollection}
               onSubjectReset={onSubjectReset}
               {...classifierProps}

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -21,6 +21,7 @@ export default function Classifier({
   workflowID
 }) {
 
+  console.log({ workflowID, subjectSetID })
   useEffect(function onLocaleChange() {
     if (locale) {
       classifierStore.setLocale(locale)


### PR DESCRIPTION
Package:
- app-project
- lib-classifier

Closes #2610.

Describe your changes:
- in `app-project` ClassifyPage set `cachePanoptesData` per workflow `prioritzed` property
- in `lib-classifier` ClassifierContainer add a hydrated state to determine if and when store should be saved to browser session storage

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
