### PR TITLE
Fix the project status check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ USER node
 RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn install --production=false --frozen-lockfile
 RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn workspace @zooniverse/react-components build
 RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn workspace @zooniverse/classifier build
+RUN echo $COMMIT_ID > /usr/src/packages/app-content-pages/public/commit_id.txt
 RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn workspace @zooniverse/fe-content-pages build
 RUN echo $COMMIT_ID > /usr/src/packages/app-project/public/commit_id.txt
 RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn workspace @zooniverse/fe-project build

--- a/packages/app-project/middleware.js
+++ b/packages/app-project/middleware.js
@@ -28,6 +28,12 @@ export function middleware(req, event) {
   if (pathname === '/Index') {
     return NextResponse.next()
   }
+  /*
+    Don't redirect or rewrite the status check.
+  */
+  if (pathname === '/commit_id.txt') {
+    return NextResponse.next()
+  }
 
   if (url.searchParams.has('language')) {
     const locale = url.searchParams.get('language')


### PR DESCRIPTION
- Pass requests for `/commit_id.txt` through to the NextJS app without rewriting the request URL.
- Publish the deployed commit for the content pages app.

## Package
app-content-pages
app-project

## Linked Issue and/or Talk Post
- fixes #3864.

## How to Review
[Build and run a docker image](https://github.com/zooniverse/front-end-monorepo#docker), then check that `http://localhost:3000/projects/commit_id.txt` and `http://localhost:3001/about/commit_id.txt` return a file. The file contents will be whatever `$COMMIT_ID` is set to in your local environment, which might be empty/undefined.
EDIT: you can pass a mock commit hash to the Docker build in order to test it. See the instructions for #2217.

```
docker compose build --build-arg COMMIT_ID=05503fc5
```

Alternatively (and much quicker), run [a branch deploy](https://github.com/zooniverse/front-end-monorepo/actions/workflows/deploy_branch.yml) for this branch, then check that the deployed branch serves the hash of the [latest commit](https://github.com/zooniverse/front-end-monorepo/pull/3865/commits):
- https://fe-project-branch.preview.zooniverse.org/projects/commit_id.txt

After this PR merges, the commit ID should be available on staging at these URLs: 
- https://fe-project.preview.zooniverse.org/projects/commit_id.txt.
- https://fe-content-pages.preview.zooniverse.org/about/commit_id.txt.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser
