### PR TITLE
Maintenance: replace deprecated Grommet 'tag' prop with 'as'

### DIFF
--- a/packages/app-project/src/shared/components/Stat/Stat.js
+++ b/packages/app-project/src/shared/components/Stat/Stat.js
@@ -7,16 +7,16 @@ function Stat ({ className, label, value }) {
   return (
     <div className={className}>
       <Text
+        as='div'
         color={{ light: 'dark-5', dark: 'light-1' }}
-        tag='div'
         size='xxlarge'
       >
         <AnimatedNumber value={value} />
       </Text>
       <Text
+        as='div'
         color={{ light: 'dark-5', dark: 'light-1' }}
         size='medium'
-        tag='div'
         weight='bold'
       >
         {label}

--- a/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/dataVisAnnotation/components/DataVisAnnotationTask.js
@@ -32,7 +32,7 @@ function DataVisAnnotationTask (props) {
 
   return (
     <Box>
-      <StyledText size='small' tag='legend'>
+      <StyledText as='legend' size='small'>
         <Markdownz>
           {task.instruction}
         </Markdownz>

--- a/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/drawing/components/DrawingTask.js
@@ -39,7 +39,7 @@ function DrawingTask(props) {
 
   return (
     <Box>
-      <StyledText size='small' tag='legend'>
+      <StyledText as='legend' size='small'>
         <Markdownz>{task.instruction}</Markdownz>
       </StyledText>
 

--- a/packages/lib-classifier/src/plugins/tasks/dropdown-simple/components/SimpleDropdownTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/dropdown-simple/components/SimpleDropdownTask.js
@@ -93,7 +93,7 @@ function SimpleDropdownTask({
     <Box
       className={className}
     >
-      <StyledText size='small' tag='legend'>
+      <StyledText as='legend' size='small'>
         <Markdownz>
           {task.instruction}
         </Markdownz>

--- a/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.js
@@ -53,7 +53,7 @@ function MultipleChoiceTask (props) {
       disabled={disabled}
       theme={theme}
     >
-      <StyledText size='small' tag='legend'>
+      <StyledText as='legend' size='small'>
         <Markdownz>
           {task.question}
         </Markdownz>

--- a/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.js
@@ -43,7 +43,7 @@ function SingleChoiceTask (props) {
       disabled={disabled}
       theme={theme}
     >
-      <StyledText size='small' tag='legend'>
+      <StyledText as='legend' size='small'>
         <Markdownz>
           {task.question}
         </Markdownz>

--- a/packages/lib-classifier/src/plugins/tasks/subjectGroupComparison/components/SubjectGroupComparisonTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/subjectGroupComparison/components/SubjectGroupComparisonTask.js
@@ -42,7 +42,7 @@ function SubjectGroupComparisonTask (props) {
       disabled={disabled}
       theme={theme}
     >
-      <StyledText size='small' tag='legend'>
+      <StyledText as='legend' size='small'>
         <Markdownz>
           {task.question}
         </Markdownz>

--- a/packages/lib-react-components/src/ZooFooter/ZooFooter.js
+++ b/packages/lib-react-components/src/ZooFooter/ZooFooter.js
@@ -134,12 +134,12 @@ export default function ZooFooter ({
           <LogoAndTagline tagLine={t('ZooFooter.tagLine')} />
           <Box
             align='end'
+            as='nav'
             direction='row'
             gap='small'
             justify='end'
             responsive={false}
             role='presentation'
-            tag='nav'
           >
             <SocialAnchor service='facebook' />
             <SocialAnchor service='twitter' />
@@ -148,6 +148,7 @@ export default function ZooFooter ({
         </Box>
 
         <Grid
+          as='section'
           fill
           gap='small'
           columns={{
@@ -155,7 +156,6 @@ export default function ZooFooter ({
             'size': '120px'
           }}
           margin={{ bottom: 'large' }}
-          tag='section'
         >
           <LinkList
             labels={projectNavListLabels}

--- a/packages/lib-react-components/src/ZooFooter/components/LinkList/LinkList.js
+++ b/packages/lib-react-components/src/ZooFooter/components/LinkList/LinkList.js
@@ -17,10 +17,10 @@ export default function LinkList ({ className, labels, urls }) {
   return (
     <StyledBox
       aria-label={title.label}
+      as='ul'
       className={className}
       direction='column'
       pad='none'
-      tag='ul'
     >
 
       <li>

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.js
@@ -67,6 +67,7 @@ export default function ZooHeader({
 
   return (
     <StyledHeader
+      as='header'
       background='black'
       direction='row'
       fill='horizontal'
@@ -74,7 +75,6 @@ export default function ZooHeader({
       pad='none'
       responsive={false}
       role='presentation'
-      tag='header'
       {...props}
     >
       <Box


### PR DESCRIPTION
## PR Overview

Packages: `app-project`, `lib-classifier`, `lib-react-components`

This PR is a minor maintenance refactor. The `tag` prop for Boxes (and by extension, all components descended from it) in Grommet is deprecated; the correct prop to use is `as`.

### Status

Ready for review, low priority.