### PR TITLE
Classifier: Add SlideTutorial stories

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
@@ -80,8 +80,9 @@ function SlideTutorial({
         <Markdownz>{step.content}</Markdownz>
       </StyledMarkdownWrapper>
         <StepNavigation
-          stepIndex={stepIndex}
           onChange={setStepIndex}
+          stepIndex={stepIndex}
+          steps={steps}
         />
       {isLastStep &&
         <Button

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
@@ -19,6 +19,19 @@ const StyledMarkdownWrapper = styled(Box)`
   }
 `
 
+/**
+A workflow slide tutorial which can be embedded directly into the classifier or shown in a popup.
+
+```
+<SlideTutorial
+  activeStep={0}
+  height='100%'
+  steps={[...steps]}
+  stepwithMedium={index => steps[index]}
+  width='40vw'
+/>
+```
+*/
 function SlideTutorial({
   activeStep = 0,
   className = '',
@@ -95,12 +108,31 @@ function SlideTutorial({
   )
 }
 
+const tutorialStep = PropTypes.shape({
+  content: PropTypes.string,
+  medium: PropTypes.string
+})
+
 SlideTutorial.propTypes = {
+  /** Array index of the current tutorial step. */
   activeStep: PropTypes.number,
+  /** Optional CSS classes */
   className: PropTypes.string,
+  /** Tutorial height (CSS units). */
+  height: PropTypes.string,
+  /** The project name */
   projectDisplayName: PropTypes.string,
+  /** Callback for the Get Started button. */
   onClick: PropTypes.func,
-  stepWithMedium: PropTypes.func.isRequired
+  /**
+    Array of tutorial steps.
+    A step is a string of markdown content and an optional reference to a media file (image/audio/video.)
+  */
+  steps: PropTypes.arrayOf(tutorialStep),
+  /** A function which should return the step and media file for a given step index. */
+  stepWithMedium: PropTypes.func.isRequired,
+  /** Tutorial width (CSS units). */
+  width: PropTypes.string,
 }
 
 export default SlideTutorial

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
@@ -2,7 +2,9 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Grommet } from 'grommet'
+
 import SlideTutorial from './SlideTutorial'
+import * as subcomponents from './components'
 // import readme from './README.md'
 import backgrounds from '../../../../../.storybook/lib/backgrounds'
 import { TutorialMediumFactory } from '@test/factories'
@@ -16,36 +18,93 @@ const config = {
 
 const darkThemeConfig = Object.assign({}, config, { backgrounds: backgrounds.darkDefault })
 
-const medium = TutorialMediumFactory.build()
-const stepWithMedium = {
-  medium,
-  step: {
+const media = [
+  TutorialMediumFactory.build({
+    src: 'https://panoptes-uploads-staging.zooniverse.org/project_attached_image/79f23ef0-f07f-42cf-b250-841c6c557d2a.jpeg'
+  }),
+  TutorialMediumFactory.build({
+    src: 'https://panoptes-uploads-staging.zooniverse.org/project_attached_image/cb1b4745-a2df-40c6-ab16-381d109f20c8.jpeg'
+  })
+]
+
+const steps = [
+  {
     content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-    medium: medium.id
+    medium: media[0].id
+  },
+  {
+    content: 'Phasellus augue diam, dignissim sit amet nulla id, congue elementum sapien. Quisque consectetur mi sed ex euismod, in rutrum eros tincidunt. Proin at massa erat. Fusce bibendum, mauris sed lacinia cursus, turpis risus dapibus eros, eu pharetra mauris turpis ut sem. Curabitur hendrerit quam id odio eleifend maximus. Morbi imperdiet fringilla nibh nec ullamcorper. Mauris consequat arcu vitae tristique venenatis. Donec purus nulla, aliquet non commodo vestibulum, fermentum non quam. Aliquam tristique nibh orci, id sagittis odio feugiat eget. ',
+    medium: media[1].id
+  }
+]
+
+function stepWithMedium(index) {
+  const medium = media[index]
+  const step = steps[index]
+  return { medium, step }
+}
+
+export default {
+  title: 'Other / SlideTutorial',
+  component: SlideTutorial,
+  subcomponents,
+  argTypes: {
+    onClick: {
+      action: 'clicked'
+    }
+  },
+  args: {
+    dark: false,
+    height: '100%',
+    projectDisplayName: 'Snapshot Guinea Pig',
+    steps,
+    stepWithMedium,
+    width: '50vw'
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'responsive'
+    }
   }
 }
-// TODO: add store connection for step navigation
-// storiesOf('SlideTutorial', module)
-//   .add('light theme', () => {
-//     return (
-//       <Grommet theme={zooTheme}>
-//         <Box height='medium' width='large'>
-//           <SlideTutorial
-//             stepWithMedium={stepWithMedium}
-//           />
-//         </Box>
-//       </Grommet>
-//     )
-//   }, config)
-//   .add('dark theme', () => {
-//     const darkZooTheme = Object.assign({}, zooTheme, { dark: true })
-//     return (
-//       <Grommet theme={darkZooTheme}>
-//         <Box height='medium' width='large'>
-//           <SlideTutorial
-//             stepWithMedium={stepWithMedium}
-//           />
-//         </Box>
-//       </Grommet>
-//     )
-//   }, darkThemeConfig)
+
+export function Default({ dark, height, onClick, projectDisplayName, steps, stepWithMedium, width }) {
+  const theme = {...zooTheme, dark }
+  return (
+    <Grommet theme={theme}>
+      <Box height='medium' width='large'>
+        <SlideTutorial
+          height={height}
+          onClick={onClick}
+          projectDisplayName={projectDisplayName}
+          steps={steps}
+          stepWithMedium={stepWithMedium}
+          width={width}
+        />
+      </Box>
+    </Grommet>
+  )
+}
+
+export function Tablet({ dark, onClick, projectDisplayName, steps, stepWithMedium }) {
+  const theme = {...zooTheme, dark }
+  return (
+    <Grommet theme={theme}>
+      <Box height='medium' width='large'>
+        <SlideTutorial
+          height={'100%'}
+          onClick={onClick}
+          projectDisplayName={projectDisplayName}
+          steps={steps}
+          stepWithMedium={stepWithMedium}
+          width={'100%'}
+        />
+      </Box>
+    </Grommet>
+  )
+}
+Tablet.parameters = {
+  viewport: {
+    defaultViewport: 'ipad'
+  }
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
@@ -4,17 +4,12 @@ import { Box, Grommet } from 'grommet'
 
 import SlideTutorial from './SlideTutorial'
 import * as subcomponents from './components'
-// import readme from './README.md'
-import backgrounds from '../../../../../.storybook/lib/backgrounds'
 import { TutorialMediumFactory } from '@test/factories'
 
-// TODO: add readme
-const config = {
-  notes: {
-    // markdown: readme
-  }
+const background = {
+  dark: 'dark-3',
+  light: 'white'
 }
-
 
 const media = [
   TutorialMediumFactory.build({
@@ -69,7 +64,7 @@ export default {
 export function Default({ dark, height, onClick, projectDisplayName, steps, stepWithMedium, width }) {
   const theme = {...zooTheme, dark }
   return (
-    <Grommet theme={theme}>
+    <Grommet background={background} theme={theme}>
       <Box height='medium' width='large'>
         <SlideTutorial
           height={height}
@@ -87,7 +82,7 @@ export function Default({ dark, height, onClick, projectDisplayName, steps, step
 export function Tablet({ dark, onClick, projectDisplayName, steps, stepWithMedium }) {
   const theme = {...zooTheme, dark }
   return (
-    <Grommet theme={theme}>
+    <Grommet background={background} theme={theme}>
       <Box height='medium' width='large'>
         <SlideTutorial
           height='100%'

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Grommet } from 'grommet'
 
@@ -16,7 +15,6 @@ const config = {
   }
 }
 
-const darkThemeConfig = Object.assign({}, config, { backgrounds: backgrounds.darkDefault })
 
 const media = [
   TutorialMediumFactory.build({
@@ -92,12 +90,12 @@ export function Tablet({ dark, onClick, projectDisplayName, steps, stepWithMediu
     <Grommet theme={theme}>
       <Box height='medium' width='large'>
         <SlideTutorial
-          height={'100%'}
+          height='100%'
           onClick={onClick}
           projectDisplayName={projectDisplayName}
           steps={steps}
           stepWithMedium={stepWithMedium}
-          width={'100%'}
+          width='100%'
         />
       </Box>
     </Grommet>

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
@@ -52,7 +52,7 @@ export default {
     projectDisplayName: 'Snapshot Guinea Pig',
     steps,
     stepWithMedium,
-    width: '50vw'
+    width: '40vw'
   },
   parameters: {
     viewport: {
@@ -69,7 +69,7 @@ export function Default({ dark, height, onClick, projectDisplayName, steps, step
       theme={zooTheme}
       themeMode={themeMode}
     >
-      <Box height='medium' width='large'>
+      <Box height='medium' width={width}>
         <SlideTutorial
           height={height}
           onClick={onClick}

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
@@ -7,8 +7,8 @@ import * as subcomponents from './components'
 import { TutorialMediumFactory } from '@test/factories'
 
 const background = {
-  dark: 'dark-3',
-  light: 'white'
+  dark: 'dark-1',
+  light: 'light-1'
 }
 
 const media = [
@@ -62,9 +62,13 @@ export default {
 }
 
 export function Default({ dark, height, onClick, projectDisplayName, steps, stepWithMedium, width }) {
-  const theme = {...zooTheme, dark }
+  const themeMode = dark ? 'dark' : 'light'
   return (
-    <Grommet background={background} theme={theme}>
+    <Grommet
+      background={background}
+      theme={zooTheme}
+      themeMode={themeMode}
+    >
       <Box height='medium' width='large'>
         <SlideTutorial
           height={height}
@@ -80,9 +84,13 @@ export function Default({ dark, height, onClick, projectDisplayName, steps, step
 }
 
 export function Tablet({ dark, onClick, projectDisplayName, steps, stepWithMedium }) {
-  const theme = {...zooTheme, dark }
+  const themeMode = dark ? 'dark' : 'light'
   return (
-    <Grommet background={background} theme={theme}>
+    <Grommet
+      background={background}
+      theme={zooTheme}
+      themeMode={themeMode}
+    >
       <Box height='medium' width='large'>
         <SlideTutorial
           height='100%'

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/StepNavigation/StepNavigation.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/StepNavigation/StepNavigation.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { Button, Box, RadioButtonGroup } from 'grommet'
 import styled from 'styled-components'
 import { FormNext, FormPrevious } from 'grommet-icons'
-import { withStores } from '@helpers'
 import { useTranslation } from 'react-i18next'
 
 const StyledButton = styled(Button)`
@@ -34,16 +33,6 @@ const StyledRadioButtonGroup = styled(RadioButtonGroup)`
     }
   }
 `
-
-function storeMapper (classifierStore) {
-  const {
-    active: tutorial
-  } = classifierStore.tutorials
-
-  return {
-    steps: tutorial?.steps
-  }
-}
 
 function StepNavigation({
   className = '',
@@ -113,5 +102,4 @@ StepNavigation.propTypes = {
   steps: PropTypes.array
 }
 
-export default withStores(StepNavigation, storeMapper)
-export { StepNavigation }
+export default StepNavigation

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/StepNavigation/StepNavigation.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/StepNavigation/StepNavigation.spec.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import sinon from 'sinon'
 import { Button } from 'grommet'
 import { FormNext, FormPrevious } from 'grommet-icons'
-import { StepNavigation } from './StepNavigation'
+import StepNavigation from './StepNavigation'
 
 const steps = [
   { content: '# Welcome' },

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/components/index.js
@@ -1,0 +1,1 @@
+export { default as StepNavigation } from './StepNavigation'


### PR DESCRIPTION
`SlideTutorial` stories were commented out in the code. This removes the commented stories and replaces them with a couple of new stories, written in CSF. `StepNavigation` is refactored as a plain component, so that we can render the tutorial without having to wrap it in a store.

I've put the new stories under `Other / SlideTutorial` in the classifier storybook.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
