### PR TITLE
Lib-classifier: Translate /plugins components with react-i18next

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.js
@@ -2,14 +2,12 @@ import PropTypes from 'prop-types'
 import React, { useContext, useState } from 'react'
 import { ThemeContext } from 'styled-components'
 import { MobXProviderContext } from 'mobx-react'
-import counterpart from 'counterpart'
 import { Tooltip } from '@zooniverse/react-components'
+import { useTranslation } from 'react-i18next'
+
 import TooltipIcon from './components/TooltipIcon'
 import { HANDLE_RADIUS } from './helpers/constants'
 import TranscriptionLineMark from './components/TranscriptionLineMark'
-import en from './locales/en'
-
-counterpart.registerTranslations('en', en)
 
 function storeMapper(stores) {
   return stores.classifierStore.workflows.active?.usesTranscriptionTask || false
@@ -22,6 +20,7 @@ function TranscriptionLine(props) {
   const [allowFinish, setAllowFinish] = useState(false)
   const usesTranscriptionTask = storeMapper(stores)
   const { active, color, mark, onFinish, scale, state } = props
+  const { t } = useTranslation('plugins')
   if (theme) {
     transcriptionTaskColors = {
       active: theme.global.colors.drawingTools.green,
@@ -56,7 +55,7 @@ function TranscriptionLine(props) {
   }
 
   if (usesTranscriptionTask && lineState === 'active' || lineState === 'default') {
-    const tooltipLabel = (lineState === 'active') ? counterpart('TranscriptionLine.editing') : counterpart('TranscriptionLine.created')
+    const tooltipLabel = (lineState === 'active') ? t('TranscriptionLine.editing') : t('TranscriptionLine.created')
     return (
       <Tooltip
         icon={<TooltipIcon fill={colorToRender} />}

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.spec.js
@@ -7,7 +7,6 @@ import { TranscriptionLine as TranscriptionLineMarkModel } from '../../models/ma
 import { DragHandle } from '@plugins/drawingTools/components'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Tooltip } from '@zooniverse/react-components'
-import en from './locales/en'
 
 describe('Components > Drawing marks > Transcription line', function () {
   let mark
@@ -270,7 +269,6 @@ describe('Components > Drawing marks > Transcription line', function () {
       expect(mark.finished).to.be.true()
       dragMove({}, { x: 10, y: 20 })
       expect(mark.finished).to.be.true()
-
     })
   })
 
@@ -467,10 +465,11 @@ describe('Components > Drawing marks > Transcription line', function () {
           }
         }
       )
-      
+
       const tooltip = wrapper.find(Tooltip)
       expect(tooltip).to.have.lengthOf(1)
-      expect(tooltip.props().label).to.equal(en.TranscriptionLine.created)
+      /** The translation function will simply return keys in a testing env */
+      expect(tooltip.props().label).to.equal('TranscriptionLine.created')
       expect(tooltip.props().icon.props.fill).to.equal(blue)
     })
 
@@ -503,7 +502,8 @@ describe('Components > Drawing marks > Transcription line', function () {
 
       const tooltip = wrapper.find(Tooltip)
       expect(tooltip).to.have.lengthOf(1)
-      expect(tooltip.props().label).to.equal(en.TranscriptionLine.editing)
+      /** The translation function will simply return keys in a testing env */
+      expect(tooltip.props().label).to.equal('TranscriptionLine.editing')
       expect(tooltip.props().icon.props.fill).to.equal(green)
     })
   })

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/locales/en.json
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/locales/en.json
@@ -1,6 +1,0 @@
-{
-  "TranscriptionLine": {
-    "editing": "Editing transcription",
-    "created": "Created transcription"
-  }
-}

--- a/packages/lib-classifier/src/plugins/tasks/DataVisAnnotationTask/components/DataVisAnnotationTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/DataVisAnnotationTask/components/DataVisAnnotationTask.js
@@ -1,16 +1,13 @@
-import counterpart from 'counterpart'
 import { Box, Text } from 'grommet'
 import { observer } from 'mobx-react'
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Markdownz } from '@zooniverse/react-components'
+
 import TaskInput from '../../components/TaskInput'
 import InputIcon from '../../components/InputIcon'
 import Graph2dRangeXIcon from './components/Graph2dRangeXIcon'
