### PR TITLE
Hide invert button

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/InvertButton/InvertButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/InvertButton/InvertButton.spec.js
@@ -11,7 +11,7 @@ import mockStore from '@test/mockStore'
 
 import InvertButtonContainer from './InvertButtonContainer'
 
-describe('Component > InvertButton', function () {
+describe.skip('Component > InvertButton', function () {
   function withStore (store) {
     return function Wrapper ({ children }) {
       return (

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/InvertButton/InvertButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/InvertButton/InvertButtonContainer.js
@@ -28,15 +28,20 @@ function InvertButtonContainer ({
   disabled = false,
   onClick = () => console.log('invert view')
 }) {
-  if (disabled) {
-    return null
-  }
-  return (
-    <InvertButton
-      active={active}
-      onClick={onClick}
-    />
-  )
+  // NOTE: there are bugs with the invert button for multiframe subjects and for line color consistency.
+  // The invert button will not be shown until those bugs can be fixed, therefore will return null as follows:
+
+  return null
+
+  // if (disabled) {
+  //   return null
+  // }
+  // return (
+  //   <InvertButton
+  //     active={active}
+  //     onClick={onClick}
+  //   />
+  // )
 }
 
 export default withStores(InvertButtonContainer, storeMapper)


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
noted in Slack per pre-deploy testing:
- invert button not working with multi-frame subjects - https://frontend.preview.zooniverse.org/projects/humphrydavy/davy-notebooks-project/classify/workflow/21240?demo=true
- line color should be consistent regardless of image inverted or not inverted

## Describe your changes
- return null for invert button regardless of whether invert button enabled

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  The following workflows have invert enabled, but shouldn't show the invert button in the image toolbar:
  - https://local.zooniverse.org:8080/?project=humphrydavy%2Fdavy-notebooks-project&env=production&demo=true&workflow=18575
  - https://local.zooniverse.org:8080/?project=1952&workflow=3602&demo=true
- What user actions should my reviewer step through to review this PR?
  - confirm invert button doesn't show in image toolbar
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature? yes, have multi-frame issue fixed, working on line color

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

## Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
