### PR TITLE
App-project: Use router locale for DailyClassificationsChart

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChart.stories.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChart.stories.js
@@ -1,5 +1,7 @@
 import zooTheme from '@zooniverse/grommet-theme'
 import { Grommet } from 'grommet'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
+import Router from 'next/router'
 
 import DailyClassificationsChartContainer from './DailyClassificationsChartContainer'
 const MOCK_DAILY_COUNTS = [
@@ -16,6 +18,26 @@ const MOCK_TOTALS = {
   today: 25
 }
 
+function RouterMock({ children }) {
+  const mockRouter = {
+    asPath: '/projects/zooniverse/snapshot-serengeti/about/research',
+    push: () => {},
+    prefetch: () => new Promise((resolve, reject) => {}),
+    query: {
+      owner: 'zooniverse',
+      project: 'snapshot-serengeti'
+    }
+  }
+
+  Router.router = mockRouter
+
+  return (
+    <RouterContext.Provider value={mockRouter}>
+      {children}
+    </RouterContext.Provider>
+  )
+}
+
 export default {
   title: 'Project App / Screens / Classify / Daily Classifications Chart',
   component: DailyClassificationsChartContainer,
@@ -28,13 +50,14 @@ export default {
 
 export function Plain({ counts, projectName, thisWeek }) {
   return (
-    <Grommet theme={zooTheme}>
-      <DailyClassificationsChartContainer
-        counts={counts}
-        thisWeek={thisWeek}
-        projectName={projectName}
-      />
-    </Grommet>
+    <RouterMock>
+      <Grommet theme={zooTheme}>
+        <DailyClassificationsChartContainer
+          counts={counts}
+          thisWeek={thisWeek}
+          projectName={projectName}
+        />
+      </Grommet>
+    </RouterMock>
   )
 }
-

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChart.stories.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChart.stories.js
@@ -21,6 +21,7 @@ const MOCK_TOTALS = {
 function RouterMock({ children }) {
   const mockRouter = {
     asPath: '/projects/zooniverse/snapshot-serengeti/about/research',
+    locale: 'en',
     push: () => {},
     prefetch: () => new Promise((resolve, reject) => {}),
     query: {

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.js
@@ -1,5 +1,5 @@
-import counterpart from 'counterpart'
 import { array, number, shape, string } from 'prop-types'
+import { useRouter } from 'next/router'
 
 import DailyClassificationsChart from './DailyClassificationsChart'
 
@@ -12,8 +12,9 @@ function DailyClassificationsChartContainer({
   projectName,
   thisWeek = []
 }) {
+  const router = useRouter()
+  const { locale } = router
   const TODAY = new Date()
-  const locale = counterpart.getLocale()
   const stats = thisWeek.map(({ count: statsCount, period }) => {
     const day = new Date(period)
     const isToday = day.getUTCDay() === TODAY.getDay()

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.spec.js
@@ -1,5 +1,6 @@
 import { shallow } from 'enzyme'
 import sinon from 'sinon'
+import * as Router from 'next/router'
 
 import DailyClassificationsChartContainer from './DailyClassificationsChartContainer'
 import DailyClassificationsChart from './DailyClassificationsChart'
@@ -8,6 +9,7 @@ describe('Component > DailyClassificationsChartContainer', function () {
   let clock
   let wrapper
   let componentWrapper
+  let routerStub
   const MOCK_DAILY_COUNTS = [
     { count: 12, period: '2019-09-30' },
     { count: 13, period: '2019-10-01' },
@@ -74,6 +76,17 @@ describe('Component > DailyClassificationsChartContainer', function () {
 
   before(function () {
     clock = sinon.useFakeTimers({ now: new Date('2019-10-06T12:00:00Z'), toFake: ['Date'] })
+    routerStub = sinon.stub(Router, 'useRouter').callsFake((component) => {
+      return {
+        asPath: '',
+        locale: 'en',
+        query: {
+          owner: 'zootester1',
+          project: 'my-project'
+        },
+        prefetch: () => Promise.resolve()
+      }
+    })
     wrapper = shallow(
       <DailyClassificationsChartContainer
         counts={MOCK_TOTALS}
@@ -86,6 +99,7 @@ describe('Component > DailyClassificationsChartContainer', function () {
 
   after(function () {
     clock.restore()
+    routerStub.restore()
   })
 
   it('should render without crashing', function () {

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.stories.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.stories.js
@@ -1,7 +1,6 @@
 import { MediaContextProvider } from '@shared/components/Media'
 import asyncStates from '@zooniverse/async-states'
 import zooTheme from '@zooniverse/grommet-theme'
-import counterpart from 'counterpart'
 import { Grommet } from 'grommet'
 import { Provider } from "mobx-react";
 import PropTypes from 'prop-types'

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsCarousel.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsCarousel.js
@@ -1,4 +1,3 @@
-import counterpart from 'counterpart'
 import { arrayOf, shape, string } from 'prop-types'
 import { Carousel } from 'grommet'
 import SubjectThumbnail from './components/SubjectThumbnail'


### PR DESCRIPTION
## Package:
app-project


## Describe your changes:
This PR refactors DailyClassificationsChart, its storybook, and tests to use Next.js's router `locale` instead of counterpart. I also removed imports of counterpart where it was unused in /src/screens.

## To Review
- Run app-project's storybook with this branch, and check the [DailyClassificationChart story](http://localhost:9001/?path=/story/project-app-screens-classify-daily-classifications-chart--plain)
- Run app-project locally with this branch, make a classification on a staging project such as [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats/classify/workflow/693), and the daily classification chart should update accordingly


## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
- [ ] Is this ready for production deployment?
