### PR TITLE
Edit LightCurveViewer saveBrushesToAnnotations props reference

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -242,11 +242,11 @@ class LightCurveViewer extends Component {
       .map((raw) => {
         const x = (raw.minX + raw.maxX) / 2
         const width = Math.abs(raw.maxX - raw.minX)
-        const toolType = props.currentTask.tools[toolIndex].type
+        const toolType = this.props.currentTask.tools[toolIndex].type
         return { x, width, tool: toolIndex, zoomLevelOnCreation: raw.zoomLevelOnCreation, toolType }
       })
 
-    props.addAnnotation(currentTask, annotations)
+    this.props.addAnnotation(currentTask, annotations)
   }
 
   /*

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -242,11 +242,11 @@ class LightCurveViewer extends Component {
       .map((raw) => {
         const x = (raw.minX + raw.maxX) / 2
         const width = Math.abs(raw.maxX - raw.minX)
-        const toolType = this.props.currentTask.tools[toolIndex].type
+        const toolType = currentTask.tools[toolIndex].type
         return { x, width, tool: toolIndex, zoomLevelOnCreation: raw.zoomLevelOnCreation, toolType }
       })
 
-    this.props.addAnnotation(currentTask, annotations)
+    addAnnotation?.(currentTask, annotations)
   }
 
   /*

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/LightCurveViewer/LightCurveViewer.js
@@ -232,6 +232,7 @@ class LightCurveViewer extends Component {
    */
   saveBrushesToAnnotations () {
     const {
+      addAnnotation,
       currentTask,
       toolIndex
     } = this.props


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- iteration on #3661, related to #3654

## Describe your changes
- edits reference to `props` to `this.props` per refactors in #3661

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - confirm bug (no `annotation.values` after drawing a few transits): https://frontend.preview.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess/classify/workflow/11235?demo=true
  - confirm fix (`annotation.values` includes transits drawn): https://local.zooniverse.org:8080/?project=1862&workflow=3317
- What user actions should my reviewer step through to review this PR?
  - draw a few transits (**in demo mode if on production project!**), click Done, note classification logged in console
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated