### PR TITLE
Projects: add Admin Mode

### DIFF
--- a/packages/app-project/public/locales/en/components.json
+++ b/packages/app-project/public/locales/en/components.json
@@ -104,6 +104,7 @@
     "talk": "Talk",
     "collect": "Collect",
     "recents": "Recents",
+    "admin": "Admin page",
     "ApprovedIcon": {
       "title": "Zooniverse Approved"
     },

--- a/packages/app-project/src/components/AdminContainer/AdminContainer.js
+++ b/packages/app-project/src/components/AdminContainer/AdminContainer.js
@@ -1,0 +1,16 @@
+import { AdminCheckbox } from '@zooniverse/react-components'
+import { MobXProviderContext, observer } from 'mobx-react'
+import { useContext } from 'react'
+
+function useAdminUser() {
+  const stores = useContext(MobXProviderContext)
+  return stores?.store.user.isAdmin
+}
+
+function AdminContainer({ checked, onChange }) {
+  const isAdmin = useAdminUser()
+
+  return isAdmin ? <AdminCheckbox onChange={onChange} checked={checked} /> : null
+}
+
+export default observer(AdminContainer)

--- a/packages/app-project/src/components/AdminContainer/AdminContainer.spec.js
+++ b/packages/app-project/src/components/AdminContainer/AdminContainer.spec.js
@@ -1,0 +1,68 @@
+import zooTheme from '@zooniverse/grommet-theme'
+import { render, screen } from '@testing-library/react'
+import { Grommet } from 'grommet'
+import { Provider } from 'mobx-react'
+import { applySnapshot } from 'mobx-state-tree'
+
+import initStore from '@stores'
+import AdminContainer from './AdminContainer.js'
+
+describe('Components > AdminContainer', function () {
+  function withStore(snapshot) {
+    const store = initStore(false)
+    applySnapshot(store, snapshot)
+    
+    return function Wrapper({ children }) {
+      return (
+        <Grommet theme={zooTheme}>
+          <Provider store={store}>
+            {children}
+          </Provider>
+        </Grommet>
+      )
+    }
+  }
+
+  const project = {
+    id: '1',
+    strings: {
+      display_name: 'Test Project'
+    }
+  }
+
+  describe('without a logged-in user', function () {
+    it('should render nothing', function () {
+      const wrapper = withStore({ project })
+      render(<AdminContainer />, { wrapper })
+      const adminToggle = screen.queryByRole('checkbox', { name: 'Admin Mode' })
+      expect(adminToggle).to.be.null()
+    })
+  })
+
+  describe('with a regular user', function () {
+    it('should render nothing', function () {
+      const user = {
+        id: '1',
+        login: 'ordinaryVolunteer'
+      }
+      const wrapper = withStore({ project, user })
+      render(<AdminContainer />, { wrapper })
+      const adminToggle = screen.queryByRole('checkbox', { name: 'Admin Mode' })
+      expect(adminToggle).to.be.null()
+    })
+  })
+
+  describe('with an admin user', function () {
+    it('should show an admin toggle', function () {
+      const user = {
+        id: '2',
+        admin: true,
+        login: 'zooAdmin'
+      }
+      const wrapper = withStore({ project, user })
+      render(<AdminContainer />, { wrapper })
+      const adminToggle = screen.queryByRole('checkbox', { name: 'Admin Mode' })
+      expect(adminToggle).to.be.ok()
+    })
+  })
+})

--- a/packages/app-project/src/components/AdminContainer/index.js
+++ b/packages/app-project/src/components/AdminContainer/index.js
@@ -1,0 +1,1 @@
+export { default } from './AdminContainer.js'

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
@@ -33,16 +33,14 @@ function storeMapper(store) {
   }
 }
 
