### PR TITLE
Survey task: refactor filter buttons onChange

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/components/CharacteristicSection.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/components/CharacteristicSection.js
@@ -1,6 +1,6 @@
 import { Box, RadioButtonGroup } from 'grommet'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useCallback } from 'react'
 import { SpacedHeading } from '@zooniverse/react-components'
 
 import FilterButton from '../../components/FilterButton'
@@ -19,7 +19,35 @@ export default function CharacteristicSection({
   selectedValueId = '',
   strings
 }) {
-  const characteristicOptions = characteristic.valuesOrder.map(valueId => {
+  const onChange = useCallback(
+    ({ target }) => onFilter(characteristicId, target?.value),
+    [characteristicId, onFilter]
+  )
+  const radioButtonLabel = useCallback((option, { checked, focus, hover }) => {
+    function clearSelection(event) {
+      /*
+      This is a workaround to prevent the label from being clicked in Chrome, when the radio
+      button is already checked. However, it makes the delete function hard to use from the keyboard.
+      */
+      event.preventDefault()
+      return onFilter(characteristicId)
+    }
+    return (
+      <FilterButton
+        characteristicId={characteristicId}
+        characteristicLabel={label}
+        checked={checked}
+        focus={focus}
+        hover={hover}
+        onDelete={clearSelection}
+        valueId={option.value}
+        valueImageSrc={option.imageSrc}
+        valueLabel={option.label}
+      />
+    )
+  }, [characteristicId, label, onFilter])
+
+  const characteristicOption = useCallback(valueId => {
     const value = characteristic?.values?.[valueId] || {}
     const valueImageSrc = images?.[value.image] || ''
     const label = strings.get(`characteristics.${characteristicId}.values.${valueId}.label`)
@@ -31,7 +59,8 @@ export default function CharacteristicSection({
       label,
       value: valueId
     })
-  })
+  }, [characteristic, characteristicId, images, strings])
+  const characteristicOptions = characteristic.valuesOrder.map(characteristicOption)
 
   return (
     <Box
@@ -56,26 +85,12 @@ export default function CharacteristicSection({
         direction='row'
         gap='xsmall'
         name={`${characteristic.label}-filter`}
-        onChange={({ target }) => onFilter(characteristicId, target.value)}
+        onChange={onChange}
         options={characteristicOptions}
         value={selectedValueId}
         wrap
       >
-        {(option, { checked, focus, hover }) => {
-          return (
-            <FilterButton
-              characteristicId={characteristicId}
-              characteristicLabel={label}
-              checked={checked}
-              focus={focus}
-              hover={hover}
-              onFilter={onFilter}
-              valueId={option.value}
-              valueImageSrc={option.imageSrc}
-              valueLabel={option.label}
-            />
-          )
-        }}
+        {radioButtonLabel}
       </RadioButtonGroup>
     </Box>
   )

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/FilterStatus/FilterStatus.js
@@ -108,6 +108,9 @@ export default function FilterStatus ({
         const value = characteristic.values?.[selectedValueId] || {}
         const valueImageSrc = images?.[value.image] || ''
         const label = strings.get(`characteristics.${characteristicId}.values.${selectedValueId}.label`)
+        function clearSelection() {
+          handleFilter(characteristicId)
+        }
 
         return (
           <FilterButton
@@ -115,7 +118,7 @@ export default function FilterStatus ({
             buttonSize='small'
             characteristicId={characteristicId}
             checked
-            onFilter={handleFilter}
+            onDelete={clearSelection}
             valueId={selectedValueId}
             valueImageSrc={valueImageSrc}
             valueLabel={label}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/components/FilterButton.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/components/FilterButton.js
@@ -1,8 +1,8 @@
-import { Box } from 'grommet'
+import { Box, Image } from 'grommet'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
-import { CloseButton, Media } from '@zooniverse/react-components'
+import { CloseButton } from '@zooniverse/react-components'
 import { useTranslation } from 'react-i18next'
 
 export const StyledFilter = styled(Box)`
@@ -17,19 +17,17 @@ export const StyledFilter = styled(Box)`
   }
 `
 
-export default function FilterButton (props) {
-  const {
-    buttonSize = 'medium',
-    characteristicId = '',
-    checked = false,
-    focus = false,
-    hover = false,
-    onFilter = () => {},
-    valueId = '',
-    valueImageSrc = '',
-    valueLabel = ''
-  } = props
-
+export default function FilterButton ({
+  buttonSize = 'medium',
+  characteristicId = '',
+  checked = false,
+  focus = false,
+  hover = false,
+  onDelete = () => {},
+  valueId = '',
+  valueImageSrc = '',
+  valueLabel = ''
+}) {
   const { t } = useTranslation('plugins')
 
   const backgroundColor = checked ? 'accent-1' : 'neutral-6'
@@ -50,8 +48,9 @@ export default function FilterButton (props) {
       round='full'
       width={containerSize}
     >
-      <Media
+      <Image
         alt={valueLabel}
+        fit='contain'
         height={mediaSize}
         src={valueImageSrc}
         width={mediaSize}
@@ -60,12 +59,7 @@ export default function FilterButton (props) {
         <CloseButton
           aria-label={t('SurveyTask.CharacteristicsFilter.removeFilter', { valueLabel })}
           data-testid={`remove-filter-${characteristicId}-${valueId}`}
-          closeFn={(event) => {
-            // Note: preventDefault and stopPropagation are to prevent the radio button input click handler from firing and re-selecting the characteristic filter
-            event.preventDefault()
-            event.stopPropagation()
-            onFilter(characteristicId)
-          }}
+          closeFn={onDelete}
         />
       )}
     </StyledFilter>
@@ -78,7 +72,7 @@ FilterButton.propTypes = {
   checked: PropTypes.bool,
   focus: PropTypes.bool,
   hover: PropTypes.bool,
-  onFilter: PropTypes.func,
+  onDelete: PropTypes.func,
   valueId: PropTypes.string,
   valueImageSrc: PropTypes.string,
   valueLabel: PropTypes.string


### PR DESCRIPTION
Refactor the filter buttons `onChange` and delete functions as callbacks that can toggle the selected option on or off (if already selected.)

Fix filter icon styling so that icons aren't clipped.

## Package
lib-classifier

## How to Review
This can be checked with the Survey Task story in the storybook. Filter icons shouldn't be clipped any more, and there shouldn't be a flash of teal placeholder for each filter radio button. Other than that, the survey task filter should continue to work as expected.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook
 
## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
