### PR TITLE
Lib-React-Components: Add storybook-react-i18next config

### DIFF
--- a/packages/lib-react-components/.storybook/i18n.js
+++ b/packages/lib-react-components/.storybook/i18n.js
@@ -1,0 +1,20 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+const supportedLngs = ['en', 'test']
+
+i18n.use(initReactI18next).init({
+  fallbackLng: 'en',
+  interpolation: {
+    escapeValue: false // not needed for react as it escapes by default
+  },
+  react: {
+    useSuspense: false
+  }
+})
+
+supportedLngs.forEach(lang => {
+  i18n.addResourceBundle(lang, 'translation', require(`../src/translations/${lang}.json`))
+})
+
+export default i18n

--- a/packages/lib-react-components/.storybook/main.js
+++ b/packages/lib-react-components/.storybook/main.js
@@ -29,7 +29,8 @@ module.exports = {
     '@storybook/addon-essentials',
     '@storybook/addon-knobs',
     '@storybook/addon-links',
-    '@storybook/addon-a11y'
+    '@storybook/addon-a11y',
+    'storybook-react-i18next'
   ],
   webpackFinal
 };

--- a/packages/lib-react-components/.storybook/preview.js
+++ b/packages/lib-react-components/.storybook/preview.js
@@ -1,10 +1,17 @@
 import { addParameters } from '@storybook/react'
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
+import i18n from './i18n'
 
 import backgrounds from './lib/backgrounds'
 
 export const parameters = {
   backgrounds: backgrounds.lightDefault,
+  i18n,
+  locale: 'en',
+  locales: {
+    en: 'English',
+    test: 'Test Language'
+  },
   viewport: {
     viewports: INITIAL_VIEWPORTS
   }

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -86,6 +86,7 @@
     "sinon": "~13.0.1",
     "sinon-chai": "~3.7.0",
     "snazzy": "~9.0.0",
+    "storybook-react-i18next": "~1.0.17",
     "style-loader": "~3.3.1",
     "styled-components": "~5.3.3",
     "webpack": "~5.70.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15589,7 +15589,7 @@ storybook-i18n@^1.0.11:
   resolved "https://registry.yarnpkg.com/storybook-i18n/-/storybook-i18n-1.0.11.tgz#21963c8353b9ab68fec0faacdaee15de39b0220e"
   integrity sha512-wHN/93ylrfdxot0MV8sMKWJF4TkJT/XOtuHnUA4CIWrenymC4o33uNcB1sOWa2UiiEqhOK3wJ5gOPOyhgjPjwA==
 
-storybook-react-i18next@~1.0.16:
+storybook-react-i18next@~1.0.16, storybook-react-i18next@~1.0.17:
   version "1.0.17"
   resolved "https://registry.yarnpkg.com/storybook-react-i18next/-/storybook-react-i18next-1.0.17.tgz#68266d450075bb3e46673b8f04acedb929470934"
   integrity sha512-xuaaPgQTqF21S0OSmkG6pmExLzYHmflM2MqyX0oy5uUzzzJzODJMFoapEuW4Ec0yxIY7hVO/PIuA+R+/lYj7fg==
@@ -16278,10 +16278,10 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1, trim@~1.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-1.0.1.tgz#68e78f6178ccab9687a610752f4f5e5a7022ee8c"
-  integrity sha512-3JVP2YVqITUisXblCDq/Bi4P9457G/sdEamInkyvCsjbTcXLXIiG7XCb4kGMFWh6JGXesS3TKxOPtrncN/xe8w==
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
 
 trough@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package:
lib-react-components

## Describe your changes:

<em>Helpful explanations that will make your reviewer happy:</em>
- What Zooniverse project should my reviewer use to review UX?
This PR only affects lib-react-components storybook.

- What user actions should my reviewer step through to review this PR?
Run `yarn storybook` with this branch locally. In the toolbar at the top of the screen, there should now be a globe button. This is the locale switcher. It should have two language options: English and Test Language.
        <img width="299" alt="selector" src="https://user-images.githubusercontent.com/23665803/157287434-a9342ad6-1248-4fb1-99b6-9fa26bc39592.png">

- Which storybook stories should be reviewed?
Stories rendered in lib-react-components' storybook should not have changed.

- Are there plans for follow up PR’s to further fix this bug or develop this feature?
There will be follow-up PR's after this one is merged to implement locale switching in each of lib-react-component's components that use `react-i18next`.


# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
- [ ] Is this ready for production deployment?
