### PR TITLE
Maintenance Week: add tests for RotateHandle

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateHandle/RotateHandle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateHandle/RotateHandle.js
@@ -9,7 +9,11 @@ const RotateHandle = forwardRef(function RotateHandle(
   const transform = `translate(${x}, ${y}) scale(${1 / scale})`
 
   return (
-    <g ref={ref} transform={transform}>
+    <g
+      data-testid='rotate-handle'
+      ref={ref}
+      transform={transform}
+    >
       <svg
         xmlns='http://www.w3.org/2000/svg'
         x='0'

--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateHandle/RotateHandle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateHandle/RotateHandle.js
@@ -1,18 +1,19 @@
 import React, { forwardRef } from 'react'
 import { string, number } from 'prop-types'
 import draggable from '../draggable'
+import { useTranslation } from 'react-i18next'
 
 const RotateHandle = forwardRef(function RotateHandle(
   { fill = 'currentColor', scale = 1, x, y },
   ref
 ) {
+  const { t } = useTranslation('components')
   const transform = `translate(${x}, ${y}) scale(${1 / scale})`
 
   return (
     <g
       ref={ref}
       transform={transform}
-      data-testid='rotate-handle'
     >
       <svg
         xmlns='http://www.w3.org/2000/svg'
@@ -23,7 +24,8 @@ const RotateHandle = forwardRef(function RotateHandle(
         viewBox='0 0 24 24'
         fill={fill}
         strokeWidth='0.5'
-        data-testid='rotate-handle-inner-svg'
+        role='img'
+        aria-label={t('DrawingTools.RotateHandle')}
       >
         <path d='M0 0h24v24H0V0z' fill='transparent' stroke='transparent' />
         <path d='M15.55 5.55L11 1v3.07C7.06 4.56 4 7.92 4 12s3.05 7.44 7 7.93v-2.02c-2.84-.48-5-2.94-5-5.91s2.16-5.43 5-5.91V10l4.55-4.45zM19.93 11c-.17-1.39-.72-2.73-1.62-3.89l-1.42 1.42c.54.75.88 1.6 1.02 2.47h2.02zM13 17.9v2.02c1.39-.17 2.74-.71 3.9-1.61l-1.44-1.44c-.75.54-1.59.89-2.46 1.03zm3.89-2.42l1.42 1.41c.9-1.16 1.45-2.5 1.62-3.89h-2.02c-.14.87-.48 1.72-1.02 2.48z' />

--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateHandle/RotateHandle.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateHandle/RotateHandle.js
@@ -10,9 +10,9 @@ const RotateHandle = forwardRef(function RotateHandle(
 
   return (
     <g
-      data-testid='rotate-handle'
       ref={ref}
       transform={transform}
+      data-testid='rotate-handle'
     >
       <svg
         xmlns='http://www.w3.org/2000/svg'
@@ -23,6 +23,7 @@ const RotateHandle = forwardRef(function RotateHandle(
         viewBox='0 0 24 24'
         fill={fill}
         strokeWidth='0.5'
+        data-testid='rotate-handle-inner-svg'
       >
         <path d='M0 0h24v24H0V0z' fill='transparent' stroke='transparent' />
         <path d='M15.55 5.55L11 1v3.07C7.06 4.56 4 7.92 4 12s3.05 7.44 7 7.93v-2.02c-2.84-.48-5-2.94-5-5.91s2.16-5.43 5-5.91V10l4.55-4.45zM19.93 11c-.17-1.39-.72-2.73-1.62-3.89l-1.42 1.42c.54.75.88 1.6 1.02 2.47h2.02zM13 17.9v2.02c1.39-.17 2.74-.71 3.9-1.61l-1.44-1.44c-.75.54-1.59.89-2.46 1.03zm3.89-2.42l1.42 1.41c.9-1.16 1.45-2.5 1.62-3.89h-2.02c-.14.87-.48 1.72-1.02 2.48z' />

--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateHandle/RotateHandle.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateHandle/RotateHandle.spec.js
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react'
 
 import RotateHandle from './RotateHandle'
 
-describe.only('Component > Rotatehandle', function () {
+describe('Component > Rotatehandle', function () {
   beforeEach(function () {
     render(
       <svg xmlns='http://www.w3.org/2000/svg'>

--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateHandle/RotateHandle.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateHandle/RotateHandle.spec.js
@@ -3,13 +3,13 @@ import { render, screen } from '@testing-library/react'
 
 import RotateHandle from './RotateHandle'
 
-describe('Component > Rotatehandle', function () {
+describe.only('Component > Rotatehandle', function () {
   beforeEach(function () {
     render(
       <svg xmlns='http://www.w3.org/2000/svg'>
         <RotateHandle
           fill='red'
-          scale={1}
+          scale={2}
           x={100}
           y={200}
         />
@@ -19,5 +19,15 @@ describe('Component > Rotatehandle', function () {
 
   it('should render without crashing', function () {
     expect(screen.queryByTestId('rotate-handle')).to.exist()
+  })
+
+  it('should have the correct transform', function () {
+    const rotateHandle = screen.queryByTestId('rotate-handle')
+    expect(rotateHandle.getAttribute('transform')).to.equal('translate(100, 200) scale(0.5)')
+  })
+
+  it('should have the correct colour', function () {
+    const innerSVG = screen.queryByTestId('rotate-handle-inner-svg')
+    expect(innerSVG.getAttribute('fill')).to.equal('red')
   })
 })

--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateHandle/RotateHandle.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateHandle/RotateHandle.spec.js
@@ -18,16 +18,17 @@ describe('Component > Rotatehandle', function () {
   })
 
   it('should render without crashing', function () {
-    expect(screen.queryByTestId('rotate-handle')).to.exist()
+    const rotateHandle = document.querySelector('g[transform]')
+    expect(rotateHandle).to.exist()
   })
 
   it('should have the correct transform', function () {
-    const rotateHandle = screen.queryByTestId('rotate-handle')
+    const rotateHandle = document.querySelector('g[transform]')
     expect(rotateHandle.getAttribute('transform')).to.equal('translate(100, 200) scale(0.5)')
   })
 
   it('should have the correct colour', function () {
-    const innerSVG = screen.queryByTestId('rotate-handle-inner-svg')
+    const innerSVG = screen.getByLabelText('DrawingTools.RotateHandle')
     expect(innerSVG.getAttribute('fill')).to.equal('red')
   })
 })

--- a/packages/lib-classifier/src/plugins/drawingTools/components/RotateHandle/RotateHandle.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/RotateHandle/RotateHandle.spec.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import RotateHandle from './RotateHandle'
+
+describe('Component > Rotatehandle', function () {
+  beforeEach(function () {
+    render(
+      <svg xmlns='http://www.w3.org/2000/svg'>
+        <RotateHandle
+          fill='red'
+          scale={1}
+          x={100}
+          y={200}
+        />
+      </svg>
+    )
+  })
+
+  it('should render without crashing', function () {
+    expect(screen.queryByTestId('rotate-handle')).to.exist()
+  })
+})

--- a/packages/lib-classifier/src/translations/en/components.json
+++ b/packages/lib-classifier/src/translations/en/components.json
@@ -48,6 +48,9 @@
       ]
     }
   },
+  "DrawingTools": {
+    "RotateHandle": "Handle for rotating drawn annotation/mark."
+  },
   "FeedbackModal": {
     "keepClassifying": "Keep Classifying",
     "label": "Feedback"


### PR DESCRIPTION
## PR Overview

Package: `lib-classifier`
Part of: Maintenance Week Oct 2022

Adds React Testing Library tests for the RotateHandle component

- RotateHandle is a mostly presentational component. (Functionality tests should be in draggable and the components that use the draggable RotateHandle.)
- Test IDs added for querying. (I based this on Rectangle.spec.js's pattern, since I can't find a good consensus online on what kind of ARIA role this should take on.)

Ready for review