### PR TITLE
getServerSideAPIHost: set default API env

### DIFF
--- a/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.spec.js
+++ b/packages/app-project/src/helpers/getDefaultPageProps/getDefaultPageProps.spec.js
@@ -365,9 +365,7 @@ describe('Helpers > getDefaultPageProps', function () {
               owner: 'test-owner',
               project: 'test-project'
             }
-            const query = {
-              env: 'production'
-            }
+            const query = {}
             const req = {
               connection: {
                 encrypted: true

--- a/packages/app-project/src/helpers/getServerSideAPIHost/getServerSideAPIHost.js
+++ b/packages/app-project/src/helpers/getServerSideAPIHost/getServerSideAPIHost.js
@@ -8,7 +8,7 @@ const deploymentEnvironments = ['staging', 'production', 'static']
   Return the internal service name for our API hosts when the app is deployed in our kubernetes cluster.
   Return undefined to use the default hostname in local development.
 */
-export default function getServerSideAPIHost(env) {
+export default function getServerSideAPIHost(env = 'production') {
   let host
   const headers = {}
   const deployEnvironment = process.env.APP_ENV


### PR DESCRIPTION
Set the default API environment to 'production', which matches our default environment for deploys.

I've also updated the tests to test against a mock API for the default `env`, rather than explicitly setting the API environment.

## Linked Issue and/or Talk Post
- #3345 sets the API host to use when the app is deployed, but the default API environment is undefined, which corresponds to `www.zooniverse.org`.
