### PR TITLE
Classifier: remove deprecated xlink from svg images

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -174,7 +174,7 @@ describe('Components > Classifier', function () {
     })
 
     it('should have a subject image', function () {
-      expect(subjectImage.getAttribute('xlink:href')).to.equal('https://foo.bar/example.png')
+      expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
     })
 
     describe('task answers', function () {
@@ -305,7 +305,7 @@ describe('Components > Classifier', function () {
     })
 
     it('should have a subject image', function () {
-      expect(subjectImage.getAttribute('xlink:href')).to.equal('https://foo.bar/example.png')
+      expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
     })
 
     it('should show the translated task instruction', function () {
@@ -435,7 +435,7 @@ describe('Components > Classifier', function () {
     })
 
     it('should have a subject image', function () {
-      expect(subjectImage.getAttribute('xlink:href')).to.equal('https://foo.bar/example.png')
+      expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
     })
 
     describe('task answers', function () {
@@ -543,7 +543,7 @@ describe('Components > Classifier', function () {
         })
 
         it('should have a subject image', function () {
-          expect(subjectImage.getAttribute('xlink:href')).to.equal('https://foo.bar/example.png')
+          expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
         })
 
         describe('task answers', function () {
@@ -811,7 +811,7 @@ describe('Components > Classifier', function () {
     })
 
     it('should show a subject image from the selected set', function () {
-      expect(subjectImage.getAttribute('xlink:href')).to.equal('https://foo.bar/example2.png')
+      expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example2.png')
     })
 
     describe('task answers', function () {
@@ -888,7 +888,7 @@ describe('Components > Classifier', function () {
     })
 
     it('should be able to view inactive workflows', function () {
-      expect(subjectImage.getAttribute('xlink:href')).to.equal('https://foo.bar/example.png')
+      expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
       expect(taskAnswers).to.have.lengthOf(workflow.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')

--- a/packages/lib-classifier/src/components/Classifier/Classifier.workflows.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.workflows.spec.js
@@ -148,7 +148,7 @@ function testWorkflow(workflowSnapshot, workflowStrings) {
   })
 
   it('should show a subject image from the selected set', function () {
-    expect(subjectImage.getAttribute('xlink:href')).to.equal('https://foo.bar/example.png')
+    expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
   })
 
   describe('task answers', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewer.spec.js
@@ -94,7 +94,7 @@ describe('ImageAndTextViewer', function () {
       expect(image).to.exist()
 
       // "https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png" is the placeholder image for the single image subject viewer
-      expect(image.getAttribute('xlink:href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+      expect(image.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
     })
 
     it('should render the frame change buttons', function () {
@@ -207,7 +207,7 @@ describe('ImageAndTextViewer', function () {
         expect(image).to.exist()
 
         // "https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png" is the placeholder image for the single image subject viewer
-        expect(image.getAttribute('xlink:href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+        expect(image.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
       })
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.spec.js
@@ -130,7 +130,7 @@ describe('Component > MultiFrameViewerContainer', function () {
       wrapper.update()
       const image = wrapper.find('image')
       expect(image).to.have.lengthOf(1)
-      expect(image.prop('xlinkHref')).to.equal('https://some.domain/image.jpg')
+      expect(image.prop('href')).to.equal('https://some.domain/image.jpg')
     })
 
     describe('with dragging enabled', function () {
@@ -138,7 +138,7 @@ describe('Component > MultiFrameViewerContainer', function () {
         wrapper.setProps({ move: true })
         const image = wrapper.find(DraggableImage)
         expect(image).to.have.lengthOf(1)
-        expect(image.prop('xlinkHref')).to.equal('https://some.domain/image.jpg')
+        expect(image.prop('href')).to.equal('https://some.domain/image.jpg')
       })
     })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGImage/SVGImage.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGImage/SVGImage.js
@@ -44,7 +44,7 @@ export default function SVGImage ({
       role='img'
       filter={invert ? 'url("#svg-invert-filter")' : undefined}
       width={naturalWidth}
-      xlinkHref={src}
+      href={src}
     />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGImage/SVGImage.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGImage/SVGImage.spec.js
@@ -17,7 +17,7 @@ describe('SVGImage', function () {
 
     const image = screen.getByRole('img', { name: 'Subject 1234' })
     expect(image).to.exist()
-    expect(image.getAttribute('xlink:href')).to.equal('https://some.domain/image.jpg')
+    expect(image.getAttribute('href')).to.equal('https://some.domain/image.jpg')
     expect(image.getAttribute('filter')).to.be.null()
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.spec.js
@@ -123,7 +123,7 @@ describe('Component > SingleImageViewerContainer', function () {
       wrapper.update()
       const image = wrapper.find('image')
       expect(image).to.have.lengthOf(1)
-      expect(image.prop('xlinkHref')).to.equal('https://some.domain/image.jpg')
+      expect(image.prop('href')).to.equal('https://some.domain/image.jpg')
     })
 
     describe('with dragging enabled', function () {
@@ -131,7 +131,7 @@ describe('Component > SingleImageViewerContainer', function () {
         wrapper.setProps({ move: true })
         const image = wrapper.find(DraggableImage)
         expect(image).to.have.lengthOf(1)
-        expect(image.prop('xlinkHref')).to.equal('https://some.domain/image.jpg')
+        expect(image.prop('href')).to.equal('https://some.domain/image.jpg')
       })
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/components/SGVGridCell/SGVGridCell.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/components/SGVGridCell/SGVGridCell.js
@@ -130,7 +130,7 @@ function SGVGridCell (props) {
           dragMove={dragMove}
           height={imageHeight}
           width={imageWidth}
-          xlinkHref={image.src}
+          href={image.src}
           x={imageX}
           y={imageY}
           transform={imageTransform}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/components/SGVGridCell/SGVGridCell.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/components/SGVGridCell/SGVGridCell.spec.js
@@ -68,7 +68,7 @@ describe('Component > SubjectGroupViewer > SGVGridCell', function () {
   it('should render an image', function () {
     const image = wrapper.find('Styled(draggable(image))')    
     expect(image).to.have.lengthOf(1)
-    expect(image.prop('xlinkHref')).to.equal('https://foo.bar/example.png')
+    expect(image.prop('href')).to.equal('https://foo.bar/example.png')
   })
   
   describe('with a pan and zoom', function () {


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
The `xlink:href` attribute for svg is [deprecated](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href).

## Describe your changes
I removed xlink:href from SVGImage and SGVGridCell components as well as any unit tests that looked for it as an attribute.

## How to Review
To test this PR, view the subject viewers in storybook that use SVGImage under the hood such as 
- SingleImageViewer
- FlipbookViewer
- MultiFrameViewer

Run any project locally that uses the above viewers such as [Wildwatch Burrowing Owl](https://local.zooniverse.org:3000/projects/sandiegozooglobal/wildwatch-burrowing-owl/classify?env=production) or i-fancy-cats.

The SubjectGroupViewer in storybook uses SGVGridCell.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected