### PR TITLE
Project: add allowedWorkflows to ClassifyPage

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -12,32 +12,23 @@ function ClassifyPageContainer({
   ...props
 }) {
   const [subjectID, setSubjectID] = useState(subjectFromURL)
-  const [canLoadWorkflowFromUrl, setCanLoadWorkflowFromUrl] = useState(true)
-  let workflowFromUrl = workflows.find(workflow => workflow.id === workflowID)
+  const collectionsModal = createRef()
 
   let assignedWorkflow
+  let allowedWorkflows = workflows.slice()
+  let assignedWorkflowLevel = 1
   if (assignedWorkflowID) {
     assignedWorkflow = workflows.find(workflow => workflow.id === assignedWorkflowID)
+    assignedWorkflowLevel = parseInt(assignedWorkflow?.configuration.level, 10)
   }
-  const collectionsModal = createRef()
+  if (workflowAssignmentEnabled) {
+    allowedWorkflows = workflows.filter(workflow => workflow.configuration.level <= assignedWorkflowLevel)
+  }
+  const workflowFromUrl = allowedWorkflows.find(workflow => workflow.id === workflowID) ?? null
 
   useEffect(function onSubjectChange() {
     setSubjectID(subjectFromURL)
   }, [subjectFromURL])
-
-  useEffect(function onAssignedWorkflowIDChange() {
-    const workflowFromURLLevel = parseInt(workflowFromUrl?.configuration?.level)
-
-    if (workflowAssignmentEnabled && assignedWorkflow && workflowFromURLLevel) {
-      const assignedWorkflowLevel = parseInt(assignedWorkflow.configuration.level)
-      const canLoad = assignedWorkflowLevel >= workflowFromURLLevel
-      setCanLoadWorkflowFromUrl(canLoad)
-    } else if (workflowAssignmentEnabled && workflowFromURLLevel !== 1) {
-      setCanLoadWorkflowFromUrl(false)
-    } else {
-      setCanLoadWorkflowFromUrl(true)
-    }
-  }, [ assignedWorkflowID, workflowAssignmentEnabled, workflowFromUrl ])
 
   function addToCollection(subjectId) {
     collectionsModal.current.open(subjectId)
@@ -56,7 +47,7 @@ function ClassifyPageContainer({
         addToCollection={addToCollection}
         onSubjectReset={onSubjectReset}
         subjectID={subjectID}
-        workflowFromUrl={(canLoadWorkflowFromUrl) ? workflowFromUrl : null}
+        workflowFromUrl={workflowFromUrl}
         workflowID={workflowID}
         workflows={workflows}
         {...props}

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -5,13 +5,14 @@ import CollectionsModal from '../../shared/components/CollectionsModal'
 
 function ClassifyPageContainer({
   assignedWorkflowID = '',
-  subjectID: subjectFromURL,
+  subjectID,
   workflowAssignmentEnabled = false,
   workflowID,
   workflows = [],
   ...props
 }) {
-  const [subjectID, setSubjectID] = useState(subjectFromURL)
+  // selected subject state is derived from the page URL, but can be reset by the Classifier component.
+  const [selectedSubjectID, setSelectedSubjectID] = useState(subjectID)
   const collectionsModal = createRef()
 
   let assignedWorkflow
@@ -27,15 +28,15 @@ function ClassifyPageContainer({
   const workflowFromUrl = allowedWorkflows.find(workflow => workflow.id === workflowID) ?? null
 
   useEffect(function onSubjectChange() {
-    setSubjectID(subjectFromURL)
-  }, [subjectFromURL])
+    setSelectedSubjectID(subjectID)
+  }, [subjectID])
 
   function addToCollection(subjectId) {
     collectionsModal.current.open(subjectId)
   }
 
   function onSubjectReset() {
-    setSubjectID(undefined)
+    setSelectedSubjectID(undefined)
   }
 
   return (
@@ -46,7 +47,7 @@ function ClassifyPageContainer({
       <ClassifyPage
         addToCollection={addToCollection}
         onSubjectReset={onSubjectReset}
-        subjectID={subjectID}
+        subjectID={selectedSubjectID}
         workflowFromUrl={workflowFromUrl}
         workflowID={workflowID}
         workflows={workflows}


### PR DESCRIPTION
Refactor the classify page to filter the available project workflows by workflow level, when workflow assignment is enabled. Don't allow a volunteer's chosen workflow (from the page URL) to be a higher level than their assigned workflow. Remove redundant state that was set by a `useEffect` hook.

I found this was useful advice on avoiding effects that set state:
https://beta.reactjs.org/apis/usestate#storing-information-from-previous-renders

Package:
app-project

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
