### PR TITLE
Add image and text subject viewer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewerContainer.js
@@ -1,0 +1,202 @@
+import { Box } from 'grommet'
+import PropTypes from 'prop-types'
+import React, { useEffect, useRef, useState } from 'react'
+import styled from 'styled-components'
+import asyncStates from '@zooniverse/async-states'
+
+import withKeyZoom from '@components/Classifier/components/withKeyZoom'
+import { withStores } from '@helpers'
+import { draggable } from '@plugins/drawingTools/components'
+
+import useSubjectImage, { placeholder } from '../SingleImageViewer/hooks/useSubjectImage'
+import locationValidator from '../../helpers/locationValidator'
+import SingleImageViewer from '../SingleImageViewer/SingleImageViewer'
+import SVGPanZoom from '../SVGComponents/SVGPanZoom'
+import SingleTextViewer from '../SingleTextViewer'
+import StepNavigation from '@components/Classifier/components/SlideTutorial/components/StepNavigation'
+
+function storeMapper (store) {
+  const {
+    enableRotation,
+    frame,
+    move,
+    rotation,
+    setFrame,
+    setOnPan,
+    setOnZoom
+  } = store.subjectViewer
+
+  const { activeStepTasks } = store.workflowSteps
+
+  const [activeInteractionTask] = activeStepTasks.filter(
+    (task) => task.type === 'drawing' || task.type === 'transcription'
+  )
+  const {
+    activeTool
+  } = activeInteractionTask || {}
+
+  return {
+    activeTool,
+    enableRotation,
+    frame,
+    move,
+    rotation,
+    setFrame,
+    setOnPan,
+    setOnZoom
+  }
+}
+
+const DraggableImage = styled(draggable('image'))`
+  cursor: move;
+`
+
+const defaultTool = {
+  validate: () => {}
+}
+
+function ImageAndTextViewerContainer ({
+  activeTool = defaultTool,
+  enableInteractionLayer = true,
+  enableRotation = () => null,
+  frame = 0,
+  ImageObject = window.Image,
+  loadingState = asyncStates.initialized,
+  move,
+  onError = () => true,
+  onKeyDown = () => true,
+  onReady = () => true,
+  rotation,
+  setFrame = () => true,
+  setOnPan = () => true,
+  setOnZoom = () => true,
+  subject
+}) {
+  const subjectImage = useRef()
+  const [dragMove, setDragMove] = useState()
+
+  // TODO: refactor with frame
+  const [location, setLocation] = useState(0)
+
+  // TODO: replace this with a better function to parse the image location from a subject.
+  const imageUrl = subject ? Object.values(subject.locations[frame])[0] : null
+  const { img, error } = useSubjectImage(ImageObject, imageUrl)
+  // default to a placeholder while image is loading.
+  const { naturalHeight, naturalWidth, src } = img
+
+  useEffect(function onImageLoad () {
+    if (src !== placeholder.src) {
+      const svgImage = subjectImage.current
+      const { width: clientWidth, height: clientHeight } = svgImage
+        ? svgImage.getBoundingClientRect()
+        : {}
+      const target = { clientHeight, clientWidth, naturalHeight, naturalWidth }
+      onReady({ target })
+    }
+  }, [src])
+
+  useEffect(function onMount () {
+    enableRotation()
+  }, [])
+
+  useEffect(function onFrameChange () {
+    activeTool?.validate()
+  }, [frame])
+
+  if (error) {
+    console.error(error)
+    onError(error)
+  }
+
+  function setOnDrag (callback) {
+    setDragMove(() => callback)
+  }
+
+  function onDrag (event, difference) {
+    dragMove?.(event, difference)
+  }
+
+  function onLocationChange () {
+    setLocation(Math.abs(location - 1))
+  }
+
+  if (loadingState === asyncStates.error) {
+    return (
+      <div>Something went wrong.</div>
+    )
+  }
+
+  const enableDrawing = (loadingState === asyncStates.success) && enableInteractionLayer
+  const SubjectImage = move ? DraggableImage : 'image'
+  const subjectImageProps = {
+    height: naturalHeight,
+    width: naturalWidth,
+    xlinkHref: src,
+    ...(move && { dragMove: onDrag })
+  }
+
+  if (loadingState !== asyncStates.initialized) {
+    return (
+      <Box
+        fill='horizontal'
+      >
+        <SVGPanZoom
+          img={subjectImage.current}
+          maxZoom={5}
+          minZoom={0.1}
+          naturalHeight={naturalHeight}
+          naturalWidth={naturalWidth}
+          setOnDrag={setOnDrag}
+          setOnPan={setOnPan}
+          setOnZoom={setOnZoom}
+          src={src}
+        >
+          {location === 0 ? (
+            <SingleImageViewer
+              enableInteractionLayer={enableDrawing}
+              height={naturalHeight}
+              onKeyDown={onKeyDown}
+              rotate={rotation}
+              width={naturalWidth}
+            >
+              <g ref={subjectImage}>
+                <SubjectImage
+                  {...subjectImageProps}
+                />
+              </g>
+            </SingleImageViewer>
+          ) : (
+            <SingleTextViewer />
+          )}
+        </SVGPanZoom>
+        <StepNavigation
+          onChange={onLocationChange}
+          stepIndex={location}
+          steps={[0, 1]}
+        />
+      </Box>
+    )
+  }
+  return null
+}
+
+ImageAndTextViewerContainer.propTypes = {
+  activeTool: PropTypes.shape({
+    validate: PropTypes.func
+  }),
+  enableInteractionLayer: PropTypes.bool,
+  enableRotation: PropTypes.func,
+  frame: PropTypes.number,
+  loadingState: PropTypes.string,
+  onError: PropTypes.func,
+  onReady: PropTypes.func,
+  setFrame: PropTypes.func,
+  setOnPan: PropTypes.func,
+  setOnZoom: PropTypes.func,
+  subject: PropTypes.shape({
+    locations: PropTypes.arrayOf(locationValidator)
+  }).isRequired
+}
+
+export default withStores(withKeyZoom(ImageAndTextViewerContainer), storeMapper)
+export { DraggableImage, ImageAndTextViewerContainer }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/index.js
@@ -1,0 +1,1 @@
+export { default } from './ImageAndTextViewerContainer.js'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getViewer/getViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getViewer/getViewer.js
@@ -1,4 +1,5 @@
 import DataImageViewer from '../../components/DataImageViewer'
