### PR TITLE
Zooniverse-React-Components: Remove Enzyme from ZooFooter

### DIFF
--- a/packages/lib-react-components/src/ZooFooter/ZooFooter.js
+++ b/packages/lib-react-components/src/ZooFooter/ZooFooter.js
@@ -6,10 +6,12 @@ import { useTranslation } from 'react-i18next'
 import '../translations/i18n'
 import i18n from 'i18next'
 
-import LinkList from './components/LinkList'
-import PolicyLinkSection from './components/PolicyLinkSection'
-import LogoAndTagline from './components/LogoAndTagline'
-import SocialAnchor from './components/SocialAnchor'
+import {
+  LinkList,
+  PolicyLinkSection,
+  LogoAndTagline,
+  SocialAnchor
+} from './components'
 
 export const StyledEasterEgg = styled(Image)`
   bottom: 100%;

--- a/packages/lib-react-components/src/ZooFooter/ZooFooter.spec.js
+++ b/packages/lib-react-components/src/ZooFooter/ZooFooter.spec.js
@@ -1,13 +1,43 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { render, screen } from '@testing-library/react'
 
 import ZooFooter from './ZooFooter'
 
-describe('<ZooFooter />', function () {
-  let wrapper
 
-  it('renders without crashing', function () {
-    wrapper = shallow(<ZooFooter />)
-    expect(wrapper).to.be.ok()
+describe('<ZooFooter />', function () {
+  let linkLists, socialLinks, policyNavigation
+
+  const LINK_LISTS = [
+    'About',
+    'Build a Project',
+    'Get Involved',
+    'News',
+    'Projects',
+    'Talk'
+  ]
+
+  const SOCIAL_LINKS = [
+    'facebook',
+    'twitter',
+    'instagram'
+  ]
+
+  before(function () {
+    render(<ZooFooter />)
+    linkLists = LINK_LISTS.map(listTitle => screen.getByRole('list', { name: listTitle})).filter(Boolean)
+    socialLinks = SOCIAL_LINKS.map(linkTitle => screen.getByRole('link', { name: linkTitle})).filter(Boolean)
+    policyNavigation = screen.getByRole('navigation', { name: 'Zooniverse Policies'})
+  })
+
+  it('should containe lists of Zooniverse links', function () {
+    expect(linkLists).to.have.lengthOf(LINK_LISTS.length)
+  })
+
+  it('should contain links to Zooniverse social media', function () {
+    expect(socialLinks).to.have.lengthOf(SOCIAL_LINKS.length)
+  })
+
+  it('should contain links to Zooniverse Policies', function () {
+    expect(policyNavigation).to.exist()
   })
 })

--- a/packages/lib-react-components/src/ZooFooter/components/LinkList/LinkList.js
+++ b/packages/lib-react-components/src/ZooFooter/components/LinkList/LinkList.js
@@ -16,6 +16,7 @@ export default function LinkList ({ className, labels, urls }) {
 
   return (
     <StyledBox
+      aria-label={title.label}
       className={className}
       direction='column'
       pad='none'

--- a/packages/lib-react-components/src/ZooFooter/components/PolicyLinkSection/PolicyLinkSection.js
+++ b/packages/lib-react-components/src/ZooFooter/components/PolicyLinkSection/PolicyLinkSection.js
@@ -1,30 +1,38 @@
 import { Anchor, Box } from 'grommet'
 import { arrayOf, string } from 'prop-types'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 import zipLabelsAndUrls from '../../helpers/zipLabelsAndUrls'
 import SpacedText from '../../../SpacedText'
 import withResponsiveContext from '../../../helpers/withResponsiveContext'
 
-function PolicyLinkSection (props) {
-  const { labels, screenSize, urls } = props
+function PolicyLinkSection ({
+  labels = [],
+  screenSize,
+  urls = []
+}) {
+  const { t } = useTranslation()
   const links = zipLabelsAndUrls(labels, urls)
   const direction = screenSize === 'small' ? 'column' : 'row'
   return (
-    <Box as='nav' direction={direction} gap='medium' role='presentation'>
-
-      {links.length > 0 && links.map(link => (
-        <Anchor
-          href={link.url}
-          key={link.url}
-          size='small'
-        >
-          <SpacedText weight='bold'>
-            {link.label}
-          </SpacedText>
-        </Anchor>
-      ))}
-
+    <Box
+      aria-label={t('ZooFooter.zooniversePolicies')}
+      as='nav'
+      direction={direction}
+      gap='medium'
+    >
+    {links.length > 0 && links.map(link => (
+      <Anchor
+        href={link.url}
+        key={link.url}
+        size='small'
+      >
+        <SpacedText weight='bold'>
+          {link.label}
+        </SpacedText>
+      </Anchor>
+    ))}
     </Box>
   )
 }

--- a/packages/lib-react-components/src/ZooFooter/components/index.js
+++ b/packages/lib-react-components/src/ZooFooter/components/index.js
@@ -1,0 +1,4 @@
+export { default as LinkList } from './LinkList'
+export { default as LogoAndTagline } from './LogoAndTagline'
+export { default as PolicyLinkSection } from './PolicyLinkSection'
+export { default as SocialAnchor } from './SocialAnchor'

--- a/packages/lib-react-components/src/translations/en.json
+++ b/packages/lib-react-components/src/translations/en.json
@@ -48,7 +48,8 @@
     "talkLabels": {
       "talk": "Talk"
     },
-    "tagLine": "People-Powered Research"
+    "tagLine": "People-Powered Research",
+    "zooniversePolicies": "Zooniverse Policies"
   },
   "ZooHeader": {
     "ariaLabel": "Site",


### PR DESCRIPTION
- Replace `enzyme` with `@testing-library/react` in `ZooFooter`.
- Add some tests for the lists of links in the footer.

`ZooFooter` wasn't tested at all, so I've written some quick tests that check if the various lists of links exist in the DOM.

## Package
lib-react-components

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