-
-import en from './locales/en'
-counterpart.registerTranslations('en', en)
 
 const StyledText = styled(Text)`
   margin: 0;

--- a/packages/lib-classifier/src/plugins/tasks/DataVisAnnotationTask/components/locales/en.json
+++ b/packages/lib-classifier/src/plugins/tasks/DataVisAnnotationTask/components/locales/en.json
@@ -1,5 +1,0 @@
-{
-  "Graph2dRangeXTask": {
-    "marksMade": "Marks made"
-  }
-}

--- a/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/components/SimpleDropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/components/SimpleDropdownTask.js
@@ -5,10 +5,7 @@ import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css } from 'styled-components'
-
-import counterpart from 'counterpart'
-import en from './locales/en'
-counterpart.registerTranslations('en', en)
+import { useTranslation } from 'react-i18next'
 
 const StyledText = styled(Text)`
   margin: 0;
@@ -31,28 +28,29 @@ function SimpleDropdownTask (props) {
     disabled,
     task,
   } = props
+  const { t } = useTranslation('plugins')
   const { value } = annotation
-  
+
   // Decide what kind of options to display.
   // Use an array of objects instead of an array of text.
   // This solves issues of duplicate text.
   const optionsToDisplay = task.options.map(opt => ({
     text: opt,
   }))
-  
+
   // If the Other option is enabled, we allow users to type in any text.
   const otherOption = {
-    text: counterpart('Dropdown.otherLabel')
+    text: t('SimpleDropdownTask.otherLabel')
   }
   if (task.allowCreate && ENABLE_OTHER_OPTION) {
     optionsToDisplay.push(otherOption)
   }
-  
+
   // Determine which option is selected.
   let selectedOption = undefined
   if (value?.option === true) {
     selectedOption = optionsToDisplay[value?.selection]
-  } else if (value?.option === false) {  // Note: this distinguishes between value = undefined
+  } else if (value?.option === false) { // Note: this distinguishes between value = undefined
     selectedOption = otherOption
   }
 
@@ -60,7 +58,7 @@ function SimpleDropdownTask (props) {
   const [customValue, setCustomValue] = React.useState((selectedOption === otherOption) ? value?.selection : '')
   const showCustomInput = (selectedOption === otherOption)
   const customInput = React.useRef()
-  
+
   // 'selection' indicates the index of the selected answer. (number)
   // If the Other option is enabled, selection can be a string.
   function setAnnotation (selection, isPresetOption = false) {
@@ -69,24 +67,24 @@ function SimpleDropdownTask (props) {
       option: isPresetOption,
     })
   }
-  
+
   function onSelectChange ({ option, selected: selectionIndex }) {
     const isPresetOption = option !== otherOption
     setCustomValue('')
-    
+
     if (isPresetOption) {
       setAnnotation(selectionIndex, true)
     } else {
       setAnnotation('', false)
     }
   }
-  
+
   function onTextInputChange () {
     const ele = customInput && customInput.current || { value: '' }
     setAnnotation(ele.value, false)
     setCustomValue(ele.value)
   }
