### PR TITLE
QuickTalk: Refactor to functional component

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -88,6 +88,7 @@ function QuickTalk ({
         />
         <Button
           a11yTitle={t('QuickTalk.aria.closeButton')}
+          autoFocus={true}
           icon={<Close size='small' />}
           onClick={() => setExpand(false)}
           plain

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
@@ -148,12 +148,12 @@ function QuickTalkContainer ({
 
       const authorization = await getBearerToken(authClient)  // Check bearer token to ensure session hasn't timed out
       const user = await authClient.checkCurrent()
-      if (!authorization || !user) throw('User not logged in')
+      if (!authorization || !user) throw new Error(t('QuickTalk.errors.noUser'))
 
       // First, get default board
       const boards = await talkClient.type('boards').get({ section, subject_default: true })
       const defaultBoard = boards && boards[0]
-      if (!defaultBoard) throw('A board for subject comments has not been setup for this project yet.')
+      if (!defaultBoard) throw new Error(t('QuickTalk.errors.noBoard'))
 
       // Next, attempt to find if the Subject already has a discussion attached to it.
       const discussions = await talkClient.type('discussions').get({

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
@@ -93,15 +93,8 @@ function QuickTalkContainer ({
   function fetchComments () {
     resetComments()
 
-    console.log('+++ DEBUG')
-    return
-
-    /*
-    const subject = this.props?.subject
     const project = subject?.project
-    if (!subject || !project) {
-      return
-    }
+    if (!subject || !project) return
 
     const section = 'project-' + project.id
     const query = {
@@ -113,20 +106,20 @@ function QuickTalkContainer ({
     }
 
     talkClient.type('comments').get(query)
-      .then (comments =>{
-        this.setState({ comments })
+      .then (allComments =>{
+        setComments(allComments)
 
         let author_ids = []
         let authors = {}
         let authorRoles = {}
 
-        author_ids = comments.map(comment => comment.user_id)
+        author_ids = allComments.map(comment => comment.user_id)
         author_ids = author_ids.filter((id, i) => author_ids.indexOf(id) === i)
 
         apiClient.type('users').get({ id: author_ids })
           .then(users => {
             users.forEach(user => authors[user.id] = user)
-            this.setState({ authors })
+            setAuthors(authors)
           })
 
         talkClient.type('roles')
@@ -140,10 +133,9 @@ function QuickTalkContainer ({
               if (!authorRoles[role.user_id]) authorRoles[role.user_id] = []
               authorRoles[role.user_id].push(role)
             })
-            this.setState({ authorRoles })
+            setAuthorRoles(authorRoles)
           })
       })
-    */
   }
 
   function resetComments () {

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
@@ -42,6 +42,7 @@ function QuickTalkContainer ({
   authClient,
   enabled = false,
   subject,
+  t = () => '',  // Translations
 }) {
 
   const [comments, setComments] = useState([])
@@ -58,25 +59,6 @@ function QuickTalkContainer ({
   }
 
   useEffect(onMount, [subject])
-
-  /*
-  componentDidMount () {
-    if (!this.props.enabled) return
-
-    this.fetchComments()
-    this.checkUser()
-  }
-
-  componentDidUpdate (prevProps) {
-    if (!this.props.enabled) return
-
-    const props = this.props
-    if (props.subject !== prevProps.subject) {  // Note: this high level comparison actually works. Comparing props.subject?.id !== prevProps.subject?.id however causes a crash when getting a new subject, since prevProps.subject would have been removed from memory.
-      this.fetchComments()
-      this.checkUser()
-    }
-  }
-  */
 
   /*
   Quick Fix: use authClient to check User resource within the QuickTalk component itself
@@ -145,26 +127,17 @@ function QuickTalkContainer ({
   }
 
   async function postComment (text) {
-    const { t } = this.props
-    const subject = this.props?.subject
     const project = subject?.project
-    const authClient = this.props?.authClient
-    if (!subject || !project || !authClient) {
-      return
-    }
+    if (!subject || !project || !authClient) return
 
     const section = `project-${project.id}`
     const discussionTitle = `Subject ${subject.id}`
 
-    this.setState({
-      postCommentStatus: asyncStates.loading,
-      postCommentStatusMessage: '',
-    })
+    setPostCommentStatus(asyncStates.loading)
+    setPostCommentStatusMessage('')
 
     try {
-      if (!text || text.trim().length === 0) {
-        throw new Error(t('QuickTalk.errors.noText'))
-      }
+      if (!text || text.trim().length === 0) throw new Error(t('QuickTalk.errors.noText'))
 
       /*
       Quick Fix: check user before posting
@@ -199,11 +172,10 @@ function QuickTalkContainer ({
         }
 
         await talkClient.type('comments').create(comment).save()
-        this.setState({
-          postCommentStatus: asyncStates.success,
-          postCommentStatusMessage: '',
-        })
-        this.fetchComments()
+
+        setPostCommentStatus(asyncStates.success)
+        setPostCommentStatusMessage('')
+        fetchComments()
 
       } else {  // Create a new discussion
 
@@ -223,19 +195,16 @@ function QuickTalkContainer ({
         }
 
         await talkClient.type('discussions').create(discussion).save()
-        this.setState({
-          postCommentStatus: asyncStates.success,
-          postCommentStatusMessage: '',
-        })
-        this.fetchComments()
+
+        setPostCommentStatus(asyncStates.success)
+        setPostCommentStatusMessage('')
+        fetchComments()
       }
 
     } catch (err) {
       console.error(err)
-      this.setState({
-        postCommentStatus: asyncStates.error,
-        postCommentStatusMessage: err?.message || err,
-      })
+      setPostCommentStatus(asyncStates.error)
+      setPostCommentStatusMessage(err?.message || err)
     }
   }
 

--- a/packages/lib-classifier/src/translations/en/components.json
+++ b/packages/lib-classifier/src/translations/en/components.json
@@ -132,7 +132,9 @@
       "loading": "Posting comment..."
     },
     "errors": {
-      "noText": "Can't post an empty comment."
+      "noBoard": "A board for subject comments has not been setup for this project yet.",
+      "noText": "Can't post an empty comment.",
+      "noUser": "User not logged in."
     }
   },
   "SlideTutorial": {


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`
Affects: experimental QuickTalk feature (only affects projects with experimental tool enabled)

This PR refactors the QuickTalkContainer into a _functional component._

- No actual functions or features have been changed (EDIT: except for the two minor changes below). Users should see no difference in the feature.
- Minor: error messages now use translated text.
- Minor: when QuickTalk panel opens, close button now automatically gets focus. (I thought I added this in 3048, but I must have dropped it, d'oh!)

### Testing

- Test on `lib-classifier` (not app-project) with a project with QuickTalk enabled, e.g. https://local.zooniverse.org:8080/?env=staging&project=darkeshard%2Ftest-project-2022&workflow=3581
- You should be able to see the QuickTalk button on the lower-right of the screen, with a number _if_ any comments already exist.
- If you click on the button, the QuickTalk panel should expand, and you should see any comments already made.
- If you're logged in, you should be able to post comments on the expanded panel.

Known UI issues: (collapsed) QuickTalk button should have a background so it doesn't blend into the page (z-index madness) ; a message saying "you should be logged in if you want to post a message" should appear on the expanded panel.

### Status

Ready for review! 👍 