### PR TITLE
Generalise Classifier workflow tests

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -14,8 +14,8 @@ import sinon from 'sinon'
 
 import RootStore from '@store'
 import { ProjectFactory, SubjectFactory, SubjectSetFactory, TutorialFactory } from '@test/factories'
-import mockStore, { defaultAuthClient, defaultClient } from '@test/mockStore/mockStore'
-import branchingWorkflow, { workflowStrings } from '@test/mockStore/branchingWorkflow'
+import mockStore, { defaultAuthClient, defaultClient } from '@test/mockStore/mockStore.js'
+import branchingWorkflow, { workflowStrings } from '@test/mockStore/branchingWorkflow.js'
 import Classifier from './Classifier'
 
 describe('Components > Classifier', function () {

--- a/packages/lib-classifier/src/components/Classifier/Classifier.workflows.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.workflows.spec.js
@@ -1,0 +1,171 @@
+import * as React from 'react'
+import { within } from '@testing-library/dom'
+import { render, screen } from '@testing-library/react'
+import asyncStates from '@zooniverse/async-states'
+import zooTheme from '@zooniverse/grommet-theme'
+import { panoptes } from '@zooniverse/panoptes-js'
+import { Grommet } from 'grommet'
+import { when } from 'mobx'
+import { Provider } from 'mobx-react'
+import { getSnapshot } from 'mobx-state-tree'
+import nock from 'nock'
+import { Factory } from 'rosie'
+import sinon from 'sinon'
+
+import RootStore from '@store'
+import { ProjectFactory, SubjectFactory, TutorialFactory, WorkflowFactory } from '@test/factories'
+import { defaultAuthClient, defaultClient } from '@test/mockStore/mockStore'
+import branchingWorkflow, { workflowStrings } from '@test/mockStore/branchingWorkflow'
+import Classifier from './Classifier'
+
+describe('Classifier > workflow types', function () {
+  this.timeout(0)
+
+  const cases = [
+    {
+      name: 'Branching workflow',
+      workflowSnapshot: branchingWorkflow,
+      workflowStrings: workflowStrings
+    },
+    {
+      name: 'PH-TESS',
+      workflowSnapshot: WorkflowFactory.build({
+        tasks: {
+          T0: {
+            help: 'mark transits on the light curve.',
+            instruction: '**Do you spot a transit?** If so, please mark it on the lightcurve to the left!    If you don\'t see any transits, continue by clicking Done or Done & Talk.',
+            tools: [{
+              type: 'graph2dRangeX',
+              label: 'Transit?'
+            }],
+            type: 'dataVisAnnotation'
+          }
+        }
+      }),
+      workflowStrings: {
+        'tasks.T0.help': 'mark transits on the light curve.',
+        'tasks.T0.instruction': '**Do you spot a transit?** If so, please mark it on the lightcurve to the left!    If you don\'t see any transits, continue by clicking Done or Done & Talk.',
+        'tasks.T0.tools.0.label': 'Transit?'
+      }
+    }
+  ]
+
+  cases.forEach(({ name, workflowSnapshot, workflowStrings }) => {
+    describe(name, function () {
+      testWorkflow(workflowSnapshot, workflowStrings)
+    })
+  })
+})
+
+function testWorkflow(workflowSnapshot, workflowStrings) {
+  let inputs, subjectImage, tabPanel, taskAnswers, taskTab, tutorialTab, workflow
+
+  function withStore(store) {
+    return function Wrapper({ children }) {
+      return (
+        <Grommet theme={zooTheme}>
+          <Provider classifierStore={store}>
+            {children}
+          </Provider>
+        </Grommet>
+      )
+    }
+  }
+
+  before(async function () {
+    sinon.replace(window, 'Image', class MockImage {
+      constructor () {
+        this.naturalHeight = 1000
+        this.naturalWidth = 500
+        setTimeout(() => this.onload(), 500)
+      }
+    })
+
+    const roles = []
+    const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+    workflowSnapshot.strings = workflowStrings
+    const projectSnapshot = ProjectFactory.build({
+      links: {
+        active_workflows: [workflowSnapshot.id],
+        workflows: [workflowSnapshot.id]
+      }
+    })
+
+    nock('https://panoptes-staging.zooniverse.org/api')
+    .persist()
+    .get('/field_guides')
+    .reply(200, { field_guides: [] })
+    .get('/project_preferences')
+    .query(true)
+    .reply(200, { project_preferences: [] })
+    .get('/project_roles')
+    .reply(200, { project_roles: [{ roles }]})
+    .get('/subjects/queued')
+    .query(true)
+    .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+    .post('/project_preferences')
+    .query(true)
+    .reply(200, { project_preferences: [] })
+
+    const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
+    const checkCurrent = sinon.stub().callsFake(() => Promise.resolve({ id: 123, login: 'mockUser' }))
+    const authClient = { ...defaultAuthClient, checkBearerToken, checkCurrent }
+    const client = { ...defaultClient, panoptes }
+    const store = RootStore.create({}, { authClient, client })
+    render(
+      <Classifier
+        classifierStore={store}
+        project={projectSnapshot}
+        workflowSnapshot={workflowSnapshot}
+      />,
+      {
+        wrapper: withStore(store)
+      }
+    )
+    await when(() => store.subjectViewer.loadingState === asyncStates.success)
+    workflow = store.workflows.active
+    taskTab = screen.getByRole('tab', { name: 'TaskArea.task'})
+    tutorialTab = screen.getByRole('tab', { name: 'TaskArea.tutorial'})
+    subjectImage = screen.getByRole('img', { name: `Subject ${subjectSnapshot.id}` })
+    tabPanel = screen.getByRole('tabpanel', { name: '1 Tab Contents'})
+    const task = workflowSnapshot.tasks.T0
+    inputs = task.answers || task.tools
+    const getLabelledInput = input => within(tabPanel).getByRole('radio', { name: input.label })
+    taskAnswers = inputs?.map(getLabelledInput)
+  })
+
+  after(function () {
+    sinon.restore()
+    nock.cleanAll()
+  })
+
+  it('should have a task tab', function () {
+    expect(taskTab).to.be.ok()
+  })
+
+  it('should have a tutorial tab', function () {
+    expect(tutorialTab).to.be.ok()
+  })
+
+  it('should show a subject image from the selected set', function () {
+    expect(subjectImage.getAttribute('xlink:href')).to.equal('https://foo.bar/example.png')
+  })
+
+  describe('task answers', function () {
+    it('should be displayed', function () {
+      expect(taskAnswers).to.have.lengthOf(inputs.length)
+    })
+
+    it('should be linked to the task', function () {
+      taskAnswers.forEach(radioButton => {
+        expect(radioButton.name).to.equal('T0')
+      })
+    })
+
+    it('should be enabled', function () {
+      taskAnswers.forEach(radioButton => {
+        expect(radioButton.disabled).to.be.false()
+      })
+    })
+  })
+}

--- a/packages/lib-classifier/src/components/Classifier/Classifier.workflows.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.workflows.spec.js
@@ -7,18 +7,18 @@ import { panoptes } from '@zooniverse/panoptes-js'
 import { Grommet } from 'grommet'
 import { when } from 'mobx'
 import { Provider } from 'mobx-react'
-import { getSnapshot } from 'mobx-state-tree'
 import nock from 'nock'
 import { Factory } from 'rosie'
 import sinon from 'sinon'
 
 import RootStore from '@store'
-import { ProjectFactory, SubjectFactory, TutorialFactory, WorkflowFactory } from '@test/factories'
+import { ProjectFactory, SubjectFactory, WorkflowFactory } from '@test/factories'
 import { defaultAuthClient, defaultClient } from '@test/mockStore/mockStore'
 import branchingWorkflow, { workflowStrings } from '@test/mockStore/branchingWorkflow'
 import Classifier from './Classifier'
 
 describe('Classifier > workflow types', function () {
+  // this turns off Mocha's time limit for slow tests
   this.timeout(0)
 
   const cases = [

--- a/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.js
@@ -47,7 +47,7 @@ function DataVisAnnotationTask (props) {
             key={`${task.taskKey}_${index}`}
             label={task.strings.get(`tools.${index}.label`)}
             labelIcon={<InputIcon icon={<Graph2dRangeXIcon />} color='white' />}
-            name='data-vis-annotation-tool'
+            name={task.taskKey}
             onChange={event => onChange(index, event)}
             required={task.required}
             type='radio'


### PR DESCRIPTION
Add `Classifier.workflows.spec.js`, which defines an array of mock workflows, then loops over that array, testing the Classifier with each workflow in turn.

This tests a branching question workflow and the PH-TESS workflow at the moment. Hopefully, it can be generalised to other types of workflow eg. transcription or survey.

## Package
lib-classifier

## How to Review
Just new tests here, so this shouldn't change how the classifier itself runs. I'd be interested in thoughts on how extensible the tests are to different types of workflows, or how we might come up with a set of tests that are general enough to test any workflow while still being useful.

This PR might be a useful jumping off point for automating tests that we currently conduct by hand ie. load a workflow into the classifier, then check that it works before deploying changes.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser