### PR TITLE
Classifier: useSubjectImage hook

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
@@ -8,7 +8,7 @@ import withKeyZoom from '@components/Classifier/components/withKeyZoom'
 import { withStores } from '@helpers'
 import { draggable } from '@plugins/drawingTools/components'
 
-import useSubjectImage from '../SingleImageViewer/hooks/useSubjectImage'
+import useSubjectImage, { placeholder } from '../SingleImageViewer/hooks/useSubjectImage'
 import FrameCarousel from './FrameCarousel'
 import locationValidator from '../../helpers/locationValidator'
 import SingleImageViewer from '../SingleImageViewer/SingleImageViewer'
@@ -50,8 +50,6 @@ const DraggableImage = styled(draggable('image'))`
   cursor: move;
 `
 
-const PLACEHOLDER_URL = 'https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png'  // Use this instead of https://www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png to save on network calls
-
 const defaultTool = {
   validate: () => {}
 }
@@ -80,10 +78,10 @@ function MultiFrameViewerContainer({
   const imageUrl = subject ? Object.values(subject.locations[frame])[0] : null
   const { img, error } = useSubjectImage(ImageObject, imageUrl)
   // default to a placeholder while image is loading.
-  const { naturalHeight = 600, naturalWidth = 800, src = PLACEHOLDER_URL } = img
+  const { naturalHeight, naturalWidth, src } = img
 
   useEffect(function onImageLoad() {
-    if (src !== PLACEHOLDER_URL) {
+    if (src !== placeholder.src) {
       const svgImage = subjectImage.current
       const { width: clientWidth, height: clientHeight } = svgImage
         ? svgImage.getBoundingClientRect()

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
@@ -1,13 +1,14 @@
 import asyncStates from '@zooniverse/async-states'
 import { Box } from 'grommet'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import withKeyZoom from '@components/Classifier/components/withKeyZoom'
 import { withStores } from '@helpers'
 import { draggable } from '@plugins/drawingTools/components'
 
+import useSubjectImage from '../SingleImageViewer/hooks/useSubjectImage'
 import FrameCarousel from './FrameCarousel'
 import locationValidator from '../../helpers/locationValidator'
 import SingleImageViewer from '../SingleImageViewer/SingleImageViewer'
@@ -49,175 +50,125 @@ const DraggableImage = styled(draggable('image'))`
   cursor: move;
 `
 
-class MultiFrameViewerContainer extends React.Component {
-  constructor () {
-    super()
-    this.dragMove = this.dragMove.bind(this)
-    this.onFrameChange = this.onFrameChange.bind(this)
-    this.setOnDrag = this.setOnDrag.bind(this)
+const PLACEHOLDER_URL = 'https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png'  // Use this instead of https://www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png to save on network calls
 
-    this.subjectImage = React.createRef()
+const defaultTool = {
+  validate: () => {}
+}
 
-    this.state = {
-      img: {}
-    }
-  }
+function MultiFrameViewerContainer({
+  activeTool = defaultTool,
+  enableInteractionLayer = true,
+  enableRotation = () => null,
+  frame = 0,
+  ImageObject = window.Image,
+  loadingState = asyncStates.initialized,
+  move,
+  onError = () => true,
+  onKeyDown = () => true,
+  onReady = () => true,
+  rotation,
+  setFrame = () => true,
+  setOnPan = () => true,
+  setOnZoom = () => true,
+  subject
+}) {
 
-  componentDidMount () {
-    this.props.enableRotation()
-    this.onLoad()
-  }
+  const subjectImage = useRef()
+  const [dragMove, setDragMove] = useState()
+  // TODO: replace this with a better function to parse the image location from a subject.
+  const imageUrl = subject ? Object.values(subject.locations[frame])[0] : null
+  const { img, error } = useSubjectImage(ImageObject, imageUrl)
+  // default to a placeholder while image is loading.
+  const { naturalHeight = 600, naturalWidth = 800, src = PLACEHOLDER_URL } = img
 
-  componentDidUpdate (prevProps) {
-    const { frame } = this.props
-    if (prevProps.frame !== frame) {
-      this.onLoad()
-    }
-  }
-
-  fetchImage (url) {
-    const { ImageObject } = this.props
-    return new Promise((resolve, reject) => {
-      const img = new ImageObject()
-      img.onload = () => resolve(img)
-      img.onerror = reject
-      img.src = url
-      return img
-    })
-  }
-
-  dragMove (event, difference) {
-    this.onDrag && this.onDrag(event, difference)
-  }
-
-  setOnDrag (callback) {
-    this.onDrag = callback
-  }
-
-  onFrameChange(frame) {
-    const {
-      activeTool,
-      setFrame
-    } = this.props
-
-    if (activeTool?.marks?.size > 0) {
-      activeTool.validate()
-    }
-
-    setFrame(frame)
-  }
-
-  async preload () {
-    const { frame, subject } = this.props
-    if (subject && subject.locations) {
-      // TODO: Validate for allowed image media mime types
-      const imageUrl = Object.values(subject.locations[frame])[0]
-      const img = await this.fetchImage(imageUrl)
-      this.setState({ img })
-      return img
-    }
-    return {}
-  }
-
-  async getImageSize () {
-    const img = await this.preload()
-    const svgImage = this.subjectImage.current
-    const { width: clientWidth, height: clientHeight } = svgImage ? svgImage.getBoundingClientRect() : {}
-    return {
-      clientHeight,
-      clientWidth,
-      naturalHeight: img.naturalHeight,
-      naturalWidth: img.naturalWidth
-    }
-  }
-
-  async onLoad () {
-    const { onError, onReady } = this.props
-    try {
-      const { clientHeight, clientWidth, naturalHeight, naturalWidth } = await this.getImageSize()
+  useEffect(function onImageLoad() {
+    if (src !== PLACEHOLDER_URL) {
+      const svgImage = subjectImage.current
+      const { width: clientWidth, height: clientHeight } = svgImage
+        ? svgImage.getBoundingClientRect()
+        : {}
       const target = { clientHeight, clientWidth, naturalHeight, naturalWidth }
       onReady({ target })
-    } catch (error) {
-      console.error(error)
-      onError(error)
     }
+  }, [src])
+
+  useEffect(function onMount() {
+    enableRotation()
+  }, [])
+
+  useEffect(function onFrameChange() {
+    activeTool?.validate()
+  }, [frame])
+
+  if (error) {
+    console.error(error)
+    onError(error)
   }
 
-  render () {
-    const {
-      enableInteractionLayer,
-      frame,
-      loadingState,
-      move,
-      onKeyDown,
-      rotation,
-      setOnPan,
-      setOnZoom,
-      subject
-    } = this.props
-    const { img } = this.state
+  function setOnDrag(callback) {
+    setDragMove(() => callback)
+  }
 
-    // If image hasn't been fully retrieved, use a placeholder
-    const src = img?.src || 'https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png'  // Use this instead of https://www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png to save on network calls
-    const naturalWidth = img?.naturalWidth || 800
-    const naturalHeight = img?.naturalHeight || 600
+  function onDrag(event, difference) {
+    dragMove?.(event, difference)
+  }
 
-    if (loadingState === asyncStates.error) {
-      return (
-        <div>Something went wrong.</div>
-      )
-    }
+  if (loadingState === asyncStates.error) {
+    return (
+      <div>Something went wrong.</div>
+    )
+  }
 
-    const enableDrawing = (loadingState === asyncStates.success) && enableInteractionLayer
-    const SubjectImage = move ? DraggableImage : 'image'
-    const subjectImageProps = {
-      height: naturalHeight,
-      width: naturalWidth,
-      xlinkHref: src,
-      ...(move && { dragMove: this.dragMove })
-    }
+  const enableDrawing = (loadingState === asyncStates.success) && enableInteractionLayer
+  const SubjectImage = move ? DraggableImage : 'image'
+  const subjectImageProps = {
+    height: naturalHeight,
+    width: naturalWidth,
+    xlinkHref: src,
+    ...(move && { dragMove: onDrag })
+  }
 
-    if (loadingState !== asyncStates.initialized) {
-      return (
-        <Box
-          direction='row'
-          fill='horizontal'
+  if (loadingState !== asyncStates.initialized) {
+    return (
+      <Box
+        direction='row'
+        fill='horizontal'
+      >
+        <FrameCarousel
+          frame={frame}
+          onFrameChange={setFrame}
+          locations={subject.locations}
+        />
+        <SVGPanZoom
+          img={subjectImage.current}
+          maxZoom={5}
+          minZoom={0.1}
+          naturalHeight={naturalHeight}
+          naturalWidth={naturalWidth}
+          setOnDrag={setOnDrag}
+          setOnPan={setOnPan}
+          setOnZoom={setOnZoom}
+          src={src}
         >
-          <FrameCarousel
-            frame={frame}
-            onFrameChange={this.onFrameChange}
-            locations={subject.locations}
-          />
-          <SVGPanZoom
-            img={this.subjectImage.current}
-            maxZoom={5}
-            minZoom={0.1}
-            naturalHeight={naturalHeight}
-            naturalWidth={naturalWidth}
-            setOnDrag={this.setOnDrag}
-            setOnPan={setOnPan}
-            setOnZoom={setOnZoom}
-            src={src}
+          <SingleImageViewer
+            enableInteractionLayer={enableDrawing}
+            height={naturalHeight}
+            onKeyDown={onKeyDown}
+            rotate={rotation}
+            width={naturalWidth}
           >
-            <SingleImageViewer
-              enableInteractionLayer={enableDrawing}
-              height={naturalHeight}
-              onKeyDown={onKeyDown}
-              rotate={rotation}
-              width={naturalWidth}
-            >
-              <g ref={this.subjectImage}>
-                <SubjectImage
-                  {...subjectImageProps}
-                />
-              </g>
-            </SingleImageViewer>
-          </SVGPanZoom>
-        </Box>
-      )
-    }
-    return null
+            <g ref={subjectImage}>
+              <SubjectImage
+                {...subjectImageProps}
+              />
+            </g>
+          </SingleImageViewer>
+        </SVGPanZoom>
+      </Box>
+    )
   }
+  return null
 }
 
 MultiFrameViewerContainer.propTypes = {
@@ -236,22 +187,6 @@ MultiFrameViewerContainer.propTypes = {
   subject: PropTypes.shape({
     locations: PropTypes.arrayOf(locationValidator)
   }).isRequired
-}
-
-MultiFrameViewerContainer.defaultProps = {
-  activeTool: {
-    validate: () => {}
-  },
-  enableInteractionLayer: true,
-  enableRotation: () => null,
-  frame: 0,
-  ImageObject: window.Image,
-  loadingState: asyncStates.initialized,
-  onError: () => true,
-  onReady: () => true,
-  setFrame: () => {},
-  setOnPan: () => true,
-  setOnZoom: () => true
 }
 
 export default withStores(withKeyZoom(MultiFrameViewerContainer), storeMapper)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -4,15 +4,15 @@ import React, { cloneElement, useRef, useEffect, useState } from 'react'
 function SVGPanZoom({
   children,
   img,
-  maxZoom,
-  minZoom,
+  maxZoom = 2,
+  minZoom = 1,
   naturalHeight,
   naturalWidth,
-  setOnDrag,
-  setOnPan,
-  setOnZoom,
+  setOnDrag = () => true,
+  setOnPan = () => true,
+  setOnZoom = () => true,
   src,
-  zooming
+  zooming = true
 }) {
   const scrollContainer = useRef()
   const defaultViewBox = {
@@ -135,15 +135,11 @@ SVGPanZoom.propTypes = {
   minZoom: PropTypes.number,
   naturalHeight: PropTypes.number.isRequired,
   naturalWidth: PropTypes.number.isRequired,
+  setOnDrag: PropTypes.func,
   setOnPan: PropTypes.func,
   setOnZoom: PropTypes.func,
   src: PropTypes.string.isRequired,
   zooming: PropTypes.bool
 }
 
-SVGPanZoom.defaultProps = {
-  maxZoom: 2,
-  minZoom: 1,
-  zooming: true
-}
 export default SVGPanZoom

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 
 import { draggable } from '@plugins/drawingTools/components'
 
-import useSubjectImage from './hooks/useSubjectImage'
+import useSubjectImage, { placeholder } from './hooks/useSubjectImage'
 import locationValidator from '../../helpers/locationValidator'
 import SingleImageViewer from './SingleImageViewer'
 import SVGPanZoom from '../SVGComponents/SVGPanZoom'
@@ -16,7 +16,6 @@ const DraggableImage = styled(draggable('image'))`
   cursor: move;
 `
 
-const PLACEHOLDER_URL = 'https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png'  // Use this instead of https://www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png to save on network calls
 function SingleImageViewerContainer({
   enableInteractionLayer = true,
   enableRotation = () => null,
@@ -40,10 +39,10 @@ function SingleImageViewerContainer({
   const imageUrl = subject ? Object.values(subject.locations[0])[0] : null
   const { img, error } = useSubjectImage(ImageObject, imageUrl)
   // default to a placeholder while image is loading.
-  const { naturalHeight = 600, naturalWidth = 800, src = PLACEHOLDER_URL } = img
+  const { naturalHeight, naturalWidth, src } = img
 
   useEffect(function onImageLoad() {
-    if (src !== PLACEHOLDER_URL) {
+    if (src !== placeholder.src) {
       const svgImage = subjectImage.current
       const { width: clientWidth, height: clientHeight } = svgImage
         ? svgImage.getBoundingClientRect()

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -1,11 +1,12 @@
 import asyncStates from '@zooniverse/async-states'
 import { inject, observer } from 'mobx-react'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import { draggable } from '@plugins/drawingTools/components'
 
+import useSubjectImage from './hooks/useSubjectImage'
 import locationValidator from '../../helpers/locationValidator'
 import SingleImageViewer from './SingleImageViewer'
 import SVGPanZoom from '../SVGComponents/SVGPanZoom'
@@ -15,152 +16,106 @@ const DraggableImage = styled(draggable('image'))`
   cursor: move;
 `
 
-class SingleImageViewerContainer extends React.Component {
-  constructor() {
-    super()
-    this.dragMove = this.dragMove.bind(this)
-    this.setOnDrag = this.setOnDrag.bind(this)
+const PLACEHOLDER_URL = 'https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png'  // Use this instead of https://www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png to save on network calls
+function SingleImageViewerContainer({
+  enableInteractionLayer = true,
+  enableRotation = () => null,
+  ImageObject = window.Image,
+  loadingState = asyncStates.initialized,
+  move = false,
+  onError = () => true,
+  onKeyDown = () => true,
+  onReady = () => true,
+  rotation = 0,
+  setOnPan = () => true,
+  setOnZoom = () => true,
+  subject,
+  title = {},
+  zoomControlFn,
+  zooming = true
+}) {
+  const subjectImage = useRef()
+  const [dragMove, setDragMove] = useState()
+  // TODO: replace this with a better function to parse the image location from a subject.
+  const imageUrl = subject ? Object.values(subject.locations[0])[0] : null
+  const { img, error } = useSubjectImage(ImageObject, imageUrl)
+  // default to a placeholder while image is loading.
+  const { naturalHeight = 600, naturalWidth = 800, src = PLACEHOLDER_URL } = img
 
-    this.subjectImage = React.createRef()
-
-    this.state = {
-      img: {}
-    }
-  }
-
-  componentDidMount() {
-    this.props.enableRotation()
-    this.onLoad()
-  }
-
-  fetchImage(url) {
-    const { ImageObject } = this.props
-    return new Promise((resolve, reject) => {
-      const img = new ImageObject()
-      img.onload = () => resolve(img)
-      img.onerror = reject
-      img.src = url
-      return img
-    })
-  }
-
-  dragMove(event, difference) {
-    this.onDrag && this.onDrag(event, difference)
-  }
-
-  setOnDrag(callback) {
-    this.onDrag = callback
-  }
-
-  async preload() {
-    const { subject } = this.props
-    if (subject && subject.locations) {
-      const imageUrl = Object.values(subject.locations[0])[0]
-      const img = await this.fetchImage(imageUrl)
-      this.setState({ img })
-      return img
-    }
-    return {}
-  }
-
-  async getImageSize() {
-    const img = await this.preload()
-    const svgImage = this.subjectImage.current
-    const { width: clientWidth, height: clientHeight } = svgImage
-      ? svgImage.getBoundingClientRect()
-      : {}
-    return {
-      clientHeight,
-      clientWidth,
-      naturalHeight: img.naturalHeight,
-      naturalWidth: img.naturalWidth
-    }
-  }
-
-  async onLoad() {
-    const { onError, onReady } = this.props
-    try {
-      const {
-        clientHeight,
-        clientWidth,
-        naturalHeight,
-        naturalWidth
-      } = await this.getImageSize()
+  useEffect(function onImageLoad() {
+    if (src !== PLACEHOLDER_URL) {
+      const svgImage = subjectImage.current
+      const { width: clientWidth, height: clientHeight } = svgImage
+        ? svgImage.getBoundingClientRect()
+        : {}
       const target = { clientHeight, clientWidth, naturalHeight, naturalWidth }
       onReady({ target })
-    } catch (error) {
-      console.error(error)
-      onError(error)
     }
+  }, [src])
+
+  useEffect(function onMount() {
+    enableRotation()
+  }, [])
+
+  if (error) {
+    console.error(error)
+    onError(error)
   }
 
-  render() {
-    const {
-      enableInteractionLayer,
-      loadingState,
-      move,
-      onKeyDown,
-      rotation,
-      setOnPan,
-      setOnZoom,
-      title,
-      zooming,
-      zoomControlFn
-    } = this.props
-    const { img } = this.state
-    
-    // If image hasn't been fully retrieved, use a placeholder
-    const src = img?.src || 'https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png'  // Use this instead of https://www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png to save on network calls
-    const naturalWidth = img?.naturalWidth || 800
-    const naturalHeight = img?.naturalHeight || 600
+  function setOnDrag(callback) {
+    setDragMove(() => callback)
+  }
 
-    if (loadingState === asyncStates.error) {
-      return <div>Something went wrong.</div>
-    }
+  function onDrag(event, difference) {
+    dragMove?.(event, difference)
+  }
 
-    const enableDrawing =
-      loadingState === asyncStates.success && enableInteractionLayer
-    const SubjectImage = move ? DraggableImage : 'image'
-    const subjectImageProps = {
-      height: naturalHeight,
-      width: naturalWidth,
-      xlinkHref: src,
-      ...(move && { dragMove: this.dragMove })
-    }
+  if (loadingState === asyncStates.error) {
+    return <div>Something went wrong.</div>
+  }
 
-    if (loadingState !== asyncStates.initialized) {
-      return (
-        <SVGPanZoom
-          img={this.subjectImage.current}
-          maxZoom={5}
-          minZoom={0.1}
-          naturalHeight={naturalHeight}
-          naturalWidth={naturalWidth}
-          setOnDrag={this.setOnDrag}
-          setOnPan={setOnPan}
-          setOnZoom={setOnZoom}
+  const enableDrawing =
+    loadingState === asyncStates.success && enableInteractionLayer
+  const SubjectImage = move ? DraggableImage : 'image'
+  const subjectImageProps = {
+    height: naturalHeight,
+    width: naturalWidth,
+    xlinkHref: src,
+    ...(move && { dragMove: onDrag })
+  }
+
+  if (loadingState !== asyncStates.initialized) {
+    return (
+      <SVGPanZoom
+        img={subjectImage.current}
+        maxZoom={5}
+        minZoom={0.1}
+        naturalHeight={naturalHeight}
+        naturalWidth={naturalWidth}
+        setOnDrag={setOnDrag}
+        setOnPan={setOnPan}
+        setOnZoom={setOnZoom}
+        zooming={zooming}
+        src={src}
+      >
+        <SingleImageViewer
+          enableInteractionLayer={enableDrawing}
+          height={naturalHeight}
+          onKeyDown={onKeyDown}
+          rotate={rotation}
+          title={title}
+          width={naturalWidth}
+          zoomControlFn={zoomControlFn}
           zooming={zooming}
-          src={src}
         >
-          <SingleImageViewer
-            enableInteractionLayer={enableDrawing}
-            height={naturalHeight}
-            onKeyDown={onKeyDown}
-            rotate={rotation}
-            title={title}
-            width={naturalWidth}
-            zoomControlFn={zoomControlFn}
-            zooming={zooming}
-          >
-            <g ref={this.subjectImage}>
-              <SubjectImage {...subjectImageProps} />
-            </g>
-          </SingleImageViewer>
-        </SVGPanZoom>
-      )
-    }
-    return null
+          <g ref={subjectImage}>
+            <SubjectImage {...subjectImageProps} />
+          </g>
+        </SingleImageViewer>
+      </SVGPanZoom>
+    )
   }
+  return null
 }
 
 SingleImageViewerContainer.propTypes = {
@@ -182,21 +137,6 @@ SingleImageViewerContainer.propTypes = {
   }),
   zoomControlFn: PropTypes.func,
   zooming: PropTypes.bool
-}
-
-SingleImageViewerContainer.defaultProps = {
-  enableInteractionLayer: true,
-  enableRotation: () => null,
-  ImageObject: window.Image,
-  loadingState: asyncStates.initialized,
-  move: false,
-  onError: () => true,
-  onReady: () => true,
-  rotation: 0,
-  setOnPan: () => true,
-  setOnZoom: () => true,
-  title: {},
-  zooming: true
 }
 
 export default withKeyZoom(SingleImageViewerContainer)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/hooks/useSubjectImage.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/hooks/useSubjectImage.js
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+
+export default function useSubjectImage(ImageObject = window.Image, url) {
+  const [img, setImg] = useState({})
+  const [error, setError] = useState()
+
+  function fetchImage() {
+    return new Promise((resolve, reject) => {
+      const img = new ImageObject()
+      img.onload = () => resolve(img)
+      img.onerror = reject
+      img.src = url
+      return img
+    })
+  }
+
+  async function onLoad() {
+    try {
+      const img = await fetchImage()
+      setImg(img)
+    } catch (error) {
+      setError(error)
+    }
+  }
+
+  useEffect(function onNewSubject() {
+    if (url) {
+      onLoad()
+    }
+  }, [url])
+
+  return { img, error }
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/hooks/useSubjectImage.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/hooks/useSubjectImage.js
@@ -1,7 +1,15 @@
 import { useEffect, useState } from 'react'
 
+const PLACEHOLDER_URL = 'https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png'  // Use this instead of https://www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png to save on network calls
+
+export const placeholder = {
+  naturalHeight: 600,
+  naturalWidth: 800,
+  src: PLACEHOLDER_URL
+}
+
 export default function useSubjectImage(ImageObject = window.Image, url) {
-  const [img, setImg] = useState({})
+  const [img, setImg] = useState(placeholder)
   const [error, setError] = useState()
 
   function fetchImage() {
@@ -16,6 +24,7 @@ export default function useSubjectImage(ImageObject = window.Image, url) {
 
   async function onLoad() {
     try {
+      setImg(placeholder)
       const img = await fetchImage()
       setImg(img)
     } catch (error) {


### PR DESCRIPTION
Refactor `SingleImageViewerContainer` and `MultiFrameViewerContainer` as functional components. Move the common image loading code into a `useSubjectImage` hook.

Package:
lib-classifier

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
