### PR TITLE
Maintenance Week: add tests for ZooniverseLogo

### DIFF
--- a/packages/lib-react-components/src/ZooniverseLogo/ZooniverseLogo.js
+++ b/packages/lib-react-components/src/ZooniverseLogo/ZooniverseLogo.js
@@ -12,7 +12,7 @@ export default function ZooniverseLogo ({ id, size, ...rest }) {
       {...rest}
     >
       <title id={id}>
-        Zooniverse Logo
+        Zooniverse
       </title>
       <g fill='currentColor' stroke='none' transform='translate(50, 50)'>
         <path d='M 0 -45 A 45 45 0 0 1 0 45 A 45 45 0 0 1 0 -45 Z M 0 -30 A 30 30 0 0 0 0 30 A 30 30 0 0 0 0 -30 Z' />

--- a/packages/lib-react-components/src/ZooniverseLogo/ZooniverseLogo.js
+++ b/packages/lib-react-components/src/ZooniverseLogo/ZooniverseLogo.js
@@ -1,7 +1,11 @@
 import React from 'react'
 import { string } from 'prop-types'
+import { useTranslation } from 'react-i18next'
+import '../translations/i18n'
 
 export default function ZooniverseLogo ({ id, size, ...rest }) {
+  const { t } = useTranslation()
+
   return (
     <svg
       role='img'
@@ -12,7 +16,7 @@ export default function ZooniverseLogo ({ id, size, ...rest }) {
       {...rest}
     >
       <title id={id}>
-        Zooniverse
+        {t('ZooniverseLogo.title')}
       </title>
       <g fill='currentColor' stroke='none' transform='translate(50, 50)'>
         <path d='M 0 -45 A 45 45 0 0 1 0 45 A 45 45 0 0 1 0 -45 Z M 0 -30 A 30 30 0 0 0 0 30 A 30 30 0 0 0 0 -30 Z' />

--- a/packages/lib-react-components/src/ZooniverseLogo/ZooniverseLogo.spec.js
+++ b/packages/lib-react-components/src/ZooniverseLogo/ZooniverseLogo.spec.js
@@ -1,5 +1,5 @@
-import { mount } from 'enzyme'
 import React from 'react'
+import { render, screen } from '@testing-library/react'
 
 import ZooniverseLogo from './ZooniverseLogo'
 
@@ -8,37 +8,36 @@ describe('ZooniverseLogo', function () {
   const ID = 'foobar'
   const SIZE = '100px'
 
-  before(function () {
-    wrapper = mount(<ZooniverseLogo id={ID} size={SIZE} />)
+  describe('with standard props', function () {
+    beforeEach(function () {
+      render(
+        <ZooniverseLogo id={ID} size={SIZE} />
+      )
+    })
+
+    it('should render without crashing', function () {
+      expect(screen).to.be.ok()
+    })
+
+    it('should set the height and width from the `size` prop', function () {
+      const zooLogo = screen.getByLabelText('Zooniverse')  // Gets the SVG
+      expect(zooLogo.getAttribute('height')).to.equal(SIZE)
+      expect(zooLogo.getAttribute('width')).to.equal(SIZE)
+    })
   })
 
-  it('should render without crashing', function () {
-    expect(wrapper).to.be.ok()
-  })
+  describe('with additional props', function () {
+    it('should pass through any other props to the SVG', function () {
+      render(
+        <ZooniverseLogo
+          id={ID}
+          size={SIZE}
+          transform={'scale(2)'}
+        />
+      )
 
-  it('should use the `id` prop for `aria-labelledby` and `title`', function () {
-    const labelledby = wrapper.find('svg').prop('aria-labelledby')
-    const titleId = wrapper.find('title').prop('id')
-    expect(labelledby).to.equal(ID)
-    expect(titleId).to.equal(ID)
-  })
-
-  it('should set the height and width from the `size` prop', function () {
-    const svg = wrapper.find('svg')
-    expect(svg.prop('height')).to.equal(SIZE)
-    expect(svg.prop('width')).to.equal(SIZE)
-  })
-
-  it('should pass through any other props to the SVG', function () {
-    const FOO = 'bar'
-    const wrapperWithProps = mount(
-      <ZooniverseLogo
-        id={ID}
-        size={SIZE}
-        foo={FOO}
-      />
-    )
-
-    expect(wrapperWithProps.find('svg').prop('foo')).to.equal(FOO)
+      const zooLogo = screen.getByLabelText('Zooniverse')  // Gets the SVG
+      expect(zooLogo.getAttribute('transform')).to.equal('scale(2)')
+    })
   })
 })

--- a/packages/lib-react-components/src/ZooniverseLogo/ZooniverseLogo.spec.js
+++ b/packages/lib-react-components/src/ZooniverseLogo/ZooniverseLogo.spec.js
@@ -20,7 +20,7 @@ describe('ZooniverseLogo', function () {
     })
 
     it('should set the height and width from the `size` prop', function () {
-      const zooLogo = screen.getByLabelText('Zooniverse')  // Gets the SVG
+      const zooLogo = screen.getByLabelText('Zooniverse Logo')  // Gets the SVG
       expect(zooLogo.getAttribute('height')).to.equal(SIZE)
       expect(zooLogo.getAttribute('width')).to.equal(SIZE)
     })
@@ -36,7 +36,7 @@ describe('ZooniverseLogo', function () {
         />
       )
 
-      const zooLogo = screen.getByLabelText('Zooniverse')  // Gets the SVG
+      const zooLogo = screen.getByLabelText('Zooniverse Logo')  // Gets the SVG
       expect(zooLogo.getAttribute('transform')).to.equal('scale(2)')
     })
   })

--- a/packages/lib-react-components/src/translations/en.json
+++ b/packages/lib-react-components/src/translations/en.json
@@ -84,5 +84,8 @@
         "signOut": "Sign out"
       }
     }
+  },
+  "ZooniverseLogo": {
+    "title": "Zooniverse Logo"
   }
 }


### PR DESCRIPTION
## PR Overview

Replaces #3733 
Package: `lib-react-components`
Part of: Maintenance Week Oct 2022

This PR adds React Testing Library tests for the ZooniverseLogo component.

- Also, the "Zooniverse Logo" title now has translations hooked up.
- No tests will be added for ZooniverseTypeLogo, since these were removed in #3732

Ready for review.