### PR TITLE
Classifier: Override mocha timeout for TaskAreaConnector

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
@@ -11,6 +11,8 @@ import mockStore from '@test/mockStore'
 import TaskAreaConnector from './TaskAreaConnector'
 
 describe('TaskAreaConnector', function () {
+  this.timeout(0)
+
   function withStore(store) {
     return function Wrapper({ children }) {
       return (


### PR DESCRIPTION
The task area connector tests have been timing out and blocking CI. This overrides the Mocha timeout for those tests.

## Package
lib-classifier

## General
- [x] Tests are passing locally and on Github
