### PR TITLE
Bump yarn to 1.22.18

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -4,4 +4,4 @@
 
 lastUpdateCheck 1578910852513
 save-prefix "~"
-yarn-path ".yarn/releases/yarn-1.22.15.cjs"
+yarn-path ".yarn/releases/yarn-1.22.18.cjs"


### PR DESCRIPTION
`yarn` is nagging that our version is out of date, so upgrade to latest allowed with `yarn policies set-version`.
