### PR TITLE
Fix ImageAndTextViewer not calling onReady or onError

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewer.spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 import { Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
 import React from 'react'
+import sinon from 'sinon'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import asyncStates from '@zooniverse/async-states'
@@ -172,6 +173,22 @@ describe('ImageAndTextViewer', function () {
       expect(screen.getByRole('button', { name: 'SlideTutorial.StepNavigation.previous' })).to.exist()
       expect(screen.getAllByRole('radio', { name: 'SlideTutorial.StepNavigation.go' })).to.have.lengthOf(2)
       expect(screen.getByRole('button', { name: 'SlideTutorial.StepNavigation.next' })).to.exist()
+    })
+
+    it('should call the onReady prop', function () {
+      const onReadySpy = sinon.spy()
+
+      render(
+        <ImageAndTextViewerConnector
+          loadingState={asyncStates.success}
+          onReady={onReadySpy}
+          subject={store.subjects.active}
+        />, {
+          wrapper: withStore(store)
+        }
+      )
+
+      expect(onReadySpy).to.have.been.calledOnce()
     })
 
     describe('when the frame is changed', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewerContainer.js
@@ -11,6 +11,8 @@ import StepNavigation from '@components/Classifier/components/SlideTutorial/comp
 function ImageAndTextViewerContainer ({
   frame = 0,
   loadingState = asyncStates.initialized,
+  onError = () => true,
+  onReady = () => true,
   setFrame = () => true,
   subject
 }) {
@@ -40,6 +42,8 @@ function ImageAndTextViewerContainer ({
           <SingleImageViewer
             enableInteractionLayer={false}
             loadingState={loadingState}
+            onError={onError}
+            onReady={onReady}
           />
           <StepNavigation
             onChange={handleFrameChange}
@@ -56,7 +60,10 @@ function ImageAndTextViewerContainer ({
           flex='grow'
           justify='between'
         >
-          <SingleTextViewer />
+          <SingleTextViewer
+            onError={onError}
+            onReady={onReady}
+          />
           <StepNavigation
             onChange={handleFrameChange}
             stepIndex={frame}


### PR DESCRIPTION
## Package
- lib-classifier

## Describe your changes
- pass onError and onReady from SubjectViewer to ImageAndTextViewer to either SingleImageViewer or SingeTextViewer

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - fix - https://local.zooniverse.org:8080/?project=1952&workflow=3594&demo=true
  - bug - https://frontend.preview.zooniverse.org/projects/markb-panoptes/digileap-testing/classify/workflow/3594?env=staging
- What user actions should my reviewer step through to review this PR? try to edit text in textFromSubject task (text input)
- Which storybook stories should be reviewed? I think N/A, bug in task related to code missing in viewer, separate stories
- Are there plans for follow up PR’s to further fix this bug or develop this feature? yes! the viewers are inconsistently getting some subject viewer store props passed from the SubjectViewer component and from the individual viewer connectors. I'm going to create an issue to refactor for consistency. 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-voiceover-os.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated