### PR TITLE
Refactor LightCurveViewer height with defined value before d3 svg defined

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -429,10 +429,12 @@ class LightCurveViewer extends Component {
     const { onKeyDown } = props
 
     const container = this.svgContainer.current
+    const containerHeight = `${container.clientHeight}px`
+
     this.d3svg = d3.select(container)
       .append('svg')
       .attr('class', 'light-curve-viewer')
-      .attr('height', '100%')
+      .attr('height', containerHeight)
       .attr('focusable', true)
       .attr('tabindex', 0)
       .on('keydown', onKeyDown)


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
In Safari v16 the light curve viewer height expands infinitely, similar to issue related to #3119 and #3139 .

## Describe your changes
- create const for container height as string with px (i.e. `"700px"`), which I believe represents the 100% height value intended
- set d3 generated svg height attribute with new const for container height

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - to confirm bug:
    - with Safari v16, load https://www.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess/classify/workflow/11235, note light curve subject viewer expands infinitely
  - to confirm fix:
    - lib-classifier - https://local.zooniverse.org:8080/?project=1862&workflow=3317
    - app-project - https://local.zooniverse.org:3000/projects/nora-dot-test/planet-finders-beta/classify/workflow/3317

- What user actions should my reviewer step through to review this PR?
  - in Safari v16 confirm light curve viewer doesn't infinitely expand / loads as expected
  - in earlier Safari versions, Chrome, and Firefox confirm light curve viewer to loads as expected
- Which storybook stories should be reviewed? I don't think helpful, but http://localhost:6006/?path=/story/subject-viewers-lightcurveviewer--light-theme&globals=locale:en;locales.en:English;locales.test:Test+Language , however, I can't confirm the bug on [deployed storybook](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/story/subject-viewers-lightcurveviewer--light-theme&globals=locale:en;locales.en:English;locales.test:Test+Language), likely because of height restrictions set by the storybook layout?
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated