### PR TITLE
Light Curve Viewer: stop Animation when new Subject loads

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -84,9 +84,6 @@ class LightCurveViewer extends Component {
   }
 
   componentDidUpdate (prevProps) {
-    const subject = this.props.subjectID
-    const prevSubject = prevProps.subjectID
-    const sameSubject = (subject === prevSubject)
     const dataChanged = this.props.dataPoints !== prevProps.dataPoints
 
     const currentTaskKey = (this.props.currentTask && this.props.currentTask.taskKey) || ''
@@ -99,7 +96,7 @@ class LightCurveViewer extends Component {
       const container = this.svgContainer.current
       const height = container.offsetHeight || 0
       const width = container.offsetWidth || 0
-      this.drawChart(width, height, sameSubject)
+      this.drawChart(width, height, false)
     } else if (!sameTask) { // Triggers when changing between Workflow tasks.
       // TODO: load annotations when changing tasks.
       // If invalid task, blank out all annotaitons

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
@@ -98,7 +98,7 @@ export function LightCurveViewerContainer({
     return { dataExtent, dataPoints }
   }, [JSONdata])
 
-  if (!subject.id || !dataPoints.length) {
+  if (!subject.id) {
     return null
   }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
@@ -78,7 +78,7 @@ export function LightCurveViewerContainer({
 }) {
   const viewer = useRef()
   const JSONdata = useJSONData(
-    subject, 
+    subject,
     () => onReady(viewer?.current),
     (error) => onError(error)
   )
@@ -86,7 +86,7 @@ export function LightCurveViewerContainer({
   const { dataExtent, dataPoints } = useMemo(() => {
     let dataExtent = { x: [], y: [] }
     let dataPoints = []
-  
+
     if (JSONdata?.x && JSONdata?.y) {
       dataExtent = {
         x: extent(JSONdata.x),
@@ -118,7 +118,6 @@ export function LightCurveViewerContainer({
       onKeyDown={onKeyDown}
       setOnPan={setOnPan}
       setOnZoom={setOnZoom}
-      subjectID={subject.id}
       toolIndex={activeToolIndex}
     />
   )


### PR DESCRIPTION
## PR Overview

Follows #2719

Whenever a new Subject is loaded on the LightCurveViewer, an "animation" plays where the data points "swoosh in" from the top-left corner. This PR attempts to fix that.

https://user-images.githubusercontent.com/13952701/155182096-b01addd1-0b1a-4fd5-931e-90395bea4824.mov

_The issue in question. In the movie above, we cycle through 3 Subjects (by clicking the Done button, not picture). There is a significant animation playing on the 2nd and 3rd Subjects loading_

### Dev Notes

**Analysis Pt 1:**
- The "swooshing" animation is triggered by `LightCurveViewer.js`'s `updateDataPoint()`'s `.transition()`.
- This in turn is triggered by `drawChart()`, when it's called when shouldAnimate is true.
- This in turn turn is triggered by EITHER...
  - **Scenario 1** `<ReactResizeDetector>` detecting a resize (shouldAnimate is true in this case)
  - **Scenario 2** `componentDidUpdate()` detecting that the data has changed (a new Subject has come in).

SIDE BAR: curiously, for Scenario 2, the previous iteration of the componentDidUpdate() code (prior to PR 2719) actually looked like this...
```
// the old code =>
if (!sameSubject) { // if sameSubject is FALSE...
  this.drawChart(width, height, sameSubject)  // ...then animate if TRUE
}
```
...which meant it would logically NEVER animate when a new Subject came in.

Anyway, Scenario 2 is easy to fix, it shouldn't animate when a new Subject comes in.

Scenario 1 however is a different story...

**Analysis pt 2:**

- After PR 2719, it appears that the LCV viewer ALWAYS starts off as an un-rendered(??) before the data points start appearing.
- This means Scenario 1 (resize) is ALWAYS triggering when the data points come in/a new Subject loads.
- Even if we force `drawChart()`'s shouldAnimate to be false all the time no matter what (an easy fix), the LCV would still "blink" when a new Subject is loaded. There'll be no distracting animation, but there's a small period of time where it looks like there's nothing to show, just an empty chart.

### Status

WIP. I'm trying to figure out why there's always a resize when a Subject loads.

Currently marked as medium priority. It's affecting live TESS users (and very annoying), but not so much that it breaks the ability to classify.