### PR TITLE
Transcription workflows: adjust subtask position

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.js
@@ -11,7 +11,7 @@ import ConfirmModal from './components/ConfirmModal'
 import SaveButton from './components/SaveButton'
 
 const MIN_POPUP_WIDTH = 350
-const MIN_POPUP_HEIGHT = 100
+const MIN_POPUP_HEIGHT = 200
 
 /**
   A popup that renders activeMark.tasks for the active mark. Incomplete task annotations are confirmed, on save or close, for required tasks.

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/helpers/getDefaultPosition/getDefaultPosition.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/helpers/getDefaultPosition/getDefaultPosition.js
@@ -1,7 +1,11 @@
-const MIN_HEIGHT = 100
+const MIN_HEIGHT = 200
 const MIN_WIDTH = 350
 
 export default function getDefaultPosition (bounds = {}, minHeight = MIN_HEIGHT, minWidth = MIN_WIDTH) {
+  const viewport = {
+    height: window?.innerHeight,
+    width: window?.innerWidth
+  }
   // Calculate default position
   let x = 0
   let y = 0
@@ -19,8 +23,18 @@ export default function getDefaultPosition (bounds = {}, minHeight = MIN_HEIGHT,
     const markWidth = bounds.width || 0
     const markHeight = bounds.height || 0
 
-    x = markX + markWidth * 0.5
-    y = markY + markHeight * 0.5
+    const xOffset = markWidth * 0.5
+    let yOffset = markHeight
+
+    // Get the distance from the bottom of the mark to the bottom of the viewport.
+    const verticalSpace = viewport.height - (markY + markHeight)
+    // If the available space is too small, push the popup upwards.
+    if (verticalSpace < minHeight) {
+      yOffset = 0 - (minHeight + markHeight)
+    }
+
+    x = markX + xOffset
+    y = markY + yOffset
   }
 
   // Keep within bounds of the viewport


### PR DESCRIPTION
- Change the minimum popup height to 200px.
- Include the visible window in position calculations.
- When the popup is below the transcribed line, place the top left corner on the bottom of the transcribed line's bounding box, not in the middle of the line.
- When the transcribed line is towards the bottom of the screen, position the popup above the transcribed line, allowing an offset for the minimum popup height and the transcribed line's bounding box.

## Package
lib-classifier

## Linked Issue and/or Talk Post
Towards #2233. (I'm not sure if the changes here would close that issue for all possible transcription documents and workflows.)

## How to Review
https://localhost:8080/?project=mariaedgeworthletters/maria-edgeworth-letters&env=production

Try transcribing some lines towards the top or the bottom of the viewport. The popup shouldn't appear outside the visible viewport any more, and should be better positioned to avoid obscuring the written lines.

<img width="885" alt="Screenshot of the transcription task, with a purple line at the bottom of the window and the text task popup positioned toward the centre of the visible window area." src="https://user-images.githubusercontent.com/59547/173841206-1916890f-6170-47c5-870f-4bcba14c00b9.png">

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
