### PR TITLE
Branch deploy k8s setup

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -1,13 +1,13 @@
 name: Deploy branch builds
 
 on:
-  # possible we can deploy on specific branch events
+  # possible we can deploy on specific branches using prefix and wildcard matches
+  # e.g. - 'deploy-branch-*'
   # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#example-excluding-branches
-  # push:
-  #   branches:
-  #     - '!master'
-  #     - 'deploy-branch-*'
-  #
+  push:
+    branches:
+      - '!master'
+      - 'branch-deploy-k8s-setup'
   # or we can deploy via dispatch which has a ref (branch / tag) passed to it for checkout actions
   # https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event
   workflow_dispatch:

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -1,0 +1,76 @@
+name: Deploy branch builds
+
+on:
+  # possible we can deploy on specific branch events
+  # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#example-excluding-branches
+  # push:
+  #   branches:
+  #     - '!master'
+  #     - 'deploy-branch-*'
+  #
+  # or we can deploy via dispatch which has a ref (branch / tag) passed to it for checkout actions
+  # https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event
+  workflow_dispatch:
+
+jobs:
+  build_and_push_image:
+    name: Build Image
+    runs-on: ubuntu-latest
+    steps:
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        push: true
+        tags: |
+          ghcr.io/zooniverse/front-end-monorepo-branch:${{ github.sha }}
+        build-args: |
+          APP_ENV=staging
+          COMMIT_ID=${{ github.sha }}
+          CONTENTFUL_ACCESS_TOKEN=${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
+          CONTENTFUL_SPACE_ID=${{ secrets.CONTENTFUL_SPACE_ID }}
+          CONTENT_ASSET_PREFIX=https://frontend.preview.zooniverse.org/about
+          SENTRY_CONTENT_DSN=https://1f0126a750244108be76957b989081e8@sentry.io/1492498
+          PROJECT_ASSET_PREFIX=https://fe-project-branch.preview.zooniverse.org/projects
+          SENTRY_PROJECT_DSN=https://2a50683835694829b4bc3cccc9adcc1b@sentry.io/1492691
+
+  deploy_branch:
+    runs-on: ubuntu-latest
+    needs: build_and_push_image
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_AKS }}
+
+    - name: Set the target AKS cluster
+      uses: Azure/aks-set-context@v2
+      with:
+        resource-group: kubernetes
+        cluster-name: microservices
+
+    - name: Modify & apply template
+      run: |
+        sed 's/__IMAGE_TAG__/${{ github.sha }}/g' kubernetes/deployment-branch.tmpl | kubectl apply -f -
+
+  slack_notification:
+    name: Slack notification
+    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
+    needs: [build_and_push_image, deploy_branch]
+    if: always()
+    with:
+      commit_id: ${{ github.sha }}
+      job_name: Build Image
+      status: ${{ needs.build_and_push_image.result }}
+      title: "FEM branch deploy complete"
+      title_link: "https://fe-project-branch.preview.zooniverse.org"
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/kubernetes/deployment-branch.tmpl
+++ b/kubernetes/deployment-branch.tmpl
@@ -1,0 +1,79 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zooniverse-org-project-branch
+spec:
+  selector:
+    app: zooniverse-org-project-branch
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zooniverse-org-project-branch
+  labels:
+    app: zooniverse-org-project-branch
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zooniverse-org-project-branch
+  template:
+    metadata:
+      labels:
+        app: zooniverse-org-project-branch
+    spec:
+      containers:
+        - name: fe-project-branch
+          image: ghcr.io/zooniverse/front-end-monorepo-branch:__IMAGE_TAG__
+          command: ["yarn", "workspace", "@zooniverse/fe-project"]
+          args: ["start"]
+          resources:
+            requests:
+              memory: "250Mi"
+              cpu: "100m"
+            limits:
+              memory: "500Mi"
+              cpu: "1000m"
+          startupProbe:
+            httpGet:
+              path: /projects/Index
+              port: 3000
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /projects/Index
+              port: 3000
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /projects/Index
+              port: 3000
+            initialDelaySeconds: 20
+            timeoutSeconds: 10
+          ports:
+            - containerPort: 3000
+          env:
+            - name: PROJECT_ASSET_PREFIX
+              value: https://fe-project-branch.preview.zooniverse.org/projects
+            - name: COMMIT_ID
+              value: __IMAGE_TAG__
+            - name: NEWRELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: newrelic-license-key
+                  key: key
+            - name: NODE_ENV
+              value: production
+            - name: PANOPTES_ENV
+              value: production
+            - name: APP_ENV
+              value: static
+            - name: SENTRY_PROJECT_DSN
+              value: https://2a50683835694829b4bc3cccc9adcc1b@sentry.io/1492691
+            - name: ENABLE_CACHE_HEADERS
+              value: "true"


### PR DESCRIPTION
Attempt to allow a k8s deployment for specific branches, similar to how the FE SSG changes PR was setup in #2531 

This PR adds an action that can be manually dispatched to allow the caller to specify which branch should be deployed and then the action & K8s yaml will go deploy that branch build of the fe-project app on a custom subdomain, https://fe-project-branch.preview.zooniverse.org

With this setup we can envisage a chat ops style cmd to deploy a known PR branch from a member of the front end team, e.g. something like `lita fem branch deploy $branch-name` and lita would issue a workflow dispatch event specifying the branch name as the dispatch ref to checkout and deploy, https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event

This K8s setup is a shared space so any subsequent deploys would 'clobber' the existing deploy, however we can look at some system in lita (redis lock key etc) to coordinate / lock these deploys as that need arises.

### TODO 
- [x] setup https://fe-project-branch.preview.zooniverse.org subdomain 
- [x] setup subdomain ingress to `zooniverse-org-project-branch` service mapping for traffic routing
- [x] setup a lita cmd to run these branch dispatch events (https://github.com/zooniverse/front-end-monorepo/actions/runs/2664354547)

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

## Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
