### PR TITLE
Improved touch event handling for drawing tools

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -18,6 +18,11 @@ const DrawingCanvas = styled('rect')`
         `}
 `
 
+function cancelEvent(event) {
+  event.preventDefault()
+  event.stopPropagation()
+}
+
 function InteractionLayer({
   activeMark,
   activeTool,
@@ -102,6 +107,9 @@ function InteractionLayer({
   }
 
   function onPointerDown(event) {
+    if (!disabled) {
+      cancelEvent(event)
+    }
     if (disabled || move) {
       return true
     }
@@ -123,6 +131,7 @@ function InteractionLayer({
   }
 
   function onPointerMove(event) {
+    cancelEvent(event)
     if (creating) {
       activeTool?.handlePointerMove?.(convertEvent(event), activeMark)
     }
@@ -135,6 +144,7 @@ function InteractionLayer({
   }
 
   function onPointerUp(event) {
+    cancelEvent(event)
     if (creating) {
       activeTool?.handlePointerUp?.(convertEvent(event), activeMark)
       if (activeMark.finished) onFinish(event)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.spec.js
@@ -88,10 +88,28 @@ describe('Component > InteractionLayer', function () {
 
     describe('pointer events', function () {
       describe('onPointerDown', function () {
+        it('should cancel the event', function () {
+          const fakeEvent = {
+            pointerId: 'fakePointer',
+            type: 'pointerdown',
+            preventDefault: sinon.stub(),
+            stopPropagation: sinon.stub(),
+            target: {
+              setPointerCapture: sinon.stub(),
+              releasePointerCapture: sinon.stub()
+            }
+          }
+          wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
+          expect(fakeEvent.preventDefault).to.have.been.calledOnce()
+          expect(fakeEvent.stopPropagation).to.have.been.calledOnce()
+        })
+
         it('should create a mark', function () {
           const fakeEvent = {
             pointerId: 'fakePointer',
             type: 'pointerdown',
+            preventDefault: sinon.stub(),
+            stopPropagation: sinon.stub(),
             target: {
               setPointerCapture: sinon.stub(),
               releasePointerCapture: sinon.stub()
@@ -105,6 +123,8 @@ describe('Component > InteractionLayer', function () {
           const fakeEvent = {
             pointerId: 'fakePointer',
             type: 'pointerdown',
+            preventDefault: sinon.stub(),
+            stopPropagation: sinon.stub(),
             target: {
               setPointerCapture: sinon.stub(),
               releasePointerCapture: sinon.stub()
@@ -121,6 +141,8 @@ describe('Component > InteractionLayer', function () {
             clientY: 20,
             pointerId: 'fakePointer',
             type: 'pointerdown',
+            preventDefault: sinon.stub(),
+            stopPropagation: sinon.stub(),
             target: {
               setPointerCapture: sinon.stub(),
               releasePointerCapture: sinon.stub()
@@ -136,6 +158,8 @@ describe('Component > InteractionLayer', function () {
           const fakeEvent = {
             pointerId: 'fakePointer',
             type: 'pointer',
+            preventDefault: sinon.stub(),
+            stopPropagation: sinon.stub(),
             target: {
               setPointerCapture: sinon.stub(),
               releasePointerCapture: sinon.stub()
@@ -146,10 +170,29 @@ describe('Component > InteractionLayer', function () {
           expect(mockMark.initialDrag).to.have.been.calledOnce()
         })
 
+        it('should cancel the event on pointer down + move', function () {
+          const fakeEvent = {
+            pointerId: 'fakePointer',
+            type: 'pointer',
+            preventDefault: sinon.stub(),
+            stopPropagation: sinon.stub(),
+            target: {
+              setPointerCapture: sinon.stub(),
+              releasePointerCapture: sinon.stub()
+            }
+          }
+          wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
+          wrapper.find(DrawingCanvas).simulate('pointermove', fakeEvent)
+          expect(fakeEvent.preventDefault).to.have.been.calledTwice()
+          expect(fakeEvent.stopPropagation).to.have.been.calledTwice()
+        })
+
         it('should capture the pointer', function () {
           const fakeEvent = {
             pointerId: 'fakePointer',
             type: 'pointer',
+            preventDefault: sinon.stub(),
+            stopPropagation: sinon.stub(),
             target: {
               setPointerCapture: sinon.stub(),
               releasePointerCapture: sinon.stub()
@@ -196,6 +239,8 @@ describe('Component > InteractionLayer', function () {
               pointerId: 'fakePointer',
               stopPropagation: sinon.stub(),
               type: 'pointer',
+              preventDefault: sinon.stub(),
+              stopPropagation: sinon.stub(),
               target: {
                 setPointerCapture: sinon.stub(),
                 releasePointerCapture: sinon.stub()
@@ -213,12 +258,31 @@ describe('Component > InteractionLayer', function () {
     })
 
     describe('onPointerUp', function () {
+      it('should cancel the event', function () {
+        const fakeEvent = {
+          pointerId: 'fakePointer',
+          type: 'pointer',
+          preventDefault: sinon.stub(),
+          stopPropagation: sinon.stub(),
+          target: {
+            setPointerCapture: sinon.stub(),
+            releasePointerCapture: sinon.stub()
+          }
+        }
+        wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
+        wrapper.find(DrawingCanvas).simulate('pointerup', fakeEvent)
+        expect(fakeEvent.preventDefault).to.have.been.calledTwice()
+        expect(fakeEvent.stopPropagation).to.have.been.calledTwice()
+      })
+
       describe('when the mark is valid', function () {
         it('should set the mark to finished', function () {
           mockMark.finish.resetHistory()
           const fakeEvent = {
             pointerId: 'fakePointer',
             type: 'pointer',
+            preventDefault: sinon.stub(),
+            stopPropagation: sinon.stub(),
             target: {
               setPointerCapture: sinon.stub(),
               releasePointerCapture: sinon.stub()
@@ -275,6 +339,8 @@ describe('Component > InteractionLayer', function () {
           const fakeEvent = {
             pointerId: 'fakePointer',
             type: 'pointer',
+            preventDefault: sinon.stub(),
+            stopPropagation: sinon.stub(),
             target: {
               setPointerCapture: sinon.stub(),
               releasePointerCapture: sinon.stub()
@@ -328,10 +394,28 @@ describe('Component > InteractionLayer', function () {
       mockMark.setCoordinates.resetHistory()
     })
 
+    it('should not cancel the event', function () {
+      const fakeEvent = {
+        pointerId: 'fakePointer',
+        type: 'pointer',
+        preventDefault: sinon.stub(),
+        stopPropagation: sinon.stub(),
+        target: {
+          setPointerCapture: sinon.stub(),
+          releasePointerCapture: sinon.stub()
+        }
+      }
+      wrapper.find(DrawingCanvas).simulate('pointerdown', fakeEvent)
+      expect(fakeEvent.preventDefault).to.have.not.been.called()
+      expect(fakeEvent.stopPropagation).to.have.not.been.called()
+    })
+
     it('should not create a mark on pointer down', function () {
       const fakeEvent = {
         pointerId: 'fakePointer',
         type: 'pointer',
+        preventDefault: sinon.stub(),
+        stopPropagation: sinon.stub(),
         target: {
           setPointerCapture: sinon.stub(),
           releasePointerCapture: sinon.stub()

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -24,6 +24,10 @@ function SingleImageViewer (props) {
   const transformLayer = useRef()
   const canvas = transformLayer.current
   const transform = `rotate(${rotate} ${width / 2} ${height / 2})`
+  const svgStyle = {}
+  if (enableInteractionLayer) {
+    svgStyle.touchAction = 'pinch-zoom'
+  }
 
   return (
     <SVGContext.Provider value={{ canvas }}>
@@ -40,6 +44,7 @@ function SingleImageViewer (props) {
         <svg
           focusable
           onKeyDown={onKeyDown}
+          style={svgStyle}
           tabIndex={0}
           viewBox={viewBox}
           xmlns='http://www.w3.org/2000/svg'


### PR DESCRIPTION
- style the SVG subject with [`touch-action: pinch-zoom`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action).
- cancel both the default handler and event bubbling for all pointer events on the drawing canvas.

This PR should apply the same changes to the drawing tools that we added to PFE in https://github.com/zooniverse/Panoptes-Front-End/pull/5411.

## Package
lib-classifier

## Linked Issue and/or Talk Post
- Towards #3534

## How to Review
Marsh Explorer is a good project to check the drawing tools on touch devices. Basically, we expect that you should be able to draw without triggering any default browser behaviours, such as scrolling the screen when you drag to create a mark.
https://www.zooniverse.org/projects/marshexplorer/marsh-explorer/classify

In the dev classifier: https://local.zooniverse.org:8080/?project=marshexplorer/marsh-explorer&env=production

This branch:
https://fe-project-branch.preview.zooniverse.org/projects/marshexplorer/marsh-explorer/

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [x] Unit tests are added or updated
