### PR TITLE
Classifier: test text task with suggestions

### DIFF
--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -10,8 +10,8 @@
     "dev": "webpack serve --config webpack.dev.js",
     "lint": "zoo-standard --fix | snazzy",
     "start": "PANOPTES_ENV=production npm run dev",
-    "test": "NODE_PATH=. NODE_ENV=test mocha --config ./test/.mocharc.json \"./{src,test}/**/*.spec.js\"",
-    "test:ci": "NODE_PATH=. NODE_ENV=test mocha --config ./test/.mocharc.json --reporter=min \"./{src,test}/**/*.spec.js\"",
+    "test": "NODE_PATH=. NODE_ENV=test mocha --exit --config ./test/.mocharc.json \"./{src,test}/**/*.spec.js\"",
+    "test:ci": "NODE_PATH=. NODE_ENV=test mocha --exit --config ./test/.mocharc.json --reporter=min \"./{src,test}/**/*.spec.js\"",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -70,7 +70,7 @@
     "@testing-library/dom": "~8.13.0",
     "@testing-library/react": "~12.1.2",
     "@testing-library/react-hooks": "~7.0.1",
-    "@testing-library/user-event": "~13.5.0",
+    "@testing-library/user-event": "~14.1.0",
     "@visx/mock-data": "~2.1.2",
     "@wojtekmaj/enzyme-adapter-react-17": "~0.6.6",
     "@zooniverse/grommet-theme": "~3.0.0",

--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.spec.js
@@ -1,7 +1,8 @@
 import zooTheme from '@zooniverse/grommet-theme'
 import { Grommet } from 'grommet'
 import React from 'react'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { when } from 'mobx'
 import { Provider } from 'mobx-react'
 import sinon from 'sinon'
