### PR TITLE
Flipbook Viewer: Display this viewer for non-transcription multiple-image-subjects

### DIFF
--- a/docs/arch/adr-46.md
+++ b/docs/arch/adr-46.md
@@ -1,0 +1,27 @@
+# Flipbook Viewer
+
+13 Oct 2022
+
+## Context
+
+Migration of projects from PFE to FEM requires building the flipbook viewer for classification of non-transcription subjects with multiple images.
+
+## Decision
+
+The Flipbook Viewer is a separate viewer than the Multiframe Viewer. The Multiframe viewer is designed and built for transription projects where pan, zoom, rotate, and annotations do not need to be consistent when flipping through multiple frames per subject.
+
+The Flipbook Viewer will have the same features as PFE, and its design is catered to landscape oriented subject images. [Invision Design](https://projects.invisionapp.com/prototype/Flipbook-Viewer-cl7ar8qa402m83i01w6uvj5hq)
+
+## Features
+
+Features of the FEM Flipbook Viewer will include:
+1. Thumbnails of each subject's images below the currently selected image. Clicking these buttons will change the currently selected image. 
+2. Next/Back buttons to navigate through available thumbnails.
+3. Play/Pause to flip/animate through the images.
+4. Switching between the "flipbook" display and "separate images" display.
+5. Full use of the ImageToolbar component (pan, zoom, rotate, invert, etc).
+6. Control of playback speed (options similar to VideoController: 4x, 2x, 1x, 0.5x, 0.25x).
+
+## Status
+
+Accepted

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/Flipbook.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/Flipbook.spec.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { expect } from 'chai'
+import * as stories from './FlipbookViewer.stories'
+import { composeStories } from '@storybook/testing-react'
+
+describe('Component > FlipbookViewer', function () {
+  const { Default } = composeStories(stories)
+
+  it('tests go here', function () {
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Box } from 'grommet'
+import PropTypes from 'prop-types'
+import locationValidator from '../../helpers/locationValidator'
+
+function FlipbookViewer({ subject }) {
+  return (
+    <Box>
+      This is the flipbook viewer. Subject locations: {subject?.locations?.length}
+    </Box>
+  )
+}
+
+FlipbookViewer.propTypes = {
+  subject: PropTypes.shape({
+    locations: PropTypes.arrayOf(locationValidator)
+  }).isRequired
+}
+
+export default FlipbookViewer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.stories.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import zooTheme from '@zooniverse/grommet-theme'
+import { Grommet } from 'grommet'
+import { Factory } from 'rosie'
+import { Provider } from 'mobx-react'
+import mockStore from '@test/mockStore'
+
+import FlipbookViewer from './FlipbookViewer'
+
+const background = {
+  dark: 'dark-1',
+  light: 'light-1'
+}
+
+const subject = Factory.build('subject', {
+  locations: [
+    {
+      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/1e54b552-4608-4701-9db9-b8342b81278a.jpeg'
+    },
+    {
+      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/098f3fb6-5021-410a-82a2-477a28b2bcd6.jpeg'
+    },
+    {
+      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/8fcb18b0-de80-42cd-ba2a-4871da30c74f.jpeg'
+    },
+    {
+      'image/jpeg': 'https://panoptes-uploads.zooniverse.org/subject_location/85d8d82a-c88d-493c-b3db-7cd9f2ca5ad8.jpeg'
+    }
+  ]
+})
+
+const store = mockStore({
+  subject: subject
+})
+
+export default {
+  title: 'Subject Viewers / FlipbookViewer',
+  component: FlipbookViewer,
+  args: {
+    dark: false
+  }
+}
+
+export const Default = ({ dark }) => {
+  const themeMode = dark ? 'dark' : 'light'
+  return (
+    <Grommet background={background} theme={zooTheme} themeMode={themeMode}>
+      <Provider classifierStore={store}>
+        <FlipbookViewer subject={subject} />
+      </Provider>
+    </Grommet>
+  )
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/README.md
@@ -1,0 +1,19 @@
+# Flipbook Viewer
+
+The Flipbook Viewer is designed and catered toward landscape oriented subjects with multiple images ( in `locations` array). See ADR 46 for additional information.
+
+## Workflow Configuration
+
+The "Pan and Zoom" section and the "Multi-Image Options" section in the lab are relevant to the Flipbook Viewer.
+
+## Subjects
+
+This viewer will display for subjects with multiple images in the `locations` array whose workflow configration does not include `multiFrame`. See SubjectStore > Subject > getViewer().
+
+## Features
+
+Props
+- 
+
+State Variables
+- 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/index.js
@@ -1,0 +1,1 @@
+export { default } from './FlipbookViewer'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getViewer/getViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/helpers/getViewer/getViewer.js
@@ -1,4 +1,5 @@
 import DataImageViewer from '../../components/DataImageViewer'
+import FlipbookViewer from '../../components/FlipbookViewer'
 import ImageAndTextViewer from '../../components/ImageAndTextViewer'
 import LightCurveViewer from '../../components/LightCurveViewer'
 import MultiFrameViewer from '../../components/MultiFrameViewer'
@@ -11,6 +12,7 @@ import VariableStarViewer from '../../components/VariableStarViewer'
 
 const viewers = {
   dataImage: DataImageViewer,
+  flipbook: FlipbookViewer,
   imageAndText: ImageAndTextViewer,
   lightCurve: LightCurveViewer,
   multiFrame: MultiFrameViewer,

--- a/packages/lib-classifier/src/helpers/subjectViewers/subjectViewers.js
+++ b/packages/lib-classifier/src/helpers/subjectViewers/subjectViewers.js
@@ -5,6 +5,11 @@ Object.defineProperty(subjectViewers, 'dataImage', {
   enumerable: true
 })
 
+Object.defineProperty(subjectViewers, 'flipbook', {
+  value: 'flipbook',
+  enumerable: true
+})
+
 Object.defineProperty(subjectViewers, 'imageAndText', {
   value: 'imageAndText',
   enumerable: true

--- a/packages/lib-classifier/src/helpers/subjectViewers/subjectViewers.spec.js
+++ b/packages/lib-classifier/src/helpers/subjectViewers/subjectViewers.spec.js
@@ -3,6 +3,7 @@ import subjectViewers from './subjectViewers'
 describe('Helpers > subjectViewers', function () {
   const viewers = [
     'dataImage',
+    'flipbook',
     'imageAndText',
     'lightCurve',
     'multiFrame',

--- a/packages/lib-classifier/src/store/SubjectStore/Subject/Subject.js
+++ b/packages/lib-classifier/src/store/SubjectStore/Subject/Subject.js
@@ -46,10 +46,6 @@ const Subject = types
         // If the Workflow configuration specifies a subject viewer, use that.
         // Otherwise, take a guess using the Subject.
 
-        const pfeMultiImageMode = configuration['multi_image_mode'] === 'separate'
-        const pfeEnableSwitchingFlipbookAndSeparate = configuration['enable_switching_flipbook_and_separate'] // expect true/false value
-        const nullViewer = pfeMultiImageMode || pfeEnableSwitchingFlipbookAndSeparate
-
         viewer = configuration.viewerType
 
         if (!viewer && counts.total === 1) {
@@ -65,13 +61,12 @@ const Subject = types
         }
 
         if (!viewer && counts.total > 1 && counts.total < 11) {
-          if (!nullViewer) {
-            if (counts.total === counts.images) {
-              viewer = subjectViewers.multiFrame
-            }
-            if (getType(self).name === 'ImageAndTextSubject') {
-              viewer = subjectViewers.imageAndText
-            }
+          // This is a subject pattern for the flipbook - Note that projects that want to use the multiFrame viewer should specify in workflow config
+          if (counts.total === counts.images) {
+            viewer = subjectViewers.flipbook
+          }
+          if (getType(self).name === 'ImageAndTextSubject') {
+            viewer = subjectViewers.imageAndText
           }
         }
       }
@@ -108,7 +103,6 @@ const Subject = types
   }))
 
   .actions(self => {
-
     function afterAttach () {
       _fetchTranscriptionReductions()
     }

--- a/packages/lib-classifier/src/store/SubjectStore/Subject/Subject.spec.js
+++ b/packages/lib-classifier/src/store/SubjectStore/Subject/Subject.spec.js
@@ -156,21 +156,20 @@ describe('Model > Subject', function () {
       })
 
       describe('multi-frame media', function () {
-        it('should return the multi-frame viewer for subjects with more than one location', function () {
-          const multiFrameSubject = SubjectFactory.build({
+        it('should return the flipbook viewer for subjects with more than one location', function () {
+          const multipleImagesSubject = SubjectFactory.build({
             locations: [
               { 'image/png': 'https://foo.bar/example.png' },
               { 'image/png': 'https://foo.bar/example.png' }
             ]
           })
-          const store = mockStore({ project, workflow, subject: multiFrameSubject })
+          const store = mockStore({ project, workflow, subject: multipleImagesSubject })
           const subject = store.subjects.active
-          expect(subject.viewer).to.equal(subjectViewers.multiFrame)
+          expect(subject.viewer).to.equal(subjectViewers.flipbook)
         })
-
 
         it('should return a null viewer for subjects with more than ten location', function () {
-          const multiFrameSubject = SubjectFactory.build({
+          const multipleImagesSubject = SubjectFactory.build({
             locations: [
               { 'image/png': 'https://foo.bar/example.png' },
               { 'image/png': 'https://foo.bar/example.png' },
@@ -185,31 +184,7 @@ describe('Model > Subject', function () {
               { 'image/png': 'https://foo.bar/example.png' }
             ]
           })
-          const store = mockStore({ project, workflow, subject: multiFrameSubject })
-          const subject = store.subjects.active
-          expect(subject.viewer).to.be.null()
-        })
-
-        it('should return a null viewer when workflow.configuration["multi_image_mode"] === "separate"', function () {
-          const multiFrameSubject = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }, { 'image/png': 'https://foo.bar/example.png' }] })
-          const workflowWithConfigSeparateMultiImage = WorkflowFactory.build({ configuration: { multi_image_mode: 'separate' } })
-          const store = mockStore({
-            project,
-            workflow: workflowWithConfigSeparateMultiImage,
-            subject: multiFrameSubject
-          })
-          const subject = store.subjects.active
-          expect(subject.viewer).to.be.null()
-        })
-
-        it('should return a null viewer when workflow.configuration["enable_switching_flipbook_and_separate"] === "true"', function () {
-          const multiFrameSubject = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }, { 'image/png': 'https://foo.bar/example.png' }] })
-          const workflowWithConfigEnableSwitching = WorkflowFactory.build({ configuration: { enable_switching_flipbook_and_separate: true } })
-          const store = mockStore({
-            project,
-            workflow: workflowWithConfigEnableSwitching,
-            subject: multiFrameSubject
-          })
+          const store = mockStore({ project, workflow, subject: multipleImagesSubject })
           const subject = store.subjects.active
           expect(subject.viewer).to.be.null()
         })

--- a/packages/lib-classifier/src/store/WorkflowStore/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
@@ -8,6 +8,7 @@ const WorkflowConfiguration = types.model({
   persist_annotations: types.optional(types.boolean, true),
   subject_viewer: types.maybe(types.enumeration('subjectViewer', [
     'dataImage',
+    'flipbook',
     'lightcurve',
     'multiFrame',
     'scatterPlot',
@@ -30,6 +31,9 @@ const WorkflowConfiguration = types.model({
       switch (self.subject_viewer) {
         case 'dataImage': {
           return subjectViewers.dataImage
+        }
+        case 'flipbook': {
+          return subjectViewers.flipbook
         }
         case 'lightcurve': {
           return subjectViewers.lightCurve


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Flipbook Project Board: https://github.com/zooniverse/front-end-monorepo/projects/21

## Describe your changes
ADR 46 describes the intended flipbook features and that this viewer is completely separate from the Multiframe Viewer.

Development of the Flipbook Viewer is divided into bite-size PR's. This PR sets up the basic classifier configuration and code files to display the flipbook for subjects with multiple images in the `locations` array. The flipbook is now the default viewer for that subject type unless a workflow config specifies `multiFrame`. See SubjectStore > Subject model > getViewer() for more details.

I included a basic storybook file and placeholder unit test file. The Flipbook Viewer component itself has a simple placeholder Grommet Box for now.


## How to Review

To see the Flipbook Viewer run locally, visit the following projects. 
- [Wildwatch Burrowing Owl](https://local.zooniverse.org:3000/projects/sandiegozooglobal/wildwatch-burrowing-owl/classify/workflow/21141?env=production)
- [A Flipbook Test Project](https://local.zooniverse.org:3000/projects/goplayoutside3/fem-flipbook-viewer/classify/workflow/22532?env=production)

Live FEM transcription projects should still show the Multiframe Viewer even though their subject type matches the flipbook. Examples: [Poets & Lovers](https://local.zooniverse.org:3000/projects/pmlogan/poets-and-lovers?env=production) or [Davy Notebooks](https://local.zooniverse.org:3000/projects/humphrydavy/davy-notebooks-project?env=production) because their workflow config includes `multiFrame` via their admin pages.

You can also see the placeholder Flipbook component in the classifier's storybook.

# Checklist

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
