### PR TITLE
Reset invert on subject change

### DIFF
--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -129,6 +129,7 @@ const SubjectViewer = types
         }
         self.dimensions = []
         self.frame = frame
+        self.invert = false
         self.loadingState = asyncStates.loading
         self.rotation = 0
       },

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.spec.js
@@ -101,12 +101,12 @@ describe('Model > SubjectViewerStore', function () {
       expect(subjectViewerStore.loadingState).to.equal(asyncStates.loading)
       expect(subjectViewerStore.dimensions).to.have.lengthOf(0)
     })
-    
-    it('should reset the rotation angle when there is a new active subject', function () {
+
+    it('should reset the invert when there is a new active subject', function () {
       subjectViewerStore.invertView()
       expect(subjectViewerStore.invert).to.be.true()
       subjectViewerStore.resetSubject()
-      expect(subjectViewerStore.rotation).to.be.false()
+      expect(subjectViewerStore.invert).to.be.false()
     })
 
     it('should reset the rotation angle when there is a new active subject', function () {

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.spec.js
@@ -101,6 +101,13 @@ describe('Model > SubjectViewerStore', function () {
       expect(subjectViewerStore.loadingState).to.equal(asyncStates.loading)
       expect(subjectViewerStore.dimensions).to.have.lengthOf(0)
     })
+    
+    it('should reset the rotation angle when there is a new active subject', function () {
+      subjectViewerStore.invertView()
+      expect(subjectViewerStore.invert).to.be.true()
+      subjectViewerStore.resetSubject()
+      expect(subjectViewerStore.rotation).to.be.false()
+    })
 
     it('should reset the rotation angle when there is a new active subject', function () {
       subjectViewerStore.rotate()


### PR DESCRIPTION
## Package
- lib-classifier

## Fixes
- invert does not reset on subject change

## Describe your changes
- reset invert to `false` on subject change

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - https://local.zooniverse.org:8080/?project=1952&workflow=3602&demo=true
- What user actions should my reviewer step through to review this PR?
  - click the invert button to invert a subject
  - click Done to get a new subject
  - new subject should not have inverted subject
- Which storybook stories should be reviewed? N/A
- Are there plans for follow up PR’s to further fix this bug or develop this feature? N/A

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated