### PR TITLE
Classifer: handle default frame for multi-image subjects

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.stories.js
@@ -34,8 +34,36 @@ const mockSubject = SubjectFactory.build({
   ]
 })
 
+const subjectWithDefaultFrame = SubjectFactory.build({
+  locations: [
+    {
+      'image/jpeg':
+        'https://panoptes-uploads.zooniverse.org/subject_location/1e54b552-4608-4701-9db9-b8342b81278a.jpeg'
+    },
+    {
+      'image/jpeg':
+        'https://panoptes-uploads.zooniverse.org/subject_location/098f3fb6-5021-410a-82a2-477a28b2bcd6.jpeg'
+    },
+    {
+      'image/jpeg':
+        'https://panoptes-uploads.zooniverse.org/subject_location/8fcb18b0-de80-42cd-ba2a-4871da30c74f.jpeg'
+    },
+    {
+      'image/jpeg':
+        'https://panoptes-uploads.zooniverse.org/subject_location/85d8d82a-c88d-493c-b3db-7cd9f2ca5ad8.jpeg'
+    }
+  ],
+  metadata: {
+    default_frame: 3
+  }
+})
+
 const store = mockStore({
   subject: mockSubject
+})
+
+const store2 = mockStore({
+  subject: subjectWithDefaultFrame
 })
 
 export default {
@@ -55,6 +83,22 @@ export const Default = ({ dark }) => {
           <FlipbookViewerContainer
             loadingState={asyncStates.success}
             subject={store.subjects.active}
+          />
+        </Box>
+      </Provider>
+    </Grommet>
+  )
+}
+
+export const WithDefaultFrame = ({ dark }) => {
+  const themeMode = dark ? 'dark' : 'light'
+  return (
+    <Grommet background={background} theme={zooTheme} themeMode={themeMode}>
+      <Provider classifierStore={store2}>
+        <Box width='large'>
+          <FlipbookViewerContainer
+            loadingState={asyncStates.success}
+            subject={store2.subjects.active}
           />
         </Box>
       </Provider>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.stories.js
@@ -62,7 +62,7 @@ const store = mockStore({
   subject: mockSubject
 })
 
-const store2 = mockStore({
+const storeWithDefaultFrame = mockStore({
   subject: subjectWithDefaultFrame
 })
 
@@ -94,11 +94,11 @@ export const WithDefaultFrame = ({ dark }) => {
   const themeMode = dark ? 'dark' : 'light'
   return (
     <Grommet background={background} theme={zooTheme} themeMode={themeMode}>
-      <Provider classifierStore={store2}>
+      <Provider classifierStore={storeWithDefaultFrame}>
         <Box width='large'>
           <FlipbookViewerContainer
             loadingState={asyncStates.success}
-            subject={store2.subjects.active}
+            subject={storeWithDefaultFrame.subjects.active}
           />
         </Box>
       </Provider>

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -125,8 +125,8 @@ const SubjectViewer = types
       resetSubject (subject) {
         let frame = 0
         // teams set default frame in the project builder
-        // here we're converting it to index (min of 0 instead of min of 1)
-        if (subject?.metadata?.default_frame >= 0) {
+        // here we're converting it to index
+        if (subject?.metadata?.default_frame > 0) {
           frame = parseInt(subject.metadata.default_frame - 1)
         }
         self.dimensions = []

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -124,8 +124,10 @@ const SubjectViewer = types
 
       resetSubject (subject) {
         let frame = 0
+        // teams set default frame in the project builder
+        // here we're converting it to index (min of 0 instead of min of 1)
         if (subject?.metadata?.default_frame >= 0) {
-          frame = parseInt(subject.metadata.default_frame)
+          frame = parseInt(subject.metadata.default_frame - 1)
         }
         self.dimensions = []
         self.frame = frame

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.spec.js
@@ -1,12 +1,9 @@
 import asyncStates from '@zooniverse/async-states'
 import { Factory } from 'rosie'
 import sinon from 'sinon'
-import SubjectStore from '../SubjectStore'
 import SubjectViewerStore from './SubjectViewerStore'
 
 describe('Model > SubjectViewerStore', function () {
-  const subject = Factory.build('subject')
-
   it('should exist', function () {
     expect(SubjectViewerStore).to.be.ok()
     expect(SubjectViewerStore).to.be.an('object')
@@ -132,12 +129,12 @@ describe('Model > SubjectViewerStore', function () {
     })
 
     describe('when the subject has a default frame of 2', function () {
-      it('should have the store frame as 2', function () {
+      it('should save frame 2 in the store as index 1', function () {
         const subjectWithDefaultFrame = Factory.build('subject', {
           metadata: { default_frame: 2 }
         })
         subjectViewerStore.resetSubject(subjectWithDefaultFrame)
-        expect(subjectViewerStore.frame).to.equal(2)
+        expect(subjectViewerStore.frame).to.equal(1)
       })
     })
   })


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
https://github.com/zooniverse/front-end-monorepo/issues/3792

## Describe your changes
For subjects with multiple images in the `locations` array, SubjectViewerStore's `resetSubject()` (called upon subject load) handles `metadata.default_frame`. This PR specifies that a default frame of 2 should be set as index 1, or a default frame of 1 should be set as index 0, etc.

## How to Review

Flipbook's storybook now has a case where the subject's default frame is 3. Viewing that story on this branch should correctly show frame 3 selected when the subject loads.

As mentioned in Issue #3792, Correct-a-cell's subjects have `default_frame` of 3, so viewing the project [locally](https://local.zooniverse.org:3000/projects/h-spiers/etch-a-cell/classify/workflow/8921?env=production) should correctly show frame 3 selected when the subject loads.

WIldwatch Burrowing Owl's subjects do not specify a default frame, so viewing the project [locally](https://local.zooniverse.org:3000/projects/sandiegozooglobal/wildwatch-burrowing-owl/classify/workflow/21141?env=production) should correctly show frame 1 selected when the subject loads.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated