### PR TITLE
Enable session storage for projects with ordered subjects

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -30,6 +30,10 @@ function ClassifyPage({
   workflowFromUrl,
   workflows = []
 }) {
+  /*
+    Enable session caching in the classifier for projects with ordered subject selection.
+  */
+  const cachePanoptesData = workflows.some(workflow => workflow.prioritized)
   const responsiveColumns = (screenSize === 'small')
     ? ['auto']
     : ['1em', 'auto', '1em']
@@ -49,7 +53,6 @@ function ClassifyPage({
   let classifierProps = {}
   if (canClassify) {
     classifierProps = {
-      cachePanoptesData: workflowFromUrl?.prioritized,
       workflowID,
       subjectSetID,
       subjectID
@@ -76,6 +79,7 @@ function ClassifyPage({
           <Grid columns={responsiveColumns} gap='small'>
             <ProjectName />
             <ClassifierWrapper
+              cachePanoptesData={cachePanoptesData}
               onAddToCollection={addToCollection}
               onSubjectReset={onSubjectReset}
               {...classifierProps}

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
@@ -213,4 +213,28 @@ describe('Component > ClassifyPage', function () {
       })
     })
   })
+
+  describe('classifier session storage', function () {
+    it('should be disabled by default', function () {
+      const workflows = [{
+        id: '1234',
+        grouped: true
+      }]
+      const wrapper = shallow(<ClassifyPage appLoadingState={asyncStates.success} workflows={workflows} />)
+      const classifier = wrapper.find(ClassifierWrapper)
+      expect(classifier.prop('cachePanoptesData')).to.be.false()
+    })
+    it('should be enabled for prioritised workflows', function () {
+      let workflows = [{
+        id: '1234',
+        grouped: true
+      },{
+        id: '3456',
+        prioritized: true
+      }]
+      const wrapper = shallow(<ClassifyPage appLoadingState={asyncStates.success} workflows={workflows} />)
+      const classifier = wrapper.find(ClassifierWrapper)
+      expect(classifier.prop('cachePanoptesData')).to.be.true()
+    })
+  })
 })


### PR DESCRIPTION
Set the `cachePanoptesData` flag for projects where any workflow uses ordered subjects. This ensures that it is set before the `Classifier` component mounts.

In #2657, I missed that `cachePanoptesData` wasn’t being set until after the classifier mounts. This PR should fix that. 

Package:
app-project

Closes #2610.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
