### PR TITLE
Bump GitHub v2 actions to v3

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#using-the-checkout-action
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16.x'
           cache: 'yarn'
@@ -20,7 +20,7 @@ jobs:
       - run: yarn install --production=false --frozen-lockfile
       - run: yarn workspace @zooniverse/react-components build
       - run: yarn workspace @zooniverse/classifier build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: build
           path: packages/*/dist/main.js
@@ -34,15 +34,15 @@ jobs:
       NODE_ENV: production
       PANOPTES_ENV: production
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
          node-version: '16.x'
          cache: 'yarn'
 
       - run: yarn install --production=false --frozen-lockfile
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: build
           path: packages/
@@ -59,15 +59,15 @@ jobs:
       CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
       CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
          node-version: '16.x'
          cache: 'yarn'
 
       - run: yarn install --production=false --frozen-lockfile
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: build
           path: packages/
@@ -78,15 +78,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
          node-version: '16.x'
          cache: 'yarn'
 
       - run: yarn install --production=false --frozen-lockfile
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: build
           path: packages/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#using-the-checkout-action
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16.x'
           cache: 'yarn'
@@ -24,7 +24,7 @@ jobs:
       - run: yarn install --production=false --frozen-lockfile
       - run: yarn workspace @zooniverse/react-components build
       - run: yarn workspace @zooniverse/classifier build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: build
           path: packages/*/dist/main.js
@@ -36,15 +36,15 @@ jobs:
     env:
       PANOPTES_ENV: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16.x'
           cache: 'yarn'
 
       - run: yarn install --production=false --frozen-lockfile
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: build
           path: packages/

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -36,7 +36,7 @@ jobs:
     needs: build_and_push_image
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set the target AKS cluster
       uses: Azure/aks-set-context@v1


### PR DESCRIPTION
These GH actions are [deprecated at v2](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). This bumps them to v3.
- checkout.
- setup-node.
- upload-artifact.
- download-artifact.
