### PR TITLE
Classifier: localise survey tasks

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.js
@@ -5,22 +5,20 @@ import React from 'react'
 import Choice from './components/Choice'
 import Chooser from './components/Chooser'
 
-function SurveyTask (props) {
-  const {
-    answers,
-    autoFocus,
-    disabled,
-    filters,
-    handleAnswers,
-    handleChoice,
-    handleDelete,
-    handleFilter,
-    handleIdentify,
-    selectedChoice,
-    selectedChoiceIds,
-    task
-  } = props
-
+function SurveyTask({
+  answers = {},
+  autoFocus = false,
+  disabled = false,
+  filters = {},
+  handleAnswers = () => {},
+  handleChoice = () => {},
+  handleDelete = () => {},
+  handleFilter = () => {},
+  handleIdentify = () => {},
+  selectedChoice = '',
+  selectedChoiceIds = [],
+  task
+}) {
   return (
     <Box
       fill
@@ -47,20 +45,6 @@ function SurveyTask (props) {
           />}
     </Box>
   )
-}
-
-SurveyTask.defaultProps = {
-  answers: {},
-  autoFocus: false,
-  disabled: false,
-  filters: {},
-  handleAnswers: () => {},
-  handleChoice: () => {},
-  handleDelete: () => {},
-  handleFilter: () => {},
-  handleIdentify: () => {},
-  selectedChoice: '',
-  selectedChoiceIds: []
 }
 
 SurveyTask.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -9,20 +9,20 @@ import Questions from './components/Questions'
 import allowIdentification from './helpers/allowIdentification'
 import getQuestionIds from './helpers/getQuestionIds'
 
-export default function Choice (props) {
-  const {
-    answers,
-    choiceId,
-    handleAnswers,
-    handleChoice,
-    handleDelete,
-    onIdentify,
-    task
-  } = props
+export default function Choice({
+  answers = {},
+  choiceId = '',
+  handleAnswers = () => {},
+  handleChoice = () => {},
+  handleDelete = () => {},
+  onIdentify = () => {},
+  task
+}) {
   const {
     choices,
     images,
-    questions
+    questions,
+    strings
   } = task
 
   const { t } = useTranslation('plugins')
@@ -62,16 +62,18 @@ export default function Choice (props) {
           ))}
         </Carousel>
       )}
-      <Heading>{choice.label}</Heading>
-      <Paragraph>{choice.description}</Paragraph>
+      <Heading>{strings.get(`choices.${choiceId}.label`)}</Heading>
+      <Paragraph>{strings.get(`choices.${choiceId}.description`)}</Paragraph>
       {choice.confusionsOrder?.length > 0 && (
         <ConfusedWith
           choices={choices}
+          choiceId={choiceId}
           confusions={choice.confusions}
           confusionsOrder={choice.confusionsOrder}
           handleChoice={handleChoice}
           hasFocus={hasFocus === 'confusions'}
           images={images}
+          strings={strings}
         />
       )}
       {questionIds.length > 0 && (
@@ -81,6 +83,7 @@ export default function Choice (props) {
           questionIds={questionIds}
           questions={questions}
           setAnswers={handleAnswers}
+          strings={strings}
         />
       )}
       <Box
@@ -111,15 +114,6 @@ export default function Choice (props) {
       </Box>
     </Box>
   )
-}
-
-Choice.defaultProps = {
-  answers: {},
-  choiceId: '',
-  handleAnswers: () => {},
-  handleChoice: () => {},
-  handleDelete: () => {},
-  onIdentify: () => {}
 }
 
 Choice.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.spec.js
