### PR TITLE
Project: only render user recents in the browser

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/RecentSubjects/RecentSubjects.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/RecentSubjects/RecentSubjects.js
@@ -6,6 +6,26 @@ import { useTranslation } from 'next-i18next'
 import ContentBox from '@shared/components/ContentBox'
 import SubjectPreview from '@shared/components/SubjectPreview'
 
+const isServer = typeof window === 'undefined'
+
+function Placeholder({ height, src }) {
+  if (isServer) {
+    return null
+  }
+
+  return (
+    <Box
+      align='center'
+      justify='center'
+      height={height}
+      overflow='hidden'
+      width={'100%'}
+    >
+      <img alt='' role='presentation' src={src} />
+    </Box>
+  )
+}
+
 function RecentSubjects ({
   isLoggedIn = false,
   recents = [],
@@ -19,6 +39,7 @@ function RecentSubjects ({
   const assetPrefix = publicRuntimeConfig.assetPrefix || ''
   const placeholderUrl = `${assetPrefix}/assets/subject-placeholder.png`
   const displayedRecents = recents.slice(0, size)
+  const placeholders = [...Array(size - displayedRecents.length)]
 
   return (
     <ContentBox title={t('Classify.RecentSubjects.title', { projectName })}>
@@ -49,20 +70,13 @@ function RecentSubjects ({
             />
           )
         })}
-        {[...Array(size - displayedRecents.length)].map((placeholder, i) => {
-          return (
-            <Box
-              align='center'
-              justify='center'
-              height={height}
-              key={i}
-              overflow='hidden'
-              width={'100%'}
-            >
-              <img alt='' role='presentation' src={placeholderUrl} />
-            </Box>
-          )
-        })}
+        {placeholders.map((placeholder, i) => (
+          <Placeholder
+            key={i}
+            height={height}
+            src={placeholderUrl}
+            />
+        ))}
       </Grid>
     </ContentBox>
   )


### PR DESCRIPTION
Refactor Recents, on the Classify page, so that the placeholder subject is null during SSR.

## Package
app-project

## Linked Issue and/or Talk Post
- closes #3606.

## How to Review
On the Classify page: 
- while logged in, check that #3606 is fixed by looking at recent subjects after leaving and returning to the page.
- while logged out, check that the placeholder images show up.

You can refer to the [Recent Subjects story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/fe-project/index.html?path=/story/project-app-screens-classify-recent-subjects--plain&globals=locale:en;locales.en:English;locales.test:Test+Language) to see how the component should be laid out.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
