### PR TITLE
Drawing tools: refactor active mark selection

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -130,6 +130,7 @@ function InteractionLayer({
 
   function onFinish(event) {
     event?.preventDefault?.()
+    event?.stopPropagation?.()
     setCreating(false)
   }
 
@@ -141,8 +142,6 @@ function InteractionLayer({
   }
 
   function onSelectMark(mark) {
-    // TODO: can we stop marks from being selected while creating is true?
-    activeMark?.finish()
     setActiveMark(mark)
   }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -1,3 +1,4 @@
+import { tryReference } from 'mobx-state-tree'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -19,7 +20,6 @@ function storeMapper(classifierStore) {
   )
 
   const {
-    activeMark,
     activeTool,
     activeToolIndex,
     hidingIndex,
@@ -29,7 +29,7 @@ function storeMapper(classifierStore) {
     taskKey
   } = activeInteractionTask || {}
 
-  const disabled = activeTool?.disabled
+  const activeMark = tryReference(() => activeInteractionTask?.activeMark)
 
   return {
     activeMark,

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Polygon/Polygon.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Polygon/Polygon.js
@@ -34,9 +34,9 @@ function Polygon({ active, mark, scale, onFinish }) {
     mark.shortenPath()
   }
 
-  function handleClosePolygon() {
+  function handleClosePolygon(event) {
     mark.finish()
-    onFinish()
+    onFinish(event)
   }
 
   const fill = finished ? 'transparent' : 'none'

--- a/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/models/DrawingTask.js
@@ -83,7 +83,7 @@ export const Drawing = types.model('Drawing', {
       },
 
       setActiveMark(mark) {
-        self.activeMark = mark
+        self.activeMark = mark?.id
       },
 
       setActiveTool(toolIndex) {


### PR DESCRIPTION
- use `tryReference` to reference `task.activeMark`, which avoids crashes caused by invalid reference errors when the active mark changes.
- use `mark.id` in `task.setActiveMark`, because MST references use node identifiers, not the nodes themselves.
- remove `activeMark.finish()` when a new mark is selected. Otherwise, creating a new mark will automatically select it and then delete it.
- cancel event bubbling, as well as the default handler, when a mark finishes.

## Package
lib-classifier

## Linked Issue and/or Talk Post
- Closes #3498.

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
