### PR TITLE
Remove trapFocus from SimpleDropdown

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/components/SimpleDropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/components/SimpleDropdownTask.js
@@ -24,13 +24,12 @@ const StyledText = styled(Text)`
 // artificially disabled. Please refer to the README. (@shaunanoordin 20200820)
 const ENABLE_OTHER_OPTION = false
 
-function SimpleDropdownTask (props) {
-  const {
-    annotation,
-    className,
-    disabled,
-    task,
-  } = props
+function SimpleDropdownTask ({
+  annotation,
+  className = '',
+  disabled = false,
+  task,
+}) {
   const { value } = annotation
   
   // Decide what kind of options to display.
@@ -86,7 +85,10 @@ function SimpleDropdownTask (props) {
     setAnnotation(ele.value, false)
     setCustomValue(ele.value)
   }
-  
+
+  const dropProps = {
+    trapFocus: false
+  }
   return (
     <Box
       className={className}
@@ -102,6 +104,7 @@ function SimpleDropdownTask (props) {
       >
         <Select
           disabled={disabled}
+          dropProps={dropProps}
           icon={<Down size='small' />}
           labelKey='text'
           onChange={onSelectChange}
@@ -123,11 +126,6 @@ function SimpleDropdownTask (props) {
       </Box>
     </Box>
   )
-}
-
-SimpleDropdownTask.defaultProps = {
-  className: '',
-  disabled: false,
 }
 
 SimpleDropdownTask.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/components/SimpleDropdownTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/components/SimpleDropdownTask.spec.js
@@ -53,6 +53,12 @@ describe('SimpleDropdownTask', function () {
       const renderedOptions = grommetSelect.props()['options'] || []
       expect(renderedOptions).to.have.length(6)
     })
+
+    it('should not trap focus', function () {
+      const grommetSelect = wrapper.find('Select')
+      const dropProps = grommetSelect.props().dropProps || {}
+      expect(dropProps.trapFocus).to.be.false()
+    })
   })
 
   describe('with an annotation', function () {


### PR DESCRIPTION
Set `trapFocus: false` on simple dropdown tasks, so that they aren't modal when open.

Try it out with the dropdown menu here:
https://localhost:8080/?project=eatyourgreens/-project-testing-ground&workflow=3489

Still to do (for #2837):
- fix select menus so that tab chooses the selected option and moves on to the next focusable element in the page.

Package:
lib-classifier

Towards #2837.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
