### PR TITLE
Refactor LightCurveViewerContainer to return null if dataPoints has no length

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
@@ -94,7 +94,7 @@ export function LightCurveViewerContainer({
     dataPoints = zip(JSONdata.x, JSONdata.y)
   }
 
-  if (!subject.id) {
+  if (!subject.id || !dataPoints.length) {
     return null
   }
 


### PR DESCRIPTION
Package:
- lib-classifier

Closes #2871.

## Describe your changes:
- from LightCurveViewerContainer only returns LightCurveViewer if `dataPoints` has length (would have length if populated from JSON data) 

<em>Helpful explanations that will make your reviewer happy:</em>
- What Zooniverse project should my reviewer use to review UX? 
  - https://local.zooniverse.org:8080/?project=7929&env=production&demo=true
  - https://local.zooniverse.org:3000/projects/nora-dot-eisner/planet-hunters-tess/classify/workflow/11235?env=production&demo=true
- What user actions should my reviewer step through to review this PR?
  - throttle to Fast 3G, reload page if necessary, focus on subject viewer
- Which storybook stories should be reviewed?
  - N/A
- Are there plans for follow up PR’s to further fix this bug or develop this feature?
  - this is a quick fix, but further refactoring could be done related to the `useJSONData` hook for a more thorough fix

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