-  
+
   return (
     <Box
       className={className}
@@ -96,7 +94,7 @@ function SimpleDropdownTask (props) {
           {task.instruction}
         </Markdownz>
       </StyledText>
-        
+
       <Box
         gap='xsmall'
       >
@@ -106,15 +104,15 @@ function SimpleDropdownTask (props) {
           labelKey='text'
           onChange={onSelectChange}
           options={optionsToDisplay}
-          placeholder={counterpart('Dropdown.selectPlaceholder')}
+          placeholder={t('SimpleDropdownTask.selectPlaceholder')}
           size='small'
           value={selectedOption}
         />
-        
+
         {(showCustomInput) &&
           <TextInput
             onChange={onTextInputChange}
-            placeholder={counterpart('Dropdown.customInputPlaceholder')}
+            placeholder={t('SimpleDropdownTask.customInputPlaceholder')}
             ref={customInput}
             size='small'
             value={customValue}

--- a/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/components/locales/en.json
+++ b/packages/lib-classifier/src/plugins/tasks/SimpleDropdownTask/components/locales/en.json
@@ -1,7 +1,0 @@
-{
-  "Dropdown": {
-    "customInputPlaceholder": "Input something",
-    "otherLabel": "Other...",
-    "selectPlaceholder": "Choose an answer"
-  }
-}

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/Choice.js
@@ -2,16 +2,12 @@ import { Box, Button, Carousel, Heading, Paragraph } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { PrimaryButton, Media } from '@zooniverse/react-components'
+import { useTranslation } from 'react-i18next'
 
 import ConfusedWith from './components/ConfusedWith'
 import Questions from './components/Questions'
 import allowIdentification from './helpers/allowIdentification'
 import getQuestionIds from './helpers/getQuestionIds'
-
-import counterpart from 'counterpart'
-import en from './locales/en'
-
-counterpart.registerTranslations('en', en)
 
 export default function Choice (props) {
   const {
@@ -28,6 +24,8 @@ export default function Choice (props) {
     images,
     questions
   } = task
+
+  const { t } = useTranslation('plugins')
 
   const choice = choices?.[choiceId] || {}
   const questionIds = getQuestionIds(choiceId, task)
@@ -100,14 +98,14 @@ export default function Choice (props) {
       >
         <Button
           fill='horizontal'
-          label={counterpart('Choice.notThis')}
+          label={t('SurveyTask.Choice.notThis')}
           onClick={() => handleDelete(choiceId)}
         />
         <PrimaryButton
           autoFocus={hasFocus === 'identify'}
           disabled={!allowIdentify}
           fill='horizontal'
-          label={counterpart('Choice.identify')}
+          label={t('SurveyTask.Choice.identify')}
           onClick={() => onIdentify()}
         />
       </Box>

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/Choice.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/Choice.spec.js
@@ -67,7 +67,7 @@ describe('Component > Choice', function () {
           task={mockTask}
         />
       )
-      expect(screen.getByText('Sometimes confused with')).to.exist()
+      expect(screen.getByText('SurveyTask.ConfusedWith.confused')).to.exist()
     })
 
     it('should render Questions', function () {

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/Choice.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/Choice.spec.js
@@ -6,9 +6,8 @@ import userEvent from '@testing-library/user-event'
 
 import { task as mockTask } from '@plugins/tasks/SurveyTask/mock-data'
 import Choice from './Choice'
-import en from './locales/en'
 
-describe.skip('Component > Choice', function () {
+describe('Component > Choice', function () {
   it('should render without crashing', function () {
     render(
       <Choice
@@ -28,7 +27,8 @@ describe.skip('Component > Choice', function () {
         task={mockTask}
       />
     )
-    userEvent.click(screen.getByText(en.Choice.notThis))
+    const button = screen.getByRole('button', { name: 'SurveyTask.Choice.notThis' })
+    userEvent.click(button)
 
     expect(handleDeleteSpy).to.have.been.calledOnceWith('KD')
   })
@@ -42,7 +42,7 @@ describe.skip('Component > Choice', function () {
         task={mockTask}
       />
     )
-    userEvent.click(screen.getByText(en.Choice.identify))
+    userEvent.click(screen.getByText('SurveyTask.Choice.identify'))
 
     expect(onIdentifySpy).to.have.been.calledOnce()
   })
@@ -150,7 +150,7 @@ describe.skip('Component > Choice', function () {
           task={mockTask}
         />
       )
-      expect(screen.getByRole('button', { name: en.Choice.identify }, { hidden: true })).to.equal(document.activeElement)
+      expect(screen.getByRole('button', { name: 'SurveyTask.Choice.identify' }, { hidden: true })).to.equal(document.activeElement)
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/ConfusedWith/ConfusedWith.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/ConfusedWith/ConfusedWith.js
@@ -3,13 +3,9 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { withTheme } from 'styled-components'
 import { SpacedHeading } from '@zooniverse/react-components'
+import { useTranslation } from 'react-i18next'
 
 import Confusion from './components/Confusion'
-
-import counterpart from 'counterpart'
-import en from './locales/en'
-
-counterpart.registerTranslations('en', en)
 
 export const StyledDropButton = styled(DropButton)`
   background-color: ${props => props.theme.global.colors[props.backgroundColor]};
@@ -29,6 +25,8 @@ function ConfusedWith (props) {
     theme
   } = props
 
+  const { t } = useTranslation('plugins')
+
   const [open, setOpen] = React.useState(false)
   function onClose () {
     setOpen(false)
@@ -39,7 +37,7 @@ function ConfusedWith (props) {
 
   return (
     <Box>
-      <SpacedHeading>{counterpart('ConfusedWith.confused')}</SpacedHeading>
+      <SpacedHeading>{t('SurveyTask.ConfusedWith.confused')}</SpacedHeading>
       <Box
         direction='row'
         wrap

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/ConfusedWith/ConfusedWith.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/ConfusedWith/ConfusedWith.spec.js
@@ -4,7 +4,6 @@ import { render, screen } from '@testing-library/react'
 import zooTheme from '@zooniverse/grommet-theme'
 
 import { task as mockTask } from '@plugins/tasks/SurveyTask/mock-data'
-import en from './locales/en'
 import { ConfusedWith } from './ConfusedWith'
 
 const KUDU = mockTask.choices.KD
@@ -33,7 +32,8 @@ describe('Component > ConfusedWith', function () {
         theme={zooTheme}
       />
     )
-    expect(screen.getByText(en.ConfusedWith.confused)).to.exist()
+    /** The translation function will simply return keys in a testing env */
+    expect(screen.getByText('SurveyTask.ConfusedWith.confused')).to.exist()
   })
 
   it('should render the appropriate confused with buttons', function () {

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/ConfusedWith/components/Confusion.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/ConfusedWith/components/Confusion.js
@@ -2,11 +2,8 @@ import { Box, Button, Carousel, Paragraph } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Media, PrimaryButton, SpacedHeading } from '@zooniverse/react-components'
+import { useTranslation } from 'react-i18next'
 
-import counterpart from 'counterpart'
-import en from '../locales/en'
-
-counterpart.registerTranslations('en', en)
 export default function Confusion (props) {
   const {
     confusion,
@@ -16,6 +13,8 @@ export default function Confusion (props) {
     images,
     onClose
   } = props
+
+  const { t } = useTranslation('plugins')
 
   return (
     <Box
@@ -56,12 +55,12 @@ export default function Confusion (props) {
       >
         <Button
           fill='horizontal'
-          label={counterpart('ConfusedWith.cancel')}
+          label={t('SurveyTask.ConfusedWith.cancel')}
           onClick={() => onClose()}
         />
         <PrimaryButton
           fill='horizontal'
-          label={counterpart('ConfusedWith.itsThis')}
+          label={t('SurveyTask.ConfusedWith.itsThis')}
           onClick={() => handleChoice(confusionId)}
         />
       </Box>

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/ConfusedWith/components/Confusion.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/ConfusedWith/components/Confusion.spec.js
@@ -5,7 +5,6 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { task as mockTask } from '@plugins/tasks/SurveyTask/mock-data'
-import en from '../locales/en'
 import Confusion from './Confusion'
 
 const ELAND = mockTask.choices.LND
@@ -81,7 +80,8 @@ describe('Component > Confusion', function () {
         images={mockTask.images}
       />
     )
-    expect(screen.getByRole('button', { name: en.ConfusedWith.cancel })).to.exist()
+    /** The translation function will simply return keys in a testing env */
+    expect(screen.getByRole('button', { name: 'SurveyTask.ConfusedWith.cancel' })).to.exist()
   })
 
   it('should call onClose when the Cancel button is clicked', function () {
@@ -96,7 +96,8 @@ describe('Component > Confusion', function () {
         onClose={onCloseSpy}
       />
     )
-    userEvent.click(screen.getByRole('button', { name: en.ConfusedWith.cancel }))
+    /** The translation function will simply return keys in a testing env */
+    userEvent.click(screen.getByRole('button', { name: 'SurveyTask.ConfusedWith.cancel' }))
     expect(onCloseSpy).to.have.been.calledOnce()
   })
 
@@ -109,7 +110,8 @@ describe('Component > Confusion', function () {
         images={mockTask.images}
       />
     )
-    expect(screen.getByRole('button', { name: en.ConfusedWith.itsThis })).to.exist()
+    /** The translation function will simply return keys in a testing env */
+    expect(screen.getByRole('button', { name: 'SurveyTask.ConfusedWith.itsThis' })).to.exist()
   })
 
   it('should call handleChoice with confusion ID when the "I think it\'s this" button is clicked', function () {
@@ -124,7 +126,8 @@ describe('Component > Confusion', function () {
         images={mockTask.images}
       />
     )
-    userEvent.click(screen.getByRole('button', { name: en.ConfusedWith.itsThis }))
+    /** The translation function will simply return keys in a testing env */
+    userEvent.click(screen.getByRole('button', { name: 'SurveyTask.ConfusedWith.itsThis' }))
     expect(handleChoiceSpy).to.have.been.calledOnceWith('LND')
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/ConfusedWith/locales/en.json
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/components/ConfusedWith/locales/en.json
@@ -1,7 +1,0 @@
-{
-  "ConfusedWith": {
-    "cancel": "Cancel",
-    "confused": "Sometimes confused with",
-    "itsThis": "I think it's this"
-  }
-}

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/locales/en.json
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Choice/locales/en.json
@@ -1,6 +1,0 @@
-{
-  "Choice": {
-    "identify": "Identify",
-    "notThis": "Not this"
-  }
-}

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/Characteristics/Characteristics.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/Characteristics/Characteristics.js
@@ -1,13 +1,9 @@
 import { Box, Button } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 import CharacteristicSection from './components/CharacteristicSection'
-
-import counterpart from 'counterpart'
-import en from '../locales/en'
-
-counterpart.registerTranslations('en', en)
 
 export default function Characteristics (props) {
   const {
@@ -17,6 +13,8 @@ export default function Characteristics (props) {
     images,
     onFilter
   } = props
+
+  const { t } = useTranslation('plugins')
 
   return (
     <Box
@@ -42,7 +40,7 @@ export default function Characteristics (props) {
         pad='small'
       >
         <Button
-          label={counterpart('CharacteristicsFilter.clearFilters')}
+          label={t('SurveyTask.CharacteristicsFilter.clearFilters')}
           onClick={() => onFilter()}
         />
       </Box>

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/Characteristics/Characteristics.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/Characteristics/Characteristics.spec.js
@@ -36,14 +36,15 @@ describe('Component > Characteristics', function () {
     })
   })
 
+  /** The translation function will simply return keys in a testing env */
   it('should render a "Clear filters" button', function () {
-    expect(wrapper.find('Button').props().label).to.equal('Clear filters')
+    expect(wrapper.find('Button').props().label).to.equal('SurveyTask.CharacteristicsFilter.clearFilters')
   })
 
   it('should call onFilter when the "Clear filters" button is clicked', function () {
     expect(onFilterSpy).to.have.not.been.called()
 
-    wrapper.find('Button').filterWhere((button) => button.props().label === 'Clear filters').at(0).simulate('click')
+    wrapper.find('Button').filterWhere((button) => button.props().label === 'SurveyTask.CharacteristicsFilter.clearFilters').at(0).simulate('click')
 
     expect(onFilterSpy).to.have.been.calledOnceWith()
   })

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/ClearFilters/ClearFilters.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/ClearFilters/ClearFilters.js
@@ -3,12 +3,7 @@ import { Clear } from 'grommet-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { PlainButton, SpacedText } from '@zooniverse/react-components'
-
-import counterpart from 'counterpart'
-import en from '../locales/en'
-
-counterpart.registerTranslations('en', en)
-
+import { useTranslation } from 'react-i18next'
 
 export default function ClearFilters (props) {
   const {
@@ -16,6 +11,8 @@ export default function ClearFilters (props) {
     showingChoices,
     totalChoices
   } = props
+
+  const { t } = useTranslation('plugins')
 
   return (
     <Box
@@ -27,13 +24,13 @@ export default function ClearFilters (props) {
       pad={{ top: 'xsmall' }}
     >
       <SpacedText>
-        {counterpart('CharacteristicsFilter.showing', { showing: showingChoices, total: totalChoices })}
+        {t('SurveyTask.CharacteristicsFilter.showing', { showing: showingChoices, total: totalChoices })}
       </SpacedText>
       <PlainButton
         disabled={showingChoices === totalChoices}
         icon={<Clear />}
         onClick={() => handleFilter()}
-        text={counterpart('CharacteristicsFilter.clearFilters')}
+        text={t('SurveyTask.CharacteristicsFilter.clearFilters')}
       />
     </Box>
   )

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.js
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.js
@@ -3,15 +3,11 @@ import PropTypes from 'prop-types'
 import React, { useRef } from 'react'
 import styled from 'styled-components'
 import { SpacedText } from '@zooniverse/react-components'
+import { useTranslation } from 'react-i18next'
 
 import Characteristics from '../Characteristics'
 import FilterButton from '../components/FilterButton'
 import FilterIcon from './FilterIcon'
-
-import counterpart from 'counterpart'
-import en from '../locales/en'
-
-counterpart.registerTranslations('en', en)
 
 const StyledDropButton = styled(DropButton)`
   border: none;
@@ -44,6 +40,8 @@ export default function FilterStatus (props) {
     characteristicsOrder,
     images
   } = task
+
+  const { t } = useTranslation('plugins')
 
   const filterStatusRef = useRef()
 
@@ -92,7 +90,7 @@ export default function FilterStatus (props) {
               light: 'neutral-1'
             }}
           >
-            {counterpart('CharacteristicsFilter.filter')}
+            {t('SurveyTask.CharacteristicsFilter.filter')}
           </StyledLabel>
         }
       />

--- a/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/locales/en.json
+++ b/packages/lib-classifier/src/plugins/tasks/SurveyTask/components/components/Chooser/components/CharacteristicsFilter/locales/en.json
@@ -1,7 +1,0 @@
-{
-  "CharacteristicsFilter": {
-    "clearFilters": "Clear filters",
-    "filter": "Filter",
-    "showing": "Showing %(showing)s of %(total)s"
-  }
-}

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/components/TextTagButtons/TextTagButtons.js
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/components/TextTagButtons/TextTagButtons.js
@@ -2,12 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Box, Text } from 'grommet'
 import { PlainButton } from '@zooniverse/react-components'
-import counterpart from 'counterpart'
-import en from './locales/en'
-
-counterpart.registerTranslations('en', en)
+import { useTranslation } from 'react-i18next'
 
 export default function TextTagButtons ({ disabled, tags, taskKey, onClick }) {
+  const { t } = useTranslation('plugins')
   if (tags.length > 0) {
     return (
       <>
@@ -15,7 +13,7 @@ export default function TextTagButtons ({ disabled, tags, taskKey, onClick }) {
           id={`textModifiers-${taskKey}`}
           weight='bold'
         >
-          {counterpart('TextTask.modifiers')}
+          {t('TextTask.TextTagButtons.modifiers')}
         </Text>
         <Box
           gap='small'

--- a/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/components/TextTagButtons/locales/en.json
+++ b/packages/lib-classifier/src/plugins/tasks/TextTask/components/TextTask/components/TextTagButtons/locales/en.json
@@ -1,5 +1,0 @@
-{
-  "TextTask": {
-    "modifiers": "Text modifiers"
-  }
-}

--- a/packages/lib-classifier/src/plugins/tasks/components/InputStatus/InputStatus.js
+++ b/packages/lib-classifier/src/plugins/tasks/components/InputStatus/InputStatus.js
@@ -1,12 +1,9 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import counterpart from 'counterpart'
 import { Text } from 'grommet'
 import styled from 'styled-components'
 import { Markdownz } from '@zooniverse/react-components'
-import en from './locales/en'
-
-counterpart.registerTranslations('en', en)
+import { useTranslation } from 'react-i18next'
 
 export const StyledInputStatus = styled(Text)`
   flex-grow: 1;
@@ -14,15 +11,16 @@ export const StyledInputStatus = styled(Text)`
 `
 
 export default function InputStatus ({ count, tool }) {
-  let status = counterpart('InputStatus.drawn', { count })
+  const { t } = useTranslation('plugins')
+  let status = t('InputStatus.drawn', { count })
   const hasMin = tool.min && tool.min > 0
   const hasMax = tool.max && tool.max < Infinity
   if (hasMin && hasMax) {
-    status = counterpart('InputStatus.maxAndMin', { count, max: tool.max, min: tool.min })
+    status = t('InputStatus.maxAndMin', { count, max: tool.max, min: tool.min })
   } else if (hasMax) {
-    status = counterpart('InputStatus.max', { count, max: tool.max })
+    status = t('InputStatus.max', { count, max: tool.max })
   } else if (hasMin) {
-    status = counterpart('InputStatus.min', { count, min: tool.min })
+    status = t('InputStatus.min', { count, min: tool.min })
   }
 
   return (

--- a/packages/lib-classifier/src/plugins/tasks/components/InputStatus/InputStatus.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/components/InputStatus/InputStatus.spec.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import InputStatus, { StyledInputStatus } from './InputStatus'
+/** The translation function will simply return keys in a testing env */
 
 describe('InputStatus', function () {
   it('should render without crashing', function () {
@@ -15,21 +16,21 @@ describe('InputStatus', function () {
 
   it('should not render any requirements if props.tool.min or props.tool.max is not defined', function () {
     const wrapper = shallow(<InputStatus />)
-    expect(wrapper.contains('0 drawn')).to.be.true()
+    expect(wrapper.contains('InputStatus.drawn')).to.be.true()
   })
 
   it('should render minimum drawing requirements if props.tool.min is defined', function () {
     const wrapper = shallow(<InputStatus tool={{ min: 1 }} />)
-    expect(wrapper.contains('0 of 1 required drawn')).to.be.true()
+    expect(wrapper.contains('InputStatus.min')).to.be.true()
   })
 
   it('should render maxmimum drawing requirements if props.tool.max is defined', function () {
     const wrapper = shallow(<InputStatus tool={{ max: 2 }} />)
-    expect(wrapper.contains('0 of 2 maximum drawn')).to.be.true()
+    expect(wrapper.contains('InputStatus.max')).to.be.true()
   })
 
   it('should render minimum and maxmimum drawing requirements if props.tool.min and props.tool.max are defined', function () {
     const wrapper = shallow(<InputStatus tool={{ min: 1, max: 2 }} />)
-    expect(wrapper.contains('0 of 1 required, 2 maximum drawn')).to.be.true()
+    expect(wrapper.contains('InputStatus.maxAndMin')).to.be.true()
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/components/InputStatus/locales/en.json
+++ b/packages/lib-classifier/src/plugins/tasks/components/InputStatus/locales/en.json
@@ -1,8 +1,0 @@
-{
-  "InputStatus": {
-    "drawn": "%(count)s drawn",
-    "max": "%(count)s of %(max)s maximum drawn",
-    "min": "%(count)s of %(min)s required drawn",
-    "maxAndMin": "%(count)s of %(min)s required, %(max)s maximum drawn"
-  }
-}

--- a/packages/lib-classifier/src/translations/en/plugins.json
+++ b/packages/lib-classifier/src/translations/en/plugins.json
@@ -11,6 +11,11 @@
     "selectPlaceholder": "Choose an answer"
   },
   "SurveyTask":{
+    "CharacteristicsFilter": {
+      "clearFilters": "Clear filters",
+      "filter": "Filter",
+      "showing": "Showing {{showing}} of {{total}}"
+    },
     "Choice": {
       "identify": "Identify",
       "notThis": "Not this"

--- a/packages/lib-classifier/src/translations/en/plugins.json
+++ b/packages/lib-classifier/src/translations/en/plugins.json
@@ -1,3 +1,6 @@
 {
-  "Foo": "bar"
+  "TranscriptionLine": {
+    "editing": "Editing transcription",
+    "created": "Created transcription"
+  }
 }

--- a/packages/lib-classifier/src/translations/en/plugins.json
+++ b/packages/lib-classifier/src/translations/en/plugins.json
@@ -5,6 +5,11 @@
     "min": "{{count}} of {{min}} required drawn",
     "maxAndMin": "{{count}} of {{min}} required, {{max}} maximum drawn"
   },
+  "SimpleDropdownTask": {
+    "customInputPlaceholder": "Input something",
+    "otherLabel": "Other...",
+    "selectPlaceholder": "Choose an answer"
+  },
   "TranscriptionLine": {
     "editing": "Editing transcription",
     "created": "Created transcription"

--- a/packages/lib-classifier/src/translations/en/plugins.json
+++ b/packages/lib-classifier/src/translations/en/plugins.json
@@ -14,6 +14,11 @@
     "Choice": {
       "identify": "Identify",
       "notThis": "Not this"
+    },
+    "ConfusedWith": {
+      "cancel": "Cancel",
+      "confused": "Sometimes confused with",
+      "itsThis": "I think it's this"
     }
   },
   "TranscriptionLine": {

--- a/packages/lib-classifier/src/translations/en/plugins.json
+++ b/packages/lib-classifier/src/translations/en/plugins.json
@@ -10,6 +10,12 @@
     "otherLabel": "Other...",
     "selectPlaceholder": "Choose an answer"
   },
+  "SurveyTask":{
+    "Choice": {
+      "identify": "Identify",
+      "notThis": "Not this"
+    }
+  },
   "TranscriptionLine": {
     "editing": "Editing transcription",
     "created": "Created transcription"

--- a/packages/lib-classifier/src/translations/en/plugins.json
+++ b/packages/lib-classifier/src/translations/en/plugins.json
@@ -1,4 +1,10 @@
 {
+  "InputStatus": {
+    "drawn": "{{count}} drawn",
+    "max": "{{count}} of {{max}} maximum drawn",
+    "min": "{{count}} of {{min}} required drawn",
+    "maxAndMin": "{{count}} of {{min}} required, {{max}} maximum drawn"
+  },
   "TranscriptionLine": {
     "editing": "Editing transcription",
     "created": "Created transcription"

--- a/packages/lib-classifier/src/translations/en/plugins.json
+++ b/packages/lib-classifier/src/translations/en/plugins.json
@@ -26,6 +26,11 @@
       "itsThis": "I think it's this"
     }
   },
+  "TextTask": {
+    "TextTagButtons": {
+      "modifiers": "Text modifiers"
+    }
+  },
   "TranscriptionLine": {
     "editing": "Editing transcription",
     "created": "Created transcription"


### PR DESCRIPTION
# Translations Management

This PR refactors lib-classifier's "plugins" components to use `react-i18next` instead of `counterpart` for string translations.

Translations project board: https://github.com/zooniverse/front-end-monorepo/projects/15

## Package:
lib-classifier

## Describe your changes:
Added components that live in `/plugins` translation keys to `/en/plugins.json`. Each key that used `counterpart('Some.String.Here’)` now uses the `t` function like `t('Some.String.Here’)`.

There was a `en.json` locale file in DataVisAnnotationTask, but the translation strings were not actually used in the component, so I removed those keys.

Some unit tests required refactoring if they looked for previous translation strings.

## To Review

Task components that can be reviewed in storybook:
- InputStatus is in the Drawing story
- Simple Dropdown
- SurveyTasks's Choice components include ConfusedWith
- SurveyTasks's Chooser components include CharacteristicsFilter
- TextTask

Drawing Tools components that can be reviewed in storybook:
- TranscriptionLine

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
- [ ] Is this ready for production deployment?
