### PR TITLE
Set default APP_ENV to 'development'

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,10 @@ More information is available in [ADR 12](docs/arch/adr-12.md) and [ADR 17](docs
 
 The yarn build scripts default to production for libraries if `PANOPTES_ENV` is not specified. The apps are always built to the production API.
 - `NODE_ENV`: the [webpack build mode](https://webpack.js.org/configuration/mode/) for libraries and the NextJS apps (production, development or undefined.)
-- `APP_ENV`: sets the [Sentry environment](https://docs.sentry.io/enriching-error-data/environments/?platform=javascript) (development, staging or production) when reporting errors.
+- `APP_ENV`: the deployment environment, logged as the [Sentry environment](https://docs.sentry.io/product/sentry-basics/environments/) with errors:
+  - `development`: local development on `localhost` or `local.zooniverse.org`.
+  - `staging`: staging on `frontend.preview.zooniverse.org`.
+  - `production`: the Zooniverse web site, `www.zooniverse.org`.
 - `CONTENTFUL_ACCESS_TOKEN`: access token for the Contentful API. Should be kept secret.
 - `CONTENTFUL_SPACE_ID`: space ID for Zooniverse About pages in Contentful. Should be kept secret.
 - `CONTENT_ASSET_PREFIX`: [NextJS asset prefix](https://nextjs.org/docs/api-reference/next.config.js/cdn-support-with-asset-prefix) for `app-content-pages`.

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -81,6 +81,8 @@ spec:
               value: production
             - name: PANOPTES_ENV
               value: production
+            - name: APP_ENV
+              value: production
             - name: SENTRY_PROJECT_DSN
               value: https://2a50683835694829b4bc3cccc9adcc1b@sentry.io/1492691
             - name: ENABLE_CACHE_HEADERS
@@ -190,6 +192,8 @@ spec:
             - name: NODE_ENV
               value: production
             - name: PANOPTES_ENV
+              value: production
+            - name: APP_ENV
               value: production
             - name: SENTRY_CONTENT_DSN
               value: https://1f0126a750244108be76957b989081e8@sentry.io/1492498

--- a/packages/app-content-pages/next.config.js
+++ b/packages/app-content-pages/next.config.js
@@ -17,7 +17,7 @@ const PANOPTES_ENV = process.env.PANOPTES_ENV || 'staging'
 const webpackConfig = require('./webpack.config')
 const assetPrefix = process.env.CONTENT_ASSET_PREFIX || ''
 const SENTRY_CONTENT_DSN = process.env.SENTRY_CONTENT_DSN
-const APP_ENV = process.env.APP_ENV || 'production'
+const APP_ENV = process.env.APP_ENV || 'development'
 const COMMIT_ID = process.env.COMMIT_ID || commitID()
 
 const nextConfig = {

--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -6,8 +6,8 @@
   "version": "0.0.1",
   "main": "index.js",
   "scripts": {
-    "build": "PANOPTES_ENV=${PANOPTES_ENV:-production} next build",
-    "dev": "PANOPTES_ENV=${PANOPTES_ENV:-production} node server/server.js",
+    "build": "APP_ENV=${APP_ENV:-development} PANOPTES_ENV=${PANOPTES_ENV:-production} next build",
+    "dev": "APP_ENV=${APP_ENV:-development} PANOPTES_ENV=${PANOPTES_ENV:-production} node server/server.js",
     "lint": "next lint",
     "start": "NODE_ENV=${NODE_ENV:-production} node server/server.js",
     "storybook": "start-storybook -p 9002 -c .storybook",

--- a/packages/app-project/next.config.js
+++ b/packages/app-project/next.config.js
@@ -25,7 +25,7 @@ const PANOPTES_ENV = process.env.PANOPTES_ENV || 'staging'
 const webpackConfig = require('./webpack.config')
 const assetPrefix = process.env.PROJECT_ASSET_PREFIX || basePath
 const SENTRY_PROJECT_DSN = process.env.SENTRY_PROJECT_DSN
-const APP_ENV = process.env.APP_ENV || 'production'
+const APP_ENV = process.env.APP_ENV || 'development'
 const COMMIT_ID = process.env.COMMIT_ID || commitID()
 
 console.info(PANOPTES_ENV, talkHosts[PANOPTES_ENV])

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -6,10 +6,10 @@
   "version": "0.0.1",
   "main": "index.js",
   "scripts": {
-    "build": "PANOPTES_ENV=${PANOPTES_ENV:-production} next build",
+    "build": "APP_ENV=${APP_ENV:-development} PANOPTES_ENV=${PANOPTES_ENV:-production} next build",
     "build-storybook": "build-storybook -s public",
-    "dev": "PANOPTES_ENV=${PANOPTES_ENV:-staging} node server/dev-server.js",
-    "dev:inspect": "PANOPTES_ENV=${PANOPTES_ENV:-staging} NODE_OPTIONS='--inspect' node server/dev-server.js",
+    "dev": "APP_ENV=${APP_ENV:-development} PANOPTES_ENV=${PANOPTES_ENV:-staging} node server/dev-server.js",
+    "dev:inspect": "APP_ENV=${APP_ENV:-development} PANOPTES_ENV=${PANOPTES_ENV:-staging} NODE_OPTIONS='--inspect' node server/dev-server.js",
     "lint": "next lint",
     "start": "NODE_ENV=${NODE_ENV:-production} node server/server.js",
     "start:dev": "NODE_ENV=${NODE_ENV:-production} node server/dev-server.js",


### PR DESCRIPTION
- set the default build and deploy environment to 'development', not 'production'.
- update the description of `APP_ENV` in the Readme.
- explicitly set `APP_ENV` in the kubernetes templates.

## Package
app-content-pages
app-project

## How to Review
Try building the apps with different environments eg. `APP_ENV=staging yarn build` should give you a build that can be deployed to staging. `APP_ENV=production yarn build` should give you a production app. In terms of the builds themselves, I think the only visible change in the HTML might be the links that are published in the page `<head>`. Staging builds should use `https://frontend.preview.zooniverse.org` and production should use `https://www.zooniverse.org`.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook
