### PR TITLE
Classifier: test the modal tutorial

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.js
@@ -68,9 +68,7 @@ function ModalTutorial ({
 }
 
 ModalTutorial.propTypes = {
-  loadingState: PropTypes.string,
-  showModal: PropTypes.bool,
-  setModalVisibility: PropTypes.func.isRequired,
+  hasNotSeenTutorialBefore: PropTypes.bool,
   tutorial: PropTypes.object
 }
 


### PR DESCRIPTION
Render the modal tutorial with and without `hasNotSeenTutorialBefore` set. Test that the close button closes the tutorial and updates user project preferences to mark the tutorial as seen.

## Package
lib-classifier

## General
- [x] Tests are passing locally and on Github
