### PR TITLE
ADR 42: record classifier store snapshots

### DIFF
--- a/docs/arch/README.md
+++ b/docs/arch/README.md
@@ -41,3 +41,4 @@
 - [ADR 39: Text subject viewer](adr-39.md)
 - [ADR 40: Next.js Internationalized Routing](adr-40.md)
 - [ADR 41: Use i18next to Translate Static Strings ](adr-41.md)
+- [ADR 42: record classifier store snapshots in session storage ](adr-42.md)

--- a/docs/arch/adr-42.md
+++ b/docs/arch/adr-42.md
@@ -1,0 +1,45 @@
+# ADR 42: Record classifier store snapshots in session storage
+
+11 March 2022
+
+## Context
+
+Volunteers on HMS NHS, which uses ordered subject selection, ran into problems where they were shown Already Seen subjects, which then prevents them from classifying further. Unlike a workflow with random selection, refreshing the page for a workflow with ordered selection will always give you back the same subject from Panoptes. A solution to this problem would be to remember their active subject state across page visits eg. going to Talk and returning.
+
+MobX State Tree is built on the concept of [snapshots](https://mobx-state-tree.js.org/concepts/snapshots), which are immutable objects representing the state of the store at a given moment. Snapshots are generated automatically whenever the store changes state, and can be retrieved with `getSnapshot`:
+
+```js
+const snapshot = getSnapshot(store)
+```
+
+Stores can be created from snapshots:
+
+```js
+const store = Store.create(snapshot)
+```
+
+or snapshots can be applied to an existing store with `applySnapshot`:
+
+```js
+applySnapshot(store, snapshot)
+```
+
+In either case, the store state should then match the snapshot.
+
+## Decision
+
+We can use snapshots to preserve volunteers' sessions by saving them to session storage, then creating the store from a stored snapshot when they enter the page eg. `const classifierStore = RootStore.create(snapshot, options)`. This is a big change to classifier behaviour, so I've split it across several PRs, making changes incrementally and verifying each step before proceeding. Internally, the saving and loading of state snapshots are implemented as hooks for the top-level `ClassifierContainer` component.
+
+## Consequences
+
+- the classifier store is written from an assumption that it starts from an empty state. On load, reactions run which reset trees and load in new data from the API. When the classifier store is created from a snapshot, the snapshot is mostly deleted by these data-fetching reactions. When starting the store from an existing state snapshot, data-fetching should be more intelligent:
+  - when a tree is empty, request new data from Panoptes.
+  - when a tree is already populated, only request fresh data if the stored resources are stale.
+- volunteers expect refreshing the page to load a new subject on  most projects. When loading the store from a snapshot, we should be careful to reset the subject queue unless the workflow explicitly uses ordered subjects.
+- loading an existing classification and continuing from a snapshot isn't supported at the moment (11 March 2022.) Leaving the classifier and returning will destroy any work in progress.
+- classifier state is saved in session storage, so that we can have multiple classifiers open in different tabs, without those pages interfering with each other.
+- session storage is behind a flag, `cachePanoptesData`, which can be passed into the classifier in order to enable storage for a project. `cachePanoptesData` is automatically set for any project that uses `workflow.prioritized`.
+
+## Status
+
+Ongoing.


### PR DESCRIPTION
An ADR to summarise the work I've been doing to persist classifier state in window session storage, mostly for Engaging Crowds projects.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
