### PR TITLE
Refactor drawing tool focus management

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/DeleteButton/DeleteButton.js
@@ -61,7 +61,7 @@ function DeleteButton ({ label, mark, onDelete, onDeselect, rotate, scale, theme
       role='button'
       stroke={STROKE_COLOR}
       strokeWidth={STROKE_WIDTH}
-      tabIndex='0'
+      tabIndex='-1'
       transform={transform}
     >
       <circle

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
@@ -186,14 +186,5 @@ Mark.propTypes = {
 }
 
 const ObservedMark = observer(Mark)
-
-ObservedMark.defaultProps = {
-  theme: {
-    global: {
-      colors: {}
-    }
-  }
-}
-
 export default draggable(withTheme(ObservedMark))
 export { Mark }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
@@ -1,6 +1,6 @@
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useEffect, useRef } from 'react'
 import styled, { css, withTheme } from 'styled-components'
 import draggable from '../draggable'
 
@@ -27,6 +27,16 @@ const StyledGroup = styled('g')`
   }
 `
 
+function focusMark(markNode) {
+  const hasFocus = markNode === document.activeElement
+  if (!hasFocus) {
+    const x = scrollX
+    const y = scrollY
+    markNode?.focus()
+    window.scrollTo(x, y)
+  }
+}
+
 function defaultHandler() {
   return true
 }
@@ -51,7 +61,7 @@ const Mark = forwardRef(function Mark(
   },
   ref
 ) {
-  const markRoot = ref ?? React.createRef()
+  const markRoot = ref ?? useRef()
   const { tool } = mark
   const mainStyle = {
     color: tool && tool.color ? tool.color : 'green',
@@ -59,38 +69,32 @@ const Mark = forwardRef(function Mark(
     stroke: tool && tool.color ? tool.color : 'green'
   }
   const focusColor = theme.global.colors[theme.global.colors.focus]
-
-  function focusMark() {
-    const hasFocus = markRoot.current === document.activeElement
-    if (!hasFocus) {
-      const x = scrollX
-      const y = scrollY
-      markRoot.current?.focus()
-      window.scrollTo(x, y)
-    }
-  }
+  const usesSubTasks = mark.isValid && mark.tasks.length > 0
 
   function openSubTaskPopup() {
-    if (
-      mark.isValid &&
-      mark.finished &&
-      !mark.subTaskVisibility &&
-      mark.tasks.length > 0
-    ) {
-      focusMark()
+    if (!mark.subTaskVisibility) {
       const markBounds = markRoot.current?.getBoundingClientRect()
       mark.setSubTaskVisibility(true, markBounds)
     }
   }
 
-  function onSubTaskVisibilityChange() {
-    if (mark.finished && !mark.subTaskVisibility) {
-      focusMark()
+  useEffect(() => {
+    if (isActive && mark.finished) {
+      focusMark(markRoot.current)
     }
-  }
+  }, [isActive, mark.finished])
 
-  React.useEffect(openSubTaskPopup, [mark.finished])
-  React.useEffect(onSubTaskVisibilityChange, [mark.subTaskVisibility])
+  useEffect(() => {
+    if (usesSubTasks && mark.finished) {
+      openSubTaskPopup()
+    }
+  }, [usesSubTasks, mark.finished])
+
+  useEffect(() => {
+    if (mark.finished && !mark.subTaskVisibility) {
+      focusMark(markRoot.current)
+    }
+  }, [mark.finished, mark.subTaskVisibility])
 
   function onKeyDown(event) {
     switch (event.key) {
@@ -114,7 +118,13 @@ const Mark = forwardRef(function Mark(
     }
   }
 
-  function select() {
+  function onPointerUp() {
+    if (usesSubTasks) {
+      openSubTaskPopup()
+    }
+  }
+
+  function onFocus() {
     markRoot.current?.scrollIntoView()
     onSelect(mark)
   }
@@ -141,9 +151,9 @@ const Mark = forwardRef(function Mark(
       dragging={dragging}
       focusable
       focusColor={focusColor}
-      onFocus={select}
+      onFocus={onFocus}
       onKeyDown={onKeyDown}
-      onPointerUp={openSubTaskPopup}
+      onPointerUp={onPointerUp}
       pointerEvents={pointerEvents}
       ref={markRoot}
       role='button'

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
@@ -40,11 +40,13 @@ function focusMark(markNode) {
 function defaultHandler() {
   return true
 }
+
 const defaultTheme = {
   global: {
     colors: {}
   }
 }
+
 const Mark = forwardRef(function Mark(
   {
     children,
@@ -125,8 +127,8 @@ const Mark = forwardRef(function Mark(
   }
 
   function onFocus() {
-    markRoot.current?.scrollIntoView()
     onSelect(mark)
+    markRoot.current?.scrollIntoView?.()
   }
 
   let transform = ''

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
@@ -80,19 +80,19 @@ const Mark = forwardRef(function Mark(
     }
   }
 
-  useEffect(() => {
+  useEffect(function onSelectMark() {
     if (isActive && mark.finished) {
       focusMark(markRoot.current)
     }
   }, [isActive, mark.finished])
 
-  useEffect(() => {
+  useEffect(function onFinishMarkWithSubTasks() {
     if (usesSubTasks && mark.finished) {
       openSubTaskPopup()
     }
   }, [usesSubTasks, mark.finished])
 
-  useEffect(() => {
+  useEffect(function onCloseSubTasks() {
     if (mark.finished && !mark.subTaskVisibility) {
       focusMark(markRoot.current)
     }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.spec.js
@@ -1,10 +1,10 @@
 import React from 'react'
-import { mount, shallow } from 'enzyme'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { expect } from 'chai'
 import sinon from 'sinon'
 import { EllipseTool, PointTool } from '@plugins/drawingTools/models/tools'
-import { Mark } from './Mark'
-import Point from '../Point'
+import { Ellipse, Mark, Point } from '@plugins/drawingTools/components'
 
 describe('Drawing tools > Mark', function () {
   const pointTool = PointTool.create({
@@ -20,6 +20,7 @@ describe('Drawing tools > Mark', function () {
   const onFinish = sinon.stub()
   const onSelect = sinon.stub()
   let wrapper
+  let svgPoint
 
   before(function () {
     sinon.stub(window, 'scrollTo')
@@ -27,17 +28,20 @@ describe('Drawing tools > Mark', function () {
       id: 'point1'
     })
     point.finish()
-    wrapper = shallow(
-      <Mark
-        label='Point 1'
-        mark={point}
-        onDelete={onDelete}
-        onFinish={onFinish}
-        onSelect={onSelect}
-      >
-        <Point mark={point} />
-      </Mark>
+    render(
+      <svg>
+        <Mark
+          label='Point 1'
+          mark={point}
+          onDelete={onDelete}
+          onFinish={onFinish}
+          onSelect={onSelect}
+        >
+          <Point mark={point} />
+        </Mark>
+      </svg>
     )
+    svgPoint = screen.getByLabelText('Point 1')
   })
 
   after(function () {
@@ -46,17 +50,31 @@ describe('Drawing tools > Mark', function () {
     window.scrollTo.restore()
   })
 
-  it('should render without crashing', function () {
-    expect(wrapper).to.be.ok()
-  })
-
   it('should render a child drawing tool', function () {
-    expect(wrapper.find(Point)).to.have.lengthOf(1)
+    expect(svgPoint).to.exist()
   })
 
   describe('on focus', function () {
-    before(function () {
-      wrapper.root().simulate('focus')
+    before(async function () {
+      const user = userEvent.setup({ delay: 'none' })
+      point = pointTool.createMark({
+        id: 'point1'
+      })
+      point.finish()
+      render(
+        <svg>
+          <Mark
+            label='Point 1'
+            mark={point}
+            onDelete={onDelete}
+            onFinish={onFinish}
+            onSelect={onSelect}
+          >
+            <Point mark={point} />
+          </Mark>
+        </svg>
+      )
+      await user.tab()
     })
 
     it('should be selected', function () {
@@ -66,26 +84,32 @@ describe('Drawing tools > Mark', function () {
 
   describe('on keydown', function () {
     describe('with backspace', function () {
-      const fakeEvent = {
-        key: 'Backspace',
-        preventDefault: sinon.stub(),
-        stopPropagation: sinon.stub()
-      }
 
-      before(function () {
-        wrapper.simulate('keydown', fakeEvent)
+      before(async function () {
+        const user = userEvent.setup({ delay: 'none' })
+        point = pointTool.createMark({
+          id: 'point1'
+        })
+        point.finish()
+        render(
+          <svg>
+            <Mark
+              label='Point 1'
+              mark={point}
+              onDelete={onDelete}
+              onFinish={onFinish}
+              onSelect={onSelect}
+            >
+              <Point mark={point} />
+            </Mark>
+          </svg>
+        )
+        await user.tab()
+        await user.keyboard('{Backspace}')
       })
 
       after(function () {
         onDelete.resetHistory()
-      })
-
-      it('should cancel event bubbling', function () {
-        expect(fakeEvent.stopPropagation).to.have.been.calledOnce()
-      })
-
-      it('should cancel the default backspace handler', function () {
-        expect(fakeEvent.preventDefault).to.have.been.calledOnce()
       })
 
       it('should be deleted', function () {
@@ -94,30 +118,36 @@ describe('Drawing tools > Mark', function () {
     })
 
     describe('with enter', function () {
-      const fakeEvent = {
-        key: 'Enter',
-        preventDefault: sinon.stub(),
-        stopPropagation: sinon.stub()
-      }
 
-      before(function () {
+      before(async function () {
+        const user = userEvent.setup({ delay: 'none' })
+        point = pointTool.createMark({
+          id: 'point1'
+        })
+        point.finish()
+        render(
+          <svg>
+            <Mark
+              label='Point 1'
+              mark={point}
+              onDelete={onDelete}
+              onFinish={onFinish}
+              onSelect={onSelect}
+            >
+              <Point mark={point} />
+            </Mark>
+          </svg>
+        )
         point.setSubTaskVisibility(false)
-        wrapper.simulate('keydown', fakeEvent)
+        await user.tab()
+        await user.keyboard('{Enter}')
       })
 
       after(function () {
         onFinish.resetHistory()
       })
 
-      it('should cancel event bubbling', function () {
-        expect(fakeEvent.stopPropagation).to.have.been.calledOnce()
-      })
-
-      it('should cancel the default enter handler', function () {
-        expect(fakeEvent.preventDefault).to.have.been.calledOnce()
-      })
-
-      it('should set subtask visibility', function () {
+      it('should open the subtasks popup', function () {
         expect(point.subTaskVisibility).to.be.true()
       })
 
@@ -127,30 +157,36 @@ describe('Drawing tools > Mark', function () {
     })
 
     describe('with space', function () {
-      const fakeEvent = {
-        key: ' ',
-        preventDefault: sinon.stub(),
-        stopPropagation: sinon.stub()
-      }
 
-      before(function () {
+      before(async function () {
+        const user = userEvent.setup({ delay: 'none' })
+        point = pointTool.createMark({
+          id: 'point1'
+        })
+        point.finish()
+        render(
+          <svg>
+            <Mark
+              label='Point 1'
+              mark={point}
+              onDelete={onDelete}
+              onFinish={onFinish}
+              onSelect={onSelect}
+            >
+              <Point mark={point} />
+            </Mark>
+          </svg>
+        )
         point.setSubTaskVisibility(false)
-        wrapper.simulate('keydown', fakeEvent)
+        await user.tab()
+        await user.keyboard('{ }')
       })
 
       after(function () {
         onFinish.resetHistory()
       })
 
-      it('should cancel event bubbling', function () {
-        expect(fakeEvent.stopPropagation).to.have.been.calledOnce()
-      })
-
-      it('should cancel the default space handler', function () {
-        expect(fakeEvent.preventDefault).to.have.been.calledOnce()
-      })
-
-      it('should set subtask visibility', function () {
+      it('should open the subtasks popup', function () {
         expect(point.subTaskVisibility).to.be.true()
       })
 
@@ -160,22 +196,29 @@ describe('Drawing tools > Mark', function () {
     })
 
     describe('with other keys', function () {
-      const fakeEvent = {
-        key: 'Tab',
-        preventDefault: sinon.stub(),
-        stopPropagation: sinon.stub()
-      }
-      before(function () {
+
+      before(async function () {
+        const user = userEvent.setup({ delay: 'none' })
+        point = pointTool.createMark({
+          id: 'point1'
+        })
+        point.finish()
+        render(
+          <svg>
+            <Mark
+              label='Point 1'
+              mark={point}
+              onDelete={onDelete}
+              onFinish={onFinish}
+              onSelect={onSelect}
+            >
+              <Point mark={point} />
+            </Mark>
+          </svg>
+        )
         point.setSubTaskVisibility(false)
-        wrapper.simulate('keydown', fakeEvent)
-      })
-
-      it('should not cancel event bubbling', function () {
-        expect(fakeEvent.stopPropagation).to.not.have.been.called()
-      })
-
-      it('should not cancel the default key handler', function () {
-        expect(fakeEvent.preventDefault).to.not.have.been.called()
+        await user.tab()
+        await user.keyboard('{Tab}')
       })
 
       it('should not be deleted', function () {
@@ -188,39 +231,114 @@ describe('Drawing tools > Mark', function () {
     })
   })
 
-  describe('mark position', function () {
-    it('should be positioned at {mark.x, mark.y}', function () {
-      point.initialPosition({ x: 50, y: 120 })
-      wrapper.setProps({ mark: point })
-      const transform = wrapper.root().prop('transform')
-      expect(transform).to.have.string('translate(50, 120)')
+  describe('on click', function () {
+    let point, svgPoint
+
+    before(function () {
+      point = pointTool.createMark({
+        id: 'point1'
+      })
+      point.finish()
+      render(
+        <svg>
+          <Mark
+            label='Point 1'
+            mark={point}
+            onDelete={onDelete}
+            onFinish={onFinish}
+            onSelect={onSelect}
+          >
+            <Point mark={point} />
+          </Mark>
+        </svg>
+      )
+      svgPoint = screen.getByLabelText('Point 1')
     })
 
-    describe( 'when rotated', function () {
-      beforeEach(function () {
-        const ellipseTool = EllipseTool.create({
-          type: 'ellipse'
-        })
-        const ellipse = ellipseTool.createMark({
-          id: 'ellipse1',
-          x: 50,
-          y: 120,
-          angle: -45
-        })
-        wrapper.setProps({ mark: ellipse })
-      })
-      it('should be rotated by mark.angle', function () {
-        const transform = wrapper.root().prop('transform')
-        expect(transform).to.have.string('rotate(-45)')
-      })
+    it('should open the subtask popup', async function () {
+      const user = userEvent.setup({ delay: 'none' })
+      point.setSubTaskVisibility(false)
+      expect(point.subTaskVisibility).to.be.false()
+      await user.click(svgPoint)
+      expect(point.subTaskVisibility).to.be.true()
     })
   })
 
-  describe('useEffect hook', function () {
+  describe('with an x,y position', function () {
+    let svgPoint
+
+    before(function () {
+      const pointTool = PointTool.create({
+        type: 'point'
+      })
+      const point = pointTool.createMark({
+        id: 'point1',
+        x: 50,
+        y: 120
+      })
+      render(
+        <svg>
+          <Mark
+            label='Point 1'
+            mark={point}
+            onDelete={onDelete}
+            onFinish={onFinish}
+            onSelect={onSelect}
+          >
+            <Point mark={point} />
+          </Mark>
+        </svg>
+      )
+      svgPoint = screen.getByLabelText('Point 1')
+    })
+
+    it('should be positioned at {mark.x, mark.y}', function () {
+      const transform = svgPoint.getAttribute('transform')
+      expect(transform).to.have.string('translate(50, 120)')
+    })
+  })
+
+  describe('with a rotation angle', function () {
+    let svgEllipse
+
+    before(function () {
+      const ellipseTool = EllipseTool.create({
+        type: 'ellipse'
+      })
+      const ellipse = ellipseTool.createMark({
+        id: 'ellipse1',
+        x: 50,
+        y: 120,
+        angle: -45
+      })
+      render(
+        <svg>
+          <Mark
+            label='Ellipse 1'
+            mark={ellipse}
+            onDelete={onDelete}
+            onFinish={onFinish}
+            onSelect={onSelect}
+          >
+            <Ellipse mark={ellipse} />
+          </Mark>
+        </svg>
+      )
+      svgEllipse = screen.getByLabelText('Ellipse 1')
+    })
+
+    it('should be rotated by mark.angle', function () {
+      const transform = svgEllipse.getAttribute('transform')
+      expect(transform).to.have.string('rotate(-45)')
+    })
+  })
+
+  describe('when the active mark is finished', function () {
     function markWrapper(mark) {
       return (
         <svg>
           <Mark
+            isActive
             label='Point 1'
             mark={mark}
             onDelete={onDelete}
@@ -233,14 +351,15 @@ describe('Drawing tools > Mark', function () {
       )
     }
 
-    describe('with finished mark and no subTaskVisibility', function () {
+    describe('when subtasks are closed', function () {
       let newMark
 
       before(function () {
         window.scrollTo.resetHistory()
         newMark = pointTool.createMark()
+        newMark.setSubTaskVisibility(false)
         newMark.finish()
-        wrapper = mount(markWrapper(newMark))
+        render(markWrapper(newMark))
       })
 
       after(function () {
@@ -248,58 +367,53 @@ describe('Drawing tools > Mark', function () {
         window.scrollTo.resetHistory()
       })
 
-      it('should set subtask visibility', function () {
+      it('should open the subtask popup', function () {
         expect(newMark.subTaskVisibility).to.be.true()
       })
+    })
+  })
 
-      it('should preserve window scroll position', function () {
-        expect(window.scrollTo).to.have.been.calledOnce()
-      })
+  describe('when subtasks are closed', function () {
+    function markWrapper(mark) {
+      return (
+        <svg>
+          <Mark
+            isActive
+            label='Point 1'
+            mark={mark}
+            onDelete={onDelete}
+            onFinish={onFinish}
+            onSelect={onSelect}
+          >
+            <Point mark={mark} />
+          </Mark>
+        </svg>
+      )
+    }
+
+    let newMark, svgPoint
+
+    before(function () {
+      window.scrollTo.resetHistory()
+      newMark = pointTool.createMark()
+      newMark.setSubTaskVisibility(true)
+      newMark.finish()
+      render(markWrapper(newMark))
+      newMark.setSubTaskVisibility(false)
+      svgPoint = screen.getByLabelText('Point 1')
     })
 
-    describe('when the mark is not finished', function () {
-      let newMark
-
-      before(function () {
-        newMark = pointTool.createMark()
-        wrapper = mount(markWrapper(newMark))
-      })
-
-      after(function () {
-        onFinish.resetHistory()
-        window.scrollTo.resetHistory()
-      })
-
-      it('should not set subtask visibility', function () {
-        expect(newMark.subTaskVisibility).to.be.false()
-      })
-
-      it('should not scroll the window',function () {
-        expect(window.scrollTo).to.not.have.been.called()
-      })
+    after(function () {
+      onFinish.resetHistory()
+      window.scrollTo.resetHistory()
     })
 
-    describe('when the subtask is visible', function () {
-      let newMark
+    it('should focus the active mark', function () {
+      expect(document.activeElement).to.equal(svgPoint)
+    })
 
-      before(function () {
-        newMark = pointTool.createMark()
-        newMark.setSubTaskVisibility(true)
-        wrapper = mount(markWrapper(newMark))
-      })
-
-      after(function () {
-        onFinish.resetHistory()
-        window.scrollTo.resetHistory()
-      })
-
-      it('should not change subtask visibility', function () {
-        expect(newMark.subTaskVisibility).to.be.true()
-      })
-
-      it('should not scroll the window',function () {
-        expect(window.scrollTo).to.not.have.been.called()
-      })
+    it('should preserve the window scroll position', function () {
+      expect(window.scrollTo).to.have.been.calledOnce()
     })
   })
 })


### PR DESCRIPTION
- Extract `focusMark` into its own function.
- Focus a mark when it is both active and finished.
- Focus a mark when its subtasks close.
- Open a mark's subtasks automatically when the mark is finished.
- Remove the delete button from the DOM tab order, since it's nested inside a focusable mark, which is masquerading as a labelled button. You can't nest buttons inside other buttons.
- Convert tests from Enzyme to React Testing Library. 

## Package
lib-classifier

## Linked Issue and/or Talk Post
- towards #3815.
- fixes #3858.

## How to Review
I have a test workflow, with various drawing tools (with and without popup questions) that you can use to test this PR from the keyboard.

From the keyboard you should be able to tab through all the drawn marks, open the sub task forms, edit the sub tasks and close each popup. You should only need a mouse (or trackpad or touch screen) to draw new marks and move them around on the screen.

You should also be able to pan and zoom with the keyboard, while marks have focus. 

Dev classifier: https://localhost:8080/?project=eatyourgreens/-project-testing-ground&workflow=3370

I Fancy Cats has an ellipse with a popup question, which is useful for testing complex gestures. The popup shouldn't open until the ellipse is finished, which takes two dragging gestures to set up both axes.
https://localhost:8080/?project=brooke/i-fancy-cats

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
