### PR TITLE
Add max height to light curve viewer Box

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -655,6 +655,7 @@ class LightCurveViewer extends Component {
       <Box
         className='light-curve-viewer'
         fill
+        height={{ max: '500px' }}
         ref={this.svgContainer}
       >
         <ReactResizeDetector


### PR DESCRIPTION
## Package
- lib-classifier, LightCurveSubjectViewer

## Linked Issue and/or Talk Post
- Towards #3654 

## Describe your changes
- adds max height to Grommet Box that wraps light curve viewer svg

_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - to confirm bug:
    - with Safari v16, load https://www.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess/classify/workflow/11235, note light curve subject viewer expands infinitely
  - to confirm fix:
    - lib-classifier - https://local.zooniverse.org:8080/?project=1862&workflow=3317?demo=true
    - app-project - https://local.zooniverse.org:3000/projects/nora-dot-test/planet-finders-beta/classify/workflow/3317?demo=true

- What user actions should my reviewer step through to review this PR?
  - in Safari v16 confirm light curve viewer doesn't infinitely expand / loads as expected
  - in earlier Safari versions, Chrome, and Firefox confirm light curve viewer to loads as expected
- Which storybook stories should be reviewed? I don't think helpful, but http://localhost:6006/?path=/story/subject-viewers-lightcurveviewer--light-theme&globals=locale:en;locales.en:English;locales.test:Test+Language , however, I can't confirm the bug on [deployed storybook](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/story/subject-viewers-lightcurveviewer--light-theme&globals=locale:en;locales.en:English;locales.test:Test+Language), likely because of height restrictions set by the storybook layout?
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no
# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated