### PR TITLE
Zooniverse-React-Components: Remove Enzyme from ZooHeader

### DIFF
--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.js
@@ -32,18 +32,17 @@ export const StyledLogoAnchor = styled(Anchor)`
   }
 `
 
-export default function ZooHeader (props) {
-  const {
-    isAdmin,
-    isNarrow,
-    register,
-    signIn,
-    signOut,
-    unreadMessages,
-    unreadNotifications,
-    user
-  } = props
-
+export default function ZooHeader({
+  isAdmin,
+  isNarrow,
+  register,
+  signIn,
+  signOut,
+  unreadMessages,
+  unreadNotifications,
+  user = {},
+  ...props
+}) {
   const { t } = useTranslation()
 
   const host = getHost()
@@ -79,12 +78,12 @@ export default function ZooHeader (props) {
       {...props}
     >
       <Box
+        as='nav'
         align='center'
         aria-label={t('ZooHeader.ariaLabel')}
         direction='row'
         pad={{ horizontal: 'medium' }}
         responsive={false}
-        tag='nav'
       >
         <StyledLogoAnchor href='http://www.zooniverse.org'>
           <ZooniverseLogo size='1.25em' id='HeaderZooniverseLogo' />

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.spec.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.spec.js
@@ -1,35 +1,73 @@
-import { shallow } from 'enzyme'
 import React from 'react'
+import { within } from '@testing-library/dom'
+import { render, screen } from '@testing-library/react'
 import MainNavList from './components/MainNavList'
 import SignedOutUserNavigation from './components/SignedOutUserNavigation'
 import SignedInUserNavigation from './components/SignedInUserNavigation'
 import ZooniverseLogo from '../ZooniverseLogo'
 import ZooHeader from './ZooHeader'
 
-const user = { display_name: 'zootester1', login: 'zootester1' }
-
 describe('ZooHeader', function () {
-  let wrapper
+  let mainNavList, zooLogo
+
   before(function () {
-    wrapper = shallow(<ZooHeader signIn={() => {}} signOut={() => {}} user={{}} />)
+    render(<ZooHeader signIn={() => {}} signOut={() => {}} />)
+    zooLogo = screen.getByRole('img', { name: 'Zooniverse Logo' })
+    mainNavList = screen.getByRole('navigation', { name: 'Site' })
   })
 
-  it('renders without crashing', function () { })
-
   it('renders ZooniverseLogo', function () {
-    expect(wrapper.find(ZooniverseLogo)).to.have.lengthOf(1)
+    expect(zooLogo).to.exist()
   })
 
   it('renders a MainNavList', function () {
-    expect(wrapper.find(MainNavList)).to.have.lengthOf(1)
+    expect(mainNavList).to.exist()
   })
 
-  it('renders SignedOutUserNavigation', function () {
-    expect(wrapper.find(SignedOutUserNavigation)).to.have.lengthOf(1)
+  describe('logged out', function () {
+    let signIn, register
+
+    before(function () {
+      render(<ZooHeader signIn={() => {}} signOut={() => {}} />)
+      signIn = screen.getByRole('button', { name: 'Sign In' })
+      register = screen.getByRole('button', { name: 'Register' })
+    })
+
+    it('should have a Sign In button', function () {
+      expect(signIn).to.exist()
+    })
+
+    it('should have a Register button', function () {
+      expect(register).to.exist()
+    })
   })
 
-  it('renders SignedInUserNavigation', function () {
-    wrapper.setProps({ user })
-    expect(wrapper.find(SignedInUserNavigation)).to.have.lengthOf(1)
+  describe('logged in', function () {
+    let userNavigation, notifications, messages, userMenu
+
+    before(function () {
+      const user = { display_name: 'zootester1', login: 'zootester1' }
+      render(<ZooHeader signIn={() => {}} signOut={() => {}} user={user} />)
+      userNavigation = screen.getByRole('navigation', { name: 'User account'})
+      notifications = within(userNavigation).getByRole('link', { name: 'Notifications'})
+      messages = within(userNavigation).getByRole('link', { name: 'Messages'})
+      userMenu = within(userNavigation).getByRole('button', { name: 'Open Menu' })
+    })
+
+    it('should have a user account menu', function () {
+      expect(userNavigation).to.exist()
+    })
+
+    it('should link to notifications', function () {
+      expect(notifications.href).to.equal('https://www.zooniverse.org/notifications')
+    })
+
+    it('should link to messages', function () {
+      expect(messages.href).to.equal('https://www.zooniverse.org/inbox')
+    })
+
+    it('should have a user menu button', function () {
+      expect(userMenu).to.exist()
+    })
   })
 })

--- a/packages/lib-react-components/src/ZooHeader/components/MainNavList/MainNavList.js
+++ b/packages/lib-react-components/src/ZooHeader/components/MainNavList/MainNavList.js
@@ -3,16 +3,14 @@ import PropTypes from 'prop-types'
 import NavListItem from '../NavListItem'
 import { Box } from 'grommet'
 
-export default function MainNavList (props) {
-  const {
-    adminNavLinkLabel,
-    adminNavLinkURL,
-    isAdmin,
-    isNarrow,
-    mainHeaderNavListLabels,
-    mainHeaderNavListURLs
-  } = props
-
+export default function MainNavList({
+  adminNavLinkLabel,
+  adminNavLinkURL,
+  isAdmin,
+  isNarrow,
+  mainHeaderNavListLabels,
+  mainHeaderNavListURLs
+}) {
   if (isNarrow) return null
 
   return (

--- a/packages/lib-react-components/src/ZooHeader/components/SignedInUserNavigation/SignedInUserNavigation.js
+++ b/packages/lib-react-components/src/ZooHeader/components/SignedInUserNavigation/SignedInUserNavigation.js
@@ -13,21 +13,19 @@ import NavListItem from '../NavListItem'
 import UserMenu from '../UserMenu'
 import { getHost } from '../../helpers'
 
-export default function SignedInUserNavigation (props) {
-  const {
-    adminNavLinkLabel,
-    adminNavLinkURL,
-    host,
-    isAdmin,
-    isNarrow,
-    mainHeaderNavListLabels,
-    mainHeaderNavListURLs,
-    unreadMessages,
-    unreadNotifications,
-    signOut,
-    user
-  } = props
-
+export default function SignedInUserNavigation({
+  adminNavLinkLabel,
+  adminNavLinkURL,
+  host,
+  isAdmin,
+  isNarrow,
+  mainHeaderNavListLabels,
+  mainHeaderNavListURLs,
+  unreadMessages,
+  unreadNotifications,
+  signOut,
+  user
+}) {
   const { t } = useTranslation()
 
   const notificationLabelString = t('ZooHeader.SignedInUserNavigation.navListLabels.notifications', {

--- a/packages/lib-react-components/src/ZooHeader/components/SignedOutUserNavigation/SignedOutUserNavigation.js
+++ b/packages/lib-react-components/src/ZooHeader/components/SignedOutUserNavigation/SignedOutUserNavigation.js
@@ -6,19 +6,17 @@ import NarrowMainNavMenu from '../NarrowMainNavMenu'
 import { useTranslation } from 'react-i18next'
 import '../../../translations/i18n'
 
-export default function SignedOutUserNavigation (props) {
-  const {
-    adminNavLinkLabel,
-    adminNavLinkURL,
-    isAdmin,
-    isNarrow,
-    mainHeaderNavListLabels,
-    mainHeaderNavListURLs,
-    register,
-    signIn,
-    user
-  } = props
-
+export default function SignedOutUserNavigation({
+  adminNavLinkLabel,
+  adminNavLinkURL,
+  isAdmin,
+  isNarrow,
+  mainHeaderNavListLabels,
+  mainHeaderNavListURLs,
+  register,
+  signIn,
+  user
+}) {
   const { t } = useTranslation()
 
   if (Object.keys(user).length === 0 && signIn) {


### PR DESCRIPTION
- Replace `enzyme` with `@testing-library/react` in `ZooHeader`.
- Test the header menus with both logged-in and logged-out users.

## Package
lib-react-components

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
