### PR TITLE
Classifier: validate drawn marks on tool change

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -181,6 +181,7 @@ function InteractionLayer({
           onFinish={onFinish}
           onSelectMark={onSelectMark}
           onMove={(mark, difference) => mark.move(difference)}
+          pointerEvents={creating ? 'none' : 'painted'}
           scale={scale}
           played={played}
         />

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -133,7 +133,7 @@ function InteractionLayer({
   }
 
   function onFinish(event) {
-    if (event?.preventDefault) event.preventDefault()
+    event?.preventDefault?.()
     setCreating(false)
     if (activeMark && !activeMark.isValid) {
       activeTool.deleteMark(activeMark)
@@ -148,6 +148,12 @@ function InteractionLayer({
         activeTool.handlePointerUp(convertEvent(event), activeMark)
       if (activeMark.finished) onFinish(event)
     }
+  }
+
+  function onSelectMark(mark) {
+    // TODO: can we stop marks from being selected while creating is true?
+    activeMark?.finish()
+    setActiveMark(mark)
   }
 
   function inactivateMark() {
@@ -176,7 +182,7 @@ function InteractionLayer({
           onDelete={inactivateMark}
           onDeselectMark={inactivateMark}
           onFinish={onFinish}
-          onSelectMark={(mark) => setActiveMark(mark)}
+          onSelectMark={onSelectMark}
           onMove={(mark, difference) => mark.move(difference)}
           scale={scale}
           played={played}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -126,9 +126,6 @@ function InteractionLayer({
   function onPointerMove(event) {
     if (creating) {
       activeTool?.handlePointerMove?.(convertEvent(event), activeMark)
-    } else {
-      // this outputs the mouse coords when not creating (ig: guideline for Polygon)
-      activeTool?.handlePointerPosition?.(convertEvent(event), activeMark)
     }
   }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -37,14 +37,14 @@ function InteractionLayer({
   const [creating, setCreating] = useState(false)
   const canvas = useRef()
 
-  useEffect(
-    function onDeleteMark() {
-      if (creating && !activeMark) {
-        setCreating(false)
-      }
-    },
-    [activeMark]
-  )
+  if (creating && !activeMark) {
+    setCreating(false)
+  }
+
+  if(activeMark?.finished && !activeMark.isValid) {
+    activeTool.deleteMark(activeMark)
+    setActiveMark(undefined)
+  }
 
   function convertEvent(event) {
     const type = event.type
@@ -132,11 +132,6 @@ function InteractionLayer({
   function onFinish(event) {
     event?.preventDefault?.()
     setCreating(false)
-    if (activeMark && !activeMark.isValid) {
-      activeTool.deleteMark(activeMark)
-      setActiveMark(undefined)
-      event?.stopPropagation()
-    }
   }
 
   function onPointerUp(event) {
@@ -171,7 +166,10 @@ function InteractionLayer({
         onPointerUp={onPointerUp}
       />
       <TranscribedLines scale={scale} />
-      <SubTaskPopup onDelete={inactivateMark} />
+      <SubTaskPopup
+        activeMark={activeMark}
+        onDelete={inactivateMark}
+      />
       {marks && (
         <DrawingToolMarks
           activeMark={activeMark}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -285,7 +285,6 @@ describe('Component > InteractionLayer', function () {
           setActiveMarkStub.resetHistory()
           wrapper.find(DrawingCanvas).simulate('pointerup', fakeEvent)
           expect(setActiveMarkStub).to.have.been.calledOnceWith(undefined)
-          expect(fakeEvent.stopPropagation).to.have.been.calledOnce()
         })
       })
     })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
@@ -14,6 +14,7 @@ function DrawingToolMarks({
   onFinish = () => true,
   onMove = () => true,
   onSelectMark = () => true,
+  pointerEvents='painted',
   scale = 1,
   played
 }) {
@@ -83,6 +84,7 @@ function DrawingToolMarks({
         onDelete={deleteMark}
         onFinish={onFinish}
         onSelect={selectMark}
+        pointerEvents={isActive ? 'painted' : pointerEvents}
         scale={scale}
       >
         <MarkingComponent

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopupContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopupContainer.js
@@ -3,27 +3,10 @@ import PropTypes from 'prop-types'
 import { observer, MobXProviderContext } from 'mobx-react'
 import SubTaskPopup from './SubTaskPopup'
 
-function useStores() {
-  const stores = React.useContext(MobXProviderContext)
-  const {
-    activeStepTasks
-  } = stores.classifierStore.workflowSteps
-
-  const [activeInteractionTask = {}] = activeStepTasks.filter(task => task.type === 'drawing' || task.type === 'transcription')
-  const {
-    activeMark
-  } = activeInteractionTask
-  return { activeMark }
-}
-
-export default observer(function SubTaskPopupContainer (props) {
-  const {
-    activeMark
-  } = useStores()
-  const {
-    onDelete
-  } = props
-
+export default observer(function SubTaskPopupContainer ({
+  activeMark,
+  onDelete
+}) {
   if (!activeMark || !activeMark.subTaskVisibility) return null
 
   return (

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopupContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopupContainer.spec.js
@@ -4,89 +4,32 @@ import React from 'react'
 import SubTaskPopupContainer from './SubTaskPopupContainer'
 import SubTaskPopup from './SubTaskPopup'
 
-function setupStores (type, activeMark) {
-  return {
-    classifierStore: {
-      workflowSteps: {
-        activeStepTasks: [
-          {
-            activeMark: activeMark || undefined,
-            type
-          }
-        ]
-      }
-    }
-  }
-}
-
 describe('Component > SubTaskPopupContainer', function () {
-  let mockUseContext, wrapper
-  afterEach(function () {
-    mockUseContext.restore()
-  })
+  let wrapper
 
   it('should render without crashing', function () {
-    mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('drawing'))
     wrapper = shallow(<SubTaskPopupContainer />)
     expect(wrapper).to.be.ok()
   })
 
-  describe('when the task is not drawing or transcription', function () {
-    it('should render nothing', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('single'))
-      wrapper = shallow(<SubTaskPopupContainer />)
-      expect(wrapper.html()).to.be.null()
-    })
+  it('should render nothing when there is no active mark', function () {
+    wrapper = shallow(<SubTaskPopupContainer />)
+    expect(wrapper.html()).to.be.null()
   })
 
-  describe('when the task is drawing', function () {
-    it('should render nothing when an active mark isn\'t defined', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('drawing'))
-      wrapper = shallow(<SubTaskPopupContainer />)
-      expect(wrapper.html()).to.be.null()
-    })
-
-    it('should render nothing when an active mark subTaskVisibility is false', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('drawing', { id: 'mark1', subTaskVisibility: false }))
-      wrapper = shallow(<SubTaskPopupContainer />)
-      expect(wrapper.html()).to.be.null()
-    })
-
-    it('should render a SubTaskPopup', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('drawing', { id: 'mark1', subTaskVisibility: true }))
-      wrapper = shallow(<SubTaskPopupContainer />)
-      expect(wrapper.find(SubTaskPopup)).to.have.lengthOf(1)
-    })
-
-    it('should pass the activeMark to the SubTaskPopup', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('drawing', { id: 'mark1', subTaskVisibility: true }))
-      expect(wrapper.find(SubTaskPopup).props().activeMark).to.deep.equal({ id: 'mark1', subTaskVisibility: true })
-    })
+  it('should render nothing when an active mark subTaskVisibility is false', function () {
+    const activeMark = { id: 'mark1', subTaskVisibility: false }
+    wrapper = shallow(<SubTaskPopupContainer activeMark={activeMark} />)
+    expect(wrapper.html()).to.be.null()
   })
 
-  describe('when the task is transcription', function () {
-    it('should render nothing when an active mark isn\'t defined', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('transcription'))
-      wrapper = shallow(<SubTaskPopupContainer />)
-      expect(wrapper.html()).to.be.null()
-    })
+  it('should render a SubTaskPopup', function () {
+    const activeMark = { id: 'mark1', subTaskVisibility: true }
+    wrapper = shallow(<SubTaskPopupContainer activeMark={activeMark} />)
+    expect(wrapper.find(SubTaskPopup)).to.have.lengthOf(1)
+  })
 
-    it('should render nothing when an active mark subTaskVisibility is false', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('transcription', { id: 'mark2', subTaskVisibility: false }))
-      wrapper = shallow(<SubTaskPopupContainer />)
-      expect(wrapper.html()).to.be.null()
-    })
-
-    it('should render a SubTaskPopup', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('transcription', { id: 'mark2', subTaskVisibility: true }))
-      wrapper = shallow(<SubTaskPopupContainer />)
-      expect(wrapper.find(SubTaskPopup)).to.have.lengthOf(1)
-    })
-
-    it('should pass the activeMark to the SubTaskPopup', function () {
-      mockUseContext = sinon.stub(React, 'useContext').callsFake(() => setupStores('transcription', { id: 'mark2', subTaskVisibility: true }))
-      wrapper = shallow(<SubTaskPopupContainer />)
-      expect(wrapper.find(SubTaskPopup).props().activeMark).to.deep.equal({ id: 'mark2', subTaskVisibility: true })
-    })
+  it('should pass the activeMark to the SubTaskPopup', function () {
+    expect(wrapper.find(SubTaskPopup).props().activeMark).to.deep.equal({ id: 'mark1', subTaskVisibility: true })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
@@ -151,6 +151,7 @@ function TranscribedLines({
                 aria-describedby={id}
                 aria-label={line.consensusText}
                 focusColor={focusColor}
+                pointerEvents={disabled ? 'none' : 'painted'}
                 tabIndex={disabled ? -1 : 0}
                 {...lineProps}
               >
@@ -192,6 +193,7 @@ function TranscribedLines({
                 aria-disabled={disabled.toString()}
                 aria-label={line.consensusText}
                 focusColor={focusColor}
+                pointerEvents={disabled ? 'none' : 'painted'}
                 tabIndex={disabled ? -1 : 0}
                 {...lineProps}
               >

--- a/packages/lib-classifier/src/plugins/drawingTools/README.md
+++ b/packages/lib-classifier/src/plugins/drawingTools/README.md
@@ -46,7 +46,6 @@ All tools should extend the Tool model by implementing the following:
 - _handlePointerDown(event, mark)_: handle pointer down events when creating `mark`. `event.x` and `event.y` contain the pointer coordinates on the SVG canvas. Implement this action to handle custom mark validation for marks that require complex gestures to create.
 - _handlePointerMove(event, mark)_: handle pointer move events when creating `mark`. `event.x` and `event.y` contain the pointer coordinates on the SVG canvas. Implement this action to handle custom mark validation for marks that require complex gestures to create.
 - _handlePointerUp(event, mark)_: handle pointer up events when creating `mark`. `event.x` and `event.y` contain the pointer coordinates on the SVG canvas. Implement this action to handle custom mark validation for marks that require complex gestures to create.
-- _handlePointerPosition(event, mark)_: outputs the pointer coordinates on the SVG canvas when not creating an annotation. Implement this action if a guideline is needed. See `polygonTool` as an example.
 
 ## Mark models
 

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
@@ -27,19 +27,27 @@ const StyledGroup = styled('g')`
   }
 `
 
+function defaultHandler() {
+  return true
+}
+const defaultTheme = {
+  global: {
+    colors: {}
+  }
+}
 const Mark = forwardRef(function Mark(
   {
     children,
-    dragging,
-    isActive,
+    dragging = false,
+    isActive = false,
     label,
     mark,
-    onDelete,
-    onFinish,
-    onSelect,
+    onDelete = defaultHandler,
+    onFinish = defaultHandler,
+    onSelect = defaultHandler,
     pointerEvents = 'painted',
-    scale,
-    theme
+    scale = 1,
+    theme = defaultTheme
   },
   ref
 ) {
@@ -163,23 +171,6 @@ Mark.propTypes = {
   tool: PropTypes.shape({
     color: PropTypes.string
   })
-}
-
-Mark.defaultProps = {
-  dragging: false,
-  isActive: false,
-  onDelete: () => true,
-  onDeselect: () => true,
-  onSelect: () => true,
-  scale: 1,
-  theme: {
-    global: {
-      colors: {}
-    }
-  },
-  tool: {
-    color: 'green'
-  }
 }
 
 const ObservedMark = observer(Mark)

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
@@ -37,6 +37,7 @@ const Mark = forwardRef(function Mark(
     onDelete,
     onFinish,
     onSelect,
+    pointerEvents = 'painted',
     scale,
     theme
   },
@@ -135,6 +136,7 @@ const Mark = forwardRef(function Mark(
       onFocus={select}
       onKeyDown={onKeyDown}
       onPointerUp={openSubTaskPopup}
+      pointerEvents={pointerEvents}
       ref={markRoot}
       role='button'
       strokeWidth={

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Mark/Mark.js
@@ -100,6 +100,9 @@ const BaseMark = types
   .actions((self) => ({
     finish() {
       self.finished = true
+      if (!self.isValid) {
+        self.tool.deleteMark(self)
+      }
     },
 
     setPreviousAnnotations(previousAnnotationValues) {

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
@@ -107,9 +107,7 @@ const Tool = types
       // then this can be moved to the tools that should delete on invalid mark
       // transcription line, ellipse
       self.marks.forEach((mark) => {
-        if (!mark.isValid) {
-          self.deleteMark(mark)
-        }
+        mark.finish()
       })
     }
   }))

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
@@ -90,10 +90,6 @@ const Tool = types
       mark.initialDrag?.(event)
     },
 
-    // this outputs the mouse coords when not creating (ig: guideline for Polygon)
-    // By default, this does nothing. Must be implemented in model/tool file (polygonTool.js)
-    handlePointerPosition(event, mark) {},
-
     handlePointerUp(event, mark) {
       mark.finish()
     },

--- a/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.js
@@ -69,9 +69,17 @@ export const Drawing = types.model('Drawing', {
       self.setToolTaskStrings(stringsSnapshot)
     }
 
+    function _onToolChange() {
+      if (self.activeToolIndex > -1) {
+        self.validate()
+        self.setActiveMark(undefined)
+      }
+    }
+
     return ({
       afterCreate() {
         addDisposer(self, autorun(_onLocaleChange))
+        addDisposer(self, autorun(_onToolChange))
       },
 
       setActiveMark(mark) {


### PR DESCRIPTION
Refactor drawing tool validation to fix a few bugs that can be triggered when drawing extended marks eg. polygons or transcription lines.
- Finish any incomplete marks when the active tool changes.
- Validate marks, and delete invalid marks, during `mark.finish()`
- Finish any incomplete marks when the Next button is pressed.
- Finish any incomplete marks when another mark is selected. 
- Turn off pointer events for drawn marks and previously transcribed lines, while drawing is in progress. This prevents them from being accidentally selected while there's an unfinished mark on the drawing canvas.


## Package
lib-classifier

## Linked Issue and/or Talk Post
- Closes #2959.


## How to Review
On my test drawing tools workflow:
- draw an incomplete polygon then switch tools.
- draw a couple of red points and an incomplete polygon then move on to the next step.

https://localhost:8080/?project=908&workflow=3370

The 'Transcribed lines' story, in the classifier storybook, is useful for testing incomplete transcription lines.
http://localhost:6006/?path=/story/drawing-tools-transcribedlines--default&globals=locale:en;locales.en:English;locales.test:Test+Language

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
