### PR TITLE
Admin mode: admins can load inactive workflows

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -4,6 +4,7 @@ import auth from 'panoptes-client/lib/auth'
 import { bool, func, string, shape } from 'prop-types'
 import asyncStates from '@zooniverse/async-states'
 
+import { useAdminMode } from '@hooks'
 import addQueryParams from '@helpers/addQueryParams'
 import { logToSentry } from '@helpers/logger'
 import ErrorMessage from './components/ErrorMessage'
@@ -35,6 +36,7 @@ export default function ClassifierWrapper({
   workflowID,
   yourStats
 }) {
+  const { adminMode } = useAdminMode()
   const nextRouter = useRouter()
   router = router || nextRouter
   const locale = router?.locale
@@ -92,6 +94,7 @@ export default function ClassifierWrapper({
       const key = userID || 'no-user'
       return (
         <Classifier
+          adminMode={adminMode}
           authClient={authClient}
           cachePanoptesData={cachePanoptesData}
           key={key}

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -10,6 +10,7 @@ import Layout from './components/Layout'
 import ModalTutorial from './components/ModalTutorial'
 
 export default function Classifier({
+  adminMode = false,
   classifierStore,
   locale,
   onError = () => true,
@@ -56,7 +57,8 @@ export default function Classifier({
     }
   }
 
-  const canPreviewWorkflows = projectRoles.indexOf('owner') > -1 ||
+  const canPreviewWorkflows = adminMode && user?.admin ||
+    projectRoles.indexOf('owner') > -1 ||
     projectRoles.indexOf('collaborator') > -1 ||
     projectRoles.indexOf('tester') > -1
 
@@ -122,6 +124,7 @@ export default function Classifier({
 }
 
 Classifier.propTypes = {
+  adminMode: PropTypes.bool,
   classifierStore: PropTypes.object.isRequired,
   locale: PropTypes.string,
   onError: PropTypes.func,

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
@@ -46,6 +46,7 @@ const client = {
 unregisterWorkers('./queue.js')
 
 export default function ClassifierContainer({
+  adminMode = false,
   authClient,
   cachePanoptesData = false,
   locale,
@@ -97,6 +98,7 @@ export default function ClassifierContainer({
         <StrictMode>
           <Provider classifierStore={classifierStore}>
             <Classifier
+              adminMode={adminMode}
               classifierStore={classifierStore}
               locale={locale}
               onError={onError}
@@ -122,6 +124,7 @@ export default function ClassifierContainer({
 }
 
 ClassifierContainer.propTypes = {
+  adminMode: PropTypes.bool,
   authClient: PropTypes.object.isRequired,
   cachePanoptesData: PropTypes.bool,
   locale: PropTypes.string,


### PR DESCRIPTION
- Add admin mode to the classifier.
- Allow admin users to override `canPreviewWorkflows` when admin mode is on.
- Test the classifier for admin users, with and without admin mode enabled.
- refactor some repeated code as functions in the `Classifier` tests.

## Package
app-project
lib-classifier

## How to Review
Admins should have permission to load any workflow on projects where they aren't already a team member. To test this out, you'll need to try loading an inactive workflow on a project that you don't own or collaborate. With admin mode turned off, the workflow won't load but it should load with admin mode turned on.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
