### PR TITLE
Project: Refactor data-fetching for favourites

### DIFF
--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -11,7 +11,7 @@ import getCookie from '@helpers/getCookie'
 import GrommetWrapper from '@helpers/GrommetWrapper'
 import Head from '@components/Head'
 import { initializeLogger, logToSentry } from '@helpers/logger'
-import { usePanoptesUser } from '@hooks'
+import { usePanoptesUser, useUserFavourites } from '@hooks'
 import { MediaContextProvider } from '@shared/components/Media'
 import initStore from '@stores'
 
@@ -46,6 +46,9 @@ function MyApp({ Component, pageProps }) {
 
   const userKey = store.user?.id || 'no-user'
   const user = usePanoptesUser(userKey)
+  const project = store.project
+  const favourites = useUserFavourites({ user, project })
+
   useEffect( function onUserChange() {
     if (user?.id) {
       store.user.set(user)
@@ -55,6 +58,12 @@ function MyApp({ Component, pageProps }) {
       store.user.clear()
     }
   }, [user])
+
+  useEffect( function onFavouritesChange() {
+    if (favourites?.id) {
+      store.user.collections.setFavourites(favourites)
+    }
+  }, [favourites])
 
   try {
     if (pageProps.statusCode) {

--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -63,6 +63,10 @@ function MyApp({ Component, pageProps }) {
     if (favourites?.id) {
       store.user.collections.setFavourites(favourites)
     }
+    // favourites are null by default.
+    if (favourites === null) {
+      store.user.collections.setFavourites(null)
+    }
   }, [favourites])
 
   try {

--- a/packages/app-project/src/hooks/index.js
+++ b/packages/app-project/src/hooks/index.js
@@ -1,1 +1,3 @@
-export { default as usePanoptesUser } from './usePanoptesUser'
+export { default as useUserFavourites } from './useUserFavourites.js'
+export { default as usePanoptesAuth } from './usePanoptesAuth.js'
+export { default as usePanoptesUser } from './usePanoptesUser.js'

--- a/packages/app-project/src/hooks/usePanoptesAuth.js
+++ b/packages/app-project/src/hooks/usePanoptesAuth.js
@@ -1,0 +1,18 @@
+import auth from 'panoptes-client/lib/auth'
+import { useEffect, useState } from 'react'
+
+export default function usePanoptesAuth(userID) {
+  const [authorization, setAuthorization] = useState()
+
+  async function checkAuth() {
+    const token = await auth.checkBearerToken()
+    const bearerToken = token ? `Bearer ${token}` : ''
+    setAuthorization(bearerToken)
+  }
+
+  useEffect(function onUserChange() {
+    checkAuth()
+  }, [userID])
+
+  return authorization
+}

--- a/packages/app-project/src/hooks/useUserFavourites.js
+++ b/packages/app-project/src/hooks/useUserFavourites.js
@@ -1,0 +1,37 @@
+import useSWR from 'swr'
+import { collections } from '@zooniverse/panoptes-js'
+
+import { usePanoptesAuth } from '@hooks'
+
+const SWRoptions = {
+  revalidateIfStale: true,
+  revalidateOnMount: true,
+  revalidateOnFocus: true,
+  revalidateOnReconnect: true,
+  refreshInterval: 0
+}
+
+async function fetchUserFavourites({ authorization, query }) {
+  const response = await collections.get({ authorization, query })
+  return response?.body?.collections
+}
+
+export default function useUserFavourites({ user, project }) {
+  const authorization = usePanoptesAuth(user?.id)
+  const query = {
+    favorite: true,
+    project_ids: [project?.id],
+    owner: user?.login
+  }
+  const key = authorization ? { authorization, query } : null
+  const { data, error } = useSWR(key, fetchUserFavourites, SWRoptions)
+  if (data) {
+    const [favourites] = data
+    return favourites
+  }
+  if (error) {
+    console.error(error)
+    return null
+  }
+  return undefined
+}

--- a/packages/app-project/src/hooks/useUserFavourites.js
+++ b/packages/app-project/src/hooks/useUserFavourites.js
@@ -27,11 +27,11 @@ export default function useUserFavourites({ user, project }) {
   const { data, error } = useSWR(key, fetchUserFavourites, SWRoptions)
   if (data) {
     const [favourites] = data
-    return favourites
+    return favourites ?? null
   }
   if (error) {
     console.error(error)
     return null
   }
-  return undefined
+  return data
 }

--- a/packages/app-project/stores/User/Collections/Collections.js
+++ b/packages/app-project/stores/User/Collections/Collections.js
@@ -125,6 +125,8 @@ const Collections = types
       setFavourites(favourites) {
         if (favourites) {
           self.favourites = Collection.create(favourites)
+        } else {
+          self.favourites = null
         }
       },
 

--- a/packages/app-project/stores/User/Collections/Collections.spec.js
+++ b/packages/app-project/stores/User/Collections/Collections.spec.js
@@ -38,46 +38,38 @@ describe('stores > Collections', function () {
       rootStore.client.collections.get.restore()
     })
 
-    it('should query the collections API', function (done) {
+    it('should query the collections API', async function () {
       expect(collectionsStore.loadingState).to.equal(asyncStates.initialized)
       const query = {
         favorite: false,
         search: 'test'
       }
 
-      collectionsStore.searchCollections(query)
-        .then(function () {
-          const params = {
-            authorization: 'Bearer ',
-            query
-          }
-          expect(collectionsStore.loadingState).to.equal(asyncStates.success)
-          expect(rootStore.client.collections.get).to.have.been.calledOnceWith(params)
-        })
-        .then(done, done)
-
-      expect(collectionsStore.loadingState).to.equal(asyncStates.loading)
+      await collectionsStore.searchCollections(query)
+      const params = {
+        authorization: 'Bearer ',
+        query
+      }
+      expect(collectionsStore.loadingState).to.equal(asyncStates.success)
+      expect(rootStore.client.collections.get).to.have.been.calledOnceWith(params)
     })
 
-    it('should store the search results', function (done) {
+    it('should store the search results', async function () {
       const query = {
         favorite: false,
         search: 'test'
       }
 
-      collectionsStore.searchCollections(query)
-        .then(function () {
-          const results = getSnapshot(rootStore.user.collections.collections)
-          const expectedResult = collections.mocks.resources.collection
-          expect(results).to.have.lengthOf(1)
-          expect(results[0].id).to.eql(expectedResult.id)
-          expect(results[0].display_name).to.eql(expectedResult.display_name)
-        })
-        .then(done, done)
+      await collectionsStore.searchCollections(query)
+      const results = getSnapshot(rootStore.user.collections.collections)
+      const expectedResult = collections.mocks.resources.collection
+      expect(results).to.have.lengthOf(1)
+      expect(results[0].id).to.eql(expectedResult.id)
+      expect(results[0].display_name).to.eql(expectedResult.display_name)
     })
   })
 
-  describe('createCollection', function () {
+  describe('createCollection', async function () {
     before(function () {
       const project = {
         id: '2',
@@ -95,8 +87,8 @@ describe('stores > Collections', function () {
           project: payload.project,
           subjects: payload.subjects
         }
-        const newCollection = Object.assign({}, collection, payload.data, { links })
-        const body = Object.assign({}, collections.mocks.responses.get.collection, { collections: [newCollection] })
+        const newCollection = { ...collection, ...payload.data, links }
+        const body = { ...collections.mocks.responses.get.collection, collections: [newCollection] }
         return Promise.resolve({ body })
       })
       collectionsStore = rootStore.user.collections
@@ -106,29 +98,22 @@ describe('stores > Collections', function () {
       rootStore.client.collections.create.restore()
     })
 
-    it('should create a new collection', function (done) {
+    it('should create a new collection', async function () {
       expect(collectionsStore.loadingState).to.equal(asyncStates.initialized)
 
-      collectionsStore.createCollection({ display_name: 'A new collection' }, [ '1', '2', '3' ])
-        .then(function () {
-          const payload = {
-            authorization: 'Bearer ',
-            data: {
-              display_name: 'A new collection',
-              favorite: false,
-              private: false
-            },
-            project: '2',
-            subjects: [ '1', '2', '3' ]
-          }
-          expect(collectionsStore.loadingState).to.equal(asyncStates.success)
-          expect(rootStore.client.collections.create).to.have.been.calledOnceWith(payload)
-        })
-        .then(done, done)
-
-      // Since this is run before fetch's thenable resolves, it should test
-      // correctly during the request.
-      expect(collectionsStore.loadingState).to.equal(asyncStates.loading)
+      await collectionsStore.createCollection({ display_name: 'A new collection' }, [ '1', '2', '3' ])
+      const payload = {
+        authorization: 'Bearer ',
+        data: {
+          display_name: 'A new collection',
+          favorite: false,
+          private: false
+        },
+        project: '2',
+        subjects: [ '1', '2', '3' ]
+      }
+      expect(collectionsStore.loadingState).to.equal(asyncStates.success)
+      expect(rootStore.client.collections.create).to.have.been.calledOnceWith(payload)
     })
   })
 
@@ -159,20 +144,13 @@ describe('stores > Collections', function () {
         rootStore.client.collections.get.restore()
       })
 
-      it('should fetch a collection', function (done) {
+      it('should fetch a collection', async function () {
         expect(collectionsStore.loadingState).to.equal(asyncStates.initialized)
 
-        collectionsStore.fetchFavourites()
-          .then(function () {
-            expect(collectionsStore.loadingState).to.equal(asyncStates.success)
-            expect(collectionsStore.favourites.id).to.equal('1')
-            expect(collectionsStore.favourites.display_name).to.equal('test collection')
-          })
-          .then(done, done)
-
-        // Since this is run before fetch's thenable resolves, it should test
-        // correctly during the request.
-        expect(collectionsStore.loadingState).to.equal(asyncStates.loading)
+        const favourites = await collectionsStore.fetchFavourites()
+        expect(collectionsStore.loadingState).to.equal(asyncStates.success)
+        expect(favourites.id).to.equal('1')
+        expect(favourites.display_name).to.equal('test collection')
       })
     })
 
@@ -188,16 +166,6 @@ describe('stores > Collections', function () {
         }
         const snapshot = { project, user }
         rootStore = initStore(true, snapshot)
-        sinon.stub(rootStore.client.collections, 'create').callsFake(function (payload) {
-          const [ favourites ] = collections.mocks.responses.get.collection.collections
-          const links = {
-            project: payload.project,
-            subjects: payload.subjects
-          }
-          const newCollection = Object.assign({}, favourites, payload.data, { links })
-          const body = Object.assign({}, collections.mocks.responses.get.collection, { collections: [newCollection] })
-          return Promise.resolve({ body })
-        })
         sinon.stub(rootStore.client.collections, 'get').callsFake(function () {
           return Promise.resolve({ body: { collections: [] } })
         })
@@ -205,75 +173,126 @@ describe('stores > Collections', function () {
       })
 
       after(function () {
-        rootStore.client.collections.create.restore()
         rootStore.client.collections.get.restore()
       })
 
-      it('should create a new collection', function (done) {
+      it('should return undefined', async function () {
         expect(collectionsStore.loadingState).to.equal(asyncStates.initialized)
-
-        collectionsStore.fetchFavourites()
-          .then(function () {
-            const favourites = getSnapshot(collectionsStore.favourites)
-            expect(collectionsStore.loadingState).to.equal(asyncStates.success)
-            expect(rootStore.client.collections.create).to.have.been.calledOnce()
-            expect(favourites.display_name).to.equal('Favorites test/project')
-            expect(favourites.links.project).to.equal('2')
-            expect(favourites.links.subjects).to.eql([])
-          })
-          .then(done, done)
-
-        // Since this is run before fetch's thenable resolves, it should test
-        // correctly during the request.
-        expect(collectionsStore.loadingState).to.equal(asyncStates.loading)
+        const favourites = await collectionsStore.fetchFavourites()
+        expect(collectionsStore.loadingState).to.equal(asyncStates.success)
+        expect(favourites).to.be.undefined()
       })
     })
   })
 
   describe('add favourites', function () {
-    before(function () {
-      const project = {
-        id: '2',
-        display_name: 'Hello',
-        slug: 'test/project'
-      }
-      const links = {
-        project: '1',
-        subjects: []
-      }
-      const favourites = Object.assign({}, collections.mocks.resources.collection, { links })
-      const user = {
-        login: 'test.user',
-        collections: { favourites }
-      }
-      const snapshot = { project, user }
-      rootStore = initStore(true, snapshot)
-      sinon.stub(rootStore.client.collections, 'addSubjects').callsFake(function (params) {
+    describe('with a favourites collection loaded', function () {
+      before(function () {
+        const project = {
+          id: '2',
+          display_name: 'Hello',
+          slug: 'test/project'
+        }
         const links = {
           project: '1',
+          subjects: []
+        }
+        const favourites = { ...collections.mocks.resources.collection, links }
+        const user = {
+          login: 'test.user',
+          collections: { favourites }
+        }
+        const snapshot = { project, user }
+        rootStore = initStore(true, snapshot)
+        sinon.stub(rootStore.client.collections, 'addSubjects').callsFake(function (params) {
+          const links = {
+            project: '1',
+            subjects: ['1', '2']
+          }
+          const newFavourites = { ...favourites, links }
+          return Promise.resolve({ body: { collections: [ newFavourites ] } })
+        })
+        collectionsStore = rootStore.user.collections
+      })
+
+      after(function () {
+        rootStore.client.collections.addSubjects.restore()
+      })
+
+      it('should add subjects to the favourites collection', async function () {
+        expect(collectionsStore.favourites.id).to.equal(collections.mocks.resources.collection.id)
+        await collectionsStore.addFavourites(['1', '2'])
+        const favourites = getSnapshot(collectionsStore.favourites)
+        const params = {
+          authorization: 'Bearer ',
+          id: favourites.id,
           subjects: ['1', '2']
         }
-        const newFavourites = Object.assign({}, favourites, { links })
-        return Promise.resolve({ body: { collections: [ newFavourites ] } })
+        expect(rootStore.client.collections.addSubjects).to.have.been.calledOnceWith(params)
+        expect(favourites.links.subjects).to.eql(['1', '2'])
       })
-      collectionsStore = rootStore.user.collections
     })
 
-    after(function () {
-      rootStore.client.collections.addSubjects.restore()
-    })
+    describe('without a favourites collection loaded', function () {
+      before(function () {
+        const project = {
+          id: '2',
+          display_name: 'Hello',
+          slug: 'test/project'
+        }
+        const links = {
+          project: '1',
+          subjects: []
+        }
+        const favourites = { ...collections.mocks.resources.collection, links }
+        const user = {
+          login: 'test.user'
+        }
+        const snapshot = { project, user }
+        rootStore = initStore(true, snapshot)
+        sinon.stub(rootStore.client.collections, 'addSubjects').callsFake(function (params) {
+          const links = {
+            project: '1',
+            subjects: ['1', '2']
+          }
+          const newFavourites = { ...favourites, links }
+          return Promise.resolve({ body: { collections: [ newFavourites ] } })
+        })
+        sinon.stub(rootStore.client.collections, 'get').callsFake(function () {
+          return Promise.resolve({ body: { collections: [] } })
+        })
+        sinon.stub(rootStore.client.collections, 'create').callsFake(function (payload) {
+          const [ favourites ] = collections.mocks.responses.get.collection.collections
+          const links = {
+            project: payload.project,
+            subjects: payload.subjects
+          }
+          const newCollection = { ...favourites, ...payload.data, links }
+          const body = { ...collections.mocks.responses.get.collection, collections: [newCollection] }
+          return Promise.resolve({ body })
+        })
+        collectionsStore = rootStore.user.collections
+      })
 
-    it('should add subjects to the favourites collection', async function () {
-      await collectionsStore.addFavourites(['1', '2'])
-      const favourites = getSnapshot(collectionsStore.favourites)
-      const params = {
-        authorization: 'Bearer ',
-        id: favourites.id,
-        subjects: ['1', '2']
-      }
-      expect(rootStore.client.collections.addSubjects).to.have.been.calledOnceWith(params)
-      expect(favourites.links.subjects).to.eql(['1', '2'])
-    })
+      after(function () {
+        rootStore.client.collections.addSubjects.restore()
+        rootStore.client.collections.get.restore()
+        rootStore.client.collections.create.restore()
+      })
+
+      it('should create a new favourites collection and add subjects to it', async function () {
+        expect(collectionsStore.favourites).to.be.null()
+        await collectionsStore.addFavourites(['1', '2'])
+        const favourites = getSnapshot(collectionsStore.favourites)
+        const params = {
+          authorization: 'Bearer ',
+          id: favourites.id,
+          subjects: ['1', '2']
+        }
+        expect(rootStore.client.collections.addSubjects).to.have.been.calledOnceWith(params)
+        expect(favourites.links.subjects).to.eql(['1', '2'])
+      })
+    }) 
   })
 
   describe('remove favourites', function () {

--- a/packages/app-project/stores/User/User.js
+++ b/packages/app-project/stores/User/User.js
@@ -45,7 +45,6 @@ const User = types
       self.login = user.login
       self.loadingState = asyncStates.success
       self.recents.fetch()
-      self.collections.fetchFavourites()
       self.collections.searchCollections({
         favorite: false,
         current_user_roles: 'owner,collaborator,contributor'

--- a/packages/lib-panoptes-js/src/resources/collections/rest.js
+++ b/packages/lib-panoptes-js/src/resources/collections/rest.js
@@ -17,15 +17,19 @@ function create (params) {
   return panoptes.post(endpoint, { collections }, { authorization })
 }
 
-function get (params) {
-  const queryParams = (params && params.query) ? params.query : {}
-  const collectionId = (params && params.id) ? params.id : ''
-  const authorization = (params && params.authorization) ? params.authorization : ''
+function get({
+  authorization = '',
+  id = '',
+  query = {}
+}) {
+  if (!id) {
+    return panoptes.get(endpoint, query, { authorization })
+  }
+  if (id && typeof id !== 'string') {
+    return raiseError('Collections: Get request id must be a string.', 'typeError')
+  }
 
-  if (!collectionId) return panoptes.get(endpoint, queryParams, { authorization })
-  if (collectionId && typeof collectionId !== 'string') return raiseError('Collections: Get request id must be a string.', 'typeError')
-
-  return panoptes.get(`${endpoint}/${collectionId}`, {}, { authorization })
+  return panoptes.get(`${endpoint}/${id}`, {}, { authorization })
 }
 
 function update (params) {


### PR DESCRIPTION
- Add a `usePanoptesAuth` hook to get bearer tokens in components.
- Add a `useUserFavourites` hook, which runs periodically to check user project favourites.
- Refactor the Collections model to fetch or create favourites when new subjects are added to favourites.
- Add tests.

## Package
app-project
lib-panoptes-js

## Linked Issue and/or Talk Post
- closes #2473.

## How to Review
Visiting a project that you've visited or classified on before, the project should try to fetch favourites when it first loads. When you favourite a new subject, it should either be added to the already loaded favourites collection, or favourites should be fetched and then updated.

Visiting a new project, favourites should be created the first time that you favourite a subject (when `user.collections.addFavourite` is called.) You shouldn't find an empty favourites collection being created by default just because you looked at a project.

If you delete your favourites collection, a new one should be created the next time that you favourite a subject on that project.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [x] Unit tests are added or updated

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected