### PR TITLE
Maintenance Week: QuickTalk tests

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -41,7 +41,7 @@ function QuickTalk ({
   screenSize,
   expand = false,
   fixedPosition = true,
-  showBadge = true // HACK: Button.badge crashes tests AND storybook for an undetermined reason. // TODO: debug 
+  showBadge = true // HACK: Button.badge crashes tests AND storybook for an undetermined reason. // TODO: debug
 }) {
   const { t } = useTranslation('components')
   // TODO: figure out if/how the QuickTalk component should/could be displayed on mobile
@@ -89,6 +89,7 @@ function QuickTalk ({
         />
         <Button
           a11yTitle='Close comments panel.'
+          data-testid='quicktalk-close-button'
           icon={<Close size='small' />}
           onClick={() => setExpand(false)}
           plain

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -69,9 +69,10 @@ function QuickTalk ({
 
   return (
     <QTPanel
+      a11yTitle='QuickTalk Comments Panel'
       elevation='medium'
+      role='dialog'
       background={{ dark: 'dark-3', light: 'light-3' }}
-      data-testid='quicktalk-panel'
     >
       <Box
         direction='row'

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -50,7 +50,6 @@ function QuickTalk ({
   if (!subject) return null
 
   const [_expand, setExpand] = React.useState(expand)
-  const a11yTitle = `Subject has ${comments.length} comment(s). Click to expand.`
   const badge = (showBadge && comments.length > 0) ? comments.length : false
 
   const QTButton = (fixedPosition) ? FixedButton : Button
@@ -59,7 +58,7 @@ function QuickTalk ({
   if (!_expand) {
     return (
       <QTButton
-        a11yTitle={a11yTitle}
+        a11yTitle={t('QuickTalk.aria.openButton', { count: comments.length })}
         onClick={() => setExpand(true)}
         icon={<Chat />}
         badge={badge}
@@ -69,7 +68,7 @@ function QuickTalk ({
 
   return (
     <QTPanel
-      a11yTitle='QuickTalk Comments Panel'
+      a11yTitle={t('QuickTalk.aria.mainPanel')}
       elevation='medium'
       role='dialog'
       background={{ dark: 'dark-3', light: 'light-3' }}
@@ -81,14 +80,14 @@ function QuickTalk ({
         pad='small'
       >
         <Anchor
-          a11yTitle='Go to Subject Discussion on Talk.'
+          a11yTitle={t('QuickTalk.aria.goToTalk')}
           label={t('QuickTalk.headerLink')}
           href={subject.talkURL}
           target='_blank'
           icon={<Chat />}
         />
         <Button
-          a11yTitle='Close comments panel.'
+          a11yTitle={t('QuickTalk.aria.closeButton')}
           icon={<Close size='small' />}
           onClick={() => setExpand(false)}
           plain

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -61,7 +61,6 @@ function QuickTalk ({
       <QTButton
         a11yTitle={a11yTitle}
         onClick={() => setExpand(true)}
-        data-testid='quicktalk-button'
         icon={<Chat />}
         badge={badge}
       />
@@ -89,7 +88,6 @@ function QuickTalk ({
         />
         <Button
           a11yTitle='Close comments panel.'
-          data-testid='quicktalk-close-button'
           icon={<Close size='small' />}
           onClick={() => setExpand(false)}
           plain

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.spec.js
@@ -59,7 +59,7 @@ const quickTalkButton_target = { name: /Subject has \d+ comment\(s\). Click to e
 const quickTalkCloseButton_target = { name: 'Close comments panel.' }
 const quickTalkPanel_target = { name: 'QuickTalk Comments Panel' }
 
-describe.only('Component > QuickTalk', function () {
+describe('Component > QuickTalk', function () {
   describe('when collapsed', function () {
     beforeEach(function () {
       render(

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.spec.js
@@ -55,6 +55,9 @@ const authorRoles = {
   '300002': [],
 }
 
+const quickTalkButton_target = { name: /Subject has \d+ comment\(s\). Click to expand./ }
+const quickTalkCloseButton_target = { name: 'Close comments panel.' }
+
 describe('Component > QuickTalk', function () {
   describe('when collapsed', function () {
     beforeEach(function () {
@@ -70,15 +73,17 @@ describe('Component > QuickTalk', function () {
     })
 
     it('should render without crashing', function () {
-      expect(screen.queryByTestId('quicktalk-button')).to.exist()
+      expect(screen.queryByRole('button', quickTalkButton_target)).to.exist()
       expect(screen.queryByTestId('quicktalk-panel')).to.not.exist()
     })
 
     it('should expand when clicked', async function () {
       const user = userEvent.setup({ delay: null })
-      await user.click(screen.queryByTestId('quicktalk-button'))
 
-      expect(screen.queryByTestId('quicktalk-button')).to.not.exist()
+      expect(screen.queryByRole('button', quickTalkButton_target)).to.exist()
+      await user.click(screen.queryByRole('button', quickTalkButton_target))
+
+      expect(screen.queryByRole('button', quickTalkButton_target)).to.not.exist()
       expect(screen.queryByTestId('quicktalk-panel')).to.exist()
     })
   })
@@ -98,7 +103,7 @@ describe('Component > QuickTalk', function () {
     })
 
     it('should render without crashing', function () {
-      expect(screen.queryByTestId('quicktalk-button')).to.not.exist()
+      expect(screen.queryByRole('button', quickTalkButton_target)).to.not.exist()
       expect(screen.queryByTestId('quicktalk-panel')).to.exist()
     })
 
@@ -108,9 +113,9 @@ describe('Component > QuickTalk', function () {
 
     it('should collapse when the close button is clicked', async function () {
       const user = userEvent.setup({ delay: null })
-      await user.click(screen.queryByTestId('quicktalk-close-button'))
+      await user.click(screen.queryByRole('button', quickTalkCloseButton_target))
 
-      expect(screen.queryByTestId('quicktalk-button')).to.exist()
+      expect(screen.queryByRole('button', quickTalkButton_target)).to.exist()
       expect(screen.queryByTestId('quicktalk-panel')).to.not.exist()
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.spec.js
@@ -57,8 +57,9 @@ const authorRoles = {
 
 const quickTalkButton_target = { name: /Subject has \d+ comment\(s\). Click to expand./ }
 const quickTalkCloseButton_target = { name: 'Close comments panel.' }
+const quickTalkPanel_target = { name: 'QuickTalk Comments Panel' }
 
-describe('Component > QuickTalk', function () {
+describe.only('Component > QuickTalk', function () {
   describe('when collapsed', function () {
     beforeEach(function () {
       render(
@@ -74,7 +75,7 @@ describe('Component > QuickTalk', function () {
 
     it('should render without crashing', function () {
       expect(screen.queryByRole('button', quickTalkButton_target)).to.exist()
-      expect(screen.queryByTestId('quicktalk-panel')).to.not.exist()
+      expect(screen.queryByRole('dialog', quickTalkPanel_target)).to.not.exist()
     })
 
     it('should expand when clicked', async function () {
@@ -84,7 +85,7 @@ describe('Component > QuickTalk', function () {
       await user.click(screen.queryByRole('button', quickTalkButton_target))
 
       expect(screen.queryByRole('button', quickTalkButton_target)).to.not.exist()
-      expect(screen.queryByTestId('quicktalk-panel')).to.exist()
+      expect(screen.queryByRole('dialog', quickTalkPanel_target)).to.exist()
     })
   })
 
@@ -104,7 +105,7 @@ describe('Component > QuickTalk', function () {
 
     it('should render without crashing', function () {
       expect(screen.queryByRole('button', quickTalkButton_target)).to.not.exist()
-      expect(screen.queryByTestId('quicktalk-panel')).to.exist()
+      expect(screen.queryByRole('dialog', quickTalkPanel_target)).to.exist()
     })
 
     it('should have the correct number of comments', function () {
@@ -116,7 +117,7 @@ describe('Component > QuickTalk', function () {
       await user.click(screen.queryByRole('button', quickTalkCloseButton_target))
 
       expect(screen.queryByRole('button', quickTalkButton_target)).to.exist()
-      expect(screen.queryByTestId('quicktalk-panel')).to.not.exist()
+      expect(screen.queryByRole('dialog', quickTalkPanel_target)).to.not.exist()
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.spec.js
@@ -55,9 +55,9 @@ const authorRoles = {
   '300002': [],
 }
 
-const quickTalkButton_target = { name: /Subject has \d+ comment\(s\). Click to expand./ }
-const quickTalkCloseButton_target = { name: 'Close comments panel.' }
-const quickTalkPanel_target = { name: 'QuickTalk Comments Panel' }
+const quickTalkButton_target = { name: 'QuickTalk.aria.openButton' }
+const quickTalkCloseButton_target = { name: 'QuickTalk.aria.closeButton' }
+const quickTalkPanel_target = { name: 'QuickTalk.aria.mainPanel' }
 
 describe('Component > QuickTalk', function () {
   describe('when collapsed', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.spec.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { QuickTalk } from './QuickTalk'
 
@@ -54,7 +55,7 @@ const authorRoles = {
   '300002': [],
 }
 
-describe.only('Component > QuickTalk', function () {
+describe('Component > QuickTalk', function () {
   describe('when collapsed', function () {
     beforeEach(function () {
       render(
@@ -73,8 +74,9 @@ describe.only('Component > QuickTalk', function () {
       expect(screen.queryByTestId('quicktalk-panel')).to.not.exist()
     })
 
-    it('should expand when clicked', function () {
-      fireEvent.click(screen.queryByTestId('quicktalk-button'))
+    it('should expand when clicked', async function () {
+      const user = userEvent.setup({ delay: null })
+      await user.click(screen.queryByTestId('quicktalk-button'))
 
       expect(screen.queryByTestId('quicktalk-button')).to.not.exist()
       expect(screen.queryByTestId('quicktalk-panel')).to.exist()
@@ -104,8 +106,9 @@ describe.only('Component > QuickTalk', function () {
       expect(screen.queryAllByRole('listitem')).to.have.length(3)
     })
 
-    it('should collapse when the close button is clicked', function () {
-      fireEvent.click(screen.queryByRole('button'))
+    it('should collapse when the close button is clicked', async function () {
+      const user = userEvent.setup({ delay: null })
+      await user.click(screen.queryByTestId('quicktalk-close-button'))
 
       expect(screen.queryByTestId('quicktalk-button')).to.exist()
       expect(screen.queryByTestId('quicktalk-panel')).to.not.exist()

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.spec.js
@@ -1,9 +1,7 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 
 import { QuickTalk } from './QuickTalk'
-
-let wrapper
 
 const subject = {
   id: '100001',
@@ -56,10 +54,10 @@ const authorRoles = {
   '300002': [],
 }
 
-describe('Component > QuickTalk', function () {
+describe.only('Component > QuickTalk', function () {
   describe('when collapsed', function () {
     beforeEach(function () {
-      wrapper = render(
+      render(
         <QuickTalk
           subject={subject}
           comments={comments}
@@ -69,23 +67,23 @@ describe('Component > QuickTalk', function () {
         />
       )
     })
-    
+
     it('should render without crashing', function () {
-      expect(wrapper.queryByTestId('quicktalk-button')).to.exist()
-      expect(wrapper.queryByTestId('quicktalk-panel')).to.not.exist()
+      expect(screen.queryByTestId('quicktalk-button')).to.exist()
+      expect(screen.queryByTestId('quicktalk-panel')).to.not.exist()
     })
-    
+
     it('should expand when clicked', function () {
-      fireEvent.click(wrapper.queryByTestId('quicktalk-button'))
-      
-      expect(wrapper.queryByTestId('quicktalk-button')).to.not.exist()
-      expect(wrapper.queryByTestId('quicktalk-panel')).to.exist()
+      fireEvent.click(screen.queryByTestId('quicktalk-button'))
+
+      expect(screen.queryByTestId('quicktalk-button')).to.not.exist()
+      expect(screen.queryByTestId('quicktalk-panel')).to.exist()
     })
   })
-  
+
   describe('when expanded', function () {
     beforeEach(function () {
-      wrapper = render(
+      render(
         <QuickTalk
           subject={subject}
           comments={comments}
@@ -96,21 +94,21 @@ describe('Component > QuickTalk', function () {
         />
       )
     })
-    
+
     it('should render without crashing', function () {
-      expect(wrapper.queryByTestId('quicktalk-button')).to.not.exist()
-      expect(wrapper.queryByTestId('quicktalk-panel')).to.exist()
+      expect(screen.queryByTestId('quicktalk-button')).to.not.exist()
+      expect(screen.queryByTestId('quicktalk-panel')).to.exist()
     })
-    
+
     it('should have the correct number of comments', function () {
-      expect(wrapper.queryAllByRole('listitem')).to.have.length(3)
+      expect(screen.queryAllByRole('listitem')).to.have.length(3)
     })
-    
+
     it('should collapse when the close button is clicked', function () {
-      fireEvent.click(wrapper.queryByRole('button'))
-      
-      expect(wrapper.queryByTestId('quicktalk-button')).to.exist()
-      expect(wrapper.queryByTestId('quicktalk-panel')).to.not.exist()
+      fireEvent.click(screen.queryByRole('button'))
+
+      expect(screen.queryByTestId('quicktalk-button')).to.exist()
+      expect(screen.queryByTestId('quicktalk-panel')).to.not.exist()
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.spec.js
@@ -11,7 +11,7 @@ const subject = {
 
 const authClient = {}
 
-describe.only('Component > QuickTalkContainer', function () {
+describe('Component > QuickTalkContainer', function () {
   describe('when collapsed', function () {
     beforeEach(function () {
       render(

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.spec.js
@@ -24,7 +24,6 @@ describe('Component > QuickTalkContainer', function () {
     })
 
     it('should render without crashing', function () {
-      screen.debug()
       expect(screen.queryByTestId('quicktalk-button')).to.exist()
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.spec.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { QuickTalkContainer } from './QuickTalkContainer'
+
+const subject = {
+  id: '100001',
+  talkURL: 'https://www.zooniverse.org/projects/zootester/test-project/talk/subjects/100001',
+}
+
+const authClient = {}
+
+describe.only('Component > QuickTalkContainer', function () {
+  describe('when collapsed', function () {
+    beforeEach(function () {
+      render(
+        <QuickTalkContainer
+          authClient={authClient}
+          enabled={true}
+          subject={subject}
+        />
+      )
+    })
+
+    it('should render without crashing', function () {
+      screen.debug()
+      expect(screen.queryByTestId('quicktalk-button')).to.exist()
+    })
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.spec.js
@@ -10,6 +10,7 @@ const subject = {
 }
 
 const authClient = {}
+const quickTalkButton_target = { name: /Subject has \d+ comment\(s\). Click to expand./ }
 
 describe('Component > QuickTalkContainer', function () {
   describe('when collapsed', function () {
@@ -24,7 +25,7 @@ describe('Component > QuickTalkContainer', function () {
     })
 
     it('should render without crashing', function () {
-      expect(screen.queryByTestId('quicktalk-button')).to.exist()
+      expect(screen.queryByRole('button', quickTalkButton_target)).to.exist()
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.spec.js
@@ -10,7 +10,7 @@ const subject = {
 }
 
 const authClient = {}
-const quickTalkButton_target = { name: /Subject has \d+ comment\(s\). Click to expand./ }
+const quickTalkButton_target = { name: 'QuickTalk.aria.openButton' }
 
 describe('Component > QuickTalkContainer', function () {
   describe('when collapsed', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/Comment.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/Comment.spec.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import Comment from './Comment'
+
+const comment = {
+  id: '200001',
+  body: 'This is the first comment',
+  is_deleted: false,
+  user_id: '300001',
+  user_login: 'zootester',
+}
+
+const author = {
+  id: '300001',
+  avatar_src: null,
+  credited_name: 'zootester',
+  display_name: 'Zooniverse Tester',
+  login: 'zootester',
+}
+
+const authorRoles = [
+  { name: 'admin', section: 'project-1234' }
+]
+
+describe('Component > QuickTalk > Comment', function () {
+  beforeEach(function () {
+    render(
+      <ul>
+        <Comment
+          author={author}
+          comment={comment}
+          roles={authorRoles}
+        />
+      </ul>
+    )
+  })
+
+  it('should render the comment', function () {
+    expect(screen.getByText('This is the first comment')).to.exist()
+  })
+
+  it('should render the author details', function () {
+    expect(screen.getByText('Zooniverse Tester')).to.exist()
+    expect(screen.getByText(/\(@\s*zootester\s*\)/)).to.exist()
+
+    expect(screen.getByAltText('Avatar for Zooniverse Tester')).to.exist()
+    expect(screen.getByAltText('Avatar for Zooniverse Tester')).to.have.property('src', 'https://static.zooniverse.org/www.zooniverse.org/assets/simple-avatar.png')
+
+  })
+
+  it('should render the correct roles', function () {
+    expect(screen.getByText(/\[\s*Researcher\s*\]/)).to.exist()
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/Comment.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/Comment.spec.js
@@ -44,8 +44,8 @@ describe('Component > QuickTalk > Comment', function () {
     expect(screen.getByText('Zooniverse Tester')).to.exist()
     expect(screen.getByText(/\(@\s*zootester\s*\)/)).to.exist()
 
-    expect(screen.getByAltText('Avatar for Zooniverse Tester')).to.exist()
-    expect(screen.getByAltText('Avatar for Zooniverse Tester')).to.have.property('src', 'https://static.zooniverse.org/www.zooniverse.org/assets/simple-avatar.png')
+    expect(screen.getByAltText('QuickTalk.aria.userAvatar')).to.exist()
+    expect(screen.getByAltText('QuickTalk.aria.userAvatar')).to.have.property('src', 'https://static.zooniverse.org/www.zooniverse.org/assets/simple-avatar.png')
 
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/PostForm.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/PostForm.spec.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import sinon from 'sinon'
+import userEvent from '@testing-library/user-event'
+
+import PostForm from './PostForm'
+import asyncStates from '@zooniverse/async-states'
+
+describe('Component > QuickTalk > PostForm', function () {
+  const postCommentSpy = sinon.spy()
+
+  beforeEach(function () {
+    render(
+      <PostForm
+        postComment={postCommentSpy}
+        postCommentStatus={asyncStates.initialized}
+        postCommentStatusMessage={undefined}
+      />
+    )
+  })
+
+  afterEach(function () {
+    postCommentSpy.resetHistory()
+  })
+
+  it('should render without crashing', function () {
+    expect(screen.getByRole('textbox', { name: 'Write comments' })).to.exist()
+    expect(screen.getByRole('button', { name: 'Post comment' })).to.exist()
+  })
+
+  it('should call post comments when the "Post" button is clicked', async function () {
+    const user = userEvent.setup({ delay: null })
+    await user.click(screen.getByRole('button', { name: 'Post comment' }))
+    expect(postCommentSpy).to.have.been.calledOnce()
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/UserAvatar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/UserAvatar.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Box, Image } from 'grommet'
+import { useTranslation } from 'react-i18next'
 
 // TEMPORARY
 // TODO: find a permanent home for this PNG
@@ -11,8 +12,9 @@ function UserAvatar ({
   displayName = '',
   size = '3em',
 }) {
+  const { t } = useTranslation('components')
   const imgSrc = (src && src.length > 0) ? src : DEFAULT_AVATAR
-  
+
   return (
     <Box
       alignSelf='center'
@@ -20,7 +22,7 @@ function UserAvatar ({
       height={size}
     >
       <Image
-        alt={`Avatar for ${displayName}`}
+        alt={t('QuickTalk.aria.userAvatar', { name: displayName })}
         src={imgSrc}
         fallback={DEFAULT_AVATAR}
       />

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/UserAvatar.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/UserAvatar.spec.js
@@ -31,8 +31,8 @@ describe('Component > QuickTalk > UserAvatar', function () {
     })
 
     it('should render the default avatar', function () {
-      expect(screen.getByAltText('Avatar for Zooniverse Tester')).to.exist()
-      expect(screen.getByAltText('Avatar for Zooniverse Tester')).to.have.property('src', 'https://static.zooniverse.org/www.zooniverse.org/assets/simple-avatar.png')
+      expect(screen.getByAltText('QuickTalk.aria.userAvatar')).to.exist()
+      expect(screen.getByAltText('QuickTalk.aria.userAvatar')).to.have.property('src', 'https://static.zooniverse.org/www.zooniverse.org/assets/simple-avatar.png')
     })
   })
 
@@ -47,8 +47,8 @@ describe('Component > QuickTalk > UserAvatar', function () {
     })
 
     it('should render the default avatar', function () {
-      expect(screen.getByAltText('Avatar for Random Dude')).to.exist()
-      expect(screen.getByAltText('Avatar for Random Dude')).to.have.property('src', 'https://example.zooniverse.org/avatar/randomDude.png')
+      expect(screen.getByAltText('QuickTalk.aria.userAvatar')).to.exist()
+      expect(screen.getByAltText('QuickTalk.aria.userAvatar')).to.have.property('src', 'https://example.zooniverse.org/avatar/randomDude.png')
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/UserAvatar.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/UserAvatar.spec.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import UserAvatar from './UserAvatar'
+
+const authorOne = {
+  id: '300001',
+  avatar_src: null,
+  credited_name: 'zootester',
+  display_name: 'Zooniverse Tester',
+  login: 'zootester',
+}
+
+const authorTwo = {
+  id: '300002',
+  avatar_src: 'https://example.zooniverse.org/avatar/randomDude.png',
+  credited_name: 'randomdude',
+  display_name: 'Random Dude',
+  login: 'randomdude',
+}
+
+describe('Component > QuickTalk > UserAvatar', function () {
+  describe('when a user has no specific avatar', function () {
+    beforeEach(function () {
+      render(
+        <UserAvatar
+          src={authorOne.avatar_src}
+          displayName={authorOne.display_name}
+        />
+      )
+    })
+
+    it('should render the default avatar', function () {
+      expect(screen.getByAltText('Avatar for Zooniverse Tester')).to.exist()
+      expect(screen.getByAltText('Avatar for Zooniverse Tester')).to.have.property('src', 'https://static.zooniverse.org/www.zooniverse.org/assets/simple-avatar.png')
+    })
+  })
+
+  describe('when a user has a specific avatar', function () {
+    beforeEach(function () {
+      render(
+        <UserAvatar
+          src={authorTwo.avatar_src}
+          displayName={authorTwo.display_name}
+        />
+      )
+    })
+
+    it('should render the default avatar', function () {
+      expect(screen.getByAltText('Avatar for Random Dude')).to.exist()
+      expect(screen.getByAltText('Avatar for Random Dude')).to.have.property('src', 'https://example.zooniverse.org/avatar/randomDude.png')
+    })
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/UserRole.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/UserRole.spec.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import UserRole from './UserRole'
+
+const roleForZooniverseAdmin = { name: 'admin', section: 'zooniverse' }
+const roleForZooniverseTeam = { name: 'team', section: 'zooniverse' }
+const roleForProjectOwner = { name: 'owner', section: 'project-1234' }
+const roleForProjectScientist = { name: 'scientist', section: 'project-1234' }
+const roleForMiscUser = { name: 'video gamer', section: 'project-1234' }
+
+describe('Component > QuickTalk > UserAvatar', function () {
+  describe('when given a specifc role', function () {
+    it('should render correct text for a Zooniverse Admin', function () {
+      render(<UserRole role={roleForZooniverseAdmin} />)
+      expect(screen.getByText(/\[\s*Zooniverse Team\s*\]/)).to.exist()
+    })
+
+    it('should render correct text for a Zooniverse Team member', function () {
+      render(<UserRole role={roleForZooniverseTeam} />)
+      expect(screen.getByText(/\[\s*Zooniverse Team\s*\]/)).to.exist()
+    })
+
+    it('should render correct text for a Project owner', function () {
+      render(<UserRole role={roleForProjectOwner} />)
+      expect(screen.getByText(/\[\s*Researcher\s*\]/)).to.exist()
+    })
+
+    it('should render correct text for a Project scientist', function () {
+      render(<UserRole role={roleForProjectScientist} />)
+      expect(screen.getByText(/\[\s*Researcher\s*\]/)).to.exist()
+    })
+
+    it('should render correct text for a Project scientist', function () {
+      render(<UserRole role={roleForMiscUser} />)
+      expect(screen.getByText(/\[\s*video gamer\s*\]/)).to.exist()
+    })
+  })
+})

--- a/packages/lib-classifier/src/translations/en/components.json
+++ b/packages/lib-classifier/src/translations/en/components.json
@@ -121,6 +121,12 @@
     "title": "Tutorial"
   },
   "QuickTalk": {
+    "aria": {
+      "openButton": "Subject has {{count}} comment(s). Click to expand.",
+      "mainPanel": "QuickTalk Comments Panel",
+      "closeButton": "Close comments panel",
+      "goToTalk": "Go to Subject Discussion on Talk"
+    },
     "headerLink": "Subject Discussion",
     "status": {
       "loading": "Posting comment..."
@@ -235,7 +241,7 @@
       },
       "TaskHelp": {
         "close": "Close",
-        "label": "Need some help with this task?" 
+        "label": "Need some help with this task?"
       }
     }
   }


### PR DESCRIPTION
## PR Overview

Part of: Maintenance Week

This PR adds tests for the QuickTalk feature, which have thus far been lacking proper tests.

- Most of the functionality tests are performed in `QuickTalk.spec.js`
- Basic tests have been added for the subcomponents
- `QuickTalkContainer.spec.js` meanwhile is missing more robust tests, due to issues with hooking it up to a mock store.
  - I think the problem is that this container might need to be rewritten as a functional component
  - For the record, this is what it needs to test for:
     - If store.project.experimental_tools contains 'quicktalk', then the QuickTalk button should render.
     - If store.project.experimental_tools doesn't contain 'quicktalk', then the QuickTalk button shouldn't render.
     - If there's no store or project, don't render.

### Status

I'm going to mark this as ready for review while I look into creating tests for other components, and rewriting the QuickTalkContainer into a functional component.