### PR TITLE
Improve Publications and Team page content accessibility

### DIFF
--- a/packages/app-content-pages/src/screens/Publications/Publications.js
+++ b/packages/app-content-pages/src/screens/Publications/Publications.js
@@ -1,5 +1,6 @@
 import counterpart from 'counterpart'
 import { Anchor, Box, Button, Heading, Paragraph } from 'grommet'
+import Link from 'next/link'
 import { array, arrayOf, bool, func, shape, string } from 'prop-types'
 import styled, { css } from 'styled-components'
 
@@ -19,9 +20,11 @@ const StyledButton = styled(Button)`
 `
 const FORM_URL = 'https://docs.google.com/forms/d/e/1FAIpQLSdbAKVT2tGs1WfBqWNrMekFE5lL4ZuMnWlwJuCuNM33QO2ZYg/viewform'
 
-function Publications (props) {
-  const { className, data, filters } = props
-
+function Publications ({
+  className,
+  data,
+  filters
+}) {
   const heading = (
     <section>
       <Heading margin={{ top: 'none' }} size='small'>
@@ -42,6 +45,7 @@ function Publications (props) {
           key={category.title}
           title={category.title}
           projects={category.projects}
+          slug={category.slug}
         />
       ))}
     </article>
@@ -51,12 +55,17 @@ function Publications (props) {
     <Box as='ul' gap='small'>
       {filters.map(filter => (
         <StyledLi key={filter.name} >
-          <StyledButton
-            active={filter.active}
-            label={filter.name}
-            onClick={filter.setActive}
-            plain
-          />
+          <Link
+            href={ filter.slug ? `#${filter.slug}` : '' }
+            passHref
+          >
+            <StyledButton
+              active={filter.active}
+              label={filter.name}
+              onClick={filter.setActive}
+              plain
+            />
+          </Link>
         </StyledLi>
       ))}
     </Box>

--- a/packages/app-content-pages/src/screens/Publications/Publications.js
+++ b/packages/app-content-pages/src/screens/Publications/Publications.js
@@ -18,8 +18,8 @@ const FORM_URL = 'https://docs.google.com/forms/d/e/1FAIpQLSdbAKVT2tGs1WfBqWNrMe
 function Publications (props) {
   const { className, data, filters } = props
 
-  const main = (
-    <article>
+  const heading = (
+    <section>
       <Heading margin={{ top: 'none' }} size='small'>
         Publications
       </Heading>
@@ -27,6 +27,11 @@ function Publications (props) {
       <Paragraph>
         To submit a new publication or update an existing one, <Anchor href={FORM_URL}>please use this form</Anchor>. We aim to post links to published papers that can be accessed by the public. Articles accepted for publication but not yet published are also fine.
       </Paragraph>
+    </section>
+  )
+
+  const main = (
+    <article>
 
       {data.map(category => (
         <Category
@@ -60,6 +65,7 @@ function Publications (props) {
         title={counterpart('Publications.title')}
       />
       <TwoColumnLayout
+        heading={heading}
         className={className}
         main={main}
         sidebar={sidebar}

--- a/packages/app-content-pages/src/screens/Publications/Publications.js
+++ b/packages/app-content-pages/src/screens/Publications/Publications.js
@@ -7,6 +7,10 @@ import Category from './components/Category'
 import TwoColumnLayout from '../../shared/components/TwoColumnLayout'
 import Head from '../../shared/components/Head'
 
+const StyledLi = styled.li`
+  list-style-type: none;
+`
+
 const StyledButton = styled(Button)`
   ${props => props.active && css`
     background: none;
@@ -44,16 +48,16 @@ function Publications (props) {
   )
 
   const sidebar = (
-    <Box gap='small'>
+    <Box as='ul' gap='small'>
       {filters.map(filter => (
-        <div key={filter.name} >
+        <StyledLi key={filter.name} >
           <StyledButton
             active={filter.active}
             label={filter.name}
             onClick={filter.setActive}
             plain
           />
-        </div>
+        </StyledLi>
       ))}
     </Box>
   )

--- a/packages/app-content-pages/src/screens/Publications/PublicationsContainer.js
+++ b/packages/app-content-pages/src/screens/Publications/PublicationsContainer.js
@@ -1,15 +1,24 @@
 import counterpart from 'counterpart'
 import { array, string } from 'prop-types'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import en from './locales/en'
 import Publications from './Publications'
 
 counterpart.registerTranslations('en', en)
 
-function PublicationsContainer(props) {
-  const { publicationsData } = props
+const isBrowser = typeof window !== 'undefined'
+
+function PublicationsContainer({publicationsData}) {
+  publicationsData.forEach(category => {
+    category.slug = category.title.toLowerCase().replaceAll(' ', '-')
+  })
   const [activeFilter, setActiveFilter] = useState(null)
+
+  useEffect(function onMount() {
+    const slug = isBrowser ? window.location.hash.slice(1) : ''
+    setActiveFilter(slug)
+  }, [])
 
   const filters = createFilters(publicationsData, activeFilter, setActiveFilter)
   const filteredPublicationsData = createFilteredPublicationsData(publicationsData, activeFilter)
@@ -31,15 +40,17 @@ export default PublicationsContainer
 
 function createFilters(publicationsData, activeFilter, setActiveFilter) {
   const showAllFilter = {
-    active: activeFilter === null,
+    active: !activeFilter,
     name: counterpart('Publications.showAll'),
-    setActive: () => setActiveFilter(null)
+    slug: '',
+    setActive: event => setActiveFilter('')
   }
 
   const categoryFilters = publicationsData.map(category => ({
-    active: activeFilter === category.title,
+    active: activeFilter === category.slug,
     name: category.title,
-    setActive: () => setActiveFilter(category.title)
+    slug: category.title.toLowerCase().replaceAll(' ', '-'),
+    setActive: event => setActiveFilter(category.slug)
   }))
 
   return [showAllFilter, ...categoryFilters]
@@ -49,6 +60,6 @@ function createFilters(publicationsData, activeFilter, setActiveFilter) {
 // no active filter.
 function createFilteredPublicationsData(publicationsData, activeFilter) {
   return activeFilter
-    ? publicationsData.filter(category => category.title === activeFilter)
+    ? publicationsData.filter(category => category.slug === activeFilter)
     : publicationsData
 }

--- a/packages/app-content-pages/src/screens/Publications/components/Category/Category.js
+++ b/packages/app-content-pages/src/screens/Publications/components/Category/Category.js
@@ -3,11 +3,14 @@ import { arrayOf, shape, string } from 'prop-types'
 
 import Project from '../Project'
 
-function Category (props) {
-  const { title, projects } = props
+function Category ({
+  title,
+  projects,
+  slug
+}) {
   return (
     <Box as='section'>
-      <Heading level='2' size='small'>
+      <Heading id={slug} level='2' size='small'>
         {title}
       </Heading>
       {projects.map(project => (

--- a/packages/app-content-pages/src/screens/Team/Team.js
+++ b/packages/app-content-pages/src/screens/Team/Team.js
@@ -1,5 +1,6 @@
 import counterpart from 'counterpart'
 import { Box, Button, Heading } from 'grommet'
+import Link from 'next/link'
 import { array, arrayOf, bool, func, shape, string } from 'prop-types'
 import styled, { css } from 'styled-components'
 
@@ -19,9 +20,11 @@ const StyledButton = styled(Button)`
   `}
 `
 
-function TeamComponent (props) {
-  const { className, data, filters } = props
-
+function TeamComponent ({
+  className,
+  data,
+  filters
+}) {
   const heading = (
     <Heading margin={{ top: 'none' }} size='small'>
       Our Team
@@ -35,6 +38,7 @@ function TeamComponent (props) {
           key={team.name}
           name={team.name}
           people={team.people}
+          slug={team.slug}
         />
       ))}
     </article>
@@ -44,12 +48,17 @@ function TeamComponent (props) {
     <Box as='ul' gap='small'>
       {filters.map(filter => (
         <StyledLi key={filter.name}>
-          <StyledButton
-            active={filter.active}
-            label={filter.name}
-            onClick={filter.setActive}
-            plain
-          />
+          <Link
+            href={ filter.slug ? `#${filter.slug}` : '' }
+            passHref
+          >
+            <StyledButton
+              active={filter.active}
+              label={filter.name}
+              onClick={filter.setActive}
+              plain
+            />
+          </Link>
         </StyledLi>
       ))}
     </Box>

--- a/packages/app-content-pages/src/screens/Team/Team.js
+++ b/packages/app-content-pages/src/screens/Team/Team.js
@@ -22,12 +22,14 @@ const StyledButton = styled(Button)`
 function TeamComponent (props) {
   const { className, data, filters } = props
 
+  const heading = (
+    <Heading margin={{ top: 'none' }} size='small'>
+      Our Team
+    </Heading>
+  )
+
   const main = (
     <article>
-      <Heading margin={{ top: 'none' }} size='small'>
-        Our Team
-      </Heading>
-
       {data && data.map(team => (
         <Team
           key={team.name}
@@ -61,6 +63,7 @@ function TeamComponent (props) {
       />
       <TwoColumnLayout
         className={className}
+        heading={heading}
         main={main}
         sidebar={sidebar}
       />

--- a/packages/app-content-pages/src/screens/Team/components/Team/Team.js
+++ b/packages/app-content-pages/src/screens/Team/components/Team/Team.js
@@ -3,11 +3,15 @@ import { arrayOf, shape, string } from 'prop-types'
 
 import Person from '../Person'
 
-function Team (props) {
-  const { name, people } = props
+function Team ({
+  name,
+  people,
+  slug
+}) {
   return (
     <Box as='section' key={name} margin={{ bottom: 'medium' }}>
       <Heading
+        id={slug}
         level='2'
         margin={{ bottom: 'small', top: 'none' }}
         size='small'

--- a/packages/app-content-pages/src/shared/components/AboutHeader/AboutHeader.js
+++ b/packages/app-content-pages/src/shared/components/AboutHeader/AboutHeader.js
@@ -15,21 +15,22 @@ function AboutHeader () {
       </Box>
 
       <Box
+        aria-label='About the Zooniverse'
         as='nav'
         direction='row'
         margin={{ bottom: 'xsmall' }}
         width='xlarge'
       >
-        <NavLink label='About' href='/about' />
-        <NavLink label='Publications' href='/about/publications' />
-        <NavLink label='Our Team' href='/about/team' />
-        <NavLink label='Acknowledgements' href='/about/acknowledgements' />
-        <NavLink label='Resources' href='/about/resources' />
-        <NavLink label='Contact Us' href='/about/contact' />
-        <NavLink label='FAQ' href='/about/faq' />
-        <NavLink label='Highlights Book' href='/about/highlights' />
-        <NavLink label='Mobile App' href='/about/mobile-app' />
-        <NavLink label='Donate' href='/about/donate' />
+        <NavLink label='About' href='/' />
+        <NavLink label='Publications' href='/publications' />
+        <NavLink label='Our Team' href='/team' />
+        <NavLink label='Acknowledgements' href='/acknowledgements' />
+        <NavLink label='Resources' href='/resources' />
+        <NavLink label='Contact Us' href='/contact' />
+        <NavLink label='FAQ' href='/faq' />
+        <NavLink label='Highlights Book' href='/highlights' />
+        <NavLink label='Mobile App' href='/mobile-app' />
+        <NavLink label='Donate' href='/donate' />
       </Box>
     </Box>
   )

--- a/packages/app-content-pages/src/shared/components/AboutHeader/AboutHeader.spec.js
+++ b/packages/app-content-pages/src/shared/components/AboutHeader/AboutHeader.spec.js
@@ -14,42 +14,42 @@ describe('Component > AboutHeader', function () {
   })
 
   it('should have an `About` link', function () {
-    expect(wrapper.find('[href="/about"]')).to.have.lengthOf(1)
+    expect(wrapper.find('[href="/"]')).to.have.lengthOf(1)
   })
 
   it('should have a `Publications` link', function () {
-    expect(wrapper.find('[href="/about/publications"]')).to.have.lengthOf(1)
+    expect(wrapper.find('[href="/publications"]')).to.have.lengthOf(1)
   })
 
   it('should have an `Our Team` link', function () {
-    expect(wrapper.find('[href="/about/team"]')).to.have.lengthOf(1)
+    expect(wrapper.find('[href="/team"]')).to.have.lengthOf(1)
   })
 
   it('should have a `Acknowledgements` link', function () {
-    expect(wrapper.find('[href="/about/acknowledgements"]')).to.have.lengthOf(1)
+    expect(wrapper.find('[href="/acknowledgements"]')).to.have.lengthOf(1)
   })
 
   it('should have a `Resources` link', function () {
-    expect(wrapper.find('[href="/about/resources"]')).to.have.lengthOf(1)
+    expect(wrapper.find('[href="/resources"]')).to.have.lengthOf(1)
   })
 
   it('should have a `Contact Us` link', function () {
-    expect(wrapper.find('[href="/about/contact"]')).to.have.lengthOf(1)
+    expect(wrapper.find('[href="/contact"]')).to.have.lengthOf(1)
   })
 
   it('should have a `FAQ` link', function () {
-    expect(wrapper.find('[href="/about/faq"]')).to.have.lengthOf(1)
+    expect(wrapper.find('[href="/faq"]')).to.have.lengthOf(1)
   })
 
   it('should have a `Highlights` link', function () {
-    expect(wrapper.find('[href="/about/highlights"]')).to.have.lengthOf(1)
+    expect(wrapper.find('[href="/highlights"]')).to.have.lengthOf(1)
   })
 
   it('should have a `Mobile App` link', function () {
-    expect(wrapper.find('[href="/about/mobile-app"]')).to.have.lengthOf(1)
+    expect(wrapper.find('[href="/mobile-app"]')).to.have.lengthOf(1)
   })
 
   it('should have a `Donate` link', function () {
-    expect(wrapper.find('[href="/about/donate"]')).to.have.lengthOf(1)
+    expect(wrapper.find('[href="/donate"]')).to.have.lengthOf(1)
   })
 })

--- a/packages/app-content-pages/src/shared/components/AboutHeader/components/NavLink/NavLink.js
+++ b/packages/app-content-pages/src/shared/components/AboutHeader/components/NavLink/NavLink.js
@@ -1,5 +1,6 @@
 import counterpart from 'counterpart'
 import { Anchor, Box } from 'grommet'
+import Link from 'next/link'
 import { withRouter } from 'next/router'
 import { string } from 'prop-types'
 
@@ -11,11 +12,18 @@ function NavLink (props) {
   const { href, label, router: { asPath } } = props
   const isActive = asPath === href
   return (
-    <Anchor href={href} size='medium' weight='normal' active={isActive}>
-      <Box pad={{ horizontal: 'small', vertical: 'xsmall' }}>
-        {label}
-      </Box>
-    </Anchor>
+    <Link href={href} passHref >
+      <Anchor
+        aria-current={ isActive ? 'page' : undefined }
+        size='medium'
+        weight='normal'
+        active={isActive}
+      >
+        <Box pad={{ horizontal: 'small', vertical: 'xsmall' }}>
+          {label}
+        </Box>
+      </Anchor>
+    </Link>
   )
 }
 

--- a/packages/app-content-pages/src/shared/components/TwoColumnLayout/TwoColumnLayout.js
+++ b/packages/app-content-pages/src/shared/components/TwoColumnLayout/TwoColumnLayout.js
@@ -4,16 +4,26 @@ import { node } from 'prop-types'
 import AboutHeader from '../AboutHeader'
 
 function TwoColumnLayout (props) {
-  const { sidebar, main } = props
+  const { heading, sidebar, main } = props
   return (
     <>
       <AboutHeader />
       <Box align='center' pad={{ horizontal: 'medium', vertical: 'large' }}>
+        <Box 
+            direction='row'
+            gap='medium'
+            width='xlarge'
+            >
+              {heading}
+
+          </Box>
         <Box
           direction='row'
           gap='medium'
           width='xlarge'
         >
+          
+
           <Box
             as='aside'
             gridArea='sidebar'
@@ -34,7 +44,8 @@ function TwoColumnLayout (props) {
 
 TwoColumnLayout.propTypes = {
   main: node,
-  sidebar: node
+  sidebar: node,
+  heading: node
 }
 
 export default TwoColumnLayout

--- a/packages/app-content-pages/src/shared/components/TwoColumnLayout/TwoColumnLayout.js
+++ b/packages/app-content-pages/src/shared/components/TwoColumnLayout/TwoColumnLayout.js
@@ -10,13 +10,18 @@ function TwoColumnLayout (props) {
       <AboutHeader />
       <Box align='center' pad={{ horizontal: 'medium', vertical: 'large' }}>
         <Box 
-            direction='row'
-            gap='medium'
-            width='xlarge'
-            >
-              {heading}
-
+          direction='row'
+          gap='medium'
+          width='xlarge'
+        >
+          <Box
+            width='medium'
+          />
+          <Box fill gridArea='heading'>
+            {heading}
           </Box>
+        </Box>
+
         <Box
           direction='row'
           gap='medium'


### PR DESCRIPTION
## Package
app-content-pages

## Linked Issue and/or Talk Post
- closes #3584.
- closes #3693. 

## Describe your changes
Made the Publications heading and content tag its own section so that screen readers can navigate the page. This (however) has slightly altered the layout.

See screenshot below:
<img width="1403" alt="Screenshot 2022-09-05 at 10 13 00" src="https://user-images.githubusercontent.com/49612167/188413676-e9856d04-ed96-4ce9-99a9-ab4d1107174c.png">

### Updates 23rd September 2022
- top-level page navigation uses [`aria-current`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) and shows the active page visually, closing #3693.
- Publications filters are marked up as a list, to match the filters on the Team page.
- Every filter is a link with a document fragment identifier, giving each section its own URL eg.
  - http://localhost:3000/about/team#the-adler-planetarium
  - http://localhost:3000/about/publications#nature

## How to Review
- Go to about, [Publications]( http://localhost:3000/about/publications) and use VoiceOver or tab through the links observe how a screen reader navigates the page.
- Reload the page after selecting a filter from the sidebar. The filtered category should be remembered across reloads.


## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Page: (http://localhost:3000/about/publications?env=staging)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook



