### PR TITLE
Project: Refactor Team page

### DIFF
--- a/packages/app-project/pages/[owner]/[project]/about/team.js
+++ b/packages/app-project/pages/[owner]/[project]/about/team.js
@@ -1,57 +1,9 @@
 import fetchProjectPage from '@helpers/fetchProjectPage'
 import getDefaultPageProps from '@helpers/getDefaultPageProps'
-import { panoptes } from '@zooniverse/panoptes-js'
 export { default } from '@screens/ProjectAboutPage'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import fetchTeam from '@helpers/fetchTeam'
 import getServerSideAPIHost from '@helpers/getServerSideAPIHost'
-import { logToSentry } from '@helpers/logger'
-
-async function fetchTeam(project, env) {
-  const { headers, host } = getServerSideAPIHost(env)
-  let teamArray = []
-  try {
-    async function getRoles(allRoles = [], page = 1) {
-      const teamQuery = {
-        env,
-        project_id: project.id,
-        page
-      }
-      const response = await panoptes.get(`/project_roles`, teamQuery, { ...headers }, host)
-      const { meta, project_roles: projectRoles } = response.body
-      if (meta.project_roles?.next_page) {
-        return await getRoles(allRoles.concat(projectRoles), meta.project_roles.next_page)
-      }
-      return allRoles.concat(projectRoles)
-    }
-
-    const roles = await getRoles()
-    const userIDs = roles.map(role => role.links.owner.id)
-
-    async function getUsers(allUsers = [], page = 1) {
-      const userQuery = {
-        env,
-        id: userIDs.join(','),
-        page
-      }
-      const response = await panoptes.get(`/users`, userQuery, { ...headers }, host)
-      const { meta, users = [] } = response.body || {}
-      if (meta.users?.next_page) {
-        return await getUsers(allUsers.concat(users), meta.users.next_page)
-      }
-      return allUsers.concat(users)
-    }
-
-    const users = await getUsers()
-    teamArray = roles.map(role => {
-      const user = users.find(u => u.id === role.links.owner.id)
-      return { ...user, roles: role.roles }
-    })
-  } catch (error) {
-    console.error('Error loading project roles:', error)
-    logToSentry(error)
-  }
-  return teamArray
-}
 
 export async function getServerSideProps({ locale, params, query, req, res }) {
   const { headers, host } = getServerSideAPIHost(query.env)

--- a/packages/app-project/pages/[owner]/[project]/about/team.js
+++ b/packages/app-project/pages/[owner]/[project]/about/team.js
@@ -6,6 +6,44 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import getServerSideAPIHost from '@helpers/getServerSideAPIHost'
 import { logToSentry } from '@helpers/logger'
 
+async function fetchTeam(project, env) {
+  const { headers, host } = getServerSideAPIHost(env)
+  let teamArray = []
+  try {
+    let allRoles = []
+
+    async function getRoles(page = 1) {
+      const teamQuery = {
+        env,
+        project_id: project.id,
+        page: page
+      }
+      const response = await panoptes.get(`/project_roles`, teamQuery, { ...headers }, host)
+      const { meta, project_roles: projectRoles } = response.body
+      allRoles = allRoles.concat(projectRoles)
+      if (meta.project_roles && meta.project_roles.next_page) {
+        return getRoles(meta.project_roles.next_page)
+      }
+    }
+    await getRoles()
+
+    const userIDs = allRoles.map(role => role.links.owner.id)
+    const response = await panoptes.get(`/users`, {
+      env,
+      id: userIDs.join(',')
+    })
+    const users = response?.body?.users || []
+    teamArray = allRoles.map(role => {
+      const user = users.find(u => u.id === role.links.owner.id)
+      return { ...user, roles: role.roles }
+    })
+  } catch (error) {
+    console.error('Error loading project roles:', error)
+    logToSentry(error)
+  }
+  return teamArray
+}
+
 export async function getServerSideProps({ locale, params, query, req, res }) {
   const { headers, host } = getServerSideAPIHost(query.env)
   const { notFound, props } = await getDefaultPageProps({ locale, params, query, req, res })
@@ -13,43 +51,7 @@ export async function getServerSideProps({ locale, params, query, req, res }) {
   const page = await fetchProjectPage(project, locale, 'team', query.env)
   const pageTitle = page?.strings?.title ?? 'Team'
 
-  async function fetchTeam() {
-    let teamArray = []
-    try {
-      let allRoles = []
-      const getRoles = async (page = 1) => {
-        const teamQuery = {
-          env: query.env,
-          project_id: project.id,
-          page: page
-        }
-        const response = await panoptes.get(`/project_roles`, teamQuery, { ...headers }, host)
-        const { meta, project_roles: projectRoles } = response.body
-        allRoles = allRoles.concat(projectRoles)
-        if (meta.project_roles && meta.project_roles.next_page) {
-          return getRoles(meta.project_roles.next_page)
-        }
-      }
-      await getRoles(1)
-
-      const userIDs = allRoles.map(role => role.links.owner.id)
-      const response = await panoptes.get(`/users`, {
-        env: query.env,
-        id: userIDs.join(',')
-      })
-      const users = response?.body?.users || []
-      teamArray = allRoles.map(role => {
-        const user = users.find(u => u.id === role.links.owner.id)
-        return { ...user, roles: role.roles }
-      })
-    } catch (error) {
-      console.error('Error loading project roles:', error)
-      logToSentry(error)
-    }
-    return teamArray
-  }
-
-  const teamArray = await fetchTeam()
+  const teamArray = await fetchTeam(project, query.env)
 
   return {
     notFound,

--- a/packages/app-project/src/helpers/fetchTeam/fetchTeam.js
+++ b/packages/app-project/src/helpers/fetchTeam/fetchTeam.js
@@ -1,0 +1,50 @@
+import { panoptes } from '@zooniverse/panoptes-js'
+import getServerSideAPIHost from '@helpers/getServerSideAPIHost'
+import { logToSentry } from '@helpers/logger'
+
+export default async function fetchTeam(project, env) {
+  const { headers, host } = getServerSideAPIHost(env)
+  let teamArray = []
+  try {
+    async function getRoles(allRoles = [], page = 1) {
+      const teamQuery = {
+        env,
+        project_id: project.id,
+        page
+      }
+      const response = await panoptes.get(`/project_roles`, teamQuery, { ...headers }, host)
+      const { meta, project_roles: projectRoles } = response.body
+      if (meta.project_roles?.next_page) {
+        return await getRoles(allRoles.concat(projectRoles), meta.project_roles.next_page)
+      }
+      return allRoles.concat(projectRoles)
+    }
+
+    const roles = await getRoles()
+    const userIDs = roles.map(role => role.links.owner.id)
+
+    async function getUsers(allUsers = [], page = 1) {
+      const userQuery = {
+        env,
+        id: userIDs.join(','),
+        page
+      }
+      const response = await panoptes.get(`/users`, userQuery, { ...headers }, host)
+      const { meta, users = [] } = response.body || {}
+      if (meta.users?.next_page) {
+        return await getUsers(allUsers.concat(users), meta.users.next_page)
+      }
+      return allUsers.concat(users)
+    }
+
+    const users = await getUsers()
+    teamArray = roles.map(role => {
+      const user = users.find(u => u.id === role.links.owner.id)
+      return { ...user, roles: role.roles }
+    })
+  } catch (error) {
+    console.error('Error loading project roles:', error)
+    logToSentry(error)
+  }
+  return teamArray
+}

--- a/packages/app-project/src/helpers/fetchTeam/index.js
+++ b/packages/app-project/src/helpers/fetchTeam/index.js
@@ -1,0 +1,1 @@
+export { default } from './fetchTeam'


### PR DESCRIPTION
Refactor the project Team page to fetch the team members with a single Panoptes API query, rather than running one query per person.

## Package
app-project

## Linked Issue and/or Talk Post
Project Team pages can be quite slow to build. Here we can see the SuperWASP Black Holes Team page taking 11s, most of which is spent in 5 calls to `/api/users`.

![New Relic report for a slow Team page, which spent ~11s on API calls to /api/users.](https://user-images.githubusercontent.com/59547/177591541-e766391a-c4fb-4bd9-a137-9e85af66b966.png)

## How to Review
Testing a project team page against a live project might be the best way to test this. Here's the team page for HMS NHS.
https://local.zooniverse.org:3000/projects/msalmon/hms-nhs-the-nautical-health-service/about/team?env=production

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
