### PR TITLE
Classifier: Save Flipbook play speed between subjects

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/components/FlipbookControls.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/components/FlipbookControls.js
@@ -7,9 +7,11 @@ import {
   FormDown
 } from 'grommet-icons'
 import PropTypes from 'prop-types'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef } from 'react'
 import styled, { withTheme, css } from 'styled-components'
 import { useTranslation } from 'react-i18next'
+import { observer } from 'mobx-react'
+import { useStores } from '@hooks'
 
 import controlsTheme from './theme'
 import locationValidator from '../../../helpers/locationValidator'
@@ -39,6 +41,18 @@ const ThumbnailButton = styled(Button)`
 
 const backgrounds = { dark: 'dark-3', light: 'neutral-6' }
 
+function storeMapper(store) {
+  const {
+    flipbookSpeed,
+    setFlipbookSpeed
+  } = store.subjectViewer
+
+  return {
+    flipbookSpeed,
+    setFlipbookSpeed
+  }
+}
+
 const FlipbookControls = ({
   currentFrame = 0,
   locations = [],
@@ -46,10 +60,9 @@ const FlipbookControls = ({
   onPlayPause = () => true,
   playing = false
 }) => {
+  const { flipbookSpeed, setFlipbookSpeed } = useStores(storeMapper)
   const { t } = useTranslation('components')
   const timeoutRef = useRef(null)
-
-  const [playbackSpeed, setPlaybackSpeed] = useState(1)
 
   const handleKeyDown = (event) => {
     const index = currentFrame
@@ -123,7 +136,7 @@ const FlipbookControls = ({
     if (playing) {
       timeoutRef.current = setTimeout(() => {
         handleNext()
-      }, 500 / playbackSpeed)
+      }, 500 / flipbookSpeed)
     }
 
     return () => {
@@ -132,7 +145,7 @@ const FlipbookControls = ({
   }, [playing, currentFrame])
 
   const handlePlaybackSpeed = e => {
-    setPlaybackSpeed(Number(e.value.slice(0, e.value.length - 1)))
+    setFlipbookSpeed(Number(e.value.slice(0, e.value.length - 1)))
   }
 
   const playPauseLabel = playing
@@ -158,7 +171,7 @@ const FlipbookControls = ({
             <Select
               a11yTitle={t('SubjectViewer.VideoController.playbackSpeed')}
               options={['0.25x', '0.5x', '1x', '2x', '4x']}
-              value={`${playbackSpeed}x`}
+              value={`${flipbookSpeed}x`}
               onChange={handlePlaybackSpeed}
               plain
               icon={<FormDown />}
@@ -237,9 +250,7 @@ FlipbookControls.propTypes = {
   locations: PropTypes.arrayOf(locationValidator).isRequired,
   onFrameChange: PropTypes.func,
   onPlayPause: PropTypes.func,
-  playIterations: PropTypes.string,
-  theme: PropTypes.object
+  playing: PropTypes.bool
 }
 
-export default withTheme(FlipbookControls)
-export { FlipbookControls }
+export default withTheme(observer(FlipbookControls))

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -12,6 +12,7 @@ const SubjectViewer = types
       naturalHeight: types.integer,
       naturalWidth: types.integer
     })),
+    flipbookSpeed: types.optional(types.number, 1),
     frame: types.optional(types.integer, 0),
     fullscreen: types.optional(types.boolean, false),
     invert: types.optional(types.boolean, false),
@@ -144,6 +145,10 @@ const SubjectViewer = types
       rotate () {
         console.log('rotating subject')
         self.rotation -= 90
+      },
+
+      setFlipbookSpeed (speed) {
+        self.flipbookSpeed = speed
       },
 
       setFrame (index) {

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.spec.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.spec.js
@@ -1,7 +1,6 @@
 import asyncStates from '@zooniverse/async-states'
 import { Factory } from 'rosie'
 import sinon from 'sinon'
-import SubjectStore from '../SubjectStore'
 import SubjectViewerStore from './SubjectViewerStore'
 
 describe('Model > SubjectViewerStore', function () {
@@ -153,6 +152,20 @@ describe('Model > SubjectViewerStore', function () {
       subjectViewerStore.rotate()
       subjectViewerStore.resetView()
       expect(subjectViewerStore.rotation).to.equal(0)
+    })
+  })
+
+  describe('Actions > setFlipbookSpeed', function () {
+    let subjectViewerStore
+
+    before(function () {
+      subjectViewerStore = SubjectViewerStore.create()
+    })
+
+    it('should set a new flipbook speed', function () {
+      expect(subjectViewerStore.flipbookSpeed).to.equal(1)
+      subjectViewerStore.setFlipbookSpeed(2)
+      expect(subjectViewerStore.flipbookSpeed).to.equal(2)
     })
   })
 


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Flipbook Project Board: https://github.com/zooniverse/front-end-monorepo/projects/21

## Describe your changes

In PFE, the flipbook viewer persists play speed when volunteers are shown a new subject. This PR moves FEM's flipbook play speed from FlipbookControls component state to a `flipbookSpeed` property on the subject viewer store. A volunteer's chosen play speed will be saved across subjects instead of resetting.

## How to Review

View [Wildwatch Burrowing Owl on PFE](https://www.zooniverse.org/projects/sandiegozooglobal/wildwatch-burrowing-owl/classify) to see how its subject viewer saves flipbook speed. Then run this branch locally and view the same project [locally](https://local.zooniverse.org:3000/projects/sandiegozooglobal/wildwatch-burrowing-owl/classify/workflow/21141?env=production). FEM's flipbook viewer should not reset play speed between subjects.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature