### PR TITLE
@zooniverse/react-components v1.2.0

### DIFF
--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -22,7 +22,7 @@
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/grommet-theme": "~3.1.0",
     "@zooniverse/panoptes-js": "~0.1.2",
-    "@zooniverse/react-components": "~1.1.0",
+    "@zooniverse/react-components": "~1.2.0",
     "babel-plugin-dynamic-import-node": "~2.3.0",
     "babel-plugin-styled-components": "~2.0.2",
     "contentful": "~9.2.3",

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -33,7 +33,7 @@
     "@zooniverse/classifier": "^0.0.1",
     "@zooniverse/grommet-theme": "~3.1.0",
     "@zooniverse/panoptes-js": "~0.1.2",
-    "@zooniverse/react-components": "~1.1.0",
+    "@zooniverse/react-components": "~1.2.0",
     "babel-plugin-dynamic-import-node": "~2.3.0",
     "babel-plugin-styled-components": "~2.0.2",
     "cookie": "~0.5.0",

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -74,7 +74,7 @@
     "@wojtekmaj/enzyme-adapter-react-17": "~0.6.6",
     "@zooniverse/grommet-theme": "~3.1.0",
     "@zooniverse/panoptes-js": "~0.1.0",
-    "@zooniverse/react-components": "~1.1.0",
+    "@zooniverse/react-components": "~1.2.0",
     "@zooniverse/standard": "~1.0.0",
     "babel-loader": "~8.2.2",
     "babel-plugin-webpack-alias": "~2.1.2",

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,17 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [1.2.0] 2022-10-03
 
 ### Added
 - Added Grommet's `target` and `full` props to modal layers.
 - Added standard width sizes to PrimaryButton according to design
+- Localisation with `react-i18n`, including full Spanish translations!
 
 ### Fixed
 - Changed `LinkList` component to use `fit-content` CSS styling to render correct height in Safari.
 - Modified matchRegex in `ping` of `Markdownz` to avoid creating username-links in typed email addresses.
 - Fixed buttons that could be rendered like disabled buttons, but still functioned as links. Grommet's `Button` allows you to add an `href` prop which will render a link (HTML anchor tag) styled like a button. It, however, accepts all `Button` props including `disabled`, but links can't be disabled. We now prevent this by checking to see if an `href` is defined and if `disabled` is true and instead render a span via the `as` prop. This impacts `PrimaryButton` and `PlainButton` which directly use Grommet's `Button`. For `CloseButton`, we've destructured `href` from the props to make sure it's not passed along because it doesn't make sense to render this component as a link.
-- Markdownz wasn't handling ordered lists as expected. The fix includes upgrading `remark` to v12, installing `remark-footnotes`, and manually applying some style attributes to <ol> and <ul>.
+- Markdownz wasn't handling ordered lists as expected. The fix includes upgrading `remark` to v12, installing `remark-footnotes`, and manually applying some style attributes to `<ol>` and `<ul>`.
+- add the `react-rnd` `default`, `position` and `size` props to `MovableModal`.
+- Allow `CloseButton` to be clicked on touch devices.
+- catch errors in `Markdownz` during server-side rendering.
+- Remove `header` tag and `presentation` role from `ZooHeader`.
+- Replace deprecated Grommet `tag` with styled-components `as` in Grommet components.
 
 ### Changed
 - All components use `react-i18next` instead of `counterpart` for translations management.

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -3,7 +3,7 @@
   "description": "Zooniverse React Components",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "dist/main.js",
   "scripts": {
     "build": "webpack --config ./webpack.dist.js",

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -9,6 +9,7 @@
     "build": "webpack --config ./webpack.dist.js",
     "build:storybook": "build-storybook",
     "lint": "zoo-standard --fix {.storybook,src,stories,test}/**/*.{js,jsx} | snazzy",
+    "prepare": "yarn build",
     "start": "start-storybook -p 6006",
     "storybook": "start-storybook -p 6007",
     "test": "mocha --config ./test/.mocharc.json \"./src/**/*.spec.js\"",


### PR DESCRIPTION
- Print HTML tags in the `lib-react-components` changelog as inline `<code>` text.
- Update changelog with new version and undocumented changes.
- Update version.
- Update installed package versions.

Once this is merged, we can `npm publish` the new version and update any projects that use `@zooniverse/react-components`.

## Package
lib-react-components

## How to Review
`npm publish --dry-run` will build and publish the new package without actually uploading it to `npm`.


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
