### PR TITLE
Classifier: remove default drawing tool gestures

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -113,7 +113,7 @@ function InteractionLayer({
     }
 
     if (creating) {
-        activeTool?.handlePointerDown?.(convertEvent(event), activeMark)
+      activeTool?.handlePointerDown?.(convertEvent(event), activeMark)
       if (activeMark.finished) onFinish(event)
       return true
     }
@@ -135,7 +135,7 @@ function InteractionLayer({
 
   function onPointerUp(event) {
     if (creating) {
-        activeTool?.handlePointerUp?.(convertEvent(event), activeMark)
+      activeTool?.handlePointerUp?.(convertEvent(event), activeMark)
       if (activeMark.finished) onFinish(event)
     }
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -113,8 +113,7 @@ function InteractionLayer({
     }
 
     if (creating) {
-      activeTool.handlePointerDown &&
-        activeTool.handlePointerDown(convertEvent(event), activeMark)
+        activeTool?.handlePointerDown?.(convertEvent(event), activeMark)
       if (activeMark.finished) onFinish(event)
       return true
     }
@@ -136,8 +135,7 @@ function InteractionLayer({
 
   function onPointerUp(event) {
     if (creating) {
-      activeTool.handlePointerUp &&
-        activeTool.handlePointerUp(convertEvent(event), activeMark)
+        activeTool?.handlePointerUp?.(convertEvent(event), activeMark)
       if (activeMark.finished) onFinish(event)
     }
   }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Ellipse/Ellipse.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Ellipse/Ellipse.js
@@ -47,6 +47,7 @@ function Ellipse({ active, mark, onFinish, scale }) {
           <DragHandle dragMove={onXHandleDrag} x={rx} y={0} scale={scale} />
           <DragHandle
             dragMove={onYHandleDrag}
+            dragEnd={mark.finish}
             x={0}
             y={-1 * ry}
             scale={scale}

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/FreehandLineTool/FreehandLineTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/FreehandLineTool/FreehandLineTool.js
@@ -14,6 +14,14 @@ const FreehandLineTool = types
       )
       self.marks.put(newMark)
       return newMark
+    },
+
+    handlePointerMove(event, mark) {
+      mark.initialDrag(event)
+    },
+
+    handlePointerUp(event, mark) {
+      mark.finish()
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/TranscriptionLineTool/TranscriptionLineTool.js
@@ -13,14 +13,6 @@ const TranscriptionLineTool = types
       mark.finish()
     },
 
-    handlePointerMove(event, mark) {
-      return
-    },
-
-    handlePointerUp(event, mark) {
-      return
-    },
-
     createMark(mark) {
       const newMark = TranscriptionLine.create(
         Object.assign({}, mark, { toolType: self.type })

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Ellipse/Ellipse.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Ellipse/Ellipse.js
@@ -16,6 +16,9 @@ const EllipseModel = types
     ry: types.optional(types.number, 0),
     angle: types.optional(types.number, 0)
   })
+  .volatile(self => ({
+    dragging: false,
+  }))
   .views((self) => ({
     get coords() {
       return {
@@ -56,16 +59,19 @@ const EllipseModel = types
   }))
   .actions((self) => ({
     initialDrag({ x, y }) {
-      const rx = self.getDistance(self.x_center, self.y_center, x, y)
-      const angle = self.getAngle(self.x_center, self.y_center, x, y)
-      self.rx = rx
-      self.ry = rx * 0.0001
-      self.angle = angle
+      if (self.dragging) {
+        const rx = self.getDistance(self.x_center, self.y_center, x, y)
+        const angle = self.getAngle(self.x_center, self.y_center, x, y)
+        self.rx = rx
+        self.ry = rx * 0.0001
+        self.angle = angle
+      }
     },
 
     initialPosition({ x, y }) {
       self.x_center = x
       self.y_center = y
+      self.dragging = true
     },
 
     move({ x, y }) {
@@ -79,6 +85,10 @@ const EllipseModel = types
       self.rx = rx
       self.ry = ry
       self.angle = angle
+    },
+
+    setDragging(dragging) {
+      self.dragging = dragging
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/CircleTool/CircleTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/CircleTool/CircleTool.js
@@ -14,6 +14,14 @@ const CircleTool = types
       )
       self.marks.put(newMark)
       return newMark
+    },
+
+    handlePointerMove(event, mark) {
+      mark.initialDrag(event)
+    },
+
+    handlePointerUp(event, mark) {
+      mark.finish()
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/EllipseTool/EllipseTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/EllipseTool/EllipseTool.js
@@ -14,6 +14,14 @@ const EllipseTool = types
       )
       self.marks.put(newMark)
       return newMark
+    },
+
+    handlePointerMove(event, mark) {
+      mark.initialDrag(event)
+    },
+
+    handlePointerUp(event, mark) {
+      mark.finish()
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/EllipseTool/EllipseTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/EllipseTool/EllipseTool.js
@@ -21,7 +21,7 @@ const EllipseTool = types
     },
 
     handlePointerUp(event, mark) {
-      mark.finish()
+      mark.setDragging(false)
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/LineTool/LineTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/LineTool/LineTool.js
@@ -14,7 +14,15 @@ const LineTool = types
       )
       self.marks.put(newMark)
       return newMark
-    }
+    },
+
+    handlePointerMove(event, mark) {
+      mark.initialDrag(event)
+    },
+
+    handlePointerUp(event, mark) {
+      mark.finish()
+    },
   }))
 
 export default types.compose('LineTool', Tool, LineTool)

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/PointTool/PointTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/PointTool/PointTool.js
@@ -15,6 +15,14 @@ const PointTool = types
       )
       self.marks.put(newMark)
       return newMark
+    },
+
+    handlePointerMove(event, mark) {
+      mark.initialDrag(event)
+    },
+
+    handlePointerUp(event, mark) {
+      mark.finish()
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/RectangleTool/RectangleTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/RectangleTool/RectangleTool.js
@@ -14,6 +14,14 @@ const RectangleTool = types
       )
       self.marks.put(newMark)
       return newMark
+    },
+
+    handlePointerMove(event, mark) {
+      mark.initialDrag(event)
+    },
+
+    handlePointerUp(event, mark) {
+      mark.finish()
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/RotateRectangleTool/RotateRectangleTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/RotateRectangleTool/RotateRectangleTool.js
@@ -14,6 +14,14 @@ const RotateRectangleTool = types
       )
       self.marks.put(newMark)
       return newMark
+    },
+
+    handlePointerMove(event, mark) {
+      mark.initialDrag(event)
+    },
+
+    handlePointerUp(event, mark) {
+      mark.finish()
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/TemporalPointTool/TemporalPointTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/TemporalPointTool/TemporalPointTool.js
@@ -14,6 +14,14 @@ const TemporalPointTool = types
       )
       self.marks.put(newMark)
       return newMark
+    },
+
+    handlePointerMove(event, mark) {
+      mark.initialDrag(event)
+    },
+
+    handlePointerUp(event, mark) {
+      mark.finish()
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/TemporalRotateRectangleTool/TemporalRotateRectangleTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/TemporalRotateRectangleTool/TemporalRotateRectangleTool.js
@@ -14,6 +14,14 @@ const TemporalRotateRectangleTool = types
       )
       self.marks.put(newMark)
       return newMark
+    },
+
+    handlePointerMove(event, mark) {
+      mark.initialDrag(event)
+    },
+
+    handlePointerUp(event, mark) {
+      mark.finish()
     }
   }))
 

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
@@ -85,13 +85,17 @@ const Tool = types
     deleteMark(mark) {
       self.marks.delete(mark.id)
     },
+    
+    handlePointerDown(event, mark) {
+      // override this action in individual drawing tools.
+    },
 
     handlePointerMove(event, mark) {
-      mark.initialDrag?.(event)
+      // override this action in individual drawing tools.
     },
 
     handlePointerUp(event, mark) {
-      mark.finish()
+      // override this action in individual drawing tools.
     },
 
     reset() {

--- a/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/tools/Tool/Tool.js
@@ -85,18 +85,6 @@ const Tool = types
     deleteMark(mark) {
       self.marks.delete(mark.id)
     },
-    
-    handlePointerDown(event, mark) {
-      // override this action in individual drawing tools.
-    },
-
-    handlePointerMove(event, mark) {
-      // override this action in individual drawing tools.
-    },
-
-    handlePointerUp(event, mark) {
-      // override this action in individual drawing tools.
-    },
 
     reset() {
       self.marks.clear()


### PR DESCRIPTION
Drawing tools were set up with a default behaviour that's common to all tools: create a new mark on drag ( `mark.initialPosition(e)` on `pointerDown` and `mark.initialDrag(e)` on `pointerMove`) then finish it on release (`mark.finish()` on `pointerUp`.) This single gesture works for points, lines, circles, rectangles and other simple shapes but doesn't work for extended shapes that require more than one gesture. Complex shapes (transcription lines, ellipses, polygons and freehand lines, at the moment) have to override the default gesture before we can add new code.

This removes the default event handlers from the `Tool` component and copies them explicitly into each drawing tool. Tool code is more verbose but there's no hidden, default tool behaviour to trip up developers of new tools.

With the changes here, ellipse tools can be configured so that they are created by two drag gestures, not one. This means that any subtask popups wait until the ellipse is complete before opening.


https://user-images.githubusercontent.com/59547/178510388-6ba2a878-228c-4fd1-99d2-c210e620a0a5.mov

Closes #2960.

## Package
lib-classifier

## How to Review
I have a test workflow that uses a variety of drawing tools.
https://localhost:8080/?project=908&workflow=3370&language=en

I Fancy Cats, `/projects/brooke/i-fancy-cats` on staging, has an ellipse with a popup question, which can be used to test the changes to the Ellipse tool.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