@@ -4,7 +4,8 @@ import sinon from 'sinon'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { task as mockTask } from '@plugins/tasks/survey/mock-data'
+import { task } from '@plugins/tasks/survey/mock-data'
+import SurveyTask from '@plugins/tasks/survey'
 import Choice from './Choice'
 
 describe('Component > Choice', function () {
@@ -13,6 +14,8 @@ describe('Component > Choice', function () {
     TODO: figure out why these tests are so slow.
   */
   this.timeout(0)
+
+  const mockTask = SurveyTask.TaskModel.create(task)
 
   it('should render without crashing', function () {
     render(

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.stories.js
@@ -3,7 +3,9 @@ import { Box, Grommet } from 'grommet'
 import React from 'react'
 
 import Choice from './Choice'
-import { task as mockTask } from '@plugins/tasks/survey/mock-data'
+import SurveyTask from '@plugins/tasks/survey'
+import { task } from '@plugins/tasks/survey/mock-data'
+const mockTask = SurveyTask.TaskModel.create(task)
 
 function StoryContext (props) {
   const { children, theme } = props

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
@@ -14,17 +14,17 @@ export const StyledDropButton = styled(DropButton)`
   padding: 5px;
 `
 
-function ConfusedWith (props) {
-  const {
-    choices,
-    confusions,
-    confusionsOrder,
-    handleChoice,
-    hasFocus,
-    images,
-    theme
-  } = props
-
+function ConfusedWith({
+  choices = {},
+  choiceId,
+  confusions = {},
+  confusionsOrder = [],
+  handleChoice = () => {},
+  hasFocus = false,
+  images = {},
+  strings,
+  theme
+} ) {
   const { t } = useTranslation('plugins')
 
   const [open, setOpen] = React.useState(false)
@@ -54,7 +54,7 @@ function ConfusedWith (props) {
           return (
             <StyledDropButton
               key={confusionId}
-              a11yTitle={choices[confusionId].label}
+              a11yTitle={strings.get(`choices.${confusionId}.label`)}
               autoFocus={hasFocus && index === 0}
               backgroundColor={backgroundColor}
               dropAlign={{
@@ -64,13 +64,14 @@ function ConfusedWith (props) {
                 <Confusion
                   confusion={choices[confusionId]}
                   confusionId={confusionId}
-                  confusionText={confusions[confusionId]}
+                  confusionText={strings.get(`choices.${choiceId}.confusions.${confusionId}`)}
                   handleChoice={handleChoice}
                   images={images}
+                  label={strings.get(`choices.${confusionId}.label`)}
                   onClose={onClose}
                 />
               }
-              label={choices[confusionId].label}
+              label={strings.get(`choices.${confusionId}.label`)}
               open={open === confusionId}
               onClose={() => onClose()}
               onOpen={() => onOpen(confusionId)}
@@ -80,15 +81,6 @@ function ConfusedWith (props) {
       </Box>
     </Box>
   )
-}
-
-ConfusedWith.defaultProps = {
-  choices: {},
-  confusions: {},
-  confusionsOrder: [],
-  handleChoice: () => {},
-  hasFocus: false,
-  images: {}
 }
 
 ConfusedWith.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.spec.js
@@ -3,12 +3,14 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import zooTheme from '@zooniverse/grommet-theme'
 
-import { task as mockTask } from '@plugins/tasks/survey/mock-data'
+import SurveyTask from '@plugins/tasks/survey'
+import { task } from '@plugins/tasks/survey/mock-data'
 import { ConfusedWith } from './ConfusedWith'
 
-const KUDU = mockTask.choices.KD
-
 describe('Component > ConfusedWith', function () {
+  const mockTask = SurveyTask.TaskModel.create(task)
+  const KUDU = mockTask.choices.KD
+
   it('should render without crashing', function () {
     render(
       <ConfusedWith
@@ -16,6 +18,7 @@ describe('Component > ConfusedWith', function () {
         confusions={KUDU.confusions}
         confusionsOrder={KUDU.confusionsOrder}
         images={mockTask.images}
+        strings={mockTask.strings}
         theme={zooTheme}
       />
     )
@@ -29,6 +32,7 @@ describe('Component > ConfusedWith', function () {
         confusions={KUDU.confusions}
         confusionsOrder={KUDU.confusionsOrder}
         images={mockTask.images}
+        strings={mockTask.strings}
         theme={zooTheme}
       />
     )
@@ -43,6 +47,7 @@ describe('Component > ConfusedWith', function () {
         confusions={KUDU.confusions}
         confusionsOrder={KUDU.confusionsOrder}
         images={mockTask.images}
+        strings={mockTask.strings}
         theme={zooTheme}
       />
     )
@@ -61,6 +66,7 @@ describe('Component > ConfusedWith', function () {
           confusionsOrder={KUDU.confusionsOrder}
           hasFocus
           images={mockTask.images}
+          strings={mockTask.strings}
           theme={zooTheme}
         />
       )
@@ -75,6 +81,7 @@ describe('Component > ConfusedWith', function () {
           confusionsOrder={KUDU.confusionsOrder}
           hasFocus
           images={mockTask.images}
+          strings={mockTask.strings}
           theme={zooTheme}
         />
       )

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.stories.js
@@ -3,7 +3,9 @@ import { Box, Grommet } from 'grommet'
 import React from 'react'
 
 import ConfusedWith from './ConfusedWith'
-import { task as mockTask } from '@plugins/tasks/survey/mock-data'
+import SurveyTask from '@plugins/tasks/survey'
+import { task } from '@plugins/tasks/survey/mock-data'
+const mockTask = SurveyTask.TaskModel.create(task)
 
 const KUDU = mockTask.choices.KD
 
@@ -40,15 +42,17 @@ export default {
   component: ConfusedWith
 }
 
-const Template = ({ choices, confusions, confusionsOrder, dark, images }) => (
+const Template = ({ choices, choiceId, confusions, confusionsOrder, dark, images, strings }) => (
   <StoryContext
     theme={{ ...zooTheme, dark }}
   >
     <ConfusedWith
       choices={choices}
+      choiceId={choiceId}
       confusions={confusions}
       confusionsOrder={confusionsOrder}
       images={images}
+      strings={strings}
     />
   </StoryContext>
 )
@@ -56,8 +60,10 @@ const Template = ({ choices, confusions, confusionsOrder, dark, images }) => (
 export const Default = Template.bind({})
 Default.args = {
   choices: mockTask.choices,
+  choiceId: 'KD',
   confusions: KUDU.confusions,
   confusionsOrder: KUDU.confusionsOrder,
   dark: false,
-  images: mockTask.images
+  images: mockTask.images,
+  strings: mockTask.strings
 }

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/components/Confusion.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/components/Confusion.js
@@ -4,16 +4,15 @@ import React from 'react'
 import { Media, PrimaryButton, SpacedHeading } from '@zooniverse/react-components'
 import { useTranslation } from 'react-i18next'
 
-export default function Confusion (props) {
-  const {
-    confusion,
-    confusionId,
-    confusionText,
-    handleChoice,
-    images,
-    onClose
-  } = props
-
+export default function Confusion({
+  confusion = {},
+  confusionId = '',
+  confusionText = '',
+  handleChoice = () => {},
+  images = {},
+  label,
+  onClose = () => true
+}) {
   const { t } = useTranslation('plugins')
 
   return (
@@ -29,7 +28,7 @@ export default function Confusion (props) {
       }}
       width='medium'
     >
-      <SpacedHeading>{confusion.label}</SpacedHeading>
+      <SpacedHeading>{label}</SpacedHeading>
       {confusion.images?.length > 0 && (
         <Carousel
           data-testid='confusion-images'
@@ -66,15 +65,6 @@ export default function Confusion (props) {
       </Box>
     </Box>
   )
-}
-
-Confusion.defaultProps = {
-  confusion: {},
-  confusionId: '',
-  confusionText: '',
-  handleChoice: () => {},
-  images: {},
-  onClose: () => {}
 }
 
 Confusion.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/components/Confusion.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/components/Confusion.spec.js
@@ -4,13 +4,15 @@ import sinon from 'sinon'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { task as mockTask } from '@plugins/tasks/survey/mock-data'
+import SurveyTask from '@plugins/tasks/survey'
+import { task } from '@plugins/tasks/survey/mock-data'
 import Confusion from './Confusion'
 
-const ELAND = mockTask.choices.LND
-const HUMAN = mockTask.choices.HMN
-
 describe('Component > Confusion', function () {
+  const mockTask = SurveyTask.TaskModel.create(task)
+  const ELAND = mockTask.choices.LND
+  const HUMAN = mockTask.choices.HMN
+
   it('should render without crashing', function () {
     render(
       <Confusion
@@ -30,6 +32,7 @@ describe('Component > Confusion', function () {
         confusionId='LND'
         confusionText='Test confusion text.'
         images={mockTask.images}
+        label={mockTask.strings.get('choices.LND.label')}
       />
     )
     expect(screen.getByText(ELAND.label)).to.be.exist()
@@ -42,6 +45,7 @@ describe('Component > Confusion', function () {
         confusionId='LND'
         confusionText='Test confusion text.'
         images={mockTask.images}
+        label={mockTask.strings.get('choices.LND.label')}
       />
     )
     expect(screen.getByTestId('confusion-images')).to.exist()
@@ -54,6 +58,7 @@ describe('Component > Confusion', function () {
         confusionId='HMN'
         confusionText='Test confusion text.'
         images={mockTask.images}
+        label={mockTask.strings.get('choices.HMN.label')}
       />
     )
     expect(screen.queryByTestId('confusion-images')).to.be.null()
@@ -66,6 +71,7 @@ describe('Component > Confusion', function () {
         confusionId='LND'
         confusionText='Test confusion text.'
         images={mockTask.images}
+        label={mockTask.strings.get('choices.LND.label')}
       />
     )
     expect(screen.getByText('Test confusion text.')).to.exist()
@@ -78,6 +84,7 @@ describe('Component > Confusion', function () {
         confusionId='LND'
         confusionText='Test confusion text.'
         images={mockTask.images}
+        label={mockTask.strings.get('choices.LND.label')}
       />
     )
     /** The translation function will simply return keys in a testing env */
@@ -95,6 +102,7 @@ describe('Component > Confusion', function () {
         confusionText='Test confusion text.'
         images={mockTask.images}
         onClose={onCloseSpy}
+        label={mockTask.strings.get('choices.LND.label')}
       />
     )
     /** The translation function will simply return keys in a testing env */
@@ -109,6 +117,7 @@ describe('Component > Confusion', function () {
         confusionId='LND'
         confusionText='Test confusion text.'
         images={mockTask.images}
+        label={mockTask.strings.get('choices.LND.label')}
       />
     )
     /** The translation function will simply return keys in a testing env */
@@ -126,6 +135,7 @@ describe('Component > Confusion', function () {
         confusionText='Test confusion text.'
         handleChoice={handleChoiceSpy}
         images={mockTask.images}
+        label={mockTask.strings.get('choices.LND.label')}
       />
     )
     /** The translation function will simply return keys in a testing env */

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/Questions.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/Questions.js
@@ -5,17 +5,16 @@ import { SpacedHeading } from '@zooniverse/react-components'
 
 import InputGroup from './components/InputGroup'
 
-export default function Questions (props) {
-  const {
-    answers,
-    hasFocus,
-    questionIds,
-    questions,
-    setAnswers
-  } = props
-
+export default function Questions({
+  answers = {},
+  hasFocus = false,
+  questionIds = [],
+  questions = {},
+  setAnswers = () => {},
+  strings
+}) {
   function handleAnswer (questionAnswer, questionId) {
-    const newAnswers = Object.assign({}, answers, { [questionId]: questionAnswer })
+    const newAnswers = { ...answers, [questionId]: questionAnswer }
 
     // if questionAnswer is an empty string (cleared radio input) or is an empty array (cleared checkbox inputs) then questionAnswer length is 0
     if (questionAnswer.length === 0) {
@@ -41,7 +40,7 @@ export default function Questions (props) {
           <Box
             key={questionId}
           >
-            <SpacedHeading>{question.label}</SpacedHeading>
+            <SpacedHeading>{strings.get(`questions.${questionId}.label`)}</SpacedHeading>
             <InputGroup
               handleAnswer={handleAnswer}
               hasFocus={hasFocus && index === 0}
@@ -55,14 +54,6 @@ export default function Questions (props) {
       })}
     </Box>
   )
-}
-
-Questions.defaultProps = {
-  answers: {},
-  hasFocus: false,
-  questionIds: [],
-  questions: {},
-  setAnswers: () => {}
 }
 
 Questions.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/Questions.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/Questions/Questions.spec.js
@@ -2,10 +2,12 @@ import { expect } from 'chai'
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 
-import { task as mockTask } from '@plugins/tasks/survey/mock-data'
+import SurveyTask from '@plugins/tasks/survey'
+import { task } from '@plugins/tasks/survey/mock-data'
 import Questions from './Questions'
 
 describe('Component > Questions', function () {
+  const mockTask = SurveyTask.TaskModel.create(task)
   const questionIds = ['HWMN', 'WHTBHVRSDS', 'RTHRNNGPRSNT']
 
   it('should render without crashing', function () {
@@ -13,6 +15,7 @@ describe('Component > Questions', function () {
       <Questions
         questionIds={questionIds}
         questions={mockTask.questions}
+        strings={mockTask.strings}
       />
     )
     expect(screen).to.be.ok()
@@ -25,6 +28,7 @@ describe('Component > Questions', function () {
       <Questions
         questionIds={questionIds}
         questions={mockTask.questions}
+        strings={mockTask.strings}
       />
     )
     expect(screen.queryAllByRole('radio', { hidden: true })).to.have.lengthOf(14)
@@ -37,6 +41,7 @@ describe('Component > Questions', function () {
         answers={{ WHTBHVRSDS: ['RSTNG', 'TNG'], HWMN: '9' }}
         questionIds={questionIds}
         questions={mockTask.questions}
+        strings={mockTask.strings}
       />
     )
     const radioInputs = screen.queryAllByRole('radio', { hidden: true })
@@ -67,6 +72,7 @@ describe('Component > Questions', function () {
           hasFocus
           questionIds={questionIds}
           questions={mockTask.questions}
+          strings={mockTask.strings}
         />
       )
       expect(screen.getByLabelText('1')).to.equal(document.activeElement)

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
@@ -7,18 +7,16 @@ import Choices from './components/Choices'
 import ClearFilters from './components/CharacteristicsFilter/ClearFilters'
 import getFilteredChoiceIds from './helpers/getFilteredChoiceIds'
 
-export default function Chooser (props) {
-  const {
-    autoFocus,
-    disabled,
-    filters,
-    handleDelete,
-    handleFilter,
-    onChoose,
-    selectedChoiceIds,
-    task
-  } = props
-
+export default function Chooser({
+  autoFocus = false,
+  disabled = false,
+  filters = {},
+  handleDelete = () => {},
+  handleFilter = () => {},
+  onChoose = () => true,
+  selectedChoiceIds = [],
+  task
+}) {
   const filteredChoiceIds = getFilteredChoiceIds(filters, task)
 
   return (
@@ -45,16 +43,6 @@ export default function Chooser (props) {
       />
     </Box>
   )
-}
-
-Chooser.defaultProps = {
-  autoFocus: false,
-  disabled: false,
-  filters: {},
-  handleDelete: () => {},
-  handleFilter: () => {},
-  selectedChoiceIds: [],
-  onChoose: () => {}
 }
 
 Chooser.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
@@ -1,4 +1,5 @@
 import { Box } from 'grommet'
+import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -7,7 +8,7 @@ import Choices from './components/Choices'
 import ClearFilters from './components/CharacteristicsFilter/ClearFilters'
 import getFilteredChoiceIds from './helpers/getFilteredChoiceIds'
 
-export default function Chooser({
+function Chooser({
   autoFocus = false,
   disabled = false,
   filters = {},
@@ -60,3 +61,5 @@ Chooser.propTypes = {
     type: PropTypes.string
   }).isRequired
 }
+
+export default observer(Chooser)

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.stories.js
@@ -3,7 +3,10 @@ import { Box, Grommet } from 'grommet'
 import React from 'react'
 
 import Chooser from './Chooser'
-import { task as mockTask } from '@plugins/tasks/survey/mock-data'
+import SurveyTask from '@plugins/tasks/survey'
+import { task } from '@plugins/tasks/survey/mock-data'
+
+const mockTask = SurveyTask.TaskModel.create(task)
 
 function StoryContext (props) {
   const { children, theme } = props

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/Characteristics.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/Characteristics.js
@@ -1,11 +1,12 @@
 import { Box, Button } from 'grommet'
+import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
 import CharacteristicSection from './components/CharacteristicSection'
 
-export default function Characteristics({
+function Characteristics({
   characteristics = {},
   characteristicsOrder = [],
   filters  = {},
@@ -67,3 +68,5 @@ Characteristics.propTypes = {
   images: PropTypes.objectOf(PropTypes.string),
   onFilter: PropTypes.func
 }
+
+export default observer(Characteristics)

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/Characteristics.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/Characteristics.js
@@ -5,15 +5,14 @@ import { useTranslation } from 'react-i18next'
 
 import CharacteristicSection from './components/CharacteristicSection'
 
-export default function Characteristics (props) {
-  const {
-    characteristics,
-    characteristicsOrder,
-    filters,
-    images,
-    onFilter
-  } = props
-
+export default function Characteristics({
+  characteristics = {},
+  characteristicsOrder = [],
+  filters  = {},
+  images = {},
+  onFilter = () => true,
+  strings
+}) {
   const { t } = useTranslation('plugins')
 
   return (
@@ -31,8 +30,10 @@ export default function Characteristics (props) {
             characteristic={characteristic}
             characteristicId={characteristicId}
             images={images}
+            label={strings.get(`characteristics.${characteristicId}.label`)}
             onFilter={onFilter}
             selectedValueId={selectedValueId}
+            strings={strings}
           />
         )
       })}
@@ -46,14 +47,6 @@ export default function Characteristics (props) {
       </Box>
     </Box>
   )
-}
-
-Characteristics.defaultProps = {
-  characteristics: {},
-  characteristicsOrder: [],
-  filters: {},
-  images: {},
-  onFilter: () => {}
 }
 
 Characteristics.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/Characteristics.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/Characteristics.spec.js
@@ -2,11 +2,13 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import sinon from 'sinon'
 
-import { task as mockTask } from '@plugins/tasks/survey/mock-data'
+import SurveyTask from '@plugins/tasks/survey'
+import { task } from '@plugins/tasks/survey/mock-data'
 import Characteristics from './Characteristics'
 import CharacteristicSection from './components/CharacteristicSection'
 
 describe('Component > Characteristics', function () {
+  const mockTask = SurveyTask.TaskModel.create(task)
   let wrapper, onFilterSpy
 
   before(function () {
@@ -17,6 +19,7 @@ describe('Component > Characteristics', function () {
         characteristicsOrder={mockTask.characteristicsOrder}
         images={mockTask.images}
         onFilter={onFilterSpy}
+        strings={mockTask.strings}
       />
     )
   })

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/components/CharacteristicSection.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/components/CharacteristicSection.js
@@ -5,24 +5,30 @@ import { SpacedHeading } from '@zooniverse/react-components'
 
 import FilterButton from '../../components/FilterButton'
 
-export default function CharacteristicSection (props) {
-  const {
-    characteristic,
-    characteristicId,
-    images,
-    onFilter,
-    selectedValueId
-  } = props
+const defaultCharacteristic = {
+  values: {},
+  valuesOrder: []
+}
 
+export default function CharacteristicSection({
+  characteristic = defaultCharacteristic,
+  characteristicId = '',
+  images = {},
+  label = '',
+  onFilter = () => true,
+  selectedValueId = '',
+  strings
+}) {
   const characteristicOptions = characteristic.valuesOrder.map(valueId => {
     const value = characteristic?.values?.[valueId] || {}
     const valueImageSrc = images?.[value.image] || ''
+    const label = strings.get(`characteristics.${characteristicId}.values.${valueId}.label`)
 
     return ({
       disabled: false,
       id: `${characteristicId}-${valueId}`,
       imageSrc: valueImageSrc,
-      label: value.label,
+      label,
       value: valueId
     })
   })
@@ -42,7 +48,7 @@ export default function CharacteristicSection (props) {
       <SpacedHeading
         margin='none'
       >
-        {characteristic.label}
+        {label}
       </SpacedHeading>
       <RadioButtonGroup
         direction='row'
@@ -67,18 +73,6 @@ export default function CharacteristicSection (props) {
       </RadioButtonGroup>
     </Box>
   )
-}
-
-CharacteristicSection.defaultProps = {
-  characteristic: {
-    label: '',
-    values: {},
-    valuesOrder: []
-  },
-  characteristicId: '',
-  images: {},
-  onFilter: () => {},
-  selectedValueId: ''
 }
 
 CharacteristicSection.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/components/CharacteristicSection.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/components/CharacteristicSection.spec.js
@@ -3,13 +3,15 @@ import { RadioButtonGroup } from 'grommet'
 import React from 'react'
 import sinon from 'sinon'
 
-import { task as mockTask } from '@plugins/tasks/survey/mock-data'
+import SurveyTask from '@plugins/tasks/survey'
+import { task } from '@plugins/tasks/survey/mock-data'
 import CharacteristicSection from './CharacteristicSection'
 import FilterButton from '../../components/FilterButton'
 
-const characteristicTail = mockTask.characteristics.TL
-
 describe('Component > CharacteristicSection', function () {
+  const mockTask = SurveyTask.TaskModel.create(task)
+  const characteristicTail = mockTask.characteristics.TL
+  
   let wrapper, onFilterSpy
 
   before(function () {
@@ -21,6 +23,7 @@ describe('Component > CharacteristicSection', function () {
         images={mockTask.images}
         onFilter={onFilterSpy}
         selectedValueId=''
+        strings={mockTask.strings}
       />
     )
   })
@@ -55,6 +58,7 @@ describe('Component > CharacteristicSection', function () {
           images={mockTask.images}
           onFilter={onFilterSpy}
           selectedValueId=''
+          strings={mockTask.strings}
         />
       )
 

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/components/CharacteristicSection.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/components/CharacteristicSection.stories.js
@@ -2,7 +2,9 @@ import zooTheme from '@zooniverse/grommet-theme'
 import { Grommet } from 'grommet'
 import React from 'react'
 
-import { task as mockTask } from '@plugins/tasks/survey/mock-data'
+import SurveyTask from '@plugins/tasks/survey'
+import { task } from '@plugins/tasks/survey/mock-data'
+const mockTask = SurveyTask.TaskModel.create(task)
 
 import CharacteristicSection from './CharacteristicSection'
 
@@ -35,7 +37,8 @@ const Template = ({
   characteristicId,
   dark,
   images,
-  selectedValueId
+  selectedValueId,
+  strings
 }) => (
   <StoryContext
     theme={{ ...zooTheme, dark }}
@@ -44,7 +47,9 @@ const Template = ({
       characteristic={characteristic}
       characteristicId={characteristicId}
       images={images}
+      label={strings.get(`characteristics.${characteristicId}.label`)}
       selectedValueId={selectedValueId}
+      strings={strings}
     />
   </StoryContext>
 )
@@ -55,5 +60,6 @@ Default.args = {
   characteristicId: 'LK',
   dark: false,
   images: mockTask.images,
-  selectedValueId: ''
+  selectedValueId: '',
+  strings: mockTask.strings
 }

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.js
@@ -28,19 +28,18 @@ const StyledLabel = styled(SpacedText)`
   text-transform: uppercase;
 `
 
-export default function FilterStatus (props) {
-  const {
-    disabled,
-    filters,
-    handleFilter,
-    task
-  } = props
+export default function FilterStatus({
+  disabled = false,
+  filters = {},
+  handleFilter = () => {},
+  task
+}) {
   const {
     characteristics,
     characteristicsOrder,
-    images
+    images,
+    strings
   } = task
-
   const { t } = useTranslation('plugins')
 
   const filterStatusRef = useRef()
@@ -75,6 +74,7 @@ export default function FilterStatus (props) {
             filters={filters}
             images={images}
             onFilter={handleFilter}
+            strings={strings}
           />
         }
         dropProps={{
@@ -99,6 +99,7 @@ export default function FilterStatus (props) {
         const selectedValueId = filters?.[characteristicId] || ''
         const value = characteristic.values?.[selectedValueId] || {}
         const valueImageSrc = images?.[value.image] || ''
+        const label = strings.get(`characteristics.${characteristicId}.values.${selectedValueId}.label`)
 
         return (
           <FilterButton
@@ -108,18 +109,12 @@ export default function FilterStatus (props) {
             onFilter={handleFilter}
             buttonSize='small'
             valueImageSrc={valueImageSrc}
-            valueLabel={value.label}
+            valueLabel={label}
           />
         )
       })}
     </Box>
   )
-}
-
-FilterStatus.defaultProps = {
-  disabled: false,
-  filters: {},
-  handleFilter: () => {}
 }
 
 FilterStatus.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.stories.js
@@ -2,7 +2,9 @@ import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Grommet } from 'grommet'
 import React from 'react'
 
-import { task as mockTask } from '@plugins/tasks/survey/mock-data'
+import SurveyTask from '@plugins/tasks/survey'
+import { task } from '@plugins/tasks/survey/mock-data'
+const mockTask = SurveyTask.TaskModel.create(task)
 
 import FilterStatus from './FilterStatus'
 

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.js
@@ -1,3 +1,4 @@
+import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 import styled, { css, withTheme } from 'styled-components'
@@ -144,4 +145,4 @@ Choices.propTypes = {
   })
 }
 
-export default withTheme(Choices)
+export default withTheme(observer(Choices))

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.js
@@ -18,16 +18,22 @@ const StyledGrid = styled.div`
   width: 100%;
 `
 
-export function Choices (props) {
-  const {
-    autoFocus,
-    disabled,
-    filteredChoiceIds,
-    handleDelete,
-    onChoose,
-    selectedChoiceIds,
-    task
-  } = props
+const defaultTheme = {
+  dark: false,
+  global: {
+    colors: {}
+  }
+}
+export function Choices({
+  autoFocus = false,
+  disabled = false,
+  filteredChoiceIds = [],
+  handleDelete = () => {},
+  onChoose = () => true,
+  selectedChoiceIds = [],
+  task,
+  theme = defaultTheme
+}) {
   const [focusIndex, setFocusIndex] = useState(0)
 
   useEffect(() => {
@@ -99,7 +105,7 @@ export function Choices (props) {
           <ChoiceButton
             key={choiceId}
             choiceId={choiceId}
-            choiceLabel={choice.label}
+            choiceLabel={task.strings.get(`choices.${choiceId}.label`)}
             disabled={disabled}
             hasFocus={hasFocus}
             onChoose={onChoose}
@@ -113,21 +119,6 @@ export function Choices (props) {
       })}
     </StyledGrid>
   )
-}
-
-Choices.defaultProps = {
-  autoFocus: false,
-  disabled: false,
-  filteredChoiceIds: [],
-  handleDelete: () => {},
-  onChoose: () => {},
-  selectedChoiceIds: [],
-  theme: {
-    dark: false,
-    global: {
-      colors: {}
-    }
-  }
 }
 
 Choices.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.spec.js
@@ -14,6 +14,7 @@ describe('Component > Choices', function () {
   let task = Task.TaskModel.create({
     choices: mockTask.choices,
     images: mockTask.images,
+    strings: mockTask.strings,
     taskKey: 'T0',
     type: 'survey'
   })

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.stories.js
@@ -3,8 +3,10 @@ import { Box, Grommet } from 'grommet'
 import React from 'react'
 
 import Choices from './Choices'
-import { task as mockTask } from '@plugins/tasks/survey/mock-data'
+import SurveyTask from '@plugins/tasks/survey'
+import { task } from '@plugins/tasks/survey/mock-data'
 
+const mockTask = SurveyTask.TaskModel.create(task)
 const filteredChoiceIds = Array.from(mockTask.choicesOrder)
 
 function StoryContext (props) {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/components/ChoiceButton.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/components/ChoiceButton.js
@@ -4,7 +4,7 @@ import {
   Text
 } from 'grommet'
 import PropTypes from 'prop-types'
-import React, { useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { Media, withThemeContext } from '@zooniverse/react-components'
 
 import theme from './theme'
@@ -25,6 +25,13 @@ function ChoiceButton({
 }) {
 
   const choiceButton = useRef(null)
+  const handleClick = useCallback(() => {
+    onChoose(choiceId)
+  }, [choiceId, onChoose])
+  const handleKeyDown = useCallback((event) => {
+    onKeyDown(choiceId, event)
+  }, [choiceId, onKeyDown])
+
   useEffect(() => {
     if (choiceButton && hasFocus) {
       choiceButton.current.focus()
@@ -66,8 +73,8 @@ function ChoiceButton({
           </Text>
         </Box>
       }
-      onClick={() => onChoose(choiceId)}
-      onKeyDown={(event) => onKeyDown(choiceId, event)}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
       selected={selected}
       size='small'
       tabIndex={tabIndex}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/components/ChoiceButton.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/components/ChoiceButton.js
@@ -11,19 +11,18 @@ import theme from './theme'
 
 export const THUMBNAIL_ASPECT_RATIO = 1.25
 
-function ChoiceButton (props) {
-  const {
-    choiceId,
-    choiceLabel,
-    disabled,
-    hasFocus,
-    onKeyDown,
-    onChoose,
-    selected,
-    src,
-    tabIndex,
-    thumbnailSize
-  } = props
+function ChoiceButton({
+  choiceId = '',
+  choiceLabel = '',
+  disabled = false,
+  hasFocus = false,
+  onKeyDown = () => true,
+  onChoose = () => true,
+  selected = false,
+  src = '',
+  tabIndex = -1,
+  thumbnailSize = 'none'
+}) {
 
   const choiceButton = useRef(null)
   useEffect(() => {
@@ -74,19 +73,6 @@ function ChoiceButton (props) {
       tabIndex={tabIndex}
     />
   )
-}
-
-ChoiceButton.defaultProps = {
-  choiceId: '',
-  choiceLabel: '',
-  disabled: false,
-  hasFocus: false,
-  onChoose: () => {},
-  onKeyDown: () => {},
-  selected: false,
-  src: '',
-  tabIndex: -1,
-  thumbnailSize: 'none'
 }
 
 ChoiceButton.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/survey/mock-data/task.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/mock-data/task.js
@@ -834,4 +834,32 @@ const task = {
   'questionsOrder': ['HWMN', 'WHTBHVRSDS', 'RTHRNNGPRSNT']
 }
 
+const strings = {}
+
+Object.entries(task.characteristics).forEach(([characteristicID, characteristic]) => {
+  const prefix = `characteristics.${characteristicID}`
+  strings[`${prefix}.label`] = characteristic.label
+  Object.entries(characteristic.values).forEach(([valueID, value]) => {
+    strings[`${prefix}.values.${valueID}.label`] = value.label
+  })
+})
+
+Object.entries(task.choices).forEach(([choiceID, choice]) => {
+  const prefix = `choices.${choiceID}`
+  strings[`${prefix}.label`] = choice.label
+  strings[`${prefix}.description`] = choice.description
+  Object.entries(choice.confusions).forEach(([confusionID, value]) => {
+    strings[`${prefix}.confusions.${confusionID}`] = value
+  })
+})
+
+Object.entries(task.questions).forEach(([questionID, question]) => {
+  const prefix = `questions.${questionID}`
+  strings[`${prefix}.label`] = question.label
+  Object.entries(question.answers).forEach(([answerID, answer]) => {
+    strings[`${prefix}.answers.${answerID}.label`] = answer.label
+  })
+})
+
+task.strings = strings
 export default task


### PR DESCRIPTION
- Pass task language strings down to survey task components.
- Use the strings map to render text for choices, questions, confusions and filters.
- Update the tests and stories to use a mock survey task with a strings map.

Based on #3193.

## Package
lib-classifier

## How to Review
Wildcam Darién in Spanish is probably a good workflow to test survey task translations:
https://localhost:8080/?project=wildcam/wildcam-darien&env=production&language=es

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
