### PR TITLE
Bug Fix: Remove hard-coded color for lists and remove Markdownz from field guide anchor

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItemAnchor/FieldGuideItemAnchor.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItemAnchor/FieldGuideItemAnchor.js
@@ -1,7 +1,6 @@
-import { Anchor, Box } from 'grommet'
+import { Anchor, Box, Paragraph } from 'grommet'
 import React from 'react'
 import { observable } from 'mobx'
-import { Markdownz } from '@zooniverse/react-components'
 import PropTypes from 'prop-types'
 import { PropTypes as MobXPropTypes } from 'mobx-react'
 import { withTheme } from 'styled-components'
@@ -18,9 +17,9 @@ export function AnchorLabel ({ className, icons, item }) {
       width='100px'
     >
       <FieldGuideItemIcon alt={item.title} fit='cover' height='100px' icon={icon} width='100px' />
-      <Markdownz>
+      <Paragraph>
         {item.title}
-      </Markdownz>
+      </Paragraph>
     </Box>
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItemAnchor/FieldGuideItemAnchor.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItemAnchor/FieldGuideItemAnchor.spec.js
@@ -2,12 +2,10 @@ import { mount, shallow } from 'enzyme'
 import sinon from 'sinon'
 import React from 'react'
 import { observable } from 'mobx'
-import { Markdownz } from '@zooniverse/react-components'
-import { Anchor } from 'grommet'
+import { Anchor, Grommet, Paragraph } from 'grommet'
 import { FieldGuideItemAnchor, AnchorLabel } from './FieldGuideItemAnchor'
 import FieldGuideItemIcon from '../FieldGuideItemIcon'
 import { FieldGuideMediumFactory } from '@test/factories'
-import { Grommet } from 'grommet'
 import zooTheme from '@zooniverse/grommet-theme'
 
 const mediumOne = FieldGuideMediumFactory.build()
@@ -75,13 +73,13 @@ describe('Component > FieldGuideItemAnchor', function () {
       expect(wrapper).to.be.ok()
     })
 
-    it('should render the item title as markdown', function () {
+    it('should render the item title', function () {
       const wrapper = shallow(
         <AnchorLabel
           icons={attachedMedia}
           item={item}
         />)
-      expect(wrapper.find(Markdownz).contains(item.title)).to.be.true()
+      expect(wrapper.find(Paragraph).contains(item.title)).to.be.true()
     })
 
     it('should render an FieldGuideItemIcon component', function () {

--- a/packages/lib-react-components/src/Markdownz/Markdownz.js
+++ b/packages/lib-react-components/src/Markdownz/Markdownz.js
@@ -104,8 +104,8 @@ class Markdownz extends React.Component {
       tbody: TableBody,
       td: TableCell,
       tr: TableRow,
-      ol: (nodeProps) => <ol style={{ color: '#000000', fontSize: '14px', marginTop: 0 }}>{nodeProps.children}</ol>,
-      ul: (nodeProps) => <ul style={{ color: '#000000', fontSize: '14px', marginTop: 0 }}>{nodeProps.children}</ul>
+      ol: (nodeProps) => <ol style={{ fontSize: '14px', marginTop: 0 }}>{nodeProps.children}</ol>,
+      ul: (nodeProps) => <ul style={{ fontSize: '14px', marginTop: 0 }}>{nodeProps.children}</ul>
     }
 
     const remarkReactComponents = Object.assign({}, componentMappings, components)


### PR DESCRIPTION
## Package
lib-classifier
lib-react-components

## Linked Issue and/or Talk Post
Bug discovered from modifying Markdownz for https://github.com/zooniverse/front-end-monorepo/issues/3039

## Describe your changes

I removed the hard-coded `{{ color: #00000 }}` from Markdownz so it doesn't interrupt dark mode styling on things like the classifier's TaskArea, etc.

Each field guide item's title is now rendered with Grommet Paragraph instead of Markdownz in FieldGuideItemAnchor. Styling should look exactly the same.

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?

Comparing Beyond Borders's TaskArea (includes lists) and its Field Guide item titles with production, the styling should appear the same. https://www.zooniverse.org/projects/mainehistory/beyond-borders-transcribing-historic-maine-land-documents/classify/workflow/18383

- Are there plans for follow up PR’s to further fix this bug or develop this feature?

If project About Pages would like their lists to match the same text color as paragraphs, a follow up PR is needed to adapt them to light/dark mode.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated
