### PR TITLE
Project header: show LocaleSwitcher in development

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
@@ -15,14 +15,18 @@ import UnderReviewLabel from './components/UnderReviewLabel'
 const StyledBox = styled(Box)`
   position: relative;
 `
+const environment = process.env.APP_ENV
 
-function ProjectHeader (props) {
-  const { className, inBeta, navLinks, screenSize, title } = props
+function ProjectHeader ({
+  availableLocales = [],
+  className = '',
+  inBeta = false,
+  navLinks = [],
+  screenSize = '',
+  title
+}) {
 
-  // hard-coded for translation feature PR testing, but
-  // should eventually be imported as props instead
-  const availableLocales = ['en', 'test']
-
+  const hasTranslations = environment === 'development' && availableLocales?.length > 1
   return (
     <StyledBox as='header' className={className}>
       <Background />
@@ -49,7 +53,7 @@ function ProjectHeader (props) {
                 <UnderReviewLabel />}
             </Box>
             <ApprovedIcon isNarrow={screenSize === 'small'} />
-            {/* {availableLocales?.length > 1 && <LocaleSwitcher availableLocales={availableLocales} />} */}
+            {hasTranslations && <LocaleSwitcher availableLocales={availableLocales} />}
           </Box>
         </Box>
         {screenSize !== 'small' && <Nav navLinks={navLinks} />}
@@ -59,19 +63,10 @@ function ProjectHeader (props) {
   )
 }
 
-ProjectHeader.defaultProps = {
-  availableLocales: [],
-  className: '',
-  inBeta: false,
-  href: '',
-  screenSize: ''
-}
-
 ProjectHeader.propTypes = {
   availableLocales: array,
   className: string,
   inBeta: bool,
-  href: string,
   navLinks: arrayOf(shape({
     href: string,
     text: string


### PR DESCRIPTION

Use `APP_ENV` to check the deploy environment. Show the `LocaleSwitcher` component in development, but not when code has been deployed to staging or production.


## Package
app-project

## How to Review
This should show the project language menu when you build and run the app locally, but should hide it for staging (`APP_ENV=staging`) and production (`APP_ENV=production`) builds.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected

## Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
