### PR TITLE
Classifier: refactor polygon tool

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/DragHandle/DragHandle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DragHandle/DragHandle.js
@@ -20,7 +20,8 @@ const DragHandle = forwardRef(function DragHandle(
     y,
     dragging = false,
     invisibleWhenDragging = false,
-    testid
+    testid,
+    ...props
   },
   ref
 ) {
@@ -32,7 +33,7 @@ const DragHandle = forwardRef(function DragHandle(
   }
 
   return (
-    <g ref={ref} transform={transform} data-testid={testid}>
+    <g ref={ref} transform={transform} data-testid={testid} {...props} >
       <StyledCircle r={radius} {...styleProps} />
       <StyledCircle r={2 * radius} fill='transparent' stroke='transparent' />
     </g>

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Polygon/Polygon.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Polygon/Polygon.js
@@ -30,18 +30,17 @@ function Polygon({ active, mark, scale, onFinish }) {
   const guideLineStrokeWidth = GUIDELINE_STROKE_WIDTH / scale
   const grabStrokeWidth = GRAB_STROKE_WIDTH / scale
 
-  function onHandleDrag(coords, i) {
-    mark.setCoordinates(coords, i)
-  }
-
   function onUndoDrawing() {
     mark.shortenPath()
   }
 
   function handleClosePolygon() {
-    onFinish()
     mark.finish()
+    onFinish()
   }
+
+  const fill = finished ? 'transparent' : 'none'
+  const strokeDasharray = finished ? undefined : '2 2'
 
   return (
     <g>
@@ -54,46 +53,30 @@ function Polygon({ active, mark, scale, onFinish }) {
         />
       )}
 
-      {/* Visible lines */}
+      /* Visible lines */
       <polyline points={path} strokeWidth={strokeWidth} fill='none' />
 
-      {/* So users can easily select the polygon */}
+      /* So users can easily select the polygon */
       <polyline
         points={path}
         strokeWidth={grabStrokeWidth}
         strokeOpacity='0'
-        fill='none'
+        fill={fill}
       />
 
-      {/* To visibly show a closed polygon */}
-      {finished && (
+      /* To visibly show a closed polygon */
         <line
           x1={lastPoint.x}
           y1={lastPoint.y}
           x2={initialPoint.x}
           y2={initialPoint.y}
           strokeWidth={strokeWidth}
+          strokeDasharray={strokeDasharray}
         />
       )}
 
       {active &&
-        points.map((point, i) => {
-          if (i === 0) {
-            /* Initial Point */
-            return (
-              <circle
-                key={`${mark.id}-${i}`}
-                r={radius}
-                cx={point.x}
-                cy={point.y}
-                fill='currentColor'
-                onPointerDown={handleClosePolygon}
-              />
-            )
-          }
-
-          /* All other points in the Polygon */
-          return (
+        points.map((point, i) => (
             <DragHandle
               key={`${mark.id}-${i}`}
               scale={scale}
@@ -101,18 +84,11 @@ function Polygon({ active, mark, scale, onFinish }) {
               x={point.x}
               y={point.y}
               fill='currentColor'
-              dragMove={(_e, d) =>
-                onHandleDrag(
-                  {
-                    x: points[i].x + d.x,
-                    y: points[i].y + d.y
-                  },
-                  i
-                )
-              }
+              dragMove={point.moveTo}
+              onPointerDown={handleClosePolygon}
             />
-          )
-        })}
+          ))
+        }
 
       {/* Guide Line */}
       {!finished &&

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Polygon/Polygon.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Polygon/Polygon.stories.js
@@ -1,0 +1,121 @@
+import zooTheme from '@zooniverse/grommet-theme'
+import React from 'react'
+import mockStore from '@test/mockStore'
+import {
+  DrawingStory,
+  subject,
+  subTasksSnapshot,
+  subtaskStrings,
+  updateStores
+} from '@plugins/drawingTools/stories/helpers.js'
+import { DrawingTaskFactory, WorkflowFactory } from '@test/factories'
+import Polygon from './'
+
+const drawingTaskSnapshot = DrawingTaskFactory.build({
+  instruction: 'Draw a polygon',
+  taskKey: 'T1',
+  tools: [
+    {
+      color: zooTheme.global.colors['drawing-red'],
+      type: 'polygon',
+      details: subTasksSnapshot
+    }
+  ],
+  type: 'drawing'
+})
+
+const taskSubtaskStrings = {}
+Object.entries(subtaskStrings).forEach(([key, value]) => {
+  taskSubtaskStrings[`tools.0.${key}`] = value
+})
+
+drawingTaskSnapshot.strings = {
+  instruction: drawingTaskSnapshot.instruction,
+  ...taskSubtaskStrings
+}
+
+// should think of a better way to do create bounds for the story
+// this is a rough approximation of what the positioning is like now
+const mockBounds = {
+  x: 100,
+  y: 100,
+  width: 0,
+  height: 0,
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0
+}
+
+function setupStores() {
+  try {
+    const workflowSubtaskStrings = {}
+    Object.entries(drawingTaskSnapshot.strings).forEach(([key, value]) => {
+      workflowSubtaskStrings[`tasks.T1.${key}`] = value
+    })
+    const strings = {
+      display_name: 'Polygon workflow',
+      'tasks.T1.instruction': 'Draw a polygon',
+      ...workflowSubtaskStrings
+    }
+    const workflow = WorkflowFactory.build({
+      strings,
+      tasks: {
+        T1: drawingTaskSnapshot
+      }
+    })
+    const mockStores = mockStore({ subject, workflow })
+    const [drawingTask] = mockStores.workflowSteps.active.tasks
+    drawingTask.setActiveTool(0)
+    const polygon = drawingTask.activeTool.createMark()
+    polygon.initialPosition({ x: 125, y: 125 })
+    polygon.setCoordinates([{ x: 125, y: 125 }, { x: 225, y: 225 }, { x: 325, y: 63 }])
+
+    return mockStores
+  } catch (error) {
+    console.error(error)
+    return null
+  }
+}
+
+const stores = setupStores()
+
+export default {
+  title: 'Drawing tools / Polygon',
+  component: Polygon,
+  parameters: {
+    viewport: {
+      defaultViewport: 'responsive'
+    }
+  }
+}
+
+export function Complete(args) {
+  updateStores(args, mockBounds, stores)
+  return <DrawingStory stores={stores} />
+}
+Complete.args = {
+  activeMark: false,
+  finished: false,
+  subtask: false
+}
+
+export function Active(args) {
+  updateStores(args, mockBounds, stores)
+  return <DrawingStory stores={stores} />
+}
+Active.args = {
+  activeMark: true,
+  finished: false,
+  subtask: false
+}
+
+export function Subtask(args) {
+  updateStores(args, mockBounds, stores)
+  return <DrawingStory stores={stores} />
+}
+Subtask.args = {
+  activeMark: true,
+  finished: true,
+  subtask: true
+}

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/PolygonTool/PolygonTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/PolygonTool/PolygonTool.js
@@ -22,15 +22,14 @@ const PolygonTool = types
     handlePointerDown(event, mark) {
       mark.appendPath(event)
     },
-    handlePointerPosition(event, mark) {
-      mark?.setGuideLine(event)
-    },
     handlePointerMove(event, mark) {
       mark?.setGuideLine(event)
     },
-    // prevents auto finish
+    // allows drag to create the first segment
     handlePointerUp(event, mark) {
-      return
+      if (mark?.points.length === 1) {
+        mark.initialDrag(event)
+      }
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/types/FixedNumber.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/types/FixedNumber.js
@@ -1,0 +1,21 @@
+import { types } from 'mobx-state-tree'
+
+export default types.custom({
+  name: 'FixedNumber',
+  fromSnapshot(snapshot) {
+    const roundedString = parseFloat(snapshot).toFixed(2)
+    return parseFloat(roundedString)
+  },
+  toSnapshot(value) {
+    const roundedString = parseFloat(value).toFixed(2)
+    return parseFloat(roundedString)
+  },
+  isTargetType(value) {
+    const roundedValue = parseFloat(value).toFixed(2)
+    return value === parseFloat(roundedValue)
+  },
+  getValidationMessage(snapshot) {
+    const value = parseFloat(snapshot)
+    return isNaN(value) ? `${snapshot} is not a number` : ''
+  }
+})

--- a/packages/lib-classifier/src/plugins/drawingTools/types/FixedNumber.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/types/FixedNumber.spec.js
@@ -1,0 +1,41 @@
+import { types } from 'mobx-state-tree'
+
+import FixedNumber from './FixedNumber.js'
+
+describe('Drawing Tools > Types > FixedNumber', function () {
+  const TestModel = types.model('TestModel', {
+    x: FixedNumber,
+    y: FixedNumber
+  })
+
+  it('should fix numbers to 2 decimal places', function () {
+    const value = TestModel.create({
+      x: 12.34567,
+      y: 456.8972
+    })
+    expect(value.x).to.equal(12.35)
+    expect(value.y).to.equal(456.90)
+  })
+
+  it('should parse strings as numbers', function () {
+    const value = TestModel.create({
+      x: '12.34567',
+      y: '456.8972'
+    })
+    expect(value.x).to.equal(12.35)
+    expect(value.y).to.equal(456.90)
+  })
+
+  it('should pass through rounded numbers', function () {
+    const value = TestModel.create({
+      x: 12.35,
+      y: 456.90
+    })
+    expect(value.x).to.equal(12.35)
+    expect(value.y).to.equal(456.90)
+  })
+
+  it('should error for an invalid snapshot', function () {
+    expect(() => TestModel.create({ x: 'not a number', y: 'also not a number' })).to.throw()
+  })
+})

--- a/packages/lib-classifier/src/plugins/drawingTools/types/index.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/types/index.js
@@ -1,0 +1,1 @@
+export { default as FixedNumber } from './FixedNumber'


### PR DESCRIPTION
Some small refactors to the polygon drawing tool:
- a `FixedNumber` type which represents numbers that are fixed to 2 decimal places.
- an `initialDrag` method which copies the initial drag for line tools.
- refactor the polygon path to use a mapped array of points.
- refactor `polygon.setCoordinates` to match other drawing tools.
- refactor Polygon drag handles to use `point.moveTo({ x, y })` for better performance.
- refactor the first point to use `DragHandle`. The starting point can now be moved!
- double click to finish the polygon from a point.
- add Polygon stories.

This PR also fixes a bug where creating an invalid polygon can crash the classifier, when the invalid mark is automatically deleted but the code tries to call `mark.finish()` on the deleted mark.

## Package
lib-classifier

## How to Review
The polygon tool story, in the classifier storybook, might be the easiest way to review this.

Alternatively, I have a test workflow for the drawing tools, which includes the polygon tool.
https://localhost:8080/?project=908&workflow=3370


https://user-images.githubusercontent.com/59547/177343336-59f8bf5b-64f5-4582-a9c7-fb94d0ca7c03.mov



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

