### PR TITLE
Classifier: localise tutorials

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
@@ -41,6 +41,7 @@ function SlideTutorial({
   pad = 'medium',
   steps = [],
   stepWithMedium,
+  strings = {},
   width
 }) {
   const [stepIndex, setStepIndex] = useState(activeStep)
@@ -83,8 +84,7 @@ function SlideTutorial({
           <Heading level='3' margin={{ bottom: 'xsmall', top: 'small' }}>
             {t('SlideTutorial.heading', { projectDisplayName })}
           </Heading>}
-        {/* TODO: translation */}
-        <Markdownz>{step.content}</Markdownz>
+        <Markdownz>{strings[`steps.${activeStep}.content`]}</Markdownz>
       </StyledMarkdownWrapper>
         <StepNavigation
           onChange={setStepIndex}
@@ -125,6 +125,8 @@ SlideTutorial.propTypes = {
   steps: PropTypes.arrayOf(tutorialStep),
   /** A function which should return the step and media file for a given step index. */
   stepWithMedium: PropTypes.func.isRequired,
+  /** Translated strings for the tutorial content */
+  strings: PropTypes.object,
   /** Tutorial width (CSS units). */
   width: PropTypes.string,
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
@@ -75,7 +75,7 @@ function SlideTutorial({
       >
         {isThereMedia &&
           <Media
-            alt={t('SlideTutorial.alt', { activeStep })}
+            alt={t('SlideTutorial.alt', { activeStep: stepIndex })}
             fit='cover'
             height={200}
             src={medium.src}
@@ -84,7 +84,7 @@ function SlideTutorial({
           <Heading level='3' margin={{ bottom: 'xsmall', top: 'small' }}>
             {t('SlideTutorial.heading', { projectDisplayName })}
           </Heading>}
-        <Markdownz>{strings[`steps.${activeStep}.content`]}</Markdownz>
+        <Markdownz>{strings[`steps.${stepIndex}.content`]}</Markdownz>
       </StyledMarkdownWrapper>
         <StepNavigation
           onChange={setStepIndex}

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.spec.js
@@ -10,6 +10,12 @@ const step = {
   content: '# Welcome'
 }
 
+const strings = {
+  display_name: 'A test tutorial',
+  'steps.0.content': step.content,
+  'steps.1.content': step.content
+}
+
 const medium = {
   content_type: 'image/gif',
   external_link: false,
@@ -53,6 +59,7 @@ describe('SlideTutorial', function () {
         activeStep={0}
         stepWithMedium={() => ({ step, medium })}
         steps={[{ step, medium }, { step, medium }]}
+        strings={strings}
       />
     )
     expect(wrapper.find(Heading)).to.have.lengthOf(1)
@@ -64,6 +71,7 @@ describe('SlideTutorial', function () {
         activeStep={1}
         stepWithMedium={() => ({ step, medium })}
         steps={[{ step, medium }, { step, medium }]}
+        strings={strings}
       />
     )
     expect(wrapper.find(Heading)).to.have.lengthOf(0)
@@ -75,6 +83,7 @@ describe('SlideTutorial', function () {
         activeStep={1}
         stepWithMedium={() => ({ step, medium })}
         steps={[{ step, medium }, { step, medium }]}
+        strings={strings}
       />
     )
     expect(wrapper.find(Button)).to.have.lengthOf(1)
@@ -86,6 +95,7 @@ describe('SlideTutorial', function () {
         activeStep={0}
         stepWithMedium={() => ({ step, medium })}
         steps={[{ step, medium }, { step, medium }]}
+        strings={strings}
       />
     )
     expect(wrapper.find(Button)).to.have.lengthOf(0)
@@ -99,6 +109,7 @@ describe('SlideTutorial', function () {
         onClick={onClick}
         stepWithMedium={() => ({ step, medium })}
         steps={[{ step, medium }, { step, medium }]}
+        strings={strings}
       />
     )
     wrapper.find(Button).simulate('click')

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
@@ -31,6 +31,12 @@ const steps = [
   }
 ]
 
+const strings = {
+  display_name: 'A slide tutorial',
+  'steps.0.content': steps[0].content,
+  'steps.1.content': steps[1].content
+}
+
 function stepWithMedium(index) {
   const medium = media[index]
   const step = steps[index]
@@ -76,6 +82,7 @@ export function Default({ dark, height, onClick, projectDisplayName, steps, step
           projectDisplayName={projectDisplayName}
           steps={steps}
           stepWithMedium={stepWithMedium}
+          strings={strings}
           width={width}
         />
       </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorialContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorialContainer.js
@@ -1,13 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { ResponsiveContext } from 'grommet'
-import { useTranslation } from 'react-i18next'
 
 import { withStores } from '@helpers'
+import { usePanoptesTranslations } from '@hooks'
 import SlideTutorial from './SlideTutorial'
 
 function storeMapper(classifierStore) {
   const {
+    locale,
     projects: {
       active: project
     },
@@ -22,20 +23,33 @@ function storeMapper(classifierStore) {
 
   return {
     activeStep,
+    locale,
     projectDisplayName: project.display_name,
     steps,
-    stepWithMedium
+    stepWithMedium,
+    tutorial
   }
 }
 
+const defaultTutorial = {
+  activeStep: 0,
+  steps: []
+}
+
 function SlideTutorialContainer({
-  activeStep = 0,
+  locale,
   pad = 'medium',
   projectDisplayName = '',
-  steps = [],
-  stepWithMedium,
+  tutorial = defaultTutorial,
   ...props
 }) {
+  const tutorialTranslation = usePanoptesTranslations({
+    translated_type: 'tutorial',
+    translated_id: tutorial?.id,
+    language: locale
+  })
+  const strings = tutorialTranslation?.strings
+  const { activeStep, steps, stepWithMedium } = tutorial
   return (
     <ResponsiveContext.Consumer>
       {size => {
@@ -48,6 +62,7 @@ function SlideTutorialContainer({
             projectDisplayName={projectDisplayName}
             steps={steps}
             stepWithMedium={stepWithMedium}
+            strings={strings}
             {...props}
           />
         )
@@ -57,10 +72,13 @@ function SlideTutorialContainer({
 }
 
 SlideTutorialContainer.propTypes = {
-  activeStep: PropTypes.number,
+  locale: PropTypes.string,
   projectDisplayName: PropTypes.string,
-  steps: PropTypes.array,
-  stepWithMedium: PropTypes.func.isRequired
+  tutorial: PropTypes.shape({
+    activeStep: PropTypes.number,
+    steps: PropTypes.array,
+    stepWithMedium: PropTypes.func.isRequired
+  })
 }
 
 export default withStores(SlideTutorialContainer, storeMapper)


### PR DESCRIPTION
- Pass translation `strings` down to tutorial components.
- Use the `strings` dictionary to show step content.

## Package
lib-classifier

## How to Review

Load PH-TESS in the dev classifier and change the language.
https://localhost:8080/?project=nora-dot-eisner/planet-hunters-tess&env=production

https://user-images.githubusercontent.com/59547/169840507-0f3cb79f-28cf-46bb-9e46-3d7932135dac.mov



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)