### PR TITLE
Classifier: Remove @inject from SubjectViewer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/SubjectViewer.spec.js
@@ -2,33 +2,33 @@ import asyncStates from '@zooniverse/async-states'
 import { shallow } from 'enzyme'
 import React from 'react'
 
-import SubjectViewer from './SubjectViewer'
+import { SubjectViewer } from './SubjectViewer'
 import SingleImageViewer from './components/SingleImageViewer'
 import VariableStarViewer from './components/VariableStarViewer'
 
 describe('Component > SubjectViewer', function () {
   it('should render without crashing', function () {
-    const wrapper = shallow(<SubjectViewer.wrappedComponent />)
+    const wrapper = shallow(<SubjectViewer />)
     expect(wrapper).to.be.ok()
   })
 
   it('should render nothing if the subject store is initialized', function () {
-    const wrapper = shallow(<SubjectViewer.wrappedComponent subjectQueueState={asyncStates.initialized} />)
+    const wrapper = shallow(<SubjectViewer subjectQueueState={asyncStates.initialized} />)
     expect(wrapper.type()).to.be.null()
   })
 
   it('should render a loading indicator if the subject store is loading', function () {
-    const wrapper = shallow(<SubjectViewer.wrappedComponent subjectQueueState={asyncStates.loading} />)
+    const wrapper = shallow(<SubjectViewer subjectQueueState={asyncStates.loading} />)
     expect(wrapper.text()).to.equal('Loading')
   })
 
   it('should render nothing if the subject store errors', function () {
-    const wrapper = shallow(<SubjectViewer.wrappedComponent subjectQueueState={asyncStates.error} />)
+    const wrapper = shallow(<SubjectViewer subjectQueueState={asyncStates.error} />)
     expect(wrapper.type()).to.be.null()
   })
 
   it('should render a subject viewer if the subject store successfully loads', function () {
-    const wrapper = shallow(<SubjectViewer.wrappedComponent subjectQueueState={asyncStates.success} subject={{ viewer: 'singleImage' }} />)
+    const wrapper = shallow(<SubjectViewer subjectQueueState={asyncStates.success} subject={{ viewer: 'singleImage' }} />)
     expect(wrapper.find(SingleImageViewer)).to.have.lengthOf(1)
   })
 
@@ -43,14 +43,14 @@ describe('Component > SubjectViewer', function () {
       }
     }
 
-    const wrapper = shallow(<SubjectViewer.wrappedComponent subjectQueueState={asyncStates.success} subject={{ viewer: 'variableStar', viewerConfiguration }} />)
+    const wrapper = shallow(<SubjectViewer subjectQueueState={asyncStates.success} subject={{ viewer: 'variableStar', viewerConfiguration }} />)
     expect(wrapper.find(VariableStarViewer).props().viewerConfiguration).to.deep.equal(viewerConfiguration)
   })
 
   describe('when there is an null viewer because of invalid subject media', function () {
     it('should render null', function () {
       const wrapper = shallow(
-        <SubjectViewer.wrappedComponent
+        <SubjectViewer
           subjectQueueState={asyncStates.success}
           subject={{ viewer: null }}
         />


### PR DESCRIPTION
Refactor the generic `SubjectViewer` container as a functional component, and remove the deprecated `@inject` decorator.

Package: lib-classifier

Towards #2712.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
