### PR TITLE
Classifier subject banners: Fix `stepHistory is undefined` on load

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Banners/Banners.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/Banners.js
@@ -32,7 +32,7 @@ function Banners({ stores }) {
   if (enableIndexedSubjectSetNextPrevButtons && hasIndexedSubjects && subjectNumber > -1) {
     return (
       <SubjectSetProgressBanner
-        checkForProgress={subject?.stepHistory.checkForProgress}
+        checkForProgress={subject?.stepHistory?.checkForProgress}
         onNext={onNext}
         onPrevious={onPrevious}
         subject={subject}


### PR DESCRIPTION
The subject progress banner added for Engaging Crowds projects, which allows you to browse Next and Previous subjects, will error if it renders before a classification has started. This will happen when a subject is defined in the page URL. This PR adds an existence check to the subject step history when checking for work in progress (which disables the Next and Previous buttons.)

To test this out in the dev classifier, with all the indexing features enabled, change `cachePanoptesData` from `false` to `true` in `dev/App.js` and load in the RBGE project with a subject set and subject selected:
https://local.zooniverse.org:8080/?project=emhaston/the-rbge-herbarium-exploring-gesneriaceae-the-african-violet-family&workflow=19381&subjectSet=99948&subject=70656987&env=production

You can also try the RGBE project in a production build of the project app at:
https://local.zooniverse.org:3000/projects/emhaston/the-rbge-herbarium-exploring-gesneriaceae-the-african-violet-family/classify/workflow/19381/subject-set/99948/subject/70656991

Package:
lib-classifier

# Review Checklist

## General

- [ ] Are the tests passing locally and on Travis?
- [ ] Is the documentation up to date?

## Components
- [ ] Has a storybook story been created or updated?
- [ ] Is the component accessible? 
  - [ ] Can it be used with a screen reader? [BBC guide to testing with VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - [ ] Can it be used from the keyboard? [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - [ ] Is it passing accessibility checks in the storybook?

## Apps

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `yarn panic && yarn bootstrap` or `docker-compose up --build` and app works as expected?

## Publishing

- [ ] Is the changelog updated?
- [ ] Are the dependencies updated for apps and libraries that are using the newly published library?

## Post-merging

- [ ] Did the app deploy to https://frontend.preview.zooniverse.org/projects/:project-name/:owner or https://frontend.preview.zooniverse.org/about?
- [ ] Is the new feature working or bug now fixed?
  - [ ] Is there a Talk or blog post written to announce the new feature(s)?
- [ ] Is the design working across browsers (Firefox, Chrome, Edge, Safari) and mobile?
  - [ ] Is this approved by our designer?
- [ ] Is this ready for production deployment?
