### PR TITLE
Project: don't render Loader component during Server-Side Rendering

### DIFF
--- a/packages/app-project/src/shared/components/Loader/Loader.js
+++ b/packages/app-project/src/shared/components/Loader/Loader.js
@@ -4,29 +4,34 @@ import { Box } from 'grommet'
 import { withTheme } from 'styled-components'
 import { useTranslation } from 'next-i18next'
 
-function Loader(props) {
+const isServer = typeof window === 'undefined'
+
+function Loader({
+  background = '',
+  color = '',
+  height = 'xxsmall',
+  loadingMessage = '',
+  margin = '',
+  pad = '',
+  theme: {
+    global: {
+      colors
+    }
+  },
+  width = 'xxsmall',
+  ...rest
+}) {
   const { t } = useTranslation('components')
-  const {
-    background = '',
-    color = '',
-    height = 'xxsmall',
-    loadingMessage = t('Loader.loading'),
-    margin = '',
-    pad = '',
-    theme: {
-      global: {
-        colors
-      }
-    },
-    width = 'xxsmall',
-    ...rest
-  } = props
   const loaderColor = color || colors.brand
+
+  if (isServer) {
+    return null
+  }
 
   return (
     <Box
       align='center'
-      a11yTitle={loadingMessage}
+      a11yTitle={loadingMessage || t('Loader.loading')}
       role='status'
       background={background}
       justify='center'

--- a/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelector.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelector.js
@@ -66,7 +66,7 @@ function WorkflowSelector ({
         </Box>
       )}
 
-      {(![asyncStates.success, asyncStates.error].includes(userReadyState)) && (
+      {([asyncStates.initialized, asyncStates.loading].includes(userReadyState)) && (
         <Loader margin={{ top: 'small' }} width='100%' />
       )}
     </Box>


### PR DESCRIPTION
- Check whether we're running in a browser window before rendering the `Loader` component.
- Refactor user loading state to simplify the workflow selector logic.

## Package
app-project

## Linked Issue and/or Talk Post
- Closes #3541.

## How to Review
Run the project app by running `yarn dev` from the `packages/app-project` directory. You should be able to load up Davy Notebooks and test the bug on the home page.
https://local.zooniverse.org:3000/projects/humphrydavy/davy-notebooks-project?env=production

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
