### PR TITLE
Convert DeleteButton enzyme test to RTL

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.spec.js
@@ -1,7 +1,6 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { render, screen } from '@testing-library/react'
 import { expect } from 'chai'
-import sinon from 'sinon'
 import { Point } from '@plugins/drawingTools/models/marks'
 import { DeleteButton } from './DeleteButton'
 
@@ -9,62 +8,12 @@ describe('Drawing tools > DeleteButton', function () {
   const mark = Point.create({ id: 'point1', x: 50, y: 50, toolType: 'point' })
 
   it('should render without crashing', function () {
-    const wrapper = shallow(<DeleteButton label='Delete' mark={mark} />)
-    expect(wrapper).to.be.ok()
-  })
+    render(<DeleteButton label='Delete' mark={mark} />)
 
-  it('should be positioned by its mark', function () {
-    const { x, y } = mark.deleteButtonPosition(1)
-    const wrapper = shallow(<DeleteButton label='Delete' mark={mark} />)
-    const transform = wrapper.root().prop('transform')
-    expect(transform).to.have.string(`translate(${x}, ${y})`)
-  })
-
-  describe('on pointer down', function () {
-    it('should call onDelete', function () {
-      const fakeEvent = new Event('pointerdown')
-      const onDelete = sinon.stub()
-      const wrapper = shallow(<DeleteButton label='Delete' mark={mark} onDelete={onDelete} />)
-      wrapper.simulate('pointerdown', fakeEvent)
-      expect(onDelete).to.have.been.calledOnce()
-    })
-  })
-
-  describe('on blur', function () {
-    it('should be deselected', function () {
-      const onDeselect = sinon.spy()
-      const wrapper = shallow(<DeleteButton label='Delete' mark={mark} onDeselect={onDeselect} />)
-      wrapper.simulate('blur')
-      expect(onDeselect).to.have.been.calledOnce()
-    })
-  })
-
-  describe('on key down', function () {
-    it('should call onDelete for Enter', function () {
-      const fakeEvent = new Event('keydown')
-      fakeEvent.key = 'Enter'
-      const onDelete = sinon.stub()
-      const wrapper = shallow(<DeleteButton label='Delete' mark={mark} onDelete={onDelete} />)
-      wrapper.simulate('keydown', fakeEvent)
-      expect(onDelete).to.have.been.calledOnce()
+    const deleteButton = screen.getByRole('button', {
+      name: /delete/i
     })
 
-    it('should call onDelete for space', function () {
-      const fakeEvent = new Event('keydown')
-      fakeEvent.key = ' '
-      const onDelete = sinon.stub()
-      const wrapper = shallow(<DeleteButton label='Delete' mark={mark} onDelete={onDelete} />)
-      wrapper.simulate('keydown', fakeEvent)
-      expect(onDelete).to.have.been.calledOnce()
-    })
-
-    it('should ignore any other key', function () {
-      const fakeEvent = new Event('keydown')
-      fakeEvent.key = 'Tab'
-      const onDelete = sinon.stub()
-      const wrapper = shallow(<DeleteButton label='Delete' mark={mark} onDelete={onDelete} />)
-      wrapper.simulate('keydown', fakeEvent)
-      expect(onDelete).to.have.not.been.called()
-    })
+    expect(deleteButton).to.exist()
   })
 })


### PR DESCRIPTION
## Package
`lib-classifier`

## Describe your changes
Converted enzyme test to RTL

The intent for the Delete Button Component test is to only ensure the button renders properly. The functionality (removing an annotation) will be tested in each tool (circle, rectangle, polygon...). This will be added in future PRs. 

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
 N/A

- What user actions should my reviewer step through to review this PR?
Checkout this branch and run `yarn test`

- Which storybook stories should be reviewed?
N/A

- Are there plans for follow up PR’s to further fix this bug or develop this feature?
Yes. Functionality of the delete button will be tested in each tool (circle, rectangle, polygon...)
