### PR TITLE
App-project: Pass language query param to PFE nav links (Talk, Collections, Recents)

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
@@ -37,18 +37,21 @@ function ProjectHeaderContainer ({ availableLocales, className, defaultWorkflow,
       },
       {
         href: `${baseUrl}/talk`,
-        text: t('ProjectHeader.talk')
+        text: t('ProjectHeader.talk'),
+        pfe: true
       },
       {
         href: `${baseUrl}/collections`,
-        text: t('ProjectHeader.collect')
+        text: t('ProjectHeader.collect'),
+        pfe: true
       }
     ]
 
     if (isLoggedIn) {
       links.push({
         href: `${baseUrl}/recents`,
-        text: t('ProjectHeader.recents')
+        text: t('ProjectHeader.recents'),
+        pfe: true
       })
     }
 

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
@@ -12,6 +12,7 @@ describe('Component > ProjectHeaderContainer', function () {
   const PROJECT_DISPLAY_NAME = 'Foobar'
   const ROUTER = {
     query: {
+      locale: 'en',
       owner: 'Foo',
       project: 'Bar'
     }

--- a/packages/app-project/src/components/ProjectHeader/components/DropdownNav/DropdownNav.js
+++ b/packages/app-project/src/components/ProjectHeader/components/DropdownNav/DropdownNav.js
@@ -7,8 +7,6 @@ import { useState } from 'react';
 import styled, { css, withTheme } from 'styled-components'
 import { useTranslation } from 'next-i18next'
 
-import addQueryParams from '@helpers/addQueryParams'
-
 const StyledAnchor = styled(Anchor)`
   padding: 10px 20px;
   text-shadow: 0 2px 2px rgba(0, 0, 0, 0.22);

--- a/packages/app-project/src/helpers/addQueryParams/README.md
+++ b/packages/app-project/src/helpers/addQueryParams/README.md
@@ -4,17 +4,18 @@ A server/client-agnostic helper function to add the current URL query parameters
 
 ## Arguments
 
-- `url` (string) - the string to append the query parameters to
-- `router` (object) - an instance of Next.js's [router](https://github.com/zeit/next.js/#userouter) object
+- `href` (string) - the string to append the query parameters to
+- `router` (object) - an instance of Next.js's [router](https://nextjs.org/docs/api-reference/next/router#userouter) object
+- `pfe` (boolean) - indicates if this is a link to a PFE page such as Talk, Collections, Recents
 
 ## Example
 
 ```js
 function SomeLinkComponent (props) {
-  const { href } = props
+  const { href, pfe } = props
   const router = useRouter()
   return (
-    <Link href={addQueryParams(href, router)} >
+    <Link href={addQueryParams(href, router, pfe)} >
       text
     </Link>
   )

--- a/packages/app-project/src/helpers/addQueryParams/addQueryParams.js
+++ b/packages/app-project/src/helpers/addQueryParams/addQueryParams.js
@@ -1,12 +1,12 @@
-/** Next.js withRouter decorator injects router into components as null in node so we need to explicitly check for falsy values */
+/** Next.js withRouter decorator injects router into components as null in node so we need to explicitly check for falsy values such as path and locale */
 /** This helper is used to form ProjectHeader links to PFE pages: Talk, Collections, Recents */
 
 import queryString from 'query-string'
 
 function addQueryParams (href, router, pfe) {
   const path = (router) ? router.asPath : ''
+  const locale = (router) ? router.locale : 'en'
   const query = queryString.extract(path)
-  const { locale } = router
 
   let newHref
   if (locale !== 'en' && pfe) {

--- a/packages/app-project/src/helpers/addQueryParams/addQueryParams.js
+++ b/packages/app-project/src/helpers/addQueryParams/addQueryParams.js
@@ -1,11 +1,20 @@
+/** Next.js withRouter decorator injects router into components as null in node so we need to explicitly check for falsy values */
+/** This helper is used to form ProjectHeader links to PFE pages: Talk, Collections, Recents */
+
 import queryString from 'query-string'
 
-function addQueryParams (url, router) {
-  // next's withRouter decorator injects router into components as null in node
-  // so, a default parameter will be ignored, so we need to explicitly check for falsy values
+function addQueryParams (href, router, pfe) {
   const path = (router) ? router.asPath : ''
   const query = queryString.extract(path)
-  return query.length ? `${url}?${query}` : url
+  const { locale } = router
+
+  let newHref
+  if (locale !== 'en' && pfe) {
+    newHref = query.length ? `${href}?${query}&language=${locale}` : `${href}?language=${locale}`
+  } else {
+    newHref = query.length ? `${href}?${query}` : href
+  }
+  return newHref
 }
 
 export default addQueryParams

--- a/packages/app-project/src/shared/components/NavLink/NavLink.js
+++ b/packages/app-project/src/shared/components/NavLink/NavLink.js
@@ -16,7 +16,7 @@ function NavLink ({
   weight,
   ...anchorProps
 }) {
-  const { href, text } = link
+  const { href, pfe, text } = link
   const isCurrentPage = router?.asPath === addQueryParams(href, router)
 
   const label = <StyledSpacedText children={text} color={color} weight={weight} />
@@ -39,9 +39,9 @@ function NavLink ({
     // We also do not wrap it with next.js's Link
     return <StyledAnchor as='span' color={color} disabled label={label} {...anchorProps} />
   }
-  
+
   return (
-    <Link href={addQueryParams(href, router)} color={color} passHref>
+    <Link href={addQueryParams(href, router, pfe)} color={color} passHref>
       <StyledAnchor color={color} label={label} {...anchorProps} />
     </Link>
   )


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
https://github.com/zooniverse/front-end-monorepo/projects/15

This PR is built on PFE behavior where inserting a query parameter, such as `language=fr`, will display the page in French.
Example: https://www.zooniverse.org/projects/zookeeper/galaxy-zoo?language=fr

## Describe your changes
In order to preserve current locale when navigating from FEM --> PFE pages, we have to insert a `language` query param. This PR updates the `addQueryParams()` helper function to handle locale when navigating specifically to PFE. Noting that this behavior is only needed while Talk, Collections, and Recents are PFE pages.

## How to Review
To review project navigation in a language other than English, run TESS locally and visit its [French home page](https://local.zooniverse.org:3000/projects/fr/nora-dot-eisner/planet-hunters-tess?env=production). Hover over the links to Talk, Collections, and Recents. The href should be formatted with query params `?env=production&language=fr`.

To review a project in English without a specified env, run i-fancy-cats locally and visit its [home page](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats). Hover over the links to Talk, Collections, and Recents. The href should not include an `env` or `language` query parameter.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
