### PR TITLE
Add a showTutorial hint to the popup tutorial

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -1,6 +1,7 @@
 import { Box, Grid } from 'grommet'
 import dynamic from 'next/dynamic'
 import { arrayOf, func, shape, string } from 'prop-types'
+import { useState } from 'react'
 import { withResponsiveContext } from '@zooniverse/react-components'
 
 import ThemeModeToggle from '@components/ThemeModeToggle'
@@ -37,6 +38,7 @@ function ClassifyPage({
   const responsiveColumns = (screenSize === 'small')
     ? ['auto']
     : ['1em', 'auto', '1em']
+  const [classifierProps, setClassifierProps]  = useState({})
 
   let subjectSetFromUrl
   if (workflowFromUrl && workflowFromUrl.subjectSets) {
@@ -51,13 +53,16 @@ function ClassifyPage({
   const isIndexed = subjectSetFromUrl?.metadata.indexFields
   canClassify = isIndexed ? !!subjectID : canClassify
 
-  let classifierProps = {}
-  if (canClassify) {
-    classifierProps = {
+  /*
+    Derive classifier state from the workflow in the URL, when the workflow changes.
+    Remember the previous classifier state if there's no workflow ID in the URL.
+  */
+  if (canClassify && classifierProps.workflowID !== workflowID) {
+    setClassifierProps({
       workflowID,
       subjectSetID,
       subjectID
-    }
+    })
   }
 
   return (

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -39,6 +39,7 @@ function ClassifyPage({
     ? ['auto']
     : ['1em', 'auto', '1em']
   const [classifierProps, setClassifierProps]  = useState({})
+  const [showTutorial, setShowTutorial] = useState(false)
 
   let subjectSetFromUrl
   if (workflowFromUrl && workflowFromUrl.subjectSets) {
@@ -54,15 +55,20 @@ function ClassifyPage({
   canClassify = isIndexed ? !!subjectID : canClassify
 
   /*
-    Derive classifier state from the workflow in the URL, when the workflow changes.
-    Remember the previous classifier state if there's no workflow ID in the URL.
+    Derive classifier state from the URL, when the URL changes.
+    Use the previous classifier state if there's no workflow ID in the URL.
   */
-  if (canClassify && classifierProps.workflowID !== workflowID) {
+  const workflowChanged = classifierProps.workflowID !== workflowID
+  const subjectSetChanged = classifierProps.subjectSetID !== subjectSetID
+  const subjectChanged = classifierProps.subjectID !== subjectID
+  const URLChanged = workflowChanged || subjectSetChanged || subjectChanged
+  if (canClassify && URLChanged) {
     setClassifierProps({
       workflowID,
       subjectSetID,
       subjectID
     })
+    setShowTutorial(true)
   }
 
   return (
@@ -88,7 +94,7 @@ function ClassifyPage({
               cachePanoptesData={cachePanoptesData}
               onAddToCollection={addToCollection}
               onSubjectReset={onSubjectReset}
-              showTutorial={canClassify}
+              showTutorial={showTutorial}
               {...classifierProps}
             />
             <ThemeModeToggle />

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -83,6 +83,7 @@ function ClassifyPage({
               cachePanoptesData={cachePanoptesData}
               onAddToCollection={addToCollection}
               onSubjectReset={onSubjectReset}
+              showTutorial={canClassify}
               {...classifierProps}
             />
             <ThemeModeToggle />

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
@@ -91,6 +91,12 @@ describe('Component > ClassifyPage', function () {
     it('should show classifier popup tutorials', function () {
       expect(classifier.prop('showTutorial')).to.be.true()
     })
+
+    it('should update the classifier when the workflow changes', function () {
+      wrapper.setProps({ workflowID: '3456' })
+      classifier = wrapper.find(ClassifierWrapper)
+      expect(classifier.prop('workflowID')).to.equal('3456')
+    })
   })
 
   describe('with a grouped workflow', function () {
@@ -147,6 +153,12 @@ describe('Component > ClassifyPage', function () {
 
       it('should show classifier popup tutorials', function () {
         expect(classifier.prop('showTutorial')).to.be.true()
+      })
+
+      it('should update the classifier when the subject set changes', function () {
+        wrapper.setProps({ subjectSetID: '5678' })
+        classifier = wrapper.find(ClassifierWrapper)
+        expect(classifier.prop('subjectSetID')).to.equal('5678')
       })
     })
 
@@ -233,6 +245,12 @@ describe('Component > ClassifyPage', function () {
 
         it('should show classifier popup tutorials', function () {
           expect(classifier.prop('showTutorial')).to.be.true()
+        })
+
+        it('should update the classifier when the subject changes', function () {
+          wrapper.setProps({ subjectID: '8901' })
+          classifier = wrapper.find(ClassifierWrapper)
+          expect(classifier.prop('subjectID')).to.equal('8901')
         })
       })
     })

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.spec.js
@@ -77,19 +77,26 @@ describe('Component > ClassifyPage', function () {
 
   describe('with a selected workflow', function () {
     let wrapper
+    let classifier
 
     before(function () {
       wrapper = shallow(<ClassifyPage appLoadingState={asyncStates.success} workflowID='1234' />)
+      classifier = wrapper.find(ClassifierWrapper)
     })
 
     it('should not show a workflow selector', function () {
       expect(wrapper.find(WorkflowMenuModal)).to.have.lengthOf(0)
+    })
+
+    it('should show classifier popup tutorials', function () {
+      expect(classifier.prop('showTutorial')).to.be.true()
     })
   })
 
   describe('with a grouped workflow', function () {
     describe('without a subject set', function () {
       let wrapper
+      let classifier
       let workflows = [{
         id: '1234',
         grouped: true
@@ -97,6 +104,7 @@ describe('Component > ClassifyPage', function () {
 
       before(function () {
         wrapper = shallow(<ClassifyPage appLoadingState={asyncStates.success} workflowFromUrl={workflows[0]} workflows={workflows} />)
+        classifier = wrapper.find(ClassifierWrapper)
       })
 
       it('should show a workflow menu', function () {
@@ -104,13 +112,17 @@ describe('Component > ClassifyPage', function () {
       })
 
       it('should not pass the workflow ID to the classifier', function () {
-        const classifier = wrapper.find(ClassifierWrapper)
         expect(classifier.prop('workflowID')).to.be.undefined()
+      })
+
+      it('should not show classifier popup tutorials', function () {
+        expect(classifier.prop('showTutorial')).to.be.false()
       })
     })
 
     describe('with a subject set', function () {
       let wrapper
+      let classifier
       let workflows = [{
         id: '1234',
         grouped: true
@@ -118,6 +130,7 @@ describe('Component > ClassifyPage', function () {
 
       before(function () {
         wrapper = shallow(<ClassifyPage appLoadingState={asyncStates.success} subjectSetID='3456' workflowID='1234' workflowFromUrl={workflows[0]} workflows={workflows} />)
+        classifier = wrapper.find(ClassifierWrapper)
       })
 
       it('should not show a workflow menu', function () {
@@ -125,13 +138,15 @@ describe('Component > ClassifyPage', function () {
       })
 
       it('should pass the workflow ID to the classifier', function () {
-        const classifier = wrapper.find(ClassifierWrapper)
         expect(classifier.prop('workflowID')).to.equal('1234')
       })
 
       it('should pass the subject set ID to the classifier', function () {
-        const classifier = wrapper.find(ClassifierWrapper)
         expect(classifier.prop('subjectSetID')).to.equal('3456')
+      })
+
+      it('should show classifier popup tutorials', function () {
+        expect(classifier.prop('showTutorial')).to.be.true()
       })
     })
 
@@ -150,6 +165,7 @@ describe('Component > ClassifyPage', function () {
 
       describe('without a subject', function () {
         let wrapper
+        let classifier
 
         before(function () {
           wrapper = shallow(
@@ -161,6 +177,7 @@ describe('Component > ClassifyPage', function () {
               workflows={workflows}
             />
           )
+          classifier = wrapper.find(ClassifierWrapper)
         })
 
         it('should show a workflow menu', function () {
@@ -168,18 +185,21 @@ describe('Component > ClassifyPage', function () {
         })
 
         it('should not pass the workflow ID to the classifier', function () {
-          const classifier = wrapper.find(ClassifierWrapper)
           expect(classifier.prop('workflowID')).to.be.undefined()
         })
 
         it('should not pass the subject set ID to the classifier', function () {
-          const classifier = wrapper.find(ClassifierWrapper)
           expect(classifier.prop('subjectSetID')).to.be.undefined()
+        })
+
+        it('should not show classifier popup tutorials', function () {
+          expect(classifier.prop('showTutorial')).to.be.false()
         })
       })
 
       describe('with a subject', function () {
         let wrapper
+        let classifier
 
         before(function () {
           wrapper = shallow(
@@ -192,6 +212,7 @@ describe('Component > ClassifyPage', function () {
               workflows={workflows}
             />
           )
+          classifier = wrapper.find(ClassifierWrapper)
         })
 
         it('should not show a workflow menu', function () {
@@ -199,18 +220,19 @@ describe('Component > ClassifyPage', function () {
         })
 
         it('should pass the workflow ID to the classifier', function () {
-          const classifier = wrapper.find(ClassifierWrapper)
           expect(classifier.prop('workflowID')).to.equal('1234')
         })
 
         it('should pass the subject set ID to the classifier', function () {
-          const classifier = wrapper.find(ClassifierWrapper)
           expect(classifier.prop('subjectSetID')).to.equal('3456')
         })
 
         it('should pass the subject ID to the classifier', function () {
-          const classifier = wrapper.find(ClassifierWrapper)
           expect(classifier.prop('subjectID')).to.equal('5678')
+        })
+
+        it('should show classifier popup tutorials', function () {
+          expect(classifier.prop('showTutorial')).to.be.true()
         })
       })
     })

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -26,6 +26,7 @@ export default function ClassifierWrapper({
   onSubjectReset = () => true,
   project,
   recents,
+  showTutorial = false,
   subjectID,
   subjectSetID,
   user,
@@ -100,6 +101,7 @@ export default function ClassifierWrapper({
           onSubjectReset={onSubjectReset}
           onToggleFavourite={onToggleFavourite}
           project={project}
+          showTutorial={showTutorial}
           subjectID={subjectID}
           subjectSetID={subjectSetID}
           workflowID={workflowID}
@@ -144,6 +146,8 @@ ClassifierWrapper.propTypes = {
   onSubjectReset: func,
   /** JSON snapshot of the active Panoptes project */
   project: shape({}),
+  /** Allow the classifier to open a popup tutorial, if necessary. */
+  showTutorial: bool,
   /** optional subjectID (from the page URL.) */
   subjectID: string,
   /** optional subject set ID (from the page URL.) */

--- a/packages/lib-classifier/dev/components/App/App.js
+++ b/packages/lib-classifier/dev/components/App/App.js
@@ -170,6 +170,7 @@ class App extends React.Component {
               onCompleteClassification={(classification, subject) => console.log('onComplete', classification, subject)}
               onError={this.onError}
               project={this.state.project}
+              showTutorial
               subjectID={this.props.subjectID}
               subjectSetID={this.props.subjectSetID}
               workflowID={workflowID}

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -14,6 +14,7 @@ export default function Classifier({
   locale,
   onError = () => true,
   project,
+  showTutorial = false,
   subjectID,
   subjectSetID,
   workflowSnapshot,
@@ -63,7 +64,7 @@ export default function Classifier({
     return (
       <>
         <Layout />
-        <ModalTutorial />
+        {showTutorial && <ModalTutorial />}
       </>
     )
   } catch (error) {
@@ -82,6 +83,7 @@ Classifier.propTypes = {
   project: PropTypes.shape({
     id: PropTypes.string.isRequired
   }).isRequired,
+  showTutorial: PropTypes.bool,
   subjectSetID: PropTypes.string,
   subjectID: PropTypes.string,
   workflowSnapshot: PropTypes.shape({

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
@@ -56,6 +56,7 @@ export default function ClassifierContainer({
   onSubjectReset = () => true,
   onToggleFavourite = () => true,
   project,
+  showTutorial=false,
   subjectID,
   subjectSetID,
   workflowID
@@ -133,6 +134,7 @@ export default function ClassifierContainer({
             locale={locale}
             onError={onError}
             project={project}
+            showTutorial={showTutorial}
             subjectSetID={subjectSetID}
             subjectID={subjectID}
             workflowSnapshot={workflowSnapshot}
@@ -166,5 +168,6 @@ ClassifierContainer.propTypes = {
   project: PropTypes.shape({
     id: PropTypes.string.isRequired
   }).isRequired,
+  showTutorial: PropTypes.bool,
   theme: PropTypes.object
 }


### PR DESCRIPTION
- Add a `showTutorial` prop to the classifier, which controls whether the `ModalTutorial` component can be rendered.
- Set `showTutorial` in the Classify page, based on the value of `canClassify` page state. This should stop tutorials from being shown if we haven't started classifying yet.
- Refactor `classifierProps` to use `useState`. That should avoid page renders where `classifierProps` is set to an empty object, while the workflow is in the process of changing.

Package:
app-project
lib-classifier

Closes #2936.

It's probably easiest to test this while not logged in, so that the popup tutorial will always appear when you start to classify on a workflow. Here are some test workflows, both of which have tutorials.
- a branching workflow: 
https://local.zooniverse.org:3000/projects/eatyourgreens/-project-testing-ground/classify/workflow/3488?env=staging&demo=true
- a grouped workflow with subject set selection before you can start classifying:
https://local.zooniverse.org:3000/projects/eatyourgreens/-project-testing-ground/classify/workflow/3586?env=staging&demo=true

On the second workflow, you should be able to choose a subject set and load a subject in the classifier before the tutorial opens. It shouldn’t appear while you’re choosing a subject set. 

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
