### PR TITLE
Classifier: survey task confusion button container styling fix

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/components/Confusion.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/components/Confusion.js
@@ -50,6 +50,7 @@ export default function Confusion({
         gap='xsmall'
         justify='center'
         margin={{ top: 'small' }}
+        overflow='hidden'
         pad={{ top: 'small' }}
       >
         <Button


### PR DESCRIPTION
## Package
- lib-classifier

## Describe your changes
- fix styling issue with Confusion button container

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - https://local.zooniverse.org:8080/?project=1634&workflow=2434
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
  - with bug: https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/story/tasks-surveytask-choice--default&globals=locale:en;locales.en:English;locales.test:Test+Language
  - with fix (locally): http://localhost:6006/?path=/story/tasks-survey-choice--default&globals=locale:en;locales.en:English;locales.test:Test+Language
- Are there plans for follow up PR’s to further fix this bug or develop this feature? No

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
