### PR TITLE
Freehand line: adjust segments before editing 

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.js
@@ -65,14 +65,13 @@ function FreehandLine({ active, mark, onFinish, scale }) {
     cancelEditing()
   }
 
-  if (editing && !dragPoint) {
+  if (active && editing && !dragPoint) {
     cancelEditing()
   }
 
-  if (!dragPoint && isClosed) {
-    if (mark.clipPath.length > 0) {
-      mark.setClipPath([])
-    }
+  if (active && !dragPoint && isClosed && clippedPath) {
+    // clear the dashed guide line when an open line is closed.
+    mark.setClipPath([])
   }
 
   function onDoubleClick(event) {


### PR DESCRIPTION
- Add `revertEdits` and `cancelClipPath` actions.
- Revert any existing clipped points before starting a new edit.
- Refactor `line.cutSegment` to take the start and end of the segment as arguments: `cutSegment(startPoint, endPoint)`.
- Refactor splicing and trimming the points array to allow for drawing in either direction. The line should now reverse if you edit in the opposite direction to the original drawing.
- Refactor the freehand line state logic to use `segmentationInProgress` which will be true if either:
  - the line path (open or closed) has been cut into two segments in the middle.
  - the line is open but we are editing the ends of a closed shape.

I've also included some fixes for small bugs that came up in the review of #3559.

These changes allow the clipped path to be modified by clicking anywhere along the line path, which allows the endpoint to be adjusted before drawing a new segment.

- double-click anywhere on a line to start editing a segment.
- click anywhere to set the end of the segment. You can change your mind and click somewhere else if you make a mistake.
- click off the line to reset and start again.


https://user-images.githubusercontent.com/59547/188265662-b393fca6-02b4-4148-8f19-9a9337d079c4.mov

## Package
lib-classifier/src/plugins/drawingTools/experimental/FreehandLine

## How to Review
You can draw, and edit, freehand lines in the Classifier storybook.
http://localhost:6006/?path=/story/drawing-tools-freehand-line--complete&globals=locale:en;locales.en:English;locales.test:Test+Language

Staged project with a drawing workflow:
https://fe-project-branch.preview.zooniverse.org/projects/eatyourgreens/-project-testing-ground/classify/workflow/3370?env=staging


https://user-images.githubusercontent.com/59547/188324525-9cd78f76-d1aa-4cb1-9311-09a05c497910.mov

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
