### PR TITLE
Daily Classifications Chart: fix locale

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartConnector.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartConnector.js
@@ -1,4 +1,5 @@
 import { MobXProviderContext, observer } from 'mobx-react'
+import { useRouter } from 'next/router'
 import { useContext } from 'react'
 
 import DailyClassificationsChartContainer from './DailyClassificationsChartContainer'
@@ -26,9 +27,13 @@ function storeMapper(store) {
 function DailyClassificationsChartConnector() {
   const { store } = useContext(MobXProviderContext)
   const { counts, thisWeek, projectName } = storeMapper(store)
+  const { locale } = useRouter()
+  const sanitizedLocale = locale === 'test' ? 'en' : locale
+
   return (
     <DailyClassificationsChartContainer
       counts={counts}
+      locale={sanitizedLocale}
       projectName={projectName}
       thisWeek={thisWeek}
     />

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.js
@@ -1,5 +1,4 @@
 import { array, number, shape, string } from 'prop-types'
-import { useRouter } from 'next/router'
 
 import DailyClassificationsChart from './DailyClassificationsChart'
 
@@ -9,20 +8,18 @@ const defaultCounts = {
 
 function DailyClassificationsChartContainer({
   counts = defaultCounts,
+  locale='en',
   projectName,
   thisWeek = []
 }) {
-  const { locale } = useRouter()
-  const sanitizedLocale = locale === 'test' ? 'en' : locale
-
   const TODAY = new Date()
   const stats = thisWeek.map(({ count: statsCount, period }) => {
     const day = new Date(period)
     const isToday = day.getUTCDay() === TODAY.getDay()
     const count = isToday ? counts.today : statsCount
-    const longLabel = day.toLocaleDateString(sanitizedLocale, { timeZone: 'UTC', weekday: 'long' })
+    const longLabel = day.toLocaleDateString(locale, { timeZone: 'UTC', weekday: 'long' })
     const alt = `${longLabel}: ${count}`
-    const label = day.toLocaleDateString(sanitizedLocale, { timeZone: 'UTC', weekday: 'narrow' })
+    const label = day.toLocaleDateString(locale, { timeZone: 'UTC', weekday: 'narrow' })
     return { alt, count, label, longLabel, period }
   })
   return (
@@ -38,6 +35,8 @@ DailyClassificationsChartContainer.propTypes = {
   counts: shape({
     today: number
   }),
+  /** The current locale. */
+  locale: string,
   /** Project name */
   projectName: string.isRequired,
   /** Array of daily stats from the stats server */

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.js
@@ -8,7 +8,7 @@ const defaultCounts = {
 
 function DailyClassificationsChartContainer({
   counts = defaultCounts,
-  locale='en',
+  locale = 'en',
   projectName,
   thisWeek = []
 }) {

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.js
@@ -12,12 +12,8 @@ function DailyClassificationsChartContainer({
   projectName,
   thisWeek = []
 }) {
-  const router = useRouter()
-  const { locale } = router
-  let sanitizedLocale = router
-  if (locale === 'test') {
-    sanitizedLocale = 'en'
-  }
+  const { locale } = useRouter()
+  const sanitizedLocale = locale === 'test' ? 'en' : locale
 
   const TODAY = new Date()
   const stats = thisWeek.map(({ count: statsCount, period }) => {

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.spec.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme'
 import sinon from 'sinon'
-import * as Router from 'next/router'
 
 import DailyClassificationsChartContainer from './DailyClassificationsChartContainer'
 import DailyClassificationsChart from './DailyClassificationsChart'
@@ -76,20 +75,10 @@ describe('Component > DailyClassificationsChartContainer', function () {
 
   before(function () {
     clock = sinon.useFakeTimers({ now: new Date('2019-10-06T12:00:00Z'), toFake: ['Date'] })
-    routerStub = sinon.stub(Router, 'useRouter').callsFake((component) => {
-      return {
-        asPath: '',
-        locale: 'en',
-        query: {
-          owner: 'zootester1',
-          project: 'my-project'
-        },
-        prefetch: () => Promise.resolve()
-      }
-    })
     wrapper = shallow(
       <DailyClassificationsChartContainer
         counts={MOCK_TOTALS}
+        locale='en'
         projectName='Test Project'
         thisWeek={MOCK_DAILY_COUNTS}
       />
@@ -99,7 +88,6 @@ describe('Component > DailyClassificationsChartContainer', function () {
 
   after(function () {
     clock.restore()
-    routerStub.restore()
   })
 
   it('should render without crashing', function () {


### PR DESCRIPTION
Set the sanitised locale to the router locale, or English.

## Linked Issue and/or Talk Post
- Fixes #3463.
- I've removed the mock router from tests, towards #3429.

## How to Review
Check the Daily Classifications Chart story with different locales, I think.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated
