### PR TITLE
Classifier: Filter prioritised subject queues

### DIFF
--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
@@ -188,7 +188,8 @@ const SubjectStore = types
             const metadataPriority = subject.metadata['#priority'] ?? subject.metadata.priority
             // subject metadata in the API response are strings, not numbers.
             const priority = metadataPriority ? parseFloat(metadataPriority) : -1
-            notSeen = priority > self.last.priority
+            const lastPriority = self.last?.priority || -1
+            notSeen = priority > lastPriority
           }
           if (notSeen && !alreadyStored) {
             self.resources.put(subject)

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
@@ -184,7 +184,9 @@ const SubjectStore = types
           const alreadyStored = self.resources.get(subject.id)
           // assume all subjects from Panoptes are unseen by default
           let notSeen = true
-          if (self.prioritized) {
+          // completed workflows fall back to random selection
+          const { user_has_finished_workflow } = subject
+          if (!user_has_finished_workflow && self.prioritized) {
             const metadataPriority = subject.metadata['#priority'] ?? subject.metadata.priority
             // subject metadata in the API response are strings, not numbers.
             const priority = metadataPriority ? parseFloat(metadataPriority) : -1

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
@@ -80,6 +80,12 @@ const SubjectStore = types
         lastSubject = self.queue[self.queue.length - 1]
       }
       return lastSubject
+    },
+    /** are subjects sorted in priority order */
+    get prioritized() {
+      const { workflows } = getRoot(self)
+      const workflow = tryReference(() => workflows?.active)
+      return workflow?.prioritized
     }
   }))
 
@@ -176,7 +182,15 @@ const SubjectStore = types
       newSubjects.forEach(subject => {
         try {
           const alreadyStored = self.resources.get(subject.id)
-          if (!alreadyStored) {
+          // assume all subjects from Panoptes are unseen by default
+          let notSeen = true
+          if (self.prioritized) {
+            const metadataPriority = subject.metadata['#priority'] ?? subject.metadata.priority
+            // subject metadata in the API response are strings, not numbers.
+            const priority = metadataPriority ? parseFloat(metadataPriority) : -1
+            notSeen = priority > self.last.priority
+          }
+          if (notSeen && !alreadyStored) {
             self.resources.put(subject)
             self.queue.push(subject.id)
           }


### PR DESCRIPTION
Add `subjects.prioritized` for prioritised workflows. Check subject priority, for priority queues, and only add new subjects with priorities beyond the last subject priority in the queue.

EDIT: bypass that check for completed workflows, which fall back to showing subjects to a volunteer in a random order.

With this change, you should always see prioritised subjects in ascending priority order, starting at the last subject that you classified, without any repeats.

Test projects:
- Davy Notebooks (uses prioritised workflows): https://local.zooniverse.org:3000/projects/humphrydavy/davy-notebooks-project/classify?env=production&demo=true
- HMS NHS (uses grouped, prioritised workflows): https://local.zooniverse.org:3000/projects/msalmon/hms-nhs-the-nautical-health-service/classify?env=production&demo=true
- RBGE Herbarium (uses grouped, prioritised, indexed workflows): https://local.zooniverse.org:3000/projects/emhaston/the-rbge-herbarium-exploring-gesneriaceae-the-african-violet-family/classify/workflow/19381?env=production&demo=true

Package:
lib-classifier

Closes #2818.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
