### PR TITLE
UI Fix: allow `<Tabs>` to have more than 2 `<Tab>`s in a row

### DIFF
--- a/packages/lib-react-components/src/Tabs/Tabs.stories.js
+++ b/packages/lib-react-components/src/Tabs/Tabs.stories.js
@@ -30,8 +30,10 @@ export const LightThemeDefault = () => (
     themeMode="light"
   >
     <Tabs>
-      <Tab title="foo">Foo</Tab>
-      <Tab title="bar">Bar</Tab>
+      <Tab title="one">One</Tab>
+      <Tab title="two">Two</Tab>
+      <Tab title="three">Three</Tab>
+      <Tab title="four">Four</Tab>
     </Tabs>
   </Grommet>
 );

--- a/packages/lib-react-components/src/Tabs/theme.js
+++ b/packages/lib-react-components/src/Tabs/theme.js
@@ -28,10 +28,14 @@ const theme = {
       const borderColor = getBorderColor(props)
       const activeTabHeaderColor = getActiveTabHeaderColor(props)
       const hoverBackgroundColor = getHoverBackground(props)
+      const tabChildren = props.children?.[0]?.props?.children
+      const flexBasis = tabChildren
+        ? `${100 / tabChildren.length}%`
+        : 'auto'
       return css`
         button[role="tab"] {
           color: ${tabHeaderColor};
-          flex: 1 1 ${100 / props.children.length}%;
+          flex: 1 1 ${flexBasis};
           > div {
             border-bottom: 1px solid ${borderColor};
             border-right: 1px solid ${borderColor};
@@ -78,7 +82,7 @@ const theme = {
       }
     },
     panel: {
-      extend: props => { 
+      extend: props => {
         const backgroundColor = getBackgroundColor(props)
         const borderColor = getBorderColor(props)
         return css`


### PR DESCRIPTION
## PR Overview

Package: `lib-react-components`

This PR fixes an issue where the `<Tabs>` component incorrectly assigns all its children to have `flex-bases: 50%`, NO MATTER the number of child `<Tab>`s.

Expected: `<Tabs>` should display all `<Tab>`s in a row, if there's space.
<img width="1020" alt="Screenshot 2022-06-30 at 18 10 47" src="https://user-images.githubusercontent.com/13952701/176737466-1e5a34fe-6182-4003-80d3-b35b3f9b353c.png">

Actual: `<Tabs>` only displays up to two `<Tab>`s in a row.
<img width="1018" alt="Screenshot 2022-06-30 at 18 11 11" src="https://user-images.githubusercontent.com/13952701/176737441-1ab7723b-8b31-4374-86bc-7df653f80747.png">

### Dev Notes

Some terminology notes:
```
<Tabs>  // This is the parent/container
  <Tab title='cat'>Meow!</Tab>  // This is the first child, with a Tab HEADER saying "cat", and a Tab BODY (or Tab Panel) saying "Meow!" 
  <Tab title='dog'>Bark!</Tab>  // ...second child
  <Tab title='shaun'>Fart!</Tab>  // ...etc
<Tabs>
```

So here's what's causing the problem:
- `<Tabs>` tries to assign each child `<Tab>` an equal flex-basis ("default size") value, i.e. `flex: 1 1 ${100 / props.children.length}%;`
- e.g. if there are 3 children, each should get `flex: 1 1 33.333%`
- Problem is, the `props.children` doesn't actually represent the number of `<Tab>` children.
- Instead, `props.children` always has two elements: the _collection_ of Tab HEADERS, and a single Tab BODY (of the first Tab, I think.)

So, to correctly calculate the number of child `<Tab>`s, we need to look at the number of children _in the collection of Tab Headers._ i.e., `props.children[0].props.children`

### How to Review

- Boot up `lib-react-components` on `master` and run `yarn storybook`
- Take a look at [Tabs > Light Theme](http://localhost:6007/?path=/story/components-tabs--light-theme-default)
- On `master`, there should be only two Tab(s) on that story - Foo and Bar - so it looks fine.
- Now, try editing the story so that it has more than two Tab(s), e.g. Foo, Bar, Zap, Kaboom
- You should see the problem: there are only up to two Tab(s) in a row.
- Now, switch to this `fix-tabs-flex-basis` branch, and you should see the problem solved.

### Checklist for Reviewer: Bug Fix

- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- ~~Unit tests are added or updated~~

### Status

Ready for review! This will affect a future QuickTalk UI improvement PR. I'll link that PR once it's up.