### PR TITLE
Drawing tool tests: wrap marks in <svg>

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/Circle/Circle.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Circle/Circle.spec.js
@@ -18,7 +18,11 @@ describe('Circle tool', function () {
   })
 
   it('should render a Circle with the coordinates provided', () => {
-    render(<Circle active mark={mark} scale={1} />)
+    render(
+      <svg xmlns='http://www.w3.org/2000/svg'>
+        <Circle active mark={mark} scale={1} />
+      </svg>
+    )
 
     expect(screen.getByTestId('circle-element'))
       .to.have.attr('r')
@@ -28,7 +32,11 @@ describe('Circle tool', function () {
   it('should change the radius when drag handle is moved', async () => {
     const user = userEvent.setup()
 
-    render(<Circle active mark={mark} scale={1} />)
+    render(
+      <svg xmlns='http://www.w3.org/2000/svg'>
+        <Circle active mark={mark} scale={1} />
+      </svg>
+    )
 
     expect(mark.x_center).to.equal(200)
     expect(mark.y_center).to.equal(200)

--- a/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.spec.js
@@ -8,7 +8,11 @@ describe('Drawing tools > DeleteButton', function () {
   const mark = Point.create({ id: 'point1', x: 50, y: 50, toolType: 'point' })
 
   it('should render without crashing', function () {
-    render(<DeleteButton label='Delete' mark={mark} />)
+    render(
+      <svg xmlns='http://www.w3.org/2000/svg'>
+        <DeleteButton label='Delete' mark={mark} />
+      </svg>
+    )
 
     const deleteButton = screen.getByRole('button', {
       name: /delete/i

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Rectangle/Rectangle.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Rectangle/Rectangle.spec.js
@@ -19,7 +19,11 @@ describe('Rectangle tool', () => {
   })
 
   it('should render a rectangle with correct dimensions and position', () => {
-    render(<Rectangle mark={mark} scale={1} />)
+    render(
+      <svg xmlns='http://www.w3.org/2000/svg'>
+        <Rectangle mark={mark} scale={1} />
+      </svg>
+    )
 
     const rectElement = screen.getByTestId('rectangle-element')
 
@@ -30,7 +34,11 @@ describe('Rectangle tool', () => {
   })
 
   it('should render an active rectangle with four drag handles', () => {
-    render(<Rectangle active mark={mark} scale={1} />)
+    render(
+      <svg xmlns='http://www.w3.org/2000/svg'>
+        <Rectangle active mark={mark} scale={1} />
+      </svg>
+    )
 
     expect(screen.getByTestId('rect-dragHandle1')).to.exist
     expect(screen.getByTestId('rect-dragHandle2')).to.exist
@@ -41,7 +49,11 @@ describe('Rectangle tool', () => {
   it('should resize when a drag handle is moved', async () => {
     const user = userEvent.setup()
 
-    render(<Rectangle active mark={mark} scale={1} />)
+    render(
+      <svg xmlns='http://www.w3.org/2000/svg'>
+        <Rectangle active mark={mark} scale={1} />
+      </svg>
+    )
 
     const rectElement = screen.getByTestId('rectangle-element')
 


### PR DESCRIPTION
Drawn marks are SVG, so need to be wrapped in an `<svg>` element in order to render without errors.

## Package
lib-classifier/src/plugins/drawingTools

## Linked Issue and/or Talk Post
- closes #3624.

## How to Review
Run the tests for `Circle`, `Rectangle` or `DeleteButton` and check for errors.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser
