### PR TITLE
Add activeTool validation on frame change to MultiFrameViewerContainer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.spec.js
@@ -140,7 +140,30 @@ describe('Component > MultiFrameViewerContainer', function () {
         expect(image).to.have.lengthOf(1)
         expect(image.prop('xlinkHref')).to.equal('https://some.domain/image.jpg')
       })
-    })  
+    })
+
+    describe('with marks from an active drawing or transcription task tool', function () {
+      const validateSpy = sinon.spy()
+
+      // testMarks is a generic Map, does not represent actual marks from a task tool
+      const testMarks = new Map([
+        [1, 'one'],
+        [2, 'two'],
+        [3, 'three']
+      ])
+
+      // mock an active drawing or transcription task tool:
+      const activeTool = {
+        marks: testMarks,
+        validate: validateSpy
+      }
+
+      it('should validate active tool marks on frame change', function () {
+        wrapper.setProps({ activeTool })
+        wrapper.instance().onFrameChange(2)
+        expect(validateSpy).to.have.been.calledOnce()
+      })
+    })
   })
 
   describe('with an invalid subject', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.spec.js
@@ -5,6 +5,7 @@ import React from 'react'
 import { DraggableImage, MultiFrameViewerContainer } from './MultiFrameViewerContainer'
 import FrameCarousel from './FrameCarousel'
 import SingleImageViewer from '../SingleImageViewer/SingleImageViewer'
+import TranscriptionLineTool from '../../../../../../plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool'
 import asyncStates from '@zooniverse/async-states'
 
 describe('Component > MultiFrameViewerContainer', function () {
@@ -142,26 +143,27 @@ describe('Component > MultiFrameViewerContainer', function () {
       })
     })
 
-    describe('with marks from an active drawing or transcription task tool', function () {
-      const validateSpy = sinon.spy()
+    describe('with invalid marks', function () {
+      // mock an active transcription task tool:
+      const activeTool = TranscriptionLineTool.create({
+        color: '#ff0000',
+        type: 'transcriptionLine'
+      })
 
-      // testMarks is a generic Map, does not represent actual marks from a task tool
-      const testMarks = new Map([
-        [1, 'one'],
-        [2, 'two'],
-        [3, 'three']
-      ])
+      // add a valid first mark:
+      const pointerEvent = { x: 10, y: 10 }
+      const validMark = activeTool.createMark({ x: 0, y: 0 })
+      activeTool.handlePointerDown(pointerEvent, validMark)
 
-      // mock an active drawing or transcription task tool:
-      const activeTool = {
-        marks: testMarks,
-        validate: validateSpy
-      }
+      // add an invalid second mark (start, but don't finish a line):
+      activeTool.createMark({ x: 15, y: 15 })
 
-      it('should validate active tool marks on frame change', function () {
+      it('should delete invalid marks on frame change', function () {
         wrapper.setProps({ activeTool })
+        expect(activeTool.marks.size).to.equal(2)
+
         wrapper.instance().onFrameChange(2)
-        expect(validateSpy).to.have.been.calledOnce()
+        expect(activeTool.marks.size).to.equal(1)
       })
     })
   })


### PR DESCRIPTION
Package:
- lib-classifier

Closes #2810.

## Describe your changes:
- adds active tool validation on frame change to MultiFrameViewerContainer

<em>Helpful explanations that will make your reviewer happy:</em>
- What Zooniverse project should my reviewer use to review UX?
  - (confirm existing issue) https://www.zooniverse.org/projects/rachaelsking/corresponding-with-quakers/classify/workflow/20543?demo=true
  - (check fixed) https://local.zooniverse.org:8080/?project=rachaelsking/corresponding-with-quakers&workflow=20543&env=production&demo=true
  - (multi frame viewer without active tool to check negative side effects) https://local.zooniverse.org:8080/?project=1876&demo=true
- What user actions should my reviewer step through to review this PR?
  1. on a frame start to create transcription line, but don't click twice to finish the line (leaving line unfinished, one dot)
  2. go to different frame, make test transcription line, everything will look ok
  3. for Corresponding Quakers answer second task Y/N question
  4. on prod - can't click Next vs on local - can click Next
- Which storybook stories should be reviewed? - n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? - maybe, this will hopefully fix most of related cases, but user can still be prevented from advancing with an incomplete line as further detailed in [this comment in the related issue ](https://github.com/zooniverse/front-end-monorepo/issues/2810#issuecomment-1062107792)

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
