### PR TITLE
Classifier: assign unique IDs to transcribed lines

### DIFF
--- a/packages/lib-classifier/src/store/SubjectStore/Subject/TranscriptionReductions/TranscriptionReductions.js
+++ b/packages/lib-classifier/src/store/SubjectStore/Subject/TranscriptionReductions/TranscriptionReductions.js
@@ -16,14 +16,14 @@ const TranscriptionReductions = types
   })
 
   .views(self => {
-    function constructCoordinates (line) {
+    function constructCoordinates(line) {
       if (line && line.clusters_x && line.clusters_y) {
         return line.clusters_x.map((point, i) => ({ x: line.clusters_x[i], y: line.clusters_y[i] }))
       }
       return []
     }
 
-    function constructText (line) {
+    function constructText(line) {
       const sentences = []
       if (line && line.clusters_text) {
         line.clusters_text.forEach(value => {
@@ -40,7 +40,7 @@ const TranscriptionReductions = types
       return sentences.map(value => value.join(' '));
     }
 
-    function constructLine (reduction, options) {
+    function constructLine(reduction, options) {
       const { frame, minimumViews, threshold } = options
       const consensusText = reduction.consensus_text
       const points = constructCoordinates(reduction)
@@ -51,14 +51,14 @@ const TranscriptionReductions = types
           reduction.number_views >= minimumViews,
         consensusText,
         frame,
-        id: cuid(),
+        id: reduction.id,
         points,
         textOptions
       }
     }
 
     return {
-      consensusLines (frame) {
+      consensusLines(frame) {
         const { reductions } = self
         let consensusLines = []
         reductions.forEach(reduction => {
@@ -67,6 +67,9 @@ const TranscriptionReductions = types
           const minimumViews = parameters?.minimum_views || DEFAULT_VIEWS_TO_RETIRE
           const currentFrameReductions = reduction.data[`frame${frame}`] || []
           const currentFrameConsensus = currentFrameReductions.map(reduction => {
+            if (!reduction.id) {
+              reduction.id = cuid()
+            }
             return constructLine(reduction, { frame, minimumViews, threshold })
           })
           consensusLines = consensusLines.concat(currentFrameConsensus)


### PR DESCRIPTION
Assign a unique ID to each reduced line that is sent back from Caesar, when that line is first calculated. This avoids a bug where the line IDs change each time that `consensusLines(frame)` is run.

## Package
lib-classifier

## Linked Issue and/or Talk Post
- closes #2082.

## How to Review
On a workflow which uses previous transcriptions, you should find that each magenta line is dimmed and disabled after a new green line has been created from that line.
https://local.zooniverse.org:3000/projects/humphrydavy/davy-notebooks-project/classify/workflow/21734?env=production

https://user-images.githubusercontent.com/59547/185199430-24042c61-3720-4a74-a106-9c7b72582387.mov



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated
