### PR TITLE
Debounce resize observers

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
@@ -24,7 +24,10 @@ function ProjectHeader({
   adminMode,
   className = ''
 }) {
-  const { width, height, ref } = useResizeDetector()
+  const { width, height, ref } = useResizeDetector({
+    refreshMode: 'debounce',
+    refreshRate: 100
+  })
   const {
     availableLocales,
     inBeta,

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.js
@@ -46,7 +46,10 @@ export default function ZooHeader({
   ...props
 }) {
   const { t } = useTranslation()
-  const { width, height, ref } = useResizeDetector()
+  const { width, height, ref } = useResizeDetector({
+    refreshMode: 'debounce',
+    refreshRate: 100
+  })
   isNarrow = isNarrow || width <= breakpoint
 
   const host = getHost()


### PR DESCRIPTION
Debounce resize observers, in the Zooniverse page header and the project header, in order to avoid resize loop limit errors from browsers.

Sentry is logging thousands of resize observer loop limit errors per week for project pages. This change might reduce or even prevent them entirely.

## Package
app-project
lib-react-components

## Linked Issue and/or Talk Post
- See the discussion on https://github.com/maslianok/react-resize-detector/issues/45.

## How to Review
I'm not entirely sure how to check this, since resize observer errors are thrown by the window, so not logged in the console. You could resize the browser window and check that adding the debounce hasn't altered the re-rendering of the Zooniverse header or the project header.

EDIT: to test this out, add an error listener to the window, then look for resize errors firing when you navigate between the pages of a project. Firefox and Chrome fire slightly different errors.

```js
window.addEventListener('error', function(e) { console.error(e) })
```
The errors in the screenshot here were fired on staging when navigating between the project home page and the About pages.
https://frontend.preview.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess/about/research
<img width="1246" alt="Screenshot of the dev console, showing a resize error on a project page after adding an error listener to the window." src="https://user-images.githubusercontent.com/59547/207630700-5f055d1f-d442-4b89-b2f5-83729a76c792.png">


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
