### PR TITLE
Project App: Use internal API service names for SSR

### DIFF
--- a/packages/app-project/pages/[env]/[owner]/[project]/about/team.js
+++ b/packages/app-project/pages/[env]/[owner]/[project]/about/team.js
@@ -3,6 +3,7 @@ import getDefaultPageProps from '@helpers/getDefaultPageProps'
 import { panoptes } from '@zooniverse/panoptes-js'
 export { default } from '@screens/ProjectAboutPage'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import getServerSideAPIHost from '@helpers/getServerSideAPIHost'
 
 export async function getStaticProps({ locale, params }) {
   const { notFound, props } = await getDefaultPageProps({ locale, params })
@@ -20,7 +21,7 @@ export async function getStaticProps({ locale, params }) {
           project_id: project.id,
           page: page
         }
-        const response = await panoptes.get(`/project_roles`, teamQuery)
+        const response = await panoptes.get(`/project_roles`, teamQuery, {}, getServerSideAPIHost(env))
         const { meta, project_roles: projectRoles } = response.body
         allRoles = allRoles.concat(projectRoles)
         if (meta.project_roles && meta.project_roles.next_page) {

--- a/packages/app-project/src/helpers/fetchProjectData/fetchProjectData.js
+++ b/packages/app-project/src/helpers/fetchProjectData/fetchProjectData.js
@@ -2,13 +2,13 @@ import { get } from 'lodash'
 import asyncStates from '@zooniverse/async-states'
 import { projects } from '@zooniverse/panoptes-js'
 
-export default async function fetchProjectData(slug, params) {
+export default async function fetchProjectData(slug, params, host) {
   const projectData = {
     loadingState: asyncStates.loading
   }
   try {
     const query = { ...params, slug }
-    const response = await projects.getWithLinkedResources({ query })
+    const response = await projects.getWithLinkedResources({ query }, host)
     const project = response.body.projects[0]
     if (!project) throw new Error(`${slug} could not be found`)
 

--- a/packages/app-project/src/helpers/fetchProjectPage/fetchProjectPage.js
+++ b/packages/app-project/src/helpers/fetchProjectPage/fetchProjectPage.js
@@ -1,13 +1,16 @@
 import fetchTranslations from '@helpers/fetchTranslations'
+import getServerSideAPIHost from '@helpers/getServerSideAPIHost'
 
 export default async function fetchProjectPage(project, locale, key, env) {
+  const host = getServerSideAPIHost(env)
   const page = project.about_pages.find(page => page.url_key === key)
   const translations = await fetchTranslations({
     translated_id: page?.id,
     translated_type: 'project_page',
     fallback: project.primary_language,
     language: locale,
-    env
+    env,
+    host
   })
   if (translations?.strings) {
     page.strings = translations.strings

--- a/packages/app-project/src/helpers/fetchSubjectSets/fetchSubjectSets.js
+++ b/packages/app-project/src/helpers/fetchSubjectSets/fetchSubjectSets.js
@@ -1,8 +1,10 @@
 import { panoptes } from '@zooniverse/panoptes-js'
 
+import getServerSideAPIHost from '@helpers/getServerSideAPIHost'
 import { logToSentry } from '@helpers/logger'
 
 async function fetchSubjectSetData(subjectSetIDs, env) {
+  const host = getServerSideAPIHost(env)
   let subject_sets = []
   try {
     const query = {
@@ -10,7 +12,7 @@ async function fetchSubjectSetData(subjectSetIDs, env) {
       id: subjectSetIDs.join(','),
       page_size: subjectSetIDs.length
     }
-    const response = await panoptes.get('/subject_sets', query)
+    const response = await panoptes.get('/subject_sets', query, {}, host)
     subject_sets = response.body.subject_sets
     await Promise.allSettled(subject_sets.map(subjectSet => fetchPreviewImage(subjectSet, env)))
   } catch (error) {
@@ -21,14 +23,15 @@ async function fetchSubjectSetData(subjectSetIDs, env) {
 }
 
 async function fetchPreviewImage (subjectSet, env) {
+  const host = getServerSideAPIHost(env)
   try {
-    const response = await panoptes
-      .get('/set_member_subjects', {
-        env,
-        subject_set_id: subjectSet.id,
-        include: 'subject',
-        page_size: 1
-      })
+    const query = {
+      env,
+      subject_set_id: subjectSet.id,
+      include: 'subject',
+      page_size: 1
+    }
+    const response = await panoptes.get('/set_member_subjects', query, {}, host)
     const { linked } = response.body
     subjectSet.subjects = linked.subjects
   } catch (error) {

--- a/packages/app-project/src/helpers/fetchTranslations/fetchTranslations.js
+++ b/packages/app-project/src/helpers/fetchTranslations/fetchTranslations.js
@@ -1,14 +1,22 @@
 import { panoptes } from '@zooniverse/panoptes-js'
 
-export default async function fetchTranslations({ translated_id, translated_type, fallback = 'en', language, env }) {
+export default async function fetchTranslations({
+  translated_id,
+  translated_type,
+  fallback = 'en',
+  language,
+  env,
+  host
+}) {
   const languages = language === fallback ? fallback : `${language},${fallback}`
   if (translated_id) {
-    const response = await panoptes.get('/translations', {
+    const query = {
       language: languages,
       translated_id,
       translated_type,
       env
-    })
+    }
+    const response = await panoptes.get('/translations', query, {}, host)
 
     const translation = response.body.translations.find(t => t.language === language)
     const original = response.body.translations.find(t => t.language === fallback)

--- a/packages/app-project/src/helpers/getServerSideAPIHost/getServerSideAPIHost.js
+++ b/packages/app-project/src/helpers/getServerSideAPIHost/getServerSideAPIHost.js
@@ -1,0 +1,19 @@
+const deployEnvironment = process.env.APP_ENV
+
+const APIHosts = {
+  production: 'http://panoptes-production-app',
+  staging: 'http://panoptes-staging-app'
+}
+
+/**
+  Return the internal service name for our API hosts when the app is deployed in our kubernetes cluster.
+  Return undefined to use the default hostname in local development.
+*/
+export default function getServerSideAPIHost(env) {
+  let host
+
+  if (deployEnvironment === 'staging' || deployEnvironment === 'production') {
+    host = APIHosts[env]
+  }
+  return host
+}

--- a/packages/app-project/src/helpers/getServerSideAPIHost/index.js
+++ b/packages/app-project/src/helpers/getServerSideAPIHost/index.js
@@ -1,0 +1,1 @@
+export { default } from './getServerSideAPIHost'

--- a/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.js
+++ b/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.js
@@ -5,6 +5,7 @@ import notFoundError from '@helpers/notFoundError'
 import fetchProjectData from '@helpers/fetchProjectData'
 import fetchTranslations from '@helpers/fetchTranslations'
 import fetchWorkflowsHelper from '@helpers/fetchWorkflowsHelper'
+import getServerSideAPIHost from '@helpers/getServerSideAPIHost'
 import initStore from '@stores'
 
 export default async function getStaticPageProps({ locale, params }) {
@@ -13,13 +14,14 @@ export default async function getStaticPageProps({ locale, params }) {
   // we'll take a snapshot of this later, to pass as a page prop.
   const store = initStore(isServer)
   const { env } = params
+  const host = getServerSideAPIHost(env)
 
   /*
     Fetch the project
   */
   if (params.owner && params.project) {
     const projectSlug = `${params.owner}/${params.project}`
-    const project = await fetchProjectData(projectSlug, { env })
+    const project = await fetchProjectData(projectSlug, { env }, host)
     applySnapshot(store.project, project)
     if (!store.project.id) {
       return notFoundError(`Project ${params.owner}/${params.project} was not found`)
@@ -52,7 +54,8 @@ export default async function getStaticPageProps({ locale, params }) {
     translated_type: 'project',
     language,
     fallback: project.primary_language,
-    env
+    env,
+    host
   })
   const strings = translations?.strings ?? project.strings
 
@@ -71,7 +74,7 @@ export default async function getStaticPageProps({ locale, params }) {
   /*
     Fetch the active project workflows
   */
-  const workflows = await fetchWorkflowsHelper(language, project.links.active_workflows, workflowID, workflowOrder, env)
+  const workflows = await fetchWorkflowsHelper(language, project.links.active_workflows, workflowID, workflowOrder, env, host)
   const props = {
     project: {
       ...project,

--- a/packages/lib-panoptes-js/src/resources/projects/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/projects/commonRequests.js
@@ -12,7 +12,7 @@ function getBySlug (params) {
   }
 
   if (queryParams.slug) {
-    return panoptes.get(endpoint, queryParams, { authorization })
+    return panoptes.get(endpoint, queryParams, { authorization }, params.host)
   }
 
   return raiseError('Projects: Get by slug request missing required parameter: slug string.', 'error')
@@ -35,7 +35,7 @@ function getWithLinkedResources (params) {
     queryParams.slug = getProjectSlugFromURL(queryParams.slug)
   }
 
-  return panoptes.get(endpoint, queryParams, { authorization })
+  return panoptes.get(endpoint, queryParams, { authorization }, params.host)
 }
 
 module.exports = { getBySlug, getWithLinkedResources }


### PR DESCRIPTION
Use internal service names to connect directly to Panoptes when the project app is deployed to our kubernetes cluster.
- Add a `getServerSideAPIHost` helper, which will return the service name for a given deployment and API environment. It falls back to the default host in local development.
- Use `getServerSideAPIHost` to set an optional hostname in all server-side data-fetching functions.

## Package
app-project

## Linked Issue and/or Talk Post
- towards #3341.

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