+import ImageAndTextViewer from '../../components/ImageAndTextViewer'
 import LightCurveViewer from '../../components/LightCurveViewer'
 import MultiFrameViewer from '../../components/MultiFrameViewer'
 import ScatterPlotViewer from '../../components/ScatterPlotViewer'
@@ -10,6 +11,7 @@ import VariableStarViewer from '../../components/VariableStarViewer'
 
 const viewers = {
   dataImage: DataImageViewer,
+  imageAndText: ImageAndTextViewer,
   lightCurve: LightCurveViewer,
   multiFrame: MultiFrameViewer,
   scatterPlot: ScatterPlotViewer,

--- a/packages/lib-classifier/src/helpers/subjectViewers/subjectViewers.js
+++ b/packages/lib-classifier/src/helpers/subjectViewers/subjectViewers.js
@@ -5,6 +5,11 @@ Object.defineProperty(subjectViewers, 'dataImage', {
   enumerable: true
 })
 
+Object.defineProperty(subjectViewers, 'imageAndText', {
+  value: 'imageAndText',
+  enumerable: true
+})
+
 Object.defineProperty(subjectViewers, 'lightCurve', {
   value: 'lightCurve',
   enumerable: true

--- a/packages/lib-classifier/src/helpers/subjectViewers/subjectViewers.spec.js
+++ b/packages/lib-classifier/src/helpers/subjectViewers/subjectViewers.spec.js
@@ -3,6 +3,7 @@ import subjectViewers from './subjectViewers'
 describe('Helpers > subjectViewers', function () {
   const viewers = [
     'dataImage',
+    'imageAndText',
     'lightCurve',
     'multiFrame',
     'scatterPlot',

--- a/packages/lib-classifier/src/store/SubjectStore/ImageAndTextSubject/ImageAndTextSubject.js
+++ b/packages/lib-classifier/src/store/SubjectStore/ImageAndTextSubject/ImageAndTextSubject.js
@@ -1,0 +1,16 @@
+import { types } from 'mobx-state-tree'
+
+import { createLocationCounts } from '@helpers'
+import Subject from '../Subject'
+import TextSubject from '../shared/TextSubject.js'
+
+const ImageAndTextSubject = types
+  .refinement(
+    'ImageAndTextSubject',
+    types.compose('ImageAndTextSubject', Subject, TextSubject),
+    subject => {
+      const counts = createLocationCounts(subject)
+      return counts.total === 2 && counts.images === 1 && counts.text === 1
+    })
+
+export default ImageAndTextSubject

--- a/packages/lib-classifier/src/store/SubjectStore/ImageAndTextSubject/ImageAndTextSubject.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore/ImageAndTextSubject/ImageAndTextSubject.spec.js
@@ -1,0 +1,154 @@
+import { expect } from 'chai'
+import { when } from 'mobx'
+import nock from 'nock'
+import asyncStates from '@zooniverse/async-states'
+
+import { SubjectFactory, WorkflowFactory } from '@test/factories'
+import mockStore from '@test/mockStore'
+import subjectViewers from '@helpers/subjectViewers'
+
+import ImageAndTextSubject from './ImageAndTextSubject'
+
+describe('Model > ImageAndTextSubject', function () {
+  const subjectSnapshot = SubjectFactory.build({
+    content: 'This is test subject content',
+    contentLoadingState: asyncStates.success,
+    locations: [
+      { 'image/png': 'http://localhost:8080/subjectImage.png' },
+      { 'text/plain': 'http://localhost:8080/subjectContent.txt' }
+    ]
+  })
+
+  const successSubjectSnapshot = SubjectFactory.build({
+    locations: [
+      { 'image/png': 'http://localhost:8080/subjectImage.png' },
+      { 'text/plain': 'http://localhost:8080/success.txt' }
+    ]
+  })
+
+  const invalidLocationsSubjectSnapshot = SubjectFactory.build({
+    locations: [
+      { 'text/plain': 'http://localhost:8080/success.txt' },
+      { 'audio/mpeg': 'http://localhost:8080/example.mp3' }
+    ]
+  })
+
+  const failureSubjectSnapshot = SubjectFactory.build({
+    locations: [
+      { 'image/png': 'http://localhost:8080/subjectImage.png' },
+      { 'text/plain': 'http://localhost:8080/failure.txt' }
+    ]
+  })
+
+  const workflowSnapshot = WorkflowFactory.build()
+  let subject
+
+  before(function () {
+    subject = ImageAndTextSubject.create(subjectSnapshot)
+  })
+
+  it('should exist', function () {
+    expect(ImageAndTextSubject).to.be.ok()
+    expect(ImageAndTextSubject).to.be.an('object')
+  })
+
+  it('should have a `locations` property', function () {
+    expect(subject.locations).to.deep.equal(subjectSnapshot.locations)
+  })
+
+  it('should have two locations', function () {
+    expect(subject.locations).to.have.lengthOf(2)
+  })
+
+  it('should have content as expected', function () {
+    expect(subject.content).to.equal(subjectSnapshot.content)
+  })
+
+  it('should have contentLoadingState as expected', function () {
+    expect(subject.contentLoadingState).to.equal(subjectSnapshot.contentLoadingState)
+  })
+
+  describe('with invalid subject locations', function () {
+    it('should throw an error', function () {
+      expect(() => ImageAndTextSubject.create(invalidLocationsSubjectSnapshot)).to.throw()
+    })
+  })
+
+  describe('with location request response that fails', function () {
+    let subject
+
+    before(async function () {
+      nock('http://localhost:8080')
+        .get('/failure.txt')
+        .reply(404)
+
+      subject = ImageAndTextSubject.create(failureSubjectSnapshot)
+
+      const store = mockStore()
+      store.workflows.setResources([workflowSnapshot])
+      store.workflows.setActive(workflowSnapshot.id)
+      store.subjects.setResources([subject])
+      store.subjects.setActive(subject.id)
+
+      await when(() => subject.contentLoadingState === asyncStates.error)
+    })
+
+    after(function () {
+      nock.cleanAll()
+    })
+
+    it('should have contentLoadingState as expected', function () {
+      expect(subject.contentLoadingState).to.equal(asyncStates.error)
+    })
+
+    it('should have error as expected', function () {
+      expect(subject.error.message).to.equal('Not Found')
+    })
+  })
+
+  describe('with location request response that succeeds', function () {
+    let subject
+
+    before(async function () {
+      nock('http://localhost:8080')
+        .get('/success.txt')
+        .reply(200, 'This is test subject content')
+
+      subject = ImageAndTextSubject.create(successSubjectSnapshot)
+
+      const store = mockStore()
+      store.workflows.setResources([workflowSnapshot])
+      store.workflows.setActive(workflowSnapshot.id)
+      store.subjects.setResources([subject])
+      store.subjects.setActive(subject.id)
+
+      await when(() => subject.contentLoadingState === asyncStates.success)
+    })
+
+    after(function () {
+      nock.cleanAll()
+    })
+
+    it('should have contentLoadingState as expected', function () {
+      expect(subject.contentLoadingState).to.equal(asyncStates.success)
+    })
+
+    it('should have content as expected', function () {
+      expect(subject.content).to.equal('This is test subject content')
+    })
+  })
+
+  describe('Views > viewer', function () {
+    before(function () {
+      const store = mockStore()
+      store.workflows.setResources([workflowSnapshot])
+      store.workflows.setActive(workflowSnapshot.id)
+      store.subjects.setResources([subject])
+      store.subjects.setActive(subject.id)
+    })
+
+    it('should return the single text viewer', function () {
+      expect(subject.viewer).to.equal(subjectViewers.imageAndText)
+    })
+  })
+})

--- a/packages/lib-classifier/src/store/SubjectStore/ImageAndTextSubject/index.js
+++ b/packages/lib-classifier/src/store/SubjectStore/ImageAndTextSubject/index.js
@@ -1,0 +1,1 @@
+export { default } from './ImageAndTextSubject'

--- a/packages/lib-classifier/src/store/SubjectStore/SingleTextSubject/SingleTextSubject.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SingleTextSubject/SingleTextSubject.js
@@ -10,7 +10,7 @@ const SingleTextSubject = types
     types.compose('SingleTextSubject', Subject, TextSubject),
     subject => {
       const counts = createLocationCounts(subject)
-      return counts.length === 1 && counts.text === 1
+      return counts.total === 1 && counts.text === 1
     })
 
 export default SingleTextSubject

--- a/packages/lib-classifier/src/store/SubjectStore/SingleTextSubject/SingleTextSubject.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SingleTextSubject/SingleTextSubject.js
@@ -1,58 +1,8 @@
-import { flow, types } from 'mobx-state-tree'
-import asyncStates from '@zooniverse/async-states'
+import { types } from 'mobx-state-tree'
 
 import { createLocationCounts } from '@helpers'
 import Subject from '../Subject'
-
-const TextSubject = types
-  .model('TextSubject', {
-    content: types.maybeNull(types.string),
-    contentLoadingState: types.optional(types.enumeration('contentLoadingState', asyncStates.values), asyncStates.initialized),
-    error: types.optional(types.maybeNull(types.frozen({})), null)
-  })
-  .actions(self => {
-    function afterAttach () {
-      if (self.contentLoadingState === asyncStates.initialized) {
-        self.fetchContent()
-      }
-    }
-
-    function getSubjectUrl () {
-      // Find locations that have a text/plain MIME type.
-      const textLocation = self.locations.find(l => l['text/plain']) || {}
-      const url = Object.values(textLocation)[0]
-      if (url) {
-        return url
-      } else {
-        throw new Error('No text url found for this subject')
-      }
-    }
-
-    function * fetchContent () {
-      self.contentLoadingState = asyncStates.loading
-
-      try {
-        const url = getSubjectUrl()
-        const response = yield fetch(url)
-        if (!response.ok) {
-          const error = new Error(response.statusText)
-          error.status = response.status
-          throw error
-        }
-        self.content = yield response.text()
-
-        self.contentLoadingState = asyncStates.success
-      } catch (error) {
-        self.contentLoadingState = asyncStates.error
-        self.error = error
-      }
-    }
-
-    return {
-      afterAttach,
-      fetchContent: flow(fetchContent)
-    }
-  })
+import TextSubject from '../shared/TextSubject'
 
 const SingleTextSubject = types
   .refinement(
@@ -60,7 +10,7 @@ const SingleTextSubject = types
     types.compose('SingleTextSubject', Subject, TextSubject),
     subject => {
       const counts = createLocationCounts(subject)
-      return subject.locations.length === 1 && counts.text === 1
+      return counts.length === 1 && counts.text === 1
     })
 
 export default SingleTextSubject

--- a/packages/lib-classifier/src/store/SubjectStore/Subject/Subject.js
+++ b/packages/lib-classifier/src/store/SubjectStore/Subject/Subject.js
@@ -1,9 +1,8 @@
 import { destroy, getRoot, tryReference, types } from 'mobx-state-tree'
 import Resource from '@store/Resource'
-import { createLocationCounts, subjectViewers, validateSubjectLocations } from '@helpers'
+import { createLocationCounts, subjectsSeenThisSession, subjectViewers, validateSubjectLocations } from '@helpers'
 import StepHistory from './StepHistory'
 import TranscriptionReductions from './TranscriptionReductions'
-import { subjectsSeenThisSession } from '@helpers'
 
 const Subject = types
   .model('Subject', {
@@ -67,7 +66,16 @@ const Subject = types
 
         if (!viewer && counts.total > 1 && counts.total < 11) {
           if (!nullViewer) {
-            viewer = subjectViewers.multiFrame
+            if (counts.total === counts.images) {
+              viewer = subjectViewers.multiFrame
+            }
+            if (
+              counts.total === 2 &&
+              counts.images === 1 &&
+              counts.text === 1
+            ) {
+              viewer = subjectViewers.imageAndText
+            }
           }
         }
       }

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
@@ -6,6 +6,7 @@ import { getIndexedSubjects, subjectSelectionStrategy } from './helpers'
 import { filterByLabel, filters } from '../../components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal'
 import ResourceStore from '@store/ResourceStore'
 import Subject from './Subject'
+import ImageAndTextSubject from './ImageAndTextSubject'
 import SingleImageSubject from './SingleImageSubject'
 import SingleTextSubject from './SingleTextSubject'
 import SingleVideoSubject from './SingleVideoSubject'
@@ -19,7 +20,7 @@ const MINIMUM_QUEUE_SIZE = 3
   for advice about using references with types.union.
 */
 
-const SingleSubject = types.union(SingleImageSubject, SingleTextSubject, SingleVideoSubject, Subject)
+const SingleSubject = types.union(ImageAndTextSubject, SingleImageSubject, SingleTextSubject, SingleVideoSubject, Subject)
 function subjectDispatcher (snapshot) {
   if (snapshot?.metadata?.['#subject_group_id']) {
     return SubjectGroup

--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.spec.js
@@ -7,6 +7,7 @@ import asyncStates from '@zooniverse/async-states'
 
 import RootStore from '@store/RootStore'
 import SubjectGroup from './SubjectGroup'
+import ImageAndTextSubject from './ImageAndTextSubject'
 import SingleImageSubject from './SingleImageSubject'
 import SingleTextSubject from './SingleTextSubject'
 import { openTalkPage, MINIMUM_QUEUE_SIZE } from './SubjectStore'
@@ -167,7 +168,7 @@ describe('Model > SubjectStore', function () {
         const queue = Array.from(subjects.resources.keys())
         expect(queue).to.deep.equal(initialSubjectIDs)
       })
-    
+
       it('should preserve the subject order', function () {
         let index = 0
         subjects.resources.forEach(function (resource, key) {
@@ -367,6 +368,34 @@ describe('Model > SubjectStore', function () {
 
     it('should be of the correct subject type', function () {
       expect(getType(subjects.active).name).to.equal('SingleTextSubject')
+    })
+  })
+
+  describe('imange and text subjects', function () {
+    let subjects
+    const imageAndTextSubjects = Factory.buildList(
+      'subject',
+      10,
+      {
+        content: 'This is test subject content',
+        contentLoadingState: asyncStates.success,
+        locations: [
+          { 'image/png': 'https://foo.bar/example.png' },
+          { 'text/plain': 'https://foo.bar/example.txt' }
+        ]
+      })
+
+    before(async function () {
+      subjects = await mockSubjectStore(imageAndTextSubjects)
+    })
+
+    it('should be valid subjects', function () {
+      const expectedSubject = ImageAndTextSubject.create(imageAndTextSubjects[1])
+      expect(subjects.resources.get(expectedSubject.id)).to.deep.equal(expectedSubject)
+    })
+
+    it('should be of the correct subject type', function () {
+      expect(getType(subjects.active).name).to.equal('ImageAndTextSubject')
     })
   })
 

--- a/packages/lib-classifier/src/store/SubjectStore/shared/TextSubject.js
+++ b/packages/lib-classifier/src/store/SubjectStore/shared/TextSubject.js
@@ -1,0 +1,53 @@
+import { flow, types } from 'mobx-state-tree'
+import asyncStates from '@zooniverse/async-states'
+
+const TextSubject = types
+  .model('TextSubject', {
+    content: types.maybeNull(types.string),
+    contentLoadingState: types.optional(types.enumeration('contentLoadingState', asyncStates.values), asyncStates.initialized),
+    error: types.optional(types.maybeNull(types.frozen({})), null)
+  })
+  .actions(self => {
+    function afterAttach () {
+      if (self.contentLoadingState === asyncStates.initialized) {
+        self.fetchContent()
+      }
+    }
+
+    function getSubjectUrl () {
+      // Find locations that have a text/plain MIME type.
+      const textLocation = self.locations.find(l => l['text/plain']) || {}
+      const url = Object.values(textLocation)[0]
+      if (url) {
+        return url
+      } else {
+        throw new Error('No text url found for this subject')
+      }
+    }
+
+    function * fetchContent () {
+      self.contentLoadingState = asyncStates.loading
+
+      try {
+        const url = getSubjectUrl()
+        const response = yield fetch(url)
+        if (!response.ok) {
+          const error = new Error(response.statusText)
+          error.status = response.status
+          throw error
+        }
+        self.content = yield response.text()
+        self.contentLoadingState = asyncStates.success
+      } catch (error) {
+        self.contentLoadingState = asyncStates.error
+        self.error = error
+      }
+    }
+
+    return {
+      afterAttach,
+      fetchContent: flow(fetchContent)
+    }
+  })
+
+export default TextSubject

--- a/packages/lib-classifier/src/store/SubjectStore/shared/TextSubject.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore/shared/TextSubject.spec.js
@@ -1,0 +1,139 @@
+import { expect } from 'chai'
+import { when } from 'mobx'
+import nock from 'nock'
+import asyncStates from '@zooniverse/async-states'
+
+import { SubjectFactory, WorkflowFactory } from '@test/factories'
+import mockStore from '@test/mockStore'
+
+import TextSubject from './TextSubject'
+import ImageAndTextSubject from '../ImageAndTextSubject'
+import SingleTextSubject from '../SingleTextSubject'
+
+describe('Model > TextSubject', function () {
+  const textSubjectSnapshot = SubjectFactory.build({
+    content: 'This is test subject content',
+    contentLoadingState: asyncStates.success,
+    locations: [
+      { 'text/plain': 'http://localhost:8080/subjectText.txt' }
+    ]
+  })
+
+  const imageAndTextSubjectSnapshot = SubjectFactory.build({
+    locations: [
+      { 'image/jpeg': 'http://localhost:8080/subjectImage.jpg' },
+      { 'text/plain': 'http://localhost:8080/success.txt' }
+    ]
+  })
+
+  const invalidLocationsSubjectSnapshot = SubjectFactory.build({
+    locations: [
+      { 'audio/mpeg': 'http://localhost:8080/example.mp3' }
+    ]
+  })
+
+  const failureSubjectSnapshot = SubjectFactory.build({
+    locations: [
+      { 'image/png': 'http://localhost:8080/subjectImage.png' },
+      { 'text/plain': 'http://localhost:8080/failure.txt' }
+    ]
+  })
+
+  const workflowSnapshot = WorkflowFactory.build()
+  let subject
+
+  before(function () {
+    subject = SingleTextSubject.create(textSubjectSnapshot)
+  })
+
+  it('should exist', function () {
+    expect(TextSubject).to.be.ok()
+    expect(TextSubject).to.be.an('object')
+  })
+
+  it('should have a `locations` property', function () {
+    expect(subject.locations).to.deep.equal(textSubjectSnapshot.locations)
+  })
+
+  it('should have one location', function () {
+    expect(subject.locations).to.have.lengthOf(1)
+  })
+
+  it('should have content as expected', function () {
+    expect(subject.content).to.equal(textSubjectSnapshot.content)
+  })
+
+  it('should have contentLoadingState as expected', function () {
+    expect(subject.contentLoadingState).to.equal(textSubjectSnapshot.contentLoadingState)
+  })
+
+  describe('with an invalid subject location', function () {
+    it('should throw an error', function () {
+      expect(() => SingleTextSubject.create(invalidLocationsSubjectSnapshot)).to.throw()
+    })
+  })
+
+  describe('with location request response that fails', function () {
+    let subject
+
+    before(async function () {
+      nock('http://localhost:8080')
+        .get('/failure.txt')
+        .reply(404)
+
+      subject = ImageAndTextSubject.create(failureSubjectSnapshot)
+
+      const store = mockStore()
+      store.workflows.setResources([workflowSnapshot])
+      store.workflows.setActive(workflowSnapshot.id)
+      store.subjects.setResources([subject])
+      store.subjects.setActive(subject.id)
+
+      await when(() => subject.contentLoadingState === asyncStates.error)
+    })
+
+    after(function () {
+      nock.cleanAll()
+    })
+
+    it('should have contentLoadingState as expected', function () {
+      expect(subject.contentLoadingState).to.equal(asyncStates.error)
+    })
+
+    it('should have error as expected', function () {
+      expect(subject.error.message).to.equal('Not Found')
+    })
+  })
+
+  describe('with location request response that succeeds', function () {
+    let subject
+
+    before(async function () {
+      nock('http://localhost:8080')
+        .get('/success.txt')
+        .reply(200, 'This is test subject content')
+
+      subject = ImageAndTextSubject.create(imageAndTextSubjectSnapshot)
+
+      const store = mockStore()
+      store.workflows.setResources([workflowSnapshot])
+      store.workflows.setActive(workflowSnapshot.id)
+      store.subjects.setResources([subject])
+      store.subjects.setActive(subject.id)
+
+      await when(() => subject.contentLoadingState === asyncStates.success)
+    })
+
+    after(function () {
+      nock.cleanAll()
+    })
+
+    it('should have contentLoadingState as expected', function () {
+      expect(subject.contentLoadingState).to.equal(asyncStates.success)
+    })
+
+    it('should have content as expected', function () {
+      expect(subject.content).to.equal('This is test subject content')
+    })
+  })
+})

--- a/packages/lib-classifier/src/store/SubjectStore/shared/index.js
+++ b/packages/lib-classifier/src/store/SubjectStore/shared/index.js
@@ -1,0 +1,1 @@
+export { default } from './TextSubject.js'


### PR DESCRIPTION
## Package
- lib-classifier

## Describe your changes
- add ImageAndTextSubject
- refactor SingleTextSubject and ImageAndTextSubject with generic TextSubject
- add ImageAndTextViewer container
- [ ] refactor ImageAndTextViewer (and SubjectViewerStore?) to use frame
- [ ] refactor with RTL
- [ ] refactor stories

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
