### PR TITLE
Project app: Refactor subject picker data fetching

### DIFF
--- a/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.spec.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.spec.js
@@ -1,13 +1,23 @@
-import { mount, shallow } from 'enzyme'
 import { Grommet } from 'grommet'
 import Link from 'next/link'
 import nock from 'nock'
+import { within } from '@testing-library/dom'
+import { render, screen } from '@testing-library/react'
 import zooTheme from '@zooniverse/grommet-theme'
 
 import SubjectPicker, { StyledBox, SubjectDataTable } from './SubjectPicker'
 
 describe('Components > Subject Picker', function () {
-  let wrapper
+  let columnHeadings, displayName, link, tableRows
+
+  function Wrapper({ children }) {
+    return (
+      <Grommet theme={zooTheme}>
+        {children}
+      </Grommet>
+    )
+  }
+
   const workflow = {
     id: '123345'
   }
@@ -19,90 +29,75 @@ describe('Components > Subject Picker', function () {
     }
   }
 
-  before(function () {
-    wrapper = shallow(
+  before(async function () {
+    // allow a generous timeout for subject data to load.
+    this.timeout(10000)
+
+    const columns = [
+      'subject_id',
+      'Page',
+      'Date'
+    ]
+    const rows = [
+      [1, '43', '23 January 1916'],
+      [2, '44', '24 January 1916'],
+      [3, '45', '25 January 1916']
+    ]
+    nock('https://subject-set-search-api.zooniverse.org/subjects')
+    .get('/4567.json')
+    .query(true)
+    .reply(200, {
+      columns,
+      rows
+    })
+    nock('https://panoptes-staging.zooniverse.org/api')
+    .get('/subjects/selection')
+    .query(true)
+    .reply(200, {
+      subjects: [
+        { id: 1, already_seen: false, retired: false },
+        { id: 2, already_seen: true, retired: false },
+        { id: 3, already_seen: true, retired: true }
+      ]
+    })
+    render(
       <SubjectPicker
         baseUrl="/workflow/12345"
         subjectSet={subjectSet}
         workflow={workflow}
-      />
+      />,
+      { wrapper: Wrapper }
     )
-  })
-
-  it('should render', function () {
-    expect(wrapper).to.be.ok()
+    // workaround to wait for the mock API calls to resolve
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    displayName = screen.getByText(subjectSet.display_name)
+    link = screen.getByRole('link', { name: 'SubjectPicker.back' })
+    const dataTable = screen.getByRole('table')
+    const [ tableHeader, tableContent ] = within(dataTable).getAllByRole('rowgroup')
+    columnHeadings = within(tableHeader).getByRole('row', {
+      name: 'subject_id Date FormSearch Page FormSearch status'
+    })
+    const subjects = [
+      '1 23 January 1916 43 SubjectPicker.unclassified',
+      '2 24 January 1916 44 SubjectPicker.alreadySeen',
+      '3 25 January 1916 45 SubjectPicker.retired'
+    ]
+    tableRows = subjects.map(subject => within(tableContent).getByRole('row', { name: subject }))
   })
 
   it('should show the subject set name', function () {
-    const displayName = wrapper.find(StyledBox)
-    expect(displayName).to.be.ok()
+    expect(displayName).to.exist()
   })
 
-  describe('subject data table', function () {
-    let wrapper
-
-    before(async function () {
-      const columns = [
-        'subject_id',
-        'Page',
-        'Date'
-      ]
-      const rows = [
-        [1, '43', '23 January 1916'],
-        [2, '44', '24 January 1916'],
-        [3, '45', '25 January 1916']
-      ]
-      nock('https://subject-set-search-api.zooniverse.org/subjects')
-      .get('/4567.json')
-      .query(true)
-      .reply(200, {
-        columns,
-        rows
-      })
-      nock('https://panoptes-staging.zooniverse.org/api')
-      .get('/subjects/selection')
-      .query(true)
-      .reply(200, {
-        subjects: [
-          { id: 1, already_seen: false, retired: false },
-          { id: 2, already_seen: true, retired: false },
-          { id: 3, already_seen: true, retired: true }
-        ]
-      })
-      wrapper = mount(
-        <SubjectPicker
-          baseUrl="/workflow/12345"
-          subjectSet={subjectSet}
-          workflow={workflow}
-        />,
-        { wrappingComponent: Grommet, wrappingComponentProps: { theme: zooTheme } }
-      )
-      // workaround to wait for the mock API calls to resolve
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    })
-
-    it('should have column headings, including indexed subject fields', function () {
-      const dataTable = wrapper.find(SubjectDataTable)
-      const headers = dataTable.prop('columns').map(column => column.header)
-      expect(headers).to.deep.equal(['subject_id', 'Date', 'Page', 'status'])
-    })
-
-    it('should have a row for each subject', function () {
-      wrapper.update()
-      const dataTable = wrapper.find(SubjectDataTable)
-      expect(dataTable.prop('data').length).to.equal(3)
-    })
+  it('should have column headings, including indexed subject fields', function () {
+    expect(columnHeadings).to.exist()
   })
 
-  describe('Back link', function () {
-    let link
+  it('should have a row for each subject', function () {
+    expect(tableRows.length).to.equal(3)
+  })
 
-    before(function () {
-      link = wrapper.find(Link).first()
-    })
-
-    it('should link to the base URL', function () {
-      expect(link.prop('href')).to.equal('/workflow/12345')
-    })
+  it('should link to the base URL', function () {
+    expect(link.href).to.equal('https://localhost/workflow/12345')
   })
 })

--- a/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.spec.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.spec.js
@@ -48,9 +48,9 @@ describe('Components > Subject Picker', function () {
         'Date'
       ]
       const rows = [
-        ['1', '43', '23 January 1916'],
-        ['2', '44', '24 January 1916'],
-        ['3', '45', '25 January 1916']
+        [1, '43', '23 January 1916'],
+        [2, '44', '24 January 1916'],
+        [3, '45', '25 January 1916']
       ]
       nock('https://subject-set-search-api.zooniverse.org/subjects')
       .get('/4567.json')

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/checkRetiredStatus.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/checkRetiredStatus.js
@@ -2,7 +2,7 @@ import { env, panoptes } from '@zooniverse/panoptes-js'
 import auth from 'panoptes-client/lib/auth'
 import { logToSentry } from '@helpers/logger'
 
-export default async function checkRetiredStatus(ids, t, workflow) {
+export default async function checkRetiredStatus(ids, workflow) {
   const token = await auth.checkBearerToken()
   const authorization = `Bearer ${token}`
   const workflow_id = workflow.id
@@ -17,8 +17,8 @@ export default async function checkRetiredStatus(ids, t, workflow) {
     { authorization })
     const { subjects } = response.body
     subjects.forEach(subject => {
-      const alreadySeen = subject.already_seen ? t('SubjectPicker.alreadySeen') : t('SubjectPicker.unclassified')
-      retirementStatuses[subject.id] = subject.retired ? t('SubjectPicker.retired') : alreadySeen
+      const alreadySeen = subject.already_seen ? 'SubjectPicker.alreadySeen' : 'SubjectPicker.unclassified'
+      retirementStatuses[subject.id] = subject.retired ? 'SubjectPicker.retired' : alreadySeen
     })
   } catch (error) {
     console.error(error)

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/checkRetiredStatus.spec.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/checkRetiredStatus.spec.js
@@ -6,7 +6,6 @@ describe('Components > Subject Picker > helpers > checkRetiredStatus', function 
 
   before(async function () {
     const subject_ids = ['1', '2', '3']
-    const t = (key) => key
     const workflow = {
       id: '1'
     }
@@ -20,7 +19,7 @@ describe('Components > Subject Picker > helpers > checkRetiredStatus', function 
         { id: 3, already_seen: true, retired: true }
       ]
     })
-    retirementStatuses = await checkRetiredStatus(subject_ids, t, workflow)
+    retirementStatuses = await checkRetiredStatus(subject_ids, workflow)
   })
 
   it('should set the status of unclassified subjects', function () {

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchStatuses.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchStatuses.js
@@ -1,28 +1,24 @@
 import { checkRetiredStatus } from './'
 
 export default async function fetchStatuses(
-  callback,
-  page_size = 10,
   subjects = [],
-  t,
-  workflow
+  workflow,
+  page_size = 10,
 ) {
+  const newRows = []
   const pages = Math.ceil(subjects.length / page_size)
   for (let page = 0; page < pages; page++) {
     const start = page * page_size
     const end = (page + 1) * page_size
     const subject_ids = subjects.slice(start, end).map(row => row.subject_id).join(',')
-    const statuses = await checkRetiredStatus(subject_ids, t, workflow)
-    const updateSeenStatus = (rows) => {
-      const newRows = rows.slice()
-      Object.entries(statuses).forEach(([ subjectID, subjectStatus ]) => {
-        const subject = newRows.find(subject => subject.subject_id === parseInt(subjectID))
-        if (subject) {
-          subject.status = subjectStatus
-        }
-      })
-      return newRows
-    }
-    callback(updateSeenStatus)
+    const statuses = await checkRetiredStatus(subject_ids, workflow)
+    Object.entries(statuses).forEach(([ subjectID, subjectStatus ]) => {
+      const subject = subjects.find(subject => subject.subject_id === parseInt(subjectID))
+      if (subject) {
+        subject.status = subjectStatus
+        newRows.push(subject)
+      }
+    })
   }
+  return newRows
 }

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchStatuses.spec.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchStatuses.spec.js
@@ -38,17 +38,8 @@ describe('Components > Subject Picker > helpers > fetchStatuses', function () {
         { id: 3, already_seen: true, retired: true }
       ]
     })
-    subjects = await fetchSubjects('1')
-    const callback = sinon.stub().callsFake(newData => {
-      if (typeof newData === 'function') {
-        subjects = newData(subjects)
-        return subjects
-      }
-      subjects = newData
-      return subjects
-    })
-    const t = (key) => key
-    await fetchStatuses(callback, 10, subjects, t, workflow)
+    const panoptesSubjects = await fetchSubjects('1')
+    subjects = await fetchStatuses(panoptesSubjects, workflow)
   })
 
   it('should generate subject data table rows with classification statuses', function () {


### PR DESCRIPTION
- refactor `fetchStatuses` to remove the callback and translation arguments.
- set state directly in the `SubjectPicker` component, after fetching data from APIs.
- refactor `useEffect` to make its dependencies explicit in the subject picker.
- refactor subject statuses to use the `useTranslation` hook in the parent component.

#3571 highlighted bad tests in the `SubjectPicker` component, which failed when we upgrade to NextJS 12.2. Here, the `fetchStatuses` helper is refactored to fetch new data and return it to the parent component. Previously, it used a callback to set state in the parent component, which led to problems when tests mocked the `setRows` function.

## Package
app-project

## How to Review
`yarn build` shouldn't generate any warnings for the `SubjectPicker` component. Many of the other build warnings are fixed in #3628.

Tests should still pass with the new code, and subject selection should still work on those projects that use it.

Test URL:
https://local.zooniverse.org:3000/projects/profdrrogerlouismartinez-davila/deciphering-secrets-unlocking-the-manuscripts-of-medieval-spain/classify/workflow/19276/subject-set/106935?env=production

Subject statuses should be correctly translated too:
https://local.zooniverse.org:3000/projects/es/profdrrogerlouismartinez-davila/deciphering-secrets-unlocking-the-manuscripts-of-medieval-spain/classify/workflow/19276/subject-set/106935?env=production

<img width="950" alt="Subject selection in Spanish, showing each subject as 'Disponible'." src="https://user-images.githubusercontent.com/59547/188473556-4983b7cf-1912-4be5-9108-a19ed7d90e7f.png">


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected