### PR TITLE
Reset the Classifier key after logging out

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -29,6 +29,7 @@ export default function ClassifierWrapper({
   subjectID,
   subjectSetID,
   user,
+  userID,
   workflowID,
   yourStats
 }) {
@@ -84,7 +85,7 @@ export default function ClassifierWrapper({
 
   try {
     if (appLoadingState === asyncStates.success) {
-      const key = user.id || 'no-user'
+      const key = userID || 'no-user'
       return (
         <Classifier
           authClient={authClient}
@@ -147,6 +148,12 @@ ClassifierWrapper.propTypes = {
   subjectID: string,
   /** optional subject set ID (from the page URL.) */
   subjectSetID: string,
+  /** Current logged-in user */
+  user: shape({
+    error: string
+  }),
+  /** Logged-in user ID */
+  userID: string,
   /** required workflow ID (from the page URL.) */
   workflowID: string
 }

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperConnector.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperConnector.js
@@ -68,6 +68,7 @@ function ClassifierWrapperConnector({ store, ...props }) {
       project={project.toJSON()}
       recents={recents}
       user={user}
+      userID={user.id}
       yourStats={yourStats}
       {...props}
     />


### PR DESCRIPTION
Explicitly pass a userID prop to the `ClassifierWrapper` component in the Classify page. Set the `Classifier` key from this prop, so that the classifier unmounts and remounts when you log out.

To test this out: sign out from PH-TESS. You should see that the classifier resets and reloads without a logged-in user.

Package:
app-project

Closes #2962.

# Review Checklist

## General

- [x] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
