### PR TITLE
Refactor TutorialStore hasNotSeenTutorialBefore to return false if UPP or tutorial not determined

### DIFF
--- a/packages/lib-classifier/src/store/TutorialStore/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore/TutorialStore.js
@@ -65,7 +65,7 @@ const TutorialStore = types
     },
 
     get hasNotSeenTutorialBefore () {
-      const uppStore = tryReference(() => getRoot(self).userProjectPreferences)
+      const uppStore = getRoot(self).userProjectPreferences
       const upp = tryReference(() => getRoot(self).userProjectPreferences.active)
       const tutorial = tryReference(() => self.active)
 

--- a/packages/lib-classifier/src/store/TutorialStore/TutorialStore.js
+++ b/packages/lib-classifier/src/store/TutorialStore/TutorialStore.js
@@ -65,8 +65,14 @@ const TutorialStore = types
     },
 
     get hasNotSeenTutorialBefore () {
+      const uppStore = tryReference(() => getRoot(self).userProjectPreferences)
       const upp = tryReference(() => getRoot(self).userProjectPreferences.active)
       const tutorial = tryReference(() => self.active)
+
+      if (uppStore?.loadingState !== asyncStates.success || !tutorial) {
+        return false
+      }
+
       if (upp && tutorial) {
         return !(upp.preferences.tutorials_completed_at?.[tutorial.id])
       }


### PR DESCRIPTION
Package:
- lib-classifier

Closes #2894 .

## Describe your changes:
- refactors TutorialStore `hasNotSeenTutorialBefore` to return `false` if:
  - UPP initialized, loading, or errors (i.e. loadingState !== success) because we don't know if user hasn't seen tutorial until UPP are loaded or if signed out store will change state to success but leave UPP.active undefined
  - if tutorial undefined 

<em>Helpful explanations that will make your reviewer happy:</em>
- What Zooniverse project should my reviewer use to review UX? any project with tutorial, noting:
  - https://local.zooniverse.org:3000/projects/nora-dot-eisner/planet-hunters-tess/classify/workflow/11235?env=production&demo=true (for signed in especially, can also test signed out)
  - https://local.zooniverse.org:8080/?project=7929&env=production&demo=true (for signed out)
- What user actions should my reviewer step through to review this PR?
  - signed in and signed out, go to classify on a project with tutorial
  - signed out should always see tutorial when starting to classify
  - signed in, after dismissing tutorial, go back to project home or Talk and then back to classify 
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? unsure at the moment


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
