### PR TITLE
Project: remove dotenv

### DIFF
--- a/packages/app-project/next.config.js
+++ b/packages/app-project/next.config.js
@@ -2,10 +2,7 @@ if (process.env.NEWRELIC_LICENSE_KEY) {
   require('newrelic')
 }
 
-require('dotenv').config()
-
 const { execSync } = require('child_process')
-const Dotenv = require('dotenv-webpack')
 const path = require('path')
 const withSourceMaps = require('@zeit/next-source-maps')()
 const { i18n } = require('./next-i18next.config')
@@ -80,12 +77,6 @@ const nextConfig = {
     if (!options.isServer) {
       config.resolve.alias['@sentry/node'] = '@sentry/browser'
     }
-    config.plugins.concat([
-      new Dotenv({
-        path: path.join(__dirname, '.env'),
-        systemvars: true
-      })
-    ])
 
     const newAliases = webpackConfig.resolve.alias
     const alias = Object.assign({}, config.resolve.alias, newAliases)

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -38,7 +38,6 @@
     "babel-plugin-styled-components": "~2.0.2",
     "cookie": "~0.5.0",
     "d3": "~6.7.0",
-    "dotenv-webpack": "~8.0.0",
     "engine.io-client": "~6.2.1",
     "express": "^4.17.1",
     "graphql": "~16.5.0",


### PR DESCRIPTION
Remove `dotenv` and `dotenv-webpack` from the project app.

## Package
app-project

## Linked Issue and/or Talk Post
There isn't a linked issue, but a recent update to lerna broke the project app when it tries to read `.env` on startup. We don't use `.env` files in production, only in local development and then only for the content pages app.

See also:
- #3479

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
