### PR TITLE
Classifier: Localise workflows

### DIFF
--- a/packages/lib-classifier/dev/index.js
+++ b/packages/lib-classifier/dev/index.js
@@ -5,12 +5,12 @@ import App from './components/App'
 
 function getQueryParams() {
   if (window.location && window.location.search) {
-    const { subject, subjectSet, workflow } = queryString.parse(window.location.search)
-    return { subject, subjectSet, workflow }
+    const { language, subject, subjectSet, workflow } = queryString.parse(window.location.search)
+    return { language, subject, subjectSet, workflow }
   }
 
   return {}
 }
 
-const { subject, subjectSet, workflow } = getQueryParams()
-ReactDOM.render(<App subjectID={subject} subjectSetID={subjectSet} workflowID={workflow} />, document.getElementById('root'))
+const { language, subject, subjectSet, workflow } = getQueryParams()
+ReactDOM.render(<App locale={language} subjectID={subject} subjectSetID={subjectSet} workflowID={workflow} />, document.getElementById('root'))

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -44,12 +44,23 @@ export default function Classifier({
 
   useEffect(function onURLChange() {
     const { workflows } = classifierStore
-    if (workflowID) {
+    if (workflowID && workflowSnapshot) {
       console.log('starting new subject queue', { workflowID, subjectSetID, subjectID })
+      workflowSnapshot.subjectSet = subjectSetID
+      workflows.setResources([workflowSnapshot])
       workflows.selectWorkflow(workflowID, subjectSetID, subjectID, canPreviewWorkflows)
     }
-  }, [canPreviewWorkflows, subjectID, subjectSetID, workflowID])
+  }, [canPreviewWorkflows, subjectID, subjectSetID, workflowID, workflowSnapshot])
 
+  useEffect(function onWorkflowStringsChange() {
+    const { workflows, subjects } = classifierStore
+    if (workflowSnapshot) {
+      // pass the subjectSetID prop into the store as part of the new workflow data
+      workflowSnapshot.subjectSet = subjectSetID
+      console.log('Refreshing workflow strings', workflowSnapshot.id)
+      workflows.setResources([workflowSnapshot])
+    }
+  }, [workflowSnapshot?.strings])
   /*
     This should run when a project owner edits a workflow, but not when a workflow updates
     as a result of receiving classifications eg. workflow.completeness.

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
@@ -11,7 +11,7 @@ import {
   tutorials as tutorialsClient
 } from '@zooniverse/panoptes-js'
 
-import { useHydratedStore, useWorkflowSnapshot } from '@hooks'
+import { useHydratedStore, usePanoptesTranslations, useWorkflowSnapshot } from '@hooks'
 import { unregisterWorkers } from '../../workers'
 import Classifier from './Classifier'
 
@@ -65,6 +65,14 @@ export default function ClassifierContainer({
   const storeEnvironment = { authClient, client }
 
   const workflowSnapshot = useWorkflowSnapshot(workflowID)
+  const workflowTranslation = usePanoptesTranslations({
+    translated_id: workflowID,
+    translated_type: 'workflow',
+    language: locale
+  })
+  if (workflowSnapshot && workflowTranslation) {
+    workflowSnapshot.strings = workflowTranslation.strings
+  }
 
   const classifierStore = useHydratedStore(storeEnvironment, cachePanoptesData, `fem-classifier-${project.id}`)
 

--- a/packages/lib-classifier/src/hooks/Readme.md
+++ b/packages/lib-classifier/src/hooks/Readme.md
@@ -17,6 +17,14 @@ Asynchronously fetch an auth token, for a given user ID. A wrapper for `authClie
   const authorization = usePanoptesAuth(user.id)
 ```
 
+## usePanoptesTranslations
+
+A wrapper for [`useSWR`](https://swr.vercel.app/), which fetches resource translations, using the default SWR options. The translations will refresh on visibility change (eg. waking from sleep), or when the classifier receives focus.
+
+```js
+const translations = usePanoptesTranslations({ translated_id, translated_type, language })
+```
+
 ## usePanoptesUser
 
 Get the logged-in user, or null if no one is logged in.

--- a/packages/lib-classifier/src/hooks/index.js
+++ b/packages/lib-classifier/src/hooks/index.js
@@ -1,5 +1,6 @@
 export { default as useHydratedStore } from './useHydratedStore'
 export { default as usePanoptesAuth } from './usePanoptesAuth'
+export { default as usePanoptesTranslations } from './usePanoptesTranslations'
 export { default as usePanoptesUser } from './usePanoptesUser'
 export { default as useProjectRoles } from './useProjectRoles'
 export { default as useStores } from './useStores'

--- a/packages/lib-classifier/src/hooks/usePanoptesTranslations.js
+++ b/packages/lib-classifier/src/hooks/usePanoptesTranslations.js
@@ -1,0 +1,28 @@
+import useSWR from 'swr'
+import { panoptes } from '@zooniverse/panoptes-js'
+
+const SWRoptions = {
+  revalidateIfStale: true,
+  revalidateOnMount: true,
+  revalidateOnFocus: true,
+  revalidateOnReconnect: true,
+  refreshInterval: 0
+}
+
+async function fetchTranslations({ translated_id, translated_type, language, fallback = 'en' }) {
+  const languages = language === fallback ? fallback : `${language},${fallback}`
+  const response = await panoptes.get('/translations', {
+    language: languages,
+    translated_id,
+    translated_type
+  })
+  const translation = response.body.translations.find(t => t.language === language)
+  const original = response.body.translations.find(t => t.language === fallback)
+  return translation || original
+}
+
+export default function usePanoptesTranslations({ translated_id, translated_type, language }) {
+  const key = translated_id ? { translated_id, translated_type, language } : null
+  const { data } = useSWR(key, fetchTranslations, SWRoptions)
+  return data
+}

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
@@ -65,7 +65,8 @@ describe('Model > DrawingTools > Tool', function () {
             question: 'which fruit?',
             answers: ['apples', 'oranges', 'pears'],
             help: '',
-            required: ''
+            required: '',
+            strings: {}
           },
           {
             taskKey: 'single',
@@ -73,7 +74,8 @@ describe('Model > DrawingTools > Tool', function () {
             question: 'how many?',
             answers: ['one', 'two', 'three'],
             help: '',
-            required: ''
+            required: '',
+            strings: {}
           },
           {
             taskKey: 'text',
@@ -81,6 +83,7 @@ describe('Model > DrawingTools > Tool', function () {
             instruction: 'Transcribe something',
             help: '',
             required: '',
+            strings: {},
             text_tags: []
           }
         ]

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
@@ -1,3 +1,4 @@
+import { getSnapshot } from 'mobx-state-tree'
 import sinon from 'sinon'
 import Tool from './Tool'
 
@@ -97,17 +98,17 @@ describe('Model > DrawingTools > Tool', function () {
       })
 
       it('should create multiple choice tasks', function () {
-        const {annotation, ...snapshot} = tool.tasks[0]
+        const {annotation, ...snapshot} = getSnapshot(tool.tasks[0])
         expect(snapshot).to.deep.equal(multipleTaskSnapshot)
       })
 
       it('should create single choice tasks', function () {
-        const {annotation, ...snapshot} = tool.tasks[1]
+        const {annotation, ...snapshot} = getSnapshot(tool.tasks[1])
         expect(snapshot).to.deep.equal(singleTaskSnapshot)
       })
 
       it('should create text tasks', function () {
-        const {annotation, ...snapshot} = tool.tasks[2]
+        const {annotation, ...snapshot} = getSnapshot(tool.tasks[2])
         expect(snapshot).to.deep.equal(textTaskSnapshot)
       })
     })

--- a/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.js
@@ -45,7 +45,7 @@ function DataVisAnnotationTask (props) {
             checked={checked}
             index={index}
             key={`${task.taskKey}_${index}`}
-            label={tool.label}
+            label={task.strings[`tools.${index}.label`]}
             labelIcon={<InputIcon icon={<Graph2dRangeXIcon />} color='white' />}
             name='data-vis-annotation-tool'
             onChange={event => onChange(index, event)}

--- a/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.js
@@ -45,7 +45,7 @@ function DataVisAnnotationTask (props) {
             checked={checked}
             index={index}
             key={`${task.taskKey}_${index}`}
-            label={task.strings[`tools.${index}.label`]}
+            label={task.strings.get(`tools.${index}.label`)}
             labelIcon={<InputIcon icon={<Graph2dRangeXIcon />} color='white' />}
             name='data-vis-annotation-tool'
             onChange={event => onChange(index, event)}

--- a/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.spec.js
@@ -1,34 +1,37 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { expect } from 'chai'
+import { default as Task } from '@plugins/tasks/dataVisAnnotation'
 import DataVisAnnotationTask from './DataVisAnnotationTask'
 import TaskInput from '../../components/TaskInput'
 
-// TODO: move this into a factory
-const task = {
-  activeToolIndex: 0,
-  instruction: 'Mark an area of the graph that is interesting.',
-  taskKey: 'T101',
-  strings: {
-    help: '',
-    instruction: 'Mark an area of the graph that is interesting.',
-    'tools.0.label': 'Transit?'
-  },
-  tools: [{
-    help: '',
-    label: 'Transit?',
-    max: 20,
-    type: 'graph2dRangeX'
-  }, {
-    help: '',
-    label: 'Transit?',
-    max: 20,
-    type: 'graph2dRangeX'
-  }],
-  type: 'dataVisAnnotation'
-}
-
 describe('DataVisAnnotationTask', function () {
+  // TODO: move this into a factory
+  const taskSnapshot = {
+    activeToolIndex: 0,
+    instruction: 'Mark an area of the graph that is interesting.',
+    taskKey: 'T101',
+    strings: {
+      help: '',
+      instruction: 'Mark an area of the graph that is interesting.',
+      'tools.0.label': 'Transit?'
+    },
+    tools: [{
+      help: '',
+      label: 'Transit?',
+      max: 20,
+      type: 'graph2dRangeX'
+    }, {
+      help: '',
+      label: 'Transit?',
+      max: 20,
+      type: 'graph2dRangeX'
+    }],
+    type: 'dataVisAnnotation'
+  }
+
+  const task = Task.TaskModel.create(taskSnapshot)
+
   describe('when it renders', function () {
     let wrapper
     before(function () {

--- a/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.spec.js
@@ -9,6 +9,11 @@ const task = {
   activeToolIndex: 0,
   instruction: 'Mark an area of the graph that is interesting.',
   taskKey: 'T101',
+  strings: {
+    help: '',
+    instruction: 'Mark an area of the graph that is interesting.',
+    'tools.0.label': 'Transit?'
+  },
   tools: [{
     help: '',
     label: 'Transit?',

--- a/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.stories.js
@@ -28,10 +28,17 @@ export default {
 }
 
 export function LightTheme({ dark, isThereTaskHelp, required, subjectReadyState }) {
+  const help = isThereTaskHelp ?
+    'Use the drawing tool to mark any dips in the light curve that look like planetary transits.' :
+    ''
   const tasks = {
     T4: {
-      instruction: 'Do you spot a transit?',
       required,
+      strings: {
+        help,
+        instruction: 'Do you spot a transit?',
+        'tools.0.label': 'Transit?'
+      },
       taskKey: 'T4',
       tools: [
         {

--- a/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/models/DataVisAnnotationTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/models/DataVisAnnotationTask.js
@@ -7,8 +7,6 @@ import DataVisAnnotation from './DataVisAnnotation'
 const DataVisTaskModel = types.model('DataVisTaskModel', {
   activeToolIndex: types.optional(types.number, 0),
   annotation: types.safeReference(DataVisAnnotation),
-  help: types.optional(types.string, ''),
-  instruction: types.maybe(types.string),
   tools: types.array(types.union({
     dispatcher: (snapshot) => {
       if (snapshot.type === 'graph2dRangeX') return Graph2dRangeXTool
@@ -28,6 +26,14 @@ const DataVisTaskModel = types.model('DataVisTaskModel', {
         task: self.taskKey,
         taskType: self.type
       })
+    },
+
+    get help () {
+      return self.strings?.help
+    },
+
+    get instruction () {
+      return self.strings?.instruction
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/models/DataVisAnnotationTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/models/DataVisAnnotationTask.js
@@ -29,11 +29,11 @@ const DataVisTaskModel = types.model('DataVisTaskModel', {
     },
 
     get help () {
-      return self.strings?.help
+      return self.strings.get('help')
     },
 
     get instruction () {
-      return self.strings?.instruction
+      return self.strings.get('instruction')
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/tasks/models/Task.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Task.js
@@ -7,6 +7,7 @@ const Task = types.model('Task', {
   annotation: types.safeReference(Annotation),
   taskKey: types.identifier,
   required: types.maybe(types.union(types.string, types.boolean)), // text task required default = false
+  strings: types.frozen({}),
   type: types.literal('default')
 })
   .views(self => ({

--- a/packages/lib-classifier/src/plugins/tasks/models/Task.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Task.js
@@ -7,7 +7,7 @@ const Task = types.model('Task', {
   annotation: types.safeReference(Annotation),
   taskKey: types.identifier,
   required: types.maybe(types.union(types.string, types.boolean)), // text task required default = false
-  strings: types.frozen({}),
+  strings: types.map(types.string),
   type: types.literal('default')
 })
   .views(self => ({

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -175,8 +175,7 @@ const WorkflowStepStore = types
             }
           })
           try {
-            const taskSnapshot = getSnapshot(task)
-            applySnapshot(task, { ...taskSnapshot, strings })
+            applySnapshot(task.strings, strings)
           } catch (error) {
             console.error(`${taskKey} ${task.type}: could not apply language strings`)
             console.error(error)

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
@@ -9,6 +9,7 @@ import {
   TranscriptionTaskFactory,
   WorkflowFactory
 } from '@test/factories'
+import { getSnapshot } from 'mobx-state-tree'
 import { Factory } from 'rosie'
 import stubPanoptesJs from '@test/stubPanoptesJs'
 
@@ -114,7 +115,7 @@ describe('Model > WorkflowStepStore', function () {
           const { taskKey } = task
           const strings = {}
           const originalTask = { ...workflow.tasks[taskKey], annotation, strings, taskKey }
-          expect(task).to.eql(originalTask)
+          expect(getSnapshot(task)).to.eql(originalTask)
         })
       })
     })
@@ -173,7 +174,7 @@ describe('Model > WorkflowStepStore', function () {
           const { taskKey } = task
           const strings = {}
           const originalTask = { ...workflow.tasks[taskKey], annotation, strings, taskKey }
-          expect(task).to.eql(originalTask)
+          expect(getSnapshot(task)).to.eql(originalTask)
         })
       })
     })
@@ -240,7 +241,7 @@ describe('Model > WorkflowStepStore', function () {
           const { taskKey } = task
           const strings = {}
           const originalTask = { ...workflow.tasks[taskKey], annotation, strings, taskKey }
-          expect(task).to.eql(originalTask)
+          expect(getSnapshot(task)).to.eql(originalTask)
         })
       })
     })

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
@@ -112,7 +112,8 @@ describe('Model > WorkflowStepStore', function () {
         step.tasks.forEach(task => {
           const annotation = undefined
           const { taskKey } = task
-          const originalTask = Object.assign({}, workflow.tasks[taskKey], { annotation, taskKey })
+          const strings = {}
+          const originalTask = { ...workflow.tasks[taskKey], annotation, strings, taskKey }
           expect(task).to.eql(originalTask)
         })
       })
@@ -170,7 +171,8 @@ describe('Model > WorkflowStepStore', function () {
         step.tasks.forEach(task => {
           const annotation = undefined
           const { taskKey } = task
-          const originalTask = Object.assign({}, workflow.tasks[taskKey], { annotation, taskKey })
+          const strings = {}
+          const originalTask = { ...workflow.tasks[taskKey], annotation, strings, taskKey }
           expect(task).to.eql(originalTask)
         })
       })
@@ -236,7 +238,8 @@ describe('Model > WorkflowStepStore', function () {
         step.tasks.forEach(task => {
           const annotation = undefined
           const { taskKey } = task
-          const originalTask = Object.assign({}, workflow.tasks[taskKey], { annotation, taskKey })
+          const strings = {}
+          const originalTask = { ...workflow.tasks[taskKey], annotation, strings, taskKey }
           expect(task).to.eql(originalTask)
         })
       })

--- a/packages/lib-classifier/src/store/WorkflowStore/Workflow/Workflow.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/Workflow/Workflow.js
@@ -28,6 +28,7 @@ const Workflow = types
     links: types.frozen({}),
     prioritized: types.optional(types.boolean, false),
     steps: types.array(WorkflowStep),
+    strings: types.maybe(types.frozen()),
     subjectSet: types.safeReference(SubjectSet),
     tasks: types.maybe(types.frozen()),
     version: types.string


### PR DESCRIPTION
Wire up workflows to the Panoptes `/translations` endpoint.
- Add a `usePanoptesTranslations` hook to fetch translations by type, ID and language.
- Add a `strings` property to workflows and tasks, which holds the dictionary of translated strings for that resource.
- Modify the data vis annotation task to show instructions, help, and tool labels from the `strings` dictionary.
- Add a `language` query param to the dev classifier.
- Add an [`autorun` reaction](https://mobx.js.org/reactions.html) to the workflow steps store, which injects new strings into the workflow tasks whenever the workflow translation changes.

## Package
lib-classifier

## How to Review
You should be able to load PH-TESS in the classifier in three different languages.
- English (default): https://localhost:8080/?project=nora-dot-eisner%2Fplanet-hunters-tess&env=production&workflow=11235
- French: https://localhost:8080/?project=nora-dot-eisner%2Fplanet-hunters-tess&env=production&language=fr&workflow=11235
- Spanish: https://localhost:8080/?project=nora-dot-eisner%2Fplanet-hunters-tess&env=production&language=es&workflow=11235

~~Changing the locale from the dropdown menu in the dev classifier will crash the store, because it dispatches an action that breaks the workflow steps store. Right now, language strings for tasks are only supported when the classifier loads, and the tasks are created.~~

You should be able to switch locales, which changes the classifier's `locale` prop, and see the task language change.

https://user-images.githubusercontent.com/59547/169001565-842f14f3-261d-4d8d-918f-a7371a2ff46a.mov




# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
