### PR TITLE
Add projects to Sentry production releases

### DIFF
--- a/.github/workflows/sentry-production-releases.yml
+++ b/.github/workflows/sentry-production-releases.yml
@@ -24,3 +24,4 @@ jobs:
       with:
         environment: production
         finalize: true
+        projects: ${{ secrets.SENTRY_PROJECT_APP }} ${{ secrets.SENTRY_CONTENT_APP }}


### PR DESCRIPTION
The `projects` key is required in order for the action to run.