-function useStores(mockStore) {
+function useStores() {
   const stores = useContext(MobXProviderContext)
-  const store = mockStore || stores.store
-  return storeMapper(store)
+  return storeMapper(stores.store)
 }
 
 function ProjectHeaderContainer({
   adminMode = false,
-  className = '',
-  mockStore
+  className = ''
 }) {
   const {
     availableLocales,
@@ -52,7 +50,7 @@ function ProjectHeaderContainer({
     isLoggedIn,
     projectName,
     slug
-  } = useStores(mockStore)
+  } = useStores()
   const { t } = useTranslation('components')
 
   function getNavLinks (isLoggedIn, baseUrl, defaultWorkflow) {
@@ -107,6 +105,9 @@ function ProjectHeaderContainer({
 }
 
 ProjectHeaderContainer.propTypes = {
+  /** Zooniverse admin mode */
+  adminMode: boolean,
+  /** Optional CSS classes */
   className: string
 }
 

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.js
@@ -17,6 +17,7 @@ function storeMapper(store) {
       slug
     },
     user: {
+      isAdmin,
       isLoggedIn
     }
   } = store
@@ -25,6 +26,7 @@ function storeMapper(store) {
     availableLocales,
     defaultWorkflow,
     inBeta,
+    isAdmin,
     isLoggedIn,
     projectName,
     slug
@@ -38,6 +40,7 @@ function useStores(mockStore) {
 }
 
 function ProjectHeaderContainer({
+  adminMode = false,
   className = '',
   mockStore
 }) {
@@ -45,6 +48,7 @@ function ProjectHeaderContainer({
     availableLocales,
     defaultWorkflow,
     inBeta,
+    isAdmin,
     isLoggedIn,
     projectName,
     slug
@@ -76,6 +80,13 @@ function ProjectHeaderContainer({
       links.push({
         href: `${baseUrl}/recents`,
         text: t('ProjectHeader.recents')
+      })
+    }
+
+    if (isLoggedIn && isAdmin && adminMode) {
+      links.push({
+        href: `/admin/project_status/${slug}`,
+        text: t('ProjectHeader.admin')
       })
     }
 

--- a/packages/app-project/src/components/index.js
+++ b/packages/app-project/src/components/index.js
@@ -1,0 +1,8 @@
+export { default as AdminContainer } from './AdminContainer'
+export { default as Announcements } from './Announcements'
+export { default as AuthModal } from './AuthModal'
+export { default as Head } from './Head'
+export { default as ProjectHeader } from './ProjectHeader'
+export { default as ProjectName } from './ProjectName'
+export { default as ThemeModeToggle } from './ThemeModeToggle'
+export { default as ZooHeaderWrapper } from './ZooHeaderWrapper'

--- a/packages/app-project/src/hooks/index.js
+++ b/packages/app-project/src/hooks/index.js
@@ -1,3 +1,4 @@
+export { default as useAdminMode } from './useAdminMode.js'
 export { default as useUserFavourites } from './useUserFavourites.js'
 export { default as usePanoptesAuth } from './usePanoptesAuth.js'
 export { default as usePanoptesUser } from './usePanoptesUser.js'

--- a/packages/app-project/src/hooks/useAdminMode.js
+++ b/packages/app-project/src/hooks/useAdminMode.js
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+
+const isBrowser = typeof window !== 'undefined'
+const localStorage = isBrowser ? window.localStorage : null
+
+export default function useAdminMode() {
+  const adminFlag = localStorage?.getItem('adminFlag')
+  const [adminState, setAdminState] = useState(adminFlag)
+  const adminMode = adminFlag && adminState
+  
+  function toggleAdmin() {
+    let newAdminState = !adminState
+    setAdminState(newAdminState)
+    if (newAdminState) {
+      localStorage?.setItem('adminFlag', true)
+    } else {
+      localStorage?.removeItem('adminFlag')
+    }
+  }
+  
+  return { adminMode, toggleAdmin }
+}

--- a/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.js
+++ b/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.js
@@ -37,7 +37,7 @@ function ProjectHomePage ({
   const locale = router?.locale
 
   return (
-    <Box border={(inBeta) ? { color: 'brand', size: 'medium' } : false}>
+    <Box data-testid='project-home-page' border={(inBeta) ? { color: 'brand', size: 'medium' } : false}>
       <Media at='default'>
         <ZooHeaderWrapper />
         <ProjectHeader adminMode={adminMode} />

--- a/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.js
+++ b/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.js
@@ -1,20 +1,24 @@
 import { Box, Grid } from 'grommet'
 import { arrayOf, bool, shape, string } from 'prop-types'
 import styled from 'styled-components'
-import { ZooFooter } from '@zooniverse/react-components'
+import { AdminCheckbox, ZooFooter } from '@zooniverse/react-components'
 import { useRouter } from 'next/router'
 
+import { useAdminMode } from '@hooks'
+import {
+  AdminContainer,
+  Announcements,
+  ProjectHeader,
+  ThemeModeToggle,
+  ZooHeaderWrapper,
+} from '@components'
 import Hero from './components/Hero'
 import MessageFromResearcher from './components/MessageFromResearcher'
 import AboutProject from './components/AboutProject'
 import ConnectWithProject from '@shared/components/ConnectWithProject'
 import ProjectStatistics from '@shared/components/ProjectStatistics'
 import ZooniverseTalk from './components/ZooniverseTalk'
-import ThemeModeToggle from '@components/ThemeModeToggle'
-import { Media } from '../../shared/components/Media'
-import Announcements from '@components/Announcements'
-import ProjectHeader from '@components/ProjectHeader'
-import ZooHeaderWrapper from '@components/ZooHeaderWrapper'
+import { Media } from '@shared/components/Media'
 
 const FullHeightBox = styled(Box)`
   min-height: 98vh;
@@ -28,13 +32,15 @@ function ProjectHomePage ({
   inBeta,
   workflows
 }) {
+  const { adminMode, toggleAdmin } = useAdminMode()
   const router = useRouter()
   const locale = router?.locale
+
   return (
     <Box border={(inBeta) ? { color: 'brand', size: 'medium' } : false}>
       <Media at='default'>
         <ZooHeaderWrapper />
-        <ProjectHeader />
+        <ProjectHeader adminMode={adminMode} />
         <Announcements />
         <Hero workflows={workflows} />
         <Box margin='small' gap='small'>
@@ -50,7 +56,7 @@ function ProjectHomePage ({
       <Media greaterThan='default'>
         <FullHeightBox margin={{ bottom: 'large' }}>
           <ZooHeaderWrapper />
-          <ProjectHeader />
+          <ProjectHeader adminMode={adminMode} />
           <Announcements />
           <RemainingHeightBox>
             <Hero workflows={workflows} isWide={true} />
@@ -76,7 +82,10 @@ function ProjectHomePage ({
           </Box>
         </Box>
       </Media>
-      <ZooFooter locale={locale} />
+      <ZooFooter
+        adminContainer={<AdminContainer onChange={toggleAdmin} checked={adminMode} />}
+        locale={locale}
+      />
     </Box>
   )
 }

--- a/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.spec.js
@@ -1,30 +1,138 @@
-import { shallow } from 'enzyme'
-import sinon from 'sinon'
+import zooTheme from '@zooniverse/grommet-theme'
+import { within } from '@testing-library/dom'
+import { render, screen } from '@testing-library/react'
+import { Grommet } from 'grommet'
+import { Provider } from 'mobx-react'
+import { applySnapshot } from 'mobx-state-tree'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
 
-import ProjectHomePage from './ProjectHomePage'
+import initStore from '@stores'
+import ProjectHomePage from './ProjectHomePage.js'
 
 describe('Component > ProjectHomePage', function () {
-  let wrapper
+  this.timeout(5000)
+
+  let homePage
+  let adminToggle
+
+  const routerMock = {
+    asPath: 'projects/foo/bar',
+    push: () => {},
+    prefetch: () => new Promise((resolve, reject) => {}),
+    query: { owner: 'foo', project: 'bar' }
+  }
+
+  function withStore(snapshot) {
+    const store = initStore(false)
+    applySnapshot(store, snapshot)
+
+    return function Wrapper({ children }) {
+      return (
+        <RouterContext.Provider value={routerMock}>
+          <Grommet theme={zooTheme}>
+            <Provider store={store}>
+              {children}
+            </Provider>
+          </Grommet>
+        </RouterContext.Provider>
+      )
+    }
+  }
 
   before(function () {
-    wrapper = shallow(<ProjectHomePage />)
-  })
-
-  it('should render without crashing', function () {
-    expect(wrapper).to.be.ok()
+    const snapshot = {
+      project: {
+        configuration: {
+          languages: ['en']
+        },
+        slug: 'Foo/Bar',
+        strings: {
+          display_name: 'Foobar'
+        },
+        links: {
+          active_workflows: ['1']
+        }
+      }
+    }
+    render(<ProjectHomePage />, { wrapper: withStore(snapshot) })
+    homePage = screen.getByTestId('project-home-page')
+    const zooFooter = within(homePage).getByRole('contentinfo')
+    adminToggle = within(zooFooter).queryByRole('checkbox', { name: 'Admin Mode' })
   })
 
   it('should not render a border for the wrapping Box container', function () {
-    expect(wrapper.props().border).to.be.false()
+    expect(homePage).to.be.ok()
+    const { border } = window.getComputedStyle(homePage)
+    expect(border).to.be.empty()
+  })
+
+  it('should not show the admin toggle', function () {
+    expect(adminToggle).to.be.null()
   })
 
   describe('with a project in beta', function () {
     before(function () {
-      wrapper = shallow(<ProjectHomePage inBeta />)
+      const snapshot = {
+        project: {
+          configuration: {
+            languages: ['en']
+          },
+          slug: 'Foo/Bar',
+          strings: {
+            display_name: 'Foobar'
+          },
+          links: {
+            active_workflows: ['1']
+          }
+        }
+      }
+      render(<ProjectHomePage inBeta />, { wrapper: withStore(snapshot) })
+      homePage = screen.getByTestId('project-home-page')
     })
 
     it('should render a border for the wrapping Box container', function () {
-      expect(wrapper.props().border).to.deep.equal({ color: 'brand', size: 'medium' })
+      expect(homePage).to.be.ok()
+      const { border } = window.getComputedStyle(homePage)
+      expect(border).to.equal('4px solid #00979d')
+    })
+  })
+
+  describe('with a logged-in admin user', function () {
+    before(function () {
+      const snapshot = {
+        project: {
+          configuration: {
+            languages: ['en']
+          },
+          slug: 'Foo/Bar',
+          strings: {
+            display_name: 'Foobar'
+          },
+          links: {
+            active_workflows: ['1']
+          }
+        },
+        user: {
+          id: '1',
+          admin: true,
+          login: 'zooVolunteer'
+        }
+      }
+      render(<ProjectHomePage />, { wrapper: withStore(snapshot) })
+      homePage = screen.getByTestId('project-home-page')
+      const zooFooter = within(homePage).getByRole('contentinfo')
+      adminToggle = within(zooFooter).getByRole('checkbox', { name: 'Admin Mode' })
+    })
+
+    // TODO: add a border to pages in admin mode.
+    it('should not have a border', function () {
+      expect(homePage).to.be.ok()
+      const { border } = window.getComputedStyle(homePage)
+      expect(border).to.be.empty()
+    })
+
+    it('should show the admin toggle in the footer', function () {
+      expect(adminToggle).to.be.ok()
     })
   })
 })

--- a/packages/app-project/src/shared/components/StandardLayout/StandardLayout.js
+++ b/packages/app-project/src/shared/components/StandardLayout/StandardLayout.js
@@ -3,24 +3,32 @@ import { Box } from 'grommet'
 import { ZooFooter } from '@zooniverse/react-components'
 import { useRouter } from 'next/router'
 
-import Announcements from '@components/Announcements'
-import ProjectHeader from '@components/ProjectHeader'
-import ZooHeaderWrapper from '@components/ZooHeaderWrapper'
+import { useAdminMode } from '@hooks'
+import {
+  AdminContainer,
+  Announcements,
+  ProjectHeader,
+  ZooHeaderWrapper
+} from '@components'
 
 function StandardLayout ({
   children,
   inBeta,
 }) {
+  const { adminMode, toggleAdmin } = useAdminMode()
   const router = useRouter()
   const locale = router?.locale
 
   return (
     <Box border={(inBeta) ? { color: 'brand', size: 'medium' } : false}>
       <ZooHeaderWrapper />
-      <ProjectHeader />
+      <ProjectHeader adminMode={adminMode} />
       <Announcements />
       {children}
-      <ZooFooter locale={locale} />
+      <ZooFooter
+        adminContainer={<AdminContainer onChange={toggleAdmin} checked={adminMode} />}
+        locale={locale}
+      />
     </Box>
   )
 }

--- a/packages/app-project/src/shared/components/StandardLayout/StandardLayout.spec.js
+++ b/packages/app-project/src/shared/components/StandardLayout/StandardLayout.spec.js
@@ -1,17 +1,95 @@
-import { shallow } from 'enzyme'
-import * as Router from 'next/router'
-import sinon from 'sinon'
+import zooTheme from '@zooniverse/grommet-theme'
+import { within } from '@testing-library/dom'
+import { render, screen } from '@testing-library/react'
+import { Grommet } from 'grommet'
+import { Provider } from 'mobx-react'
+import { applySnapshot } from 'mobx-state-tree'
 
-import StandardLayout from './StandardLayout'
+import initStore from '@stores'
+import StandardLayout from './StandardLayout.js'
 
 describe('Component > StandardLayout', function () {
-  let wrapper
+  let adminToggle
+  let zooHeader
+  let zooFooter
+
+  function withStore(snapshot) {
+    const store = initStore(false)
+    applySnapshot(store, snapshot)
+
+    return function Wrapper({ children }) {
+      return (
+        <Grommet theme={zooTheme}>
+          <Provider store={store}>
+            {children}
+          </Provider>
+        </Grommet>
+      )
+    }
+  }
 
   before(function () {
-    wrapper = shallow(<StandardLayout />)
+    const snapshot = {
+      project: {
+        configuration: {
+          languages: ['en']
+        },
+        slug: 'Foo/Bar',
+        strings: {
+          display_name: 'Foobar'
+        },
+        links: {
+          active_workflows: ['1']
+        }
+      }
+    }
+    render(<StandardLayout />, { wrapper: withStore(snapshot)})
+    zooHeader = screen.getByRole('banner')
+    zooFooter = screen.getByRole('contentinfo')
+    adminToggle = within(zooFooter).queryByRole('checkbox', { name: 'Admin Mode' })
   })
 
-  it('should render without crashing', function () {
-    expect(wrapper).to.be.ok()
+  it('should show the Zooniverse header', function () {
+    expect(zooHeader).to.be.ok()
+  })
+
+  it('should show the Zooniverse footer', function () {
+    expect(zooFooter).to.be.ok()
+  })
+
+  it('should not show the admin toggle', function () {
+    expect(adminToggle).to.be.null()
+  })
+
+  describe('with a logged-in admin', function () {
+    before(function () {
+      const snapshot = {
+        project: {
+          configuration: {
+            languages: ['en']
+          },
+          slug: 'Foo/Bar',
+          strings: {
+            display_name: 'Foobar'
+          },
+          links: {
+            active_workflows: ['1']
+          }
+        },
+        user: {
+          id: '1',
+          admin: true,
+          login: 'zooVolunteer'
+        }
+      }
+      render(<StandardLayout />, { wrapper: withStore(snapshot)})
+      zooHeader = screen.getByRole('banner')
+      zooFooter = screen.getByRole('contentinfo')
+      adminToggle = within(zooFooter).getByRole('checkbox', { name: 'Admin Mode' })
+    })
+
+    it('should show the admin toggle', function () {
+      expect(adminToggle).to.be.ok()
+    })
   })
 })

--- a/packages/app-project/stores/User/User.js
+++ b/packages/app-project/stores/User/User.js
@@ -10,6 +10,7 @@ import numberString from '@stores/types/numberString'
 
 const User = types
   .model('User', {
+    admin: types.optional(types.boolean, false),
     avatar_src: types.maybeNull(types.string),
     collections: types.optional(Collections, {}),
     display_name: types.maybeNull(types.string),
@@ -24,6 +25,10 @@ const User = types
   .views(self => ({
     get displayName () {
       return self.display_name
+    },
+
+    get isAdmin() {
+      return self.admin
     },
 
     get isLoggedIn () {
@@ -48,10 +53,11 @@ const User = types
     },
 
     set(user) {
-      self.id = user.id
-      self.display_name = user.display_name
-      self.login = user.login
-      self.loadingState = asyncStates.success
+      const userSnapshot = {
+        ...user,
+        loadingState: asyncStates.success
+      }
+      applySnapshot(self, userSnapshot)
       self.recents.fetch()
       self.collections.searchCollections({
         favorite: false,


### PR DESCRIPTION
- add `user.admin` to logged-in users.
- add a `useAdminMode` hook to manage admin state across project pages.
- add `AdminContainer` to the footer, which manages the 'Admin Mode' toggle button.
- add the project admin link to project navigation.
- add named exports for project components to make imports easier to write.
- add RTL tests for the project header, project home page and standard layout.

## Package
app-project

## How to Review
- Logged in as an admin: the admin toggle should be enabled in the page footer. When it's on, the project admin page link is added to the project navigation.
- Logged out, or logged in as a non-admin user, you should just see the regular project.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
