### PR TITLE
Freehand lines: optimise annotation size

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/README.md
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/README.md
@@ -60,12 +60,11 @@ A user can use the `Undo` feature after a path has been closed!
 
 ## Path Classification Data Structure
 
-When a `<path>` is sent to our api, its sent as an array of objects where each object is an x and y coordinate.
+When a `<path>` is sent to our api, its sent as an array of x coordinates and an array of y coordinates.
 
 ```json
-points: [
-  {x: 345, y:160},
-  {x: 350, y:165},
-  {x: 355, y:170}
-]
+{
+  "pathX": "[ 345, 350, 355… ]",
+  "pathY": "[ 160, 165, 170… ]"
+}
 ```


### PR DESCRIPTION
A couple of optimisations to reduce the size of marks produced by the freehand line tool.
- Replace `line.points` with `line.pathX` and `line.pathY`, which are flat arrays of the line's `x` and `y` coordinates.
- Set a minimum distance of 0.5px between adjacent points when appending to the line, or inserting new points.
- refactor the calculation of the SVG path with `useMemo`.

## Linked Issues
- https://github.com/zooniverse/Panoptes-Front-End/issues/4423
- https://github.com/zooniverse/Panoptes-Front-End/issues/3551

## Package
lib-classifier/src/plugins/drawingTools/experimental

## How to Review
It's probably best to test this on a real cell from Etch-A-Cell, to try out the drawing tools with a large annotation.
https://localhost:8080/?project=h-spiers/etch-a-cell&workflow=8921&env=production

Alternatively, try out the deployed PR branch here:
https://fe-project-branch.preview.zooniverse.org/projects/h-spiers/etch-a-cell/classify/workflow/8921


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
