### PR TITLE
Run coverage reports on changes to main branch

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,4 +1,4 @@
-name: Build and test
+name: test build
 
 on:
   pull_request
@@ -25,32 +25,6 @@ jobs:
           name: build
           path: packages/*/dist/main.js
 
-  run_tests:
-    name: Run tests
-    runs-on: ubuntu-latest
-    needs: build
-    env:
-      PANOPTES_ENV: test
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 16
-        uses: actions/setup-node@v2
-        with:
-          node-version: '16.x'
-          cache: 'yarn'
-
-      - run: yarn install --production=false --frozen-lockfile
-      - uses: actions/download-artifact@v2
-        with:
-          name: build
-          path: packages/
-      - run: yarn test:ci
-      - run: yarn coverage-lcov
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-    
   build_apps:
     name: Build NextJS apps
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,56 @@
+name: Coverage report
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build libraries
+    runs-on: ubuntu-latest
+    steps:
+    # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#using-the-checkout-action
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          cache: 'yarn'
+
+      - run: yarn install --production=false --frozen-lockfile
+      - run: yarn workspace @zooniverse/react-components build
+      - run: yarn workspace @zooniverse/classifier build
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: packages/*/dist/main.js
+
+  run_tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      PANOPTES_ENV: test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          cache: 'yarn'
+
+      - run: yarn install --production=false --frozen-lockfile
+      - uses: actions/download-artifact@v2
+        with:
+          name: build
+          path: packages/
+      - run: yarn test:ci
+      - run: yarn coverage-lcov
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Split the `ci-tests` workflow into two workflows:
- `ci-build`, which builds the libraries, apps and storybooks after pushes to PRs.
- `coverage`, which runs the tests and generates a coverage report after pushes to PRs and merges to `master`. It can also be run manually from the Actions panel.

#2581 broke our coverage reports, so that the last build reported was 14 December 2021. This PR restores test and coverage reports on changes to `master`.
https://coveralls.io/github/zooniverse/front-end-monorepo
