### PR TITLE
Project App: Refactor naming of mockStore when it's injected as a component prop

### DIFF
--- a/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationConnector.js
+++ b/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationConnector.js
@@ -7,11 +7,10 @@ export const DynamicallyImportedAuthenticationInvitationContainer = dynamic(
   { ssr: false }
 )
 
-function useStores(store) {
+function useStores(mockStore) {
   const stores = useContext(MobXProviderContext)
-  if (!store) {
-    store = stores.store
-  }
+  const store = mockStore || stores.store
+
   const { isLoggedIn } = store.user
   const { sessionCount } = store.user.personalization
   const { isComplete } = store.project
@@ -22,8 +21,8 @@ function useStores(store) {
   }
 }
 
-function AuthenticationInvitationConnector ({ store }) {
-  const { isVisible = false } = useStores(store)
+function AuthenticationInvitationConnector ({ mockStore }) {
+  const { isVisible = false } = useStores(mockStore)
 
   return (
     <DynamicallyImportedAuthenticationInvitationContainer isVisible={isVisible} />

--- a/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationConnector.spec.js
+++ b/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationConnector.spec.js
@@ -22,7 +22,7 @@ describe('Component > AuthenticationInvitationConnector', function () {
 
   before(function () {
     wrapper = shallow(
-      <AuthenticationInvitationConnector store={mockStore.store} />
+      <AuthenticationInvitationConnector mockStore={mockStore.store} />
     )
     componentWrapper = wrapper.find(DynamicallyImportedAuthenticationInvitationContainer)
   })
@@ -39,7 +39,7 @@ describe('Component > AuthenticationInvitationConnector', function () {
     before(function () {
       mockStore.store.project.isComplete = true
       wrapper = shallow(
-        <AuthenticationInvitationConnector store={mockStore.store} />
+        <AuthenticationInvitationConnector mockStore={mockStore.store} />
       )
       componentWrapper = wrapper.find(DynamicallyImportedAuthenticationInvitationContainer)
     })
@@ -56,7 +56,7 @@ describe('Component > AuthenticationInvitationConnector', function () {
   describe('when the user is logged in', function () {
     before(function () {
       mockStore.store.user.isLoggedIn = true
-      wrapper = shallow(<AuthenticationInvitationConnector store={mockStore.store} />)
+      wrapper = shallow(<AuthenticationInvitationConnector mockStore={mockStore.store} />)
       componentWrapper = wrapper.find(DynamicallyImportedAuthenticationInvitationContainer)
     })
 
@@ -72,7 +72,7 @@ describe('Component > AuthenticationInvitationConnector', function () {
   describe('when the session classification count is less than five', function () {
     before(function () {
       mockStore.store.user.personalization.sessionCount = 3
-      wrapper = shallow(<AuthenticationInvitationConnector store={mockStore.store} />)
+      wrapper = shallow(<AuthenticationInvitationConnector mockStore={mockStore.store} />)
       componentWrapper = wrapper.find(DynamicallyImportedAuthenticationInvitationContainer)
     })
 

--- a/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.js
+++ b/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.js
@@ -5,11 +5,10 @@ import { useTranslation } from 'next-i18next'
 import NavLink from '@shared/components/NavLink'
 import GenericAnnouncement from '../GenericAnnouncement'
 
-function useStores(store) {
+function useStores(mockStore) {
   const stores = useContext(MobXProviderContext)
-  if (!store) {
-    store = stores.store
-  }
+  const store = mockStore || stores.store
+
   // TODO: Add a boolean that returns the state of the existence of a results page
   const { baseUrl, isComplete } = store.project
 
@@ -19,12 +18,12 @@ function useStores(store) {
   }
 }
 
-function FinishedAnnouncementConnector ({ store }) {
+function FinishedAnnouncementConnector ({ mockStore }) {
   const { t } = useTranslation('components')
   const { 
     baseUrl = '',
     isVisible = false
-  } = useStores(store)
+  } = useStores(mockStore)
   const announcement = t('Announcements.FinishedAnnouncement.announcement')
   const link = {
     href: `${baseUrl}/about/results`,

--- a/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.spec.js
+++ b/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.spec.js
@@ -19,7 +19,7 @@ describe('Component > FinishedAnnouncementConnector', function () {
 
   before(function () {
     wrapper = shallow(
-      <FinishedAnnouncementConnector store={mockStore.store} theme={zooTheme} />
+      <FinishedAnnouncementConnector mockStore={mockStore.store} theme={zooTheme} />
     )
     componentWrapper = wrapper.find(GenericAnnouncement)
   })
@@ -32,7 +32,7 @@ describe('Component > FinishedAnnouncementConnector', function () {
     expect(componentWrapper).to.have.lengthOf(0)
     mockStore.store.project.isComplete = true
     wrapper = shallow(
-      <FinishedAnnouncementConnector store={mockStore.store} theme={zooTheme} />
+      <FinishedAnnouncementConnector mockStore={mockStore.store} theme={zooTheme} />
     )
     componentWrapper = wrapper.find(GenericAnnouncement)
     expect(componentWrapper).to.have.lengthOf(1)

--- a/packages/app-project/src/components/Announcements/components/ProjectAnnouncement/ProjectAnnouncementConnector.js
+++ b/packages/app-project/src/components/Announcements/components/ProjectAnnouncement/ProjectAnnouncementConnector.js
@@ -3,11 +3,9 @@ import { useContext } from 'react'
 
 import GenericAnnouncement from '../GenericAnnouncement'
 
-function useStores(store) {
+function useStores(mockStore) {
   const stores = useContext(MobXProviderContext)
-  if (!store) {
-    store = stores.store
-  }
+  const store = mockStore || stores.store
   const { announcement } = store.project.configuration
   const {
     dismissProjectAnnouncementBanner,
@@ -21,12 +19,12 @@ function useStores(store) {
   }
 }
 
-function ProjectAnnouncementConnector ({ store, ...props }) {
+function ProjectAnnouncementConnector ({ mockStore, ...props }) {
   const { 
     announcement = '',
     dismissBanner,
     isVisible = false
-  } = useStores(store)
+  } = useStores(mockStore)
 
   return (isVisible && announcement)
     ? <GenericAnnouncement

--- a/packages/app-project/src/components/Announcements/components/ProjectAnnouncement/ProjectAnnouncementConnector.spec.js
+++ b/packages/app-project/src/components/Announcements/components/ProjectAnnouncement/ProjectAnnouncementConnector.spec.js
@@ -3,8 +3,6 @@ import sinon from 'sinon'
 import { ProjectAnnouncementConnector } from './ProjectAnnouncementConnector'
 import GenericAnnouncement from '../GenericAnnouncement'
 
-
-
 describe('Component > ProjectAnnouncementConnector', function () {
   let wrapper
   let componentWrapper
@@ -25,7 +23,7 @@ describe('Component > ProjectAnnouncementConnector', function () {
   }
 
   before(function () {
-    wrapper = shallow(<ProjectAnnouncementConnector store={mockStore.store} />)
+    wrapper = shallow(<ProjectAnnouncementConnector mockStore={mockStore.store} />)
     componentWrapper = wrapper.find(GenericAnnouncement)
   })
 
@@ -37,7 +35,7 @@ describe('Component > ProjectAnnouncementConnector', function () {
     expect(wrapper.html()).to.be.null()
     expect(componentWrapper).to.have.lengthOf(0)
     mockStore.store.ui.showAnnouncement = true
-    wrapper = shallow(<ProjectAnnouncementConnector store={mockStore.store} />)
+    wrapper = shallow(<ProjectAnnouncementConnector mockStore={mockStore.store} />)
     componentWrapper = wrapper.find(GenericAnnouncement)
     expect(componentWrapper).to.have.lengthOf(1)
   })

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
@@ -31,15 +31,15 @@ function storeMapper(store) {
   }
 }
 
-function useStores(store) {
+function useStores(mockStore) {
   const stores = useContext(MobXProviderContext)
-  store = store || stores.store
+  const store = mockStore || stores.store
   return storeMapper(store)
 }
 
 function ProjectHeaderContainer({
   className = '',
-  store
+  mockStore
 }) {
   const {
     availableLocales,
@@ -48,7 +48,7 @@ function ProjectHeaderContainer({
     isLoggedIn,
     projectName,
     slug
-  } = useStores(store)
+  } = useStores(mockStore)
   const { t } = useTranslation('components')
 
   function getNavLinks (isLoggedIn, baseUrl, defaultWorkflow) {

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
@@ -21,7 +21,7 @@ describe('Component > ProjectHeaderContainer', function () {
       }
     }
     wrapper = shallow(
-      <ProjectHeaderContainer store={mockStore} />
+      <ProjectHeaderContainer mockStore={mockStore} />
     )
     projectHeader = wrapper.find(ProjectHeader)
   })
@@ -64,7 +64,7 @@ describe('Component > ProjectHeaderContainer', function () {
         }
       }
       wrapper = shallow(
-        <ProjectHeaderContainer store={mockStore} />
+        <ProjectHeaderContainer mockStore={mockStore} />
       )
       const projectHeader = wrapper.find(ProjectHeader)
 
@@ -91,7 +91,7 @@ describe('Component > ProjectHeaderContainer', function () {
       }
       wrapper = shallow(
         <ProjectHeaderContainer
-          store={mockStore}
+          mockStore={mockStore}
         />
       )
       const projectHeader = wrapper.find(ProjectHeader)

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperConnector.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperConnector.js
@@ -1,15 +1,12 @@
 import { MobXProviderContext, observer } from 'mobx-react'
-import { func, string, shape } from 'prop-types'
+import { func, string } from 'prop-types'
 import { useContext } from 'react'
-import asyncStates from '@zooniverse/async-states'
 
 import ClassifierWrapper from './ClassifierWrapper'
 
-function useStore(store) {
+function useStore(mockStore) {
   const stores = useContext(MobXProviderContext)
-  if (!store) {
-    store = stores.store
-  }
+  const store = mockStore || stores.store
   const {
     appLoadingState,
     project,
@@ -46,7 +43,7 @@ function useStore(store) {
   />
   ```
 */
-function ClassifierWrapperConnector({ store, ...props }) {
+function ClassifierWrapperConnector({ mockStore, ...props }) {
   const {
     appLoadingState,
     collections,
@@ -55,7 +52,7 @@ function ClassifierWrapperConnector({ store, ...props }) {
     recents,
     user,
     yourStats
-  } = useStore(store)
+  } = useStore(mockStore)
 
   return (
     <ClassifierWrapper

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperConnector.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapperConnector.spec.js
@@ -6,43 +6,43 @@ import ClassifierWrapperConnector from './ClassifierWrapperConnector'
 
 describe('Component > ClassifierWrapperConnector', function () {
   let wrapper
-  let store
+  let mockStore
 
   describe('after logging in', function () {
     before(function () {
-      store = initStore(true, {
+      mockStore = initStore(true, {
         user: {
           id: '1',
           loadingState: asyncStates.success,
           login: 'testUser'
         }
       })
-      wrapper = shallow(<ClassifierWrapperConnector store={store} />)
+      wrapper = shallow(<ClassifierWrapperConnector mockStore={mockStore} />)
     })
 
     describe('classifier wrapper props', function () {
       it('should include collections', function () {
-        expect(wrapper.props().collections).to.equal(store.user.collections)
+        expect(wrapper.props().collections).to.equal(mockStore.user.collections)
       })
 
       it('should include recents', function () {
-        expect(wrapper.props().recents).to.equal(store.user.recents)
+        expect(wrapper.props().recents).to.equal(mockStore.user.recents)
       })
 
       it('should include your personal stats', function () {
-        expect(wrapper.props().yourStats).to.equal(store.user.personalization)
+        expect(wrapper.props().yourStats).to.equal(mockStore.user.personalization)
       })
 
       it('should include the project', function () {
-        expect(wrapper.props().project).to.deep.equal(store.project)
+        expect(wrapper.props().project).to.deep.equal(mockStore.project)
       })
 
       it('should include the logged-in user', function () {
-        expect(wrapper.props().user).to.equal(store.user)
+        expect(wrapper.props().user).to.equal(mockStore.user)
       })
 
       it('should include the theme mode', function () {
-        expect(wrapper.props().mode).to.equal(store.ui.mode)
+        expect(wrapper.props().mode).to.equal(mockStore.ui.mode)
       })
     })
   })

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalConnector.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalConnector.js
@@ -3,11 +3,9 @@ import PropTypes from 'prop-types'
 import { MobXProviderContext, observer } from 'mobx-react'
 import WorkflowAssignmentModalContainer from './WorkflowAssignmentModalContainer'
 
-function useStore (store) {
+function useStore (mockStore) {
   const stores = useContext(MobXProviderContext)
-  if (!store) {
-    store = stores.store
-  }
+  const store = mockStore || stores.store
 
   return {
     assignedWorkflowID: store.user.personalization.projectPreferences.settings?.workflow_id,
@@ -15,11 +13,11 @@ function useStore (store) {
   }
 }
 
-function WorkflowAssignmentModalConnector ({ currentWorkflowID, store, ...rest }) {
+function WorkflowAssignmentModalConnector ({ currentWorkflowID, mockStore, ...rest }) {
   const {
     assignedWorkflowID = '',
     promptAssignment
-  } = useStore(store)
+  } = useStore(mockStore)
 
   return (
     <WorkflowAssignmentModalContainer

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalConnector.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModalConnector.spec.js
@@ -22,7 +22,7 @@ describe('Component > WorkflowAssignmentModalConnector', function () {
         }
       }
     }
-    wrapper = shallow(<WorkflowAssignmentModalConnector currentWorkflowID='555' className='test' store={mockStore.store} />)
+    wrapper = shallow(<WorkflowAssignmentModalConnector currentWorkflowID='555' className='test' mockStore={mockStore.store} />)
   })
 
   after(function () {

--- a/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelectorConnector.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelectorConnector.js
@@ -3,11 +3,9 @@ import { useContext } from 'react'
 
 import WorkflowSelector from './WorkflowSelector'
 
-function useStores(store) {
+function useStores(mockStore) {
   const stores = useContext(MobXProviderContext)
-  if (!store) {
-    store = stores.store
-  }
+  const store = mockStore || stores.store
 
   return {
     uppLoaded: store.user.personalization.projectPreferences.isLoaded,
@@ -18,14 +16,14 @@ function useStores(store) {
   }
 }
 
-function WorkflowSelectorConnector({ store, ...props }) {
+function WorkflowSelectorConnector({ mockStore, ...props }) {
   const {
     uppLoaded,
     uppSettings,
     userReadyState,
     workflowAssignmentEnabled = false,
     workflowDescription
-  } = useStores(store)
+  } = useStores(mockStore)
   const assignedWorkflowID = uppSettings?.workflow_id || ''
   return (
     <WorkflowSelector

--- a/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelectorConnector.spec.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelectorConnector.spec.js
@@ -28,7 +28,7 @@ describe('Component > Hero > WorkflowSelector > WorkflowSelectorConnector', func
     workflows = [{ id: '5' }]
     wrapper = shallow(
       <WorkflowSelectorConnector
-        store={mockStore.store}
+        mockStore={mockStore.store}
         workflows={workflows}
       />
     )


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
This is a follow-up to unit test refactoring started in #3571.

## Describe your changes

A mocked store object is injected as a prop for several components in a testing environment. I've refactored the naming of `mockStore` to make it clear this is not a prop normally passed to a component in the production app.

## How to Review

This is mostly a refactor for our unit tests, so tests should be passing locally and on Github. The General UX checklist with i-fancy-cats is also a good review tool to check that all project pages (Home, About, Classify) load without error.

I'll make another PR with the same refactor for lib-classifier.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook