### PR TITLE
Revert "Refactor LightCurveViewer height with defined value before d3 svg defined"

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -429,12 +429,10 @@ class LightCurveViewer extends Component {
     const { onKeyDown } = props
 
     const container = this.svgContainer.current
-    const containerHeight = `${container.clientHeight}px`
-
     this.d3svg = d3.select(container)
       .append('svg')
       .attr('class', 'light-curve-viewer')
-      .attr('height', containerHeight)
+      .attr('height', '100%')
       .attr('focusable', true)
       .attr('tabindex', 0)
       .on('keydown', onKeyDown)


### PR DESCRIPTION
Reverts zooniverse/front-end-monorepo#3646

Cuts off x-axis:
![Screen Shot 2022-09-14 at 4 34 23 PM](https://user-images.githubusercontent.com/12118751/190271538-f0fa3b19-bb5a-4870-bc53-7543200a8355.png)
