### PR TITLE
Roll Grommet back to ~2.19.0

### DIFF
--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -28,7 +28,7 @@
     "counterpart": "~0.18.6",
     "dotenv-webpack": "~7.1.0",
     "express": "^4.17.1",
-    "grommet": "~2.21.0",
+    "grommet": "~2.19.0",
     "grommet-icons": "~4.7.0",
     "lodash": "~4.17.11",
     "mobx": "~6.4.0",

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -43,7 +43,7 @@
     "express": "^4.17.1",
     "graphql": "~16.3.0",
     "graphql-request": "~4.1.0",
-    "grommet": "~2.21.0",
+    "grommet": "~2.19.0",
     "grommet-icons": "~4.7.0",
     "lodash": "~4.17.11",
     "luxon": "~2.3.0",

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -85,7 +85,7 @@
     "css-loader": "~6.7.0",
     "dirty-chai": "~2.0.1",
     "enzyme": "~3.11.0",
-    "grommet": "~2.21.0",
+    "grommet": "~2.19.0",
     "grommet-icons": "~4.7.0",
     "html-webpack-plugin": "~5.5.0",
     "ignore-styles": "~5.0.1",

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -73,7 +73,7 @@
     "dedent": "~0.7.0",
     "dirty-chai": "~2.0.1",
     "enzyme": "~3.11.0",
-    "grommet": "~2.21.0",
+    "grommet": "~2.19.0",
     "grommet-icons": "~4.7.0",
     "jsdom": "~19.0.0",
     "lodash": "~4.17.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9360,7 +9360,7 @@ graphql@~16.3.0:
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.3.0.tgz#a91e24d10babf9e60c706919bb182b53ccdffc05"
   integrity sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==
 
-grommet-icons@^4.7.0, grommet-icons@~4.7.0:
+grommet-icons@^4.6.2, grommet-icons@~4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.7.0.tgz#1d537b2bdc507be07d5643309d433bbe1464c5b6"
   integrity sha512-ptw8x86Age/Yz6SplCLtJ8q1z/4ZLktMruCOnE6oTgc7hcIV/8ieOucTrLbu+PDi7rKxoP321O3OG3Zo/3qXjw==
@@ -9372,15 +9372,15 @@ grommet-styles@^0.2.0:
   resolved "https://registry.yarnpkg.com/grommet-styles/-/grommet-styles-0.2.0.tgz#b2eac2b7e2747cb523434d21728ce5234f8ce4f4"
   integrity sha512-0OMSYuGeyifYKpg4Gv2HzL8rUdd0ddnJ5LbCBKgDuloC71XIwr9g/Fxa6rs737MbPV7OZ4pEm4wvrjH4epzf1A==
 
-grommet@~2.21.0:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/grommet/-/grommet-2.21.0.tgz#7798ba9e4ad9a0ccf8a45929548dc903cc15f19b"
-  integrity sha512-KMmqGDg59IFR5pFN58bicoMpCLiizH0+VTq496TOamQFuIit6w2RMINsyO/LSREfKOBKARg3UAaDQQpdxxWLXw==
+grommet@~2.19.0:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/grommet/-/grommet-2.19.1.tgz#50b706a87cb6289abd10322c256b00336d86a1b1"
+  integrity sha512-tnFLACh0+eaHGUia79C8SFctsQBce9kQcNjOEM8WemlSFv8/0hUJLuaEvgdcGw9ZL22i8g/0s6m+tuJAqvQmYg==
   dependencies:
-    grommet-icons "^4.7.0"
+    grommet-icons "^4.6.2"
     hoist-non-react-statics "^3.2.0"
-    markdown-to-jsx "^7.1.5"
-    prop-types "^15.8.1"
+    markdown-to-jsx "^7.1.3"
+    prop-types "^15.7.2"
 
 growl@1.10.5:
   version "1.10.5"
@@ -11475,7 +11475,7 @@ markdown-table@^1.1.0:
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
 
-markdown-to-jsx@^7.1.3, markdown-to-jsx@^7.1.5:
+markdown-to-jsx@^7.1.3:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.6.tgz#421487df2a66fe4231d94db653a34da033691e62"
   integrity sha512-1wrIGZYwIG2gR3yfRmbr4FlQmhaAKoKTpRo4wur4fp9p0njU1Hi7vR8fj0AUKKIcPduiJmPprzmCB5B/GvlC7g==


### PR DESCRIPTION
Grommet 2.20 fixed [a bug in `TextInput`](https://github.com/grommet/grommet/pull/5860) with suggestions, where suggestions should always be shown when you type into the text box. Our `TextTaskWithSuggestions` relies on the old behaviour, where you could type text without seeing any suggestions. This PR rolls Grommet back to 2.19 as a workaround for #2948 until the text task can be fixed.

Package:
app-content-pages
app-project
lib-classifier
lib-react-components

Temporary workaround for #2948, while we work on a fix.

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
