### PR TITLE
Refactor Markdownz as a functional component

### DIFF
--- a/packages/lib-react-components/src/Markdownz/Markdownz.js
+++ b/packages/lib-react-components/src/Markdownz/Markdownz.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 import {
   Anchor,
@@ -25,127 +25,126 @@ import Media from '../Media'
 import withThemeContext from '../helpers/withThemeContext'
 import theme from './theme'
 
-const hashtag = '#'
-const at = '@'
-const subjectSymbol = '^S'
+const HASHTAG = '#'
+const AT = '@'
+const SUBJECT_SYMBOL = '^S'
 
-class Markdownz extends React.Component {
-  buildResourceURL (resource, symbol) {
-    if (!resource) return ''
-    const { baseURI, projectSlug } = this.props
-    const baseURL = (projectSlug) ? `${baseURI}/projects/${projectSlug}` : baseURI
+export const RESTRICTED_USERNAMES = ['admins', 'moderators', 'researchers', 'scientists', 'team', 'support']
 
-    if (symbol === hashtag) return (projectSlug) ? `${baseURL}/talk/tag/${resource}` : `${baseURL}/talk/search?query=%23${resource}`
-    if (symbol === at) return `${baseURL}/users/${resource}`
-    if (symbol === subjectSymbol && projectSlug) return `${baseURL}/talk/subjects/${resource}`
+// Support image resizing, video, and audio using markdown's image syntax
+export function renderMedia(nodeProps) {
+  let width, height
+  const imgSizeRegex = /=(\d+(%|px|em|rem|vw)?)x(\d+(%|px|em|rem|vh)?)?/
+  let alt = nodeProps.alt
+  const src = nodeProps.src
+  const match = alt.match(imgSizeRegex)
 
-    return ''
+  if (match && match.length > 0) {
+    width = parseInt(match[1])
+    height = parseInt(match[3])
+    alt = alt.split(match[0])[0].trim()
+    if (width && !height) height = 'none'
   }
 
-  shouldResourceBeLinkable (resource, symbol) {
-    const { projectSlug, restrictedUserNames } = this.props
-
-    if (symbol === at) return !restrictedUserNames.includes(resource)
-    if (symbol === subjectSymbol) return !!projectSlug
-
-    return true
-  }
-
-  // Support image resizing, video, and audio using markdown's image syntax
-  renderMedia (nodeProps) {
-    let width, height
-    const imgSizeRegex = /=(\d+(%|px|em|rem|vw)?)x(\d+(%|px|em|rem|vh)?)?/
-    let alt = nodeProps.alt
-    const src = nodeProps.src
-    const match = alt.match(imgSizeRegex)
-
-    if (match && match.length > 0) {
-      width = parseInt(match[1])
-      height = parseInt(match[3])
-      alt = alt.split(match[0])[0].trim()
-      if (width && !height) height = 'none'
-    }
-
-    if (src) return <Media alt={alt} height={height} src={src} width={width} />
-    return null
-  }
-
-  replaceImageString (img, altText, imageURL, imageSize) {
-    return `![${altText} ${imageSize}](${imageURL})`
-  }
-
-  render () {
-    const { children, components, settings } = this.props
-
-    if (!children) return null
-
-    if (Object.keys(components).includes('img')) {
-      console.warn('Overriding the rendering function for the img tag may break the syntax support for image resizing and using image markup for video and audio. Are you sure you want to do this?')
-    }
-
-    const imageRegex = /!\[([^\]]+?)\]\((https:\/\/[^)]+?) (=\d+?(|%|px|em|rem|vw)x\d*?(|%|px|em|rem|vh))\)/g
-    const newChildren = children.replace(imageRegex, this.replaceImageString)
-
-    const componentMappings = {
-      a: Anchor,
-      h1: (nodeProps) => <Heading level='1'>{nodeProps.children}</Heading>,
-      h2: (nodeProps) => <Heading level='2'>{nodeProps.children}</Heading>,
-      h3: (nodeProps) => <Heading level='3'>{nodeProps.children}</Heading>,
-      h4: (nodeProps) => <Heading level='4'>{nodeProps.children}</Heading>,
-      h5: (nodeProps) => <Heading level='5'>{nodeProps.children}</Heading>,
-      h6: (nodeProps) => <Heading level='6'>{nodeProps.children}</Heading>,
-      hr: () => <hr style={{ width: '100%' }} />,
-      img: (nodeProps) => this.renderMedia(nodeProps),
-      p: Paragraph,
-      span: Text,
-      table: Table,
-      tfoot: TableFooter,
-      thead: TableHeader,
-      tbody: TableBody,
-      td: TableCell,
-      tr: TableRow,
-      ol: (nodeProps) => <ol style={{ fontSize: '14px', marginTop: 0 }}>{nodeProps.children}</ol>,
-      ul: (nodeProps) => <ul style={{ fontSize: '14px', marginTop: 0 }}>{nodeProps.children}</ul>
-    }
-
-    const remarkReactComponents = Object.assign({}, componentMappings, components)
-    const remarkSettings = Object.assign({}, settings)
-
-    try {
-      const markdown = remark()
-        .data('settings', remarkSettings)
-        .use(emoji)
-        .use(remarkSubSuper)
-        .use(externalLinks)
-        .use(footnotes, { inlineNotes: true })
-        .use(ping, {
-          ping: (resource, symbol) => this.shouldResourceBeLinkable(resource, symbol), // We could support passing in a prop to call a function here
-          pingSymbols: [at, hashtag, subjectSymbol],
-          resourceURL: (resource, symbol) => this.buildResourceURL(resource, symbol)
-        })
-        .use(toc)
-        .use(remark2react, { remarkReactComponents })
-        .processSync(newChildren).result
-
-      return (
-        <React.Fragment>
-          {markdown}
-        </React.Fragment>
-      )
-    } catch (error) {
-      console.error(error)
-      return <p>{error.message}</p>
-    }
-    
-  }
+  if (src) return <Media alt={alt} height={height} src={src} width={width} />
+  return null
 }
 
-Markdownz.defaultProps = {
-  baseURI: '',
-  components: {},
-  projectSlug: '',
-  restrictedUserNames: ['admins', 'moderators', 'researchers', 'scientists', 'team', 'support'],
-  settings: {}
+const componentMappings = {
+  a: Anchor,
+  h1: ({ children }) => <Heading level='1'>{children}</Heading>,
+  h2: ({ children }) => <Heading level='2'>{children}</Heading>,
+  h3: ({ children }) => <Heading level='3'>{children}</Heading>,
+  h4: ({ children }) => <Heading level='4'>{children}</Heading>,
+  h5: ({ children }) => <Heading level='5'>{children}</Heading>,
+  h6: ({ children }) => <Heading level='6'>{children}</Heading>,
+  hr: () => <hr style={{ width: '100%' }} />,
+  img: renderMedia,
+  p: Paragraph,
+  span: Text,
+  table: Table,
+  tfoot: TableFooter,
+  thead: TableHeader,
+  tbody: TableBody,
+  td: TableCell,
+  tr: TableRow,
+  ol: ({ children }) => <ol style={{ fontSize: '14px', marginTop: 0 }}>{children}</ol>,
+  ul: ({ children }) => <ul style={{ fontSize: '14px', marginTop: 0 }}>{children}</ul>
+}
+
+export function buildResourceURL(baseURI, projectSlug, resource, symbol) {
+  if (!resource) return ''
+  const baseURL = (projectSlug) ? `${baseURI}/projects/${projectSlug}` : baseURI
+
+  if (symbol === HASHTAG) return (projectSlug) ? `${baseURL}/talk/tag/${resource}` : `${baseURL}/talk/search?query=%23${resource}`
+  if (symbol === AT) return `${baseURL}/users/${resource}`
+  if (symbol === SUBJECT_SYMBOL && projectSlug) return `${baseURL}/talk/subjects/${resource}`
+
+  return ''
+}
+
+export function shouldResourceBeLinkable(restrictedUserNames, projectSlug, resource, symbol) {
+  if (symbol === AT) return !restrictedUserNames.includes(resource)
+  if (symbol === SUBJECT_SYMBOL) return !!projectSlug
+  return true
+}
+
+export function replaceImageString(img, altText, imageURL, imageSize) {
+  return `![${altText} ${imageSize}](${imageURL})`
+}
+
+function Markdownz({
+  baseURI = '',
+  children,
+  components = {},
+  projectSlug = '',
+  restrictedUserNames = RESTRICTED_USERNAMES,
+  settings = {}
+}) {
+  if (!children) return null
+
+  if (Object.keys(components).includes('img')) {
+    console.warn('Overriding the rendering function for the img tag may break the syntax support for image resizing and using image markup for video and audio. Are you sure you want to do this?')
+  }
+
+  const imageRegex = /!\[([^\]]+?)\]\((https:\/\/[^)]+?) (=\d+?(|%|px|em|rem|vw)x\d*?(|%|px|em|rem|vh))\)/g
+  const newChildren = children.replace(imageRegex, replaceImageString)
+
+  const remarkReactComponents = { ...componentMappings, ...components }
+  const remarkSettings = { ...settings }
+
+  const pingCallback = useCallback(
+    (resource, symbol) => shouldResourceBeLinkable(restrictedUserNames, projectSlug, resource, symbol),
+    [restrictedUserNames, projectSlug]
+  )
+  const resourceURL = useCallback(
+    (resource, symbol) => buildResourceURL(baseURI, projectSlug, resource, symbol),
+    [baseURI, projectSlug]
+  )
+  let markdown = null
+  try {
+    markdown = remark()
+      .data('settings', remarkSettings)
+      .use(emoji)
+      .use(remarkSubSuper)
+      .use(externalLinks)
+      .use(footnotes, { inlineNotes: true })
+      .use(ping, {
+        ping: pingCallback,
+        pingSymbols: [AT, HASHTAG, SUBJECT_SYMBOL],
+        resourceURL
+      })
+      .use(toc)
+      .use(remark2react, { remarkReactComponents })
+      .processSync(newChildren).result
+  } catch (error) {
+    markdown = error.message
+  }
+  return (
+    <React.Fragment>
+      {markdown}
+    </React.Fragment>
+  )
 }
 
 Markdownz.propTypes = {

--- a/packages/lib-react-components/src/Markdownz/Markdownz.spec.js
+++ b/packages/lib-react-components/src/Markdownz/Markdownz.spec.js
@@ -1,7 +1,8 @@
 import React from 'react'
-import { shallow } from 'enzyme'
 import sinon from 'sinon'
 import { Anchor, Paragraph } from 'grommet'
+import { render, screen } from '@testing-library/react'
+
 import Media from '../Media'
 import {
   Markdownz,
@@ -16,27 +17,19 @@ import { markdown } from './helpers/testExamples'
 // TO DO: Add back working snapshots to test the overall HTML output
 // We have to use snapshots with styled-components because of the generated class names
 describe('<Markdownz />', function () {
-  let wrapper
-
-  it('renders without crashing', function () {
-    wrapper = shallow(<Markdownz>{markdown}</Markdownz>)
-    expect(wrapper).to.be.ok()
-  })
-
   it('parses markdown to jsx', function () {
-    wrapper = shallow(<Markdownz>{markdown}</Markdownz>)
-    expect(wrapper.find(Anchor)).to.have.lengthOf(10)
-    expect(wrapper.find(Paragraph)).to.have.lengthOf(17)
+    const { container } = render(<Markdownz>{markdown}</Markdownz>)
+    expect(container.querySelectorAll('a[href]')).to.have.lengthOf(12)
+    expect(container.querySelectorAll('p')).to.have.lengthOf(17)
   })
 
   describe('at-mentions', function () {
     ['srallen', 'am.zooni', 'a-user'].forEach(function (username) {
       describe(username, function () {
-        function findMention (sentence) {
-          wrapper = shallow(<Markdownz>{sentence}</Markdownz>)
-          const pingAnchor = wrapper.find({ href: `/users/${username}` })
-          expect(pingAnchor).to.have.lengthOf(1)
-          expect(pingAnchor.text()).to.equal(`@${username}`)
+        function findMention(sentence) {
+          render(<Markdownz>{sentence}</Markdownz>)
+          const pingAnchor = screen.getByRole('link', { name: `@ ${username}` })
+          expect(pingAnchor.href).to.equal(`https://localhost/users/${username}`)
         }
 
         it('should be recognised at the beginning of a sentence', function () {
@@ -59,10 +52,9 @@ describe('<Markdownz />', function () {
 
   it('correctly parses a subject mention in project context', function () {
     const sentence = `Look at this interesting subject: ^S1234.`
-    wrapper = shallow(<Markdownz projectSlug='zooniverse/snapshot-wakanda'>{sentence}</Markdownz>)
-    const pingAnchor = wrapper.find({ href: '/projects/zooniverse/snapshot-wakanda/talk/subjects/1234' })
-    expect(pingAnchor).to.have.lengthOf(1)
-    expect(pingAnchor.text()).to.equal('^S1234')
+    render(<Markdownz projectSlug='zooniverse/snapshot-wakanda'>{sentence}</Markdownz>)
+    const pingAnchor = screen.getByRole('link', { name: '^S 1234' })
+    expect(pingAnchor.href).to.equal('https://localhost/projects/zooniverse/snapshot-wakanda/talk/subjects/1234')
   })
 
   describe('#buildResourceURL', function () {

--- a/packages/lib-react-components/src/Markdownz/Markdownz.spec.js
+++ b/packages/lib-react-components/src/Markdownz/Markdownz.spec.js
@@ -1,6 +1,4 @@
 import React from 'react'
-import sinon from 'sinon'
-import { Anchor, Paragraph } from 'grommet'
 import { render, screen } from '@testing-library/react'
 
 import Media from '../Media'

--- a/packages/lib-react-components/test/setup.js
+++ b/packages/lib-react-components/test/setup.js
@@ -13,7 +13,7 @@ chai.use(sinonChai)
 global.React = React
 global.expect = chai.expect
 
-const jsdom = new JSDOM('<!doctype html><html><body></body></html>')
+const jsdom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://localhost'})
 const { window } = jsdom
 
 function copyProps (src, target) {


### PR DESCRIPTION
Rewrite `Markdownz` as a functional component and update tests that rely on it being a class.

Remove Enzyme from the tests. 

Where class methods were being tested directly, I rewrote them as pure functions and rewrote the tests to test those functions. 

## Package
lib-react-components

## Linked Issue and/or Talk Post
- follows #3678.

## How to Review
Probably easiest to review this by running the tests and checking the Markdownz stories in the storybook, which seem to comprehensively test expected Markdown support.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [ ] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
