### PR TITLE
Project: pin devcert to 1.2.0

### DIFF
--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -84,7 +84,7 @@
     "babel-plugin-webpack-alias": "~2.1.2",
     "chai": "~4.3.4",
     "chai-dom": "~1.11.0",
-    "devcert": "~1.2.0",
+    "devcert": "1.2.0",
     "dirty-chai": "~2.0.1",
     "enzyme": "~3.11.0",
     "eslint-config-next": "~12.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7534,10 +7534,10 @@ detect-port@^1.3.0:
     address "^1.0.1"
     debug "^2.6.0"
 
-devcert@~1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/devcert/-/devcert-1.2.1.tgz#cb545583f4dfd33ed5358dacc3756d4c3878b858"
-  integrity sha512-R7DqtMtsNmFVY75kzRHXON3hXoJili2xxlEcZgHi0VHSx8aJECfm7ZqAquXzTeAM/I9f8G2pHc/zq5k6iXHQzA==
+devcert@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/devcert/-/devcert-1.2.0.tgz#7fb0fa2ca4c73baf3a3053973e80ebc5899fb20d"
+  integrity sha512-Tca9LUcmDegqTxlnQLTxVARS3MqYT+eWJfskXykefknT9jPoSJEA+t5BkDq5C5Tz+gVmAWmOH5vvKMfLJO/UhQ==
   dependencies:
     "@types/configstore" "^2.1.1"
     "@types/debug" "^0.0.30"
@@ -7554,7 +7554,6 @@ devcert@~1.2.0:
     eol "^0.9.1"
     get-port "^3.2.0"
     glob "^7.1.2"
-    is-valid-domain "^0.1.6"
     lodash "^4.17.4"
     mkdirp "^0.5.1"
     password-prompt "^1.0.4"
@@ -10587,13 +10586,6 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
-
-is-valid-domain@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/is-valid-domain/-/is-valid-domain-0.1.6.tgz#3c85469d2938f170c8f82ce6e52df8ad9fca8105"
-  integrity sha512-ZKtq737eFkZr71At8NxOFcP9O1K89gW3DkdrGMpp1upr/ueWjj+Weh4l9AI4rN0Gt8W2M1w7jrG2b/Yv83Ljpg==
-  dependencies:
-    punycode "^2.1.1"
 
 is-weakref@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Downgrade `devcert` to 1.2.0 so that we can run a local development server again.

## Package
app-project

## Linked Issue and/or Talk Post
https://github.com/davewasmer/devcert/issues/83