### PR TITLE
Classifier: more stringent workflow version checks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -36,6 +36,13 @@ describe('Components > Classifier', function () {
     let subjectImage, tabPanel, taskAnswers, taskTab, tutorialTab, workflow
 
     before(function () {
+      sinon.replace(window, 'Image', class MockImage {
+        constructor () {
+          this.naturalHeight = 1000
+          this.naturalWidth = 500
+          setTimeout(() => this.onload(), 5000)
+        }
+      })
       const subject = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
       const store = mockStore({ subject })
       const project = store.projects.active
@@ -60,6 +67,10 @@ describe('Components > Classifier', function () {
       const task = workflowSnapshot.tasks.T0
       const getAnswerInput = answer => within(tabPanel).getByRole('radio', { name: answer.label })
       taskAnswers = task.answers.map(getAnswerInput)
+    })
+
+    after(function () {
+      sinon.restore()
     })
 
     it('should have a task tab', function () {
@@ -96,7 +107,14 @@ describe('Components > Classifier', function () {
   describe('after the subject has loaded', function () {
     let subjectImage, tabPanel, taskAnswers, taskTab, tutorialTab, workflow
 
-    before(function () {
+    before(async function () {
+      sinon.replace(window, 'Image', class MockImage {
+        constructor () {
+          this.naturalHeight = 1000
+          this.naturalWidth = 500
+          setTimeout(() => this.onload(), 500)
+        }
+      })
       const subject = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
       const store = mockStore({ subject })
       const project = store.projects.active
@@ -114,7 +132,7 @@ describe('Components > Classifier', function () {
           wrapper: withStore(store)
         }
       )
-      store.subjectViewer.onSubjectReady()
+      await when(() => store.subjectViewer.loadingState === asyncStates.success)
       taskTab = screen.getByRole('tab', { name: 'TaskArea.task'})
       tutorialTab = screen.getByRole('tab', { name: 'TaskArea.tutorial'})
       subjectImage = screen.getByRole('img', { name: `Subject ${subject.id}` })
@@ -122,6 +140,10 @@ describe('Components > Classifier', function () {
       const task = workflowSnapshot.tasks.T0
       const getAnswerInput = answer => within(tabPanel).getByRole('radio', { name: answer.label })
       taskAnswers = task.answers.map(getAnswerInput)
+    })
+
+    after(function () {
+      sinon.restore()
     })
 
     it('should have a task tab', function () {
@@ -158,7 +180,14 @@ describe('Components > Classifier', function () {
   describe('when the locale changes', function () {
     let locale, subjectImage, tabPanel, taskAnswers, taskTab, tutorialTab, workflow
 
-    before(function () {
+    before(async function () {
+      sinon.replace(window, 'Image', class MockImage {
+        constructor () {
+          this.naturalHeight = 1000
+          this.naturalWidth = 500
+          setTimeout(() => this.onload(), 500)
+        }
+      })
       const subject = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
       const store = mockStore({ subject })
       const project = store.projects.active
@@ -177,7 +206,7 @@ describe('Components > Classifier', function () {
           wrapper: withStore(store)
         }
       )
-      store.subjectViewer.onSubjectReady()
+      await when(() => store.subjectViewer.loadingState === asyncStates.success)
       rerender(
         <Classifier
           classifierStore={store}
@@ -196,6 +225,10 @@ describe('Components > Classifier', function () {
       const task = workflowSnapshot.tasks.T0
       const getAnswerInput = answer => within(tabPanel).getByRole('radio', { name: answer.label })
       taskAnswers = task.answers.map(getAnswerInput)
+    })
+
+    after(function () {
+      sinon.restore()
     })
 
     it('should update the global locale', function () {
@@ -237,6 +270,13 @@ describe('Components > Classifier', function () {
     let subjectImage, tabPanel, taskAnswers, taskTab, tutorialTab, workflow
 
     before(async function () {
+      sinon.replace(window, 'Image', class MockImage {
+        constructor () {
+          this.naturalHeight = 1000
+          this.naturalWidth = 500
+          setTimeout(() => this.onload(), 500)
+        }
+      })
       const roles = []
       const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
       const workflowSnapshot = branchingWorkflow
@@ -286,8 +326,7 @@ describe('Components > Classifier', function () {
           wrapper: withStore(store)
         }
       )
-      await when(() => store.subjects.loadingState === asyncStates.success)
-      store.subjectViewer.onSubjectReady()
+      await when(() => store.subjectViewer.loadingState === asyncStates.success)
       const newSnapshot = {
         ...workflowSnapshot,
         version: '0.1',
@@ -316,7 +355,7 @@ describe('Components > Classifier', function () {
         }
       )
       workflow = store.workflows.active
-      store.subjectViewer.onSubjectReady()
+      await when(() => store.subjectViewer.loadingState === asyncStates.success)
       taskTab = screen.getByRole('tab', { name: 'TaskArea.task'})
       tutorialTab = screen.getByRole('tab', { name: 'TaskArea.tutorial'})
       subjectImage = screen.getByRole('img', { name: `Subject ${subjectSnapshot.id}` })
@@ -327,8 +366,7 @@ describe('Components > Classifier', function () {
     })
 
     after(function () {
-      panoptes.get.restore()
-      panoptes.post.restore()
+      sinon.restore()
     })
 
     it('should have a task tab', function () {
@@ -369,6 +407,13 @@ describe('Components > Classifier', function () {
         let subjectImage, tabPanel, taskAnswers, taskTab, tutorialTab, workflow
 
         before(async function () {
+          sinon.replace(window, 'Image', class MockImage {
+            constructor () {
+              this.naturalHeight = 1000
+              this.naturalWidth = 500
+              setTimeout(() => this.onload(), 500)
+            }
+          })
           const roles = [role]
           const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
           const workflowSnapshot = branchingWorkflow
@@ -418,9 +463,8 @@ describe('Components > Classifier', function () {
               wrapper: withStore(store)
             }
           )
-          await when(() => store.subjects.loadingState === asyncStates.success)
+          await when(() => store.subjectViewer.loadingState === asyncStates.success)
           workflow = store.workflows.active
-          store.subjectViewer.onSubjectReady()
           taskTab = screen.getByRole('tab', { name: 'TaskArea.task'})
           tutorialTab = screen.getByRole('tab', { name: 'TaskArea.tutorial'})
           subjectImage = screen.queryByRole('img', { name: `Subject ${subjectSnapshot.id}` })
@@ -431,8 +475,7 @@ describe('Components > Classifier', function () {
         })
 
         after(function () {
-          panoptes.get.restore()
-          panoptes.post.restore()
+          sinon.restore()
         })
 
         it('should have a task tab', function () {
@@ -472,6 +515,13 @@ describe('Components > Classifier', function () {
     let subjectImage, tabPanel, taskAnswers, taskTab, tutorialTab, workflow
 
     before(async function () {
+      sinon.replace(window, 'Image', class MockImage {
+        constructor () {
+          this.naturalHeight = 1000
+          this.naturalWidth = 500
+          setTimeout(() => this.onload(), 500)
+        }
+      })
       const roles = []
       const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
       const workflowSnapshot = branchingWorkflow
@@ -532,8 +582,7 @@ describe('Components > Classifier', function () {
     })
 
     after(function () {
-      panoptes.get.restore()
-      panoptes.post.restore()
+      sinon.restore()
     })
 
     it('should have a task tab', function () {
@@ -561,6 +610,13 @@ describe('Components > Classifier', function () {
     let tutorialHeading
 
     before(async function () {
+      sinon.replace(window, 'Image', class MockImage {
+        constructor () {
+          this.naturalHeight = 1000
+          this.naturalWidth = 500
+          setTimeout(() => this.onload(), 500)
+        }
+      })
       const subject = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
       const steps = [
         { content: "Hello" },
@@ -588,6 +644,10 @@ describe('Components > Classifier', function () {
       tutorialHeading = await screen.findByRole('heading', { name: 'ModalTutorial.title' })
     })
 
+    after(function () {
+      sinon.restore()
+    })
+
     it('should show the popup tutorial', function () {
       expect(tutorialHeading).to.exist()
     })
@@ -597,6 +657,13 @@ describe('Components > Classifier', function () {
     let tutorialHeading
 
     before(async function () {
+      sinon.replace(window, 'Image', class MockImage {
+        constructor () {
+          this.naturalHeight = 1000
+          this.naturalWidth = 500
+          setTimeout(() => this.onload(), 500)
+        }
+      })
       const subject = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
       const steps = [
         { content: "Hello" },
@@ -622,6 +689,10 @@ describe('Components > Classifier', function () {
       )
       await when(() => store.tutorials.active.hasNotBeenSeen)
       tutorialHeading = screen.queryByRole('heading', { name: 'ModalTutorial.title' })
+    })
+
+    after(function () {
+      sinon.restore()
     })
 
     it('should not show the popup tutorial', function () {

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -48,7 +48,6 @@ describe('Components > Classifier', function () {
           project={projectSnapshot}
           workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
-          workflowVersion={workflowSnapshot?.version}
         />,
         {
           wrapper: withStore(store)
@@ -110,7 +109,6 @@ describe('Components > Classifier', function () {
           project={projectSnapshot}
           workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
-          workflowVersion={workflowSnapshot?.version}
         />,
         {
           wrapper: withStore(store)
@@ -174,7 +172,6 @@ describe('Components > Classifier', function () {
           project={projectSnapshot}
           workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
-          workflowVersion={workflowSnapshot?.version}
         />,
         {
           wrapper: withStore(store)
@@ -215,6 +212,135 @@ describe('Components > Classifier', function () {
 
     it('should have a subject image', function () {
       expect(subjectImage).to.be.ok()
+    })
+
+    describe('task answers', function () {
+      it('should be displayed', function () {
+        expect(taskAnswers).to.have.lengthOf(workflow.tasks.T0.answers.length)
+      })
+
+      it('should be linked to the task', function () {
+        taskAnswers.forEach(radioButton => {
+          expect(radioButton.name).to.equal('T0')
+        })
+      })
+
+      it('should be enabled', function () {
+        taskAnswers.forEach(radioButton => {
+          expect(radioButton.disabled).to.be.false()
+        })
+      })
+    })
+  })
+
+  describe('when the workflow version changes', function () {
+    let subjectImage, tabPanel, taskAnswers, taskTab, tutorialTab, workflow
+
+    before(async function () {
+      const roles = []
+      const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+      const workflowSnapshot = branchingWorkflow
+      workflowSnapshot.strings = workflowStrings
+      const projectSnapshot = ProjectFactory.build({
+        links: {
+          active_workflows: [workflowSnapshot.id],
+          workflows: [workflowSnapshot.id]
+        }
+      })
+      sinon.stub(panoptes, 'get').callsFake((endpoint, query, headers) => {
+        switch (endpoint) {
+          case '/field_guides': {
+            const field_guides = []
+            return Promise.resolve({ body: { field_guides }})
+          }
+          case '/project_preferences': {
+            const project_preferences = []
+            return Promise.resolve({ body: { project_preferences }})
+          }
+          case '/project_roles': {
+            const project_roles = [{ roles }]
+            return Promise.resolve({ body: { project_roles }})
+          }
+          case '/subjects/queued': {
+            const subjects = [subjectSnapshot, ...Factory.buildList('subject', 9)]
+            return Promise.resolve({ body: { subjects }})
+          }
+        }
+      })
+      sinon.stub(panoptes, 'post').callsFake((...args) => {
+        return Promise.resolve({ headers: {}, body: { project_preferences: []}})
+      })
+      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
+      const checkCurrent = sinon.stub().callsFake(() => Promise.resolve({ id: 123, login: 'mockUser' }))
+      const authClient = { ...defaultAuthClient, checkBearerToken, checkCurrent }
+      const client = { ...defaultClient, panoptes }
+      const store = RootStore.create({}, { authClient, client })
+      const { rerender } = render(
+        <Classifier
+          classifierStore={store}
+          project={projectSnapshot}
+          workflowID={workflowSnapshot.id}
+          workflowSnapshot={workflowSnapshot}
+        />,
+        {
+          wrapper: withStore(store)
+        }
+      )
+      await when(() => store.subjects.loadingState === asyncStates.success)
+      store.subjectViewer.onSubjectReady()
+      const newSnapshot = {
+        ...workflowSnapshot,
+        version: '0.1',
+        strings: {
+          ...workflowSnapshot.strings,
+          'tasks.T0.answers.0.label': 'Answer one',
+          'tasks.T0.answers.1.label': 'Answer two'
+        },
+        tasks: {
+          ...workflowSnapshot.tasks,
+          T0: {
+            ...workflowSnapshot.tasks.T0,
+            answers: [{ label: 'Answer one', next: 'T1' }, { label: 'Answer two', next: 'T2' }]
+          }
+        }
+      }
+      rerender(
+        <Classifier
+          classifierStore={store}
+          project={projectSnapshot}
+          workflowID={newSnapshot.id}
+          workflowSnapshot={newSnapshot}
+        />,
+        {
+          wrapper: withStore(store)
+        }
+      )
+      workflow = store.workflows.active
+      store.subjectViewer.onSubjectReady()
+      taskTab = screen.getByRole('tab', { name: 'TaskArea.task'})
+      tutorialTab = screen.getByRole('tab', { name: 'TaskArea.tutorial'})
+      subjectImage = screen.getByRole('img', { name: `Subject ${subjectSnapshot.id}` })
+      tabPanel = screen.getByRole('tabpanel', { name: '1 Tab Contents'})
+      const task = workflowSnapshot.tasks.T0
+      const getAnswerInput = answer => within(tabPanel).queryByRole('radio', { name: answer.label })
+      taskAnswers = task.answers.map(getAnswerInput)
+    })
+
+    after(function () {
+      panoptes.get.restore()
+      panoptes.post.restore()
+    })
+
+    it('should have a task tab', function () {
+      expect(taskTab).to.be.ok()
+    })
+
+    it('should have a tutorial tab', function () {
+      expect(tutorialTab).to.be.ok()
+    })
+
+    it('should have a subject image', function () {
+      expect(subjectImage).to.exist()
     })
 
     describe('task answers', function () {
@@ -287,7 +413,6 @@ describe('Components > Classifier', function () {
               project={projectSnapshot}
               workflowID={workflowSnapshot.id}
               workflowSnapshot={workflowSnapshot}
-              workflowVersion={workflowSnapshot.version}
             />,
             {
               wrapper: withStore(store)
@@ -391,7 +516,6 @@ describe('Components > Classifier', function () {
           project={projectSnapshot}
           workflowID={workflowSnapshot.id}
           workflowSnapshot={workflowSnapshot}
-          workflowVersion={workflowSnapshot.version}
         />,
         {
           wrapper: withStore(store)
@@ -456,7 +580,6 @@ describe('Components > Classifier', function () {
           showTutorial
           workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
-          workflowVersion={workflowSnapshot?.version}
         />,
         {
           wrapper: withStore(store)
@@ -492,7 +615,6 @@ describe('Components > Classifier', function () {
           project={projectSnapshot}
           workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
-          workflowVersion={workflowSnapshot?.version}
         />,
         {
           wrapper: withStore(store)

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -14,7 +14,7 @@ import sinon from 'sinon'
 import RootStore from '@store'
 import { ProjectFactory, SubjectFactory, TutorialFactory } from '@test/factories'
 import mockStore, { defaultAuthClient, defaultClient } from '@test/mockStore/mockStore'
-import branchingWorkflow from '@test/mockStore/branchingWorkflow'
+import branchingWorkflow, { workflowStrings } from '@test/mockStore/branchingWorkflow'
 import Classifier from './Classifier'
 
 describe('Components > Classifier', function () {
@@ -246,6 +246,7 @@ describe('Components > Classifier', function () {
           const roles = [role]
           const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
           const workflowSnapshot = branchingWorkflow
+          workflowSnapshot.strings = workflowStrings
           const projectSnapshot = ProjectFactory.build({
             links: {
               active_workflows: [],
@@ -349,6 +350,7 @@ describe('Components > Classifier', function () {
       const roles = []
       const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
       const workflowSnapshot = branchingWorkflow
+      workflowSnapshot.strings = workflowStrings
       const projectSnapshot = ProjectFactory.build({
         links: {
           active_workflows: [],

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
@@ -138,7 +138,6 @@ export default function ClassifierContainer({
             subjectSetID={subjectSetID}
             subjectID={subjectID}
             workflowSnapshot={workflowSnapshot}
-            workflowVersion={workflowSnapshot?.version}
             workflowID={workflowSnapshot?.id}
           />
         </Provider>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBackgroundLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBackgroundLayer.spec.js
@@ -2,19 +2,22 @@ import sinon from 'sinon'
 
 import addBackgroundLayer from './addBackgroundLayer'
 
-const selectionFixture = { append: Function.prototype }
-const attrStub = sinon.stub().returnsThis()
-const appendStub = sinon.stub(selectionFixture, 'append')
-  .returns({ attr: attrStub })
-
-const chartStyle = {
-  background: '#005d69' // Zooniverse Dark Teal
-}
-
 describe('LightCurveViewer > d3 > addBackgroundLayer', function () {
+  let attrStub, appendStub
+  const selectionFixture = { append: Function.prototype }
+
+  const chartStyle = {
+    background: '#005d69' // Zooniverse Dark Teal
+  }
+
+  before(function () {
+    attrStub = sinon.stub().returnsThis()
+    appendStub = sinon.stub(selectionFixture, 'append')
+    .returns({ attr: attrStub })
+  })
+
   afterEach(function () {
-    appendStub.resetHistory()
-    attrStub.resetHistory()
+    sinon.resetHistory()
   })
 
   it('should exist', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBorderLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addBorderLayer.spec.js
@@ -2,12 +2,16 @@ import sinon from 'sinon'
 
 import addBorderLayer from './addBorderLayer'
 
-const selectionFixture = { append: Function.prototype }
-const attrStub = sinon.stub().returnsThis()
-const appendStub = sinon.stub(selectionFixture, 'append')
-  .returns({ attr: attrStub })
-
 describe('LightCurveViewer > d3 > addBorderLayer', function () {
+  let attrStub, appendStub
+  const selectionFixture = { append: Function.prototype }
+
+  before(function () {
+    attrStub = sinon.stub().returnsThis()
+    appendStub = sinon.stub(selectionFixture, 'append')
+      .returns({ attr: attrStub })
+  })
+
   afterEach(function () {
     appendStub.resetHistory()
     attrStub.resetHistory()

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addDataLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addDataLayer.spec.js
@@ -2,12 +2,16 @@ import sinon from 'sinon'
 
 import addDataLayer from './addDataLayer'
 
-const selectionFixture = { append: Function.prototype }
-const attrStub = sinon.stub().returnsThis()
-const appendStub = sinon.stub(selectionFixture, 'append')
-  .returns({ attr: attrStub })
-
 describe('LightCurveViewer > d3 > addDataLayer', function () {
+  let attrStub, appendStub
+  const selectionFixture = { append: Function.prototype }
+
+  before(function () {
+    attrStub = sinon.stub().returnsThis()
+    appendStub = sinon.stub(selectionFixture, 'append')
+      .returns({ attr: attrStub })
+  })
+
   afterEach(function () {
     appendStub.resetHistory()
     attrStub.resetHistory()

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addInterfaceLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/addInterfaceLayer.spec.js
@@ -2,16 +2,20 @@ import sinon from 'sinon'
 
 import addInterfaceLayer from './addInterfaceLayer'
 
-const selectionFixture = { append: Function.prototype }
-const attrStub = sinon.stub().returnsThis()
-const styleStub = sinon.stub().returnsThis()
-const appendStub = sinon.stub(selectionFixture, 'append')
-  .returns({
-    attr: attrStub,
-    style: styleStub
+describe('LightCurveViewer > d3 > addInterfaceLayer', function () {
+  let attrStub, appendStub, styleStub
+  const selectionFixture = { append: Function.prototype }
+
+  before(function () {
+    attrStub = sinon.stub().returnsThis()
+    styleStub = sinon.stub().returnsThis()
+    appendStub = sinon.stub(selectionFixture, 'append')
+      .returns({
+        attr: attrStub,
+        style: styleStub
+      })
   })
 
-describe('LightCurveViewer > d3 > addInterfaceLayer', function () {
   afterEach(function () {
     appendStub.resetHistory()
     attrStub.resetHistory()

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setDataPointStyle.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/d3/setDataPointStyle.spec.js
@@ -2,15 +2,19 @@ import sinon from 'sinon'
 
 import setDataPointStyle from './setDataPointStyle'
 
-const selectionFixture = { attr: Function.prototype }
-const attrStub = sinon.stub(selectionFixture, 'attr').returnsThis()
-
-const chartStyle = {
-  color: '#eff2f5', // Zooniverse Light Grey
-  dataPointSize: '1.5'
-}
-
 describe('LightCurveViewer > d3 > setDataPointStyle', function () {
+  let attrStub
+
+  const selectionFixture = { attr: Function.prototype }
+  const chartStyle = {
+    color: '#eff2f5', // Zooniverse Light Grey
+    dataPointSize: '1.5'
+  }
+
+  before(function () {
+    attrStub = sinon.stub(selectionFixture, 'attr').returnsThis()
+  })
+
   afterEach(function () {
     attrStub.resetHistory()
   })

--- a/packages/lib-classifier/src/store/ResourceStore/ResourceStore.spec.js
+++ b/packages/lib-classifier/src/store/ResourceStore/ResourceStore.spec.js
@@ -47,7 +47,14 @@ describe('Model > ResourceStore', function () {
       }
     }
   }
-  sinon.spy(clientStub.panoptes, 'get')
+
+  before(function () {
+    sinon.spy(clientStub.panoptes, 'get')
+  })
+
+  after(function () {
+    clientStub.panoptes.get.restore()
+  })
 
   beforeEach(function () {
     resourceStore = ResourceStore.create(resourcesStub)

--- a/packages/lib-classifier/test/mockStore/branchingWorkflow.js
+++ b/packages/lib-classifier/test/mockStore/branchingWorkflow.js
@@ -23,7 +23,7 @@ const alternativeTask = {
 }
 
 export default WorkflowFactory.build({
-  display_name: 'A test workflow',
+  display_name: 'Branching workflow',
   first_task: 'T0',
   tasks: {
     T0: singleChoiceTask,
@@ -32,3 +32,18 @@ export default WorkflowFactory.build({
   },
   version: '0.0'
 })
+
+export const workflowStrings = {
+  display_name: 'Branching workflow',
+  'tasks.T0.question': 'Is there a cat?',
+  'tasks.T0.answers.0.label': 'yes',
+  'tasks.T0.answers.1.label': 'no',
+  'tasks.T1.question': 'What is/are the cats doing?',
+  'tasks.T1.answers.0.label': 'napping',
+  'tasks.T1.answers.1.label': 'standing',
+  'tasks.T1.answers.2.label': 'playing',
+  'tasks.T2.question': 'Favourite fruit?',
+  'tasks.T2.answers.0.label': 'oranges',
+  'tasks.T2.answers.1.label': 'apples',
+  'tasks.T2.answers.2.label': 'bananas',
+}


### PR DESCRIPTION
Make the check for workflow version changes more stringent, before re-rendering the classifier and starting a new classification.
- remove the `workflowVersion` prop from the classifier.
- check `workflowSnapshot.version` against the active workflow in the store.
- only re-render the classifier if `workflowVersionChanged` is true.
- merge `workflowSnapshot` into any existing workflow, to avoid #3256, where `workflowSnapshot.subjectSet` could be set to a subject set that isn't in the store.
- add some tests which rerender the classifier after a workflow version change, with new task answers.
- update all the classifier tests to mock the image `load` event, when an image subject loads.
- add tests for a grouped workflow with linked subject sets, to catch #3256.

## Package
app-project
lib-classifier

## Linked Issue and/or Talk Post
Closes #3218.
Closes #3256.

## How to Review
The bug doesn't exist in the standalone classifier. To check it, you'll need to uncomment the language menu (`LocaleSwitcher`) in the `ProjectHeader` component, `yarn build` the classifier then build and start the project app: `yarn build && yarn start:dev`.

Browse to any production project and try changing language after making some annotations.

On PH-TESS, there's a bug in the light curve viewer where annotations can't be deleted if they're already in the store when the component mounts. I haven't addressed that here, so you'll find that you can't delete transits after changing language. Other tasks on other projects should be ok.

~~I'll be able to add tests once #3046 is merged.~~

To check #3256, load Poets and Lovers in the project app, then check that you can switch subject sets without crashing the classifier.
https://local.zooniverse.org:3000/projects/pmlogan/poets-and-lovers/classify/workflow/21362/subject-set/104801

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated
