### PR TITLE
Video subjects: Add touch styles

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
@@ -126,6 +126,10 @@ function SingleVideoViewerContainer({
 
   const canvas = transformLayer?.current
   const interactionLayerScale = clientWidth / videoWidth
+  const svgStyle = {}
+  if (enableDrawing) {
+    svgStyle.touchAction = 'pinch-zoom'
+  }
 
   return (
     <>
@@ -151,6 +155,7 @@ function SingleVideoViewerContainer({
                       ref={interactionLayerSVG}
                       focusable
                       onKeyDown={onKeyDown}
+                      style={svgStyle}
                       tabIndex={0}
                       viewBox={`0 0 ${videoWidth} ${videoHeight}`}
                       xmlns='http://www.w3.org/2000/svg'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Box } from 'grommet'
-import React, { useState, useRef } from 'react'
+import { MobXProviderContext } from 'mobx-react'
+import React, { useContext, useState, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import asyncStates from '@zooniverse/async-states'
 
@@ -24,8 +25,13 @@ const DrawingLayer = styled.div`
   cursor: default;
 `
 
+function useDrawingTask() {
+  const store = useContext(MobXProviderContext)?.classifierStore
+  const drawingTasks = store?.workflowSteps.findTasksByType('drawing')
+  return !!drawingTasks?.length
+}
+
 function SingleVideoViewerContainer({
-  enableInteractionLayer = false,
   loadingState = asyncStates.initialized,
   onError = () => true,
   onReady = () => true,
@@ -46,6 +52,8 @@ function SingleVideoViewerContainer({
   const transformLayer = useRef()
 
   const { t } = useTranslation('components')
+
+  const enableInteractionLayer = useDrawingTask()
 
   /* ==================== load subject ==================== */
 


### PR DESCRIPTION
When drawing is enabled for video subjects, style the root SVG element with `touch-action: pinch-zoom;` so that dragging doesn't scroll the screen.

## Package
lib-classifier

## Linked Issue and/or Talk Post
- #3535.
- #3534.

## How to Review
On an iOS device, or Chrome on Android, you should find that you can draw a rectangle on a Solar Jets subject without the window scrolling when you drag the shape.
https://frontend.preview.zooniverse.org/projects/eostlund/video-project/classify/workflow/16843

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated