### PR TITLE
Set staging environment to 'staging'

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -28,7 +28,7 @@ jobs:
           ghcr.io/zooniverse/front-end-monorepo-staging:latest
           ghcr.io/zooniverse/front-end-monorepo-staging:${{ github.sha }}
         build-args: |
-          APP_ENV="staging"
+          APP_ENV=staging
           COMMIT_ID=${{ github.sha }}
           CONTENTFUL_ACCESS_TOKEN=${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
           CONTENTFUL_SPACE_ID=${{ secrets.CONTENTFUL_SPACE_ID }}


### PR DESCRIPTION
Code that uses the environment looks for `staging`, not `"staging"`.

## Linked Issue and/or Talk Post
- #3345 uses `APP_ENV` to decide which host names to use for the Panoptes API.

