### PR TITLE
Classifier: localise dropdown task options

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/dropdown-simple/components/SimpleDropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/dropdown-simple/components/SimpleDropdownTask.js
@@ -2,6 +2,7 @@ import { Markdownz, pxToRem } from '@zooniverse/react-components'
 import { Box, Select, Text, TextInput } from 'grommet'
 import { Down } from 'grommet-icons'
 import { observer } from 'mobx-react'
+import { getSnapshot } from 'mobx-state-tree'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css } from 'styled-components'
@@ -21,21 +22,24 @@ const StyledText = styled(Text)`
 // artificially disabled. Please refer to the README. (@shaunanoordin 20200820)
 const ENABLE_OTHER_OPTION = false
 
-function SimpleDropdownTask (props) {
-  const {
-    annotation,
-    className,
-    disabled,
-    task,
-  } = props
+function SimpleDropdownTask({
+  annotation,
+  className = '',
+  disabled = false,
+  task,
+}) {
   const { t } = useTranslation('plugins')
   const { value } = annotation
+  const stringsSnapshot = getSnapshot(task.strings)
+  const optionsPrefix = 'selects.0.options.*.'
 
   // Decide what kind of options to display.
   // Use an array of objects instead of an array of text.
   // This solves issues of duplicate text.
-  const optionsToDisplay = task.options.map(opt => ({
-    text: opt,
+  const optionsToDisplay = Object.entries(stringsSnapshot)
+  .filter(([key, value]) => key.startsWith(optionsPrefix))
+  .map(([key, value]) => ({
+    text: value
   }))
 
   // If the Other option is enabled, we allow users to type in any text.
@@ -121,11 +125,6 @@ function SimpleDropdownTask (props) {
       </Box>
     </Box>
   )
-}
-
-SimpleDropdownTask.defaultProps = {
-  className: '',
-  disabled: false,
 }
 
 SimpleDropdownTask.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/dropdown-simple/components/SimpleDropdownTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/dropdown-simple/components/SimpleDropdownTask.spec.js
@@ -5,25 +5,30 @@ import { Select } from 'grommet'
 import SimpleDropdownTask from './SimpleDropdownTask'
 import { default as Task } from '@plugins/tasks/dropdown-simple'
 
-const simpleDropdownTask = {
-  allowCreate: false,
-  options: [
-    'Red',
-    'Blue',
-    'Yellow',
-    'Green',
-    'White',
-    'Black',
-  ],
-  required: false,
-  strings: {
-    instruction: 'Choose your favourite colour'
-  },
-  taskKey: 'T1',
-  type: 'dropdown-simple'
-}
-
 describe('SimpleDropdownTask', function () {
+  const simpleDropdownTask = {
+    allowCreate: false,
+    options: [
+      'Red',
+      'Blue',
+      'Yellow',
+      'Green',
+      'White',
+      'Black',
+    ],
+    required: false,
+    strings: {
+      instruction: 'Choisissez votre couleur préférée',
+      'selects.0.options.*.0.label': 'Rouge',
+      'selects.0.options.*.1.label': 'Bleu',
+      'selects.0.options.*.2.label': 'Jaunde',
+      'selects.0.options.*.3.label': 'Vert',
+      'selects.0.options.*.4.label': 'Blanc',
+      'selects.0.options.*.5.label': 'Noire'
+    },
+    taskKey: 'T1',
+    type: 'dropdown-simple'
+  }
   const task = Task.TaskModel.create(simpleDropdownTask)
   const annotation = task.defaultAnnotation()
 
@@ -62,7 +67,7 @@ describe('SimpleDropdownTask', function () {
 
     before(function () {
       annotation.update({
-        selection: 2,  // Corresponds to "Yellow"
+        selection: 2,  // Corresponds to "Jaunde"
         option: true,
       })
       wrapper = shallow(
@@ -75,7 +80,7 @@ describe('SimpleDropdownTask', function () {
 
     it('should pass the selected annotation to the Select sub-element', function () {
       const grommetSelect = wrapper.find('Select').first()
-      expect(grommetSelect.prop('value')['text']).to.equal('Yellow')
+      expect(grommetSelect.prop('value')['text']).to.equal('Jaunde')
     })
   })
 

--- a/packages/lib-classifier/src/plugins/tasks/dropdown-simple/components/SimpleDropdownTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/dropdown-simple/components/SimpleDropdownTask.stories.js
@@ -40,7 +40,14 @@ export function LightTheme({ dark, isThereTaskHelp, required, subjectReadyState 
     ],
     required,
     strings: {
-      instruction: 'Choose your favourite colour'
+      help: 'Choose an option from the list of options.',
+      instruction: 'Select your favourite colour.',
+      'selects.0.options.*.0.label': 'Red',
+      'selects.0.options.*.1.label': 'Blue',
+      'selects.0.options.*.2.label': 'Yellow',
+      'selects.0.options.*.3.label': 'Green',
+      'selects.0.options.*.4.label': 'White',
+      'selects.0.options.*.5.label': 'Black'
     },
     taskKey: 'init',
     type: 'dropdown-simple',


### PR DESCRIPTION
Use `task.strings.get()` for dropdown menu options.

Based on #3193.

## Package
lib-classifier

## How to Review
I've updated the test and story to use French strings for a task with English options. I've also got a test workflow in three languages.
https://localhost:8080/?project=908&workflow=3339&language=fr

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
