### PR TITLE
Fixed accessibility issue: content filters are before the publications list in the tab order

### DIFF
--- a/packages/app-content-pages/src/shared/components/TwoColumnLayout/TwoColumnLayout.js
+++ b/packages/app-content-pages/src/shared/components/TwoColumnLayout/TwoColumnLayout.js
@@ -4,19 +4,16 @@ import { node } from 'prop-types'
 import AboutHeader from '../AboutHeader'
 
 function TwoColumnLayout (props) {
-  const { main, sidebar } = props
+  const { sidebar, main } = props
   return (
     <>
       <AboutHeader />
       <Box align='center' pad={{ horizontal: 'medium', vertical: 'large' }}>
         <Box
-          direction='row-reverse'
+          direction='row'
           gap='medium'
           width='xlarge'
         >
-          <Box fill gridArea='main'>
-            {main}
-          </Box>
           <Box
             as='aside'
             gridArea='sidebar'
@@ -24,6 +21,11 @@ function TwoColumnLayout (props) {
           >
             {sidebar}
           </Box>
+          
+          <Box fill gridArea='main'>
+            {main}
+          </Box>
+          
         </Box>
       </Box>
     </>


### PR DESCRIPTION
## Package
app-content-pages

## Linked Issue and/or Talk Post
#1699 

## Describe your changes
The sidebar with the filters has been placed before the list of publications so that individuals with screen readers can tab through the filtered controls before getting to the publications list.
I also changed the width of the sidebar from medium --> small to improve the responsive layout.

## How to Review
_Helpful explanations that will make your reviewer happy:_
- Run the app-content-pages using yarn dev.
- Navigate to the about/publications page (http://localhost:3000/about/publications)
- Tab through the links and it should go from 'Donate' to 'Show All'
- Alternatively, activate screen reader (CMD+F5 on macOSv.12.5) and see how the page navigates straight to the filter on the sidebar instead of the main body- more useful for screen readers.

- Are there plans for follow up PR’s to further fix this bug or develop this feature?
--> Sidebar needs appropriate filter label but this is a separate issue.
--> H1 tag will be separated from the main body as it needs to be before the filter but this is a separate issue.

# Checklist

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and change log has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Staging page: (http://localhost:3000/about/publications?env=staging)
Development page: (http://localhost:3000/about/publications)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
- Tested using Chrome v.104, Firefox v.104, Safari v.15.6

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
