### PR TITLE
QuickTalk: Improve UI

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -105,7 +105,12 @@ function QuickTalk ({
             plain
           />
         </Box>
-        <Box overflow='auto' tabIndex='0'>
+        <Box
+          aria-label={t('QuickTalk.panelContent')}
+          overflow={{ vertical: 'auto', horizontal: 'hidden' }}
+          role='group'
+          tabIndex='0'
+        >
           <Box flex={false} pad={{ bottom: 'small', left: 'small', right: 'small' }}>
             {comments.length > 0 && (
               <UnorderedList as='ul' flex={false}>

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { withResponsiveContext } from '@zooniverse/react-components'
-import { Anchor, Box, Button } from 'grommet'
+import { Anchor, Box, Button, Paragraph } from 'grommet'
 import { Chat, Close } from 'grommet-icons'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
@@ -117,6 +117,14 @@ function QuickTalk ({
               postCommentStatus={postCommentStatus}
               postCommentStatusMessage={postCommentStatusMessage}
             />
+          )}
+          {!userId && (
+            <Box
+              background={{ dark: 'dark-1', light: 'light-1' }}
+              margin={{ horizontal: 'none', 'vertical': 'xsmall' }}
+            >
+              <Paragraph textAlign="center">{t('QuickTalk.loginToPost')}</Paragraph>
+            </Box>
           )}
         </Box>
       </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { withResponsiveContext } from '@zooniverse/react-components'
-import { Anchor, Box, Button, Keyboard, Paragraph } from 'grommet'
-import { Chat, Close } from 'grommet-icons'
+import { Anchor, Box, Button, Heading, Keyboard, Paragraph } from 'grommet'
+import { Chat, Close, FormNextLink } from 'grommet-icons'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import asyncStates from '@zooniverse/async-states'
@@ -88,15 +88,11 @@ function QuickTalk ({
           direction='row'
           flex={false}
           justify='between'
-          pad='small'
+          pad={{ vertical: 'none', horizontal: 'small'}}
         >
-          <Anchor
-            a11yTitle={t('QuickTalk.aria.goToTalk')}
-            label={t('QuickTalk.headerLink')}
-            href={subject.talkURL}
-            target='_blank'
-            icon={<Chat />}
-          />
+          <Heading level='4' margin={{ top: 'small', bottom: 'none' }} pad='none'>
+            {t('QuickTalk.aria.panelHeading')}
+          </Heading>
           <Button
             a11yTitle={t('QuickTalk.aria.closeButton')}
             autoFocus={true}
@@ -106,7 +102,7 @@ function QuickTalk ({
           />
         </Box>
         <Box
-          aria-label={t('QuickTalk.panelContent')}
+          aria-label={t('QuickTalk.aria.panelContent')}
           overflow={{ vertical: 'auto', horizontal: 'hidden' }}
           role='group'
           tabIndex='0'
@@ -164,6 +160,17 @@ function QuickTalk ({
               </Paragraph>
             </Box>
           )}
+          <Anchor
+            alignSelf='center'
+            label={t('QuickTalk.aria.goToTalk')}
+            href={subject.talkURL}
+            icon={<FormNextLink size='small' />}
+            margin='xsmall'
+            target='_blank'
+            rel='nofollow noopener noreferrer'
+            reverse={true}
+            size='xsmall'
+          />
         </Box>
       </QTPanel>
     </Keyboard>

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import { withResponsiveContext } from '@zooniverse/react-components'
 import { Anchor, Box, Button, Heading, Keyboard, Paragraph } from 'grommet'
 import { Chat, Close, FormNextLink } from 'grommet-icons'
@@ -48,9 +48,22 @@ function QuickTalk ({
   fixedPosition = true,
   showBadge = true // HACK: Button.badge crashes tests AND storybook for an undetermined reason. // TODO: debug
 }) {
+  const panelContent = useRef()
   const { t } = useTranslation('components')
   // TODO: figure out if/how the QuickTalk component should/could be displayed on mobile
   // if (screenSize === 'small') return null
+
+  useEffect(function scrollToLatestComment () {
+    if (postCommentStatus === asyncStates.success) {
+      // Comments appear at the bottom, so scroll to the bottom
+      const newYCoord = panelContent.current?.scrollHeight
+      panelContent.current?.scrollTo({
+        top: newYCoord,
+        left: 0,
+        behavior: 'smooth'
+      })
+    }
+  }, [ postCommentStatus ])
 
   if (!subject) return null
 
@@ -102,6 +115,7 @@ function QuickTalk ({
           />
         </Box>
         <Box
+          ref={panelContent}
           aria-label={t('QuickTalk.aria.panelContent')}
           overflow={{ vertical: 'auto', horizontal: 'hidden' }}
           role='group'

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { withResponsiveContext } from '@zooniverse/react-components'
-import { Anchor, Box, Button, Paragraph } from 'grommet'
+import { Anchor, Box, Button, Keyboard, Paragraph } from 'grommet'
 import { Chat, Close } from 'grommet-icons'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
@@ -67,84 +67,86 @@ function QuickTalk ({
   }
 
   return (
-    <QTPanel
-      a11yTitle={t('QuickTalk.aria.mainPanel')}
-      elevation='medium'
-      role='dialog'
-      background={{ dark: 'dark-3', light: 'light-3' }}
-    >
-      <Box
-        direction='row'
-        flex={false}
-        justify='between'
-        pad='small'
+    <Keyboard onEsc={() => setExpand(false)}>
+      <QTPanel
+        a11yTitle={t('QuickTalk.aria.mainPanel')}
+        elevation='medium'
+        role='dialog'
+        background={{ dark: 'dark-3', light: 'light-3' }}
       >
-        <Anchor
-          a11yTitle={t('QuickTalk.aria.goToTalk')}
-          label={t('QuickTalk.headerLink')}
-          href={subject.talkURL}
-          target='_blank'
-          icon={<Chat />}
-        />
-        <Button
-          a11yTitle={t('QuickTalk.aria.closeButton')}
-          autoFocus={true}
-          icon={<Close size='small' />}
-          onClick={() => setExpand(false)}
-          plain
-        />
-      </Box>
-      <Box overflow='auto'>
-        <Box flex={false} pad={{ bottom: 'small', left: 'small', right: 'small' }}>
-          {comments.length > 0 && (
-            <UnorderedList as='ul' flex={false}>
-              {comments.map(comment => {
-                const author = authors[comment.user_id]
-                const roles = authorRoles[comment.user_id]
-
-                return (
-                  <Comment
-                    key={`quicktalk-comment-${comment.id}`}
-                    comment={comment}
-                    author={author}
-                    roles={roles}
-                  />
-                )
-              })}
-            </UnorderedList>
-          )}
-          {!comments.length && (
-            <Box
-              background={{ dark: 'dark-1', light: 'light-1' }}
-              margin={{ horizontal: 'none', 'vertical': 'xsmall' }}
-              pad='xsmall'
-            >
-              <Paragraph textAlign='center'>
-                {t('QuickTalk.subjectHasNoComments')}
-              </Paragraph>
-            </Box>
-          )}
-          {userId && (
-            <PostForm
-              postComment={postComment}
-              postCommentStatus={postCommentStatus}
-              postCommentStatusMessage={postCommentStatusMessage}
-            />
-          )}
-          {!userId && (
-            <Box
-              background={{ dark: 'dark-1', light: 'light-1' }}
-              margin={{ horizontal: 'none', 'vertical': 'xsmall' }}
-              pad='xsmall'
-            >
-              <Paragraph textAlign='center'>
-                {t('QuickTalk.loginToPost')}
-              </Paragraph>
-            </Box>
-          )}
+        <Box
+          direction='row'
+          flex={false}
+          justify='between'
+          pad='small'
+        >
+          <Anchor
+            a11yTitle={t('QuickTalk.aria.goToTalk')}
+            label={t('QuickTalk.headerLink')}
+            href={subject.talkURL}
+            target='_blank'
+            icon={<Chat />}
+          />
+          <Button
+            a11yTitle={t('QuickTalk.aria.closeButton')}
+            autoFocus={true}
+            icon={<Close size='small' />}
+            onClick={() => setExpand(false)}
+            plain
+          />
         </Box>
-      </Box>
-    </QTPanel>
+        <Box overflow='auto'>
+          <Box flex={false} pad={{ bottom: 'small', left: 'small', right: 'small' }}>
+            {comments.length > 0 && (
+              <UnorderedList as='ul' flex={false}>
+                {comments.map(comment => {
+                  const author = authors[comment.user_id]
+                  const roles = authorRoles[comment.user_id]
+
+                  return (
+                    <Comment
+                      key={`quicktalk-comment-${comment.id}`}
+                      comment={comment}
+                      author={author}
+                      roles={roles}
+                    />
+                  )
+                })}
+              </UnorderedList>
+            )}
+            {!comments.length && (
+              <Box
+                background={{ dark: 'dark-1', light: 'light-1' }}
+                margin={{ horizontal: 'none', 'vertical': 'xsmall' }}
+                pad='xsmall'
+              >
+                <Paragraph textAlign='center'>
+                  {t('QuickTalk.subjectHasNoComments')}
+                </Paragraph>
+              </Box>
+            )}
+            {userId && (
+              <PostForm
+                postComment={postComment}
+                postCommentStatus={postCommentStatus}
+                postCommentStatusMessage={postCommentStatusMessage}
+              />
+            )}
+            {!userId && (
+              <Box
+                background={{ dark: 'dark-1', light: 'light-1' }}
+                margin={{ horizontal: 'none', 'vertical': 'xsmall' }}
+                pad='xsmall'
+              >
+                <Paragraph textAlign='center'>
+                  {t('QuickTalk.loginToPost')}
+                </Paragraph>
+              </Box>
+            )}
+          </Box>
+        </Box>
+      </QTPanel>
+    </Keyboard>
   )
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -96,21 +96,34 @@ function QuickTalk ({
       </Box>
       <Box overflow='auto'>
         <Box flex={false} pad={{ bottom: 'small', left: 'small', right: 'small' }}>
-          <UnorderedList as='ul' flex={false}>
-            {comments.map(comment => {
-              const author = authors[comment.user_id]
-              const roles = authorRoles[comment.user_id]
+          {comments.length > 0 && (
+            <UnorderedList as='ul' flex={false}>
+              {comments.map(comment => {
+                const author = authors[comment.user_id]
+                const roles = authorRoles[comment.user_id]
 
-              return (
-                <Comment
-                  key={`quicktalk-comment-${comment.id}`}
-                  comment={comment}
-                  author={author}
-                  roles={roles}
-                />
-              )
-            })}
-          </UnorderedList>
+                return (
+                  <Comment
+                    key={`quicktalk-comment-${comment.id}`}
+                    comment={comment}
+                    author={author}
+                    roles={roles}
+                  />
+                )
+              })}
+            </UnorderedList>
+          )}
+          {!comments.length && (
+            <Box
+              background={{ dark: 'dark-1', light: 'light-1' }}
+              margin={{ horizontal: 'none', 'vertical': 'xsmall' }}
+              pad='xsmall'
+            >
+              <Paragraph textAlign='center'>
+                {t('QuickTalk.subjectHasNoComments')}
+              </Paragraph>
+            </Box>
+          )}
           {userId && (
             <PostForm
               postComment={postComment}
@@ -122,8 +135,11 @@ function QuickTalk ({
             <Box
               background={{ dark: 'dark-1', light: 'light-1' }}
               margin={{ horizontal: 'none', 'vertical': 'xsmall' }}
+              pad='xsmall'
             >
-              <Paragraph textAlign="center">{t('QuickTalk.loginToPost')}</Paragraph>
+              <Paragraph textAlign='center'>
+                {t('QuickTalk.loginToPost')}
+              </Paragraph>
             </Box>
           )}
         </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -18,7 +18,12 @@ const FixedBox = styled(Box)`
   max-height: 80vh;
 `
 
-const FixedButton = styled(Button)`
+const ButtonContainer = styled(Box)`
+  border-radius: 1em;
+`
+
+const FixedButtonContainer = styled(Box)`
+  border-radius: 1em;
   position: fixed;
   bottom: 1em;
   right: 1em;
@@ -52,17 +57,22 @@ function QuickTalk ({
   const [_expand, setExpand] = React.useState(expand)
   const badge = (showBadge && comments.length > 0) ? comments.length : false
 
-  const QTButton = (fixedPosition) ? FixedButton : Button
+  const QTButtonContainer = (fixedPosition) ? FixedButtonContainer : ButtonContainer
   const QTPanel = (fixedPosition) ? FixedBox : Box
 
   if (!_expand) {
     return (
-      <QTButton
-        a11yTitle={t('QuickTalk.aria.openButton', { count: comments.length })}
-        onClick={() => setExpand(true)}
-        icon={<Chat />}
-        badge={badge}
-      />
+      <QTButtonContainer
+        background={{ dark: 'dark-3', light: 'light-3' }}
+        elevation='small'
+      >
+        <Button
+          a11yTitle={t('QuickTalk.aria.openButton', { count: comments.length })}
+          onClick={() => setExpand(true)}
+          icon={<Chat />}
+          badge={badge}
+        />
+      </QTButtonContainer>
     )
   }
 

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -13,7 +13,7 @@ import PostForm from './components/PostForm'
 const FixedBox = styled(Box)`
   position: fixed;
   bottom: 1em;
-  right: 1em;
+  right: 2.5em;
   max-width: 80vw;
   max-height: 80vh;
 `
@@ -26,7 +26,7 @@ const FixedButtonContainer = styled(Box)`
   border-radius: 1em;
   position: fixed;
   bottom: 1em;
-  right: 1em;
+  right: 2.5em;
 `
 
 const UnorderedList = styled(Box)`

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.js
@@ -105,7 +105,7 @@ function QuickTalk ({
             plain
           />
         </Box>
-        <Box overflow='auto'>
+        <Box overflow='auto' tabIndex='0'>
           <Box flex={false} pad={{ bottom: 'small', left: 'small', right: 'small' }}>
             {comments.length > 0 && (
               <UnorderedList as='ul' flex={false}>
@@ -135,25 +135,30 @@ function QuickTalk ({
                 </Paragraph>
               </Box>
             )}
-            {userId && (
-              <PostForm
-                postComment={postComment}
-                postCommentStatus={postCommentStatus}
-                postCommentStatusMessage={postCommentStatusMessage}
-              />
-            )}
-            {!userId && (
-              <Box
-                background={{ dark: 'dark-1', light: 'light-1' }}
-                margin={{ horizontal: 'none', 'vertical': 'xsmall' }}
-                pad='xsmall'
-              >
-                <Paragraph textAlign='center'>
-                  {t('QuickTalk.loginToPost')}
-                </Paragraph>
-              </Box>
-            )}
           </Box>
+        </Box>
+        <Box
+          flex={false}
+          pad={{ horizontal: 'small', vertical: 'xsmall' }}
+        >
+          {userId && (
+            <PostForm
+              postComment={postComment}
+              postCommentStatus={postCommentStatus}
+              postCommentStatusMessage={postCommentStatusMessage}
+            />
+          )}
+          {!userId && (
+            <Box
+              background={{ dark: 'dark-1', light: 'light-1' }}
+              margin={{ horizontal: 'none', 'vertical': 'xsmall' }}
+              pad='xsmall'
+            >
+              <Paragraph textAlign='center'>
+                {t('QuickTalk.loginToPost')}
+              </Paragraph>
+            </Box>
+          )}
         </Box>
       </QTPanel>
     </Keyboard>

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import asyncStates from '@zooniverse/async-states'
 import { withTranslation } from 'react-i18next'

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/PostForm.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/PostForm.js
@@ -59,7 +59,7 @@ function PostForm ({
       pad='xsmall'
     >
       {statusText && (
-        <Text role='status'>{statusText}</Text>
+        <Text role='status' aria-live="polite">{statusText}</Text>
       )}
       <Form onSubmit={onSubmit}>
         <TextArea

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/PostForm.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/PostForm.js
@@ -48,6 +48,8 @@ function PostForm ({
     statusText = t('QuickTalk.status.initialized')
   } else if (postCommentStatus === asyncStates.loading) {
     statusText = t('QuickTalk.status.loading')
+  } else if (postCommentStatus === asyncStates.success) {
+    statusText = t('QuickTalk.status.success')
   }
 
   return (

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/PostForm.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/PostForm.js
@@ -1,8 +1,3 @@
-/*
-TODO
-- [ ] Show status visually, e.g. when loading, and when there's an error.
- */
-
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Box, Form, Text, TextArea } from 'grommet'
@@ -49,6 +44,8 @@ function PostForm ({
   let statusText
   if (postCommentStatusMessage) {
     statusText = postCommentStatusMessage
+  } else if (postCommentStatus === asyncStates.initialized) {
+    statusText = t('QuickTalk.status.initialized')
   } else if (postCommentStatus === asyncStates.loading) {
     statusText = t('QuickTalk.status.loading')
   }

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/PostForm.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/PostForm.js
@@ -56,7 +56,7 @@ function PostForm ({
     <Box
       background={{ dark: 'dark-1', light: 'light-1' }}
       flex={false}
-      pad='small'
+      pad='xsmall'
     >
       {statusText && (
         <Text role='status'>{statusText}</Text>

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/PostForm.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/PostForm.js
@@ -59,7 +59,7 @@ function PostForm ({
       pad='small'
     >
       {statusText && (
-        <Text>{statusText}</Text>
+        <Text role='status'>{statusText}</Text>
       )}
       <Form onSubmit={onSubmit}>
         <TextArea

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/PostForm.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/components/PostForm.spec.js
@@ -9,28 +9,76 @@ import asyncStates from '@zooniverse/async-states'
 describe('Component > QuickTalk > PostForm', function () {
   const postCommentSpy = sinon.spy()
 
-  beforeEach(function () {
-    render(
-      <PostForm
-        postComment={postCommentSpy}
-        postCommentStatus={asyncStates.initialized}
-        postCommentStatusMessage={undefined}
-      />
-    )
+  describe('when initialized', function () {
+    beforeEach(function () {
+      render(
+        <PostForm
+          postComment={postCommentSpy}
+          postCommentStatus={asyncStates.initialized}
+          postCommentStatusMessage={undefined}
+        />
+      )
+    })
+
+    afterEach(function () {
+      postCommentSpy.resetHistory()
+    })
+
+    it('should render without crashing', function () {
+      expect(screen.getByRole('textbox', { name: 'Write comments' })).to.exist()
+      expect(screen.getByRole('button', { name: 'Post comment' })).to.exist()
+    })
+
+    it('should have a "ready to post" status message', function () {
+      expect(screen.getByRole('status')).to.have.text('QuickTalk.status.initialized')
+    })
+
+    it('should call post comments when the "Post" button is clicked', async function () {
+      const user = userEvent.setup({ delay: null })
+      await user.click(screen.getByRole('button', { name: 'Post comment' }))
+      expect(postCommentSpy).to.have.been.calledOnce()
+    })
   })
 
-  afterEach(function () {
-    postCommentSpy.resetHistory()
+  describe('when posting a comment', function () {
+    it('should have a "posting comment" status message', function () {
+      render(
+        <PostForm
+          postComment={undefined}
+          postCommentStatus={asyncStates.loading}
+          postCommentStatusMessage={undefined}
+        />
+      )
+
+      expect(screen.getByRole('status')).to.have.text('QuickTalk.status.loading')
+    })
   })
 
-  it('should render without crashing', function () {
-    expect(screen.getByRole('textbox', { name: 'Write comments' })).to.exist()
-    expect(screen.getByRole('button', { name: 'Post comment' })).to.exist()
+  describe('after successfully posting a comment', function () {
+    it('should have a "posting successful" status message', function () {
+      render(
+        <PostForm
+          postComment={undefined}
+          postCommentStatus={asyncStates.success}
+          postCommentStatusMessage={undefined}
+        />
+      )
+
+      expect(screen.getByRole('status')).to.have.text('QuickTalk.status.success')
+    })
   })
 
-  it('should call post comments when the "Post" button is clicked', async function () {
-    const user = userEvent.setup({ delay: null })
-    await user.click(screen.getByRole('button', { name: 'Post comment' }))
-    expect(postCommentSpy).to.have.been.calledOnce()
+  describe('after failing to post a comment', function () {
+    it('should have an error message', function () {
+      render(
+        <PostForm
+          postComment={undefined}
+          postCommentStatus={asyncStates.error}
+          postCommentStatusMessage={'Oh no something went wrong'}
+        />
+      )
+
+      expect(screen.getByRole('status')).to.have.text('Oh no something went wrong')
+    })
   })
 })

--- a/packages/lib-classifier/src/translations/en/components.json
+++ b/packages/lib-classifier/src/translations/en/components.json
@@ -134,6 +134,7 @@
     "loginToPost": "Please login to post a comment.",
     "subjectHasNoComments": "This Subject doesn't have any comments yet.",
     "status": {
+      "initialized": "Leave a note about this subject",
       "loading": "Posting comment..."
     },
     "errors": {

--- a/packages/lib-classifier/src/translations/en/components.json
+++ b/packages/lib-classifier/src/translations/en/components.json
@@ -131,6 +131,7 @@
       "goToTalk": "Go to Subject Discussion on Talk"
     },
     "headerLink": "Subject Discussion",
+    "panelContent": "Subject Discussion comments",
     "loginToPost": "Please login to post a comment.",
     "subjectHasNoComments": "This Subject doesn't have any comments yet.",
     "status": {

--- a/packages/lib-classifier/src/translations/en/components.json
+++ b/packages/lib-classifier/src/translations/en/components.json
@@ -128,10 +128,10 @@
       "openButton": "Subject has {{count}} comment(s). Click to expand.",
       "mainPanel": "QuickTalk Comments Panel",
       "closeButton": "Close comments panel",
-      "goToTalk": "Go to Subject Discussion on Talk"
+      "goToTalk": "Or, view this Subject Discussion on Talk (opens new window)",
+      "panelContent": "Subject Discussion comments",
+      "panelHeading": "Subject Discussion"
     },
-    "headerLink": "Subject Discussion",
-    "panelContent": "Subject Discussion comments",
     "loginToPost": "Please login to post a comment.",
     "subjectHasNoComments": "This Subject doesn't have any comments yet.",
     "status": {

--- a/packages/lib-classifier/src/translations/en/components.json
+++ b/packages/lib-classifier/src/translations/en/components.json
@@ -131,6 +131,7 @@
       "goToTalk": "Go to Subject Discussion on Talk"
     },
     "headerLink": "Subject Discussion",
+    "loginToPost": "Please login to post a comment.",
     "status": {
       "loading": "Posting comment..."
     },

--- a/packages/lib-classifier/src/translations/en/components.json
+++ b/packages/lib-classifier/src/translations/en/components.json
@@ -132,6 +132,7 @@
     },
     "headerLink": "Subject Discussion",
     "loginToPost": "Please login to post a comment.",
+    "subjectHasNoComments": "This Subject doesn't have any comments yet.",
     "status": {
       "loading": "Posting comment..."
     },

--- a/packages/lib-classifier/src/translations/en/components.json
+++ b/packages/lib-classifier/src/translations/en/components.json
@@ -135,7 +135,8 @@
     "subjectHasNoComments": "This Subject doesn't have any comments yet.",
     "status": {
       "initialized": "Leave a note about this subject",
-      "loading": "Posting comment..."
+      "loading": "Posting comment...",
+      "success": "Comment posted!"
     },
     "errors": {
       "failPostComment": "Couldn't add comments to existing discussion.",


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`
Affects: QuickTalk experimental feature

This PR attempts to improve the UI for the QuickTalk component.

The goals of this PR:
- Improve messaging for (expanded) QuickTalk panel
  - [x] If a user isn't logged in, a message now appears prompting them login if they want to post a comment. (Previously, there was nothing indicating what users should do)
  - [x] If a Subject has no comments, a message now appears informing volunteers. (Previously, a Subject with no comments just left a blank QuickTalk panel.)
      <img width="300" alt="image" src="https://user-images.githubusercontent.com/13952701/176209396-956d6ff4-fbd8-4dc0-a4b7-c2e61b9616a7.png">
      _Above: the messages that appear when a Subject has no comments, and user isn't logged in._
  - [x] The "Post Comment" form now has additional text for when the form is ready for use ("Leave a note about this subject") and when the post is successful ("Comment posted!"). These two new messages come before/after the "Posting comment..." message, and as always, an error message overrides this.
    - Accessibility: status messages are now marked with role="status"
- [x] Solve the issue of the (collapsed) QuickTalk button not being visually distinguishable on 
    <img width="300" alt="image" src="https://user-images.githubusercontent.com/13952701/176210137-09b78c4d-b7b8-4521-b598-1c2bbb3d8ab5.png">
    _Above: the QuickTalk button (on lower right) merges visually with the content a large Task area._
  - [x] OPTION 1: provide the QuickTalk button some background to make it a "solid visual" item. (UPDATE: see [below](https://github.com/zooniverse/front-end-monorepo/pull/3351#issuecomment-1169156164))
  - OPTION 2: make QuickTalk a **tab,** alongside Task and Tutorial in the TaskArea. (might spin off this idea into its own experimental PR) (UPDATE: this is a separate PR)

Not addressed in this PR (probably):
- Advanced keyboard navigation.
- Paging, for Subjects with 10+ comments.

⚠️ TO INVESTIGATE:
- On `lib-classifier`, when a user logs out, the "Post Comment" textbox doesn't disappear immediately.
  - Is there a similar issue on `app-project`?
  - User CAN'T post while logged out though, so that's safe. ("User is not logged in" error message will appear, despite the textbox being there.)

### Status

~~WIP~~

Ready for review.
- [Update 1](https://github.com/zooniverse/front-end-monorepo/pull/3351#issuecomment-1169156164): QT button now has a solid visual design
- [Update 2](https://github.com/zooniverse/front-end-monorepo/pull/3351#issuecomment-1169228936): layout and keyboard input improved
- [Update 3](https://github.com/zooniverse/front-end-monorepo/pull/3351#issuecomment-1169261656): testing recommendations