### PR TITLE
Test the Classifier

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -46,7 +46,6 @@ describe('Components > Classifier', function () {
         <Classifier
           classifierStore={store}
           project={projectSnapshot}
-          subjectID={subject?.id}
           workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
           workflowVersion={workflowSnapshot?.version}
@@ -107,7 +106,6 @@ describe('Components > Classifier', function () {
         <Classifier
           classifierStore={store}
           project={projectSnapshot}
-          subjectID={subject?.id}
           workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
           workflowVersion={workflowSnapshot?.version}
@@ -172,7 +170,6 @@ describe('Components > Classifier', function () {
           classifierStore={store}
           locale='en'
           project={projectSnapshot}
-          subjectID={subject?.id}
           workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
           workflowVersion={workflowSnapshot?.version}
@@ -187,7 +184,6 @@ describe('Components > Classifier', function () {
           classifierStore={store}
           locale='fr'
           project={projectSnapshot}
-          subjectID={subject?.id}
           workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
           workflowVersion={workflowSnapshot?.version}

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -15,7 +15,6 @@ import RootStore from '@store'
 import { ProjectFactory, SubjectFactory } from '@test/factories'
 import mockStore, { defaultAuthClient, defaultClient } from '@test/mockStore/mockStore'
 import branchingWorkflow from '@test/mockStore/branchingWorkflow'
-import stubPanoptesJs from '@test/stubPanoptesJs'
 import Classifier from './Classifier'
 
 describe('Components > Classifier', function () {

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -1,13 +1,21 @@
 import * as React from 'react'
-import zooTheme from '@zooniverse/grommet-theme'
-import { Grommet } from 'grommet'
 import { within } from '@testing-library/dom'
 import { render, screen } from '@testing-library/react'
+import asyncStates from '@zooniverse/async-states'
+import zooTheme from '@zooniverse/grommet-theme'
+import { panoptes } from '@zooniverse/panoptes-js'
+import { Grommet } from 'grommet'
+import { when } from 'mobx'
 import { Provider } from 'mobx-react'
 import { getSnapshot } from 'mobx-state-tree'
+import { Factory } from 'rosie'
+import sinon from 'sinon'
 
-import { SubjectFactory } from '@test/factories'
-import mockStore from '@test/mockStore'
+import RootStore from '@store'
+import { ProjectFactory, SubjectFactory } from '@test/factories'
+import mockStore, { defaultAuthClient, defaultClient } from '@test/mockStore/mockStore'
+import branchingWorkflow from '@test/mockStore/branchingWorkflow'
+import stubPanoptesJs from '@test/stubPanoptesJs'
 import Classifier from './Classifier'
 
 describe('Components > Classifier', function () {
@@ -226,6 +234,191 @@ describe('Components > Classifier', function () {
       it('should be enabled', function () {
         taskAnswers.forEach(radioButton => {
           expect(radioButton.disabled).to.be.false()
+        })
+      })
+    })
+  })
+
+  describe('with permission to view an inactive workflow', function () {
+    before(async function () {
+      const roles = ['owner']
+      const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+      const workflowSnapshot = branchingWorkflow
+      const projectSnapshot = ProjectFactory.build({
+        links: {
+          active_workflows: [],
+          workflows: [workflowSnapshot.id]
+        }
+      })
+      sinon.stub(panoptes, 'get').callsFake((endpoint, query, headers) => {
+        switch (endpoint) {
+          case '/field_guides': {
+            const field_guides = []
+            return Promise.resolve({ body: { field_guides }})
+          }
+          case '/project_preferences': {
+            const project_preferences = []
+            return Promise.resolve({ body: { project_preferences }})
+          }
+          case '/project_roles': {
+            const project_roles = [{ roles }]
+            return Promise.resolve({ body: { project_roles }})
+          }
+          case '/subjects/queued': {
+            const subjects = [subjectSnapshot, ...Factory.buildList('subject', 9)]
+            return Promise.resolve({ body: { subjects }})
+          }
+        }
+      })
+      sinon.stub(panoptes, 'post').callsFake((...args) => {
+        return Promise.resolve({ headers: {}, body: { project_preferences: []}})
+      })
+      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
+      const checkCurrent = sinon.stub().callsFake(() => Promise.resolve({ id: 123, login: 'mockUser' }))
+      const authClient = { ...defaultAuthClient, checkBearerToken, checkCurrent }
+      const client = { ...defaultClient, panoptes }
+      const store = RootStore.create({}, { authClient, client })
+      render(
+        <Classifier
+          classifierStore={store}
+          project={projectSnapshot}
+          workflowID={workflowSnapshot.id}
+          workflowSnapshot={workflowSnapshot}
+          workflowVersion={workflowSnapshot.version}
+        />,
+        {
+          wrapper: withStore(store)
+        }
+      )
+      await when(() => store.subjects.loadingState === asyncStates.success)
+      store.subjectViewer.onSubjectReady()
+      taskTab = screen.getByRole('tab', { name: 'TaskArea.task'})
+      tutorialTab = screen.getByRole('tab', { name: 'TaskArea.tutorial'})
+      subjectImage = screen.queryByRole('img', { name: `Subject ${subjectSnapshot.id}` })
+      tabPanel = screen.getByRole('tabpanel', { name: '1 Tab Contents'})
+      const task = workflowSnapshot.tasks.T0
+      const getAnswerInput = answer => within(tabPanel).getByRole('radio', { name: answer.label })
+      taskAnswers = task.answers.map(getAnswerInput)
+    })
+
+    after(function () {
+      panoptes.get.restore()
+      panoptes.post.restore()
+    })
+
+    it('should have a task tab', function () {
+      expect(taskTab).to.be.ok()
+    })
+
+    it('should have a tutorial tab', function () {
+      expect(tutorialTab).to.be.ok()
+    })
+
+    it('should have a subject image', function () {
+      expect(subjectImage).to.be.ok()
+    })
+
+    describe('task answers', function () {
+      it('should be displayed', function () {
+        expect(taskAnswers).to.have.lengthOf(workflow.tasks.T0.answers.length)
+      })
+
+      it('should be linked to the task', function () {
+        taskAnswers.forEach(radioButton => {
+          expect(radioButton.name).to.equal('T0')
+        })
+      })
+
+      it('should be enabled', function () {
+        taskAnswers.forEach(radioButton => {
+          expect(radioButton.disabled).to.be.false()
+        })
+      })
+    })
+  })
+
+  describe('without permission to view an inactive workflow', function () {
+    before(async function () {
+      const roles = []
+      const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+      const workflowSnapshot = branchingWorkflow
+      const projectSnapshot = ProjectFactory.build({
+        links: {
+          active_workflows: [],
+          workflows: [workflowSnapshot.id]
+        }
+      })
+      sinon.stub(panoptes, 'get').callsFake((endpoint, query, headers) => {
+        switch (endpoint) {
+          case '/field_guides': {
+            const field_guides = []
+            return Promise.resolve({ body: { field_guides }})
+          }
+          case '/project_preferences': {
+            const project_preferences = []
+            return Promise.resolve({ body: { project_preferences }})
+          }
+          case '/project_roles': {
+            const project_roles = [{ roles }]
+            return Promise.resolve({ body: { project_roles }})
+          }
+          case '/subjects/queued': {
+            const subjects = [subjectSnapshot, ...Factory.buildList('subject', 9)]
+            return Promise.resolve({ body: { subjects }})
+          }
+        }
+      })
+      sinon.stub(panoptes, 'post').callsFake((...args) => {
+        return Promise.resolve({ headers: {}, body: { project_preferences: []}})
+      })
+      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
+      const checkCurrent = sinon.stub().callsFake(() => Promise.resolve({ id: 123, login: 'mockUser' }))
+      const authClient = { ...defaultAuthClient, checkBearerToken, checkCurrent }
+      const client = { ...defaultClient, panoptes }
+      const store = RootStore.create({}, { authClient, client })
+      render(
+        <Classifier
+          classifierStore={store}
+          project={projectSnapshot}
+          workflowID={workflowSnapshot.id}
+          workflowSnapshot={workflowSnapshot}
+          workflowVersion={workflowSnapshot.version}
+        />,
+        {
+          wrapper: withStore(store)
+        }
+      )
+      store.subjectViewer.onSubjectReady()
+      taskTab = screen.queryByRole('tab', { name: 'TaskArea.task'})
+      tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
+      subjectImage = screen.queryByRole('img', { name: `Subject ${subjectSnapshot.id}` })
+      tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const task = workflowSnapshot.tasks.T0
+      const getAnswerInput = answer => within(tabPanel).queryByRole('radio', { name: answer.label })
+      taskAnswers = task.answers.map(getAnswerInput)
+    })
+
+    after(function () {
+      panoptes.get.restore()
+      panoptes.post.restore()
+    })
+
+    it('should have a task tab', function () {
+      expect(taskTab).to.be.ok()
+    })
+
+    it('should have a tutorial tab', function () {
+      expect(tutorialTab).to.be.ok()
+    })
+
+    it('should not have a subject image', function () {
+      expect(subjectImage).to.be.null()
+    })
+
+    describe('task answers', function () {
+      it('should not be displayed', function () {
+        taskAnswers.forEach(radioButton => {
+          expect(radioButton).to.be.null()
         })
       })
     })

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -52,7 +52,9 @@ describe('Components > Classifier', function () {
       tutorialTab = screen.getByRole('tab', { name: 'TaskArea.tutorial'})
       subjectImage = screen.getByRole('img', { name: `Subject ${subject.id}` })
       tabPanel = screen.getByRole('tabpanel', { name: '1 Tab Contents'})
-      taskAnswers = within(tabPanel).getAllByRole('radio')
+      const task = workflowSnapshot.tasks.T0
+      const getAnswerInput = answer => within(tabPanel).getByRole('radio', { name: answer.label })
+      taskAnswers = task.answers.map(getAnswerInput)
     })
 
     it('should have a task tab', function () {
@@ -112,7 +114,9 @@ describe('Components > Classifier', function () {
       tutorialTab = screen.getByRole('tab', { name: 'TaskArea.tutorial'})
       subjectImage = screen.getByRole('img', { name: `Subject ${subject.id}` })
       tabPanel = screen.getByRole('tabpanel', { name: '1 Tab Contents'})
-      taskAnswers = within(tabPanel).getAllByRole('radio')
+      const task = workflowSnapshot.tasks.T0
+      const getAnswerInput = answer => within(tabPanel).getByRole('radio', { name: answer.label })
+      taskAnswers = task.answers.map(getAnswerInput)
     })
 
     it('should have a task tab', function () {

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -149,4 +149,85 @@ describe('Components > Classifier', function () {
       })
     })
   })
+
+  describe('when the locale changes', function () {
+    let locale
+
+    before(function () {
+      const subject = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+      const store = mockStore({ subject })
+      const project = store.projects.active
+      const projectSnapshot = { ...getSnapshot(project) }
+      workflow = store.workflows.active
+      const workflowSnapshot = { ...getSnapshot(workflow) }
+      const { rerender } = render(
+        <Classifier
+          classifierStore={store}
+          locale='en'
+          project={projectSnapshot}
+          subjectID={subject?.id}
+          workflowID={workflowSnapshot?.id}
+          workflowSnapshot={workflowSnapshot}
+          workflowVersion={workflowSnapshot?.version}
+        />,
+        {
+          wrapper: withStore(store)
+        }
+      )
+      store.subjectViewer.onSubjectReady()
+      rerender(
+        <Classifier
+          classifierStore={store}
+          locale='fr'
+          project={projectSnapshot}
+          subjectID={subject?.id}
+          workflowID={workflowSnapshot?.id}
+          workflowSnapshot={workflowSnapshot}
+          workflowVersion={workflowSnapshot?.version}
+        />,
+      )
+      locale = store.locale
+      taskTab = screen.getByRole('tab', { name: 'TaskArea.task'})
+      tutorialTab = screen.getByRole('tab', { name: 'TaskArea.tutorial'})
+      subjectImage = screen.getByRole('img', { name: `Subject ${subject.id}` })
+      tabPanel = screen.getByRole('tabpanel', { name: '1 Tab Contents'})
+      const task = workflowSnapshot.tasks.T0
+      const getAnswerInput = answer => within(tabPanel).getByRole('radio', { name: answer.label })
+      taskAnswers = task.answers.map(getAnswerInput)
+    })
+
+    it('should update the global locale', function () {
+      expect(locale).to.equal('fr')
+    })
+
+    it('should have a task tab', function () {
+      expect(taskTab).to.be.ok()
+    })
+
+    it('should have a tutorial tab', function () {
+      expect(tutorialTab).to.be.ok()
+    })
+
+    it('should have a subject image', function () {
+      expect(subjectImage).to.be.ok()
+    })
+
+    describe('task answers', function () {
+      it('should be displayed', function () {
+        expect(taskAnswers).to.have.lengthOf(workflow.tasks.T0.answers.length)
+      })
+
+      it('should be linked to the task', function () {
+        taskAnswers.forEach(radioButton => {
+          expect(radioButton.name).to.equal('T0')
+        })
+      })
+
+      it('should be enabled', function () {
+        taskAnswers.forEach(radioButton => {
+          expect(radioButton.disabled).to.be.false()
+        })
+      })
+    })
+  })
 })

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -1,0 +1,148 @@
+import * as React from 'react'
+import zooTheme from '@zooniverse/grommet-theme'
+import { Grommet } from 'grommet'
+import { within } from '@testing-library/dom'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'mobx-react'
+import { getSnapshot } from 'mobx-state-tree'
+
+import { SubjectFactory } from '@test/factories'
+import mockStore from '@test/mockStore'
+import Classifier from './Classifier'
+
+describe('Components > Classifier', function () {
+  let subjectImage, tabPanel, taskAnswers, taskTab, tutorialTab, workflow
+
+  this.timeout(0)
+
+  function withStore(store) {
+    return function Wrapper({ children }) {
+      return (
+        <Grommet theme={zooTheme}>
+          <Provider classifierStore={store}>
+            {children}
+          </Provider>
+        </Grommet>
+      )
+    }
+  }
+
+  describe('while the subject is loading', function () {
+    before(function () {
+      const subject = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+      const store = mockStore({ subject })
+      const project = store.projects.active
+      const projectSnapshot = { ...getSnapshot(project) }
+      workflow = store.workflows.active
+      const workflowSnapshot = { ...getSnapshot(workflow) }
+      render(
+        <Classifier
+          classifierStore={store}
+          project={projectSnapshot}
+          subjectID={subject?.id}
+          workflowID={workflowSnapshot?.id}
+          workflowSnapshot={workflowSnapshot}
+          workflowVersion={workflowSnapshot?.version}
+        />,
+        {
+          wrapper: withStore(store)
+        }
+      )
+      taskTab = screen.getByRole('tab', { name: 'TaskArea.task'})
+      tutorialTab = screen.getByRole('tab', { name: 'TaskArea.tutorial'})
+      subjectImage = screen.getByRole('img', { name: `Subject ${subject.id}` })
+      tabPanel = screen.getByRole('tabpanel', { name: '1 Tab Contents'})
+      taskAnswers = within(tabPanel).getAllByRole('radio')
+    })
+
+    it('should have a task tab', function () {
+      expect(taskTab).to.be.ok()
+    })
+
+    it('should have a tutorial tab', function () {
+      expect(tutorialTab).to.be.ok()
+    })
+
+    it('should have a subject image', function () {
+      expect(subjectImage).to.be.ok()
+    })
+
+    describe('task answers', function () {
+      it('should be displayed', function () {
+        expect(taskAnswers).to.have.lengthOf(workflow.tasks.T0.answers.length)
+      })
+
+      it('should be linked to the task', function () {
+        taskAnswers.forEach(radioButton => {
+          expect(radioButton.name).to.equal('T0')
+        })
+      })
+
+      it('should be disabled', function () {
+        taskAnswers.forEach(radioButton => {
+          expect(radioButton.disabled).to.be.true()
+        })
+      })
+    })
+  })
+
+  describe('after the subject has loaded', function () {
+    before(function () {
+      const subject = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+      const store = mockStore({ subject })
+      const project = store.projects.active
+      const projectSnapshot = { ...getSnapshot(project) }
+      workflow = store.workflows.active
+      const workflowSnapshot = { ...getSnapshot(workflow) }
+      render(
+        <Classifier
+          classifierStore={store}
+          project={projectSnapshot}
+          subjectID={subject?.id}
+          workflowID={workflowSnapshot?.id}
+          workflowSnapshot={workflowSnapshot}
+          workflowVersion={workflowSnapshot?.version}
+        />,
+        {
+          wrapper: withStore(store)
+        }
+      )
+      store.subjectViewer.onSubjectReady()
+      taskTab = screen.getByRole('tab', { name: 'TaskArea.task'})
+      tutorialTab = screen.getByRole('tab', { name: 'TaskArea.tutorial'})
+      subjectImage = screen.getByRole('img', { name: `Subject ${subject.id}` })
+      tabPanel = screen.getByRole('tabpanel', { name: '1 Tab Contents'})
+      taskAnswers = within(tabPanel).getAllByRole('radio')
+    })
+
+    it('should have a task tab', function () {
+      expect(taskTab).to.be.ok()
+    })
+
+    it('should have a tutorial tab', function () {
+      expect(tutorialTab).to.be.ok()
+    })
+
+    it('should have a subject image', function () {
+      expect(subjectImage).to.be.ok()
+    })
+
+    describe('task answers', function () {
+      it('should be displayed', function () {
+        expect(taskAnswers).to.have.lengthOf(workflow.tasks.T0.answers.length)
+      })
+
+      it('should be linked to the task', function () {
+        taskAnswers.forEach(radioButton => {
+          expect(radioButton.name).to.equal('T0')
+        })
+      })
+
+      it('should be enabled', function () {
+        taskAnswers.forEach(radioButton => {
+          expect(radioButton.disabled).to.be.false()
+        })
+      })
+    })
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -244,7 +244,7 @@ describe('Components > Classifier', function () {
     allowedRoles.forEach(function (role) {
       describe(role, function () {
         before(async function () {
-          const roles = ['owner']
+          const roles = [role]
           const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
           const workflowSnapshot = branchingWorkflow
           const projectSnapshot = ProjectFactory.build({

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -84,6 +84,7 @@ function SingleImageViewerContainer({
   }
 
   if (loadingState !== asyncStates.initialized) {
+    const subjectID = subject?.id || 'unknown'
     return (
       <SVGPanZoom
         img={subjectImage.current}
@@ -108,7 +109,11 @@ function SingleImageViewerContainer({
           zooming={zooming}
         >
           <g ref={subjectImage}>
-            <SubjectImage {...subjectImageProps} />
+            <SubjectImage
+              role='img'
+              aria-label={`Subject ${subjectID}`}
+              {...subjectImageProps}
+            />
           </g>
         </SingleImageViewer>
       </SVGPanZoom>

--- a/packages/lib-classifier/src/translations/i18n.js
+++ b/packages/lib-classifier/src/translations/i18n.js
@@ -19,7 +19,7 @@ supportedLngs.forEach((lang) => {
     i18n.addResourceBundle(
       lang,
       n,
-      require(`@translations/${lang}/${n}.json`)
+      require(`./${lang}/${n}.json`)
     )
   })
 })

--- a/packages/lib-classifier/test/mockStore/mockStore.js
+++ b/packages/lib-classifier/test/mockStore/mockStore.js
@@ -8,7 +8,7 @@ import stubPanoptesJs from '@test/stubPanoptesJs'
 
 import branchingWorkflow from './branchingWorkflow'
 
-const defaultClient = {
+export const defaultClient = {
   caesar: { request: sinon.stub().callsFake(() => Promise.resolve({})) },
   tutorials: {
     get: sinon.stub().callsFake(() =>
@@ -19,8 +19,14 @@ const defaultClient = {
   }
 }
 
+export const defaultAuthClient = {
+  checkBearerToken: sinon.stub().callsFake(() => Promise.resolve(null)),
+  checkCurrent: sinon.stub().callsFake(() => Promise.resolve(null))
+}
+
 /** build a mock store, with a branching workflow, steps, tasks and subjects. */
 export default function mockStore({
+  authClient = defaultAuthClient,
   client = defaultClient,
   project,
   subject,
@@ -82,10 +88,7 @@ export default function mockStore({
       }
     }
   }, {
-    authClient: {
-      checkBearerToken: sinon.stub().callsFake(() => Promise.resolve(null)),
-      checkCurrent: sinon.stub().callsFake(() => Promise.resolve(null))
-    },
+    authClient: { ...defaultAuthClient, ...authClient },
     client: { ...defaultClient, panoptes, ...client }
   })
   rootStore.subjects.setActiveSubject(subjectSnapshot.id)


### PR DESCRIPTION
Add tests that render the classifier with a mock workflow and single image subject. Check the rendered classifier for the two task area tabs, the task answers and the SVG subject image. Test that locale changes are passed to the store, and that user roles are checked before loading a workflow.

## Package
lib-classifier

## General
- [x] Tests are passing locally and on Github
