### PR TITLE
App-project: Translate Announcements components with next-i18next

### DIFF
--- a/packages/app-project/.storybook/i18n.js
+++ b/packages/app-project/.storybook/i18n.js
@@ -2,7 +2,7 @@ import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
 const supportedLngs = ['en']
-const namespaces = ['screens']
+const namespaces = ['components', 'screens']
 
 i18n.use(initReactI18next).init({
   fallbackLng: 'en',

--- a/packages/app-project/pages/[owner]/[project]/about/education.js
+++ b/packages/app-project/pages/[owner]/[project]/about/education.js
@@ -8,7 +8,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   return {
     notFound,
     props: {
-      ...(await serverSideTranslations(locale, ['screens'])),
+      ...(await serverSideTranslations(locale, ['components', 'screens'])),
       pageTitle: 'Education',
       pageType: 'education',
       ...props

--- a/packages/app-project/pages/[owner]/[project]/about/faq.js
+++ b/packages/app-project/pages/[owner]/[project]/about/faq.js
@@ -8,7 +8,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   return {
     notFound,
     props: {
-      ...(await serverSideTranslations(locale, ['screens'])),
+      ...(await serverSideTranslations(locale, ['components', 'screens'])),
       pageTitle: 'FAQ',
       pageType: 'faq',
       ...props

--- a/packages/app-project/pages/[owner]/[project]/about/research.js
+++ b/packages/app-project/pages/[owner]/[project]/about/research.js
@@ -8,7 +8,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   return {
     notFound,
     props: {
-      ...(await serverSideTranslations(locale, ['screens'])),
+      ...(await serverSideTranslations(locale, ['components', 'screens'])),
       pageTitle: 'Research',
       pageType: 'science_case',
       ...props

--- a/packages/app-project/pages/[owner]/[project]/about/results.js
+++ b/packages/app-project/pages/[owner]/[project]/about/results.js
@@ -8,7 +8,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   return {
     notFound,
     props: {
-      ...(await serverSideTranslations(locale, ['screens'])),
+      ...(await serverSideTranslations(locale, ['components', 'screens'])),
       pageTitle: 'Results',
       pageType: 'results',
       ...props

--- a/packages/app-project/pages/[owner]/[project]/about/team.js
+++ b/packages/app-project/pages/[owner]/[project]/about/team.js
@@ -54,7 +54,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   return {
     notFound,
     props: {
-      ...(await serverSideTranslations(locale, ['screens'])),
+      ...(await serverSideTranslations(locale, ['components', 'screens'])),
       pageTitle: 'The Team',
       pageType: 'team',
       ...props,

--- a/packages/app-project/pages/[owner]/[project]/classify/index.js
+++ b/packages/app-project/pages/[owner]/[project]/classify/index.js
@@ -21,7 +21,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   return ({
     notFound,
     props: {
-      ...(await serverSideTranslations(locale, ['screens'])),
+      ...(await serverSideTranslations(locale, ['components', 'screens'])),
       pageTitle: 'Classify',
       ...props
     }

--- a/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/index.js
+++ b/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/index.js
@@ -16,7 +16,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   return ({
     notFound,
     props: {
-      ...(await serverSideTranslations(locale, ['screens'])),
+      ...(await serverSideTranslations(locale, ['components', 'screens'])),
       ...defaultProps,
       pageTitle,
       workflowID : params.workflowID

--- a/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/subject-set/[subjectSetID]/index.js
+++ b/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/subject-set/[subjectSetID]/index.js
@@ -18,7 +18,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   return ({
     notFound,
     props : {
-      ...(await serverSideTranslations(locale, ['screens'])),
+      ...(await serverSideTranslations(locale, ['components', 'screens'])),
       ...defaultProps,
       pageTitle,
       subjectSetID,

--- a/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/subject-set/[subjectSetID]/subject/[subjectID]/index.js
+++ b/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/subject-set/[subjectSetID]/subject/[subjectID]/index.js
@@ -19,7 +19,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   return ({
     notFound,
     props: {
-      ...(await serverSideTranslations(locale, ['screens'])),
+      ...(await serverSideTranslations(locale, ['components', 'screens'])),
       ...defaultProps,
       pageTitle,
       subjectID,

--- a/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/subject/[subjectID]/index.js
+++ b/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/subject/[subjectID]/index.js
@@ -12,7 +12,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   return ({
     notFound,
     props: {
-      ...(await serverSideTranslations(locale, ['screens'])),
+      ...(await serverSideTranslations(locale, ['components', 'screens'])),
       ...defaultProps,
       pageTitle,
       subjectID,

--- a/packages/app-project/pages/[owner]/[project]/index.js
+++ b/packages/app-project/pages/[owner]/[project]/index.js
@@ -7,7 +7,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   return ({ 
     notFound,
     props: {
-      ...(await serverSideTranslations(locale, ['screens'])),
+      ...(await serverSideTranslations(locale, ['components', 'screens'])),
       ...props
     }
   })

--- a/packages/app-project/public/locales/en/components.json
+++ b/packages/app-project/public/locales/en/components.json
@@ -1,0 +1,9 @@
+{
+  "Announcements": {
+    "AuthenticationInvitation": {
+      "announcement": "Please sign in or sign up to track your contributions.",
+      "register": "register",
+      "signIn": "sign in"
+    }
+  }
+}

--- a/packages/app-project/public/locales/en/components.json
+++ b/packages/app-project/public/locales/en/components.json
@@ -4,6 +4,10 @@
       "announcement": "Please sign in or sign up to track your contributions.",
       "register": "register",
       "signIn": "sign in"
+    },
+    "FinishedAnnouncement": {
+      "announcement": "Finished! Looks like this project is out of data at the moment!",
+      "seeResults": "See Results"
     }
   }
 }

--- a/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationContainer.js
+++ b/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationContainer.js
@@ -1,31 +1,30 @@
-import { useState } from 'react';
+import { useState } from 'react'
 import styled from 'styled-components'
+import { useTranslation } from 'next-i18next'
+
 import { Anchor } from 'grommet'
 import NavLink from '@shared/components/NavLink'
 import GenericAnnouncement from '../GenericAnnouncement'
-import en from './locales/en'
-import counterpart from 'counterpart'
-
-counterpart.registerTranslations('en', en)
 
 const StyledAnchor = styled(Anchor)`
   line-height: 19px;
 `
 
 export default function AuthenticationInvitationContainer({ isVisible }) {
+  const { t } = useTranslation('components')
   const [dismissed, setDismissed] = useState(false)
   const { pathname } = window.location
   const signInLink = {
     href: `${pathname}?login=true`,
-    text: counterpart('AuthenticationInvitation.signIn')
+    text: t('Announcements.AuthenticationInvitation.signIn')
   }
   const registerLink = {
     href: `${pathname}?register=true`,
-    text: counterpart('AuthenticationInvitation.register')
+    text: t('Announcements.AuthenticationInvitation.register')
   }
 
   // TODO: maybe show project specific message here. Then fallback on generic.
-  const announcement = counterpart('AuthenticationInvitation.announcement')
+  const announcement = t('Announcements.AuthenticationInvitation.announcement')
 
   function dismissBanner() {
     setDismissed(true)

--- a/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationContainer.spec.js
+++ b/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationContainer.spec.js
@@ -4,8 +4,6 @@ import AuthenticationInvitationContainer from './AuthenticationInvitationContain
 import GenericAnnouncement from '../GenericAnnouncement'
 import NavLink from '@shared/components/NavLink'
 
-import en from './locales/en'
-
 describe('Component > AuthenticationInvitationContainer', function () {
   let wrapper, componentWrapper
 
@@ -22,24 +20,14 @@ describe('Component > AuthenticationInvitationContainer', function () {
     expect(componentWrapper).to.have.lengthOf(1)
   })
 
-  it('should pass down the required props', function () {
-    expect(componentWrapper.props().announcement).to.equal(en.AuthenticationInvitation.announcement)
-  })
-
   it('should have a link to the login form', function () {
     const signInLink = wrapper.find(NavLink).first()
-    expect(signInLink.props().link).to.deep.equal({
-      href: `${window.location.pathname}?login=true`,
-      text: en.AuthenticationInvitation.signIn
-    })
+    expect(signInLink.props().link.href).to.equal(`${window.location.pathname}?login=true`)
   })
 
   it('should have a link to the register form', function () {
     const registerLink = wrapper.find(NavLink).last()
-    expect(registerLink.props().link).to.deep.equal({
-      href: `${window.location.pathname}?register=true`,
-      text: en.AuthenticationInvitation.register
-    })
+    expect(registerLink.props().link.href).to.equal(`${window.location.pathname}?register=true`)
   })
 
   describe('when not visible', function () {

--- a/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/locales/en.json
+++ b/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/locales/en.json
@@ -1,7 +1,0 @@
-{
-  "AuthenticationInvitation": {
-    "announcement": "Please sign in or sign up to track your contributions.",
-    "register": "register",
-    "signIn": "sign in"
-  }
-}

--- a/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.js
+++ b/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.js
@@ -1,12 +1,9 @@
 import { MobXProviderContext, observer } from 'mobx-react'
 import { useContext } from 'react'
-import counterpart from 'counterpart'
+import { useTranslation } from 'next-i18next'
 
 import NavLink from '@shared/components/NavLink'
-import en from './locales/en'
 import GenericAnnouncement from '../GenericAnnouncement'
-
-counterpart.registerTranslations('en', en)
 
 function useStores(store) {
   const stores = useContext(MobXProviderContext)
@@ -23,14 +20,15 @@ function useStores(store) {
 }
 
 function FinishedAnnouncementConnector ({ store }) {
+  const { t } = useTranslation('components')
   const { 
     baseUrl = '',
     isVisible = false
   } = useStores(store)
-  const announcement = counterpart('FinishedAnnouncement.announcement')
+  const announcement = t('Announcements.FinishedAnnouncement.announcement')
   const link = {
     href: `${baseUrl}/about/results`,
-    text: counterpart('FinishedAnnouncement.seeResults')
+    text: t('Announcements.FinishedAnnouncement.seeResults')
   }
 
   if (isVisible) {

--- a/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.spec.js
+++ b/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.spec.js
@@ -3,7 +3,6 @@ import zooTheme from '@zooniverse/grommet-theme'
 
 import { FinishedAnnouncementConnector } from './FinishedAnnouncementConnector'
 import GenericAnnouncement from '../GenericAnnouncement'
-import en from './locales/en'
 
 describe('Component > FinishedAnnouncementConnector', function () {
   let wrapper
@@ -37,9 +36,5 @@ describe('Component > FinishedAnnouncementConnector', function () {
     )
     componentWrapper = wrapper.find(GenericAnnouncement)
     expect(componentWrapper).to.have.lengthOf(1)
-  })
-
-  it('should pass down the required props', function () {
-    expect(componentWrapper.props().announcement).to.equal(en.FinishedAnnouncement.announcement)
   })
 })

--- a/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/locales/en.json
+++ b/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/locales/en.json
@@ -1,6 +1,0 @@
-{
-  "FinishedAnnouncement": {
-    "announcement": "Finished! Looks like this project is out of data at the moment!",
-    "seeResults": "See Results"
-  }
-}


### PR DESCRIPTION
# Translations Management
This PR refactors app-project's Announcements components to use `next-i18next` instead of `counterpart` for string translations.

Translations project board: https://github.com/zooniverse/front-end-monorepo/projects/15

## Package:
app-project

## Describe your changes:
Added AuthenticationInvitation and FinishedAnnouncement translation keys to `/en/components.json`. Each key that used `counterpart('Some.String.Here')` now uses the `t` function like `t('Some.String.Here')`.

I also passed `'components'` to each `getServerSideProps` function to bundle the new dictionary file.

Changes to tests involve removing tests that looked for passing of props rather than testing elements rendered to the UI.

## To Review
Run `yarn storybook` with this branch and check that AuthenticationInvitation and FinishedAnnouncement render their translated text.

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
- [ ] Is this ready for production deployment?
