### PR TITLE
Classifier: Localise workflow task text

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -111,7 +111,7 @@ Classifier.propTypes = {
   subjectSetID: PropTypes.string,
   subjectID: PropTypes.string,
   workflowSnapshot: PropTypes.shape({
-    id: PropTypes.string
-  }),
-  workflowID: PropTypes.string.isRequired
+    id: PropTypes.string,
+    version: PropTypes.string
+  })
 }

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -177,7 +177,7 @@ describe('Components > Classifier', function () {
   })
 
   describe('when the locale changes', function () {
-    let locale, subjectImage, tabPanel, taskAnswers, taskTab, tutorialTab, workflow
+    let locale, subjectImage, tabPanel, taskInstruction, taskAnswers, taskTab, tutorialTab, workflow
 
     before(async function () {
       sinon.replace(window, 'Image', class MockImage {
@@ -187,12 +187,43 @@ describe('Components > Classifier', function () {
           setTimeout(() => this.onload(), 500)
         }
       })
-      const subject = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
-      const store = mockStore({ subject })
-      const project = store.projects.active
-      const projectSnapshot = { ...getSnapshot(project) }
-      workflow = store.workflows.active
-      const workflowSnapshot = { ...getSnapshot(workflow) }
+
+      const roles = []
+      const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+
+      nock('https://panoptes-staging.zooniverse.org/api')
+          .persist()
+          .get('/field_guides')
+          .reply(200, { field_guides: [] })
+          .get('/project_preferences')
+          .query(true)
+          .reply(200, { project_preferences: [] })
+          .get('/project_roles')
+          .reply(200, { project_roles: [{ roles }]})
+          .get('/subjects/queued')
+          .query(true)
+          .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+          .post('/project_preferences')
+          .query(true)
+          .reply(200, { project_preferences: [] })
+
+      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
+      const checkCurrent = sinon.stub().callsFake(() => Promise.resolve({ id: 123, login: 'mockUser' }))
+      const authClient = { ...defaultAuthClient, checkBearerToken, checkCurrent }
+      const client = { ...defaultClient, panoptes }
+
+      const workflowSnapshot = branchingWorkflow
+      workflowSnapshot.strings = workflowStrings
+
+      const projectSnapshot = ProjectFactory.build({
+        links: {
+          active_workflows: [workflowSnapshot.id],
+          workflows: [workflowSnapshot.id]
+        }
+      })
+
+      const store = RootStore.create({}, { authClient, client })
+
       const { rerender } = render(
         <Classifier
           classifierStore={store}
@@ -204,28 +235,56 @@ describe('Components > Classifier', function () {
           wrapper: withStore(store)
         }
       )
+
       await when(() => store.subjectViewer.loadingState === asyncStates.success)
+
+      // locale changes when the language menu changes.
       rerender(
         <Classifier
           classifierStore={store}
           locale='fr'
           project={projectSnapshot}
           workflowSnapshot={workflowSnapshot}
-          workflowVersion={workflowSnapshot?.version}
         />,
       )
+      // workflow strings update after the translations API request resolves.
+      const frenchStrings = { ...workflowStrings }
+      Object.entries(frenchStrings).forEach(([key, value]) => {
+        const frenchValue = `${value} - French translation.`
+        frenchStrings[key] = frenchValue
+      })
+      const frenchSnapshot = { ...workflowSnapshot, strings: frenchStrings }
+      rerender(
+        <Classifier
+          classifierStore={store}
+          locale='fr'
+          project={projectSnapshot}
+          workflowSnapshot={frenchSnapshot}
+        />,
+      )
+      // wait for task strings to be updated in the store.
+      await when(() => {
+        const [task] = store.workflowSteps.active?.tasks
+        return (task.question === 'Is there a cat? - French translation.')
+      })
+      workflow = store.workflows.active
       locale = store.locale
       taskTab = screen.getByRole('tab', { name: 'TaskArea.task'})
       tutorialTab = screen.getByRole('tab', { name: 'TaskArea.tutorial'})
-      subjectImage = screen.getByRole('img', { name: `Subject ${subject.id}` })
+      subjectImage = screen.getByRole('img', { name: `Subject ${subjectSnapshot.id}` })
       tabPanel = screen.getByRole('tabpanel', { name: '1 Tab Contents'})
-      const task = workflowSnapshot.tasks.T0
-      const getAnswerInput = answer => within(tabPanel).getByRole('radio', { name: answer.label })
+      const task = frenchSnapshot.tasks.T0
+      taskInstruction = within(tabPanel).getByText('Is there a cat? - French translation.')
+      function getAnswerInput(answer) {
+        const label = answer.label
+        return within(tabPanel).getByRole('radio', { name: label })
+      }
       taskAnswers = task.answers.map(getAnswerInput)
     })
 
     after(function () {
       sinon.restore()
+      nock.cleanAll()
     })
 
     it('should update the global locale', function () {
@@ -242,6 +301,10 @@ describe('Components > Classifier', function () {
 
     it('should have a subject image', function () {
       expect(subjectImage.getAttribute('xlink:href')).to.equal('https://foo.bar/example.png')
+    })
+
+    it('should show the translated task instruction', function () {
+      expect(taskInstruction).to.exist()
     })
 
     describe('task answers', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/components/SGVGridCell/SGVGridCell.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/components/SGVGridCell/SGVGridCell.spec.js
@@ -19,8 +19,10 @@ describe('Component > SubjectGroupViewer > SGVGridCell', function () {
   let wrapper, annotation
   
   const task = Task.TaskModel.create({
-    question: 'Please select the cells that look weird.',
     required: true,
+    strings: {
+      question: 'Please select the cells that look weird.',
+    },
     taskKey: 'init',
     type: 'subjectGroupComparison'
   })

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -55,7 +55,6 @@ export function MultipleTasks({ dark, isThereTaskHelp, required, subjectReadySta
   const tasks = {
     init: {
       answers: [{ label: 'yes' }, { label: 'no' }],
-      question: 'Is there a cat?',
       required,
       strings: {
         help: isThereTaskHelp ? 'Choose an answer from the choices given, then press Done.' : '',
@@ -66,7 +65,6 @@ export function MultipleTasks({ dark, isThereTaskHelp, required, subjectReadySta
     },
     T1: {
       answers: [{ label: 'sleeping' }, { label: 'playing' }, { label: 'looking indifferent' }],
-      question: 'What is it doing?',
       required,
       strings: {
         help: isThereTaskHelp ? 'Pick as many answers as apply, then press Done.' : '',

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -55,17 +55,23 @@ export function MultipleTasks({ dark, isThereTaskHelp, required, subjectReadySta
   const tasks = {
     init: {
       answers: [{ label: 'yes' }, { label: 'no' }],
-      help: 'Choose an answer from the choices given, then press Done.',
       question: 'Is there a cat?',
       required,
+      strings: {
+        help: isThereTaskHelp ? 'Choose an answer from the choices given, then press Done.' : '',
+        question: 'Is there a cat?'
+      },
       taskKey: 'init',
       type: 'single'
     },
     T1: {
       answers: [{ label: 'sleeping' }, { label: 'playing' }, { label: 'looking indifferent' }],
-      help: 'Pick as many answers as apply, then press Done.',
       question: 'What is it doing?',
       required,
+      strings: {
+        help: isThereTaskHelp ? 'Pick as many answers as apply, then press Done.' : '',
+        question: 'What is it doing?'
+      },
       taskKey: 'T1',
       type: 'multiple'
     }

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
@@ -21,20 +21,26 @@ describe('Model > DrawingTools > Tool', function () {
     const details = [
       {
         type: 'multiple',
-        question: 'which fruit?',
         answers: ['apples', 'oranges', 'pears'],
-        required: ''
+        required: '',
+        strings: {
+          question: 'which fruit?'
+        }
       },
       {
         type: 'single',
-        question: 'how many?',
         answers: ['one', 'two', 'three'],
-        required: ''
+        required: '',
+        strings: {
+          question: 'how many?'
+        }
       },
       {
         type: 'text',
-        instruction: 'Transcribe something',
-        required: ''
+        required: '',
+        strings: {
+          instruction: 'Transcribe something'
+        }
       }
     ]
     const tool = Tool.create(Object.assign({}, toolData, { details }))
@@ -63,18 +69,20 @@ describe('Model > DrawingTools > Tool', function () {
           {
             taskKey: 'multiple',
             type: 'multiple',
-            question: 'which fruit?',
             answers: ['apples', 'oranges', 'pears'],
             required: '',
-            strings: {}
+            strings: {
+              question: 'which fruit?'
+            }
           },
           {
             taskKey: 'single',
             type: 'single',
-            question: 'how many?',
             answers: ['one', 'two', 'three'],
             required: '',
-            strings: {}
+            strings: {
+              question: 'how many?'
+            }
           },
           {
             taskKey: 'text',
@@ -121,7 +129,9 @@ describe('Model > DrawingTools > Tool', function () {
           {
             taskKey: 'drawing',
             type: 'drawing',
-            question: 'which fruit?',
+            strings: {
+              question: 'which fruit?'
+            },
             tools: []
           }
         ]

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
@@ -79,9 +79,10 @@ describe('Model > DrawingTools > Tool', function () {
           {
             taskKey: 'text',
             type: 'text',
-            instruction: 'Transcribe something',
             required: '',
-            strings: {},
+            strings: {
+              instruction: 'Transcribe something'
+            },
             text_tags: []
           }
         ]

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.spec.js
@@ -65,7 +65,6 @@ describe('Model > DrawingTools > Tool', function () {
             type: 'multiple',
             question: 'which fruit?',
             answers: ['apples', 'oranges', 'pears'],
-            help: '',
             required: '',
             strings: {}
           },
@@ -74,7 +73,6 @@ describe('Model > DrawingTools > Tool', function () {
             type: 'single',
             question: 'how many?',
             answers: ['one', 'two', 'three'],
-            help: '',
             required: '',
             strings: {}
           },
@@ -82,7 +80,6 @@ describe('Model > DrawingTools > Tool', function () {
             taskKey: 'text',
             type: 'text',
             instruction: 'Transcribe something',
-            help: '',
             required: '',
             strings: {},
             text_tags: []

--- a/packages/lib-classifier/src/plugins/drawingTools/stories/helpers.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/stories/helpers.js
@@ -14,21 +14,33 @@ export const subject = SubjectFactory.build({
 
 export const subTasksSnapshot = [
   {
-    instruction: 'Name your favourite fruit.',
+    strings: {
+      help: 'Do drawing sub-tasks show help? Should they?',
+      instruction: 'Name your favourite fruit.'
+    },
     taskKey: 'T0.0',
     type: 'text'
   },
   {
     answers: [{ label: "yes" }, { label: "no" }],
-    help: "",
-    question: "Is it tasty?",
+    strings: {
+      'answers.0.label': 'yes',
+      'answers.1.label': 'no',
+      help: '',
+      question: 'Is it tasty?',
+    },
     taskKey: 'T0.1',
     type: 'single'
   },
   {
     answers: [{ label: "cat" }, { label: "dog" }, { label: "bird" }],
-    help: "",
-    question: "Select your favourite animals.",
+    strings: {
+      'answers.0.label': 'cat',
+      'answers.1.label': 'dog',
+      'answers.2.label': 'bird',
+      help: '',
+      question: 'Select your favourite animals.'
+    },
     taskKey: 'T0.2',
     type: 'multiple'
   }

--- a/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.spec.js
@@ -9,7 +9,6 @@ describe('DataVisAnnotationTask', function () {
   // TODO: move this into a factory
   const taskSnapshot = {
     activeToolIndex: 0,
-    instruction: 'Mark an area of the graph that is interesting.',
     taskKey: 'T101',
     strings: {
       help: '',

--- a/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/models/DataVisAnnotationTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/models/DataVisAnnotationTask.js
@@ -20,10 +20,6 @@ const DataVisTaskModel = types.model('DataVisTaskModel', {
       return self.tools[self.activeToolIndex]
     },
 
-    get instruction() {
-      return self.strings.get('instruction')
-    },
-
     defaultAnnotation (id = cuid()) {
       return DataVisAnnotation.create({
         id,

--- a/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/models/DataVisAnnotationTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/models/DataVisAnnotationTask.js
@@ -20,20 +20,16 @@ const DataVisTaskModel = types.model('DataVisTaskModel', {
       return self.tools[self.activeToolIndex]
     },
 
+    get instruction() {
+      return self.strings.get('instruction')
+    },
+
     defaultAnnotation (id = cuid()) {
       return DataVisAnnotation.create({
         id,
         task: self.taskKey,
         taskType: self.type
       })
-    },
-
-    get help () {
-      return self.strings.get('help')
-    },
-
-    get instruction () {
-      return self.strings.get('instruction')
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.spec.js
@@ -2,35 +2,33 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { expect } from 'chai'
 import sinon from 'sinon'
+
+import { default as Task } from '@plugins/tasks/drawing'
 import DrawingTask from './DrawingTask'
 import TaskInput from '../../components/TaskInput'
 
-// TODO: move to factory
-const task = {
-  activeToolIndex: 0,
-  help: 'Help content.',
-  instruction: 'Draw something.',
-  taskKey: 'T0',
-  tools: [{
-    label: 'Line',
-    max: 3,
-    type: 'line',
-    marks: {
-      size: 0
-    }
-  }, {
-    label: 'Point',
-    min: 1,
-    type: 'point',
-    marks: {
-      size: 0
-    }
-  }],
-  type: 'drawing',
-  setActiveTool: sinon.stub()
-}
-
 describe('DrawingTask', function () {
+  // TODO: move to factory
+  const task = Task.TaskModel.create({
+    activeToolIndex: 0,
+    help: 'Help content.',
+    strings: {
+      instruction: 'Draw something.',
+    },
+    taskKey: 'T0',
+    tools: [{
+      label: 'Line',
+      max: 3,
+      type: 'line'
+    }, {
+      label: 'Point',
+      min: 1,
+      type: 'point'
+    }],
+    type: 'drawing',
+    setActiveTool: sinon.stub()
+  })
+
   describe('when it renders', function () {
     let wrapper
     before(function () {

--- a/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.stories.js
@@ -31,9 +31,12 @@ export default {
 export function Drawing({ dark, isThereTaskHelp, required, subjectReadyState }) {
   const tasks = {
     T2: {
-      help: 'Draw on the image.',
       instruction: 'Draw something',
       required,
+      strings: {
+        help: isThereTaskHelp ? 'Draw on the image.' : '',
+        instruction: 'Draw something'
+      },
       taskKey: 'T2',
       tools: [
         {

--- a/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.stories.js
@@ -31,7 +31,6 @@ export default {
 export function Drawing({ dark, isThereTaskHelp, required, subjectReadyState }) {
   const tasks = {
     T2: {
-      instruction: 'Draw something',
       required,
       strings: {
         help: isThereTaskHelp ? 'Draw on the image.' : '',

--- a/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingAnnotation.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingAnnotation.spec.js
@@ -108,7 +108,9 @@ describe('Model > DrawingAnnotation', function () {
                 type: 'point',
                 details: [{
                   type: 'single',
-                  question: 'Yes or no?',
+                  strings: {
+                    question: 'Yes or no?'
+                  },
                   answers: [ 'yes', 'no' ]
                 }]
               }

--- a/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.js
@@ -17,7 +17,6 @@ export const Drawing = types.model('Drawing', {
   annotation: types.safeReference(DrawingAnnotation),
   shownMarks: types.optional(types.enumeration(Object.keys(SHOWN_MARKS)), SHOWN_MARKS.ALL),
   hidingIndex: types.maybeNull(types.number),
-  instruction: types.string,
   tools: types.array(GenericTool),
   type: types.literal('drawing')
 })

--- a/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.js
@@ -15,7 +15,6 @@ export const Drawing = types.model('Drawing', {
   activeMark: types.safeReference(GenericMark),
   activeToolIndex: types.optional(types.number, 0),
   annotation: types.safeReference(DrawingAnnotation),
-  help: types.optional(types.string, ''),
   shownMarks: types.optional(types.enumeration(Object.keys(SHOWN_MARKS)), SHOWN_MARKS.ALL),
   hidingIndex: types.maybeNull(types.number),
   instruction: types.string,

--- a/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.spec.js
@@ -39,7 +39,9 @@ describe('Model > DrawingTask', function () {
   }
 
   const drawingTaskSnapshot = {
-    instruction: "Mark each cat's face and tail. Draw an ellipse around each cat's face (not including the ears), and mark the tail tip with a point.",
+    strings: {
+      instruction: "Mark each cat's face and tail. Draw an ellipse around each cat's face (not including the ears), and mark the tail tip with a point."
+    },
     taskKey: 'T3',
     tools: [pointTool, lineTool],
     type: 'drawing'
@@ -61,7 +63,9 @@ describe('Model > DrawingTask', function () {
   }
 
   const drawingTaskRequiredSubtaskSnapshot = {
-    instruction: "Mark each cat's face and tail. Draw an ellipse around each cat's face (not including the ears), and mark the tail tip with a point.",
+    strings: {
+      instruction: "Mark each cat's face and tail. Draw an ellipse around each cat's face (not including the ears), and mark the tail tip with a point."
+    },
     taskKey: 'T4',
     tools: [pointToolWithRequiredSubtask],
     type: 'drawing'

--- a/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.spec.js
@@ -7,20 +7,26 @@ describe('Model > DrawingTask', function () {
   const details = [
     {
       type: 'multiple',
-      question: 'which fruit?',
       answers: ['apples', 'oranges', 'pears'],
-      required: ''
+      required: '',
+      strings: {
+        question: 'which fruit?'
+      }
     },
     {
       type: 'single',
-      question: 'how many?',
       answers: ['one', 'two', 'three'],
-      required: ''
+      required: '',
+      strings: {
+        question: 'how many?'
+      }
     },
     {
       type: 'text',
-      instruction: 'Transcribe something',
-      required: ''
+      required: '',
+      strings: {
+        instruction: 'Transcribe something'
+      }
     }
   ]
 
@@ -50,9 +56,11 @@ describe('Model > DrawingTask', function () {
   const singleRequiredSubtask = {
     taskKey: 'T4.0.0',
     type: 'single',
-    question: 'how many?',
     answers: ['one', 'two', 'three'],
-    required: true
+    required: true,
+    strings: {
+      question: 'how many?'
+    }
   }
 
   const pointToolWithRequiredSubtask = {

--- a/packages/lib-classifier/src/plugins/tasks/dropdown-simple/components/SimpleDropdownTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/dropdown-simple/components/SimpleDropdownTask.spec.js
@@ -6,7 +6,6 @@ import SimpleDropdownTask from './SimpleDropdownTask'
 import { default as Task } from '@plugins/tasks/dropdown-simple'
 
 const simpleDropdownTask = {
-  instruction: 'Choose your favourite colour',
   allowCreate: false,
   options: [
     'Red',
@@ -17,6 +16,9 @@ const simpleDropdownTask = {
     'Black',
   ],
   required: false,
+  strings: {
+    instruction: 'Choose your favourite colour'
+  },
   taskKey: 'T1',
   type: 'dropdown-simple'
 }

--- a/packages/lib-classifier/src/plugins/tasks/dropdown-simple/components/SimpleDropdownTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/dropdown-simple/components/SimpleDropdownTask.stories.js
@@ -29,7 +29,6 @@ export default {
 
 export function LightTheme({ dark, isThereTaskHelp, required, subjectReadyState }) {
   const simpleDropdownTask = {
-    instruction: 'Choose your favourite colour',
     allowCreate: false,
     options: [
       'Red',
@@ -40,6 +39,9 @@ export function LightTheme({ dark, isThereTaskHelp, required, subjectReadyState 
       'Black',
     ],
     required,
+    strings: {
+      instruction: 'Choose your favourite colour'
+    },
     taskKey: 'init',
     type: 'dropdown-simple',
   }

--- a/packages/lib-classifier/src/plugins/tasks/dropdown-simple/models/SimpleDropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/dropdown-simple/models/SimpleDropdownTask.js
@@ -18,7 +18,6 @@ const MenuOptions = types.refinement('MenuOptions',
 const SimpleDropdown = types.model('SimpleDropdown', {
   allowCreate: types.optional(types.boolean, false),
   annotation: types.safeReference(SimpleDropdownAnnotation),
-  instruction: types.optional(types.string, ''),
   options: MenuOptions,
   type: types.literal('dropdown-simple'),
 })

--- a/packages/lib-classifier/src/plugins/tasks/dropdown-simple/models/SimpleDropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/dropdown-simple/models/SimpleDropdownTask.js
@@ -18,7 +18,6 @@ const MenuOptions = types.refinement('MenuOptions',
 const SimpleDropdown = types.model('SimpleDropdown', {
   allowCreate: types.optional(types.boolean, false),
   annotation: types.safeReference(SimpleDropdownAnnotation),
-  help: types.optional(types.string, ''),
   instruction: types.optional(types.string, ''),
   options: MenuOptions,
   type: types.literal('dropdown-simple'),

--- a/packages/lib-classifier/src/plugins/tasks/dropdown-simple/models/SimpleDropdownTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/dropdown-simple/models/SimpleDropdownTask.spec.js
@@ -5,7 +5,6 @@ import { MIN_OPTIONS, MAX_OPTIONS } from './SimpleDropdownTask'
 describe('Model > SimpleDropdownTask', function () {
   const { TaskModel, AnnotationModel } = SimpleDropdownTask
   const simpleDropdownTask = {
-    instruction: 'Choose your favourite colour',
     allowCreate: false,
     options: [
       'Red',
@@ -16,6 +15,9 @@ describe('Model > SimpleDropdownTask', function () {
       'Black',
     ],
     required: false,
+    strings: {
+      instruction: 'Choose your favourite colour'
+    },
     taskKey: 'T1',
     type: 'dropdown-simple'
   }

--- a/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/components/TextFromSubjectContainer.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/components/TextFromSubjectContainer.spec.js
@@ -11,7 +11,9 @@ describe('TextFromSubjectContainer', function () {
   let wrapper
 
   const task = Task.TaskModel.create({
-    instruction: 'Correct the text',
+    strings: {
+      instruction: 'Correct the text'
+    },
     taskKey: 'T0',
     type: 'textFromSubject'
   })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/components/TextFromSubjectTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/components/TextFromSubjectTask.spec.js
@@ -10,7 +10,9 @@ describe('TextFromSubjectTask', function () {
   let wrapper
 
   const task = Task.TaskModel.create({
-    instruction: 'Correct the text',
+    strings: {
+      instruction: 'Correct the text'
+    },
     taskKey: 'T0',
     type: 'textFromSubject'
   })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/components/TextFromSubjectTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/components/TextFromSubjectTask.stories.js
@@ -38,9 +38,11 @@ export default {
 export function Default ({ contentLoadingState, dark, isThereTaskHelp, required, subjectReadyState }) {
   const tasks = {
     T0: {
-      help: 'Edit the text in the box.',
-      instruction: 'Correct the text',
       required,
+      strings: {
+        help: 'Edit the text in the box.',
+        instruction: 'Correct the text'
+      },
       taskKey: 'T0',
       type: 'textFromSubject'
     }

--- a/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/models/TextFromSubjectTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/models/TextFromSubjectTask.js
@@ -6,7 +6,6 @@ import TextFromSubjectAnnotation from './TextFromSubjectAnnotation'
 
 const TextFromSubject = types.model('TextFromSubject', {
   annotation: types.safeReference(TextFromSubjectAnnotation),
-  instruction: types.string,
   type: types.literal('textFromSubject')
 })
   .views(self => ({

--- a/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/models/TextFromSubjectTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/models/TextFromSubjectTask.js
@@ -6,7 +6,6 @@ import TextFromSubjectAnnotation from './TextFromSubjectAnnotation'
 
 const TextFromSubject = types.model('TextFromSubject', {
   annotation: types.safeReference(TextFromSubjectAnnotation),
-  help: types.optional(types.string, ''),
   instruction: types.string,
   type: types.literal('textFromSubject')
 })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/models/TextFromSubjectTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/models/TextFromSubjectTask.spec.js
@@ -14,7 +14,9 @@ describe('Model > TextFromSubjectTask', function () {
       { label: 'yes', next: 'S2' },
       { label: 'no', next: 'S3' }
     ],
-    question: 'Do you exist?',
+    strings: {
+      question: 'Do you exist?'
+    },
     required: '',
     taskKey: 'T1',
     type: 'single'

--- a/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/models/TextFromSubjectTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/models/TextFromSubjectTask.spec.js
@@ -2,7 +2,9 @@ import TextFromSubjectTask from '@plugins/tasks/experimental/textFromSubject'
 
 describe('Model > TextFromSubjectTask', function () {
   const textFromSubjectTask = {
-    instruction: 'Type something here',
+    strings: {
+      instruction: 'Type something here'
+    },
     taskKey: 'T0',
     type: 'textFromSubject'
   }

--- a/packages/lib-classifier/src/plugins/tasks/models/Task.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Task.js
@@ -29,6 +29,10 @@ const Task = types.model('Task', {
       return self.strings.get('instruction')
     },
 
+    get question() {
+      return self.strings.get('question')
+    },
+
     isComplete(annotation) {
       return !self.required || !!annotation?.isComplete
     },

--- a/packages/lib-classifier/src/plugins/tasks/models/Task.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Task.js
@@ -21,6 +21,10 @@ const Task = types.model('Task', {
       })
     },
 
+    get help() {
+      return self.strings.get('help')
+    },
+
     isComplete(annotation) {
       return !self.required || !!annotation?.isComplete
     },

--- a/packages/lib-classifier/src/plugins/tasks/models/Task.js
+++ b/packages/lib-classifier/src/plugins/tasks/models/Task.js
@@ -25,6 +25,10 @@ const Task = types.model('Task', {
       return self.strings.get('help')
     },
 
+    get instruction() {
+      return self.strings.get('instruction')
+    },
+
     isComplete(annotation) {
       return !self.required || !!annotation?.isComplete
     },

--- a/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.spec.js
@@ -7,8 +7,10 @@ import Task from '@plugins/tasks/multiple'
 describe('MultipleChoiceTask', function () {
   const task = Task.TaskModel.create({
     answers: [{ label: 'napping' }, { label: 'standing' }, { label: 'playing' }],
-    question: 'What is/are the cat(s) doing?',
     required: '',
+    strings: {
+      question: 'What is/are the cat(s) doing?'
+    },
     taskKey: 'T1',
     type: 'multiple'
   })

--- a/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.stories.js
@@ -31,7 +31,6 @@ export function LightTheme({ dark, isThereTaskHelp, required, subjectReadyState 
   const tasks = {
     T1: {
       answers: [{ label: 'sleeping' }, { label: 'playing' }, { label: 'looking indifferent' }],
-      question: 'What is it doing?',
       required,
       strings: {
         help: isThereTaskHelp ? 'Pick as many answers as apply, then press Done.' : '',

--- a/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.stories.js
@@ -31,9 +31,12 @@ export function LightTheme({ dark, isThereTaskHelp, required, subjectReadyState 
   const tasks = {
     T1: {
       answers: [{ label: 'sleeping' }, { label: 'playing' }, { label: 'looking indifferent' }],
-      help: 'Pick as many answers as apply, then press Done.',
       question: 'What is it doing?',
       required,
+      strings: {
+        help: isThereTaskHelp ? 'Pick as many answers as apply, then press Done.' : '',
+        question: 'What is it doing?'
+      },
       taskKey: 'T1',
       type: 'multiple'
     }

--- a/packages/lib-classifier/src/plugins/tasks/multiple/models/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/multiple/models/MultipleChoiceTask.js
@@ -11,7 +11,6 @@ const MultipleChoice = types.model('MultipleChoice', {
   answers: types.array(types.frozen({
     label: types.string
   })),
-  help: types.optional(types.string, ''),
   question: types.string,
   type: types.literal('multiple')
 })

--- a/packages/lib-classifier/src/plugins/tasks/multiple/models/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/multiple/models/MultipleChoiceTask.js
@@ -11,7 +11,6 @@ const MultipleChoice = types.model('MultipleChoice', {
   answers: types.array(types.frozen({
     label: types.string
   })),
-  question: types.string,
   type: types.literal('multiple')
 })
   .views(self => ({

--- a/packages/lib-classifier/src/plugins/tasks/multiple/models/MultipleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/multiple/models/MultipleChoiceTask.spec.js
@@ -1,18 +1,20 @@
 import { types } from 'mobx-state-tree'
 import MultipleChoiceTask from '@plugins/tasks/multiple'
 
-const multipleChoiceTask = {
-  answers: [
-    { label: 'leaves', _key: Math.random() },
-    { label: 'flowers', _key: Math.random() }
-  ],
-  question: 'What do you see?',
-  required: '',
-  taskKey: 'T2',
-  type: 'multiple'
-}
-
 describe('Model > MultipleChoiceTask', function () {
+  const multipleChoiceTask = {
+    answers: [
+      { label: 'leaves', _key: Math.random() },
+      { label: 'flowers', _key: Math.random() }
+    ],
+    required: '',
+    strings: {
+      question: 'What do you see?'
+    },
+    taskKey: 'T2',
+    type: 'multiple'
+  }
+
   it('should exist', function () {
     const multipleChoiceTaskInstance = MultipleChoiceTask.TaskModel.create(multipleChoiceTask)
     expect(multipleChoiceTaskInstance).to.be.ok()

--- a/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.spec.js
@@ -7,8 +7,10 @@ import Task from '@plugins/tasks/single'
 describe('SingleChoiceTask', function () {
   const task = Task.TaskModel.create({
     answers: [{ label: 'yes' }, { label: 'no' }],
-    question: 'Is there a cat?',
     required: 'true',
+    strings: {
+      question: 'Is there a cat?'
+    },
     taskKey: 'init',
     type: 'single'
   })

--- a/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.stories.js
@@ -31,9 +31,12 @@ export function LightTheme({ dark, isThereTaskHelp, required, subjectReadyState 
   const tasks = {
     init: {
       answers: [{ label: 'yes' }, { label: 'no' }],
-      help: 'Choose an answer from the choices given, then press Done.',
       question: 'Is there a cat?',
       required,
+      strings: {
+        help: isThereTaskHelp ? 'Choose an answer from the choices given, then press Done.' : '',
+        question: 'Is there a cat?'
+      },
       taskKey: 'init',
       type: 'single'
     }

--- a/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.stories.js
@@ -31,7 +31,6 @@ export function LightTheme({ dark, isThereTaskHelp, required, subjectReadyState 
   const tasks = {
     init: {
       answers: [{ label: 'yes' }, { label: 'no' }],
-      question: 'Is there a cat?',
       required,
       strings: {
         help: isThereTaskHelp ? 'Choose an answer from the choices given, then press Done.' : '',

--- a/packages/lib-classifier/src/plugins/tasks/single/models/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/models/SingleChoiceTask.js
@@ -12,7 +12,6 @@ const SingleChoice = types.model('SingleChoice', {
     label: types.string,
     next: types.maybe(types.string)
   })),
-  question: types.string,
   type: types.literal('single')
 })
   .views(self => ({

--- a/packages/lib-classifier/src/plugins/tasks/single/models/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/models/SingleChoiceTask.js
@@ -12,7 +12,6 @@ const SingleChoice = types.model('SingleChoice', {
     label: types.string,
     next: types.maybe(types.string)
   })),
-  help: types.optional(types.string, ''),
   question: types.string,
   type: types.literal('single')
 })

--- a/packages/lib-classifier/src/plugins/tasks/single/models/SingleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/models/SingleChoiceTask.spec.js
@@ -1,18 +1,20 @@
 import { types } from 'mobx-state-tree'
 import SingleChoiceTask from '@plugins/tasks/single'
 
-const singleChoiceTask = {
-  answers: [
-    { label: 'yes', next: 'S2' },
-    { label: 'no', next: 'S3' }
-  ],
-  question: 'Do you exist?',
-  required: '',
-  taskKey: 'T1',
-  type: 'single'
-}
-
 describe('Model > SingleChoiceTask', function () {
+  const singleChoiceTask = {
+    answers: [
+      { label: 'yes', next: 'S2' },
+      { label: 'no', next: 'S3' }
+    ],
+    required: '',
+    strings: {
+      question: 'Do you exist?'
+    },
+    taskKey: 'T1',
+    type: 'single'
+  }
+
   it('should exist', function () {
     const singleChoiceTaskInstance = SingleChoiceTask.TaskModel.create(singleChoiceTask)
     expect(singleChoiceTaskInstance).to.be.ok()

--- a/packages/lib-classifier/src/plugins/tasks/subjectGroupComparison/components/SubjectGroupComparisonTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/subjectGroupComparison/components/SubjectGroupComparisonTask.spec.js
@@ -6,8 +6,10 @@ import { default as Task } from '@plugins/tasks/subjectGroupComparison'
 
 describe('SubjectGroupComparisonTask', function () {
   const task = Task.TaskModel.create({
-    question: 'Please select the cells that look weird.',
     required: true,
+    strings: {
+      question: 'Please select the cells that look weird.'
+    },
     taskKey: 'init',
     type: 'subjectGroupComparison'
   })

--- a/packages/lib-classifier/src/plugins/tasks/subjectGroupComparison/models/SubjectGroupComparisonTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/subjectGroupComparison/models/SubjectGroupComparisonTask.js
@@ -8,7 +8,6 @@ import SubjectGroupComparisonAnnotation from './SubjectGroupComparisonAnnotation
 
 const SubjectGroupComparison = types.model('SubjectGroupComparison', {
   annotation: types.safeReference(SubjectGroupComparisonAnnotation),
-  help: types.optional(types.string, ''),
   question: types.string,
   type: types.literal('subjectGroupComparison')
 })

--- a/packages/lib-classifier/src/plugins/tasks/subjectGroupComparison/models/SubjectGroupComparisonTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/subjectGroupComparison/models/SubjectGroupComparisonTask.js
@@ -8,7 +8,6 @@ import SubjectGroupComparisonAnnotation from './SubjectGroupComparisonAnnotation
 
 const SubjectGroupComparison = types.model('SubjectGroupComparison', {
   annotation: types.safeReference(SubjectGroupComparisonAnnotation),
-  question: types.string,
   type: types.literal('subjectGroupComparison')
 })
   .views(self => ({

--- a/packages/lib-classifier/src/plugins/tasks/subjectGroupComparison/models/SubjectGroupComparisonTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/subjectGroupComparison/models/SubjectGroupComparisonTask.spec.js
@@ -2,8 +2,10 @@ import { types } from 'mobx-state-tree'
 import SubjectGroupComparisonTask from '@plugins/tasks/subjectGroupComparison'
 
 const subjectGroupTask = {
-  question: 'Which of these cells look weird?',
   required: false,
+  strings: {
+    question: 'Which of these cells look weird?'
+  },
   taskKey: 'T2',
   type: 'subjectGroupComparison'
 }

--- a/packages/lib-classifier/src/plugins/tasks/survey/models/SurveyTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/models/SurveyTask.js
@@ -35,7 +35,6 @@ const Survey = types.model('Survey', {
   choices: types.frozen({}),
   choicesOrder: types.array(types.string),
   exclusions: types.array(types.string),
-  help: types.optional(types.string, ''),
   images: types.frozen({}),
   inclusions: types.array(types.string),
   questions: types.frozen({}),

--- a/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/TextTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/TextTask.spec.js
@@ -24,7 +24,9 @@ describe('Text Task', function () {
     let modifiers, textInput
 
     const task = Task.TaskModel.create({
-      instruction: 'Type something here',
+      strings: {
+        instruction: 'Type something here'
+      },
       taskKey: 'T0',
       type: 'text'
     })

--- a/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/TextTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/TextTask.stories.js
@@ -53,9 +53,11 @@ export function Default({ dark, isThereTaskHelp, required, subjectReadyState }) 
 export function withSuggestions({ dark, isThereTaskHelp, required, subjectReadyState }) {
   const tasks = {
     T0: {
-      help: 'Type something into the text box.',
-      instruction: 'Type something here',
       required,
+      strings: {
+        help: isThereTaskHelp ? 'Pick one of the suggestions.' : '',
+        instruction: 'Type something here'
+      },
       taskKey: 'T0',
       text_tags: ['insertion', 'deletion', '&'],
       type: 'text'

--- a/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/TextTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/TextTask.stories.js
@@ -30,9 +30,12 @@ export default {
 export function Default({ dark, isThereTaskHelp, required, subjectReadyState }) {
   const tasks = {
     T0: {
-      help: 'Type something into the text box.',
       instruction: 'Type something here',
       required,
+      strings: {
+        help: isThereTaskHelp ? 'Type something into the text box.' : '',
+        instruction: 'Type something here'
+      },
       taskKey: 'T0',
       text_tags: ['insertion', 'deletion', '&'],
       type: 'text'

--- a/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/TextTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/TextTask.stories.js
@@ -30,7 +30,6 @@ export default {
 export function Default({ dark, isThereTaskHelp, required, subjectReadyState }) {
   const tasks = {
     T0: {
-      instruction: 'Type something here',
       required,
       strings: {
         help: isThereTaskHelp ? 'Type something into the text box.' : '',

--- a/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/DefaultTextTask/DefaultTextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/DefaultTextTask/DefaultTextTask.js
@@ -1,3 +1,4 @@
+import { observer } from 'mobx-react'
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Box, Text, TextArea } from 'grommet'
@@ -10,7 +11,7 @@ const StyledText = styled(Text)`
   margin: 10px 0;
 `
 
-export default function DefaultTextTask ({
+function DefaultTextTask ({
   autoFocus = false,
   disabled = false,
   setTagSelection = () => true,
@@ -79,3 +80,5 @@ DefaultTextTask.propTypes = {
   value: PropTypes.string.isRequired,
   updateAnnotation: PropTypes.func
 }
+
+export default observer(DefaultTextTask)

--- a/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.js
@@ -1,3 +1,4 @@
+import { observer } from 'mobx-react'
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Box, TextInput, Text } from 'grommet'
@@ -10,7 +11,7 @@ const StyledText = styled(Text)`
   margin: 10px 0;
 `
 
-export default function TextTaskWithSuggestions ({
+function TextTaskWithSuggestions ({
   autoFocus = false,
   disabled = false,
   onSelectSuggestion = () => true,
@@ -90,3 +91,5 @@ TextTaskWithSuggestions.propTypes = {
   value: PropTypes.string.isRequired,
   updateAnnotation: PropTypes.func
 }
+
+export default observer(TextTaskWithSuggestions)

--- a/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
@@ -13,7 +13,9 @@ describe('TextTask > Components > TextTaskWithSuggestions', function () {
   before(function () {
     sinon.stub(window, 'scrollTo')
     task = Task.TaskModel.create({
-      instruction: 'Type something here',
+      strings: {
+        instruction: 'Type something here',
+      },
       taskKey: 'T0',
       text_tags: ['insertion', 'deletion'],
       type: 'text'

--- a/packages/lib-classifier/src/plugins/tasks/text/models/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/models/TextTask.js
@@ -5,7 +5,6 @@ import TextAnnotation from './TextAnnotation'
 
 const Text = types.model('Text', {
   annotation: types.safeReference(TextAnnotation),
-  instruction: types.string,
   required: types.maybe(types.union(types.string, types.boolean)),
   text_tags: types.array(types.string),
   type: types.literal('text')

--- a/packages/lib-classifier/src/plugins/tasks/text/models/TextTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/models/TextTask.js
@@ -5,7 +5,6 @@ import TextAnnotation from './TextAnnotation'
 
 const Text = types.model('Text', {
   annotation: types.safeReference(TextAnnotation),
-  help: types.optional(types.string, ''),
   instruction: types.string,
   required: types.maybe(types.union(types.string, types.boolean)),
   text_tags: types.array(types.string),

--- a/packages/lib-classifier/src/plugins/tasks/text/models/TextTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/models/TextTask.spec.js
@@ -3,7 +3,9 @@ import TextTask from '@plugins/tasks/text'
 
 describe('Model > TextTask', function () {
   const textTask = {
-    instruction: 'Type something here',
+    strings: {
+      instruction: 'Type something here'
+    },
     taskKey: 'T0',
     text_tags: ['insertion', 'deletion', '&'],
     type: 'text'

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.spec.js
@@ -29,6 +29,10 @@ describe('Model > WorkflowStepStore', function () {
           ['S1', { taskKeys: ['T1'] }],
           ['S2', { taskKeys: ['T2'] }]
         ],
+        strings: {
+          'tasks.T1.question': 'Is there a galaxy?',
+          'tasks.T2.question': 'Check all of the colors that apply'
+        },
         tasks: {
           T1: SingleChoiceTaskFactory.build(),
           T2: MultipleChoiceTaskFactory.build()
@@ -90,8 +94,7 @@ describe('Model > WorkflowStepStore', function () {
         step.tasks.forEach(task => {
           const annotation = undefined
           const { taskKey } = task
-          const strings = {}
-          const originalTask = { ...workflow.tasks[taskKey], annotation, strings, taskKey }
+          const originalTask = { ...workflow.tasks[taskKey], annotation, taskKey }
           expect(getSnapshot(task)).to.eql(originalTask)
         })
       })
@@ -118,6 +121,12 @@ describe('Model > WorkflowStepStore', function () {
     before(async function () {
       workflow = WorkflowFactory.build({
         first_task: 'T1',
+        strings: {
+          display_name: 'test workflow',
+          'tasks.T1.question': 'Is there a galaxy?',
+          'tasks.T2.question': 'Check all of the colors that apply',
+          'tasks.T3.question': 'Check all of the colors that apply'
+        },
         tasks: {
           T1: SingleChoiceTaskFactory.build(),
           T2: MultipleChoiceTaskFactory.build(),
@@ -149,8 +158,7 @@ describe('Model > WorkflowStepStore', function () {
         step.tasks.forEach(task => {
           const annotation = undefined
           const { taskKey } = task
-          const strings = {}
-          const originalTask = { ...workflow.tasks[taskKey], annotation, strings, taskKey }
+          const originalTask = { ...workflow.tasks[taskKey], annotation, taskKey }
           expect(getSnapshot(task)).to.eql(originalTask)
         })
       })
@@ -178,6 +186,13 @@ describe('Model > WorkflowStepStore', function () {
     before(async function () {
       workflow = WorkflowFactory.build({
         first_task: 'T1',
+        strings: {
+          display_name: 'test workflow',
+          'tasks.T1.question': 'Is there a galaxy?',
+          'tasks.T2.question': 'Check all of the colors that apply',
+          'tasks.T3.question': 'Check all of the colors that apply',
+          'tasks.T5.question': 'Check all of the colors that apply'
+        },
         tasks: {
           T1: SingleChoiceTaskFactory.build({
             answers: [
@@ -216,8 +231,7 @@ describe('Model > WorkflowStepStore', function () {
         step.tasks.forEach(task => {
           const annotation = undefined
           const { taskKey } = task
-          const strings = {}
-          const originalTask = { ...workflow.tasks[taskKey], annotation, strings, taskKey }
+          const originalTask = { ...workflow.tasks[taskKey], annotation, taskKey }
           expect(getSnapshot(task)).to.eql(originalTask)
         })
       })

--- a/packages/lib-classifier/src/stories/components/MockTask/MockTask.js
+++ b/packages/lib-classifier/src/stories/components/MockTask/MockTask.js
@@ -37,7 +37,7 @@ function addStepToStore(taskSnapshots = {}, isThereTaskHelp = true) {
   const workflow = MockTask.store.workflows.resources.get(workflowSnapshot.id)
   applySnapshot(workflow, workflowSnapshot)
   MockTask.store.workflowSteps.setStepsAndTasks(workflowSnapshot)
-  MockTask.store.workflowSteps.setTaskStrings()
+  MockTask.store.workflowSteps.setTaskStrings(strings)
   MockTask.store.subjects.active.stepHistory.start()
 }
 

--- a/packages/lib-classifier/test/factories/tasks/DrawingTaskFactory.js
+++ b/packages/lib-classifier/test/factories/tasks/DrawingTaskFactory.js
@@ -3,7 +3,6 @@ import { Factory } from 'rosie'
 // TODO make configurable on tool type
 
 export default new Factory()
-  .attr('help', '')
   .attr('instruction', 'Please draw something')
   .attr('tools', [])
   .attr('type', 'drawing')

--- a/packages/lib-classifier/test/factories/tasks/MultipleChoiceTaskFactory.js
+++ b/packages/lib-classifier/test/factories/tasks/MultipleChoiceTaskFactory.js
@@ -7,5 +7,7 @@ export default new Factory()
     { label: 'green' }
   ])
   .attr('required', '')
-  .attr('question', 'Check all of the colors that apply')
+  .attr('strings', {
+    question: 'Check all of the colors that apply'
+  })
   .attr('type', 'multiple')

--- a/packages/lib-classifier/test/factories/tasks/MultipleChoiceTaskFactory.js
+++ b/packages/lib-classifier/test/factories/tasks/MultipleChoiceTaskFactory.js
@@ -6,7 +6,6 @@ export default new Factory()
     { label: 'blue' },
     { label: 'green' }
   ])
-  .attr('help', '')
   .attr('required', '')
   .attr('question', 'Check all of the colors that apply')
   .attr('type', 'multiple')

--- a/packages/lib-classifier/test/factories/tasks/SingleChoiceTaskFactory.js
+++ b/packages/lib-classifier/test/factories/tasks/SingleChoiceTaskFactory.js
@@ -6,6 +6,8 @@ export default new Factory()
     { label: 'No' }
   ])
   .attr('required', 'true')
-  .attr('question', 'Is there a galaxy?')
+  .attr('strings', {
+    question: 'Is there a galaxy?'
+  })
   .attr('taskKey', '')
   .attr('type', 'single')

--- a/packages/lib-classifier/test/factories/tasks/SingleChoiceTaskFactory.js
+++ b/packages/lib-classifier/test/factories/tasks/SingleChoiceTaskFactory.js
@@ -5,7 +5,6 @@ export default new Factory()
     { label: 'Yes' },
     { label: 'No' }
   ])
-  .attr('help', '')
   .attr('required', 'true')
   .attr('question', 'Is there a galaxy?')
   .attr('taskKey', '')

--- a/packages/lib-classifier/test/factories/tasks/TextTaskFactory.js
+++ b/packages/lib-classifier/test/factories/tasks/TextTaskFactory.js
@@ -5,7 +5,6 @@ export default new Factory()
     'insertion',
     'deletion'
   ])
-  .attr('help', '')
   .attr('required', false)
   .attr('instruction', 'Enter some text')
   .attr('taskKey', '')

--- a/packages/lib-classifier/test/factories/tasks/TranscriptionTaskFactory.js
+++ b/packages/lib-classifier/test/factories/tasks/TranscriptionTaskFactory.js
@@ -1,7 +1,6 @@
 import { Factory } from 'rosie'
 
 export default new Factory()
-  .attr('help', '')
   .attr('instruction', 'Please transcribe the text')
   .attr('tools', [{
     details: [{


### PR DESCRIPTION
Following on from #3145, this localises `task.help`, `task.instruction` and `task.question` by converting them to views, which read their values from `task.strings.help`, `task.strings.instruction` and `task.strings.question` respectively.

I've tried to update as many tests and stories as possible to use translation strings, so this branch will be the base branch for all other work on workflow tasks.

Closes #3299.

## Package
lib-classifier

## How to Review
This dropdown task on staging has instructions in three languages.
https://localhost:8080/?project=908&workflow=3339

Every Name Counts, on production, has task instructions and questions in English and German. The subject content can be distressing, though.
https://localhost:8080/?project=arolsen-archives/every-name-counts&env=production&workflow=18126&language=de

https://user-images.githubusercontent.com/59547/170210370-923654f2-1064-4193-b01f-a9c2c48b320e.mov


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
