### PR TITLE
Admin Mode: check for logged-in admin user

### DIFF
--- a/packages/app-project/src/hooks/useAdminMode.js
+++ b/packages/app-project/src/hooks/useAdminMode.js
@@ -1,13 +1,24 @@
-import { useState } from 'react'
+import { MobXProviderContext } from 'mobx-react'
+import { useContext, useEffect, useState } from 'react'
 
 const isBrowser = typeof window !== 'undefined'
 const localStorage = isBrowser ? window.localStorage : null
 
 export default function useAdminMode() {
-  const adminFlag = localStorage?.getItem('adminFlag')
-  const [adminState, setAdminState] = useState(!!adminFlag)
-  const adminMode = adminFlag && adminState
-  
+  const { store } = useContext(MobXProviderContext)
+  const [adminState, setAdminState] = useState(false)
+  const adminMode = store?.user.isAdmin && adminState
+
+  useEffect(function onUserChange() {
+    const user = store?.user
+    if (user?.isAdmin) {
+      const adminFlag = !!localStorage?.getItem('adminFlag')
+      setAdminState(adminFlag)
+    } else {
+      localStorage?.removeItem('adminFlag')
+    }
+  }, [store?.user.isAdmin])
+
   function toggleAdmin() {
     let newAdminState = !adminState
     setAdminState(newAdminState)

--- a/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.js
+++ b/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.js
@@ -22,7 +22,13 @@ import ProjectStatistics from '@shared/components/ProjectStatistics'
 import ZooniverseTalk from './components/ZooniverseTalk'
 import { Media } from '@shared/components/Media'
 
-export const adminBorderImage = 'repeating-linear-gradient(45deg, #000, #000 25px, #ff0 25px, #ff0 50px) 5'
+export const adminBorderImage = 'repeating-linear-gradient(45deg,#000,#000 25px,#ff0 25px,#ff0 50px) 5'
+
+const PageBox = styled(Box)`
+  &.admin {
+    border-image: ${adminBorderImage};
+  }
+`
 
 const FullHeightBox = styled(Box)`
   min-height: 98vh;
@@ -50,18 +56,15 @@ function ProjectHomePage ({
 
   const adminBorder = { size: 'medium' }
   const betaBorder = { color: 'brand', size: 'medium' }
-  const pageStyle = {}
-  if (adminMode) {
-    pageStyle.borderImage = adminBorderImage
-  }
   let border = adminMode ? adminBorder : false
   border = inBeta ? betaBorder : border
+  const className = adminMode ? 'admin' : undefined
 
   return (
-    <Box
+    <PageBox
+      className={className}
       data-testid='project-home-page'
       border={border}
-      style={pageStyle}
     >
       <Media at='default'>
         <header>
@@ -115,7 +118,7 @@ function ProjectHomePage ({
         adminContainer={<AdminContainer onChange={toggleAdmin} checked={adminMode} />}
         locale={locale}
       />
-    </Box>
+    </PageBox>
   )
 }
 

--- a/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.spec.js
@@ -5,6 +5,7 @@ import { Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
 import { applySnapshot } from 'mobx-state-tree'
 import { RouterContext } from 'next/dist/shared/lib/router-context'
+import nock from 'nock'
 
 import initStore from '@stores'
 import ProjectHomePage, { adminBorderImage } from './ProjectHomePage.js'
@@ -40,6 +41,20 @@ describe('Component > ProjectHomePage', function () {
   }
 
   before(function () {
+    nock('https://talk-staging.zooniverse.org')
+    .persist()
+    .get('/notifications')
+    .query(true)
+    .reply(200, {})
+    .get('/conversations')
+    .query(true)
+    .reply(200, {})
+    // TODO: Recent Talk subjects are using the Panoptes client instead of the Talk API client.
+    nock('https://panoptes-staging.zooniverse.org/api')
+    .persist()
+    .get('/comments')
+    .query(true)
+    .reply(200, { comments: [] })
     const snapshot = {
       project: {
         configuration: {
@@ -58,6 +73,10 @@ describe('Component > ProjectHomePage', function () {
     homePage = screen.getByTestId('project-home-page')
     const zooFooter = within(homePage).getByRole('contentinfo')
     adminToggle = within(zooFooter).queryByRole('checkbox', { name: 'Admin Mode' })
+  })
+
+  after(function () {
+    nock.cleanAll()
   })
 
   it('should not render a border for the wrapping Box container', function () {

--- a/packages/app-project/src/shared/components/StandardLayout/StandardLayout.js
+++ b/packages/app-project/src/shared/components/StandardLayout/StandardLayout.js
@@ -4,6 +4,7 @@ import { observer, MobXProviderContext } from 'mobx-react'
 import { useContext } from 'react'
 import { ZooFooter } from '@zooniverse/react-components'
 import { useRouter } from 'next/router'
+import styled from 'styled-components'
 
 import { useAdminMode } from '@hooks'
 import {
@@ -13,7 +14,12 @@ import {
   ZooHeaderWrapper
 } from '@components'
 
-export const adminBorderImage = 'repeating-linear-gradient(45deg, #000, #000 25px, #ff0 25px, #ff0 50px) 5'
+export const adminBorderImage = 'repeating-linear-gradient(45deg,#000,#000 25px,#ff0 25px,#ff0 50px) 5'
+const PageBox = styled(Box)`
+  &.admin {
+    border-image: ${adminBorderImage};
+  }
+`
 
 function useStores() {
   const { store } = useContext(MobXProviderContext)
@@ -33,15 +39,12 @@ function StandardLayout ({
 
   const adminBorder = { size: 'medium' }
   const betaBorder = { color: 'brand', size: 'medium' }
-  const pageStyle = {}
-  if (adminMode) {
-    pageStyle.borderImage = adminBorderImage
-  }
   let border = adminMode ? adminBorder : false
   border = inBeta ? betaBorder : border
+  const className = adminMode ? 'admin' : undefined
 
   return (
-    <Box data-testid='project-page' border={border} style={pageStyle}>
+    <PageBox className={className} data-testid='project-page' border={border}>
       <header>
         <ZooHeaderWrapper />
         <ProjectHeader adminMode={adminMode} />
@@ -52,7 +55,7 @@ function StandardLayout ({
         adminContainer={<AdminContainer onChange={toggleAdmin} checked={adminMode} />}
         locale={locale}
       />
-    </Box>
+    </PageBox>
   )
 }
 


### PR DESCRIPTION
- check for an admin user in the `useAdminMode` hook.
- wait for an admin user to log in before adding the admin border to the page.
- clear admin mode on log out.
- style the page border with `styled()` when Admin Mode is on.
- mock the Talk API when the page requests unread notifications and messages.

## Package
app-project

## Linked Issue and/or Talk Post
- closes #3690.
- closes #3747.

## How to Review
When I set up the `useAdminMode` hook, I forgot to check for a logged-in admin user. With the changes here, admin mode requires both a logged-in admin user and the admin toggle (in the page footer) to be set. When the page loads, admin mode should wait until your user profile has loaded before adding the page border, which fixes #3690. Admin mode should be turned off when you sign out, which fixes #3747.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated
