### PR TITLE
Quick Talk: fix user authorisation

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
@@ -67,8 +67,8 @@ function QuickTalkContainer ({
   async function checkUser () {
     if (!authClient) return
 
-    const authorization = await getBearerToken(authClient)  // Check bearer token to ensure session hasn't timed out
     const user = await authClient.checkCurrent()
+    const authorization = await getBearerToken(authClient)  // Check bearer token to ensure session hasn't timed out
     setUserId((authorization && user) ? user.id : undefined)
   }
 
@@ -146,8 +146,8 @@ function QuickTalkContainer ({
       - see https://github.com/zooniverse/front-end-monorepo/discussions/2362
        */
 
-      const authorization = await getBearerToken(authClient)  // Check bearer token to ensure session hasn't timed out
       const user = await authClient.checkCurrent()
+      const authorization = await getBearerToken(authClient)  // Check bearer token to ensure session hasn't timed out
       if (!authorization || !user) throw new Error(t('QuickTalk.errors.noUser'))
 
       // First, get default board


### PR DESCRIPTION
A quick fix for auth in `QuickTalk`. Establish a Panoptes user session before requesting a bearer token. This avoids a bug where `authorization` can be empty when you are actually logged in.

## Package
lib-classifier

## How to Review
This is a quick fix for a bug where the first comment you post fails, because the auth token is requested before `checkCurrent()` has established a Panoptes user session.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
