### PR TITLE
Classifier: better handling of invalid tasks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.js
@@ -33,9 +33,18 @@ function Task ({
   task,
   ...props
 }) {
-  const { TaskComponent } = task.type === 'dropdown-simple'? tasks.dropdownSimple : tasks[task.type]
+  const TaskPlugin = task.type === 'dropdown-simple'? tasks.dropdownSimple : tasks[task.type]
+  const TaskComponent = TaskPlugin?.TaskComponent
   let annotation
   let suggestions
+
+  if (!TaskComponent) {
+    return (
+      <Paragraph>
+        <code>{task.taskKey} {task.type}</code> is not a supported task type.
+      </Paragraph>
+    )
+  }
 
   if (latest) {
     ([ annotation ] = latest.annotations.filter(annotation => annotation.task === task.taskKey))
@@ -47,10 +56,6 @@ function Task ({
   
   if (!annotation) {
     return <Paragraph>Annotation missing for task <code>{task.taskKey}</code></Paragraph>
-  }
-
-  if (!TaskComponent) {
-    return (<Paragraph>Task component could not be rendered.</Paragraph>)
   }
 
   return (

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.spec.js
@@ -127,4 +127,35 @@ describe('Components > Task', function () {
       })
     })
   })
+
+  describe('invalid tasks', function () {
+    it('should display an error message', function () {
+      const task = {
+        taskKey: 'init',
+        type: 'dropdown',
+        instruction: '',
+        options: []
+      }
+      const workflowSnapshot = WorkflowFactory.build({
+        id: 'tasksWorkflow',
+        display_name: 'A test workflow',
+        tasks: {
+          init: task
+        },
+        version: '0.0'
+      })
+      const store = mockStore({ workflow: workflowSnapshot })
+      const wrapper = mount(
+        <Task
+          store={store}
+          task={task}
+        />, {
+          wrappingComponent: Grommet,
+          wrappingComponentProps: { theme: zooTheme }
+        }
+      )
+      const errorMessage = wrapper.find('p').text()
+      expect(errorMessage).to.equal('init dropdown is not a supported task type.')
+    })
+  })
 })

--- a/packages/lib-classifier/src/hooks/useHydratedStore.js
+++ b/packages/lib-classifier/src/hooks/useHydratedStore.js
@@ -29,7 +29,13 @@ function initStore({ cachePanoptesData, storageKey, storeEnv }) {
       initialState = loadSnapshot(storageKey)
     }
 
-    store = RootStore.create(initialState, storeEnv)
+    try {
+      store = RootStore.create(initialState, storeEnv)
+    } catch (error) {
+      console.error('Unable to hydrate store from session storage.')
+      console.error(error)
+      store = RootStore.create({}, storeEnv)
+    }
 
     if (cachePanoptesData) {
       persist(storageKey, store)


### PR DESCRIPTION
- Catch undefined tasks in the `Task` component, and display an error message in place of the task.
- Catch invalid snapshot errors, when the store loads, and create a new, empty store.

## Package
lib-classifier

## Linked Issue and/or Talk Post
- Closes #3292.
- Closes #3251.

## How to Review
The task bug only exists in the production build of the classifier, so build the classifier then run the project app (either development or production build) and load this test workflow, which contains a task where the type is 'dropdown'.
https://local.zooniverse.org:3000/projects/eatyourgreens/-project-testing-ground/classify/workflow/3489?env=staging

<img width="1278" alt="Screenshot of the classifier showing an error message in place of one task: T0 dropdown is not a supported task type." src="https://user-images.githubusercontent.com/59547/173024120-dbeeddaf-8c37-4b92-8bc2-78062c91f917.png">


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
