### PR TITLE
Refactor SingleTextViewer with deconstructed single text subject

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewerConnector.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewerConnector.js
@@ -8,8 +8,12 @@ function storeMapper (store) {
     }
   } = store
 
+  const { content, contentLoadingState, error } = subject
+
   return {
-    subject
+    content,
+    contentLoadingState,
+    error
   }
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewerConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewerConnector.spec.js
@@ -8,7 +8,12 @@ import SingleTextViewerContainer from './SingleTextViewerContainer'
 const mockStore = {
   classifierStore: {
     subjects: {
-      active: { id: '1' }
+      active: {
+        id: '1',
+        content: 'subject text',
+        contentLoadingState: 'success',
+        error: null
+      }
     }
   }
 }
@@ -30,9 +35,9 @@ describe('SingleTextViewerConnector', function () {
     expect(wrapper).to.be.ok()
   })
 
-  it('should pass the active subject as a prop', function () {
-    expect(containerProps.subject).to.deep.equal(
-      mockStore.classifierStore.subjects.active
-    )
+  it('should pass the subject content, contentLoadingState, and error as props', function () {
+    expect(containerProps.content).to.equal('subject text')
+    expect(containerProps.contentLoadingState).to.equal('success')
+    expect(containerProps.error).to.be.null()
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewerContainer.js
@@ -4,18 +4,13 @@ import asyncStates from '@zooniverse/async-states'
 
 import SingleTextViewer from './SingleTextViewer'
 
-const defaultSubject = {
-  content: '',
-  contentLoadingState: asyncStates.initialized
-}
-
 export default function SingleTextViewerContainer ({
+  content = '',
+  contentLoadingState = asyncStates.initialized,
+  error = null,
   onError = () => true,
-  onReady = () => true,
-  subject = defaultSubject
+  onReady = () => true
 }) {
-  const { content, contentLoadingState } = subject
-
   if (contentLoadingState === asyncStates.success) {
     onReady()
 
@@ -26,18 +21,16 @@ export default function SingleTextViewerContainer ({
     )
   }
 
-  if (subject?.error) {
-    onError(subject.error)
+  if (error) {
+    onError(error)
   }
 
   return null
 }
 
 SingleTextViewerContainer.propTypes = {
+  content: PropTypes.string,
+  contentLoadingState: PropTypes.oneOf(asyncStates.values),
   onError: PropTypes.func,
-  onReady: PropTypes.func,
-  subject: PropTypes.shape({
-    content: PropTypes.string,
-    contentLoadingState: PropTypes.oneOf(asyncStates.values)
-  })
+  onReady: PropTypes.func
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewerContainer.spec.js
@@ -50,13 +50,7 @@ describe('Component > SingleTextViewerContainer', function () {
   it('should render without crashing', function () {
     const wrapper = mount(<SingleTextViewerContainer />)
     expect(wrapper).to.be.ok()
-  })
-
-  describe('without a subject', function () {
-    it('should render null with the default props', function () {
-      const wrapper = mount(<SingleTextViewerContainer />)
-      expect(wrapper.html()).to.be.null()
-    })
+    expect(wrapper.html()).to.be.null()
   })
 
   describe('with content loading state of error', function () {
@@ -68,9 +62,11 @@ describe('Component > SingleTextViewerContainer', function () {
 
       wrapper = mount(
         <SingleTextViewerContainer
+          content={errorSubject.content}
+          contentLoadingState={errorSubject.contentLoadingState}
+          error={errorSubject.error}
           onError={onErrorSpy}
           onReady={onReadySpy}
-          subject={errorSubject}
         />)
     })
 
@@ -96,13 +92,15 @@ describe('Component > SingleTextViewerContainer', function () {
 
       wrapper = mount(
         <SingleTextViewerContainer
+          content={subject.content}
+          contentLoadingState={subject.contentLoadingState}
+          error={subject.error}
           onError={onErrorSpy}
           onReady={onReadySpy}
-          subject={subject}
         />)
     })
 
-    it('should display the text subject content', function () {
+    it('should render the text subject content', function () {
       const stv = wrapper.find(SingleTextViewer)
       expect(stv.prop('content')).to.equal(subject.content)
     })
@@ -116,7 +114,11 @@ describe('Component > SingleTextViewerContainer', function () {
     })
 
     it('should update text subject content when there is a new subject', function () {
-      wrapper.setProps({ subject: nextSubject })
+      wrapper.setProps({
+        content: nextSubject.content,
+        contentLoadingState: nextSubject.contentLoadingState,
+        error: nextSubject.error
+      })
       const stv = wrapper.find(SingleTextViewer)
       expect(stv.prop('content')).to.equal(nextSubject.content)
     })
@@ -131,9 +133,11 @@ describe('Component > SingleTextViewerContainer', function () {
 
       wrapper = mount(
         <SingleTextViewerContainer
+          content={initializedSubject.content}
+          contentLoadingState={initializedSubject.contentLoadingState}
+          error={initializedSubject.error}
           onError={onErrorSpy}
           onReady={onReadySpy}
-          subject={initializedSubject}
         />)
     })
 
@@ -159,9 +163,11 @@ describe('Component > SingleTextViewerContainer', function () {
 
       wrapper = mount(
         <SingleTextViewerContainer
+          content={loadingSubject.content}
+          contentLoadingState={loadingSubject.contentLoadingState}
+          error={loadingSubject.error}
           onError={onErrorSpy}
           onReady={onReadySpy}
-          subject={loadingSubject}
         />)
     })
 
@@ -177,10 +183,17 @@ describe('Component > SingleTextViewerContainer', function () {
       expect(onReadySpy).to.not.have.been.called()
     })
 
-    it('should update text subject content when the subject loads successfully', function () {
-      wrapper.setProps({ subject: subject })
-      const stv = wrapper.find(SingleTextViewer)
-      expect(stv.prop('content')).to.equal(subject.content)
+    describe('when content loading state changes to success', function () {
+      it('should render the text subject content', function () {
+        wrapper.setProps({
+          content: 'text content loaded',
+          contentLoadingState: asyncStates.success
+        })
+
+        const stv = wrapper.find(SingleTextViewer)
+        expect(stv.prop('content')).to.equal('text content loaded')
+        expect(onReadySpy).to.have.been.calledOnce()
+      })
     })
   })
 })


### PR DESCRIPTION
## Package
- lib-classifier

## Issue
- single text subject viewer fails to render content when single text subject `contentLoadingState` changes to `success`
- basic react component mistake on my part :face_palm, a change in the nested property of a prop won't trigger a re-render, previously the SingleTextViewerContainer had the subject as the prop, so when subject stayed the same but properties changed (notably contentLoadingState) the container did not update because the subject was still the same subject, solution here is to deconstruct the subject in the connector and pass the meaningful properties of a single text subject as props into the container, and the container will now update when those properties change, as expected

## Describe your changes
- refactor SingleTextViewerConnector and SingleTextViewerContainer with single text subject content, contentLoadingState, and error properties

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - (confirm issue) https://frontend.preview.zooniverse.org/projects/markb-panoptes/digileap-testing/classify/workflow/3585?env=staging
  - (confirm fix locally) https://local.zooniverse.org:3000/projects/markb-panoptes/digileap-testing/classify/workflow/3585
- What user actions should my reviewer step through to review this PR?
  - load project and workflow linked above
  - to confirm issue (doesn't always have issue, if don't see issue try signing in, going back to project home then select "TextTaskFromSubject" workflow) - note that single text viewer doesn't render content and disables textFromSubject task
  - to confirm fix - note that single text viewer renders content and textFromSubject task is not disabled
- Which storybook stories should be reviewed? N/A, story is based on component, not connector or container
- Are there plans for follow up PR’s to further fix this bug or develop this feature? currently working image and text subject viewer, which utilizes the singleTextViewer

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated
