### PR TITLE
NextJS: remove outdated babel plugins

### DIFF
--- a/packages/app-content-pages/.babelrc
+++ b/packages/app-content-pages/.babelrc
@@ -1,24 +1,7 @@
 {
-  "plugins": [
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
-    "dynamic-import-node"
-  ],
-  "presets": ["next/babel"],
   "env": {
-    "dev": {
-      "plugins": [
-        "babel-plugin-styled-components",
-      ]
-    },
-    "production": {
-      "plugins": [
-        "babel-plugin-styled-components",
-      ]
-    },
     "test": {
-      "plugins": [
-        "babel-plugin-styled-components",
-      ]
+      "presets": ["next/babel"]
     }
   }
 }

--- a/packages/app-content-pages/next.config.js
+++ b/packages/app-content-pages/next.config.js
@@ -34,11 +34,19 @@ const nextConfig = {
   assetPrefix,
   basePath: '/about', 
 
+  compiler: {
+    styledComponents: true,
+  },
+
   env: {
     COMMIT_ID,
     PANOPTES_ENV,
     SENTRY_CONTENT_DSN,
     APP_ENV
+  },
+
+  experimental: {
+    forceSwcTransforms: true,
   },
 
   reactStrictMode: true,

--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -15,16 +15,13 @@
     "test:ci": "BABEL_ENV=test mocha --config ./test/.mocharc.json --reporter=min \"./{src,server,test}/**/*.spec.js\""
   },
   "dependencies": {
-    "@babel/plugin-proposal-decorators": "~7.20.0",
-    "@sentry/browser": "~7.21.0",
-    "@sentry/node": "~7.21.0",
+    "@sentry/browser": "~7.20.0",
+    "@sentry/node": "~7.20.0",
     "@zeit/next-source-maps": "0.0.4-canary.1",
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/grommet-theme": "~3.1.0",
     "@zooniverse/panoptes-js": "~0.2.0",
     "@zooniverse/react-components": "~1.2.0",
-    "babel-plugin-dynamic-import-node": "~2.3.0",
-    "babel-plugin-styled-components": "~2.0.2",
     "contentful": "~9.2.3",
     "counterpart": "~0.18.6",
     "dotenv": "~16.0.1",

--- a/packages/app-content-pages/pages/_document.js
+++ b/packages/app-content-pages/pages/_document.js
@@ -20,7 +20,7 @@ export default class MyDocument extends Document {
       const initialProps = await Document.getInitialProps(ctx)
       return {
         ...initialProps,
-        styles: <>{initialProps.styles}{sheet.getStyleElement()}</>
+        styles: [initialProps.styles, sheet.getStyleElement()]
       }
     } finally {
       sheet.seal()

--- a/packages/app-content-pages/src/shared/components/AuthModal/AuthModalContainer.js
+++ b/packages/app-content-pages/src/shared/components/AuthModal/AuthModalContainer.js
@@ -88,10 +88,7 @@ AuthModalContainer.propTypes = {
   }).isRequired
 }
 
-@inject('store')
-@withRouter
-@observer
-class DecoratedAuthModalContainer extends AuthModalContainer { }
+const DecoratedAuthModalContainer = inject('store')(withRouter(observer(AuthModalContainer)))
 
 export default DecoratedAuthModalContainer
 export { AuthModalContainer }

--- a/packages/app-content-pages/src/shared/components/AuthModal/components/LoginForm/LoginFormContainer.js
+++ b/packages/app-content-pages/src/shared/components/AuthModal/components/LoginForm/LoginFormContainer.js
@@ -66,9 +66,7 @@ LoginFormContainer.defaultProps = {
   closeModal: () => {}
 }
 
-@inject('store')
-@observer
-class DecoratedLoginFormContainer extends LoginFormContainer { }
+const DecoratedLoginFormContainer = inject('store')(observer(LoginFormContainer))
 
 export default DecoratedLoginFormContainer
 export { LoginFormContainer }

--- a/packages/app-content-pages/src/shared/components/AuthModal/components/RegisterForm/RegisterFormContainer.js
+++ b/packages/app-content-pages/src/shared/components/AuthModal/components/RegisterForm/RegisterFormContainer.js
@@ -112,9 +112,7 @@ RegisterFormContainer.defaultProps = {
   closeModal: () => { }
 }
 
-@inject('store')
-@observer
-class DecoratedRegisterFormContainer extends RegisterFormContainer { }
+const DecoratedRegisterFormContainer = inject('store')(observer(RegisterFormContainer))
 
 export default DecoratedRegisterFormContainer
 export { RegisterFormContainer }

--- a/packages/app-project/.babelrc
+++ b/packages/app-project/.babelrc
@@ -1,25 +1,10 @@
 {
-  "plugins": [
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
-    "dynamic-import-node"
-  ],
-  "presets": ["next/babel"],
   "env": {
-    "dev": {
-      "plugins": [
-        "babel-plugin-styled-components",
-      ]
-    },
-    "production": {
-      "plugins": [
-        "babel-plugin-styled-components",
-      ]
-    },
     "test": {
       "plugins": [
-        "babel-plugin-styled-components",
         [ "babel-plugin-webpack-alias", { "config": "./webpack.config.test.js" } ]
-      ]
+      ],
+      "presets": ["next/babel"]
     }
   }
 }

--- a/packages/app-project/next.config.js
+++ b/packages/app-project/next.config.js
@@ -38,12 +38,20 @@ const nextConfig = {
   assetPrefix,
   basePath: '/projects',
 
+  compiler: {
+    styledComponents: true,
+  },
+
   env: {
     COMMIT_ID,
     PANOPTES_ENV,
     SENTRY_PROJECT_DSN,
     APP_ENV,
     TALK_HOST
+  },
+
+  experimental: {
+    forceSwcTransforms: true,
   },
 
   async headers() {

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@artsy/fresnel": "~6.1.0",
-    "@babel/plugin-proposal-decorators": "~7.20.0",
     "@sentry/browser": "~7.21.0",
     "@sentry/node": "~7.21.0",
     "@sindresorhus/string-hash": "~1.2.0",
@@ -34,8 +33,6 @@
     "@zooniverse/grommet-theme": "~3.1.0",
     "@zooniverse/panoptes-js": "~0.2.0",
     "@zooniverse/react-components": "~1.2.0",
-    "babel-plugin-dynamic-import-node": "~2.3.0",
-    "babel-plugin-styled-components": "~2.0.2",
     "cookie": "~0.5.0",
     "d3": "~6.7.0",
     "engine.io-client": "~6.2.1",

--- a/packages/app-project/pages/[panoptesEnv]/[owner]/[project]/logger.js
+++ b/packages/app-project/pages/[panoptesEnv]/[owner]/[project]/logger.js
@@ -10,8 +10,6 @@ function storeMapper(stores) {
   }
 }
 
-@inject(storeMapper)
-@observer
 class Logger extends Component {
   static async getInitialProps({ query = {}, res }) {
     const environment = query.env || process.env.NODE_ENV
@@ -48,4 +46,4 @@ class Logger extends Component {
   }
 }
 
-export default Logger
+export default inject(storeMapper)(observer(Logger))

--- a/packages/app-project/pages/_document.js
+++ b/packages/app-project/pages/_document.js
@@ -29,7 +29,7 @@ export default class MyDocument extends Document {
       const initialProps = await Document.getInitialProps(ctx)
       return {
         ...initialProps,
-        styles: <>{initialProps.styles}{sheet.getStyleElement()}</>
+        styles: [initialProps.styles, sheet.getStyleElement()]
       }
     } catch (error) {
       logToSentry(error)

--- a/packages/app-project/src/components/AuthModal/AuthModalContainer.js
+++ b/packages/app-project/src/components/AuthModal/AuthModalContainer.js
@@ -88,10 +88,7 @@ AuthModalContainer.propTypes = {
   }).isRequired
 }
 
-@inject('store')
-@withRouter
-@observer
-class DecoratedAuthModalContainer extends AuthModalContainer { }
+const DecoratedAuthModalContainer = inject('store')(withRouter(observer(AuthModalContainer)))
 
 export default DecoratedAuthModalContainer
 export { AuthModalContainer }

--- a/packages/app-project/src/components/AuthModal/components/LoginForm/LoginFormContainer.js
+++ b/packages/app-project/src/components/AuthModal/components/LoginForm/LoginFormContainer.js
@@ -65,10 +65,8 @@ LoginFormContainer.defaultProps = {
   t: (key) => key
 }
 
-// Noting that mobx decorators are outdated https://michel.codes/blogs/mobx6
-@inject('store')
-@observer
-class DecoratedLoginFormContainer extends LoginFormContainer { }
+// Noting that mobx inject is outdated https://michel.codes/blogs/mobx6
+const DecoratedLoginFormContainer = inject('store')(observer(LoginFormContainer))
 
 export default withTranslation('components')(DecoratedLoginFormContainer)
 export { LoginFormContainer }

--- a/packages/app-project/src/components/AuthModal/components/RegisterForm/RegisterFormContainer.js
+++ b/packages/app-project/src/components/AuthModal/components/RegisterForm/RegisterFormContainer.js
@@ -113,9 +113,7 @@ RegisterFormContainer.defaultProps = {
   t: (key) => key
 }
 
-@inject('store')
-@observer
-class DecoratedRegisterFormContainer extends RegisterFormContainer { }
+const DecoratedRegisterFormContainer = inject('store')(observer(RegisterFormContainer))
 
 export default withTranslation('components')(DecoratedRegisterFormContainer)
 export { RegisterFormContainer }

--- a/packages/app-project/src/components/Head/HeadContainer.js
+++ b/packages/app-project/src/components/Head/HeadContainer.js
@@ -81,10 +81,7 @@ HeadContainer.propTypes = {
   })
 }
 
-@inject(storeMapper)
-@withRouter
-@observer
-class DecoratedHeadContainer extends HeadContainer {}
+const DecoratedHeadContainer = inject(storeMapper)(withRouter(observer(HeadContainer)))
 
 export default DecoratedHeadContainer
 export { HeadContainer }

--- a/packages/app-project/src/components/ProjectName/ProjectNameContainer.js
+++ b/packages/app-project/src/components/ProjectName/ProjectNameContainer.js
@@ -11,8 +11,6 @@ function storeMapper (stores) {
   }
 }
 
-@inject(storeMapper)
-@observer
 class ProjectNameContainer extends Component {
   render () {
     return (
@@ -25,4 +23,4 @@ ProjectNameContainer.propTypes = {
   projectName: string
 }
 
-export default ProjectNameContainer
+export default inject(storeMapper)(observer(ProjectNameContainer))

--- a/packages/app-project/src/components/ThemeModeToggle/ThemeModeToggleContainer.js
+++ b/packages/app-project/src/components/ThemeModeToggle/ThemeModeToggleContainer.js
@@ -12,8 +12,6 @@ function storeMapper (stores) {
   }
 }
 
-@inject(storeMapper)
-@observer
 class ThemeModeToggleContainer extends Component {
   render () {
     const { mode, toggleMode } = this.props
@@ -35,4 +33,4 @@ ThemeModeToggleContainer.defaultProps = {
   mode: 'light'
 }
 
-export default ThemeModeToggleContainer
+export default inject(storeMapper)(observer(ThemeModeToggleContainer))

--- a/packages/app-project/src/helpers/GrommetWrapper/GrommetWrapperContainer.js
+++ b/packages/app-project/src/helpers/GrommetWrapper/GrommetWrapperContainer.js
@@ -13,8 +13,6 @@ function storeMapper (stores) {
   }
 }
 
-@inject(storeMapper)
-@observer
 class GrommetWrapperContainer extends Component {
   mergeThemes () {
     const { mode, theme } = this.props
@@ -51,4 +49,4 @@ GrommetWrapperContainer.defaultProps = {
   theme
 }
 
-export default GrommetWrapperContainer
+export default inject(storeMapper)(observer(GrommetWrapperContainer))

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/FinishedForTheDayContainer.js
@@ -60,10 +60,7 @@ FinishedForTheDayContainer.defaultProps = {
   projectName: ''
 }
 
-@inject(storeMapper)
-@withRouter
-@observer
-class DecoratedFinishedForTheDayContainer extends FinishedForTheDayContainer { }
+const DecoratedFinishedForTheDayContainer = inject(storeMapper)(withRouter(observer(FinishedForTheDayContainer)))
 
 export {
   DecoratedFinishedForTheDayContainer as default,

--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/RelatedProjectsModalContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/RelatedProjects/components/RelatedProjectsModal/RelatedProjectsModalContainer.js
@@ -10,8 +10,6 @@ function storeMapper (stores) {
   }
 }
 
-@inject(storeMapper)
-@observer
 class RelatedProjectsModalContainer extends Component {
   render () {
     const { projectTitle } = this.props
@@ -28,4 +26,4 @@ RelatedProjectsModalContainer.propTypes = {
   projectTitle: string.isRequired
 }
 
-export default RelatedProjectsModalContainer
+export default inject(storeMapper)(observer(RelatedProjectsModalContainer))

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Background/BackgroundContainer.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Background/BackgroundContainer.js
@@ -22,9 +22,7 @@ BackgroundContainer.propTypes = {
   backgroundSrc: string.isRequired
 }
 
-@inject(storeMapper)
-@observer
-class DecoratedBackgroundContainer extends BackgroundContainer { }
+const DecoratedBackgroundContainer = inject(storeMapper)(observer(BackgroundContainer))
 
 export {
   DecoratedBackgroundContainer as default,

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/IntroductionContainer.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/Introduction/IntroductionContainer.js
@@ -42,10 +42,7 @@ IntroductionContainer.propTypes = {
   title: string.isRequired
 }
 
-@inject(storeMapper)
-@withRouter
-@observer
-class DecoratedIntroductionContainer extends IntroductionContainer {}
+const DecoratedIntroductionContainer = inject(storeMapper)(withRouter(observer(IntroductionContainer)))
 
 export {
   DecoratedIntroductionContainer as default,

--- a/packages/app-project/src/screens/ProjectHomePage/components/MessageFromResearcher/MessageFromResearcherContainer.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/MessageFromResearcher/MessageFromResearcherContainer.js
@@ -84,9 +84,7 @@ MessageFromResearcherContainer.propTypes = {
   })
 }
 
-@inject(storeMapper)
-@observer
-class WrappedMessageFromResearcherContainer extends MessageFromResearcherContainer {}
+const WrappedMessageFromResearcherContainer = inject(storeMapper)(observer(MessageFromResearcherContainer))
 
 export default WrappedMessageFromResearcherContainer
 export { MessageFromResearcherContainer }

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/JoinInButton/JoinInButtonContainer.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/JoinInButton/JoinInButtonContainer.js
@@ -28,8 +28,5 @@ JoinInButtonContainer.propTypes = {
   }).isRequired
 }
 
-@withRouter
-class DecoratedJoinInButtonContainer extends JoinInButtonContainer { }
-
-export default DecoratedJoinInButtonContainer
+export default withRouter(JoinInButtonContainer)
 export { JoinInButtonContainer }

--- a/packages/app-project/src/shared/components/CollectionsModal/CollectionsModalContainer.js
+++ b/packages/app-project/src/shared/components/CollectionsModal/CollectionsModalContainer.js
@@ -23,8 +23,6 @@ function storeMapper (stores) {
   }
 }
 
-@inject(storeMapper)
-@observer
 class CollectionsModalContainer extends Component {
   constructor () {
     super()
@@ -124,4 +122,4 @@ CollectionsModalContainer.defaultProps = {
   searchCollections: Function.prototype
 }
 
-export default CollectionsModalContainer
+export default inject(storeMapper)(observer(CollectionsModalContainer))

--- a/packages/app-project/src/shared/components/ConnectWithProject/ConnectWithProjectContainer.js
+++ b/packages/app-project/src/shared/components/ConnectWithProject/ConnectWithProjectContainer.js
@@ -13,8 +13,6 @@ function storeMapper (stores) {
   }
 }
 
-@inject(storeMapper)
-@observer
 class ConnectWithProjectContainer extends Component {
   render () {
     const { projectName, urls } = this.props
@@ -33,4 +31,4 @@ ConnectWithProjectContainer.propTypes = {
   }))
 }
 
-export default ConnectWithProjectContainer
+export default inject(storeMapper)(observer(ConnectWithProjectContainer))

--- a/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatisticsContainer.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/ProjectStatisticsContainer.js
@@ -64,10 +64,7 @@ ProjectStatisticsContainer.defaultProps = {
   volunteers: 0
 }
 
-@inject(storeMapper)
-@withRouter
-@observer
-class DecoratedProjectStatisticsContainer extends ProjectStatisticsContainer {}
+const DecoratedProjectStatisticsContainer = inject(storeMapper)(withRouter(observer(ProjectStatisticsContainer)))
 
 export {
   DecoratedProjectStatisticsContainer as default,

--- a/packages/app-project/src/shared/components/ProjectStatistics/components/CompletionBar/CompletionBarContainer.js
+++ b/packages/app-project/src/shared/components/ProjectStatistics/components/CompletionBar/CompletionBarContainer.js
@@ -27,9 +27,7 @@ CompletionBarContainer.defaultProps = {
   completeness: 0
 }
 
-@inject(storeMapper)
-@observer
-class DecoratedCompletionBarContainer extends CompletionBarContainer {}
+const DecoratedCompletionBarContainer = inject(storeMapper)(observer(CompletionBarContainer))
 
 export {
   DecoratedCompletionBarContainer as default,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5530,13 +5530,6 @@ babel-plugin-apply-mdx-type-prop@1.6.22:
     "@babel/helper-plugin-utils" "7.10.4"
     "@mdx-js/util" "1.6.22"
 
-babel-plugin-dynamic-import-node@~2.3.0:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"
-  integrity sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
-  dependencies:
-    object.assign "^4.1.0"
-
 babel-plugin-emotion@^10.0.27:
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz#a1fe3503cff80abfd0bdda14abd2e8e57a79d17d"
@@ -5635,7 +5628,7 @@ babel-plugin-react-docgen@^4.2.1:
     lodash "^4.17.15"
     react-docgen "^5.0.0"
 
-"babel-plugin-styled-components@>= 1.12.0", babel-plugin-styled-components@~2.0.2:
+"babel-plugin-styled-components@>= 1.12.0":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz#c81ef34b713f9da2b7d3f5550df0d1e19e798086"
   integrity sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==


### PR DESCRIPTION
- Replace `babel-plugin-styled-components` with the [built-in styled components compiler](https://styled-components.com/docs/advanced#nextjs) for both NextJS apps.
- Remove `babel-plugin-dynamic-import-node`. Async imports are supported in Node now.
- Remove class decorators. They were a noble attempt at more readable syntax but no one liked them. 
- Use SWC for builds. Keep Babel to run the tests.

## Package
app-content-pages
app-project

## How to Review
There are a few options. Pick the one you're most comfortable with:
- [Build and start both NextJS apps locally](https://github.com/zooniverse/front-end-monorepo/#with-node-and-yarn) to verify that they still work without these plugins.
- [Build and start a Docker image](https://github.com/zooniverse/front-end-monorepo/#docker), then check both NextJS apps on localhost.
- [Build and deploy a Docker image of this branch](https://github.com/zooniverse/front-end-monorepo/actions/workflows/deploy_branch.yml), then check the project app on https://fe-project-branch.preview.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess. There's no branch preview on kubernetes for the content pages app.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [ ] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Maintenance
- [x] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
