### PR TITLE
Project: show workflow menu in stories

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenuModal/WorkflowMenuModal.stories.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenuModal/WorkflowMenuModal.stories.js
@@ -2,10 +2,23 @@ import asyncStates from '@zooniverse/async-states'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
+import { applySnapshot } from 'mobx-state-tree'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
 
 import { mockWorkflow as mockGroupedWorkflow } from '@shared/components/SubjectSetPicker/helpers'
 import initStore from '@stores'
 import WorkflowMenuModal from './WorkflowMenuModal'
+
+const router = {
+  locale: 'en',
+  query: {
+    owner: 'test-owner',
+    project: 'test-project'
+  },
+  prefetch() {
+    return Promise.resolve()
+  }
+}
 
 const snapshot = {
   project: {
@@ -24,12 +37,15 @@ const snapshot = {
   user: {
     loadingState: asyncStates.success,
     personalization: {
-      projectPreferences: {}
+      projectPreferences: {
+        loadingState: asyncStates.success
+      }
     }
   }
 }
 
 const store = initStore(false, snapshot)
+applySnapshot(store.user, snapshot.user)
 
 const WORKFLOWS = [
   {
@@ -56,18 +72,20 @@ function StoryContext (props) {
   const { children, theme } = props
 
   return (
-    <Grommet
-      background={{
-        dark: 'dark-1',
-        light: 'light-1'
-      }}
-      theme={theme}
-      themeMode={(theme.dark) ? 'dark' : 'light'}
-    >
-      <Provider store={store}>
-        {children}
-      </Provider>
-    </Grommet>
+    <RouterContext.Provider value={router}>
+      <Grommet
+        background={{
+          dark: 'dark-1',
+          light: 'light-1'
+        }}
+        theme={theme}
+        themeMode={(theme.dark) ? 'dark' : 'light'}
+      >
+        <Provider store={store}>
+          {children}
+        </Provider>
+      </Grommet>
+    </RouterContext.Provider>
   )
 }
 

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.stories.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.stories.js
@@ -2,13 +2,26 @@ import { MediaContextProvider } from '@shared/components/Media'
 import asyncStates from '@zooniverse/async-states'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Grommet } from 'grommet'
-import { Provider } from "mobx-react";
+import { Provider } from "mobx-react"
+import { applySnapshot } from 'mobx-state-tree'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
 import PropTypes from 'prop-types'
-import { Component } from 'react';
+import { Component } from 'react'
 import sinon from 'sinon'
 
 import initStore from '@stores'
 import Hero from './'
+
+const router = {
+  locale: 'en',
+  query: {
+    owner: 'test-owner',
+    project: 'test-project'
+  },
+  prefetch() {
+    return Promise.resolve()
+  }
+}
 
 const snapshot = {
   project: {
@@ -27,29 +40,34 @@ const snapshot = {
   user: {
     loadingState: asyncStates.success,
     personalization: {
-      projectPreferences: {}
+      projectPreferences: {
+        loadingState: asyncStates.success
+      }
     }
   }
 }
 
 const store = initStore(false, snapshot)
+applySnapshot(store.user, snapshot.user)
 
 function MockProjectContext({ children, theme }) {
   return (
-    <MediaContextProvider>
-      <Provider store={store}>
-        <Grommet
-          background={{
-            dark: 'dark-1',
-            light: 'light-1'
-          }}
-          theme={theme}
-          themeMode={(theme.dark) ? 'dark' : 'light'}
-        >
-          {children}
-        </Grommet>
-      </Provider>
-    </MediaContextProvider>
+    <RouterContext.Provider value={router}>
+      <MediaContextProvider>
+        <Provider store={store}>
+          <Grommet
+            background={{
+              dark: 'dark-1',
+              light: 'light-1'
+            }}
+            theme={theme}
+            themeMode={(theme.dark) ? 'dark' : 'light'}
+          >
+            {children}
+          </Grommet>
+        </Provider>
+      </MediaContextProvider>
+    </RouterContext.Provider>
   )
 }
 const WORKFLOWS = [

--- a/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelector.stories.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelector.stories.js
@@ -2,6 +2,7 @@ import asyncStates from '@zooniverse/async-states'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
 
 import WorkflowSelector from './WorkflowSelector'
 import * as subcomponents from './components'
@@ -19,6 +20,17 @@ const store = {
       2) "Location": Smartphone-friendly, series of questions on the geographic location of the nest.  
       3) "Nest Attempt: Smartphone-friendly, for data-entry lovers to record nest attempt data on cards.  
       4) "Comments": For transcription lovers, we ask you to transcribe all the written comments on the cards.`
+  }
+}
+
+const router = {
+  locale: 'en',
+  query: {
+    owner: 'test-owner',
+    project: 'test-project'
+  },
+  prefetch() {
+    return Promise.resolve()
   }
 }
 
@@ -59,18 +71,20 @@ function StoryContext (props) {
   const { children, theme } = props
 
   return (
-    <Grommet
-      background={{
-        dark: 'dark-1',
-        light: 'light-1'
-      }}
-      theme={theme}
-      themeMode={(theme.dark) ? 'dark' : 'light'}
-    >
-      <Provider store={store}>
-        {children}
-      </Provider>
-    </Grommet>
+    <RouterContext.Provider value={router}>
+      <Grommet
+        background={{
+          dark: 'dark-1',
+          light: 'light-1'
+        }}
+        theme={theme}
+        themeMode={(theme.dark) ? 'dark' : 'light'}
+      >
+        <Provider store={store}>
+          {children}
+        </Provider>
+      </Grommet>
+    </RouterContext.Provider>
   )
 }
 

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.js
@@ -79,10 +79,10 @@ WorkflowSelectButton.propTypes = {
     Optional custom router. Overrides the default NextJS.
     Useful for mocking the router in stories and shallow tests.
   */
-  router: PropTypes.shape({
-    query: PropTypes.shape({
-      owner: PropTypes.string,
-      project: PropTypes.string
+  router: shape({
+    query: shape({
+      owner: string,
+      project: string
     })
   }),
   theme: object,


### PR DESCRIPTION
- Fix broken prop types in `WorkflowSelectButton`.
- Add a mock `RouterContext` to `Hero` and `WorkflowMenuModal` stories.
- The workflow menu waits for the user to load, so apply a snapshot of a mock, loaded user to the mock store in stories.

## Package
app-project

## Linked Issue and/or Talk Post
- closes #3567.

## How to Review
Open the project storybook and check the stories for Screens > Project Home > Hero and Screens > Classify > Workflow Menu Modal. Both of them should show a list of mock workflows.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated
