### PR TITLE
Add project page-level headers

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
@@ -38,7 +38,7 @@ function ProjectHeader({
   }
 
   return (
-    <StyledBox as='header' className={className}>
+    <StyledBox className={className}>
       <Background />
       <StyledBox
         align='center'

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeaderContainer.spec.js
@@ -9,7 +9,7 @@ import initStore from '@stores'
 import { ProjectHeaderContainer } from './ProjectHeaderContainer.js'
 
 describe('Component > ProjectHeaderContainer', function () {
-  let projectHeader
+  let navMenu, projectTitle
 
   function withStore(snapshot) {
     const store = initStore(false)
@@ -44,21 +44,16 @@ describe('Component > ProjectHeaderContainer', function () {
       }
     }
     render(<ProjectHeaderContainer />, { wrapper: withStore(snapshot)})
-    projectHeader = screen.getByRole('banner')
-  })
-
-  it('should render the `ProjectHeader` component', function () {
-    expect(projectHeader).to.be.ok()
+    projectTitle = screen.getByRole('heading', { level: 1, name: PROJECT_DISPLAY_NAME })
+    navMenu = screen.getByRole('navigation', { name: 'ProjectHeader.ProjectNav.ariaLabel' })
   })
 
   it('should display the project title', function () {
-    const title = within(projectHeader).getByRole('heading', { level: 1, name: PROJECT_DISPLAY_NAME })
-    expect(title).to.be.ok()
+    expect(projectTitle).to.be.ok()
   })
 
   describe('when not logged in', function () {
     it('should pass down the default nav links', function () {
-      const navMenu = within(projectHeader).getByRole('navigation', { name: 'ProjectHeader.ProjectNav.ariaLabel' })
       const navLinks = within(navMenu).getAllByRole('link')
       expect(navLinks.length).to.be.above(0)
       expect(navLinks[0].href).to.equal('https://localhost/Foo/Bar/about/research')
@@ -89,8 +84,7 @@ describe('Component > ProjectHeaderContainer', function () {
         }
       }
       render(<ProjectHeaderContainer />, { wrapper: withStore(snapshot)})
-      const projectHeader = screen.getByRole('banner')
-      const navMenu = within(projectHeader).getByRole('navigation', { name: 'ProjectHeader.ProjectNav.ariaLabel' })
+      const navMenu = screen.getByRole('navigation', { name: 'ProjectHeader.ProjectNav.ariaLabel' })
       const navLinks = within(navMenu).getAllByRole('link')
 
       expect(navLinks.length).to.be.above(0)
@@ -120,8 +114,7 @@ describe('Component > ProjectHeaderContainer', function () {
         }
       }
       render(<ProjectHeaderContainer adminMode />, { wrapper: withStore(snapshot)})
-      const projectHeader = screen.getByRole('banner')
-      const navMenu = within(projectHeader).getByRole('navigation', { name: 'ProjectHeader.ProjectNav.ariaLabel' })
+      const navMenu = screen.getByRole('navigation', { name: 'ProjectHeader.ProjectNav.ariaLabel' })
       const navLinks = within(navMenu).getAllByRole('link')
 
       expect(navLinks.length).to.be.above(0)
@@ -150,8 +143,7 @@ describe('Component > ProjectHeaderContainer', function () {
         }
       }
       render(<ProjectHeaderContainer />, { wrapper: withStore(snapshot)})
-      const projectHeader = screen.getByRole('banner')
-      const navMenu = within(projectHeader).getByRole('navigation', { name: 'ProjectHeader.ProjectNav.ariaLabel' })
+      const navMenu = screen.getByRole('navigation', { name: 'ProjectHeader.ProjectNav.ariaLabel' })
       const navLinks = within(navMenu).getAllByRole('link')
 
       expect(navLinks.length).to.be.above(0)

--- a/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.js
+++ b/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.js
@@ -54,9 +54,11 @@ function ProjectHomePage ({
       style={pageStyle}
     >
       <Media at='default'>
-        <ZooHeaderWrapper />
-        <ProjectHeader adminMode={adminMode} />
-        <Announcements />
+        <header>
+          <ZooHeaderWrapper />
+          <ProjectHeader adminMode={adminMode} />
+          <Announcements />
+        </header>
         <Hero workflows={workflows} />
         <Box margin='small' gap='small'>
           <ThemeModeToggle />
@@ -70,9 +72,11 @@ function ProjectHomePage ({
 
       <Media greaterThan='default'>
         <FullHeightBox margin={{ bottom: 'large' }}>
-          <ZooHeaderWrapper />
-          <ProjectHeader adminMode={adminMode} />
-          <Announcements />
+          <header>
+            <ZooHeaderWrapper />
+            <ProjectHeader adminMode={adminMode} />
+            <Announcements />
+          </header>
           <RemainingHeightBox>
             <Hero workflows={workflows} isWide={true} />
           </RemainingHeightBox>

--- a/packages/app-project/src/shared/components/ContentBox/ContentBox.js
+++ b/packages/app-project/src/shared/components/ContentBox/ContentBox.js
@@ -43,7 +43,6 @@ function ContentBox (props) {
       {showHeader && (
         <Box
           align='center'
-          as='header'
           direction='row'
           justify={title ? 'between' : 'end'}
           margin={{ bottom: 'small' }}

--- a/packages/app-project/src/shared/components/StandardLayout/StandardLayout.js
+++ b/packages/app-project/src/shared/components/StandardLayout/StandardLayout.js
@@ -32,9 +32,11 @@ function StandardLayout ({
 
   return (
     <Box data-testid='project-page' border={border} style={pageStyle}>
-      <ZooHeaderWrapper />
-      <ProjectHeader adminMode={adminMode} />
-      <Announcements />
+      <header>
+        <ZooHeaderWrapper />
+        <ProjectHeader adminMode={adminMode} />
+        <Announcements />
+      </header>
       {children}
       <ZooFooter
         adminContainer={<AdminContainer onChange={toggleAdmin} checked={adminMode} />}

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.js
@@ -67,14 +67,12 @@ export default function ZooHeader({
 
   return (
     <StyledHeader
-      as='header'
       background='black'
       direction='row'
       fill='horizontal'
       justify='between'
       pad='none'
       responsive={false}
-      role='presentation'
       {...props}
     >
       <Box


### PR DESCRIPTION
- Remove `header` from the `ProjectHeader` and `ContentBox` components.
- Remove presentational `header` from `ZooHeader`.
- Add headers to the `StandardLayout` template, and to the `ProjectHomePage` component, so that each project page only has one page-level banner, which includes the Zooniverse site header, the project header and any project announcements.

Deployed to https://fe-project-branch.preview.zooniverse.org/projects/brooke/i-fancy-cats?env=staging

## Package
app-project
lib-react-components

## Linked Issue and/or Talk Post
- closes #3710.
- closes #3717.

## How to Review
Browsing a project now, there should only be one page-level header on each page. If you open the rotor in VoiceOver, there should only be one page banner listed under Landmarks.


https://user-images.githubusercontent.com/59547/192894951-328e08ca-0e79-4b98-afeb-034121cd0d85.mov



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
