### PR TITLE
Classifier: Adjust FieldGuideButton text styling

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuideButton/FieldGuideButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuideButton/FieldGuideButton.js
@@ -27,7 +27,6 @@ export const StyledButton = styled(Button)`
 
 const StyledSpacedText = styled(SpacedText)`
   line-height: 1.2;
-  word-break: break-all;
 `
 
 const StyledHelpIcon = styled(HelpIcon)`
@@ -42,7 +41,7 @@ export function ButtonLabel () {
 
   return (
     <Box as='span' align='center' direction='column'>
-      <StyledSpacedText size='xsmall' color='white'>
+      <StyledSpacedText size='xsmall' color='white' textAlign='center'>
         {t('FieldGuide.FieldGuideButton.buttonLabel')}
       </StyledSpacedText>
       <StyledHelpIcon />


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
https://github.com/zooniverse/front-end-monorepo/issues/3414

## Describe your changes
Removed word-break: all and center-aligned FieldGuideButton's text.

## How to Review
To review on a live project, run any project such as PH TESS locally and check out its Classify page.
To review using Storybook, run lib-classifier's stories and check out Field Guide.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
