### PR TITLE
Fix mark selectors in DrawingToolMarks tests

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
@@ -40,18 +40,21 @@ describe('Components > DrawingToolMarks', function () {
 
   it('should render a line', function () {
     const wrapper = shallow(<DrawingToolMarks marks={marks} />)
-    expect(wrapper.find('Line').prop('mark')).to.equal(line)
+    const Line = line.toolComponent
+    expect(wrapper.find(Line).prop('mark')).to.equal(line)
   })
 
   it('should render a point', function () {
     const wrapper = shallow(<DrawingToolMarks marks={marks} />)
-    expect(wrapper.find('Point').prop('mark')).to.equal(point)
+    const Point = point.toolComponent
+    expect(wrapper.find(Point).prop('mark')).to.equal(point)
   })
 
   describe('with an active mark', function () {
     it('should show that mark as active', function () {
       const wrapper = shallow(<DrawingToolMarks activeMark={{ id: 'point1' }} marks={marks} />)
-      expect(wrapper.find('Point').prop('active')).to.be.true()
+      const Point = point.toolComponent
+      expect(wrapper.find(Point).prop('active')).to.be.true()
     })
 
     it('should render a delete button', function () {


### PR DESCRIPTION
`mobx-react@7.3.0` fixes a bug in components that are decorated with `observer()`, but `DrawingToolMarks` tests rely on the old behaviour and fail after the upgrade. This upgrades the tests to use component selectors, instead of display names, which fixes the bug.

This PR will fix the failing tests in #2858, allowing us to upgrade `mobx-react`.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
