### PR TITLE
Classifier tasks: Copy task.required for legacy dropdowns

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/dropdown-simple/models/helpers/legacyDropdownAdapter/legacyDropdownAdapter.js
+++ b/packages/lib-classifier/src/plugins/tasks/dropdown-simple/models/helpers/legacyDropdownAdapter/legacyDropdownAdapter.js
@@ -6,6 +6,7 @@ export function legacyDropdownAdapter(snapshot) {
     newSnapshot.allowCreate = menu.allowCreate
     newSnapshot.help = snapshot.help
     newSnapshot.instruction = snapshot.instruction
+    newSnapshot.required = menu.required
     newSnapshot.taskKey = snapshot.taskKey
     newSnapshot.type = 'dropdown-simple'
     const options = menu.options['*']

--- a/packages/lib-classifier/src/plugins/tasks/dropdown-simple/models/helpers/legacyDropdownAdapter/legacyDropdownAdapter.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/dropdown-simple/models/helpers/legacyDropdownAdapter/legacyDropdownAdapter.spec.js
@@ -33,6 +33,7 @@ describe('SimpleDropdownTask > panoptesAdapter', function () {
         selects: [
           {
             allowCreate: false,
+            required: true,
             options: {
               '*': [
                 { label: 'One', value: 1 },
@@ -52,6 +53,7 @@ describe('SimpleDropdownTask > panoptesAdapter', function () {
         type: 'dropdown-simple',
         help: 'This is some task help',
         instruction: 'This is the task instruction',
+        required: true,
         options: [ 'One', 'Two' ]
       })
     })
@@ -69,6 +71,7 @@ describe('SimpleDropdownTask > panoptesAdapter', function () {
         selects: [
           {
             allowCreate: false,
+            required: true,
             options: {
               '*': [
                 { label: 'One', value: 1 },
@@ -79,6 +82,7 @@ describe('SimpleDropdownTask > panoptesAdapter', function () {
           },
           {
             allowCreate: false,
+            required: false,
             options: {
               '*': [
                 { label: 'Red', value: 1 },


### PR DESCRIPTION
Copy the `required` flag across when creating simple dropdown tasks from legacy dropdown tasks.

## Package
lib-classifier/src/plugins/tasks/simple-dropdown

## Linked Issue and/or Talk Post
- fixes #3639 

## How to Review
The dropdown task should require an answer now, on this test workflow.
https://frontend.preview.zooniverse.org/projects/markbouslog/test-project-mb/classify/workflow/3852

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated

