### PR TITLE
Project: clear stored User on log out

### DIFF
--- a/packages/app-project/stores/User/User.js
+++ b/packages/app-project/stores/User/User.js
@@ -1,5 +1,5 @@
 import asyncStates from '@zooniverse/async-states'
-import { flow, types } from 'mobx-state-tree'
+import { applySnapshot, flow, types } from 'mobx-state-tree'
 import auth from 'panoptes-client/lib/auth'
 
 import Collections from './Collections'
@@ -33,10 +33,18 @@ const User = types
 
   .actions(self => ({
     clear() {
-      self.id = null
-      self.display_name = null
-      self.login = null
-      self.loadingState = asyncStates.success
+      const loggedOutUser = {
+        id: null,
+        display_name: null,
+        login: null,
+        loadingState: asyncStates.success,
+        personalization: {
+          projectPreferences: {
+            loadingState: asyncStates.success
+          }
+        }
+      }
+      applySnapshot(self, loggedOutUser)
     },
 
     set(user) {


### PR DESCRIPTION
Use `applySnapshot` to clear the stored user on sign out, including collections, recents and personalisation.

## Package
app-project

## Linked Issue and/or Talk Post
- closes #3608.

## How to Review
- Log in and out of a project that you've classified on. Recent subjects should only be displayed while you are logged in.
- Also check that the classifier loads properly for both logged-in and logged-out volunteers.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated

