### PR TITLE
Classifier: Refactor LightCurveViewer to use Chart component

### DIFF
--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -37,7 +37,6 @@
     "mobx-utils": "~6.0.4",
     "react-i18next": "~11.18.0",
     "react-player": "~2.10.0",
-    "react-resize-detector": "~7.1.1",
     "swr": "~1.3.0",
     "valid-url": "~1.0.9"
   },

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -55,10 +55,6 @@ class LightCurveViewer extends Component {
     this.xAxis = null
     this.yAxis = null
 
-    // Chart dimensions, updated on drawChart()
-    this.chartWidth = 100
-    this.chartHeight = 100
-
     // Each Annotation is represented as a single D3 Brush
     this.annotationBrushes = [] // This keeps track of the annotation-brushes in existence, including the DEFAULT brush (the interface brush, for creating new annotations) that exists even when there are no annotations.
 
@@ -136,9 +132,6 @@ class LightCurveViewer extends Component {
     const container = this.svgContainer.current
     const { height, width } = container?.getBoundingClientRect()
     if (height && width) {
-      this.chartWidth = width
-      this.chartHeight = height
-
       /*
       Limit zoom panning to x-direction (yMin=0, yMax=0), and don't allow panning
       beyond the start-ish (xMin=0-margin) or end-ish (xMax=width+margin) of the

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewerContainer.js
@@ -1,5 +1,6 @@
 import asyncStates from '@zooniverse/async-states'
 import { extent } from 'd3'
+import { Box } from 'grommet'
 import { zip } from 'lodash'
 import PropTypes from 'prop-types'
 import React, { useMemo, useRef } from 'react'
@@ -103,23 +104,25 @@ export function LightCurveViewerContainer({
   }
 
   return (
-    <LightCurveViewer
-      addAnnotation={addAnnotation}
-      annotation={annotation}
-      currentTask={activeDataVisTask}
-      dataExtent={dataExtent}
-      dataPoints={dataPoints}
-      drawFeedbackBrushes={drawFeedbackBrushes}
-      enableAnnotate={enableAnnotate}
-      enableMove={enableMove}
-      feedback={feedback}
-      forwardRef={viewer}
-      interactionMode={interactionMode}
-      onKeyDown={onKeyDown}
-      setOnPan={setOnPan}
-      setOnZoom={setOnZoom}
-      toolIndex={activeToolIndex}
-    />
+    <Box width='100%' height='500px'>
+      <LightCurveViewer
+        addAnnotation={addAnnotation}
+        annotation={annotation}
+        currentTask={activeDataVisTask}
+        dataExtent={dataExtent}
+        dataPoints={dataPoints}
+        drawFeedbackBrushes={drawFeedbackBrushes}
+        enableAnnotate={enableAnnotate}
+        enableMove={enableMove}
+        feedback={feedback}
+        forwardRef={viewer}
+        interactionMode={interactionMode}
+        onKeyDown={onKeyDown}
+        setOnPan={setOnPan}
+        setOnZoom={setOnZoom}
+        toolIndex={activeToolIndex}
+      />
+    </Box>
   )
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/index.js
@@ -1,0 +1,5 @@
+export { default as Background } from './Background'
+export { default as Chart } from './Chart'
+export { default as SVGImage } from './SVGImage'
+export { default as VisXZoom } from './VisXZoom'
+export { default as ZoomEventLayer } from './ZoomEventLayer'

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,18 +147,6 @@
     resolve "^1.14.2"
     semver "^6.1.2"
 
-"@babel/helper-define-polyfill-provider@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.2.tgz#bd10d0aca18e8ce012755395b05a79f45eca5073"
-  integrity sha512-r9QJJ+uDWrd+94BSPcP6/de67ygLtvVy6cK4luE6MOuDsZIdoaPBnfSpbO/+LTifjPckbKXRuI9BB/Z2/y3iTg==
-  dependencies:
-    "@babel/helper-compilation-targets" "^7.17.7"
-    "@babel/helper-plugin-utils" "^7.16.7"
-    debug "^4.1.1"
-    lodash.debounce "^4.0.8"
-    resolve "^1.14.2"
-    semver "^6.1.2"
-
 "@babel/helper-define-polyfill-provider@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz#8612e55be5d51f0cd1f36b4a5a83924e89884b7a"
@@ -5507,7 +5495,7 @@ babel-plugin-named-exports-order@^0.0.2:
   resolved "https://registry.yarnpkg.com/babel-plugin-named-exports-order/-/babel-plugin-named-exports-order-0.0.2.tgz#ae14909521cf9606094a2048239d69847540cb09"
   integrity sha512-OgOYHOLoRK+/mvXU9imKHlG6GkPLYrUCvFXG/CM93R/aNNO8pOOF4aS+S8CCHMDQoNSeiOYEZb/G6RwL95Jktw==
 
-babel-plugin-polyfill-corejs2@^0.3.2, babel-plugin-polyfill-corejs2@^0.3.3:
+babel-plugin-polyfill-corejs2@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz#5d1bd3836d0a19e1b84bbf2d9640ccb6f951c122"
   integrity sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==
@@ -5524,14 +5512,6 @@ babel-plugin-polyfill-corejs3@^0.1.0:
     "@babel/helper-define-polyfill-provider" "^0.1.5"
     core-js-compat "^3.8.1"
 
-babel-plugin-polyfill-corejs3@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.3.tgz#d7e09c9a899079d71a8b670c6181af56ec19c5c7"
-  integrity sha512-zKsXDh0XjnrUEW0mxIHLfjBfnXSMr5Q/goMe/fxpQnLm07mcOZiIZHBNWCMx60HmdvjxfXcalac0tfFg0wqxyw==
-  dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.3.2"
-    core-js-compat "^3.21.0"
-
 babel-plugin-polyfill-corejs3@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz#56ad88237137eade485a71b52f72dbed57c6230a"
@@ -5540,7 +5520,7 @@ babel-plugin-polyfill-corejs3@^0.6.0:
     "@babel/helper-define-polyfill-provider" "^0.3.3"
     core-js-compat "^3.25.1"
 
-babel-plugin-polyfill-regenerator@^0.4.0, babel-plugin-polyfill-regenerator@^0.4.1:
+babel-plugin-polyfill-regenerator@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz#390f91c38d90473592ed43351e801a9d3e0fd747"
   integrity sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==
@@ -6846,14 +6826,7 @@ copy-to-clipboard@^3.3.1:
   dependencies:
     toggle-selection "^1.0.6"
 
-core-js-compat@^3.21.0, core-js-compat@^3.25.1, core-js-compat@^3.8.1:
-  version "3.25.1"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.25.1.tgz#6f13a90de52f89bbe6267e5620a412c7f7ff7e42"
-  integrity sha512-pOHS7O0i8Qt4zlPW/eIFjwp+NrTPx+wTL0ctgI2fHn31sZOq89rDsmtc/A2vAX7r6shl+bmVI+678He46jgBlw==
-  dependencies:
-    browserslist "^4.21.3"
-
-core-js-compat@^3.25.1:
+core-js-compat@^3.25.1, core-js-compat@^3.8.1:
   version "3.25.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.25.1.tgz#6f13a90de52f89bbe6267e5620a412c7f7ff7e42"
   integrity sha512-pOHS7O0i8Qt4zlPW/eIFjwp+NrTPx+wTL0ctgI2fHn31sZOq89rDsmtc/A2vAX7r6shl+bmVI+678He46jgBlw==


### PR DESCRIPTION
- add named exports to `@viewers/components/SVGComponents`.
- Use the `Chart` component as the root `svg` element of `LightCurveViewer`.
- refactor `LightCurveViewer` to use `height` and `width` from the SVG's client bounding rectangle.
- draw the SVG chart on component mount.
- wrap `LightCurveViewer` in a fixed-height box, like `ScatterPlotViewer`.

## Package
lib-classifier

- Closes #3654.

## How to Review
Dev classifier: https://localhost:8080/?project=nora-dot-eisner/planet-hunters-tess&env=production&demo=true

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
