### PR TITLE
Classifier: fix text task with autosuggest

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.js
@@ -27,6 +27,8 @@ export default function TextTaskWithSuggestions (props) {
     trapFocus: false
   }
 
+  const displayedSuggestions = value ? [] : suggestions
+
   function onChange() {
     updateAnnotation(textInput)
   }
@@ -64,7 +66,7 @@ export default function TextTaskWithSuggestions (props) {
           id={`${task.taskKey}-${task.type}`}
           onChange={onChange}
           onSelect={(event) => onSelectSuggestion(event, textInput)}
-          suggestions={suggestions}
+          suggestions={displayedSuggestions}
           ref={textInput}
           value={value}
         />


### PR DESCRIPTION
The text task with suggestions should only show suggested text when the text input is empty (#2948.) This checks the current annotation value before displaying suggestions.

Includes #2965.
Closes #2948.

You can test this in the Transcribed Lines story, where the text suggestions menu should stay closed when you edit a line.
http://localhost:6006/?path=/story/drawing-tools-transcribedlines--default&globals=locale:en;locales.en:English;locales.test:Test+Language

https://user-images.githubusercontent.com/59547/161284984-37c98ecd-9cbf-49aa-89e2-f835c14c7221.mov



## Package
lib-classifier

## Linked Issue and/or Talk Post
#2948 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

## Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
