### PR TITLE
Fix broken textFromSubjectAnnotation tests

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/models/TextFromSubjectAnnotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/models/TextFromSubjectAnnotation.spec.js
@@ -14,14 +14,13 @@ describe('Model > TextFromSubjectAnnotation', function () {
     ]
   })
 
-  const taskSnapshot = Task.TaskModel.create({
-    instruction: 'Correct the text',
-    taskKey: 'T0',
-    type: 'textFromSubject'
-  })
-
   const workflowSnapshot = WorkflowFactory.build({
-    tasks: [taskSnapshot]
+    tasks: {
+      T0: {
+        instruction: 'Correct the text',
+        type: 'textFromSubject'
+      }
+    }
   })
 
   let textFromSubjectAnnotation


### PR DESCRIPTION
#3043 added a broken mock for text-from-subject tasks. This fixes the broken tests, which are failing in #3145

## Package
lib-classifier

## Linked Issue and/or Talk Post
#3145 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
