### PR TITLE
Classifier: Refactor ClassifierContainer effect hooks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
@@ -78,30 +78,6 @@ export default function ClassifierContainer({
 
   useEffect(function onMount() {
     /*
-    If the project uses session storage, we need to do some
-    processing of the store after it loads.
-    */
-    if (cachePanoptesData) {
-      const { subjects, workflows } = classifierStore
-      if (!workflows.active?.prioritized) {
-        /*
-        In this case, we delete the saved queue so that
-        refreshing the classifier will load a new, randomised
-        subject queue.
-        */
-        console.log('randomising the subject queue.')
-        subjects.reset()
-        subjects.advance()
-      }
-      if (subjects.active) {
-        /*
-          This is a hack to start a new classification from a snapshot.
-        */
-        console.log('store hydrated with active subject', subjects.active.id)
-        classifierStore.startClassification()
-      }
-    }
-    /*
     This should run after the store is created and hydrated.
     Otherwise, hydration will overwrite the callbacks with
     their defaults.

--- a/packages/lib-classifier/src/hooks/useHydratedStore.js
+++ b/packages/lib-classifier/src/hooks/useHydratedStore.js
@@ -37,7 +37,31 @@ function initStore({ cachePanoptesData, storageKey, storeEnv }) {
       store = RootStore.create({}, storeEnv)
     }
 
+    /*
+    If the project uses session storage, we need to do some
+    processing of the store after it loads.
+    */
     if (cachePanoptesData) {
+      if (!store.workflows.active?.prioritized) {
+        /*
+        In this case, we delete the saved queue so that
+        refreshing the classifier will load a new, randomised
+        subject queue.
+        */
+        console.log('randomising the subject queue.')
+        store.subjects.reset()
+        store.subjects.advance()
+      }
+      if (store.subjects.active) {
+        /*
+          This is a hack to start a new classification from a snapshot.
+        */
+        console.log('store hydrated with active subject', store.subjects.active.id)
+        store.startClassification()
+      }
+      /*
+        Save snapshots to storage whenever the store changes.
+      */
       persist(storageKey, store)
     }
     makeInspectable(store)


### PR DESCRIPTION
There's some code in `ClassifierContainer` which runs when the classifier mounts, but should only run when the window loads and the classifier store is created. This moves that code into the `useHydratedStore` hook, where it runs when the store is first created.

The effect of this is that reloading the page should give you a new subject, as expected, but unmounting and mounting the classifier by navigating the NextJS app, eg. by changing locale, should preserve your current subject and classification, even when session storage is enabled for your project.

Closes #3218.

## Package
lib-classifier

## How to Review
The changes are in the classifier, but to test them you'll need to unmount and mount the classifier in Classify pages in the project app. I've got a test project, on staging, which has session caching enabled (it has one prioritised workflow.) You can test it out with this single answer task, where selected answers should be remembered except when you reload the page.

https://local.zooniverse.org:3000/projects/es/eatyourgreens/-project-testing-ground/classify/workflow/1483?env=staging

On this branch, you should find that you can select an answer on that question task, navigate away to About or Home, and your subject and classification are preserved when you navigate back with the browser Back button. Reloading the page should reset the classifier and load a new subject.

It would also help to test this with the project language menu enabled, so uncomment `LocaleSwitcher` in the `ProjectHeader` component.
https://github.com/zooniverse/front-end-monorepo/blob/6b26a1850b2f812a7ad83590659fc6c8937c9010/packages/app-project/src/components/ProjectHeader/ProjectHeader.js#L52

You should find that the current subject and any selected answers are preserved when the page language changes, but reloading should load a new subject and start a new classification.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
