### PR TITLE
Content pages: log SSR errors with @sentry/node

### DIFF
--- a/packages/app-content-pages/next.config.js
+++ b/packages/app-content-pages/next.config.js
@@ -31,7 +31,10 @@ const nextConfig = {
     APP_ENV
   },
 
-  webpack: (config) => {
+  webpack: (config, options) => {
+    if (!options.isServer) {
+      config.resolve.alias['@sentry/node'] = '@sentry/browser'
+    }
     config.plugins.concat([
       new Dotenv({
         path: path.join(__dirname, '.env'),

--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@babel/plugin-proposal-decorators": "~7.18.2",
     "@sentry/browser": "~7.7.0",
+    "@sentry/node": "~7.7.0",
     "@zeit/next-source-maps": "0.0.4-canary.1",
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/grommet-theme": "~3.0.0",

--- a/packages/app-content-pages/src/helpers/logger/initializeSentry.js
+++ b/packages/app-content-pages/src/helpers/logger/initializeSentry.js
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/browser'
+import * as Sentry from '@sentry/node'
 
 export default function initializeSentry () {
   const dsn = process.env.SENTRY_CONTENT_DSN

--- a/packages/app-content-pages/src/helpers/logger/logNodeError.js
+++ b/packages/app-content-pages/src/helpers/logger/logNodeError.js
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/browser'
+import * as Sentry from '@sentry/node'
 
 export default function logNodeError (error) {
   const dsn = process.env.SENTRY_CONTENT_DSN

--- a/packages/app-content-pages/src/helpers/logger/logReactError.js
+++ b/packages/app-content-pages/src/helpers/logger/logReactError.js
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/browser'
+import * as Sentry from '@sentry/node'
 
 export default function logReactError (error, errorInfo) {
   const dsn = process.env.SENTRY_CONTENT_DSN


### PR DESCRIPTION
Install `@sentry/node` in the content pages app. Configure webpack to use `@sentry/browser` for logging in browser bundles.

## Package
app-content-pages

## Linked Issue and/or Talk Post
This brings `app-content-pages` into line with the Sentry setup that we use in the project app (#2044.)

Note that [the latest Sentry/NextJS example](https://github.com/vercel/next.js/tree/canary/examples/with-sentry) now uses the [`@sentry/nextjs`](https://docs.sentry.io/platforms/javascript/guides/nextjs/) package for both server-side and client-side logging. We should consider upgrading to that.

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