@@ -91,9 +92,11 @@ describe('ModalTutorial', function () {
 
   describe('on close', function () {
     let store
+    let user
 
     beforeEach(async function () {
       store = mockStore()
+      user = userEvent.setup()
       const tutorialSnapshot = TutorialFactory.build({ steps })
       store.tutorials.setTutorials([tutorialSnapshot])
       await when(() => store.userProjectPreferences.loadingState === asyncStates.success)
@@ -104,7 +107,7 @@ describe('ModalTutorial', function () {
       })
     })
 
-    it('should record the active tutorial as complete', function () {
+    it('should record the active tutorial as complete', async function () {
       const clock = sinon.useFakeTimers({ now: new Date('2022-03-01T12:00:00Z'), toFake: ['Date'] })
       const tutorial = store.tutorials.active
       const seen = new Date().toISOString()
@@ -118,13 +121,13 @@ describe('ModalTutorial', function () {
         }
       )
       const closeButton = screen.getByRole('button', { name: 'Close' })
-      fireEvent.click(closeButton)
+      await user.click(closeButton)
       const upp = store.userProjectPreferences.active
       expect(upp?.preferences.tutorials_completed_at[tutorial.id]).to.equal(seen)
       clock.restore()
     })
 
-    it('should close the tutorial', function () {
+    it('should close the tutorial', async function () {
       const tutorial = store.tutorials.active
       const wrapper = render(
         <ModalTutorial
@@ -138,7 +141,7 @@ describe('ModalTutorial', function () {
       let tutorialTitle = screen.getByRole('heading', { level: 2, name: 'ModalTutorial.title' })
       expect(tutorialTitle).to.be.ok()
       const closeButton = screen.getByRole('button', { name: 'Close' })
-      fireEvent.click(closeButton)
+      await user.click(closeButton)
       tutorialTitle = screen.queryByRole('heading', { level: 2, name: 'ModalTutorial.title' })
       expect(tutorialTitle).to.be.null()
     })

--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.spec.js
@@ -96,7 +96,7 @@ describe('ModalTutorial', function () {
 
     beforeEach(async function () {
       store = mockStore()
-      user = userEvent.setup()
+      user = userEvent.setup({ delay: null })
       const tutorialSnapshot = TutorialFactory.build({ steps })
       store.tutorials.setTutorials([tutorialSnapshot])
       await when(() => store.userProjectPreferences.loadingState === asyncStates.success)

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.spec.js
@@ -18,8 +18,9 @@ describe.skip('Component > Choice', function () {
     expect(screen).to.be.ok()
   })
 
-  it('should call handleDelete when "Not this" button clicked', function () {
+  it('should call handleDelete when "Not this" button clicked', async function () {
     const handleDeleteSpy = sinon.spy()
+    const user = userEvent.setup()
     render(
       <Choice
         choiceId='KD'
@@ -28,13 +29,14 @@ describe.skip('Component > Choice', function () {
       />
     )
     const button = screen.getByRole('button', { name: 'SurveyTask.Choice.notThis' })
-    userEvent.click(button)
+    await user.click(button)
 
     expect(handleDeleteSpy).to.have.been.calledOnceWith('KD')
   })
 
-  it('should call onIdentify when "Identify" button clicked', function () {
+  it('should call onIdentify when "Identify" button clicked', async function () {
     const onIdentifySpy = sinon.spy()
+    const user = userEvent.setup()
     render(
       <Choice
         choiceId='FR'
@@ -42,7 +44,7 @@ describe.skip('Component > Choice', function () {
         task={mockTask}
       />
     )
-    userEvent.click(screen.getByText('SurveyTask.Choice.identify'))
+    await user.click(screen.getByText('SurveyTask.Choice.identify'))
 
     expect(onIdentifySpy).to.have.been.calledOnce()
   })

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.spec.js
@@ -20,7 +20,7 @@ describe.skip('Component > Choice', function () {
 
   it('should call handleDelete when "Not this" button clicked', async function () {
     const handleDeleteSpy = sinon.spy()
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
     render(
       <Choice
         choiceId='KD'
@@ -36,7 +36,7 @@ describe.skip('Component > Choice', function () {
 
   it('should call onIdentify when "Identify" button clicked', async function () {
     const onIdentifySpy = sinon.spy()
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
     render(
       <Choice
         choiceId='FR'

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.spec.js
@@ -7,7 +7,13 @@ import userEvent from '@testing-library/user-event'
 import { task as mockTask } from '@plugins/tasks/survey/mock-data'
 import Choice from './Choice'
 
-describe.skip('Component > Choice', function () {
+describe('Component > Choice', function () {
+  /*
+    Disable the default mocha timeout.
+    TODO: figure out why these tests are so slow.
+  */
+  this.timeout(0)
+
   it('should render without crashing', function () {
     render(
       <Choice

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/components/Confusion.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/components/Confusion.spec.js
@@ -84,8 +84,9 @@ describe('Component > Confusion', function () {
     expect(screen.getByRole('button', { name: 'SurveyTask.ConfusedWith.cancel' })).to.exist()
   })
 
-  it('should call onClose when the Cancel button is clicked', function () {
+  it('should call onClose when the Cancel button is clicked', async function () {
     const onCloseSpy = sinon.spy()
+    const user = userEvent.setup()
 
     render(
       <Confusion
@@ -97,7 +98,7 @@ describe('Component > Confusion', function () {
       />
     )
     /** The translation function will simply return keys in a testing env */
-    userEvent.click(screen.getByRole('button', { name: 'SurveyTask.ConfusedWith.cancel' }))
+    await user.click(screen.getByRole('button', { name: 'SurveyTask.ConfusedWith.cancel' }))
     expect(onCloseSpy).to.have.been.calledOnce()
   })
 
@@ -114,8 +115,9 @@ describe('Component > Confusion', function () {
     expect(screen.getByRole('button', { name: 'SurveyTask.ConfusedWith.itsThis' })).to.exist()
   })
 
-  it('should call handleChoice with confusion ID when the "I think it\'s this" button is clicked', function () {
+  it('should call handleChoice with confusion ID when the "I think it\'s this" button is clicked', async function () {
     const handleChoiceSpy = sinon.spy()
+    const user = userEvent.setup()
 
     render(
       <Confusion
@@ -127,7 +129,7 @@ describe('Component > Confusion', function () {
       />
     )
     /** The translation function will simply return keys in a testing env */
-    userEvent.click(screen.getByRole('button', { name: 'SurveyTask.ConfusedWith.itsThis' }))
+    await user.click(screen.getByRole('button', { name: 'SurveyTask.ConfusedWith.itsThis' }))
     expect(handleChoiceSpy).to.have.been.calledOnceWith('LND')
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/components/Confusion.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/components/Confusion.spec.js
@@ -86,7 +86,7 @@ describe('Component > Confusion', function () {
 
   it('should call onClose when the Cancel button is clicked', async function () {
     const onCloseSpy = sinon.spy()
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
 
     render(
       <Confusion
@@ -117,7 +117,7 @@ describe('Component > Confusion', function () {
 
   it('should call handleChoice with confusion ID when the "I think it\'s this" button is clicked', async function () {
     const handleChoiceSpy = sinon.spy()
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
 
     render(
       <Confusion

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/components/InputGroup/components/QuestionInput.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/components/InputGroup/components/QuestionInput.spec.js
@@ -90,8 +90,9 @@ describe('Component > QuestionInput', function () {
     })
 
     describe('onChange', function () {
-      it('should call handleCheckBoxChange with checked and value', function () {
+      it('should call handleCheckBoxChange with checked and value', async function () {
         const handleCheckBoxChangeSpy = sinon.spy()
+        const user = userEvent.setup()
         render(
           <Grommet
             theme={zooTheme}
@@ -109,7 +110,7 @@ describe('Component > QuestionInput', function () {
           </Grommet>
         )
         expect(handleCheckBoxChangeSpy).to.not.have.been.called()
-        userEvent.click(screen.getByLabelText('Eating'))
+        await user.click(screen.getByLabelText('Eating'))
         expect(handleCheckBoxChangeSpy).to.have.been.calledWith('TNG', true)
       })
     })
@@ -196,8 +197,9 @@ describe('Component > QuestionInput', function () {
     })
 
     describe('onClick', function () {
-      it('should call handleRadioChange with value and checked', function () {
+      it('should call handleRadioChange with value and checked', async function () {
         const handleRadioChangeSpy = sinon.spy()
+        const user = userEvent.setup()
         render(
           <Grommet
             theme={zooTheme}
@@ -215,14 +217,15 @@ describe('Component > QuestionInput', function () {
           </Grommet>
         )
         expect(handleRadioChangeSpy).to.not.have.been.called()
-        userEvent.click(screen.getByLabelText('Yes'))
+        await user.click(screen.getByLabelText('Yes'))
         expect(handleRadioChangeSpy).to.have.been.calledWith('S')
       })
     })
 
     describe('onKeyDown', function () {
-      it('should call handleRadioKeyDown on keyDown of the input', function () {
+      it('should call handleRadioKeyDown on keyDown of the input', async function () {
         const handleRadioKeyDownSpy = sinon.spy()
+        const user = userEvent.setup()
         render(
           <Grommet
             theme={zooTheme}
@@ -240,7 +243,7 @@ describe('Component > QuestionInput', function () {
           </Grommet>
         )
         expect(handleRadioKeyDownSpy).to.not.have.been.called()
-        userEvent.type(screen.getByLabelText('Yes'), '{backspace}')
+        await user.type(screen.getByLabelText('Yes'), '{backspace}')
         expect(handleRadioKeyDownSpy).to.have.been.calledOnce()
       })
     })

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/components/InputGroup/components/QuestionInput.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/components/InputGroup/components/QuestionInput.spec.js
@@ -92,7 +92,7 @@ describe('Component > QuestionInput', function () {
     describe('onChange', function () {
       it('should call handleCheckBoxChange with checked and value', async function () {
         const handleCheckBoxChangeSpy = sinon.spy()
-        const user = userEvent.setup()
+        const user = userEvent.setup({ delay: null })
         render(
           <Grommet
             theme={zooTheme}
@@ -199,7 +199,7 @@ describe('Component > QuestionInput', function () {
     describe('onClick', function () {
       it('should call handleRadioChange with value and checked', async function () {
         const handleRadioChangeSpy = sinon.spy()
-        const user = userEvent.setup()
+        const user = userEvent.setup({ delay: null })
         render(
           <Grommet
             theme={zooTheme}
@@ -225,7 +225,7 @@ describe('Component > QuestionInput', function () {
     describe('onKeyDown', function () {
       it('should call handleRadioKeyDown on keyDown of the input', async function () {
         const handleRadioKeyDownSpy = sinon.spy()
-        const user = userEvent.setup()
+        const user = userEvent.setup({ delay: null })
         render(
           <Grommet
             theme={zooTheme}

--- a/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
@@ -37,6 +37,11 @@ describe('TextTask > Components > TextTaskWithSuggestions', function () {
   })
 
   it('should show text suggestions', async function () {
+    /*
+      This test takes 4s to run. The workaround is to disable the default mocha timeout.
+      TODO: figure out why these tests are so slow.
+    */
+    this.timeout(0)
     const user = userEvent.setup({ delay: null })
     const suggestions = ['one', 'two', 'three']
     render(

--- a/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 import React from 'react'
 import { default as Task } from '@plugins/tasks/text'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import TextTaskWithSuggestions from './TextTaskWithSuggestions'
 
 describe('TextTask > Components > TextTaskWithSuggestions', function () {
@@ -14,26 +15,38 @@ describe('TextTask > Components > TextTaskWithSuggestions', function () {
   // default text annotation value = ''
   const annotation = task.defaultAnnotation()
 
-  it('should render without crashing', function () {
-    render(
-      <TextTaskWithSuggestions
-        task={task}
-        value={annotation.value}
-      />
-    )
-
-    expect(screen).to.be.ok()
-  })
-
   it('should have a labelled TextInput', function () {
     render(
       <TextTaskWithSuggestions
+        suggestions={['one', 'two', 'three']}
         task={task}
         value={annotation.value}
       />
     )
 
-    expect(screen.getByText(task.instruction)).to.exist()
+    expect(screen.getByLabelText(task.instruction)).to.exist()
+  })
+
+  it('should show text suggestions', async function () {
+    const user = userEvent.setup()
+    const suggestions = ['one', 'two', 'three']
+    render(
+      <TextTaskWithSuggestions
+        suggestions={suggestions}
+        task={task}
+        value={annotation.value}
+      />
+    )
+
+    const textInput = screen.getByLabelText(task.instruction)
+    await user.pointer({
+      keys: '[MouseLeft]',
+      target: textInput
+    })
+    suggestions.forEach(suggestion => {
+      const option = screen.getByRole('button', { name: suggestion })
+      expect(option).to.exist()
+    })
   })
 
   describe('with value and suggestions', function () {
@@ -51,6 +64,28 @@ describe('TextTask > Components > TextTaskWithSuggestions', function () {
       )
 
       expect(screen.getByDisplayValue(annotation.value)).to.exist()
+    })
+
+    it('should not show text suggestions', async function () {
+      const user = userEvent.setup()
+      const suggestions = ['one', 'two', 'three']
+      render(
+        <TextTaskWithSuggestions
+          suggestions={suggestions}
+          task={task}
+          value={annotation.value}
+        />
+      )
+
+      const textInput = screen.getByLabelText(task.instruction)
+      await user.pointer({
+        keys: '[MouseLeft]',
+        target: textInput
+      })
+      suggestions.forEach(suggestion => {
+        const option = screen.queryByRole('button', { name: suggestion })
+        expect(option).to.be.null()
+      })
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
@@ -37,7 +37,7 @@ describe('TextTask > Components > TextTaskWithSuggestions', function () {
   })
 
   it('should show text suggestions', async function () {
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
     const suggestions = ['one', 'two', 'three']
     render(
       <TextTaskWithSuggestions
@@ -72,7 +72,7 @@ describe('TextTask > Components > TextTaskWithSuggestions', function () {
     })
 
     it('should not show text suggestions', async function () {
-      const user = userEvent.setup()
+      const user = userEvent.setup({ delay: null })
       const suggestions = ['one', 'two', 'three']
       render(
         <TextTaskWithSuggestions

--- a/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
@@ -12,15 +12,13 @@ describe('TextTask > Components > TextTaskWithSuggestions', function () {
     text_tags: ['insertion', 'deletion'],
     type: 'text'
   })
-  // default text annotation value = ''
-  const annotation = task.defaultAnnotation()
 
   it('should have a labelled TextInput', function () {
     render(
       <TextTaskWithSuggestions
         suggestions={['one', 'two', 'three']}
         task={task}
-        value={annotation.value}
+        value=''
       />
     )
 
@@ -34,7 +32,7 @@ describe('TextTask > Components > TextTaskWithSuggestions', function () {
       <TextTaskWithSuggestions
         suggestions={suggestions}
         task={task}
-        value={annotation.value}
+        value=''
       />
     )
 
@@ -50,20 +48,16 @@ describe('TextTask > Components > TextTaskWithSuggestions', function () {
   })
 
   describe('with value and suggestions', function () {
-    before(function () {
-      annotation.update('This is an updated annotation value.')
-    })
-
     it('should render the value', function () {
       render(
         <TextTaskWithSuggestions
           suggestions={['one', 'two', 'three']}
           task={task}
-          value={annotation.value}
+          value='This is an updated annotation value.'
         />
       )
 
-      expect(screen.getByDisplayValue(annotation.value)).to.exist()
+      expect(screen.getByDisplayValue('This is an updated annotation value.')).to.exist()
     })
 
     it('should not show text suggestions', async function () {
@@ -73,7 +67,7 @@ describe('TextTask > Components > TextTaskWithSuggestions', function () {
         <TextTaskWithSuggestions
           suggestions={suggestions}
           task={task}
-          value={annotation.value}
+          value='This is an updated annotation value.'
         />
       )
 

--- a/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
@@ -1,16 +1,27 @@
-import { expect } from 'chai'
-import React from 'react'
-import { default as Task } from '@plugins/tasks/text'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { expect } from 'chai'
+import React from 'react'
+import sinon from 'sinon'
+
+import { default as Task } from '@plugins/tasks/text'
 import TextTaskWithSuggestions from './TextTaskWithSuggestions'
 
 describe('TextTask > Components > TextTaskWithSuggestions', function () {
-  const task = Task.TaskModel.create({
-    instruction: 'Type something here',
-    taskKey: 'T0',
-    text_tags: ['insertion', 'deletion'],
-    type: 'text'
+  let task
+
+  before(function () {
+    sinon.stub(window, 'scrollTo')
+    task = Task.TaskModel.create({
+      instruction: 'Type something here',
+      taskKey: 'T0',
+      text_tags: ['insertion', 'deletion'],
+      type: 'text'
+    })
+  })
+
+  after(function () {
+    window.scrollTo.restore()
   })
 
   it('should have a labelled TextInput', function () {

--- a/packages/lib-classifier/test/.mocharc.json
+++ b/packages/lib-classifier/test/.mocharc.json
@@ -11,8 +11,8 @@
     "ignore-styles"
   ],
   "file": [
-    "./test/enzyme-config.js",
-    "./test/setup.js"
+    "./test/setup.js",
+    "./test/enzyme-config.js"
   ],
   "reporter": "spec",
   "ui": "bdd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3741,6 +3741,11 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+"@testing-library/user-event@~14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.1.0.tgz#db479c06271b72a4d41cf595ec2ad7ff078c1d72"
+  integrity sha512-+CGfMXlVM+OwREHDEsfTGsXIMI+rjr3a7YBUSutq7soELht+8kQrM5k46xa/WLfHdtX/wqsDIleL6bi4i+xz0w==
+
 "@tippyjs/react@~4.2.6":
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/@tippyjs/react/-/react-4.2.6.tgz#971677a599bf663f20bb1c60a62b9555b749cc71"


### PR DESCRIPTION
- upgrade `user-events` to 14 (13.5 is no longer maintained.)
- test the text task with suggestions when we click into it, both with and without an existing value. Suggestions should show when the input is empty.
- fix broken test setup. Enzyme must be set up after JSDOM.
- disable timeouts on slow-running tests, so we can run the `Choice` tests again.

Follow up to #3001, which fixed a bug in transcription projects but didn't add tests.

## Package
lib-classifier

## General
- [ ] Tests are passing locally and on Github
