### PR TITLE
Workaround Storybook 6.5 import bug

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingAnnotation.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingAnnotation.js
@@ -3,7 +3,7 @@ import DrawingTask from './DrawingTask'
 import Annotation from '../../models/Annotation'
 import * as markTypes from '@plugins/drawingTools/models/marks'
 
-const allDrawingMarks = Object.values(markTypes)
+const allDrawingMarks = Object.values(markTypes).filter(markType => markType.isType)
 const GenericMark = types.union(...allDrawingMarks)
 
 const Drawing = types.model('Drawing', {

--- a/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.js
@@ -6,9 +6,9 @@ import * as tools from '@plugins/drawingTools/models/tools'
 import * as markTypes from '@plugins/drawingTools/models/marks'
 import DrawingAnnotation from './DrawingAnnotation'
 
-const markModels = Object.values(markTypes)
+const markModels = Object.values(markTypes).filter(markType => markType.isType)
 const GenericMark = types.union(...markModels)
-const toolModels = Object.values(tools)
+const toolModels = Object.values(tools).filter(toolType => toolType.isType)
 const GenericTool = types.union(...toolModels)
 
 export const Drawing = types.model('Drawing', {

--- a/packages/lib-classifier/src/store/WorkflowStepStore/Step/Step.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/Step/Step.js
@@ -1,7 +1,7 @@
 import { types } from 'mobx-state-tree'
 import * as tasks from '@plugins/tasks'
 
-const taskModels = Object.values(tasks).map(task => task.TaskModel)
+const taskModels = Object.values(tasks).map(task => task.TaskModel).filter(Boolean)
 
 function taskDispatcher (snapshot) {
   switch (snapshot.type) {


### PR DESCRIPTION
Since Storybook 6.5.0, importing all of a module's named exports adds an extra `__namedExportsOrder` key, which then breaks the MST store in stories, where it expects each named import to be an MST model.

This PR works around the bug by filtering imports to check that each model is actually a model, using `type.isType`.

See https://github.com/storybookjs/storybook/issues/17587 but what you should notice on the main branch, at the moment, is that the classifier story fails for any story that uses `@test/mockStore`, because the store fails to build. This PR should fix that and get all the stories showing again.

## Package
lib-classifier

## Linked Issue and/or Talk Post
https://github.com/storybookjs/storybook/issues/17587

## How to Review
Build the classifier storybook with `yarn storybook` and check that the stories load without error. With Storybook 6.5.0, I'm seeing most of the subject viewer and task stories fail.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
