### PR TITLE
QuickTalk: data-fetching with SWR

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
@@ -81,14 +81,7 @@ function QuickTalkContainer ({
     try {
       if (!text || text.trim().length === 0) throw new Error(t('QuickTalk.errors.noText'))
 
-      /*
-      Quick Fix: check user before posting
-      - this is because we can never be 100% sure when a user has logged out on lib-classifier
-      - long-term, we want to pass down the User resource from app-project
-      - see https://github.com/zooniverse/front-end-monorepo/discussions/2362
-       */
-
-      const authorization = await getBearerToken(authClient)  // Check bearer token to ensure session hasn't timed out
+      const authorization = await getBearerToken(authClient)  // Get a refreshed auth token for posting comments.
       if (!authorization) throw new Error(t('QuickTalk.errors.noUser'))
 
       // First, get default board

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
@@ -110,8 +110,9 @@ function QuickTalkContainer ({
 
       } else {  // Create a new discussion
 
-        const response = await postTalkDiscussion (text, discussionTitle, subject, defaultBoard, user, authorization)
-        if (!response?.ok) throw new Error(t('QuickTalk.errors.failPostDiscussion'))
+        const discussion = await postTalkDiscussion (text, discussionTitle, subject, defaultBoard, user, authorization)
+        if (!discussion) throw new Error(t('QuickTalk.errors.failPostDiscussion'))
+        comments.push(discussion.latest_comment)
 
         setPostCommentStatus(asyncStates.success)
         setPostCommentStatusMessage('')

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
@@ -101,8 +101,9 @@ function QuickTalkContainer ({
 
       if (existingDiscussion) { // Add to the existing discussion
 
-        const response = await postTalkComment(text, existingDiscussion, user, authorization)
-        if (!response?.ok) throw new Error(t('QuickTalk.errors.failPostComment'))
+        const newComment = await postTalkComment(text, existingDiscussion, user, authorization)
+        if (!newComment) throw new Error(t('QuickTalk.errors.failPostComment'))
+        comments.push(newComment)
 
         setPostCommentStatus(asyncStates.success)
         setPostCommentStatusMessage('')

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.spec.js
@@ -1,7 +1,11 @@
+import zooTheme from '@zooniverse/grommet-theme'
+import { Grommet } from 'grommet'
 import React from 'react'
+import { Provider } from 'mobx-react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import mockStore from '@test/mockStore'
 import { QuickTalkContainer } from './QuickTalkContainer'
 
 const subject = {
@@ -13,14 +17,30 @@ const authClient = {}
 const quickTalkButton_target = { name: 'QuickTalk.aria.openButton' }
 
 describe('Component > QuickTalkContainer', function () {
+  function withStore(store) {
+    return function Wrapper({ children }) {
+      return (
+        <Grommet theme={zooTheme}>
+          <Provider classifierStore={store}>
+            {children}
+          </Provider>
+        </Grommet>
+      )
+    }
+  }
+
   describe('when collapsed', function () {
     beforeEach(function () {
+      const store = mockStore()
       render(
         <QuickTalkContainer
           authClient={authClient}
           enabled={true}
           subject={subject}
-        />
+        />,
+        {
+          wrapper: withStore(store)
+        }
       )
     })
 

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/helpers/postTalkComment.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/helpers/postTalkComment.js
@@ -9,6 +9,10 @@ export default async function postTalkComment (text, discussion, user, authoriza
     discussion_id: +discussion.id,
   }
 
-  return talkAPI.post('/comments', { comments }, { authorization })
-    .then(response => response)
+  const response = await talkAPI.post('/comments', { comments }, { authorization })
+  if (response?.body?.comments) {
+    const [comment] = response.body.comments
+    return comment
+  }
+  return null
 }

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/helpers/postTalkDiscussion.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/helpers/postTalkDiscussion.js
@@ -18,6 +18,10 @@ export default async function postTalkDiscussion (text, title, subject, board, u
     comments: comments,
   }
 
-  return talkAPI.post('/discussions', { discussions }, { authorization })
-    .then(response => response)
+  const response = await talkAPI.post('/discussions', { discussions }, { authorization })
+  if (response?.body?.discussions) {
+    const [discussion] = response.body.discussions
+    return discussion
+  }
+  return null
 }


### PR DESCRIPTION
This converts all the `QuickTalk` data fetching functions to use SWR (stale-while-revalidate.) New comments are parsed out of the POST response and appended to the `comments` array, so that they appear without refreshing the whole list and losing your place.

~~Labelled as draft until comments are refreshed after you post a new comment.~~

## Package
lib-classifier

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
