### PR TITLE
Classifier: add forwardRef to withFeatureFlag

### DIFF
--- a/packages/lib-classifier/src/helpers/withFeatureFlag/withFeatureFlag.js
+++ b/packages/lib-classifier/src/helpers/withFeatureFlag/withFeatureFlag.js
@@ -1,5 +1,6 @@
-import React from 'react'
-import { withStores } from '@helpers'
+import React, { forwardRef } from 'react'
+import { observer } from 'mobx-react'
+import { useStores } from '@hooks'
 
 function storeMapper(classifierStore) {
   const project = classifierStore?.projects.active
@@ -14,14 +15,12 @@ export default function withFeatureFlag(
   featureFlag
 ) {
 
-  function WithFeatureFlag({
-    project,
-    ...props
-  }) {
+  function WithFeatureFlag(props, ref) {
+    const { project } = useStores(storeMapper)
     if (project?.experimental_tools.includes(featureFlag)) {
-      return <Component {...props} />
+      return <Component ref={ref} {...props} />
     }
     return null
   }
-  return withStores(WithFeatureFlag, storeMapper)
+  return observer(forwardRef(WithFeatureFlag))
 }


### PR DESCRIPTION
- Add `forwardRef` to `withFeatureFlag`, so that refs are passed to the wrapped component.
- Refactor `withFeatureFlag` to use `useStores` and `observer`.

## Package
lib-classifier

## Linked Issue and/or Talk Post
- #3413 wraps a `Tab` component, but tabs use refs passed down from their parent `Tabs`.

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook
 
## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
