### PR TITLE
Freehand line: cancel edits on deselect

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.js
@@ -56,6 +56,12 @@ function FreehandLine({ active, mark, onFinish, scale }) {
     (point, index) => index === 0 ? `M ${point.x},${point.y}` : `L ${point.x},${point.y}`
   ).join(' ')
 
+  if (clippedPath && !active) {
+    mark.setCoordinates(mark.originalPath)
+    mark.setClipPath([])
+    cancelEditing()
+  }
+
   if (editing && !dragPoint) {
     cancelEditing()
   }

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/FreehandLine/FreehandLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/FreehandLine/FreehandLine.js
@@ -107,6 +107,7 @@ const FreehandLineModel = types
   .volatile(self => ({
     clipPath: types.array(SingleCoord),
     dragPoint: types.maybeNull(SingleCoord),
+    originalPath: types.array(SingleCoord),
     targetPoint: types.maybeNull(SingleCoord)
   }))
   .actions((self) => ({
@@ -122,7 +123,7 @@ const FreehandLineModel = types
     },
 
     setCoordinates(points) {
-      self.points = points
+      self.points = points.map(({ x, y }) => ({ x, y }))
     },
 
     move() {
@@ -160,6 +161,7 @@ const FreehandLineModel = types
       const deleteCount = targetIndex - dragIndex - 1
       const distFromEnd = self.points.length - targetIndex - 1
       const spansStartPoint = self.isClosed && (distFromEnd + dragIndex) < deleteCount
+      self.originalPath = self.points.map(({ x, y }) => ({ x, y }))
       if (!spansStartPoint) {
         /*
         Segment lies entirely within the line path, so splice points


### PR DESCRIPTION
- copy the current line path to `mark.originalPoints` before cutting a freehand line.
- listen to changes in the `active` prop and restore the original line when `active` is false (when the line loses focus.)

## Package
lib-classifier

## Linked Issue and/or Talk Post
- closes #3558.

## How to Review
Draw a freehand line, start to edit  it then try selecting another mark, or switching to a different drawing tool. On this branch, switching away from a line should cancel editing and restore the original line.


https://user-images.githubusercontent.com/59547/185629689-98efd437-37cf-4e61-8b82-02097e6ebdb6.mov



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
