### PR TITLE
Enable React automatic runtime

### DIFF
--- a/packages/lib-classifier/.babelrc
+++ b/packages/lib-classifier/.babelrc
@@ -9,7 +9,9 @@
     "@babel/plugin-proposal-logical-assignment-operators"
   ],
   "presets": [
-    "@babel/preset-react",
+    ["@babel/preset-react", { 
+      "runtime": "automatic"
+    }],
     ["@babel/preset-env", {
       "modules": false,
       "targets": {
@@ -24,7 +26,9 @@
       ],
       "presets": [
         "@babel/preset-env",
-        "@babel/preset-react"
+        ["@babel/preset-react", { 
+          "runtime": "automatic"
+        }]
       ]
     }
   }

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -16,7 +16,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@babel/plugin-transform-runtime": "~7.19.1",
+    "@babel/runtime": "~7.19.1",
     "@sentry/browser": "~7.20.0",
     "@visx/axis": "~2.14.0",
     "@visx/event": "~2.6.0",
@@ -54,6 +54,7 @@
     "@babel/core": "~7.20.2",
     "@babel/plugin-proposal-decorators": "~7.20.0",
     "@babel/plugin-proposal-logical-assignment-operators": "~7.18.6",
+    "@babel/plugin-transform-runtime": "~7.19.1",
     "@babel/preset-env": "~7.20.2",
     "@babel/preset-react": "~7.18.6",
     "@babel/register": "~7.18.6",

--- a/packages/lib-react-components/.babelrc
+++ b/packages/lib-react-components/.babelrc
@@ -3,7 +3,9 @@
     "babel-plugin-styled-components"
   ],
   "presets": [
-    "@babel/preset-react",
+    ["@babel/preset-react", {
+      "runtime": "automatic"
+    }],
     "@babel/preset-env"
   ]
 }

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,13 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] 2022-11-08
+
+### Changed
+- Enabled the React automatic runtime.
+
 ## [1.2.1] 2022-11-03
 
 ### Added
-- export `useProgressiveImage` hook.
+- Export `useProgressiveImage` hook.
 
 ### Changed
-- removed `react-progressive-image` from the `Media` component.
+- Removed `react-progressive-image` from the `Media` component.
 
 ## [1.2.0] 2022-10-03
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1121,6 +1121,13 @@
   dependencies:
     regenerator-runtime "^0.13.10"
 
+"@babel/runtime@~7.19.1":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
+  integrity sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.7", "@babel/template@^7.18.10", "@babel/template@^7.18.6":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"


### PR DESCRIPTION
- Enable the [React automatic runtime](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) for the classifier and Zooniverse React Components.
- Fix [`@babel/runtime`](https://babeljs.io/docs/en/babel-plugin-transform-runtime) in classifier builds.

## Package
lib-classifier
lib-react-components

## How to Review
Check that `@zooniverse/react-components` and `@zooniverse/classifier` build and run properly, both in the NextJS apps and in the tests and storybooks. CI should check most of that for us.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
