### PR TITLE
Classifier: Replace QuickTalk HOCs with hooks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.spec.js
@@ -33,11 +33,7 @@ describe('Component > QuickTalkContainer', function () {
     beforeEach(function () {
       const store = mockStore()
       render(
-        <QuickTalkContainer
-          authClient={authClient}
-          enabled={true}
-          subject={subject}
-        />,
+        <QuickTalkContainer />,
         {
           wrapper: withStore(store)
         }


### PR DESCRIPTION
Refactor `QuickTalk` to replace `withTranslation` with `useTranslation`, `withStores` with `useStores` and `authClient` with `usePanoptesAuth`.

## Package
lib-classifier

## How to Review
Shaun's test project uses QuickTalk on staging.
https://localhost:8080/?project=darkeshard/test-project-2022&workflow=3581&env=staging

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
