### PR TITLE
NextJS apps: enable Strict Mode

### DIFF
--- a/packages/app-content-pages/next.config.js
+++ b/packages/app-content-pages/next.config.js
@@ -31,6 +31,8 @@ const nextConfig = {
     APP_ENV
   },
 
+  reactStrictMode: true,
+
   webpack: (config, options) => {
     if (!options.isServer) {
       config.resolve.alias['@sentry/node'] = '@sentry/browser'

--- a/packages/app-project/next.config.js
+++ b/packages/app-project/next.config.js
@@ -63,6 +63,8 @@ const nextConfig = {
     assetPrefix
   },
 
+  reactStrictMode: true,
+
   async redirects() {
     return [
       {


### PR DESCRIPTION
Turn on [React Strict Mode](https://reactjs.org/docs/strict-mode.html) for both NextJS apps.

## Package
app-content-pages
app-project

## How to Review
Running the apps in development (`yarn dev`) will now use [Strict Mode](https://reactjs.org/docs/strict-mode.html). You'll see console warnings for deprecated features or code that may cause problems in future versions of React. Otherwise, both apps should continue to work as usual.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook
