### PR TITLE
Classifier: Refactor subject snapshots

### DIFF
--- a/packages/lib-classifier/src/store/SubjectStore/Subject/Subject.js
+++ b/packages/lib-classifier/src/store/SubjectStore/Subject/Subject.js
@@ -16,7 +16,7 @@ const Subject = types
     selected_at: types.maybe(types.string),
     selection_state: types.maybe(types.string),
     shouldDiscuss: types.maybe(types.frozen()),
-    stepHistory: types.optional(StepHistory, () => StepHistory.create({})),
+    stepHistory: types.maybe(StepHistory),
     user_has_finished_workflow: types.optional(types.boolean, false),
     transcriptionReductions: types.maybe(TranscriptionReductions)
   })
@@ -132,6 +132,11 @@ const Subject = types
       }
     }
 
+    function startClassification() {
+      self.stepHistory = StepHistory.create({})
+      self.stepHistory.start()
+    }
+
     function toggleFavorite () {
       const rootStore = getRoot(self)
       self.favorite = !self.favorite
@@ -144,6 +149,7 @@ const Subject = types
       addToCollection,
       markAsSeen,
       openInTalk,
+      startClassification,
       toggleFavorite
     }
   })

--- a/packages/lib-classifier/src/store/SubjectStore/Subject/Subject.js
+++ b/packages/lib-classifier/src/store/SubjectStore/Subject/Subject.js
@@ -21,6 +21,12 @@ const Subject = types
     transcriptionReductions: types.maybe(TranscriptionReductions)
   })
 
+  .postProcessSnapshot(snapshot => {
+    const newSnapshot = Object.assign({}, snapshot)
+    delete newSnapshot.stepHistory
+    return newSnapshot
+  })
+
   .views(self => ({
     get talkURL () {
       if (self.project) {

--- a/packages/lib-classifier/src/store/SubjectStore/Subject/TranscriptionReductions/TranscriptionReductions.js
+++ b/packages/lib-classifier/src/store/SubjectStore/Subject/TranscriptionReductions/TranscriptionReductions.js
@@ -79,7 +79,9 @@ const TranscriptionReductions = types
   .actions(self => {
     return {
       afterAttach () {
-        self.fetchCaesarReductions()
+        if (self.reductions.length === 0) {
+          self.fetchCaesarReductions()
+        }
       },
 
       fetchCaesarReductions: flow(function * fetchCaesarReductions () {

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
@@ -322,6 +322,11 @@ const SubjectStore = types
     }
 
     function reset () {
+      /*
+      This line stops the classifier from crashing when changing workflows.
+      TODO: It's a safeReference, so why is it not being cleared automatically?
+      */
+      self.active = undefined
       self.resources.clear()
       self.available.clear()
     }

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
@@ -103,7 +103,7 @@ const SubjectStore = types
 
       // start a new history for each new subject and classification.
       if (self.classification && subject) {
-        subject.stepHistory.start()
+        subject.startClassification()
       }
     }
 

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.spec.js
@@ -326,8 +326,8 @@ describe('Model > SubjectStore', function () {
     })
 
     it('should be valid subjects', function () {
-      const expectedSubject = SingleImageSubject.create(imageSubjects[0])
-      expect(subjects.active).to.deep.equal(expectedSubject)
+      const expectedSubject = SingleImageSubject.create(imageSubjects[1])
+      expect(subjects.resources.get(expectedSubject.id)).to.deep.equal(expectedSubject)
     })
 
     it('should be of the correct subject type', function () {
@@ -344,8 +344,8 @@ describe('Model > SubjectStore', function () {
     })
 
     it('should be valid subjects', function () {
-      const expectedSubject = SingleTextSubject.create(textSubjects[0])
-      expect(subjects.active).to.deep.equal(expectedSubject)
+      const expectedSubject = SingleTextSubject.create(textSubjects[1])
+      expect(subjects.resources.get(expectedSubject.id)).to.deep.equal(expectedSubject)
     })
 
     it('should be of the correct subject type', function () {
@@ -359,7 +359,6 @@ describe('Model > SubjectStore', function () {
       'subject',
       10,
       {
-        id: 'testGroup',
         locations: [
           { 'image/png': 'https://foo.bar/example.png' },
           { 'image/png': 'https://foo.bar/example.png' },
@@ -377,8 +376,8 @@ describe('Model > SubjectStore', function () {
     })
 
     it('should be valid subjects', function () {
-      const expectedSubject = SubjectGroup.create(subjectGroups[0])
-      expect(subjects.active).to.deep.equal(expectedSubject)
+      const expectedSubject = SubjectGroup.create(subjectGroups[1])
+      expect(subjects.resources.get(expectedSubject.id)).to.deep.equal(expectedSubject)
     })
     
     it('should be of the correct "subject group" type', function () {


### PR DESCRIPTION
- refactor `subject.stepHistory` as `subject.startClassification()`, which starts a new undo history when a subject becomes active.
- remove `subject.stepHistory` from snapshots.
- refactor `subject.transcriptionReductions` so that they are only fetched from Caesar when empty.
- explicitly set `subjects.active` to undefined on reset, despite it being `types.safeReference`.

Testing URL:
https://local.zooniverse.org:3000/projects/humphrydavy/davy-notebooks-project?env=production&demo=true

Package:
lib-classifier

Closes #2799.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
