### PR TITLE
Classifier: Refactor naming of mockStore when it's injected as a component prop

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Banners/Banners.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/Banners.js
@@ -7,8 +7,8 @@ import SubjectSetProgressBanner from './components/SubjectSetProgressBanner'
 import WorkflowIsFinishedBanner from './components/WorkflowIsFinishedBanner'
 import UserHasFinishedWorkflowBanner from './components/UserHasFinishedWorkflowBanner'
 
-function useStores(stores) {
-  const { classifierStore } = stores ?? React.useContext(MobXProviderContext)
+function useStores(mockStores) {
+  const { classifierStore } = mockStores ?? React.useContext(MobXProviderContext)
   return {
     project: classifierStore.projects.active,
     subject: classifierStore.subjects.active,
@@ -17,8 +17,8 @@ function useStores(stores) {
   }
 }
 
-function Banners({ stores }) {
-  const { project, subject, subjects, workflow } = useStores(stores)
+function Banners({ mockStores }) {
+  const { project, subject, subjects, workflow } = useStores(mockStores)
   const subjectNumber = subject?.priority ?? -1
 
   const hasIndexedSubjects = workflow?.hasIndexedSubjects

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/Banners.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/Banners.spec.js
@@ -76,9 +76,9 @@ describe('Component > Banners', function () {
 
   describe('while the subject is loading', function () {
     before(function () {
-      const stores = buildMocks({})
-      stores.classifierStore.subjects.reset()
-      wrapper = shallow(<Banners stores={stores} />)
+      const mockStores = buildMocks({})
+      mockStores.classifierStore.subjects.reset()
+      wrapper = shallow(<Banners mockStores={mockStores} />)
     })
 
     it('should not render', function () {
@@ -88,8 +88,8 @@ describe('Component > Banners', function () {
 
   describe('default banners', function () {
     before(function () {
-      const stores = buildMocks({})
-      wrapper = shallow(<Banners stores={stores} />)
+      const mockStores = buildMocks({})
+      wrapper = shallow(<Banners mockStores={mockStores} />)
     })
 
     it('should render without crashing', function () {
@@ -115,7 +115,7 @@ describe('Component > Banners', function () {
 
   describe('with #priority metadata', function () {
     before(function () {
-      const stores = buildMocks({
+      const mockStores = buildMocks({
         metadata: {
           ['#priority']: 37
         }
@@ -126,7 +126,7 @@ describe('Component > Banners', function () {
         prioritized: true,
         subjectSet: '1'
       })
-      wrapper = shallow(<Banners stores={stores} />)
+      wrapper = shallow(<Banners mockStores={mockStores} />)
     })
 
     it('should render without crashing', function () {
@@ -140,7 +140,7 @@ describe('Component > Banners', function () {
 
   describe('with priority metadata', function () {
     before(function () {
-      const stores = buildMocks({
+      const mockStores = buildMocks({
         metadata: {
           priority: 37
         }
@@ -151,7 +151,7 @@ describe('Component > Banners', function () {
         prioritized: true,
         subjectSet: '1'
       })
-      wrapper = shallow(<Banners stores={stores} />)
+      wrapper = shallow(<Banners mockStores={mockStores} />)
     })
 
     it('should render without crashing', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
@@ -1,13 +1,11 @@
 import React, { useState } from 'react'
 import { observer } from 'mobx-react'
-import PropTypes from 'prop-types'
 import asyncStates from '@zooniverse/async-states'
 import { useTranslation } from 'react-i18next'
 import useSWR from 'swr'
 
 import { withFeatureFlag } from '@helpers'
 import { usePanoptesAuth, usePanoptesUser, useStores } from '@hooks'
-import { getBearerToken } from '@store/utils'
 import QuickTalk from './QuickTalk'
 
 import getDefaultTalkBoard from './helpers/getDefaultTalkBoard'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopupContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopupContainer.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types'
-import { observer, MobXProviderContext } from 'mobx-react'
+import { observer } from 'mobx-react'
 import SubTaskPopup from './SubTaskPopup'
 
 export default observer(function SubTaskPopupContainer ({

--- a/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
@@ -1,5 +1,5 @@
 import { MobXProviderContext } from 'mobx-react'
-import React, { Component, forwardRef, useContext } from 'react'
+import React, { Component, forwardRef } from 'react'
 
 function withKeyZoom (WrappedComponent) {
   const ALLOWED_TAGS = ['svg', 'button', 'g', 'rect']


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
This is a follow-up to work started in #3571 and #3616.

## Describe your changes

A mocked store object is injected as a prop for several components in a testing environment. I've refactored the naming of mockStore to make it clear this is not a prop normally passed to a component in the production app.

I also included a few linting cleanups.

## How to Review
This is mostly a refactor for our unit tests, so tests should be passing locally and on Github. The Classify page for any project should load without error (i-fancy-cats linked below has a banner). Storybook should also load as expected.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook