### PR TITLE
Classifier: localise drawing task tools

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.js
@@ -51,7 +51,7 @@ function DrawingTask(props) {
             disabled={tool.disabled}
             index={index}
             key={`${task.taskKey}_${index}`}
-            label={tool.label}
+            label={task.strings.get(`tools.${index}.label`)}
             labelIcon={
               <InputIcon
                 icon={<ToolIcon type={tool.type} />}

--- a/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.spec.js
@@ -14,14 +14,14 @@ describe('DrawingTask', function () {
     help: 'Help content.',
     strings: {
       instruction: 'Draw something.',
+      'tools.0.label': 'Line',
+      'tools.1.label': 'Point'
     },
     taskKey: 'T0',
     tools: [{
-      label: 'Line',
       max: 3,
       type: 'line'
     }, {
-      label: 'Point',
       min: 1,
       type: 'point'
     }],

--- a/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.stories.js
@@ -34,36 +34,36 @@ export function Drawing({ dark, isThereTaskHelp, required, subjectReadyState }) 
       required,
       strings: {
         help: isThereTaskHelp ? 'Draw on the image.' : '',
-        instruction: 'Draw something'
+        instruction: 'Draw something',
+        'tools.0.label': 'Draw a line',
+        'tools.1.label': 'Point please.',
+        'tools.2.label': 'Draw under the text',
+        'tools.3.label': 'Draw a rectangle',
+        'tools.4.label': 'Draw an ellipse'
       },
       taskKey: 'T2',
       tools: [
         {
           color: zooTheme.global.colors['drawing-red'],
           help: '',
-          label: 'Draw a line',
           type: 'line'
         }, {
           color: zooTheme.global.colors['drawing-blue'],
           help: '',
-          label: 'Point please.',
           min: 1,
           max: 2,
           type: 'point',
         }, {
           color: zooTheme.global.colors['drawing-green'],
           help: '',
-          label: 'Draw under the text',
           type: 'transcriptionLine'
         }, {
           color: zooTheme.global.colors['drawing-orange'],
           help: '',
-          label: 'Draw a rectangle',
           type: 'rectangle',
         }, {
           color: zooTheme.global.colors['drawing-yellow'],
           help: '',
-          label: 'Draw an ellipse',
           type: 'ellipse',
         }
       ],

--- a/packages/lib-classifier/src/plugins/tasks/experimental/transcription/TranscriptionTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/transcription/TranscriptionTask.stories.js
@@ -34,6 +34,7 @@ export function LightTheme({ dark, isThereTaskHelp, required, subjectReadyState 
       strings: {
         help: 'Underline the line to transcribe with two clicks, then enter in the text transcription.',
         instruction: 'Underline and transcribe',
+        'tools.0.label': 'Draw under the text'
       },
       taskKey: 'T3',
       tools: [


### PR DESCRIPTION
Use `task.strings.get()` for the tool labels in drawing and transcription tasks.

Based on #3193.

## Package
lib-classifier


## How to Review
Try this out on Rosetta Zoo:
https://localhost:8080/?project=ellenjj/rosetta-zoo&env=production
or in the project app:
https://local.zooniverse.org:3000/projects/fr/ellenjj/rosetta-zoo/classify/workflow/19473?env=production


https://user-images.githubusercontent.com/59547/170259934-ac80c841-18e7-4367-90f9-c0e8ba79b308.mov


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook
 
## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
