### PR TITLE
Classifier: localise drawing subtasks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.stories.js
@@ -26,6 +26,11 @@ const workflowSnapshot = WorkflowFactory.build({
   steps: [
     ['S1', { stepKey: 'S1', taskKeys: ['T0']}]
   ],
+  strings: {
+    display_name: 'a test workflow',
+    'tasks.T0.instruction': 'Transcribe a line',
+    'tasks.T0.tools.0.details.0.instruction': 'Transcribe the text'
+  },
   tasks: {
     T0: {
       instruction: 'Transcribe a line',

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Circle/Circle.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Circle/Circle.stories.js
@@ -5,8 +5,9 @@ import {
   DrawingStory,
   subject,
   subTasksSnapshot,
+  subtaskStrings,
   updateStores
-} from '@plugins/drawingTools/stories/helpers'
+} from '@plugins/drawingTools/stories/helpers.js'
 import { DrawingTaskFactory, WorkflowFactory } from '@test/factories'
 import Circle from './'
 
@@ -23,6 +24,16 @@ const drawingTaskSnapshot = DrawingTaskFactory.build({
   type: 'drawing'
 })
 
+const taskSubtaskStrings = {}
+Object.entries(subtaskStrings).forEach(([key, value]) => {
+  taskSubtaskStrings[`tools.0.${key}`] = value
+})
+
+drawingTaskSnapshot.strings = {
+  instruction: drawingTaskSnapshot.instruction,
+  ...taskSubtaskStrings
+}
+
 const mockBounds = {
   x: 200,
   y: 200,
@@ -36,7 +47,17 @@ const mockBounds = {
 
 function setupStores() {
   try {
+    const workflowSubtaskStrings = {}
+    Object.entries(drawingTaskSnapshot.strings).forEach(([key, value]) => {
+      workflowSubtaskStrings[`tasks.T1.${key}`] = value
+    })
+    const strings = {
+      display_name: 'Circle workflow',
+      'tasks.T1.instruction': 'Draw a circle',
+      ...workflowSubtaskStrings
+    }
     const workflow = WorkflowFactory.build({
+      strings,
       tasks: {
         T1: drawingTaskSnapshot
       }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Ellipse/Ellipse.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Ellipse/Ellipse.stories.js
@@ -5,8 +5,9 @@ import {
   DrawingStory,
   subject,
   subTasksSnapshot,
+  subtaskStrings,
   updateStores
-} from '@plugins/drawingTools/stories/helpers'
+} from '@plugins/drawingTools/stories/helpers.js'
 import { DrawingTaskFactory, WorkflowFactory } from '@test/factories'
 import Ellipse from './'
 
@@ -23,6 +24,16 @@ const drawingTaskSnapshot = DrawingTaskFactory.build({
   type: 'drawing'
 })
 
+const taskSubtaskStrings = {}
+Object.entries(subtaskStrings).forEach(([key, value]) => {
+  taskSubtaskStrings[`tools.0.${key}`] = value
+})
+
+drawingTaskSnapshot.strings = {
+  instruction: drawingTaskSnapshot.instruction,
+  ...taskSubtaskStrings
+}
+
 // should think of a better way to do create bounds for the story
 // this is a rough approximation of what the positioning is like now
 const mockBounds = {
@@ -38,7 +49,17 @@ const mockBounds = {
 
 function setupStores() {
   try {
+    const workflowSubtaskStrings = {}
+    Object.entries(drawingTaskSnapshot.strings).forEach(([key, value]) => {
+      workflowSubtaskStrings[`tasks.T1.${key}`] = value
+    })
+    const strings = {
+      display_name: 'Ellipse workflow',
+      'tasks.T1.instruction': 'Draw a circle',
+      ...workflowSubtaskStrings
+    }
     const workflow = WorkflowFactory.build({
+      strings,
       tasks: {
         T1: drawingTaskSnapshot
       }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Line/Line.stories.js
@@ -3,7 +3,13 @@ import zooTheme from '@zooniverse/grommet-theme'
 import cuid from 'cuid'
 import mockStore from '@test/mockStore'
 import DrawingTask from '@plugins/tasks/drawing/models/DrawingTask'
-import { DrawingStory, subject, subTasksSnapshot, updateStores } from '@plugins/drawingTools/stories/helpers'
+import {
+  DrawingStory,
+  subject,
+  subTasksSnapshot,
+  subtaskStrings,
+  updateStores
+} from '@plugins/drawingTools/stories/helpers.js'
 import { DrawingTaskFactory, WorkflowFactory } from '@test/factories'
 import Line from './'
 
@@ -18,6 +24,15 @@ const drawingTaskSnapshot = DrawingTaskFactory.build({
   type: 'drawing'
 })
 
+const taskSubtaskStrings = {}
+Object.entries(subtaskStrings).forEach(([key, value]) => {
+  taskSubtaskStrings[`tools.0.${key}`] = value
+})
+
+drawingTaskSnapshot.strings = {
+  instruction: drawingTaskSnapshot.instruction,
+  ...taskSubtaskStrings
+}
 
 // should think of a better way to do create bounds for the story
 // this is a rough approximation of what the positioning is like now
@@ -34,7 +49,17 @@ const mockBounds = {
 
 function setupStores() {
   try {
+    const workflowSubtaskStrings = {}
+    Object.entries(drawingTaskSnapshot.strings).forEach(([key, value]) => {
+      workflowSubtaskStrings[`tasks.T1.${key}`] = value
+    })
+    const strings = {
+      display_name: 'Line workflow',
+      'tasks.T1.instruction': 'Draw a circle',
+      ...workflowSubtaskStrings
+    }
     const workflow = WorkflowFactory.build({
+      strings,
       tasks: {
         T1: drawingTaskSnapshot
       }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Point/Point.stories.js
@@ -3,7 +3,13 @@ import zooTheme from '@zooniverse/grommet-theme'
 import cuid from 'cuid'
 import mockStore from '@test/mockStore'
 import DrawingTask from '@plugins/tasks/drawing/models/DrawingTask'
-import { DrawingStory, subject, subTasksSnapshot, updateStores } from '@plugins/drawingTools/stories/helpers'
+import {
+  DrawingStory,
+  subject,
+  subTasksSnapshot,
+  subtaskStrings,
+  updateStores
+} from '@plugins/drawingTools/stories/helpers.js'
 import { DrawingTaskFactory, WorkflowFactory } from '@test/factories'
 import Point from './'
 
@@ -18,6 +24,15 @@ const drawingTaskSnapshot = DrawingTaskFactory.build({
   type: 'drawing'
 })
 
+const taskSubtaskStrings = {}
+Object.entries(subtaskStrings).forEach(([key, value]) => {
+  taskSubtaskStrings[`tools.0.${key}`] = value
+})
+
+drawingTaskSnapshot.strings = {
+  instruction: drawingTaskSnapshot.instruction,
+  ...taskSubtaskStrings
+}
 
 // should think of a better way to do create bounds for the story
 // this is a rough approximation of what the positioning is like now
@@ -34,7 +49,17 @@ const mockBounds = {
 
 function setupStores () {
   try {
+    const workflowSubtaskStrings = {}
+    Object.entries(drawingTaskSnapshot.strings).forEach(([key, value]) => {
+      workflowSubtaskStrings[`tasks.T1.${key}`] = value
+    })
+    const strings = {
+      display_name: 'Point workflow',
+      'tasks.T1.instruction': 'Draw a circle',
+      ...workflowSubtaskStrings
+    }
     const workflow = WorkflowFactory.build({
+      strings,
       tasks: {
         T1: drawingTaskSnapshot
       }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Rectangle/Rectangle.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Rectangle/Rectangle.stories.js
@@ -3,7 +3,13 @@ import React from 'react'
 import cuid from 'cuid'
 import mockStore from '@test/mockStore'
 import DrawingTask from '@plugins/tasks/drawing/models/DrawingTask'
-import { DrawingStory, subject, subTasksSnapshot, updateStores } from '@plugins/drawingTools/stories/helpers'
+import {
+  DrawingStory,
+  subject,
+  subTasksSnapshot,
+  subtaskStrings,
+  updateStores
+} from '@plugins/drawingTools/stories/helpers.js'
 import {
   DrawingTaskFactory,
   WorkflowFactory
@@ -23,6 +29,15 @@ const drawingTaskSnapshot = DrawingTaskFactory.build({
   type: 'drawing'
 })
 
+const taskSubtaskStrings = {}
+Object.entries(subtaskStrings).forEach(([key, value]) => {
+  taskSubtaskStrings[`tools.0.${key}`] = value
+})
+
+drawingTaskSnapshot.strings = {
+  instruction: drawingTaskSnapshot.instruction,
+  ...taskSubtaskStrings
+}
 
 // should think of a better way to do create bounds for the story
 // this is a rough approximation of what the positioning is like now
@@ -39,7 +54,17 @@ const mockBounds = {
 
 function setupStores() {
   try {
+    const workflowSubtaskStrings = {}
+    Object.entries(drawingTaskSnapshot.strings).forEach(([key, value]) => {
+      workflowSubtaskStrings[`tasks.T1.${key}`] = value
+    })
+    const strings = {
+      display_name: 'Rectangle workflow',
+      'tasks.T1.instruction': 'Draw a circle',
+      ...workflowSubtaskStrings
+    }
     const workflow = WorkflowFactory.build({
+      strings,
       tasks: {
         T1: drawingTaskSnapshot
       }

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/TranscriptionLine.stories.js
@@ -3,7 +3,7 @@ import React from 'react'
 import cuid from 'cuid'
 import mockStore from '@test/mockStore'
 import DrawingTask from '@plugins/tasks/drawing/models/DrawingTask'
-import { DrawingStory, subject, updateStores } from '@plugins/drawingTools/stories/helpers'
+import { DrawingStory, subject, updateStores } from '@plugins/drawingTools/stories/helpers.js'
 import { DrawingTaskFactory, WorkflowFactory } from '@test/factories'
 import TranscriptionLine from './'
 
@@ -37,7 +37,13 @@ const mockBounds = {
 
 function setupStores() {
   try {
+    const strings = {
+      display_name: 'Transcription line workflow',
+      'tasks.T1.instruction': 'Draw a line under the text',
+      'tasks.T1.tools.0.details.0.instruction': 'transcribe the text.'
+    }
     const workflow = WorkflowFactory.build({
+      strings,
       tasks: {
         T1: drawingTaskSnapshot
       }

--- a/packages/lib-classifier/src/plugins/drawingTools/stories/helpers.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/stories/helpers.js
@@ -46,6 +46,20 @@ export const subTasksSnapshot = [
   }
 ]
 
+export const subtaskStrings = {
+  'details.0.help': 'Do drawing sub-tasks show help? Should they?',
+  'details.0.instruction': 'Name your favourite fruit.',
+  'details.1.help': '',
+  'details.1.question': 'Is it tasty?',
+  'details.1.answers.0.label': 'yes',
+  'details.1.answers.1.label': 'no',
+  'details.2.help': '',
+  'details.2.question': 'Select your favourite animals.',
+  'details.2.answers.0.label': 'cat',
+  'details.2.answers.1.label': 'dog',
+  'details.2.answers.2.label': 'bird'
+}
+
 export function updateStores({ activeMark, finished, subtask }, mockBounds, stores) {
   const [ drawingTask ] = stores.workflowSteps.activeStepTasks
   const [ mark ] = drawingTask.marks

--- a/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.js
@@ -1,5 +1,6 @@
 import cuid from 'cuid'
-import { types } from 'mobx-state-tree'
+import { autorun } from 'mobx'
+import { addDisposer, applySnapshot, getSnapshot, types } from 'mobx-state-tree'
 import Task from '../../models/Task'
 import SHOWN_MARKS from '@helpers/shownMarks'
 import * as tools from '@plugins/drawingTools/models/tools'
@@ -28,7 +29,7 @@ export const Drawing = types.model('Drawing', {
     newSnapshot.tools = []
     snapshot.tools?.forEach((tool, toolIndex) => {
       const toolKey = `${snapshot.taskKey}.${toolIndex}`
-      const toolSnapshot = Object.assign({}, tool, { key: toolKey })
+      const toolSnapshot = { ...tool, key: toolKey }
       newSnapshot.tools.push(toolSnapshot)
     })
     return newSnapshot
@@ -63,41 +64,65 @@ export const Drawing = types.model('Drawing', {
   }))
   .actions(self => {
 
-    function setActiveMark (mark) {
-      self.activeMark = mark
+    function _onLocaleChange() {
+      const stringsSnapshot = getSnapshot(self.strings)
+      self.setToolTaskStrings(stringsSnapshot)
     }
 
-    function setActiveTool (toolIndex) {
-      self.activeToolIndex = toolIndex
-    }
+    return ({
+      afterCreate() {
+        addDisposer(self, autorun(_onLocaleChange))
+      },
 
-    function complete(annotation) {
-      self.subTaskVisibility = false
-    }
+      setActiveMark(mark) {
+        self.activeMark = mark
+      },
 
-    function reset () {
-      self.tools.forEach(tool => tool.reset())
-      self.activeToolIndex = 0
-      self.subTaskVisibility = false
-    }
+      setActiveTool(toolIndex) {
+        self.activeToolIndex = toolIndex
+      },
 
-    function togglePreviousMarks () {
-      self.shownMarks = self.shownMarks === SHOWN_MARKS.ALL ? SHOWN_MARKS.NONE : SHOWN_MARKS.ALL
-      self.hidingIndex = self.shownMarks === SHOWN_MARKS.NONE ? self.marks.length : 0
-    }
+      complete(annotation) {
+        self.subTaskVisibility = false
+      },
 
-    function validate () {
-      self.tools.forEach(tool => tool.validate())
-    }
+      reset() {
+        self.tools.forEach(tool => tool.reset())
+        self.activeToolIndex = 0
+        self.subTaskVisibility = false
+      },
 
-    return {
-      complete,
-      reset,
-      setActiveMark,
-      setActiveTool,
-      togglePreviousMarks,
-      validate
-    }
+      setToolTaskStrings(stringsSnapshot) {
+        const stringEntries = Object.entries(stringsSnapshot)
+        self.tools.forEach((tool, toolIndex) => {
+          const toolPrefix = `tools.${toolIndex}`
+          tool.tasks.forEach((task, taskIndex) => {
+            const prefix = `${toolPrefix}.details.${taskIndex}.`
+            const taskStrings = stringEntries.filter(([key, value]) => key.startsWith(prefix))
+            const taskStringsSnapshot = {}
+            taskStrings.forEach(([key, value]) => {
+              const newKey = key.slice(prefix.length)
+              taskStringsSnapshot[newKey] = value
+            })
+            try {
+              applySnapshot(task.strings, taskStringsSnapshot)
+            } catch (error) {
+              console.error(`${task.taskKey} ${task.type}: could not apply language strings`)
+              console.error(error)
+            }
+          })
+        })
+      },
+
+      togglePreviousMarks() {
+        self.shownMarks = self.shownMarks === SHOWN_MARKS.ALL ? SHOWN_MARKS.NONE : SHOWN_MARKS.ALL
+        self.hidingIndex = self.shownMarks === SHOWN_MARKS.NONE ? self.marks.length : 0
+      },
+
+      validate() {
+        self.tools.forEach(tool => tool.validate())
+      }
+    })
   })
 
 const DrawingTask = types.compose('DrawingTask', Task, Drawing)

--- a/packages/lib-classifier/src/plugins/tasks/experimental/transcription/TranscriptionTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/transcription/TranscriptionTask.stories.js
@@ -30,9 +30,11 @@ export default {
 export function LightTheme({ dark, isThereTaskHelp, required, subjectReadyState }) {
   const tasks = {
     T3: {
-      help: 'Underline the line to transcribe with two clicks, then enter in the text transcription.',
-      instruction: 'Underline and transcribe',
       required,
+      strings: {
+        help: 'Underline the line to transcribe with two clicks, then enter in the text transcription.',
+        instruction: 'Underline and transcribe',
+      },
       taskKey: 'T3',
       tools: [
         {


### PR DESCRIPTION
- Add `task.setToolTaskStrings(stringsSnapshot)` to drawing and transcription tasks. It parses individual task strings from `stringsSnapshot` for each drawing tool, then applies those snapshots to each tool subtask in `tool.tasks`.
- Run `self.setToolTaskStrings` whenever a drawing task's language strings change.
- Add tests.

- Based on #3193.
- Closes #3313.

## Package
lib-classifier

## How to Review
Each drawing tool in the storybook has a subtask story, which can be used to check that the task instructions and questions are displayed correctly. Compare with #3193, where the questions and instructions are missing.

#3198 adds localised answers for the question tasks.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
