### PR TITLE
Markdownz: catch parsing errors

### DIFF
--- a/packages/lib-react-components/src/Markdownz/Markdownz.js
+++ b/packages/lib-react-components/src/Markdownz/Markdownz.js
@@ -111,26 +111,32 @@ class Markdownz extends React.Component {
     const remarkReactComponents = Object.assign({}, componentMappings, components)
     const remarkSettings = Object.assign({}, settings)
 
-    const markdown = remark()
-      .data('settings', remarkSettings)
-      .use(emoji)
-      .use(remarkSubSuper)
-      .use(externalLinks)
-      .use(footnotes, { inlineNotes: true })
-      .use(ping, {
-        ping: (resource, symbol) => this.shouldResourceBeLinkable(resource, symbol), // We could support passing in a prop to call a function here
-        pingSymbols: [at, hashtag, subjectSymbol],
-        resourceURL: (resource, symbol) => this.buildResourceURL(resource, symbol)
-      })
-      .use(toc)
-      .use(remark2react, { remarkReactComponents })
-      .processSync(newChildren).result
+    try {
+      const markdown = remark()
+        .data('settings', remarkSettings)
+        .use(emoji)
+        .use(remarkSubSuper)
+        .use(externalLinks)
+        .use(footnotes, { inlineNotes: true })
+        .use(ping, {
+          ping: (resource, symbol) => this.shouldResourceBeLinkable(resource, symbol), // We could support passing in a prop to call a function here
+          pingSymbols: [at, hashtag, subjectSymbol],
+          resourceURL: (resource, symbol) => this.buildResourceURL(resource, symbol)
+        })
+        .use(toc)
+        .use(remark2react, { remarkReactComponents })
+        .processSync(newChildren).result
 
-    return (
-      <React.Fragment>
-        {markdown}
-      </React.Fragment>
-    )
+      return (
+        <React.Fragment>
+          {markdown}
+        </React.Fragment>
+      )
+    } catch (error) {
+      console.error(error)
+      return <p>{error.message}</p>
+    }
+    
   }
 }
 


### PR DESCRIPTION
Add a try/catch block to Markdownz so that markdown parsing errors don't crash the parent app, making the page unusable. When there is a parsing error, the error message is displayed instead of the original content.

<img width="1241" alt="The Maria Edgeworth Letters team page, showing 'document is not defined' instead of the page content." src="https://user-images.githubusercontent.com/59547/191247590-7b0c7923-fc93-413a-ac12-61a084607194.png">

## Package
lib-react-components

## Linked Issue and/or Talk Post
- closes #3673.


## How to Review
With these changes, markdown errors in the Maria Edgeworth Letters team page will be caught during server-side rendering, and the page content should at least show correctly when React runs in the browser and renders the content for a second time.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
