### PR TITLE
App-project: Enable locale switcher for live site

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
@@ -15,7 +15,6 @@ import UnderReviewLabel from './components/UnderReviewLabel'
 const StyledBox = styled(Box)`
   position: relative;
 `
-const environment = process.env.APP_ENV
 
 function ProjectHeader ({
   availableLocales = [],
@@ -25,8 +24,7 @@ function ProjectHeader ({
   screenSize = '',
   title
 }) {
-
-  const hasTranslations = environment === 'development' && availableLocales?.length > 1
+  const hasTranslations = availableLocales?.length > 1
   return (
     <StyledBox as='header' className={className}>
       <Background />

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.spec.js
@@ -36,8 +36,7 @@ describe('Component > ProjectHeader', function () {
     expect(wrapper.find(UnderReviewLabel)).to.have.lengthOf(0)
   })
 
-  // pending until we're ready to implement translations on live FEM projects
-  xit('should not render a `<LocaleToggle />` component', function () {
+  it('should not render a `<LocaleToggle />` component', function () {
     expect(wrapper.find(LocaleSwitcher)).to.have.length(0)
   })
 
@@ -51,8 +50,7 @@ describe('Component > ProjectHeader', function () {
     })
   })
 
-  // pending until we're ready to implement translations on live FEM projects
-  xdescribe('when the project has available translations', function () {
+  describe('when the project has available translations', function () {
     before(function () {
       wrapper = shallow(<ProjectHeader availableLocales={['en', 'fr']} title={TITLE} />)
     })


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
~~Note: This PR is blocked from being merged until #3447 is merged.~~

## Describe your changes
This PR removes the check for a development environment so the language dropdown will appear on the production site.

## How to Review
Because this change will have no effect on locally-hosted FEM, I recommend using TESS to complete the general checklist below, and then double checking the LocaleSwitcher appears on the staged site once merged to master: https://frontend.preview.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
