### PR TITLE
Classifier: Refactor workflow strings as a map

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -1,7 +1,6 @@
 import { applySnapshot, getSnapshot } from 'mobx-state-tree'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
-import zooTheme from '@zooniverse/grommet-theme'
 import '../../translations/i18n'
 import i18n from 'i18next'
 

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -1,5 +1,5 @@
 import { Provider } from 'mobx-react'
-import { getSnapshot } from 'mobx-state-tree'
+import { applySnapshot, getSnapshot } from 'mobx-state-tree'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 import zooTheme from '@zooniverse/grommet-theme'
@@ -65,8 +65,9 @@ export default function Classifier({
   useEffect(function onWorkflowStringsChange() {
     const { workflows } = classifierStore
     if (workflowSnapshot) {
+      const workflow = workflows.resources.get(workflowSnapshot.id)
       console.log('Refreshing workflow strings', workflowSnapshot.id)
-      workflows.setResources([workflowSnapshot])
+      applySnapshot(workflow.strings, workflowSnapshot.strings)
     }
   }, [workflowSnapshot?.strings])
   /*

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -19,9 +19,10 @@ export default function Classifier({
   subjectID,
   subjectSetID,
   workflowSnapshot,
-  workflowID
 }) {
 
+  const workflowID = workflowSnapshot?.id
+  const workflowStrings = workflowSnapshot?.strings
   const user = usePanoptesUser()
   const projectRoles = useProjectRoles(project?.id, user?.id)
   let workflowVersionChanged = false
@@ -55,21 +56,21 @@ export default function Classifier({
 
   useEffect(function onURLChange() {
     const { workflows } = classifierStore
-    if (workflowID && workflowSnapshot) {
+    if (workflowID) {
       console.log('starting new subject queue', { workflowID, subjectSetID, subjectID })
       workflows.setResources([workflowSnapshot])
       workflows.selectWorkflow(workflowID, subjectSetID, subjectID, canPreviewWorkflows)
     }
-  }, [canPreviewWorkflows, subjectID, subjectSetID, workflowID, workflowSnapshot])
+  }, [canPreviewWorkflows, subjectID, subjectSetID, workflowID])
 
   useEffect(function onWorkflowStringsChange() {
     const { workflows } = classifierStore
-    if (workflowSnapshot) {
-      const workflow = workflows.resources.get(workflowSnapshot.id)
-      console.log('Refreshing workflow strings', workflowSnapshot.id)
-      applySnapshot(workflow.strings, workflowSnapshot.strings)
+    if (workflowStrings) {
+      const workflow = workflows.resources.get(workflowID)
+      console.log('Refreshing workflow strings', workflowID)
+      applySnapshot(workflow.strings, workflowStrings)
     }
-  }, [workflowSnapshot?.strings])
+  }, [workflowID, workflowStrings])
   /*
     This should run when a project owner edits a workflow, but not when a workflow updates
     as a result of receiving classifications eg. workflow.completeness.

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -1,4 +1,3 @@
-import { Provider } from 'mobx-react'
 import { applySnapshot, getSnapshot } from 'mobx-state-tree'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -54,7 +54,6 @@ describe('Components > Classifier', function () {
         <Classifier
           classifierStore={store}
           project={projectSnapshot}
-          workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
         />,
         {
@@ -126,7 +125,6 @@ describe('Components > Classifier', function () {
         <Classifier
           classifierStore={store}
           project={projectSnapshot}
-          workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
         />,
         {
@@ -200,7 +198,6 @@ describe('Components > Classifier', function () {
           classifierStore={store}
           locale='en'
           project={projectSnapshot}
-          workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
         />,
         {
@@ -213,7 +210,6 @@ describe('Components > Classifier', function () {
           classifierStore={store}
           locale='fr'
           project={projectSnapshot}
-          workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
           workflowVersion={workflowSnapshot?.version}
         />,
@@ -320,7 +316,6 @@ describe('Components > Classifier', function () {
         <Classifier
           classifierStore={store}
           project={projectSnapshot}
-          workflowID={workflowSnapshot.id}
           workflowSnapshot={workflowSnapshot}
         />,
         {
@@ -348,7 +343,6 @@ describe('Components > Classifier', function () {
         <Classifier
           classifierStore={store}
           project={projectSnapshot}
-          workflowID={newSnapshot.id}
           workflowSnapshot={newSnapshot}
         />,
         {
@@ -457,7 +451,6 @@ describe('Components > Classifier', function () {
             <Classifier
               classifierStore={store}
               project={projectSnapshot}
-              workflowID={workflowSnapshot.id}
               workflowSnapshot={workflowSnapshot}
             />,
             {
@@ -565,7 +558,6 @@ describe('Components > Classifier', function () {
         <Classifier
           classifierStore={store}
           project={projectSnapshot}
-          workflowID={workflowSnapshot.id}
           workflowSnapshot={workflowSnapshot}
         />,
         {
@@ -635,7 +627,6 @@ describe('Components > Classifier', function () {
           locale='en'
           project={projectSnapshot}
           showTutorial
-          workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
         />,
         {
@@ -681,7 +672,6 @@ describe('Components > Classifier', function () {
           classifierStore={store}
           locale='en'
           project={projectSnapshot}
-          workflowID={workflowSnapshot?.id}
           workflowSnapshot={workflowSnapshot}
         />,
         {
@@ -761,7 +751,6 @@ describe('Components > Classifier', function () {
           classifierStore={store}
           project={projectSnapshot}
           subjectSetID='1'
-          workflowID={workflowSnapshot.id}
           workflowSnapshot={workflowSnapshot}
         />,
         {
@@ -774,7 +763,6 @@ describe('Components > Classifier', function () {
           classifierStore={store}
           project={projectSnapshot}
           subjectSetID='2'
-          workflowID={workflowSnapshot.id}
           workflowSnapshot={workflowSnapshot}
         />,
         {

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -361,7 +361,7 @@ describe('Components > Classifier', function () {
       tutorialTab = screen.getByRole('tab', { name: 'TaskArea.tutorial'})
       subjectImage = screen.getByRole('img', { name: `Subject ${subjectSnapshot.id}` })
       tabPanel = screen.getByRole('tabpanel', { name: '1 Tab Contents'})
-      const task = workflowSnapshot.tasks.T0
+      const task = newSnapshot.tasks.T0
       const getAnswerInput = answer => within(tabPanel).queryByRole('radio', { name: answer.label })
       taskAnswers = task.answers.map(getAnswerInput)
     })

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
@@ -138,7 +138,6 @@ export default function ClassifierContainer({
             subjectSetID={subjectSetID}
             subjectID={subjectID}
             workflowSnapshot={workflowSnapshot}
-            workflowID={workflowSnapshot?.id}
           />
         </Provider>
       )

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -85,15 +85,16 @@ const WorkflowStepStore = types
   }))
   .actions(self => {
     function _onWorkflowChange() {
+      // Reset steps and tasks when the workflow ID or version change.
       if (self.workflow?.id && self.workflow?.version) {
         self.reset()
         self.setStepsAndTasks()
-        self.setTaskStrings(getSnapshot(self.workflow.strings))
       }
     }
 
     function _onLocaleChange() {
-      if (self.locale && self.workflow?.strings) {
+      // Update task language strings when the workflow language changes.
+      if (self.workflow?.strings) {
         self.setTaskStrings(getSnapshot(self.workflow.strings))
       }
     }
@@ -138,9 +139,10 @@ const WorkflowStepStore = types
     }
 
     function setStepsAndTasks () {
-      const { steps, tasks } = self.workflow
+      const { steps, strings, tasks } = self.workflow
       self.setSteps(steps)
       self.setTasks(tasks)
+      self.setTaskStrings(getSnapshot(strings))
     }
 
     function setSteps (steps) {

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -92,8 +92,8 @@ const WorkflowStepStore = types
       }
     }
 
-    function _onLocaleChange() {
-      // Update task language strings when the workflow language changes.
+    function _onWorkflowStringsChange() {
+      // Pass workflow strings down to task strings when they change.
       if (self.workflow?.strings) {
         self.setTaskStrings(getSnapshot(self.workflow.strings))
       }
@@ -101,7 +101,7 @@ const WorkflowStepStore = types
 
     function afterAttach () {
       addDisposer(self, autorun(_onWorkflowChange))
-      addDisposer(self, autorun(_onLocaleChange))
+      addDisposer(self, autorun(_onWorkflowStringsChange))
     }
 
     function getNextStepKey () {

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -180,7 +180,7 @@ const WorkflowStepStore = types
           try {
             applySnapshot(task.strings, taskStringsSnapshot)
           } catch (error) {
-            console.error(`${taskKey} ${task.type}: could not apply language strings`)
+            console.error(`${task.taskKey} ${task.type}: could not apply language strings`)
             console.error(error)
           }
         })

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -85,9 +85,10 @@ const WorkflowStepStore = types
   }))
   .actions(self => {
     function _onWorkflowChange() {
-      if (self.workflow) {
+      if (self.workflow?.id && self.workflow?.version) {
         self.reset()
         self.setStepsAndTasks()
+        self.setTaskStrings(getSnapshot(self.workflow.strings))
       }
     }
 

--- a/packages/lib-classifier/src/store/WorkflowStore/Workflow/Workflow.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/Workflow/Workflow.js
@@ -28,7 +28,7 @@ const Workflow = types
     links: types.frozen({}),
     prioritized: types.optional(types.boolean, false),
     steps: types.array(WorkflowStep),
-    strings: types.maybe(types.frozen()),
+    strings: types.map(types.string),
     subjectSet: types.safeReference(SubjectSet),
     tasks: types.maybe(types.frozen()),
     version: types.string

--- a/packages/lib-classifier/src/store/WorkflowStore/WorkflowStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/WorkflowStore.js
@@ -1,4 +1,3 @@
-import { autorun } from 'mobx'
 import { addDisposer, flow, getRoot, tryReference, types } from 'mobx-state-tree'
 import ResourceStore from '@store/ResourceStore'
 import Workflow from './Workflow'


### PR DESCRIPTION
`types.frozen` is assumed to be immutable, but `workflow.strings` changes when the locale changes. This refactors `workflow.strings` as an observable map, applying new snapshots of the language strings when the locale changes.

`WorkflowStepStore` is also updated to explicitly update task strings whenever the workflow version changes, so that workflow edits in the project builder are shown in the classifier's task panel.

- Closes #3266.
- Based on #3220, so take a look at that first.

## Package
lib-classifier

## How to Review
Open a workflow in either the dev classifier or the project app. Change the workflow's language strings by either editing the workflow in the project builder or by switching to another language on the project's Classify page.

This PR should also fix background refresh in the classifier, so that the displayed workflow is always the most up-to-date version.

https://user-images.githubusercontent.com/59547/172350935-42703218-c32a-4859-a8be-e489e37f8450.mov



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
