### PR TITLE
Project: Refactor /classify redirects

### DIFF
--- a/packages/app-project/pages/[owner]/[project]/classify/index.js
+++ b/packages/app-project/pages/[owner]/[project]/classify/index.js
@@ -1,19 +1,17 @@
-import getDefaultPageProps from '@helpers/getDefaultPageProps'
-export { default } from '@screens/ClassifyPage'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import getDefaultPageProps from '@helpers/getDefaultPageProps'
 
-export async function getServerSideProps({ locale, params, query, req, res }) {
+export { default } from '@screens/ClassifyPage'
+
+export async function getServerSideProps({ defaultLocale, locale, params, query, req, res, resolvedUrl }) {
   const { notFound, props } = await getDefaultPageProps({ locale, params, query, req, res })
   if (props.workflowID) {
-    const { env } = query
-    const { project } = props.initialState
-    const { workflows } = props
-    const workflow = workflows?.find(workflow => workflow.id === params.workflowID)
-    const workflowPath = `/${project?.slug}/classify/workflow/${props.workflowID}`
-    const destination = env ? `${workflowPath}?env=${env}` : workflowPath
+    const [requestPath, requestQuery] = resolvedUrl.split('?')
+    const pathname = locale === defaultLocale ? requestPath : `/${locale}${requestPath}`
+    const search = requestQuery ? `?${requestQuery}` : ''
     return ({
       redirect: {
-        destination,
+        destination: `${pathname}/workflow/${props.workflowID}${search}`,
         permanent: true
       }
     })


### PR DESCRIPTION
- use [`context.resolvedUrl` and `context.defaultLocale`](https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props#context-parameter) to construct the redirect.
- prepend the locale to the new URL path.

## Package
app-project

## Linked Issue and/or Talk Post
 - closes #3436.

## How to Review
Load `/classify` for any project with a single workflow. You should be redirected to the workflow page: `/classify/workflow/[workflowID]`. The redirect should preserve the locale and any query parameters in the request URL.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
