### PR TITLE
Classifier: Test `ClassificationQueue` with fake timers

### DIFF
--- a/packages/lib-classifier/src/store/utils/ClassificationQueue.js
+++ b/packages/lib-classifier/src/store/utils/ClassificationQueue.js
@@ -6,9 +6,9 @@ import * as Sentry from '@sentry/browser'
 import { panoptes } from '@zooniverse/panoptes-js'
 import { getBearerToken } from './'
 
-const FAILED_CLASSIFICATION_QUEUE_NAME = 'failed-classifications'
-const MAX_RECENTS = 10
-const RETRY_INTERVAL = 5 * 60 * 1000
+export const FAILED_CLASSIFICATION_QUEUE_NAME = 'failed-classifications'
+export const MAX_RECENTS = 10
+export const RETRY_INTERVAL = 5 * 60 * 1000
 
 class ClassificationQueue {
   constructor (api, onClassificationSaved, authClient) {
@@ -19,6 +19,7 @@ class ClassificationQueue {
     this.flushTimeout = null
     this.onClassificationSaved = onClassificationSaved || function () { return true }
     this.endpoint = '/classifications'
+    this.flushToBackend = this.flushToBackend.bind(this)
   }
 
   add (classification) {
@@ -90,7 +91,7 @@ class ClassificationQueue {
         try {
           this.store(classificationData)
           if (!this.flushTimeout) {
-            this.flushTimeout = setTimeout(this.flushToBackend.bind(this), RETRY_INTERVAL)
+            this.flushTimeout = setTimeout(this.flushToBackend, RETRY_INTERVAL)
           }
         } catch (saveQueueError) {
           console.error('Failed to update classification queue:', saveQueueError)

--- a/packages/lib-classifier/src/store/utils/ClassificationQueue.spec.js
+++ b/packages/lib-classifier/src/store/utils/ClassificationQueue.spec.js
@@ -1,17 +1,20 @@
 import { expect } from 'chai'
 import sinon from 'sinon'
-import ClassificationQueue from './ClassificationQueue'
+import ClassificationQueue, { RETRY_INTERVAL } from './ClassificationQueue'
 
 // TODO: migrate this to use panoptes js stub and factories
 describe('ClassificationQueue', function () {
   let apiClient
   let classificationQueue
   let classificationData = { annotations: [], metadata: {} }
+
   afterEach(function () {
     classificationQueue._saveQueue([])
   })
+
   describe('sends classifications to the backend', function () {
     let postSpy
+
     beforeEach(function () {
       apiClient = {
         post: () => Promise.resolve({ body: { classifications: [{ id: '1' }] }, status: 201, ok: true })
@@ -19,6 +22,7 @@ describe('ClassificationQueue', function () {
       postSpy = sinon.spy(apiClient, 'post')
       classificationQueue = new ClassificationQueue(apiClient)
     })
+
     it('saves classifications to the API', async function () {
       await classificationQueue.add(classificationData)
       expect(postSpy).to.have.been.called()
@@ -26,10 +30,12 @@ describe('ClassificationQueue', function () {
         expect(response.ok).to.be.true()
       })
     })
+
     it('does not store saved classifications', async function () {
       await classificationQueue.add(classificationData)
       expect(classificationQueue.length()).to.equal(0)
     })
+
     it('adds saved classifications to the recents queue', async function () {
       await classificationQueue.add(classificationData)
       expect(classificationQueue.recents).to.have.lengthOf(1)
@@ -37,22 +43,30 @@ describe('ClassificationQueue', function () {
   })
 
   describe('keeps classifications in localStorage if backend fails', function () {
+    let clock
     let postSpy
+
+    before(function () {
+      clock = sinon.useFakeTimers({ global })
+    })
+
+    after(function () {
+      clock.restore()
+    })
+
     beforeEach(function () {
-      apiClient = { post: () =>
-        Promise.reject(new Error('Stubbing error response'))
-          .catch(() => { return { body: {}, ok: false, status: 504 } })
+      apiClient = { 
+        post: () => {
+          const error = new Error('Stubbing error response')
+          error.status = 504
+          return Promise.reject(error)
+        }
       }
       postSpy = sinon.spy(apiClient, 'post')
       classificationData = { annotations: [], metadata: {} }
       classificationQueue = new ClassificationQueue(apiClient)
-      sinon.stub(global, 'setTimeout').callsFake(() => 100)
-      sinon.stub(global, 'clearTimeout')
     })
-    afterEach(function () {
-      global.setTimeout.restore()
-      global.clearTimeout.restore()
-    })
+
     it('should not save failed classifications', async function () {
       try {
         await classificationQueue.add(classificationData)
@@ -62,34 +76,98 @@ describe('ClassificationQueue', function () {
         })
       } catch (error) {}
     })
+
     it('should queue failed classifications to retry', async function () {
       try {
         await classificationQueue.add(classificationData)
         expect(classificationQueue.length()).to.equal(1)
       } catch (e) {}
     })
+
     it('should not add failed classifications to recents', async function () {
       try {
         await classificationQueue.add(classificationData)
         expect(classificationQueue.recents).to.have.lengthOf(0)
       } catch (e) {}
     })
+
     it('should set a timer to retry failed classifications', async function () {
-      sinon.stub(classificationQueue.flushToBackend, 'bind').callsFake(() => classificationQueue.flushToBackend)
-      try {
-        await classificationQueue.add(classificationData)
-        expect(global.setTimeout.withArgs(classificationQueue.flushToBackend)).to.have.been.calledOnce()
-        expect(classificationQueue.flushTimeout).to.equal(100)
-      } catch (e) {}
-      classificationQueue.flushToBackend.bind.restore()
+      expect(classificationQueue.flushTimeout).to.be.null()
+      await classificationQueue.add(classificationData)
+      expect(classificationQueue.flushTimeout).to.exist()
     })
-    it('should cancel any existing timer before flushing the queue', function () {
-      classificationQueue.flushTimeout = 100
+
+    it('should cancel any existing timer before flushing the queue', async function () {
+      await classificationQueue.add(classificationData)
+      expect(classificationQueue.flushTimeout).to.exist()
       classificationQueue.add(classificationData)
-      expect(global.clearTimeout.withArgs(100)).to.have.been.calledOnce()
       expect(classificationQueue.flushTimeout).to.be.null()
     })
   })
+
+  describe('with invalid classifications', function () {
+    let clock
+    let postSpy
+
+    before(function () {
+      clock = sinon.useFakeTimers({ global })
+    })
+
+    after(function () {
+      clock.restore()
+    })
+
+    beforeEach(function () {
+      apiClient = { 
+        post: () => {
+          const error = new Error('Stubbing error response')
+          error.status = 422
+          return Promise.reject(error)
+        }
+      }
+      postSpy = sinon.spy(apiClient, 'post')
+      classificationData = { annotations: [], metadata: {} }
+      classificationQueue = new ClassificationQueue(apiClient)
+    })
+
+    it('should not save failed classifications', async function () {
+      try {
+        await classificationQueue.add(classificationData)
+        expect(postSpy).to.have.been.called()
+        postSpy.returnValues[0].then((response) => {
+          expect(response.ok).to.be.false()
+        })
+      } catch (error) {}
+    })
+
+    it('should not queue failed classifications to retry', async function () {
+      try {
+        await classificationQueue.add(classificationData)
+        expect(classificationQueue.length()).to.equal(0)
+      } catch (e) {}
+    })
+
+    it('should not add failed classifications to recents', async function () {
+      try {
+        await classificationQueue.add(classificationData)
+        expect(classificationQueue.recents).to.have.lengthOf(0)
+      } catch (e) {}
+    })
+
+    it('should not set a timer to retry failed classifications', async function () {
+      expect(classificationQueue.flushTimeout).to.be.null()
+      await classificationQueue.add(classificationData)
+      expect(classificationQueue.flushTimeout).to.be.null()
+    })
+
+    it('should cancel any existing timer before flushing the queue', async function () {
+      classificationQueue.flushTimeout = setTimeout(classificationQueue.flushToBackend, RETRY_INTERVAL)
+      expect(classificationQueue.flushTimeout).to.exist()
+      classificationQueue.add(classificationData)
+      expect(classificationQueue.flushTimeout).to.be.null()
+    })
+  })
+
   describe('with a slow network connection', function () {
     let apiClient
     let postSpy


### PR DESCRIPTION
- Clean up the `ClassificationQueue` tests, to make them easier to read. 
- Use fake timers to test the retry timeouts.
- Add tests for the case where a classification can't be saved (422 response.)

## Package
lib-classifier


## General
- [x] Tests are passing locally and on Github
