### PR TITLE
Classifier: Set ModalTutorial as complete on close

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.js
@@ -37,6 +37,7 @@ function ModalTutorial ({
 
   function onClose() {
     setActive(false)
+    tutorial.setSeenTime()
   }
 
   if (tutorial) {

--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.spec.js
@@ -1,9 +1,14 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
+import { when } from 'mobx'
+import { Provider } from 'mobx-react'
+import sinon from 'sinon'
+
 import { ModalTutorial } from './ModalTutorial'
 import { Modal } from '@zooniverse/react-components'
 import asyncStates from '@zooniverse/async-states'
-import { TutorialFactory } from '@test/factories'
+import { TutorialFactory, UPPFactory } from '@test/factories'
+import mockStore  from '@test/mockStore'
 
 const tutorial = TutorialFactory.build()
 
@@ -21,13 +26,74 @@ describe('ModalTutorial', function () {
   it('should render a Modal when a tutorial is successfully loaded', function () {
     const wrapper = shallow(
       <ModalTutorial
-        loadingState={asyncStates.success}
-        setModalVisibility={() => { }}
         tutorial={tutorial}
       />
     )
 
     expect(wrapper.find(Modal)).to.have.lengthOf(1)
+  })
+
+  describe('on close', function () {
+    let store
+
+    beforeEach(async function () {
+      store = mockStore()
+      const tutorialSnapshot = TutorialFactory.build()
+      store.tutorials.setTutorials([tutorialSnapshot])
+      await when(() => store.userProjectPreferences.loadingState === asyncStates.success)
+      const upp = UPPFactory.build()
+      store.userProjectPreferences.setUPP(upp)
+      store.userProjectPreferences.setHeaders({
+        etag: 'mockETagForTests'
+      })
+    })
+
+    it('should record the active tutorial as complete', function () {
+      const clock = sinon.useFakeTimers({ now: new Date('2022-03-01T12:00:00Z'), toFake: ['Date'] })
+      const tutorial = store.tutorials.active
+      const seen = new Date().toISOString()
+      const wrapper = mount(
+        <ModalTutorial
+          tutorial={tutorial}
+        />,
+        {
+          wrappingComponent: Provider,
+          wrappingComponentProps: { classifierStore: store }
+        }
+      )
+      // open a tutorial
+      wrapper.setProps({ hasNotSeenTutorialBefore: true })
+      wrapper.update()
+      const closeFn = wrapper.find(Modal).prop('closeFn')
+      closeFn()
+      wrapper.update()
+      const upp = store.userProjectPreferences.active
+      expect(upp?.preferences.tutorials_completed_at[tutorial.id]).to.equal(seen)
+      clock.restore()
+    })
+
+    it('should close the tutorial', function () {
+      const tutorial = store.tutorials.active
+      const wrapper = mount(
+        <ModalTutorial
+          tutorial={tutorial}
+        />,
+        {
+          wrappingComponent: Provider,
+          wrappingComponentProps: { classifierStore: store }
+        }
+      )
+      // open a tutorial
+      wrapper.setProps({ hasNotSeenTutorialBefore: true })
+      wrapper.update()
+      let active = wrapper.find(Modal).prop('active')
+      expect(active).to.be.true()
+      const closeFn = wrapper.find(Modal).prop('closeFn')
+      closeFn()
+      wrapper.update()
+      active = wrapper.find(Modal).prop('active')
+      expect(active).to.be.false()
+    })
   })
 
   // TODO: Enzyme doesn't support React `createContext` yet which Grommet uses

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
@@ -39,7 +39,6 @@ function SlideTutorial({
   onClick = () => true,
   height,
   pad = 'medium',
-  setSeenTime = () => true,
   steps = [],
   stepWithMedium,
   width
@@ -57,11 +56,6 @@ function SlideTutorial({
         <Paragraph>{t('SlideTutorial.error')}</Paragraph>
       </Box>
     )
-  }
-
-  function getStarted() {
-    setSeenTime()
-    onClick()
   }
 
   return (
@@ -100,7 +94,7 @@ function SlideTutorial({
       {isLastStep &&
         <Button
           label={t('SlideTutorial.getStarted')}
-          onClick={getStarted}
+          onClick={onClick}
           margin={{ top: 'medium' }}
           primary
         />}

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.spec.js
@@ -104,18 +104,4 @@ describe('SlideTutorial', function () {
     wrapper.find(Button).simulate('click')
     expect(onClick).to.have.been.calledOnce()
   })
-
-  it('should set the tutorial as seen when Get Started is clicked', function () {
-    const setSeenTime = sinon.spy()
-    const wrapper = shallow(
-      <SlideTutorial
-        activeStep={1}
-        setSeenTime={setSeenTime}
-        stepWithMedium={() => ({ step, medium })}
-        steps={[{ step, medium }, { step, medium }]}
-      />
-    )
-    wrapper.find(Button).simulate('click')
-    expect(setSeenTime).to.have.been.calledOnce()
-  })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorialContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorialContainer.js
@@ -19,12 +19,10 @@ function storeMapper(classifierStore) {
   } = classifierStore
 
   const steps = tutorial?.steps
-  const setSeenTime = tutorial?.setSeenTime
 
   return {
     activeStep,
     projectDisplayName: project.display_name,
-    setSeenTime,
     steps,
     stepWithMedium
   }
@@ -34,7 +32,6 @@ function SlideTutorialContainer({
   activeStep = 0,
   pad = 'medium',
   projectDisplayName = '',
-  setSeenTime = () => true,
   steps = [],
   stepWithMedium,
   ...props
@@ -49,7 +46,6 @@ function SlideTutorialContainer({
             height={height}
             pad={pad}
             projectDisplayName={projectDisplayName}
-            setSeenTime={setSeenTime}
             steps={steps}
             stepWithMedium={stepWithMedium}
             {...props}
@@ -63,7 +59,6 @@ function SlideTutorialContainer({
 SlideTutorialContainer.propTypes = {
   activeStep: PropTypes.number,
   projectDisplayName: PropTypes.string,
-  setSeenTime: PropTypes.func,
   steps: PropTypes.array,
   stepWithMedium: PropTypes.func.isRequired
 }

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
@@ -52,6 +52,7 @@ export default function TaskArea({
 
   function onClose() {
     setActiveIndex(0)
+    tutorial?.setSeenTime()
   }
 
   return (

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.spec.js
@@ -77,11 +77,14 @@ describe('TaskArea', function () {
   describe('when the tutorial closes', function () {
     let setActiveTutorialSpy
     let wrapper
+
     before(function () {
       setActiveTutorialSpy = sinon.spy()
+      tutorial.setSeenTime = sinon.stub()
       wrapper = shallow(<TaskArea setActiveTutorial={setActiveTutorialSpy} tutorial={tutorial} />)
       wrapper.find(SlideTutorial).simulate('click')
     })
+
     afterEach(function () {
       setActiveTutorialSpy.resetHistory()
     })
@@ -92,6 +95,10 @@ describe('TaskArea', function () {
 
     it('should activate the tasks tab', function () {
       expect(wrapper.find(Tabs).props().activeIndex).to.equal(0)
+    })
+
+    it('should mark the tutorial as complete', function () {
+      expect(tutorial.setSeenTime).to.have.been.calledOnce()
     })
   })
 })


### PR DESCRIPTION
Call `tutorial.setSeenTime()` when the modal tutorial is closed by either activating the close button, clicking outside the popup, or pressing the `Esc` key. That marks the tutorial as complete in user project preferences.

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
