### PR TITLE
Drawing tools: edit freehand lines

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.js
@@ -37,7 +37,7 @@ function createPoint(event) {
 }
 
 function FreehandLine({ active, mark, onFinish, scale }) {
-  const { path, initialPoint, lastPoint, finished, isClosed, isCloseToStart } = mark
+  const { path, initialPoint, lastPoint, finished, isClosed } = mark
   const lineRef = useRef()
   const [editing, setEditing] = useState(false)
 
@@ -79,8 +79,8 @@ function FreehandLine({ active, mark, onFinish, scale }) {
     mark.shortenPath()
   }
 
-  const dragPoint = !isCloseToStart && mark.dragPoint
-  const targetPoint = !isCloseToStart && mark.targetPoint
+  const dragPoint = !mark.isCloseToStart && mark.dragPoint
+  const targetPoint = !mark.isCloseToStart && mark.targetPoint
   if (editing && !dragPoint) {
     cancelEditing()
   }

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.js
@@ -52,7 +52,7 @@ function FreehandLine({ active, mark, onFinish, scale }) {
 
   const dragPoint = !mark.isCloseToStart && mark.dragPoint
   const targetPoint = !mark.isCloseToStart && mark.targetPoint
-  let clippedPath = mark.clipPath.map(
+  const clippedPath = mark.clipPath.map(
     (point, index) => index === 0 ? `M ${point.x},${point.y}` : `L ${point.x},${point.y}`
   ).join(' ')
 
@@ -61,7 +61,9 @@ function FreehandLine({ active, mark, onFinish, scale }) {
   }
 
   if (!editing && isClosed) {
-    clippedPath = ''
+    if (mark.clipPath.length > 0) {
+      mark.setClipPath([])
+    }
   }
 
   function onDoubleClick(event) {

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.js
@@ -67,18 +67,6 @@ function FreehandLine({ active, mark, onFinish, scale }) {
     setEditing(false)
   }
 
-  function spliceLine(coords) {
-    mark.splicePath(coords)
-  }
-
-  function continueLine(coords) {
-    mark.appendPath(coords)
-  }
-
-  function onUndoDrawing() {
-    mark.shortenPath()
-  }
-
   const dragPoint = !mark.isCloseToStart && mark.dragPoint
   const targetPoint = !mark.isCloseToStart && mark.targetPoint
   if (editing && !dragPoint) {
@@ -103,7 +91,7 @@ function FreehandLine({ active, mark, onFinish, scale }) {
           scale={scale}
           x={initialPoint.x}
           y={initialPoint.y}
-          undoDrawing={onUndoDrawing}
+          undoDrawing={mark.shortenPath}
         />
       )}
       <path
@@ -132,7 +120,7 @@ function FreehandLine({ active, mark, onFinish, scale }) {
           y={lastPoint.y}
           fill='transparent'
           invisibleWhenDragging={true}
-          dragMove={continueLine}
+          dragMove={mark.appendPath}
         />
       }
       {active && targetPoint && (
@@ -151,7 +139,7 @@ function FreehandLine({ active, mark, onFinish, scale }) {
           fill='transparent'
           invisibleWhenDragging={true}
           onClick={!targetPoint ? cancelEditing : undefined}
-          dragMove={spliceLine}
+          dragMove={mark.splicePath}
         />
       }
     </StyledGroup>

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.js
@@ -41,6 +41,20 @@ function FreehandLine({ active, mark, onFinish, scale }) {
   const lineRef = useRef()
   const [editing, setEditing] = useState(false)
 
+  const dragPoint = !mark.isCloseToStart && mark.dragPoint
+  const targetPoint = !mark.isCloseToStart && mark.targetPoint
+  let clippedPath = mark.clipPath.map(
+    (point, index) => index === 0 ? `M ${point.x},${point.y}` : `L ${point.x},${point.y}`
+  ).join(' ')
+
+  if (editing && !dragPoint) {
+    cancelEditing()
+  }
+
+  if (!editing && isClosed) {
+    clippedPath = ''
+  }
+
   function onDoubleClick(event) {
     const svgPoint = createPoint(event)
     const { x, y } = svgPoint.matrixTransform
@@ -65,12 +79,6 @@ function FreehandLine({ active, mark, onFinish, scale }) {
     mark.setTargetPoint(null)
     mark.setDragPoint(null)
     setEditing(false)
-  }
-
-  const dragPoint = !mark.isCloseToStart && mark.dragPoint
-  const targetPoint = !mark.isCloseToStart && mark.targetPoint
-  if (editing && !dragPoint) {
-    cancelEditing()
   }
   return (
     <StyledGroup
@@ -113,6 +121,13 @@ function FreehandLine({ active, mark, onFinish, scale }) {
         }}
         fill='none'
       />
+      {active && clippedPath &&
+        <path
+          d={clippedPath}
+          strokeDasharray='2 2'
+          strokeWidth={STROKE_WIDTH}
+        />
+      }
       {active && finished && !editing && !isClosed &&
         <DragHandle
           scale={scale}

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.js
@@ -20,7 +20,7 @@ const StyledGroup = styled.g`
 `
 
 const STROKE_WIDTH = 1
-const GRAB_STROKE_WIDTH = 4
+const GRAB_STROKE_WIDTH = 10
 const FINISHER_RADIUS = 3
 
 function createPoint(event) {

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/FreehandLine/FreehandLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/FreehandLine/FreehandLine.js
@@ -7,14 +7,14 @@ import { FixedNumber } from '@plugins/drawingTools/types/'
 
 const MINIMUM_POINTS = 20
 
-const singleCoord = types.model({
+const SingleCoord = types.model('SingleCoord', {
   x: FixedNumber,
   y: FixedNumber
 })
 
 const FreehandLineModel = types
   .model('FreehandLineModel', {
-    points: types.array(singleCoord)
+    points: types.array(SingleCoord)
   })
   .views((self) => ({
     get coords() {
@@ -61,33 +61,61 @@ const FreehandLineModel = types
         return ''
       }
       const path = [`M ${firstCoord.x},${firstCoord.y}`]
-      otherCoords.forEach(({ x, y }) => {
-        path.push(`L ${x},${y}`)
+      otherCoords.forEach(point => {
+        const { x, y } = point
+        const pointPath = point === self.targetPoint ? `M ${x},${y}` : `L ${x},${y}`
+        path.push(pointPath)
       })
       // closes the drawing path
-      if (self.isCloseToStart) {
+      if (self.isClosed) {
         path.push('Z')
       }
       return path.join(' ')
     },
 
-    // this determines if drawing point is close to initial point
-    get isCloseToStart() {
+    get isClosed() {
+      if (self.dragPoint) {
+        return false
+      }
       const firstPoint = self.initialPoint
       const lastPoint = self.lastPoint
-      const distX = lastPoint.x - firstPoint.x
-      const distY = lastPoint.y - firstPoint.y
-      const dist = Math.sqrt(distX * distX + distY * distY)
-      return dist < 10
+      if (firstPoint && lastPoint) {
+        const dist = self.getDistance(firstPoint.x, firstPoint.y, lastPoint.x, lastPoint.y)
+        return dist < 10
+      }
+      return false
+    },
+
+    // this determines if drawing point is close to initial point
+    get isCloseToStart() {
+      const { dragPoint, targetPoint } = self
+      if (dragPoint && targetPoint) {
+        const dist = self.getDistance(dragPoint.x, dragPoint.y, targetPoint.x, targetPoint.y)
+        return dist < 10
+      }
+      return false
     },
 
     get toolComponent() {
       return FreehandLineComponent
+    },
+
+    selectPoint({ x, y }) {
+      const distances = self.points.map(point => self.getDistance(x, y, point.x, point.y))
+      const minDistance = Math.min(...distances)
+      const selectedIndex = distances.indexOf(minDistance)
+      return self.points[selectedIndex]
     }
+  }))
+  .volatile(self => ({
+    dragPoint: types.maybeNull(SingleCoord),
+    targetPoint: types.maybeNull(SingleCoord)
   }))
   .actions((self) => ({
     initialPosition({ x, y }) {
-      self.points.push({ x: x, y: y })
+      self.points.push({ x, y })
+      self.dragPoint = null
+      self.targetPoint = null
     },
 
     initialDrag({ x, y }) {
@@ -103,7 +131,42 @@ const FreehandLineModel = types
     },
 
     appendPath({ x, y }) {
-      self.points.push({ x: x, y: y })
+      if (!self.isClosed) {
+        self.points.push({ x, y})
+      }
+    },
+
+    splicePath({ x, y }) {
+      if (!self.targetPoint) {
+        return true
+      }
+      const dragIndex = self.points.indexOf(self.dragPoint)
+      const nextPoint = dragIndex + 1
+      self.points.splice(nextPoint, 0, { x, y })
+      self.dragPoint = self.points[nextPoint]
+    },
+
+    cutSegment(point) {
+      const dragIndex = self.points.indexOf(self.dragPoint)
+      const targetIndex = self.points.indexOf(point)
+      if ( targetIndex > dragIndex ) {
+        const deleteCount = targetIndex - dragIndex
+        self.points.splice(dragIndex + 1, deleteCount)
+        self.targetPoint = self.points[dragIndex + 1]
+      } else {
+        const deleteCount = dragIndex - targetIndex
+        self.points.splice(targetIndex + 1, deleteCount)
+        self.dragPoint = self.points[targetIndex]
+        self.targetPoint = self.points[targetIndex + 1]
+      }
+    },
+
+    setDragPoint(point) {
+      self.dragPoint = point
+    },
+
+    setTargetPoint(point) {
+      self.targetPoint = point
     },
 
     shortenPath() {


### PR DESCRIPTION
- Add an `editing` state to freehand lines.
- Double-click to start editing, then click a second time to select the area to cut.
- Drag the open drag handle to draw. Editing automatically ends when you reach the target point.
- ~~Closed shapes aren't fully supported at the moment.~~
- Undo isn't supported at the moment, to cancel accidental cutting of line segments.


https://user-images.githubusercontent.com/59547/179710672-1f6fb58c-a9bc-4479-b837-449dc9059cea.mov


## Package
lib-classifier

## How to Review
Freehand lines should be editable in any project that uses them, or in the Freehand Line story in the classifier storybook.

This PR doesn't include undo/redo, but a future PR could wrap `line.points` in an undo manager, so that we can undo and redo changes to a line. [UndoManager](https://github.com/mobxjs/mobx-state-tree/blob/master/packages/mst-middlewares/README.md#undomanager) is an MST middleware that records patches to a model, which we've used elsewhere in the classifier to handle the 'Next' and 'Back' buttons.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

