### PR TITLE
Project app pages: fix broken Array.find

### DIFF
--- a/packages/app-project/pages/[owner]/[project]/classify/index.js
+++ b/packages/app-project/pages/[owner]/[project]/classify/index.js
@@ -8,7 +8,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
     const { env } = query
     const { project } = props.initialState
     const { workflows } = props
-    const workflow = workflows.find(workflow => workflow.id === params.workflowID)
+    const workflow = workflows?.find(workflow => workflow.id === params.workflowID)
     const workflowPath = `/${project?.slug}/classify/workflow/${props.workflowID}`
     const destination = env ? `${workflowPath}?env=${env}` : workflowPath
     return ({

--- a/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/index.js
+++ b/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/index.js
@@ -7,7 +7,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   const { env } = query
   const { notFound, props: defaultProps } = await getDefaultPageProps({ locale, params, query, req, res })
   const { workflows } = defaultProps
-  const workflow = workflows.find(workflow => workflow.id === params.workflowID)
+  const workflow = workflows?.find(workflow => workflow.id === params.workflowID)
   const pageTitle = workflow?.displayName || null
   if (workflow?.grouped) {
     workflow.subjectSets = await fetchSubjectSets(workflow, env)

--- a/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/subject-set/[subjectSetID]/index.js
+++ b/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/subject-set/[subjectSetID]/index.js
@@ -8,11 +8,11 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   const { notFound, props: defaultProps } = await getDefaultPageProps({ locale, params, query, req, res })
   const { subjectSetID, workflowID } = params
   const { workflows } = defaultProps
-  const workflow = workflows.find(workflow => workflow.id === workflowID)
+  const workflow = workflows?.find(workflow => workflow.id === workflowID)
   let pageTitle = workflow?.displayName || null
   if (workflow?.grouped) {
     workflow.subjectSets = await fetchSubjectSets(workflow, env)
-    const subjectSet = workflow.subjectSets.find(subjectSet => subjectSet.id === subjectSetID)
+    const subjectSet = workflow.subjectSets?.find(subjectSet => subjectSet.id === subjectSetID)
     pageTitle = `${subjectSet?.display_name} | ${workflow?.displayName}`
   }
   return ({

--- a/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/subject-set/[subjectSetID]/subject/[subjectID]/index.js
+++ b/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/subject-set/[subjectSetID]/subject/[subjectID]/index.js
@@ -9,11 +9,11 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   const { subjectID, subjectSetID, workflowID } = params
   const props = { ...defaultProps, subjectID, subjectSetID, workflowID }
   const { workflows } = defaultProps
-  const workflow = workflows.find(workflow => workflow.id === params.workflowID)
+  const workflow = workflows?.find(workflow => workflow.id === params.workflowID)
   let pageTitle = workflow?.displayName || null
   if (workflow?.grouped) {
     workflow.subjectSets = await fetchSubjectSets(workflow, env)
-    const subjectSet = workflow.subjectSets.find(subjectSet => subjectSet.id === subjectSetID)
+    const subjectSet = workflow.subjectSets?.find(subjectSet => subjectSet.id === subjectSetID)
     pageTitle = `${subjectSet?.display_name} | ${workflow?.displayName}`
   }
   return ({

--- a/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/subject/[subjectID]/index.js
+++ b/packages/app-project/pages/[owner]/[project]/classify/workflow/[workflowID]/subject/[subjectID]/index.js
@@ -6,7 +6,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   const { notFound, props: defaultProps } = await getDefaultPageProps({ locale, params, query, req, res })
   const { subjectID, workflowID } = params
   const { workflows } = defaultProps
-  const workflow = workflows.find(workflow => workflow.id === params.workflowID)
+  const workflow = workflows?.find(workflow => workflow.id === params.workflowID)
   const pageTitle = workflow?.displayName || null
 
   return ({


### PR DESCRIPTION
Add existential checks to `workflows.find()` and `subjectSets.find()` calls in the project app pages, so that they return a 404 response rather than erroring on the server when workflows or subject sets don't exist.

## Package
app-project

## Linked Issue and/or Talk Post
Closes #3319.

## How to Review
See #3319 for instructions to reproduce the bug, and check whether it's fixed. On this branch, you should see 404 responses, not 500 errors, if a project or workflow can't be found in the Panoptes API.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated
