### PR TITLE
app-project: Fix broken dark/light mode theme toggle

### DIFF
--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -39,6 +39,7 @@ function MyApp({ Component, pageProps }) {
 
   function onMount() {
     console.info(`Deployed commit is ${process.env.COMMIT_ID}`)
+    store.ui.readCookies()
     store.user.checkCurrent()
   }
   useEffect(onMount, [])

--- a/packages/app-project/src/helpers/getCookie/getCookie.js
+++ b/packages/app-project/src/helpers/getCookie/getCookie.js
@@ -1,8 +1,8 @@
 import cookie from 'cookie'
 
-export default function getCookie (req, name) {
-  if (req?.headers?.cookie) {
-    const parsedCookie = cookie.parse(req.headers.cookie)
+export default function getCookie (name) {
+  if (document?.cookie) {
+    const parsedCookie = cookie.parse(document.cookie)
     if (parsedCookie && parsedCookie[name]) {
       return parsedCookie[name]
     }

--- a/packages/app-project/src/helpers/getCookie/getCookie.spec.js
+++ b/packages/app-project/src/helpers/getCookie/getCookie.spec.js
@@ -3,6 +3,10 @@ import { expect } from 'chai'
 import getCookie from './getCookie'
 
 describe('Helper > getCookie', function () {
+  after(function () {
+    document.cookie = null
+  })
+
   it('should return an empty string if there is not a next.js context', function () {
     const value = getCookie()
     expect(value).to.be.a('string')
@@ -16,31 +20,22 @@ describe('Helper > getCookie', function () {
   })
 
   it('should return an empty string if a name parameter is not defined', function () {
-    const cookie = 'mode=light; path=/; max-age=31536000'
-    const req = {
-      headers: { cookie }
-    }
-    const value = getCookie(req)
+    document.cookie = 'mode=light; path=/; max-age=31536000'
+    const value = getCookie()
     expect(value).to.be.a('string')
     expect(value).to.have.lengthOf(0)
   })
 
   it('should return an empty string if the cookie does not contain a value for the name parameter', function () {
-    const cookie = 'mode=light; path=/; max-age=31536000'
-    const req = {
-      headers: { cookie }
-    }
-    const value = getCookie(req, 'foo')
+    document.cookie = 'mode=light; path=/; max-age=31536000'
+    const value = getCookie('foo')
     expect(value).to.be.a('string')
     expect(value).to.have.lengthOf(0)
   })
 
   it('should return the value for the specified name parameter', function () {
-    const cookie = 'mode=light; path=/; max-age=31536000'
-    const req = {
-      headers: { cookie }
-    }
-    const value = getCookie(req, 'mode')
+    document.cookie = 'mode=light; path=/; max-age=31536000'
+    const value = getCookie('mode')
     expect(value).to.be.a('string')
     expect(value).to.have.equal('light')
   })

--- a/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.js
+++ b/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.js
@@ -1,4 +1,3 @@
-import getCookie from '@helpers/getCookie'
 import getStaticPageProps from '@helpers/getStaticPageProps'
 
 const environment = process.env.APP_ENV
@@ -8,12 +7,7 @@ const HOSTS = {
   staging: 'https://frontend.preview.zooniverse.org'
 }
 
-export default async function getDefaultPageProps({ params, query, req }) {
-
-  // cookie is in the next.js context req object
-  const mode = getCookie(req, 'mode') || null
-  const dismissedAnnouncementBanner = getCookie(req, 'dismissedAnnouncementBanner') || null
-
+export default async function getDefaultPageProps({ params, query }) {
   const { props: staticProps } = await getStaticPageProps({ params, query })
   const { project, notFound, title, workflowID, workflows } = staticProps
   const host = HOSTS[environment] || 'https://localhost:3000'
@@ -21,11 +15,7 @@ export default async function getDefaultPageProps({ params, query, req }) {
     snapshot for store hydration in the browser
   */
   const initialState = {
-    project,
-    ui: {
-      dismissedAnnouncementBanner,
-      mode
-    }
+    project
   }
 
   const props = {

--- a/packages/app-project/stores/UI.js
+++ b/packages/app-project/stores/UI.js
@@ -95,7 +95,7 @@ const UI = types
       const { slug } = getRoot(self).project
       document.cookie = cookie.serialize('dismissedProjectAnnouncementBanner', self.dismissedProjectAnnouncementBanner, {
         domain: getCookieDomain(),
-        path: `/${slug}`,
+        path: `/projects/${slug}`,
       })
     },
 

--- a/packages/app-project/stores/UI.js
+++ b/packages/app-project/stores/UI.js
@@ -3,6 +3,7 @@ import { addDisposer, getRoot, onPatch, types } from 'mobx-state-tree'
 import cookie from 'cookie'
 import stringHash from '@sindresorhus/string-hash'
 
+import getCookie from '@helpers/getCookie'
 // process.browser doesn't exist in the jsdom test environment
 const canSetCookie = process.browser || process.env.BABEL_ENV === 'test'
 
@@ -81,6 +82,13 @@ const UI = types
       const { announcement } = getRoot(self).project.configuration
       const announcementHash = stringHash(announcement)
       self.dismissedProjectAnnouncementBanner = announcementHash
+    },
+
+    readCookies() {
+      if (canSetCookie) {
+        self.mode = getCookie('mode') || 'light'
+        self.dismissedProjectAnnouncementBanner = parseInt(getCookie('dismissedProjectAnnouncementBanner'), 10) || null
+      }
     },
 
     setProjectAnnouncementBannerCookie() {

--- a/packages/app-project/stores/UI.spec.js
+++ b/packages/app-project/stores/UI.spec.js
@@ -112,11 +112,11 @@ describe('Stores > UI', function () {
 
     it('should update the cookie if the store mode does not equal the stored cookie mode', function () {
       store.setDarkMode()
-      let mode = cookie.parse(document.cookie).mode
-      expect(mode).to.equal('dark')
+      store.readCookies()
+      expect(store.mode).to.equal('dark')
       store.setLightMode()
-      mode = cookie.parse(document.cookie).mode
-      expect(mode).to.equal('light')
+      store.readCookies()
+      expect(store.mode).to.equal('light')
     })
   })
 
@@ -200,10 +200,11 @@ describe('Stores > UI', function () {
       document.cookie = cookie.serialize('dismissedProjectAnnouncementBanner', 1234567890, {
         path: `/projects/${PROJECT.slug}`
       })
+      store.readCookies()
+      expect(store.dismissedProjectAnnouncementBanner).to.equal(1234567890)
       store.dismissProjectAnnouncementBanner()
-      const parsedCookie = cookie.parse(document.cookie) || {}
-      const cookieHash = parseInt(parsedCookie.dismissedProjectAnnouncementBanner, 10)
-      expect(cookieHash).to.equal(ANNOUNCEMENT_HASH)
+      store.readCookies()
+      expect(store.dismissedProjectAnnouncementBanner).to.equal(ANNOUNCEMENT_HASH)
     })
   })
 })

--- a/packages/app-project/stores/initStore.js
+++ b/packages/app-project/stores/initStore.js
@@ -35,9 +35,8 @@ function initStore (isServer, snapshot = null, client = defaultClient) {
       Only apply store state that was generated on the server.
       TODO: won't this overwrite local changes to the UI store?
     */
-    const { project, ui } = snapshot
+    const { project } = snapshot
     applySnapshot(store.project, project)
-    applySnapshot(store.ui, ui)
   }
 
   return store


### PR DESCRIPTION
Remove server-side cookie handling and the `initialState.ui` page prop. Read cookies in the browser on app mount and apply to the store. This should remember your selected theme across projects, rather than using cached page props from the CDN.

To test this out, toggle the theme between light and dark, then check that it persists across page transitions, and also after refreshing the page.

Package:
app-project

Closes #2555.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
