### PR TITLE
Update Panoptes JavaScript Client to 4.1.0

### DIFF
--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -41,7 +41,7 @@
     "newrelic": "^9.0.0",
     "next": "~12.3.0",
     "next-absolute-url": "~1.2.2",
-    "panoptes-client": "~4.0.0",
+    "panoptes-client": "~4.1.0",
     "path-match": "~1.2.4",
     "react": "~17.0.2",
     "react-dom": "~17.0.2",

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -54,7 +54,7 @@
     "newrelic": "~9.1.0",
     "next": "~12.3.0",
     "next-i18next": "~12.0.0",
-    "panoptes-client": "~4.0.0",
+    "panoptes-client": "~4.1.0",
     "path-match": "~1.2.4",
     "polished": "~4.2.2",
     "react": "~17.0.2",

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -95,7 +95,7 @@
     "mocha": "~10.0.0",
     "mst-middlewares": "~5.1.0",
     "nock": "~13.2.1",
-    "panoptes-client": "~4.0.0",
+    "panoptes-client": "~4.1.0",
     "polished": "~4.2.2",
     "process": "~0.11.10",
     "query-string": "~7.1.0",


### PR DESCRIPTION
## PR Overview

This PR is a dependency bump for PJC, and is mostly a security patch. One small thing to note is that the "override API hosts via query string" feature has now been **removed** in 4.1.0

⚠️ WARNING: this PR is not yet ready to merge.

- We're waiting for 4.1.0 to be published on [NPM](https://www.npmjs.com/package/panoptes-client)
- I also need to run a yarn bootstrap on this to update the yarn locks.