### PR TITLE
Classifier: Remove `inject` from MetaTools

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.js
@@ -1,17 +1,28 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Box } from 'grommet'
-import { inject, observer } from 'mobx-react'
 import { FavouritesButton, withResponsiveContext } from '@zooniverse/react-components'
+
 import Metadata from './components/Metadata'
 import CollectionsButton from './components/CollectionsButton'
 import HidePreviousMarksButton from './components/HidePreviousMarksButton'
 import SHOWN_MARKS from '@helpers/shownMarks'
+import { withStores } from '@helpers'
 
-function storeMapper (stores) {
-  const { active: subject, isThereMetadata } = stores.classifierStore.subjects
-  const { interactionTask } = stores.classifierStore.workflowSteps
-  const upp = stores.classifierStore.userProjectPreferences.active
+function storeMapper(store) {
+  const {
+    subjects: {
+      active: subject,
+      isThereMetadata
+    },
+    userProjectPreferences: {
+      active: upp
+    },
+    workflowSteps: {
+      interactionTask
+    }
+  } = store
+
   return {
     interactionTask,
     isThereMetadata,
@@ -20,8 +31,6 @@ function storeMapper (stores) {
   }
 }
 
-@inject(storeMapper)
-@observer
 class MetaTools extends React.Component {
   constructor () {
     super()
@@ -79,7 +88,7 @@ class MetaTools extends React.Component {
   }
 }
 
-MetaTools.wrappedComponent.defaultProps = {
+MetaTools.defaultProps = {
   className: '',
   interactionTask: {},
   isThereMetadata: false,
@@ -87,7 +96,7 @@ MetaTools.wrappedComponent.defaultProps = {
   upp: null
 }
 
-MetaTools.wrappedComponent.propTypes = {
+MetaTools.propTypes = {
   className: PropTypes.string,
   interactionTask: PropTypes.shape({
     shownMarks: PropTypes.string,
@@ -100,5 +109,5 @@ MetaTools.wrappedComponent.propTypes = {
   upp: PropTypes.object
 }
 
-export default withResponsiveContext(MetaTools)
+export default withStores(withResponsiveContext(MetaTools), storeMapper)
 export { MetaTools }

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/MetaTools.spec.js
@@ -24,18 +24,18 @@ const interactionTask = {
 
 describe('Component > MetaTools', function () {
   it('should render without crashing', function () {
-    const wrapper = shallow(<MetaTools.wrappedComponent />)
+    const wrapper = shallow(<MetaTools />)
     expect(wrapper).to.be.ok()
   })
 
   describe('Metadata', function () {
     it('should render a Metadata component', function () {
-      const wrapper = shallow(<MetaTools.wrappedComponent />)
+      const wrapper = shallow(<MetaTools />)
       expect(wrapper.find(Metadata)).to.have.lengthOf(1)
     })
 
     it('should pass along the isThereMetadata and subject resource metadata props', function () {
-      const wrapper = shallow(<MetaTools.wrappedComponent isThereMetadata subject={subjectWithMetadata} />)
+      const wrapper = shallow(<MetaTools isThereMetadata subject={subjectWithMetadata} />)
       const metadataComponentProps = wrapper.find(Metadata).props()
       expect(metadataComponentProps.isThereMetadata).to.be.true()
       expect(metadataComponentProps.metadata).to.equal(subjectWithMetadata.metadata)
@@ -44,60 +44,60 @@ describe('Component > MetaTools', function () {
 
   describe('FavouritesButton', function () {
     it('should render a FavouritesButton component', function () {
-      const wrapper = shallow(<MetaTools.wrappedComponent />)
+      const wrapper = shallow(<MetaTools />)
       expect(wrapper.find(FavouritesButton)).to.have.lengthOf(1)
     })
 
     it('should call toggle favourites on click of the FavouritesButton', function () {
       const subjectMethod = { toggleFavorite: sinon.spy() }
-      const wrapper = shallow(<MetaTools.wrappedComponent subject={subjectMethod} />)
+      const wrapper = shallow(<MetaTools subject={subjectMethod} />)
       wrapper.find(FavouritesButton).simulate('click')
       expect(subjectMethod.toggleFavorite).to.have.been.calledOnce()
     })
 
     it('should disable the FavouritesButton if there is no user project preferences', function () {
-      const wrapper = shallow(<MetaTools.wrappedComponent subject={favoriteSubject} />)
+      const wrapper = shallow(<MetaTools subject={favoriteSubject} />)
       expect(wrapper.find(FavouritesButton).props().disabled).to.be.true()
     })
 
     it('should enable the FavouritesButton if there is user project preferences', function () {
-      const wrapper = shallow(<MetaTools.wrappedComponent subject={favoriteSubject} upp={{ id: '1' }} />)
+      const wrapper = shallow(<MetaTools subject={favoriteSubject} upp={{ id: '1' }} />)
       expect(wrapper.find(FavouritesButton).props().disabled).to.be.false()
     })
 
     it('should check the FavouritesButton if the subject is a favorite', function () {
-      const wrapper = shallow(<MetaTools.wrappedComponent subject={favoriteSubject} upp={{ id: '1' }} />)
+      const wrapper = shallow(<MetaTools subject={favoriteSubject} upp={{ id: '1' }} />)
       expect(wrapper.find(FavouritesButton).props().checked).to.be.true()
     })
 
     it('should not check the FavouritesButton if the subject is not a favorite', function () {
-      const wrapper = shallow(<MetaTools.wrappedComponent subject={subjectWithMetadata} upp={{ id: '1' }} />)
+      const wrapper = shallow(<MetaTools subject={subjectWithMetadata} upp={{ id: '1' }} />)
       expect(wrapper.find(FavouritesButton).props().checked).to.be.false()
     })
   })
 
   describe('CollectionsButton', function () {
     it('should render a CollectionsButton component', function () {
-      const wrapper = shallow(<MetaTools.wrappedComponent />)
+      const wrapper = shallow(<MetaTools />)
       expect(wrapper.find(CollectionsButton)).to.have.lengthOf(1)
     })
 
     it('should call to add to collection on click of the CollectionsButton', function () {
       const subjectMethod = { addToCollection: sinon.spy() }
-      const addToCollectionSpy = sinon.spy(MetaTools.wrappedComponent.prototype, 'addToCollection')
-      const wrapper = shallow(<MetaTools.wrappedComponent subject={subjectMethod} />)
+      const addToCollectionSpy = sinon.spy(MetaTools.prototype, 'addToCollection')
+      const wrapper = shallow(<MetaTools subject={subjectMethod} />)
       wrapper.find(CollectionsButton).simulate('click')
       expect(addToCollectionSpy).to.have.been.calledOnce()
       expect(subjectMethod.addToCollection).to.have.been.calledOnce()
     })
 
     it('should disable the CollectionsButton if there is no user project preferences', function () {
-      const wrapper = shallow(<MetaTools.wrappedComponent subject={favoriteSubject} />)
+      const wrapper = shallow(<MetaTools subject={favoriteSubject} />)
       expect(wrapper.find(CollectionsButton).props().disabled).to.be.true()
     })
 
     it('should enable the CollectionsButton if there is user project preferences', function () {
-      const wrapper = shallow(<MetaTools.wrappedComponent subject={favoriteSubject} upp={{ id: '1' }} />)
+      const wrapper = shallow(<MetaTools subject={favoriteSubject} upp={{ id: '1' }} />)
       expect(wrapper.find(CollectionsButton).props().disabled).to.be.false()
     })
   })
@@ -105,7 +105,7 @@ describe('Component > MetaTools', function () {
   describe('HidePreviousMarksButton', function () {
     describe('without an interaction task', function () {
       it('should not render', function () {
-        const wrapper = shallow(<MetaTools.wrappedComponent />)
+        const wrapper = shallow(<MetaTools />)
         expect(wrapper.find(HidePreviousMarksButton)).to.have.lengthOf(0)
       })
     })
@@ -114,7 +114,7 @@ describe('Component > MetaTools', function () {
       let wrapper
 
       beforeEach(function () {
-        wrapper = shallow(<MetaTools.wrappedComponent interactionTask={interactionTask} />)
+        wrapper = shallow(<MetaTools interactionTask={interactionTask} />)
       })
 
       it('should render', function () {


### PR DESCRIPTION
Replace `inject` with `withStores` in subject `MetaTools`.

## Package
lib-classifier

## Linked Issue and/or Talk Post
#2712

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
