### PR TITLE
LightCurveViewer: change height to 80vh, fix Safari 15 issues

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -432,7 +432,7 @@ class LightCurveViewer extends Component {
     this.d3svg = d3.select(container)
       .append('svg')
       .attr('class', 'light-curve-viewer')
-      .attr('height', '100%')
+      .attr('height', '80vh')  // height=100% was used to fill available Subject image space, but doesn't work on Safari 15. This locks LCV to a height relative to the viewport
       .attr('width', '100%')
       .attr('focusable', true)
       .attr('tabindex', 0)


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`
Affects: LightCurveViewer component, Planet Hunters TESS project

This PR fixes an issue where the LightCurveViewer doesn't work with Safari 15.

**The Problem:** When you view [Planet Hunters TESS](https://www.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess) on Safari 15, you don't "see" the light curve graph. Actually, what's happening is that the graph has a height of 33 million pixels.

<img width="1073" alt="Screenshot 2022-05-10 at 16 57 54" src="https://user-images.githubusercontent.com/13952701/167671610-a0e41480-79af-465b-9b93-205221d28d6a.png">

_Above: screenshot of the Light Curve Viewer on Planet Hunters TESS, using Safari. The light curve graph isn't visible, and if you inspect the element, you'll see that the SVG element is absurdly tall._

<img width="964" alt="image" src="https://user-images.githubusercontent.com/13952701/167672007-d33a8912-aec8-4a49-81f1-511f9024f819.png">

_Above: screenshot of the LCV on PHTESS, using Chrome. This is the expected view._

**Analysis:**
- The LightCurveViewer exists in an SVG with the setup `<svg height="100%" width="100%>`
- The height="100%" is supposed to make the LCV fill the space available on the Subject panel
- Unfortunately, _Safari 15_ seems to have changed how this logic works, and instead makes the LCV fill the space of 33 million pixels. 
- (To be specific, it's the combination of svg.height=100% and... something else, which I'm still figuring out. Probably how the divs are nested, maybe a parent was missing an explicit height. Just adding svg.height=100% to the SingleImageViewer for example doesn't break it on Safari 15.)

**Solution:** set that SVG to <svg height="80vh" width="100%> so the LightCurveViewer _always mostly fits_ into the browser viewport.

### How To Review

- Choose a series of browsers to test this on: **Safari 15,** Chrome, Firefox, etc.
  - _Note: I've already tested with macOS + Safari15/ Chrome101/FF100_
  - _If someone can test for Safari 14, and for Safari on an iPhone, that'd be ace!_
- Open a project that uses light curve data.
  - Example on `app-project`: https://local.zooniverse.org:3000/projects/nora-dot-test/planet-finders-beta (preferred, don't forget to yarn bootstrap and solve that issue with devcert, if applicable)
  - Example on `lib-classifier`: https://local.zooniverse.org:8080/?env=staging&project=nora-dot-test/planet-finders-beta&workflow=3317&demo=true
- Expectations:
  - **You should be able to see the whole light curve graph on the screen** (main test)
  - You should be able to pan the Subject (mouse click to drag, or left/right keys) and zoom (mouse wheel, UI buttons, or +/- keys) and reset the view (UI button)
  - You should be able to add (click-drag), remove (press 'x' button), and edit (drag to resize, drag to move) annotations
  - You should be able to submit Classifications

### Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

**General**
- [x] Tests are passing locally and on Github
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

**Bug Fix**
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- ~~Unit tests are added or updated~~

### Status

Ready for review!

This is a fairly high priority bug since it affects a major project, but let's discuss on Slack if we should immediately deploy on merge (hotfix), or if this is OK to wait for our weekly deploy (tomorrow or Thu, I think?)