### PR TITLE
Classifier: Refactor survey task tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "panic-button": "./bin/panic-button.sh",
     "storybook": "lerna run --parallel storybook",
     "test": "lerna run --parallel test",
-    "test:ci": "nyc lerna run --parallel test:ci"
+    "test:ci": "nyc --silent lerna run --parallel test:ci"
   },
   "engines": {
     "node": ">=16"

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -178,7 +178,7 @@ describe('SurveyTask', function () {
           const fireChoiceButton = screen.getByLabelText('Fire')
           // select the Fire choice
           await user.click(fireChoiceButton)
-          const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Fire')
+          const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify')
           // identify the Fire choice
           await user.click(identifyButton)
           // confirm the remaining choices are the 3 choices that match the red filter
@@ -496,7 +496,7 @@ describe('SurveyTask', function () {
         expect(choiceHeading).to.be.ok()
         // tabbing to the "Not this" button
         await user.keyboard('[Tab][Tab]')
-        const notThisButton = screen.getByLabelText('SurveyTask.Choice.notThis Nothing here')
+        const notThisButton = screen.getByLabelText('SurveyTask.Choice.notThis')
         expect(notThisButton).to.equal(document.activeElement)
         // pressing Enter to close the choice (Nothing here)
         await user.keyboard('[Enter]')
@@ -520,7 +520,7 @@ describe('SurveyTask', function () {
         expect(choiceHeading).to.be.ok()
         // tabbing to the "Identify" button
         await user.keyboard('[Tab][Tab][Tab]')
-        const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Nothing here')
+        const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify')
         expect(identifyButton).to.equal(document.activeElement)
         // pressing Enter to identify and close the choice (Nothing here)
         await user.keyboard('[Enter]')
@@ -541,7 +541,7 @@ describe('SurveyTask', function () {
         render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark) and pressing Enter to open the choice (Aardvark)
         await user.keyboard('[Tab][Enter]')
-        let identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Aardvark')
+        let identifyButton = screen.getByLabelText('SurveyTask.Choice.identify')
         // confirm the Identify button is disabled, pending required questions answered
         expect(identifyButton.disabled).to.be.true()
         // the required questions for Aardvark are "How many?" and "What behavior do you see?"
@@ -550,7 +550,7 @@ describe('SurveyTask', function () {
         // tabbing (x3) to the "How many?" question, selecting the "1" answer with space key, tabbing (x4) to the "What behavior do you see?" question, selecting the "Eating" answer with space key
         await user.keyboard('[Tab][Tab][Tab][Space][Tab][Tab][Tab][Tab][Space]')
         // confirm the Identify button is enabled, now that required questions are answered
-        identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Aardvark')
+        identifyButton = screen.getByLabelText('SurveyTask.Choice.identify')
         // confirm the Identify button is enabled, now that required questions answered
         expect(identifyButton.disabled).to.be.false()
       })
@@ -561,7 +561,7 @@ describe('SurveyTask', function () {
       render(<NoFiltersStory />)
       let choiceButton = screen.getByLabelText('Fire')
       await user.click(choiceButton)
-      const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Fire')
+      const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify')
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
       // confirm choices showing
@@ -588,7 +588,7 @@ describe('SurveyTask', function () {
       render(<NoFiltersStory />)
       let choiceButton = screen.getByLabelText('Fire')
       await user.click(choiceButton)
-      const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Fire')
+      const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify')
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
       // confirm choices showing

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -343,25 +343,6 @@ describe('SurveyTask', function () {
         expect(fireChoiceButton.getAttribute('aria-checked')).to.equal('true')
       })
 
-      it('should disable the Identify button until required questions are answered', async function () {
-        const user = userEvent.setup({ delay: null })
-        const { getByRole } = render(<DefaultStory />)
-        const choiceButton = getByRole('menuitemcheckbox', { name: 'Aardvark' })
-        await user.click(choiceButton)
-        let identifyButton = getByRole('button', { name: 'SurveyTask.Choice.identify' })
-        // confirm the Identify button is disabled, pending required questions answered
-        expect(identifyButton.disabled).to.be.true()
-        // the required questions for Aardvark are "How many?" and "What behavior do you see?"
-        // the following answers "How many?" with "3" and "What behavior do you see?" with "Eating"
-        const howManyInput = getByRole('radio', { name: "3" })
-        await user.click(howManyInput)
-        const whatBehaviorsInput = getByRole('checkbox', { name: "Eating" })
-        await user.click(whatBehaviorsInput)
-        identifyButton = getByRole('button', { name: 'SurveyTask.Choice.identify' })
-        // confirm the Identify button is enabled, now that required questions answered
-        expect(identifyButton.disabled).to.be.false()
-      })
-
       it('should disable "Done & Talk" and "Done" buttons', async function () {
         const user = userEvent.setup({ delay: null })
         const { getByRole } = render(<DefaultStory />)

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -67,9 +67,9 @@ describe('SurveyTask', function () {
       const NoFiltersStory = composeStory(NoFilters, Meta)
       
       it('should not show a filter button', function () {
-        const { queryByRole } = render(<NoFiltersStory />)
+        const { queryByText } = render(<NoFiltersStory />)
         
-        const filterButton = queryByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+        const filterButton = queryByText('SurveyTask.CharacteristicsFilter.filter')
         
         expect(filterButton).to.not.exist()
       })
@@ -113,9 +113,9 @@ describe('SurveyTask', function () {
     describe('when the Filter button is clicked', function () {
       it('should show characteristic filter sections', async function () {
         const user = userEvent.setup({ delay: null })
-        const { getAllByRole, getByRole } = render(<DefaultStory />)
+        const { getAllByRole, getByText } = render(<DefaultStory />)
         // filterButton is the Filter button above the choices
-        const filterButton = getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+        const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
         await user.click(filterButton)
         // the filterSections are the characteristic filter sections, i.e. the sections for "Like", "Pattern", and "Color" for the mock task
         const filterSections = getAllByRole('radiogroup')
@@ -126,8 +126,8 @@ describe('SurveyTask', function () {
       describe('when filters are clicked', function () {
         it('should show the filter button with a remove filter button', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getByRole, getByTestId } = render(<DefaultStory />)
-          const filterButton = getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+          const { getByTestId, getByText } = render(<DefaultStory />)
+          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
           // the stripesFilterButton is the button to filter choices by "stripes". Stripes is a specific value of the "Pattern" characteristic.
           const stripesFilterButton = getByTestId('filter-PTTRN-STRPS')
@@ -146,8 +146,8 @@ describe('SurveyTask', function () {
 
         it('should show the choices that match the filter', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByRole, getByTestId } = render(<DefaultStory />)
-          const filterButton = getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+          const { getAllByRole, getByTestId, getByText } = render(<DefaultStory />)
+          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
           const redFilterButton = getByTestId('filter-CLR-RD')
           expect(redFilterButton).to.be.ok()
@@ -165,8 +165,8 @@ describe('SurveyTask', function () {
 
         it.skip('should persist filters after a choice is selected', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByRole, getByTestId } = render(<DefaultStory />)
-          const filterButton = getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+          const { getAllByRole, getByTestId, getByText } = render(<DefaultStory />)
+          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
 
           // open the characteristics filters
           await user.click(filterButton)
@@ -175,14 +175,10 @@ describe('SurveyTask', function () {
           await user.click(redFilterButton)
           // close the characteristics filters
           await user.click(filterButton)
-          const fireChoiceButton = getByRole('menuitemcheckbox', { name: 'Fire' })
-          expect(fireChoiceButton).to.be.ok()
-
+          const fireChoiceButton = getByText('Fire')
           // select the Fire choice
           await user.click(fireChoiceButton)
-          const identifyButton = getByRole('button', { name: 'SurveyTask.Choice.identify' })
-          expect(identifyButton).to.be.ok()
-
+          const identifyButton = getByText('SurveyTask.Choice.identify')
           // identify the Fire choice
           await user.click(identifyButton)
           // confirm the remaining choices are the 3 choices that match the red filter
@@ -195,8 +191,8 @@ describe('SurveyTask', function () {
 
         it.skip('should remove the filter on remove filter button click (within Characteristics)', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByRole, getByTestId } = render(<DefaultStory />)
-          const filterButton = getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+          const { getAllByRole, getByTestId, getByText } = render(<DefaultStory />)
+          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
           const stripesFilterButton = getByTestId('filter-PTTRN-STRPS')
           // click/apply the stripes filter
@@ -213,8 +209,8 @@ describe('SurveyTask', function () {
 
         it.skip('should remove the filter on remove filter button click (within FilterStatus)', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByRole, getByTestId } = render(<DefaultStory />)
-          const filterButton = getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+          const { getAllByRole, getByTestId, getByText } = render(<DefaultStory />)
+          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
           const stripesFilterButton = getByTestId('filter-PTTRN-STRPS')
           // click/apply the stripes filter
@@ -235,8 +231,8 @@ describe('SurveyTask', function () {
 
         it.skip('should remove filters on Clear Filters button click (within Characteristics) ', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getByRole, getByTestId, queryByTestId } = render(<DefaultStory />)
-          const filterButton = getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+          const { getByRole, getByTestId, queryByTestId, getByText } = render(<DefaultStory />)
+          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
           // click/apply the like a cow/horse filter
           const cowHorseFilterButton = getByTestId('filter-LK-CWHRS')
@@ -263,8 +259,8 @@ describe('SurveyTask', function () {
 
         it.skip('should remove filters on Clear Filters button click (within Chooser)', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByRole, getByTestId } = render(<DefaultStory />)
-          const filterButton = getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+          const { getAllByRole, getByTestId, getByText } = render(<DefaultStory />)
+          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
           const cowHorseFilterButton = getByTestId('filter-LK-CWHRS')
           // click/apply the like a cow/horse filter
@@ -277,7 +273,7 @@ describe('SurveyTask', function () {
           // confirm the choices remaining are the 1 choice (Kudu) that matches the cow/horse and tan/yellow filters
           expect(choiceButtons.length).to.equal(1)
 
-          const clearFiltersButton = getByRole('button', { name: 'Clear SurveyTask.CharacteristicsFilter.clearFilters' })
+          const clearFiltersButton = getByText('SurveyTask.CharacteristicsFilter.clearFilters')
           // clear the filters
           await user.click(clearFiltersButton)
           choiceButtons = getAllByRole('menuitemcheckbox')
@@ -373,7 +369,7 @@ describe('SurveyTask', function () {
         const { getAllByRole, getByRole } = render(<DefaultStory />)
         // tabbing to the Filter button
         await user.keyboard('[Tab]')
-        const filterButton = getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+        const filterButton = getByRole( 'button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
         expect(filterButton).to.equal(document.activeElement)
         
         // pressing the Enter key to open the Filter button
@@ -405,10 +401,10 @@ describe('SurveyTask', function () {
           expect(solidFilterRemoveButton).to.be.ok()
         })
 
-        it.skip('should show the choices that match the filter', async function () {
+        it('should show the choices that match the filter', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByRole } = render(<DefaultStory />)
-          const filterButton = getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+          const { getAllByRole, getByText } = render(<DefaultStory />)
+          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
           // tabbing to and opening the Filter button
           await user.keyboard('[Tab][Enter]')
           // tabbing to the pattern section that contains the solid filter and selecting the solid filter with space key
@@ -423,10 +419,10 @@ describe('SurveyTask', function () {
           expect(choiceButtons[2]).to.have.text('Kudu')
         })
 
-        it.skip('should remove the filter on remove filter button keypress (within Characteristics)', async function () {
+        it('should remove the filter on remove filter button keypress (within Characteristics)', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByRole, queryByTestId } = render(<DefaultStory />)
-          const filterButton = getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+          const { getAllByRole, queryByTestId, getByText } = render(<DefaultStory />)
+          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
           // tabbing to and opening the Filter button
           await user.keyboard('[Tab][Enter]')
           // tabbing to the pattern section that contains the solid filter and selecting the solid filter with space key
@@ -449,10 +445,10 @@ describe('SurveyTask', function () {
           expect(choiceButtons.length).to.equal(6)
         })
 
-        it.skip('should remove the filter on remove filter button keypress (within FilterStatus)', async function () {
+        it('should remove the filter on remove filter button keypress (within FilterStatus)', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByRole, getByTestId } = render(<DefaultStory />)
-          const filterButton = getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+          const { getAllByRole, getByTestId, getByText } = render(<DefaultStory />)
+          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
           // tabbing to and opening the Filter button
           await user.keyboard('[Tab][Enter]')
           // tabbing to the pattern section that contains the solid filter and selecting the solid filter with space key
@@ -572,10 +568,10 @@ describe('SurveyTask', function () {
 
     it.skip('should remove a previously identified choice with delete key', async function () {
       const user = userEvent.setup({ delay: null })
-      const { getAllByRole, getByRole } = render(<NoFiltersStory />)
+      const { getAllByRole, getByRole, getByText } = render(<NoFiltersStory />)
       let choiceButton = getByRole('menuitemcheckbox', { name: 'Fire' })
       await user.click(choiceButton)
-      const identifyButton = getByRole('button', { name: 'SurveyTask.Choice.identify' })
+      const identifyButton = getByText('SurveyTask.Choice.identify')
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
       // confirm choices showing
@@ -598,10 +594,10 @@ describe('SurveyTask', function () {
 
     it.skip('should remove a previously identified choice with backspace key', async function () {
       const user = userEvent.setup({ delay: null })
-      const { getAllByRole, getByRole } = render(<NoFiltersStory />)
+      const { getAllByRole, getByRole, getByText } = render(<NoFiltersStory />)
       let choiceButton = getByRole('menuitemcheckbox', { name: 'Fire' })
       await user.click(choiceButton)
-      const identifyButton = getByRole('button', { name: 'SurveyTask.Choice.identify' })
+      const identifyButton = getByText('SurveyTask.Choice.identify')
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
       // confirm choices showing

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -512,7 +512,7 @@ describe('SurveyTask', function () {
         expect(choiceImages).to.be.ok()
       })
 
-      it.skip('should show choices with recent choice as active choice when Not This button keyed with Enter', async function () {
+      it('should show choices with recent choice as active choice when Not This button keyed with Enter', async function () {
         const user = userEvent.setup({ delay: null })
         render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark), arrowing up to the last choice (Nothing here), and pressing Enter to open the choice (Nothing here)
@@ -535,7 +535,7 @@ describe('SurveyTask', function () {
         expect(choiceButtons.length).to.equal(6)
       })
 
-      it.skip('should show choices with identified choice as active choice when Identify keyed with Enter', async function () {
+      it('should show choices with identified choice as active choice when Identify keyed with Enter', async function () {
         const user = userEvent.setup({ delay: null })
         render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark), arrowing up to the last choice (Nothing here), and pressing Enter to open the choice (Nothing here)
@@ -561,7 +561,7 @@ describe('SurveyTask', function () {
         expect(nothingHereChoiceButton).to.equal(document.activeElement)
       })
 
-      it.skip('should disable the Identify button until required questions are answered', async function () {
+      it('should disable the Identify button until required questions are answered', async function () {
         const user = userEvent.setup({ delay: null })
         render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark) and pressing Enter to open the choice (Aardvark)

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -17,7 +17,7 @@ describe('SurveyTask', function () {
         render(<DefaultStory />)
         
         // filterButton is the Filter button above the choices
-        const filterButton = screen.getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+        const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
         
         expect(filterButton).to.be.ok()
       })
@@ -50,7 +50,7 @@ describe('SurveyTask', function () {
       it('should show a Clear Filters button', function () {
         render(<DefaultStory />)
         
-        const clearFiltersButton = screen.getByRole('button', { name: 'Clear SurveyTask.CharacteristicsFilter.clearFilters' })
+        const clearFiltersButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.clearFilters')
         
         expect(clearFiltersButton).to.be.ok()
       })
@@ -58,7 +58,7 @@ describe('SurveyTask', function () {
       it('should disable the Clear Filters button if showing choices = total choices', function () {
         render(<DefaultStory />)
         
-        const clearFiltersButton = screen.getByRole('button', { name: 'Clear SurveyTask.CharacteristicsFilter.clearFilters' })
+        const clearFiltersButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.clearFilters')
         
         expect(clearFiltersButton).to.have.attribute('disabled')
       })
@@ -102,7 +102,7 @@ describe('SurveyTask', function () {
       it('should not not show a clear filters button', function () {
         render(<NoFiltersStory />)
         
-        const clearFiltersButton = screen.queryByRole('button', { name: 'Clear SurveyTask.CharacteristicsFilter.clearFilters' })
+        const clearFiltersButton = screen.queryByLabelText('Clear SurveyTask.CharacteristicsFilter.clearFilters')
         
         expect(clearFiltersButton).to.not.exist()
       })
@@ -178,7 +178,7 @@ describe('SurveyTask', function () {
           const fireChoiceButton = screen.getByLabelText('Fire')
           // select the Fire choice
           await user.click(fireChoiceButton)
-          const identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
+          const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Fire')
           // identify the Fire choice
           await user.click(identifyButton)
           // confirm the remaining choices are the 3 choices that match the red filter
@@ -239,7 +239,7 @@ describe('SurveyTask', function () {
           expect(cowHorseFilterRemoveButton).to.be.ok()
           expect(tanYellowFilterRemoveButton).to.be.ok()
 
-          const clearFiltersButton = screen.getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.clearFilters' })
+          const clearFiltersButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.clearFilters')
           // clear the filters
           await user.click(clearFiltersButton)
           cowHorseFilterRemoveButton = screen.queryByTestId('remove-filter-LK-CWHRS')
@@ -262,7 +262,7 @@ describe('SurveyTask', function () {
           // confirm the choices remaining are the 1 choice (Kudu) that matches the cow/horse and tan/yellow filters
           expect(choiceButtons.length).to.equal(1)
 
-          const clearFiltersButton = screen.getByRole('button', { name: 'Clear SurveyTask.CharacteristicsFilter.clearFilters' })
+          const clearFiltersButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.clearFilters')
           // clear the filters
           await user.click(clearFiltersButton)
           choicesMenu = screen.getByTestId('choices-menu')
@@ -299,7 +299,7 @@ describe('SurveyTask', function () {
         render(<DefaultStory />)
         const choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
         await user.click(choiceButton)
-        const notThisButton = screen.getByRole('button', { name: 'SurveyTask.Choice.notThis' })
+        const notThisButton = screen.getByLabelText('SurveyTask.Choice.notThis Fire')
         // close choice (Fire) component
         await user.click(notThisButton)
         // confirm choice (Fire) heading, and therefore choice, is not shown
@@ -316,7 +316,7 @@ describe('SurveyTask', function () {
         render(<DefaultStory />)
         const choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
         await user.click(choiceButton)
-        const identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
+        const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Fire')
         // identify choice (Fire) and close choice (Fire) component
         await user.click(identifyButton)
         // confirm choice (Fire) heading, and therefore choice, is not shown
@@ -496,7 +496,7 @@ describe('SurveyTask', function () {
         expect(choiceHeading).to.be.ok()
         // tabbing to the "Not this" button
         await user.keyboard('[Tab][Tab]')
-        const notThisButton = screen.getByRole('button', { name: 'SurveyTask.Choice.notThis' })
+        const notThisButton = screen.getByLabelText('SurveyTask.Choice.notThis Nothing here')
         expect(notThisButton).to.equal(document.activeElement)
         // pressing Enter to close the choice (Nothing here)
         await user.keyboard('[Enter]')
@@ -520,7 +520,7 @@ describe('SurveyTask', function () {
         expect(choiceHeading).to.be.ok()
         // tabbing to the "Identify" button
         await user.keyboard('[Tab][Tab][Tab]')
-        const identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
+        const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Nothing here')
         expect(identifyButton).to.equal(document.activeElement)
         // pressing Enter to identify and close the choice (Nothing here)
         await user.keyboard('[Enter]')
@@ -541,7 +541,7 @@ describe('SurveyTask', function () {
         render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark) and pressing Enter to open the choice (Aardvark)
         await user.keyboard('[Tab][Enter]')
-        let identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
+        let identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Aardvark')
         // confirm the Identify button is disabled, pending required questions answered
         expect(identifyButton.disabled).to.be.true()
         // the required questions for Aardvark are "How many?" and "What behavior do you see?"
@@ -550,7 +550,7 @@ describe('SurveyTask', function () {
         // tabbing (x3) to the "How many?" question, selecting the "1" answer with space key, tabbing (x4) to the "What behavior do you see?" question, selecting the "Eating" answer with space key
         await user.keyboard('[Tab][Tab][Tab][Space][Tab][Tab][Tab][Tab][Space]')
         // confirm the Identify button is enabled, now that required questions are answered
-        identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
+        identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Aardvark')
         // confirm the Identify button is enabled, now that required questions answered
         expect(identifyButton.disabled).to.be.false()
       })
@@ -561,7 +561,7 @@ describe('SurveyTask', function () {
       render(<NoFiltersStory />)
       let choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
       await user.click(choiceButton)
-      const identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
+      const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Fire')
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
       // confirm choices showing
@@ -588,7 +588,7 @@ describe('SurveyTask', function () {
       render(<NoFiltersStory />)
       let choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
       await user.click(choiceButton)
-      const identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
+      const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Fire')
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
       // confirm choices showing

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -50,7 +50,7 @@ describe('SurveyTask', function () {
       it('should show a Clear Filters button', function () {
         render(<DefaultStory />)
         
-        const clearFiltersButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.clearFilters')
+        const clearFiltersButton = screen.getByText('SurveyTask.CharacteristicsFilter.clearFilters')
         
         expect(clearFiltersButton).to.be.ok()
       })
@@ -58,7 +58,7 @@ describe('SurveyTask', function () {
       it('should disable the Clear Filters button if showing choices = total choices', function () {
         render(<DefaultStory />)
         
-        const clearFiltersButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.clearFilters')
+        const clearFiltersButton = screen.getByRole('button', { name: 'Clear SurveyTask.CharacteristicsFilter.clearFilters' })
         
         expect(clearFiltersButton).to.have.attribute('disabled')
       })
@@ -99,10 +99,10 @@ describe('SurveyTask', function () {
         expect(choicesShowingCount).to.not.exist()
       })
 
-      it('should not not show a clear filters button', function () {
+      it('should not not show a Clear Filters button', function () {
         render(<NoFiltersStory />)
         
-        const clearFiltersButton = screen.queryByLabelText('Clear SurveyTask.CharacteristicsFilter.clearFilters')
+        const clearFiltersButton = screen.queryByText('SurveyTask.CharacteristicsFilter.clearFilters')
         
         expect(clearFiltersButton).to.not.exist()
       })
@@ -138,11 +138,11 @@ describe('SurveyTask', function () {
         })
         
         it('should show the filter button with a remove filter button', async function () {
-          // the stripesFilterButton is the button to filter choices by "stripes". Stripes is a specific value of the "Pattern" characteristic.
+          // the stripesFilterButton is the button to filter choices by "stripes". Stripes is a specific value of the "Pattern" characteristic
           const stripesFilterButton = screen.getByTestId('filter-PTTRN-STRPS')
           expect(stripesFilterButton).to.be.ok()
 
-          // the stripesFilterRemoveButton is the small x button that appears over a filter to remove the filter, after it is selected. The presence of this button indicates that the filter is selected. The absence of this button indicates that the filter is not selected.
+          // the stripesFilterRemoveButton is the small x button that appears over a filter to remove the filter, after it is selected. The presence of this button indicates that the filter is selected. The absence of this button indicates that the filter is not selected
           let characteristicsSection = screen.getByTestId('characteristics')
           let stripesFilterRemoveButton = within(characteristicsSection).queryByTestId('remove-filter-PTTRN-STRPS')
           expect(stripesFilterRemoveButton).to.be.null()
@@ -157,12 +157,13 @@ describe('SurveyTask', function () {
           const redFilterButton = screen.getByTestId('filter-CLR-RD')
           expect(redFilterButton).to.be.ok()
 
-          // the following user events filter choices by the color red and then close the characteristics filters, returning to the list of choices.
+          // the following user events filter choices by the color red and then close the characteristics filters, returning to the list of choices
 
           await user.click(redFilterButton)
           await user.click(filterButton)
           const choicesMenu = screen.getByTestId('choices-menu')
           const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          // confirm the choices are the 3 choices that match the red filter
           expect(choiceButtons.length).to.equal(3)
           expect(choiceButtons[0]).to.have.text('Aardvark')
           expect(choiceButtons[1]).to.have.text('Kudu')
@@ -175,15 +176,15 @@ describe('SurveyTask', function () {
           await user.click(redFilterButton)
           // close the characteristics filters
           await user.click(filterButton)
-          const fireChoiceButton = screen.getByLabelText('Fire')
+          const fireChoiceButton = screen.getByText('Fire')
           // select the Fire choice
           await user.click(fireChoiceButton)
-          const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify')
+          const identifyButton = screen.getByText('SurveyTask.Choice.identify')
           // identify the Fire choice
           await user.click(identifyButton)
-          // confirm the remaining choices are the 3 choices that match the red filter
           const choicesMenu = screen.getByTestId('choices-menu')
           const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          // confirm the remaining choices are the 3 choices that match the red filter
           expect(choiceButtons.length).to.equal(3)
           expect(choiceButtons[0]).to.have.text('Aardvark')
           expect(choiceButtons[1]).to.have.text('Kudu')
@@ -196,12 +197,16 @@ describe('SurveyTask', function () {
           await user.click(stripesFilterButton)
           const characteristicsSection = screen.getByTestId('characteristics')
           const stripesFilterRemoveButton = within(characteristicsSection).getByTestId('remove-filter-PTTRN-STRPS')
+          // confirm the stripes filter is selected by checking for the presence of the remove filter button
+          expect(stripesFilterRemoveButton).to.be.ok()
+
           // remove the stripes filter
           await user.click(stripesFilterRemoveButton)
+          // close the characteristics filters
           await user.click(filterButton)
-          // confirm the choices are the total 6 choices, not filtered by the stripes filter
           const choicesMenu = screen.getByTestId('choices-menu')
           const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          // confirm the choices are the total 6 choices, not filtered by the stripes filter
           expect(choiceButtons.length).to.equal(6)
         })
 
@@ -219,9 +224,9 @@ describe('SurveyTask', function () {
           const stripesFilterRemoveButton = within(filterStatusSection).getByTestId('remove-filter-PTTRN-STRPS')
           // remove the stripes filter
           await user.click(stripesFilterRemoveButton)
-          // confirm the choices are the total 6 choices, not filtered by the stripes filter
           choicesMenu = screen.getByTestId('choices-menu')
           choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          // confirm the choices are the total 6 choices, not filtered by the stripes filter
           expect(choiceButtons.length).to.equal(6)
         })
 
@@ -239,7 +244,7 @@ describe('SurveyTask', function () {
           expect(cowHorseFilterRemoveButton).to.be.ok()
           expect(tanYellowFilterRemoveButton).to.be.ok()
 
-          const clearFiltersButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.clearFilters')
+          const clearFiltersButton = within(characteristicsSection).getByText('SurveyTask.CharacteristicsFilter.clearFilters')
           // clear the filters
           await user.click(clearFiltersButton)
           cowHorseFilterRemoveButton = screen.queryByTestId('remove-filter-LK-CWHRS')
@@ -262,7 +267,7 @@ describe('SurveyTask', function () {
           // confirm the choices remaining are the 1 choice (Kudu) that matches the cow/horse and tan/yellow filters
           expect(choiceButtons.length).to.equal(1)
 
-          const clearFiltersButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.clearFilters')
+          const clearFiltersButton = screen.getByText('SurveyTask.CharacteristicsFilter.clearFilters')
           // clear the filters
           await user.click(clearFiltersButton)
           choicesMenu = screen.getByTestId('choices-menu')
@@ -273,21 +278,21 @@ describe('SurveyTask', function () {
       })
     })
 
-    describe.skip('when a choice is clicked', function () {
-      it('should show the choice heading', async function () {
+    describe('when a choice is clicked', function () {
+      it('should show the choice description', async function () {
         const user = userEvent.setup({ delay: null })
         render(<DefaultStory />)
-        const choiceButton = screen.getByLabelText('Aardvark')
+        const choiceButton = screen.getByText('Aardvark')
         await user.click(choiceButton)
-        const choiceHeading = screen.getByRole('heading', { name: 'Aardvark' })
+        const choiceDescription = screen.getByText('Not as awesome as a pangolin, but surprisingly big.')
 
-        expect(choiceHeading).to.be.ok()
+        expect(choiceDescription).to.be.ok()
       })
 
       it('should show choice images', async function () {
         const user = userEvent.setup({ delay: null })
         render(<DefaultStory />)
-        const choiceButton = screen.getByLabelText('Fire')
+        const choiceButton = screen.getByText('Fire')
         await user.click(choiceButton)
         const choiceImages = screen.getByTestId('choice-images')
         
@@ -297,14 +302,14 @@ describe('SurveyTask', function () {
       it('should show choices when Not This button is clicked', async function () {
         const user = userEvent.setup({ delay: null })
         render(<DefaultStory />)
-        const choiceButton = screen.getByLabelText('Fire')
+        const choiceButton = screen.getByText('Fire')
         await user.click(choiceButton)
-        const notThisButton = screen.getByLabelText('SurveyTask.Choice.notThis Fire')
+        const notThisButton = screen.getByText('SurveyTask.Choice.notThis')
         // close choice (Fire) component
         await user.click(notThisButton)
-        // confirm choice (Fire) heading, and therefore choice, is not shown
-        const choiceHeading = screen.queryByRole('heading', { name: 'Fire' })
-        expect(choiceHeading).to.be.null()
+        // confirm choice (Fire) description, and therefore choice, is not shown
+        const choiceDescription = screen.queryByText('It\'s a fire. Pretty sure you know what this looks like.')
+        expect(choiceDescription).to.be.null()
         // confirm choices are shown
         const choicesMenu = screen.getByTestId('choices-menu')
         const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
@@ -314,20 +319,20 @@ describe('SurveyTask', function () {
       it('should show choices with selected choice checked when Identify button is clicked', async function () {
         const user = userEvent.setup({ delay: null })
         render(<DefaultStory />)
-        const choiceButton = screen.getByLabelText('Fire')
+        const choiceButton = screen.getByText('Fire')
         await user.click(choiceButton)
-        const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Fire')
+        const identifyButton = screen.getByText('SurveyTask.Choice.identify')
         // identify choice (Fire) and close choice (Fire) component
         await user.click(identifyButton)
-        // confirm choice (Fire) heading, and therefore choice, is not shown
-        const choiceHeading = screen.queryByRole('heading', { name: 'Fire' })
-        expect(choiceHeading).to.be.null()
+        // confirm choice (Fire) description, and therefore choice, is not shown
+        const choiceDescription = screen.queryByText('It\'s a fire. Pretty sure you know what this looks like.')
+        expect(choiceDescription).to.be.null()
         // confirm choices are shown
         const choicesMenu = screen.getByTestId('choices-menu')
         const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
         expect(choiceButtons.length).to.equal(6)
         // confirm choice (Fire) is shown as checked
-        const fireChoiceButton = screen.getByLabelText('Fire')
+        const fireChoiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
         expect(fireChoiceButton.getAttribute('aria-checked')).to.equal('true')
       })
 
@@ -340,7 +345,7 @@ describe('SurveyTask', function () {
         expect(doneAndTalkButton.disabled).to.be.false()
         expect(doneButton.disabled).to.be.false()
 
-        const choiceButton = screen.getByLabelText('Aardvark')
+        const choiceButton = screen.getByText('Aardvark')
         await user.click(choiceButton)
         doneAndTalkButton = screen.getByRole('button', { name: 'TaskArea.Tasks.DoneAndTalkButton.doneAndTalk' })
         doneButton = screen.getByRole('button', { name: 'TaskArea.Tasks.DoneButton.done' })
@@ -354,6 +359,62 @@ describe('SurveyTask', function () {
   describe('with user keystrokes', function () {
     const DefaultStory = composeStory(Default, Meta)
     const NoFiltersStory = composeStory(NoFilters, Meta)
+
+    it('should remove a previously identified choice with delete key', async function () {
+      const user = userEvent.setup({ delay: null })
+      render(<NoFiltersStory />)
+      let choiceButton = screen.getByText('Fire')
+      await user.click(choiceButton)
+      const identifyButton = screen.getByText('SurveyTask.Choice.identify')
+      // identify choice (Fire) and close choice (Fire) component
+      await user.click(identifyButton)
+      // confirm choices showing
+      let choicesMenu = screen.getByTestId('choices-menu')
+      const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+      expect(choiceButtons.length).to.equal(6)
+      
+      // confirm choice Fire selected
+      choiceButton = within(choicesMenu).getByRole('menuitemcheckbox', { name: 'Fire' })
+      expect(choiceButton.getAttribute('aria-checked')).to.equal('true')
+      
+      // confirm choice Fire active element
+      expect(choiceButton).to.equal(document.activeElement)
+      
+      // press delete key to remove choice (Fire)
+      await user.keyboard('[Delete]')
+      choicesMenu = screen.getByTestId('choices-menu')
+      choiceButton = within(choicesMenu).getByRole('menuitemcheckbox', { name: 'Fire' })
+      // confirm choice Fire not selected
+      expect(choiceButton.getAttribute('aria-checked')).to.equal('false')
+    })
+
+    it('should remove a previously identified choice with backspace key', async function () {
+      const user = userEvent.setup({ delay: null })
+      render(<NoFiltersStory />)
+      let choiceButton = screen.getByText('Fire')
+      await user.click(choiceButton)
+      const identifyButton = screen.getByText('SurveyTask.Choice.identify')
+      // identify choice (Fire) and close choice (Fire) component
+      await user.click(identifyButton)
+      // confirm choices showing
+      let choicesMenu = screen.getByTestId('choices-menu')
+      const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+      expect(choiceButtons.length).to.equal(6)
+      
+      // confirm choice Fire selected
+      choiceButton = within(choicesMenu).getByRole('menuitemcheckbox', { name: 'Fire' })
+      expect(choiceButton.getAttribute('aria-checked')).to.equal('true')
+      
+      // confirm choice Fire active element
+      expect(choiceButton).to.equal(document.activeElement)
+      
+      // press backspace key to remove choice (Fire)
+      await user.keyboard('[Backspace]')
+      choicesMenu = screen.getByTestId('choices-menu')
+      choiceButton = within(choicesMenu).getByRole('menuitemcheckbox', { name: 'Fire' })
+      // confirm choice Fire not selected
+      expect(choiceButton.getAttribute('aria-checked')).to.equal('false')
+    })
 
     describe('when the Filter button is keyed with Enter', function () {
       it('should show characteristic filter sections', async function () {
@@ -384,11 +445,11 @@ describe('SurveyTask', function () {
         })  
 
         it('should show the filter button with a remove filter button', async function () {
-          // the solidFilterButton is the button to filter choices by "solid". Solid is a specific value of the "Pattern" characteristic.
+          // the solidFilterButton is the button to filter choices by "solid". Solid is a specific value of the "Pattern" characteristic
           const solidFilterButton = screen.getByTestId('filter-PTTRN-SLD')
           expect(solidFilterButton).to.be.ok()
 
-          // the solidFilterRemoveButton is the small x button that appears over a filter to remove the filter, after it is selected. The presence of this button indicates that the filter is selected. The absence of this button indicates that the filter is not selected.
+          // the solidFilterRemoveButton is the small x button that appears over a filter to remove the filter, after it is selected. The presence of this button indicates that the filter is selected. The absence of this button indicates that the filter is not selected
           let characteristicsSection = screen.queryByTestId('characteristics')
           let solidFilterRemoveButton = within(characteristicsSection).queryByTestId('remove-filter-PTTRN-SLD')
           expect(solidFilterRemoveButton).to.be.null()
@@ -462,17 +523,16 @@ describe('SurveyTask', function () {
     })
 
     describe('when a choice is selected with Enter', function () {
-      it('should show the choice heading', async function () {
+      it('should show the choice description', async function () {
         const user = userEvent.setup({ delay: null })
         render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark)
         await user.keyboard('[Tab]')
-        const choiceButton = screen.getByLabelText('Aardvark')
-        expect(choiceButton).to.equal(document.activeElement)
+        const choiceButton = screen.getByText('Aardvark')
         // pressing Enter to open the choice (Aardvark)
         await user.keyboard('[Enter]')
-        const choiceHeading = screen.getByRole('heading', { name: 'Aardvark' })
-        expect(choiceHeading).to.be.ok()
+        const choiceDescription = screen.getByText('Not as awesome as a pangolin, but surprisingly big.')
+        expect(choiceDescription).to.be.ok()
       })
 
       it('should show choice images', async function () {
@@ -492,17 +552,17 @@ describe('SurveyTask', function () {
         await user.keyboard('[Tab]')
         await user.keyboard('[ArrowUp]')
         await user.keyboard('[Enter]')
-        let choiceHeading = screen.getByRole('heading', { name: 'Nothing here' })
-        expect(choiceHeading).to.be.ok()
+        let choiceDescription = screen.getByText('Don\'t tell the plant biologists we called vegetation \"nothing here\"!')
+        expect(choiceDescription).to.be.ok()
         // tabbing to the "Not this" button
         await user.keyboard('[Tab][Tab]')
-        const notThisButton = screen.getByLabelText('SurveyTask.Choice.notThis')
+        const notThisButton = screen.getByRole('button', { name: 'SurveyTask.Choice.notThis' })
         expect(notThisButton).to.equal(document.activeElement)
         // pressing Enter to close the choice (Nothing here)
         await user.keyboard('[Enter]')
-        // confirm choice (Nothing here) heading, and therefore choice, is not shown
-        choiceHeading = screen.queryByRole('heading', { name: 'Nothing here' })
-        expect(choiceHeading).to.be.null()
+        // confirm choice (Nothing here) description, and therefore choice, is not shown
+        choiceDescription = screen.queryByText('Don\'t tell the plant biologists we called vegetation \"nothing here\"!')
+        expect(choiceDescription).to.be.null()
         // confirm choices are shown
         const choicesMenu = screen.getByTestId('choices-menu')
         const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
@@ -516,23 +576,23 @@ describe('SurveyTask', function () {
         await user.keyboard('[Tab]')
         await user.keyboard('[ArrowUp]')
         await user.keyboard('[Enter]')
-        let choiceHeading = screen.getByRole('heading', { name: 'Nothing here' })
-        expect(choiceHeading).to.be.ok()
+        let choiceDescription = screen.getByText('Don\'t tell the plant biologists we called vegetation \"nothing here\"!')
+        expect(choiceDescription).to.be.ok()
         // tabbing to the "Identify" button
         await user.keyboard('[Tab][Tab][Tab]')
-        const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify')
+        const identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
         expect(identifyButton).to.equal(document.activeElement)
         // pressing Enter to identify and close the choice (Nothing here)
         await user.keyboard('[Enter]')
-        // confirm choice (Nothing here) heading, and therefore choice, is not shown
-        choiceHeading = screen.queryByRole('heading', { name: 'Fire' })
-        expect(choiceHeading).to.be.null()
+        // confirm choice (Nothing here) description, and therefore choice, is not shown
+        choiceDescription = screen.queryByText('Don\'t tell the plant biologists we called vegetation \"nothing here\"!')
+        expect(choiceDescription).to.be.null()
         // confirm choices are shown
         const choicesMenu = screen.getByTestId('choices-menu')
         const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
         expect(choiceButtons.length).to.equal(6)
         // confirm the identified choice (Nothing here) is the active choice
-        const nothingHereChoiceButton = screen.getByLabelText('Nothing here')
+        const nothingHereChoiceButton = screen.getByRole('menuitemcheckbox', { name: 'Nothing here' })
         expect(nothingHereChoiceButton).to.equal(document.activeElement)
       })
 
@@ -541,7 +601,7 @@ describe('SurveyTask', function () {
         render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark) and pressing Enter to open the choice (Aardvark)
         await user.keyboard('[Tab][Enter]')
-        let identifyButton = screen.getByLabelText('SurveyTask.Choice.identify')
+        let identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
         // confirm the Identify button is disabled, pending required questions answered
         expect(identifyButton.disabled).to.be.true()
         // the required questions for Aardvark are "How many?" and "What behavior do you see?"
@@ -550,64 +610,10 @@ describe('SurveyTask', function () {
         // tabbing (x3) to the "How many?" question, selecting the "1" answer with space key, tabbing (x4) to the "What behavior do you see?" question, selecting the "Eating" answer with space key
         await user.keyboard('[Tab][Tab][Tab][Space][Tab][Tab][Tab][Tab][Space]')
         // confirm the Identify button is enabled, now that required questions are answered
-        identifyButton = screen.getByLabelText('SurveyTask.Choice.identify')
+        identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
         // confirm the Identify button is enabled, now that required questions answered
         expect(identifyButton.disabled).to.be.false()
       })
-    })
-
-    it.skip('should remove a previously identified choice with delete key', async function () {
-      const user = userEvent.setup({ delay: null })
-      render(<NoFiltersStory />)
-      let choiceButton = screen.getByLabelText('Fire')
-      await user.click(choiceButton)
-      const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify')
-      // identify choice (Fire) and close choice (Fire) component
-      await user.click(identifyButton)
-      // confirm choices showing
-      const choicesMenu = screen.getByTestId('choices-menu')
-      const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
-      expect(choiceButtons.length).to.equal(6)
-      
-      // confirm choice Fire selected
-      choiceButton = screen.getByLabelText('Fire')
-      expect(choiceButton.getAttribute('aria-checked')).to.equal('true')
-      
-      // confirm choice Fire active element
-      expect(choiceButton).to.equal(document.activeElement)
-      
-      // press delete key to remove choice (Fire)
-      await user.keyboard('[Delete]')
-      // confirm choice Fire not selected
-      choiceButton = screen.getByLabelText('Fire')
-      expect(choiceButton.getAttribute('aria-checked')).to.equal('false')
-    })
-
-    it.skip('should remove a previously identified choice with backspace key', async function () {
-      const user = userEvent.setup({ delay: null })
-      render(<NoFiltersStory />)
-      let choiceButton = screen.getByLabelText('Fire')
-      await user.click(choiceButton)
-      const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify')
-      // identify choice (Fire) and close choice (Fire) component
-      await user.click(identifyButton)
-      // confirm choices showing
-      const choicesMenu = screen.getByTestId('choices-menu')
-      const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
-      expect(choiceButtons.length).to.equal(6)
-      
-      // confirm choice Fire selected
-      choiceButton = screen.getByLabelText('Fire')
-      expect(choiceButton.getAttribute('aria-checked')).to.equal('true')
-      
-      // confirm choice Fire active element
-      expect(choiceButton).to.equal(document.activeElement)
-      
-      // press backspace key to remove choice (Fire)
-      await user.keyboard('[Backspace]')
-      // confirm choice Fire not selected
-      choiceButton = screen.getByLabelText('Fire')
-      expect(choiceButton.getAttribute('aria-checked')).to.equal('false')
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -256,9 +256,14 @@ describe('SurveyTask', function () {
     })
 
     describe('when a choice is clicked', function () {
-      it('should show the choice description', async function () {
-        const user = userEvent.setup({ delay: null })
+      let user
+
+      beforeEach(function () {
+        user = userEvent.setup({ delay: null })
         render(<DefaultStory />)
+      })
+
+      it('should show the choice description', async function () {
         const choiceButton = screen.getByText('Aardvark')
         await user.click(choiceButton)
         const choiceDescription = screen.getByText('Not as awesome as a pangolin, but surprisingly big.')
@@ -267,8 +272,6 @@ describe('SurveyTask', function () {
       })
 
       it('should show choice images', async function () {
-        const user = userEvent.setup({ delay: null })
-        render(<DefaultStory />)
         const choiceButton = screen.getByText('Fire')
         await user.click(choiceButton)
         const choiceImages = screen.getByTestId('choice-images')
@@ -277,8 +280,6 @@ describe('SurveyTask', function () {
       })
 
       it('should show choices when Not This button is clicked', async function () {
-        const user = userEvent.setup({ delay: null })
-        render(<DefaultStory />)
         const choiceButton = screen.getByText('Fire')
         await user.click(choiceButton)
         const notThisButton = screen.getByText('SurveyTask.Choice.notThis')
@@ -293,8 +294,6 @@ describe('SurveyTask', function () {
       })
 
       it('should show choices with selected choice checked when Identify button is clicked', async function () {
-        const user = userEvent.setup({ delay: null })
-        render(<DefaultStory />)
         const choiceButton = screen.getByText('Fire')
         await user.click(choiceButton)
         const identifyButton = screen.getByText('SurveyTask.Choice.identify')
@@ -312,8 +311,6 @@ describe('SurveyTask', function () {
       })
 
       it('should disable "Done & Talk" and "Done" buttons', async function () {
-        const user = userEvent.setup({ delay: null })
-        render(<DefaultStory />)
         let doneAndTalkButton = screen.getByRole('button', { name: 'TaskArea.Tasks.DoneAndTalkButton.doneAndTalk' })
         let doneButton = screen.getByRole('button', { name: 'TaskArea.Tasks.DoneButton.done' })
         // mock task doesn't require an identified choice, so confirm the Done & Talk and Done buttons are enabled before selecting a choice
@@ -334,9 +331,13 @@ describe('SurveyTask', function () {
   describe('with user keystrokes', function () {
     const DefaultStory = composeStory(Default, Meta)
     const NoFiltersStory = composeStory(NoFilters, Meta)
+    let user
+
+    beforeEach(function () {
+      user = userEvent.setup({ delay: null })
+    })
 
     it('should remove a previously identified choice with delete key', async function () {
-      const user = userEvent.setup({ delay: null })
       render(<NoFiltersStory />)
       let choiceButton = screen.getByText('Fire')
       await user.click(choiceButton)
@@ -362,7 +363,6 @@ describe('SurveyTask', function () {
     })
 
     it('should remove a previously identified choice with backspace key', async function () {
-      const user = userEvent.setup({ delay: null })
       render(<NoFiltersStory />)
       let choiceButton = screen.getByText('Fire')
       await user.click(choiceButton)
@@ -389,7 +389,6 @@ describe('SurveyTask', function () {
 
     describe('when the Filter button is keyed with Enter', function () {
       it('should show characteristic filter sections', async function () {
-        const user = userEvent.setup({ delay: null })
         render(<DefaultStory />)
         // tabbing to the Filter button
         await user.keyboard('[Tab]')
@@ -490,9 +489,14 @@ describe('SurveyTask', function () {
     })
 
     describe('when a choice is selected with Enter', function () {
-      it('should show the choice description', async function () {
-        const user = userEvent.setup({ delay: null })
+      let user
+
+      beforeEach(function () {
+        user = userEvent.setup({ delay: null })
         render(<NoFiltersStory />)
+      })
+
+      it('should show the choice description', async function () {
         // tabbing to the first choice (Aardvark)
         await user.keyboard('[Tab]')
         const choiceButton = screen.getByText('Aardvark')
@@ -503,8 +507,6 @@ describe('SurveyTask', function () {
       })
 
       it('should show choice images', async function () {
-        const user = userEvent.setup({ delay: null })
-        render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark) and pressing Enter to open the choice (Aardvark)
         await user.keyboard('[Tab][Enter]')
         const choiceImages = screen.getByTestId('choice-images')
@@ -513,8 +515,6 @@ describe('SurveyTask', function () {
       })
 
       it('should show choices with recent choice as active choice when Not This button keyed with Enter', async function () {
-        const user = userEvent.setup({ delay: null })
-        render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark), arrowing up to the last choice (Nothing here), and pressing Enter to open the choice (Nothing here)
         await user.keyboard('[Tab]')
         await user.keyboard('[ArrowUp]')
@@ -536,8 +536,6 @@ describe('SurveyTask', function () {
       })
 
       it('should show choices with identified choice as active choice when Identify keyed with Enter', async function () {
-        const user = userEvent.setup({ delay: null })
-        render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark), arrowing up to the last choice (Nothing here), and pressing Enter to open the choice (Nothing here)
         await user.keyboard('[Tab]')
         await user.keyboard('[ArrowUp]')
@@ -562,8 +560,6 @@ describe('SurveyTask', function () {
       })
 
       it('should disable the Identify button until required questions are answered', async function () {
-        const user = userEvent.setup({ delay: null })
-        render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark) and pressing Enter to open the choice (Aardvark)
         await user.keyboard('[Tab][Enter]')
         let identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -11,23 +11,26 @@ describe('SurveyTask', function () {
   
   describe('when choices are showing / without a selected choice', function () {
     describe('with characteristic filters', function () {
-      const DefaultStory = composeStory(Default, Meta)
+      let filterButton, choiceButtons, choicesShowingCount, clearFiltersButton
+
+      before(function () {
+        const DefaultStory = composeStory(Default, Meta)
+        render(<DefaultStory />)
+        // filterButton is the Filter button above the choices
+        filterButton = screen.queryByLabelText('SurveyTask.CharacteristicsFilter.filter')
+        const choiceMenu = document.querySelector('[role=menu]')
+        // choiceButtons are the menu items / buttons for the various choices (i.e. for the mock task the various animals)
+        choiceButtons = choiceMenu.querySelectorAll('[role=menuitemcheckbox]')
+        // choicesShowingCount is the text below choices that notes "Showing X of Y"
+        choicesShowingCount = screen.queryByText('SurveyTask.CharacteristicsFilter.showing')
+        clearFiltersButton = screen.queryByRole('button', { name: 'SurveyTask.CharacteristicsFilter.clearFilters' })
+      })
 
       it('should show a filter button', function () {
-        render(<DefaultStory />)
-        
-        // filterButton is the Filter button above the choices
-        const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
-        
         expect(filterButton).to.be.ok()
       })
 
       it('should show the choices', function () {
-        render(<DefaultStory />)
-        
-        // choiceButtons are the menu items / buttons for the various choices (i.e. for the mock task the various animals)
-        const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
-        
         expect(choiceButtons.length).to.equal(6)
         expect(choiceButtons[0]).to.have.text('Aardvark')
         expect(choiceButtons[1]).to.have.text('Elephant')
@@ -38,48 +41,39 @@ describe('SurveyTask', function () {
       })
 
       it('should show the choices showing count out of total choices count', function () {
-        render(<DefaultStory />)
-        
-        // choicesShowingCount is the text below choices that notes "Showing X of Y"
-        const choicesShowingCount = screen.getByText('SurveyTask.CharacteristicsFilter.showing')
-        
         expect(choicesShowingCount).to.be.ok()
       })
 
       it('should show a Clear Filters button', function () {
-        render(<DefaultStory />)
-        
-        const clearFiltersButton = screen.getByText('SurveyTask.CharacteristicsFilter.clearFilters')
-        
         expect(clearFiltersButton).to.be.ok()
       })
 
       it('should disable the Clear Filters button if showing choices = total choices', function () {
-        render(<DefaultStory />)
-        
-        const clearFiltersButton = screen.getByRole('button', { name: 'Clear SurveyTask.CharacteristicsFilter.clearFilters' })
-        
         expect(clearFiltersButton).to.have.attribute('disabled')
       })
     })
 
     describe('without characteristic filters', function () {
-      const NoFiltersStory = composeStory(NoFilters, Meta)
+      let filterButton, choiceButtons, choicesShowingCount, clearFiltersButton
+
+      before(function () {
+        const NoFiltersStory = composeStory(NoFilters, Meta)
+        render(<NoFiltersStory />)
+        // filterButton is the Filter button above the choices
+        filterButton = screen.queryByLabelText('SurveyTask.CharacteristicsFilter.filter')
+        const choiceMenu = document.querySelector('[role=menu]')
+        // choiceButtons are the menu items / buttons for the various choices (i.e. for the mock task the various animals)
+        choiceButtons = choiceMenu.querySelectorAll('[role=menuitemcheckbox]')
+        // choicesShowingCount is the text below choices that notes "Showing X of Y"
+        choicesShowingCount = screen.queryByText('SurveyTask.CharacteristicsFilter.showing')
+        clearFiltersButton = screen.queryByRole('button', { name: 'SurveyTask.CharacteristicsFilter.clearFilters' })
+      })
       
       it('should not show a filter button', function () {
-        render(<NoFiltersStory />)
-        
-        const filterButton = screen.queryByText('SurveyTask.CharacteristicsFilter.filter')
-        
         expect(filterButton).to.not.exist()
       })
 
       it('should show the choices', function () {
-        render(<NoFiltersStory />)
-        
-        // choiceButtons are the menu items / buttons for the various choices (i.e. for the mock task the various animals)
-        const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
-        
         expect(choiceButtons.length).to.equal(6)
         expect(choiceButtons[0]).to.have.text('Aardvark')
         expect(choiceButtons[1]).to.have.text('Elephant')
@@ -90,18 +84,10 @@ describe('SurveyTask', function () {
       })
 
       it('should not show the choices showing count out of total choices count', function () {
-        render(<NoFiltersStory />)
-        
-        const choicesShowingCount = screen.queryByText('SurveyTask.CharacteristicsFilter.showing')
-        
         expect(choicesShowingCount).to.not.exist()
       })
 
       it('should not not show a Clear Filters button', function () {
-        render(<NoFiltersStory />)
-        
-        const clearFiltersButton = screen.queryByText('SurveyTask.CharacteristicsFilter.clearFilters')
-        
         expect(clearFiltersButton).to.not.exist()
       })
     })

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -25,9 +25,9 @@ describe('SurveyTask', function () {
       it('should show the choices', function () {
         render(<DefaultStory />)
         
-        const choicesMenu = screen.getByTestId('choices-menu')
+        const choicesMenu = document.querySelector('[role=menu]')
         // choiceButtons are the menu items / buttons for the various choices (i.e. for the mock task the various animals)
-        const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+        const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
         
         expect(choiceButtons.length).to.equal(6)
         expect(choiceButtons[0]).to.have.text('Aardvark')
@@ -78,9 +78,9 @@ describe('SurveyTask', function () {
       it('should show the choices', function () {
         render(<NoFiltersStory />)
         
-        const choicesMenu = screen.getByTestId('choices-menu')
+        const choicesMenu = document.querySelector('[role=menu]')
         // choiceButtons are the menu items / buttons for the various choices (i.e. for the mock task the various animals)
-        const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+        const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
         
         expect(choiceButtons.length).to.equal(6)
         expect(choiceButtons[0]).to.have.text('Aardvark')
@@ -161,8 +161,8 @@ describe('SurveyTask', function () {
 
           await user.click(redFilterButton)
           await user.click(filterButton)
-          const choicesMenu = screen.getByTestId('choices-menu')
-          const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          const choicesMenu = document.querySelector('[role=menu]')
+          const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
           // confirm the choices are the 3 choices that match the red filter
           expect(choiceButtons.length).to.equal(3)
           expect(choiceButtons[0]).to.have.text('Aardvark')
@@ -182,8 +182,8 @@ describe('SurveyTask', function () {
           const identifyButton = screen.getByText('SurveyTask.Choice.identify')
           // identify the Fire choice
           await user.click(identifyButton)
-          const choicesMenu = screen.getByTestId('choices-menu')
-          const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          const choicesMenu = document.querySelector('[role=menu]')
+          const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
           // confirm the remaining choices are the 3 choices that match the red filter
           expect(choiceButtons.length).to.equal(3)
           expect(choiceButtons[0]).to.have.text('Aardvark')
@@ -204,8 +204,8 @@ describe('SurveyTask', function () {
           await user.click(stripesFilterRemoveButton)
           // close the characteristics filters
           await user.click(filterButton)
-          const choicesMenu = screen.getByTestId('choices-menu')
-          const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          const choicesMenu = document.querySelector('[role=menu]')
+          const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
           // confirm the choices are the total 6 choices, not filtered by the stripes filter
           expect(choiceButtons.length).to.equal(6)
         })
@@ -216,16 +216,16 @@ describe('SurveyTask', function () {
           await user.click(stripesFilterButton)
           await user.click(filterButton)
           // confirm the stripes filter is applied, of the total 6 choices only 1 choice (Kudu) matches the stripes filter
-          let choicesMenu = screen.getByTestId('choices-menu')
-          let choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          let choicesMenu = document.querySelector('[role=menu]')
+          let choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
           expect(choiceButtons.length).to.equal(1)
 
           const filterStatusSection = screen.getByTestId('filter-status')
           const stripesFilterRemoveButton = within(filterStatusSection).getByTestId('remove-filter-PTTRN-STRPS')
           // remove the stripes filter
           await user.click(stripesFilterRemoveButton)
-          choicesMenu = screen.getByTestId('choices-menu')
-          choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          choicesMenu = document.querySelector('[role=menu]')
+          choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
           // confirm the choices are the total 6 choices, not filtered by the stripes filter
           expect(choiceButtons.length).to.equal(6)
         })
@@ -262,16 +262,16 @@ describe('SurveyTask', function () {
           // click/apply the color tan/yellow filter
           await user.click(tanYellowFilterButton)
           await user.click(filterButton)
-          let choicesMenu = screen.getByTestId('choices-menu')
-          let choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          let choicesMenu = document.querySelector('[role=menu]')
+          let choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
           // confirm the choices remaining are the 1 choice (Kudu) that matches the cow/horse and tan/yellow filters
           expect(choiceButtons.length).to.equal(1)
 
           const clearFiltersButton = screen.getByText('SurveyTask.CharacteristicsFilter.clearFilters')
           // clear the filters
           await user.click(clearFiltersButton)
-          choicesMenu = screen.getByTestId('choices-menu')
-          choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          choicesMenu = document.querySelector('[role=menu]')
+          choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
           // confirm the choices are the total 6 choices, not filtered by the cow/horse and tan/yellow filters
           expect(choiceButtons.length).to.equal(6)
         })
@@ -311,8 +311,8 @@ describe('SurveyTask', function () {
         const choiceDescription = screen.queryByText('It\'s a fire. Pretty sure you know what this looks like.')
         expect(choiceDescription).to.be.null()
         // confirm choices are shown
-        const choicesMenu = screen.getByTestId('choices-menu')
-        const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+        const choicesMenu = document.querySelector('[role=menu]')
+        const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
         expect(choiceButtons.length).to.equal(6)
       })
 
@@ -328,8 +328,8 @@ describe('SurveyTask', function () {
         const choiceDescription = screen.queryByText('It\'s a fire. Pretty sure you know what this looks like.')
         expect(choiceDescription).to.be.null()
         // confirm choices are shown
-        const choicesMenu = screen.getByTestId('choices-menu')
-        const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+        const choicesMenu = document.querySelector('[role=menu]')
+        const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
         expect(choiceButtons.length).to.equal(6)
         // confirm choice (Fire) is shown as checked
         const fireChoiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
@@ -369,8 +369,8 @@ describe('SurveyTask', function () {
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
       // confirm choices showing
-      let choicesMenu = screen.getByTestId('choices-menu')
-      const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+      let choicesMenu = document.querySelector('[role=menu]')
+      const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
       expect(choiceButtons.length).to.equal(6)
       
       // confirm choice Fire selected
@@ -382,7 +382,7 @@ describe('SurveyTask', function () {
       
       // press delete key to remove choice (Fire)
       await user.keyboard('[Delete]')
-      choicesMenu = screen.getByTestId('choices-menu')
+      choicesMenu = document.querySelector('[role=menu]')
       choiceButton = within(choicesMenu).getByRole('menuitemcheckbox', { name: 'Fire' })
       // confirm choice Fire not selected
       expect(choiceButton.getAttribute('aria-checked')).to.equal('false')
@@ -397,8 +397,8 @@ describe('SurveyTask', function () {
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
       // confirm choices showing
-      let choicesMenu = screen.getByTestId('choices-menu')
-      const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+      let choicesMenu = document.querySelector('[role=menu]')
+      const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
       expect(choiceButtons.length).to.equal(6)
       
       // confirm choice Fire selected
@@ -410,7 +410,7 @@ describe('SurveyTask', function () {
       
       // press backspace key to remove choice (Fire)
       await user.keyboard('[Backspace]')
-      choicesMenu = screen.getByTestId('choices-menu')
+      choicesMenu = document.querySelector('[role=menu]')
       choiceButton = within(choicesMenu).getByRole('menuitemcheckbox', { name: 'Fire' })
       // confirm choice Fire not selected
       expect(choiceButton.getAttribute('aria-checked')).to.equal('false')
@@ -467,8 +467,8 @@ describe('SurveyTask', function () {
           // close the filters
           await user.click(filterButton)
           // confirming that the choices are filtered by the solid filter
-          const choicesMenu = screen.getByTestId('choices-menu')
-          const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          const choicesMenu = document.querySelector('[role=menu]')
+          const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
           expect(choiceButtons.length).to.equal(3)
           expect(choiceButtons[0]).to.have.text('Aardvark')
           expect(choiceButtons[1]).to.have.text('Elephant')
@@ -492,8 +492,8 @@ describe('SurveyTask', function () {
           // close the filters
           await user.click(filterButton)
           // confirm the choices are the total 6 choices, not filtered by the solid filter
-          const choicesMenu = screen.getByTestId('choices-menu')
-          const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          const choicesMenu = document.querySelector('[role=menu]')
+          const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
           expect(choiceButtons.length).to.equal(6)
         })
 
@@ -508,15 +508,15 @@ describe('SurveyTask', function () {
           // close the filters
           await user.click(filterButton)
           // confirm the solid filter is applied, of the total 6 choices only 1 choice (Kudu) matches the solid filter
-          let choicesMenu = screen.getByTestId('choices-menu')
-          let choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          let choicesMenu = document.querySelector('[role=menu]')
+          let choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
           expect(choiceButtons.length).to.equal(3)
 
           // remove the solid filter with the "Remove solid filter" small x button in the Filter Status component
           await user.keyboard('[Tab][Space]')
           // confirm the choices are the total 6 choices, not filtered by the solid filter
-          choicesMenu = screen.getByTestId('choices-menu')
-          choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+          choicesMenu = document.querySelector('[role=menu]')
+          choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
           expect(choiceButtons.length).to.equal(6)
         })
       })
@@ -564,8 +564,8 @@ describe('SurveyTask', function () {
         choiceDescription = screen.queryByText('Don\'t tell the plant biologists we called vegetation \"nothing here\"!')
         expect(choiceDescription).to.be.null()
         // confirm choices are shown
-        const choicesMenu = screen.getByTestId('choices-menu')
-        const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+        const choicesMenu = document.querySelector('[role=menu]')
+        const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
         expect(choiceButtons.length).to.equal(6)
       })
 
@@ -588,8 +588,8 @@ describe('SurveyTask', function () {
         choiceDescription = screen.queryByText('Don\'t tell the plant biologists we called vegetation \"nothing here\"!')
         expect(choiceDescription).to.be.null()
         // confirm choices are shown
-        const choicesMenu = screen.getByTestId('choices-menu')
-        const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
+        const choicesMenu = document.querySelector('[role=menu]')
+        const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
         expect(choiceButtons.length).to.equal(6)
         // confirm the identified choice (Nothing here) is the active choice
         const nothingHereChoiceButton = screen.getByRole('menuitemcheckbox', { name: 'Nothing here' })

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -562,16 +562,16 @@ describe('SurveyTask', function () {
       it('should disable the Identify button until required questions are answered', async function () {
         // tabbing to the first choice (Aardvark) and pressing Enter to open the choice (Aardvark)
         await user.keyboard('[Tab][Enter]')
-        let identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
+        let identifyButton = screen.getByTestId('choice-identify-button')
         // confirm the Identify button is disabled, pending required questions answered
         expect(identifyButton.disabled).to.be.true()
         // the required questions for Aardvark are "How many?" and "What behavior do you see?"
-        // the following answers "How many?" with "1" and "What behavior do you see?" with "Eating"
+        // the following answers "How many?" with "1" and "What behavior do you see?" with "Resting"
         
-        // tabbing (x3) to the "How many?" question, selecting the "1" answer with space key, tabbing (x4) to the "What behavior do you see?" question, selecting the "Eating" answer with space key
-        await user.keyboard('[Tab][Tab][Tab][Space][Tab][Tab][Tab][Tab][Space]')
+        // tabbing (x3) to the "How many?" question, selecting the "1" answer with space key, tabbing (x1) to the "What behavior do you see?" question, selecting the "Resting" answer with space key
+        await user.keyboard('[Tab][Tab][Tab][Space][Tab][Space]')
         // confirm the Identify button is enabled, now that required questions are answered
-        identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
+        identifyButton = screen.getByTestId('choice-identify-button')
         // confirm the Identify button is enabled, now that required questions answered
         expect(identifyButton.disabled).to.be.false()
       })

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -25,8 +25,9 @@ describe('SurveyTask', function () {
       it('should show the choices', function () {
         render(<DefaultStory />)
         
+        const choicesMenu = screen.getByTestId('choices-menu')
         // choiceButtons are the menu items / buttons for the various choices (i.e. for the mock task the various animals)
-        const choiceButtons = screen.getAllByRole('menuitemcheckbox')
+        const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
         
         expect(choiceButtons.length).to.equal(6)
         expect(choiceButtons[0]).to.have.text('Aardvark')
@@ -77,8 +78,9 @@ describe('SurveyTask', function () {
       it('should show the choices', function () {
         render(<NoFiltersStory />)
         
+        const choicesMenu = screen.getByTestId('choices-menu')
         // choiceButtons are the menu items / buttons for the various choices (i.e. for the mock task the various animals)
-        const choiceButtons = screen.getAllByRole('menuitemcheckbox')
+        const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
         
         expect(choiceButtons.length).to.equal(6)
         expect(choiceButtons[0]).to.have.text('Aardvark')
@@ -115,10 +117,11 @@ describe('SurveyTask', function () {
         const user = userEvent.setup({ delay: null })
         render(<DefaultStory />)
         // filterButton is the Filter button above the choices
-        const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
+        const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
         await user.click(filterButton)
+        const characteristicsSection = screen.getByTestId('characteristics')
         // the filterSections are the characteristic filter sections, i.e. the sections for "Like", "Pattern", and "Color" for the mock task
-        const filterSections = screen.getAllByRole('radiogroup')
+        const filterSections = within(characteristicsSection).getAllByRole('radiogroup')
         
         expect(filterSections.length).to.equal(3)
       })
@@ -127,7 +130,7 @@ describe('SurveyTask', function () {
         it('should show the filter button with a remove filter button', async function () {
           const user = userEvent.setup({ delay: null })
           render(<DefaultStory />)
-          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
+          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
           // the stripesFilterButton is the button to filter choices by "stripes". Stripes is a specific value of the "Pattern" characteristic.
           const stripesFilterButton = screen.getByTestId('filter-PTTRN-STRPS')
@@ -147,7 +150,7 @@ describe('SurveyTask', function () {
         it('should show the choices that match the filter', async function () {
           const user = userEvent.setup({ delay: null })
           render(<DefaultStory />)
-          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
+          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
           const redFilterButton = screen.getByTestId('filter-CLR-RD')
           expect(redFilterButton).to.be.ok()
@@ -156,7 +159,8 @@ describe('SurveyTask', function () {
 
           await user.click(redFilterButton)
           await user.click(filterButton)
-          const choiceButtons = screen.getAllByRole('menuitemcheckbox')
+          const choicesMenu = screen.getByTestId('choices-menu')
+          const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(3)
           expect(choiceButtons[0]).to.have.text('Aardvark')
           expect(choiceButtons[1]).to.have.text('Kudu')
@@ -166,7 +170,7 @@ describe('SurveyTask', function () {
         it.skip('should persist filters after a choice is selected', async function () {
           const user = userEvent.setup({ delay: null })
           render(<DefaultStory />)
-          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
+          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
 
           // open the characteristics filters
           await user.click(filterButton)
@@ -175,14 +179,15 @@ describe('SurveyTask', function () {
           await user.click(redFilterButton)
           // close the characteristics filters
           await user.click(filterButton)
-          const fireChoiceButton = screen.getByText('Fire')
+          const fireChoiceButton = screen.getByLabelText('Fire')
           // select the Fire choice
           await user.click(fireChoiceButton)
-          const identifyButton = screen.getByText('SurveyTask.Choice.identify')
+          const identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
           // identify the Fire choice
           await user.click(identifyButton)
           // confirm the remaining choices are the 3 choices that match the red filter
-          const choiceButtons = screen.getAllByRole('menuitemcheckbox')
+          const choicesMenu = screen.getByTestId('choices-menu')
+          const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(3)
           expect(choiceButtons[0]).to.have.text('Aardvark')
           expect(choiceButtons[1]).to.have.text('Kudu')
@@ -192,7 +197,7 @@ describe('SurveyTask', function () {
         it.skip('should remove the filter on remove filter button click (within Characteristics)', async function () {
           const user = userEvent.setup({ delay: null })
           render(<DefaultStory />)
-          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
+          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
           const stripesFilterButton = screen.getByTestId('filter-PTTRN-STRPS')
           // click/apply the stripes filter
@@ -203,21 +208,23 @@ describe('SurveyTask', function () {
           await user.click(stripesFilterRemoveButton)
           await user.click(filterButton)
           // confirm the choices are the total 6 choices, not filtered by the stripes filter
-          const choiceButtons = screen.getAllByRole('menuitemcheckbox')
+          const choicesMenu = screen.getByTestId('choices-menu')
+          const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(6)
         })
 
         it.skip('should remove the filter on remove filter button click (within FilterStatus)', async function () {
           const user = userEvent.setup({ delay: null })
           render(<DefaultStory />)
-          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
+          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
           const stripesFilterButton = screen.getByTestId('filter-PTTRN-STRPS')
           // click/apply the stripes filter
           await user.click(stripesFilterButton)
           await user.click(filterButton)
           // confirm the stripes filter is applied, of the total 6 choices only 1 choice (Kudu) matches the stripes filter
-          let choiceButtons = screen.getAllByRole('menuitemcheckbox')
+          let choicesMenu = screen.getByTestId('choices-menu')
+          let choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(1)
 
           const filterStatusSection = screen.getByTestId('filter-status')
@@ -225,14 +232,15 @@ describe('SurveyTask', function () {
           // remove the stripes filter
           await user.click(stripesFilterRemoveButton)
           // confirm the choices are the total 6 choices, not filtered by the stripes filter
-          choiceButtons = screen.getAllByRole('menuitemcheckbox')
+          choicesMenu = screen.getByTestId('choices-menu')
+          choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(6)
         })
 
         it.skip('should remove filters on Clear Filters button click (within Characteristics) ', async function () {
           const user = userEvent.setup({ delay: null })
           render(<DefaultStory />)
-          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
+          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
           // click/apply the like a cow/horse filter
           const cowHorseFilterButton = screen.getByTestId('filter-LK-CWHRS')
@@ -260,7 +268,7 @@ describe('SurveyTask', function () {
         it.skip('should remove filters on Clear Filters button click (within Chooser)', async function () {
           const user = userEvent.setup({ delay: null })
           render(<DefaultStory />)
-          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
+          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
           const cowHorseFilterButton = screen.getByTestId('filter-LK-CWHRS')
           // click/apply the like a cow/horse filter
@@ -269,14 +277,16 @@ describe('SurveyTask', function () {
           // click/apply the color tan/yellow filter
           await user.click(tanYellowFilterButton)
           await user.click(filterButton)
-          let choiceButtons = screen.getAllByRole('menuitemcheckbox')
+          let choicesMenu = screen.getByTestId('choices-menu')
+          let choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
           // confirm the choices remaining are the 1 choice (Kudu) that matches the cow/horse and tan/yellow filters
           expect(choiceButtons.length).to.equal(1)
 
-          const clearFiltersButton = screen.getByText('SurveyTask.CharacteristicsFilter.clearFilters')
+          const clearFiltersButton = screen.getByRole('button', { name: 'Clear SurveyTask.CharacteristicsFilter.clearFilters' })
           // clear the filters
           await user.click(clearFiltersButton)
-          choiceButtons = screen.getAllByRole('menuitemcheckbox')
+          choicesMenu = screen.getByTestId('choices-menu')
+          choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
           // confirm the choices are the total 6 choices, not filtered by the cow/horse and tan/yellow filters
           expect(choiceButtons.length).to.equal(6)
         })
@@ -316,7 +326,8 @@ describe('SurveyTask', function () {
         const choiceHeading = screen.queryByRole('heading', { name: 'Fire' })
         expect(choiceHeading).to.be.null()
         // confirm choices are shown
-        const choiceButtons = screen.getAllByRole('menuitemcheckbox')
+        const choicesMenu = screen.getByTestId('choices-menu')
+        const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
         expect(choiceButtons.length).to.equal(6)
       })
 
@@ -332,7 +343,8 @@ describe('SurveyTask', function () {
         const choiceHeading = screen.queryByRole('heading', { name: 'Fire' })
         expect(choiceHeading).to.be.null()
         // confirm choices are shown
-        const choiceButtons = screen.getAllByRole('menuitemcheckbox')
+        const choicesMenu = screen.getByTestId('choices-menu')
+        const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
         expect(choiceButtons.length).to.equal(6)
         // confirm choice (Fire) is shown as checked
         const fireChoiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
@@ -375,7 +387,8 @@ describe('SurveyTask', function () {
         // pressing the Enter key to open the Filter button
         await user.keyboard('[Enter]')
         // the filterSections are the characteristic filter sections, i.e. the sections for "Like", "Pattern", and "Color" for the mock task
-        const filterSections = screen.getAllByRole('radiogroup')
+        const characteristicsSection = screen.getByTestId('characteristics')
+        const filterSections = within(characteristicsSection).getAllByRole('radiogroup')
         expect(filterSections.length).to.equal(3)
       })
 
@@ -404,7 +417,7 @@ describe('SurveyTask', function () {
         it('should show the choices that match the filter', async function () {
           const user = userEvent.setup({ delay: null })
           render(<DefaultStory />)
-          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
+          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
           // tabbing to and opening the Filter button
           await user.keyboard('[Tab][Enter]')
           // tabbing to the pattern section that contains the solid filter and selecting the solid filter with space key
@@ -412,7 +425,8 @@ describe('SurveyTask', function () {
           // close the filters
           await user.click(filterButton)
           // confirming that the choices are filtered by the solid filter
-          const choiceButtons = screen.getAllByRole('menuitemcheckbox')
+          const choicesMenu = screen.getByTestId('choices-menu')
+          const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(3)
           expect(choiceButtons[0]).to.have.text('Aardvark')
           expect(choiceButtons[1]).to.have.text('Elephant')
@@ -422,7 +436,7 @@ describe('SurveyTask', function () {
         it('should remove the filter on remove filter button keypress (within Characteristics)', async function () {
           const user = userEvent.setup({ delay: null })
           render(<DefaultStory />)
-          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
+          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
           // tabbing to and opening the Filter button
           await user.keyboard('[Tab][Enter]')
           // tabbing to the pattern section that contains the solid filter and selecting the solid filter with space key
@@ -441,14 +455,15 @@ describe('SurveyTask', function () {
           // close the filters
           await user.click(filterButton)
           // confirm the choices are the total 6 choices, not filtered by the solid filter
-          const choiceButtons = screen.getAllByRole('menuitemcheckbox')
+          const choicesMenu = screen.getByTestId('choices-menu')
+          const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(6)
         })
 
         it('should remove the filter on remove filter button keypress (within FilterStatus)', async function () {
           const user = userEvent.setup({ delay: null })
           render(<DefaultStory />)
-          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
+          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
           // tabbing to and opening the Filter button
           await user.keyboard('[Tab][Enter]')
           // tabbing to the pattern section that contains the solid filter and selecting the solid filter with space key
@@ -461,13 +476,15 @@ describe('SurveyTask', function () {
           // close the filters
           await user.click(filterButton)
           // confirm the solid filter is applied, of the total 6 choices only 1 choice (Kudu) matches the solid filter
-          let choiceButtons = screen.getAllByRole('menuitemcheckbox')
+          let choicesMenu = screen.getByTestId('choices-menu')
+          let choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(3)
 
           // remove the solid filter with the "Remove solid filter" small x button in the Filter Status component
           await user.keyboard('[Tab][Space]')
           // confirm the choices are the total 6 choices, not filtered by the solid filter
-          choiceButtons = screen.getAllByRole('menuitemcheckbox')
+          choicesMenu = screen.getByTestId('choices-menu')
+          choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(6)
         })
       })
@@ -516,7 +533,8 @@ describe('SurveyTask', function () {
         choiceHeading = screen.queryByRole('heading', { name: 'Nothing here' })
         expect(choiceHeading).to.be.null()
         // confirm choices are shown
-        const choiceButtons = screen.getAllByRole('menuitemcheckbox')
+        const choicesMenu = screen.getByTestId('choices-menu')
+        const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
         expect(choiceButtons.length).to.equal(6)
       })
 
@@ -539,7 +557,8 @@ describe('SurveyTask', function () {
         choiceHeading = screen.queryByRole('heading', { name: 'Fire' })
         expect(choiceHeading).to.be.null()
         // confirm choices are shown
-        const choiceButtons = screen.getAllByRole('menuitemcheckbox')
+        const choicesMenu = screen.getByTestId('choices-menu')
+        const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
         expect(choiceButtons.length).to.equal(6)
         // confirm the identified choice (Nothing here) is the active choice
         const nothingHereChoiceButton = screen.getByRole('menuitemcheckbox', { name: 'Nothing here' })
@@ -571,11 +590,12 @@ describe('SurveyTask', function () {
       render(<NoFiltersStory />)
       let choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
       await user.click(choiceButton)
-      const identifyButton = screen.getByText('SurveyTask.Choice.identify')
+      const identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
       // confirm choices showing
-      const choiceButtons = screen.getAllByRole('menuitemcheckbox')
+      const choicesMenu = screen.getByTestId('choices-menu')
+      const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
       expect(choiceButtons.length).to.equal(6)
       
       // confirm choice Fire selected
@@ -597,11 +617,12 @@ describe('SurveyTask', function () {
       render(<NoFiltersStory />)
       let choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
       await user.click(choiceButton)
-      const identifyButton = screen.getByText('SurveyTask.Choice.identify')
+      const identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
       // confirm choices showing
-      const choiceButtons = screen.getAllByRole('menuitemcheckbox')
+      const choicesMenu = screen.getByTestId('choices-menu')
+      const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
       expect(choiceButtons.length).to.equal(6)
       
       // confirm choice Fire selected

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -127,11 +127,17 @@ describe('SurveyTask', function () {
       })
 
       describe('when filters are clicked', function () {
-        it('should show the filter button with a remove filter button', async function () {
-          const user = userEvent.setup({ delay: null })
+        let user, filterButton
+        
+        beforeEach(async function () {
+          user = userEvent.setup({ delay: null })
           render(<DefaultStory />)
-          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
+          // click the Filter button above choices to open the characteristics filters
+          filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
+        })
+        
+        it('should show the filter button with a remove filter button', async function () {
           // the stripesFilterButton is the button to filter choices by "stripes". Stripes is a specific value of the "Pattern" characteristic.
           const stripesFilterButton = screen.getByTestId('filter-PTTRN-STRPS')
           expect(stripesFilterButton).to.be.ok()
@@ -148,10 +154,6 @@ describe('SurveyTask', function () {
         })
 
         it('should show the choices that match the filter', async function () {
-          const user = userEvent.setup({ delay: null })
-          render(<DefaultStory />)
-          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
-          await user.click(filterButton)
           const redFilterButton = screen.getByTestId('filter-CLR-RD')
           expect(redFilterButton).to.be.ok()
 
@@ -167,13 +169,7 @@ describe('SurveyTask', function () {
           expect(choiceButtons[2]).to.have.text('Fire')
         })
 
-        it.skip('should persist filters after a choice is selected', async function () {
-          const user = userEvent.setup({ delay: null })
-          render(<DefaultStory />)
-          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
-
-          // open the characteristics filters
-          await user.click(filterButton)
+        it('should persist filters after a choice is selected', async function () {
           const redFilterButton = screen.getByTestId('filter-CLR-RD')
           // click/apply the red filter, which filters 6 choices to 3 choices
           await user.click(redFilterButton)
@@ -194,11 +190,7 @@ describe('SurveyTask', function () {
           expect(choiceButtons[2]).to.have.text('Fire')
         })
 
-        it.skip('should remove the filter on remove filter button click (within Characteristics)', async function () {
-          const user = userEvent.setup({ delay: null })
-          render(<DefaultStory />)
-          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
-          await user.click(filterButton)
+        it('should remove the filter on remove filter button click (within Characteristics)', async function () {
           const stripesFilterButton = screen.getByTestId('filter-PTTRN-STRPS')
           // click/apply the stripes filter
           await user.click(stripesFilterButton)
@@ -213,11 +205,7 @@ describe('SurveyTask', function () {
           expect(choiceButtons.length).to.equal(6)
         })
 
-        it.skip('should remove the filter on remove filter button click (within FilterStatus)', async function () {
-          const user = userEvent.setup({ delay: null })
-          render(<DefaultStory />)
-          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
-          await user.click(filterButton)
+        it('should remove the filter on remove filter button click (within FilterStatus)', async function () {
           const stripesFilterButton = screen.getByTestId('filter-PTTRN-STRPS')
           // click/apply the stripes filter
           await user.click(stripesFilterButton)
@@ -237,11 +225,7 @@ describe('SurveyTask', function () {
           expect(choiceButtons.length).to.equal(6)
         })
 
-        it.skip('should remove filters on Clear Filters button click (within Characteristics) ', async function () {
-          const user = userEvent.setup({ delay: null })
-          render(<DefaultStory />)
-          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
-          await user.click(filterButton)
+        it('should remove filters on Clear Filters button click (within Characteristics) ', async function () {
           // click/apply the like a cow/horse filter
           const cowHorseFilterButton = screen.getByTestId('filter-LK-CWHRS')
           await user.click(cowHorseFilterButton)
@@ -265,11 +249,7 @@ describe('SurveyTask', function () {
           expect(tanYellowFilterRemoveButton).to.be.null()
         })
 
-        it.skip('should remove filters on Clear Filters button click (within Chooser)', async function () {
-          const user = userEvent.setup({ delay: null })
-          render(<DefaultStory />)
-          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
-          await user.click(filterButton)
+        it('should remove filters on Clear Filters button click (within Chooser)', async function () {
           const cowHorseFilterButton = screen.getByTestId('filter-LK-CWHRS')
           // click/apply the like a cow/horse filter
           await user.click(cowHorseFilterButton)
@@ -393,11 +373,17 @@ describe('SurveyTask', function () {
       })
 
       describe('when filters are keyed', function () {
-        it('should show the filter button with a remove filter button', async function () {
-          const user = userEvent.setup({ delay: null })
+        let user, filterButton
+
+        beforeEach(async function () {
+          user = userEvent.setup({ delay: null })
           render(<DefaultStory />)
+          filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
           // tabbing to and opening the Filter button
           await user.keyboard('[Tab][Enter]')
+        })  
+
+        it('should show the filter button with a remove filter button', async function () {
           // the solidFilterButton is the button to filter choices by "solid". Solid is a specific value of the "Pattern" characteristic.
           const solidFilterButton = screen.getByTestId('filter-PTTRN-SLD')
           expect(solidFilterButton).to.be.ok()
@@ -415,11 +401,6 @@ describe('SurveyTask', function () {
         })
 
         it('should show the choices that match the filter', async function () {
-          const user = userEvent.setup({ delay: null })
-          render(<DefaultStory />)
-          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
-          // tabbing to and opening the Filter button
-          await user.keyboard('[Tab][Enter]')
           // tabbing to the pattern section that contains the solid filter and selecting the solid filter with space key
           await user.keyboard('[Tab][Tab][Space]')
           // close the filters
@@ -434,11 +415,6 @@ describe('SurveyTask', function () {
         })
 
         it('should remove the filter on remove filter button keypress (within Characteristics)', async function () {
-          const user = userEvent.setup({ delay: null })
-          render(<DefaultStory />)
-          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
-          // tabbing to and opening the Filter button
-          await user.keyboard('[Tab][Enter]')
           // tabbing to the pattern section that contains the solid filter and selecting the solid filter with space key
           await user.keyboard('[Tab][Tab][Space]')
           // confirm the solid filter is selected with existence of the related remove filter button
@@ -461,11 +437,6 @@ describe('SurveyTask', function () {
         })
 
         it('should remove the filter on remove filter button keypress (within FilterStatus)', async function () {
-          const user = userEvent.setup({ delay: null })
-          render(<DefaultStory />)
-          const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
-          // tabbing to and opening the Filter button
-          await user.keyboard('[Tab][Enter]')
           // tabbing to the pattern section that contains the solid filter and selecting the solid filter with space key
           await user.keyboard('[Tab][Tab][Space]')
           // confirm the solid filter is selected with existence of the related remove filter button

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -14,19 +14,19 @@ describe('SurveyTask', function () {
       const DefaultStory = composeStory(Default, Meta)
 
       it('should show a filter button', function () {
-        const { getByRole } = render(<DefaultStory />)
+        render(<DefaultStory />)
         
         // filterButton is the Filter button above the choices
-        const filterButton = getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+        const filterButton = screen.getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
         
         expect(filterButton).to.be.ok()
       })
 
       it('should show the choices', function () {
-        const { getAllByRole } = render(<DefaultStory />)
+        render(<DefaultStory />)
         
         // choiceButtons are the menu items / buttons for the various choices (i.e. for the mock task the various animals)
-        const choiceButtons = getAllByRole('menuitemcheckbox')
+        const choiceButtons = screen.getAllByRole('menuitemcheckbox')
         
         expect(choiceButtons.length).to.equal(6)
         expect(choiceButtons[0]).to.have.text('Aardvark')
@@ -38,26 +38,26 @@ describe('SurveyTask', function () {
       })
 
       it('should show the choices showing count out of total choices count', function () {
-        const { getByText } = render(<DefaultStory />)
+        render(<DefaultStory />)
         
         // choicesShowingCount is the text below choices that notes "Showing X of Y"
-        const choicesShowingCount = getByText('SurveyTask.CharacteristicsFilter.showing')
+        const choicesShowingCount = screen.getByText('SurveyTask.CharacteristicsFilter.showing')
         
         expect(choicesShowingCount).to.be.ok()
       })
 
       it('should show a Clear Filters button', function () {
-        const { getByRole } = render(<DefaultStory />)
+        render(<DefaultStory />)
         
-        const clearFiltersButton = getByRole('button', { name: 'Clear SurveyTask.CharacteristicsFilter.clearFilters' })
+        const clearFiltersButton = screen.getByRole('button', { name: 'Clear SurveyTask.CharacteristicsFilter.clearFilters' })
         
         expect(clearFiltersButton).to.be.ok()
       })
 
       it('should disable the Clear Filters button if showing choices = total choices', function () {
-        const { getByRole } = render(<DefaultStory />)
+        render(<DefaultStory />)
         
-        const clearFiltersButton = getByRole('button', { name: 'Clear SurveyTask.CharacteristicsFilter.clearFilters' })
+        const clearFiltersButton = screen.getByRole('button', { name: 'Clear SurveyTask.CharacteristicsFilter.clearFilters' })
         
         expect(clearFiltersButton).to.have.attribute('disabled')
       })
@@ -67,18 +67,18 @@ describe('SurveyTask', function () {
       const NoFiltersStory = composeStory(NoFilters, Meta)
       
       it('should not show a filter button', function () {
-        const { queryByText } = render(<NoFiltersStory />)
+        render(<NoFiltersStory />)
         
-        const filterButton = queryByText('SurveyTask.CharacteristicsFilter.filter')
+        const filterButton = screen.queryByText('SurveyTask.CharacteristicsFilter.filter')
         
         expect(filterButton).to.not.exist()
       })
 
       it('should show the choices', function () {
-        const { getAllByRole } = render(<NoFiltersStory />)
+        render(<NoFiltersStory />)
         
         // choiceButtons are the menu items / buttons for the various choices (i.e. for the mock task the various animals)
-        const choiceButtons = getAllByRole('menuitemcheckbox')
+        const choiceButtons = screen.getAllByRole('menuitemcheckbox')
         
         expect(choiceButtons.length).to.equal(6)
         expect(choiceButtons[0]).to.have.text('Aardvark')
@@ -90,17 +90,17 @@ describe('SurveyTask', function () {
       })
 
       it('should not show the choices showing count out of total choices count', function () {
-        const { queryByText } = render(<NoFiltersStory />)
+        render(<NoFiltersStory />)
         
-        const choicesShowingCount = queryByText('SurveyTask.CharacteristicsFilter.showing')
+        const choicesShowingCount = screen.queryByText('SurveyTask.CharacteristicsFilter.showing')
         
         expect(choicesShowingCount).to.not.exist()
       })
 
       it('should not not show a clear filters button', function () {
-        const { queryByRole } = render(<NoFiltersStory />)
+        render(<NoFiltersStory />)
         
-        const clearFiltersButton = queryByRole('button', { name: 'Clear SurveyTask.CharacteristicsFilter.clearFilters' })
+        const clearFiltersButton = screen.queryByRole('button', { name: 'Clear SurveyTask.CharacteristicsFilter.clearFilters' })
         
         expect(clearFiltersButton).to.not.exist()
       })
@@ -113,12 +113,12 @@ describe('SurveyTask', function () {
     describe('when the Filter button is clicked', function () {
       it('should show characteristic filter sections', async function () {
         const user = userEvent.setup({ delay: null })
-        const { getAllByRole, getByText } = render(<DefaultStory />)
+        render(<DefaultStory />)
         // filterButton is the Filter button above the choices
-        const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
+        const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
         await user.click(filterButton)
         // the filterSections are the characteristic filter sections, i.e. the sections for "Like", "Pattern", and "Color" for the mock task
-        const filterSections = getAllByRole('radiogroup')
+        const filterSections = screen.getAllByRole('radiogroup')
         
         expect(filterSections.length).to.equal(3)
       })
@@ -126,37 +126,37 @@ describe('SurveyTask', function () {
       describe('when filters are clicked', function () {
         it('should show the filter button with a remove filter button', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getByTestId, getByText } = render(<DefaultStory />)
-          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
+          render(<DefaultStory />)
+          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
           // the stripesFilterButton is the button to filter choices by "stripes". Stripes is a specific value of the "Pattern" characteristic.
-          const stripesFilterButton = getByTestId('filter-PTTRN-STRPS')
+          const stripesFilterButton = screen.getByTestId('filter-PTTRN-STRPS')
           expect(stripesFilterButton).to.be.ok()
 
           // the stripesFilterRemoveButton is the small x button that appears over a filter to remove the filter, after it is selected. The presence of this button indicates that the filter is selected. The absence of this button indicates that the filter is not selected.
-          let characteristicsSection = getByTestId('characteristics')
+          let characteristicsSection = screen.getByTestId('characteristics')
           let stripesFilterRemoveButton = within(characteristicsSection).queryByTestId('remove-filter-PTTRN-STRPS')
           expect(stripesFilterRemoveButton).to.be.null()
           
           await user.click(stripesFilterButton)
-          characteristicsSection = getByTestId('characteristics')
+          characteristicsSection = screen.getByTestId('characteristics')
           stripesFilterRemoveButton = within(characteristicsSection).getByTestId('remove-filter-PTTRN-STRPS')
           expect(stripesFilterRemoveButton).to.be.ok()
         })
 
         it('should show the choices that match the filter', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByTestId, getByText } = render(<DefaultStory />)
-          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
+          render(<DefaultStory />)
+          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
-          const redFilterButton = getByTestId('filter-CLR-RD')
+          const redFilterButton = screen.getByTestId('filter-CLR-RD')
           expect(redFilterButton).to.be.ok()
 
           // the following user events filter choices by the color red and then close the characteristics filters, returning to the list of choices.
 
           await user.click(redFilterButton)
           await user.click(filterButton)
-          const choiceButtons = getAllByRole('menuitemcheckbox')
+          const choiceButtons = screen.getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(3)
           expect(choiceButtons[0]).to.have.text('Aardvark')
           expect(choiceButtons[1]).to.have.text('Kudu')
@@ -165,24 +165,24 @@ describe('SurveyTask', function () {
 
         it.skip('should persist filters after a choice is selected', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByTestId, getByText } = render(<DefaultStory />)
-          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
+          render(<DefaultStory />)
+          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
 
           // open the characteristics filters
           await user.click(filterButton)
-          const redFilterButton = getByTestId('filter-CLR-RD')
+          const redFilterButton = screen.getByTestId('filter-CLR-RD')
           // click/apply the red filter, which filters 6 choices to 3 choices
           await user.click(redFilterButton)
           // close the characteristics filters
           await user.click(filterButton)
-          const fireChoiceButton = getByText('Fire')
+          const fireChoiceButton = screen.getByText('Fire')
           // select the Fire choice
           await user.click(fireChoiceButton)
-          const identifyButton = getByText('SurveyTask.Choice.identify')
+          const identifyButton = screen.getByText('SurveyTask.Choice.identify')
           // identify the Fire choice
           await user.click(identifyButton)
           // confirm the remaining choices are the 3 choices that match the red filter
-          const choiceButtons = getAllByRole('menuitemcheckbox')
+          const choiceButtons = screen.getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(3)
           expect(choiceButtons[0]).to.have.text('Aardvark')
           expect(choiceButtons[1]).to.have.text('Kudu')
@@ -191,67 +191,67 @@ describe('SurveyTask', function () {
 
         it.skip('should remove the filter on remove filter button click (within Characteristics)', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByTestId, getByText } = render(<DefaultStory />)
-          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
+          render(<DefaultStory />)
+          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
-          const stripesFilterButton = getByTestId('filter-PTTRN-STRPS')
+          const stripesFilterButton = screen.getByTestId('filter-PTTRN-STRPS')
           // click/apply the stripes filter
           await user.click(stripesFilterButton)
-          const characteristicsSection = getByTestId('characteristics')
+          const characteristicsSection = screen.getByTestId('characteristics')
           const stripesFilterRemoveButton = within(characteristicsSection).getByTestId('remove-filter-PTTRN-STRPS')
           // remove the stripes filter
           await user.click(stripesFilterRemoveButton)
           await user.click(filterButton)
           // confirm the choices are the total 6 choices, not filtered by the stripes filter
-          const choiceButtons = getAllByRole('menuitemcheckbox')
+          const choiceButtons = screen.getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(6)
         })
 
         it.skip('should remove the filter on remove filter button click (within FilterStatus)', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByTestId, getByText } = render(<DefaultStory />)
-          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
+          render(<DefaultStory />)
+          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
-          const stripesFilterButton = getByTestId('filter-PTTRN-STRPS')
+          const stripesFilterButton = screen.getByTestId('filter-PTTRN-STRPS')
           // click/apply the stripes filter
           await user.click(stripesFilterButton)
           await user.click(filterButton)
           // confirm the stripes filter is applied, of the total 6 choices only 1 choice (Kudu) matches the stripes filter
-          let choiceButtons = getAllByRole('menuitemcheckbox')
+          let choiceButtons = screen.getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(1)
 
-          const filterStatusSection = getByTestId('filter-status')
+          const filterStatusSection = screen.getByTestId('filter-status')
           const stripesFilterRemoveButton = within(filterStatusSection).getByTestId('remove-filter-PTTRN-STRPS')
           // remove the stripes filter
           await user.click(stripesFilterRemoveButton)
           // confirm the choices are the total 6 choices, not filtered by the stripes filter
-          choiceButtons = getAllByRole('menuitemcheckbox')
+          choiceButtons = screen.getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(6)
         })
 
         it.skip('should remove filters on Clear Filters button click (within Characteristics) ', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getByRole, getByTestId, queryByTestId, getByText } = render(<DefaultStory />)
-          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
+          render(<DefaultStory />)
+          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
           // click/apply the like a cow/horse filter
-          const cowHorseFilterButton = getByTestId('filter-LK-CWHRS')
+          const cowHorseFilterButton = screen.getByTestId('filter-LK-CWHRS')
           await user.click(cowHorseFilterButton)
           // click/apply the color tan/yellow filter
-          const tanYellowFilterButton = getByTestId('filter-CLR-TNLLW')
+          const tanYellowFilterButton = screen.getByTestId('filter-CLR-TNLLW')
           await user.click(tanYellowFilterButton)
-          const characteristicsSection = getByTestId('characteristics')
+          const characteristicsSection = screen.getByTestId('characteristics')
           let cowHorseFilterRemoveButton = within(characteristicsSection).getByTestId('remove-filter-LK-CWHRS')
           let tanYellowFilterRemoveButton = within(characteristicsSection).getByTestId('remove-filter-CLR-TNLLW')
           // confirm the cow/horse and tan/yellow filters are applied
           expect(cowHorseFilterRemoveButton).to.be.ok()
           expect(tanYellowFilterRemoveButton).to.be.ok()
 
-          const clearFiltersButton = getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.clearFilters' })
+          const clearFiltersButton = screen.getByRole('button', { name: 'SurveyTask.CharacteristicsFilter.clearFilters' })
           // clear the filters
           await user.click(clearFiltersButton)
-          cowHorseFilterRemoveButton = queryByTestId('remove-filter-LK-CWHRS')
-          tanYellowFilterRemoveButton = queryByTestId('remove-filter-CLR-TNLLW')
+          cowHorseFilterRemoveButton = screen.queryByTestId('remove-filter-LK-CWHRS')
+          tanYellowFilterRemoveButton = screen.queryByTestId('remove-filter-CLR-TNLLW')
           // confirm the cow/horse and tan/yellow filters are removed
           expect(cowHorseFilterRemoveButton).to.be.null()
           expect(tanYellowFilterRemoveButton).to.be.null()
@@ -259,24 +259,24 @@ describe('SurveyTask', function () {
 
         it.skip('should remove filters on Clear Filters button click (within Chooser)', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByTestId, getByText } = render(<DefaultStory />)
-          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
+          render(<DefaultStory />)
+          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
           await user.click(filterButton)
-          const cowHorseFilterButton = getByTestId('filter-LK-CWHRS')
+          const cowHorseFilterButton = screen.getByTestId('filter-LK-CWHRS')
           // click/apply the like a cow/horse filter
           await user.click(cowHorseFilterButton)
-          const tanYellowFilterButton = getByTestId('filter-CLR-TNLLW')
+          const tanYellowFilterButton = screen.getByTestId('filter-CLR-TNLLW')
           // click/apply the color tan/yellow filter
           await user.click(tanYellowFilterButton)
           await user.click(filterButton)
-          let choiceButtons = getAllByRole('menuitemcheckbox')
+          let choiceButtons = screen.getAllByRole('menuitemcheckbox')
           // confirm the choices remaining are the 1 choice (Kudu) that matches the cow/horse and tan/yellow filters
           expect(choiceButtons.length).to.equal(1)
 
-          const clearFiltersButton = getByText('SurveyTask.CharacteristicsFilter.clearFilters')
+          const clearFiltersButton = screen.getByText('SurveyTask.CharacteristicsFilter.clearFilters')
           // clear the filters
           await user.click(clearFiltersButton)
-          choiceButtons = getAllByRole('menuitemcheckbox')
+          choiceButtons = screen.getAllByRole('menuitemcheckbox')
           // confirm the choices are the total 6 choices, not filtered by the cow/horse and tan/yellow filters
           expect(choiceButtons.length).to.equal(6)
         })
@@ -286,72 +286,72 @@ describe('SurveyTask', function () {
     describe.skip('when a choice is clicked', function () {
       it('should show the choice heading', async function () {
         const user = userEvent.setup({ delay: null })
-        const { getByRole } = render(<DefaultStory />)
-        const choiceButton = getByRole('menuitemcheckbox', { name: 'Aardvark' })
+        render(<DefaultStory />)
+        const choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Aardvark' })
         await user.click(choiceButton)
-        const choiceHeading = getByRole('heading', { name: 'Aardvark' })
+        const choiceHeading = screen.getByRole('heading', { name: 'Aardvark' })
 
         expect(choiceHeading).to.be.ok()
       })
 
       it('should show choice images', async function () {
         const user = userEvent.setup({ delay: null })
-        const { getByRole, getByTestId } = render(<DefaultStory />)
-        const choiceButton = getByRole('menuitemcheckbox', { name: 'Fire' })
+        render(<DefaultStory />)
+        const choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
         await user.click(choiceButton)
-        const choiceImages = getByTestId('choice-images')
+        const choiceImages = screen.getByTestId('choice-images')
         
         expect(choiceImages).to.be.ok()
       })
 
       it('should show choices when Not This button is clicked', async function () {
         const user = userEvent.setup({ delay: null })
-        const { getAllByRole, getByRole, queryByRole } = render(<DefaultStory />)
-        const choiceButton = getByRole('menuitemcheckbox', { name: 'Fire' })
+        render(<DefaultStory />)
+        const choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
         await user.click(choiceButton)
-        const notThisButton = getByRole('button', { name: 'SurveyTask.Choice.notThis' })
+        const notThisButton = screen.getByRole('button', { name: 'SurveyTask.Choice.notThis' })
         // close choice (Fire) component
         await user.click(notThisButton)
         // confirm choice (Fire) heading, and therefore choice, is not shown
-        const choiceHeading = queryByRole('heading', { name: 'Fire' })
+        const choiceHeading = screen.queryByRole('heading', { name: 'Fire' })
         expect(choiceHeading).to.be.null()
         // confirm choices are shown
-        const choiceButtons = getAllByRole('menuitemcheckbox')
+        const choiceButtons = screen.getAllByRole('menuitemcheckbox')
         expect(choiceButtons.length).to.equal(6)
       })
 
       it('should show choices with selected choice checked when Identify button is clicked', async function () {
         const user = userEvent.setup({ delay: null })
-        const { getAllByRole, getByRole, queryByRole } = render(<DefaultStory />)
-        const choiceButton = getByRole('menuitemcheckbox', { name: 'Fire' })
+        render(<DefaultStory />)
+        const choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
         await user.click(choiceButton)
-        const identifyButton = getByRole('button', { name: 'SurveyTask.Choice.identify' })
+        const identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
         // identify choice (Fire) and close choice (Fire) component
         await user.click(identifyButton)
         // confirm choice (Fire) heading, and therefore choice, is not shown
-        const choiceHeading = queryByRole('heading', { name: 'Fire' })
+        const choiceHeading = screen.queryByRole('heading', { name: 'Fire' })
         expect(choiceHeading).to.be.null()
         // confirm choices are shown
-        const choiceButtons = getAllByRole('menuitemcheckbox')
+        const choiceButtons = screen.getAllByRole('menuitemcheckbox')
         expect(choiceButtons.length).to.equal(6)
         // confirm choice (Fire) is shown as checked
-        const fireChoiceButton = getByRole('menuitemcheckbox', { name: 'Fire' })
+        const fireChoiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
         expect(fireChoiceButton.getAttribute('aria-checked')).to.equal('true')
       })
 
       it('should disable "Done & Talk" and "Done" buttons', async function () {
         const user = userEvent.setup({ delay: null })
-        const { getByRole } = render(<DefaultStory />)
-        let doneAndTalkButton = getByRole('button', { name: 'TaskArea.Tasks.DoneAndTalkButton.doneAndTalk' })
-        let doneButton = getByRole('button', { name: 'TaskArea.Tasks.DoneButton.done' })
+        render(<DefaultStory />)
+        let doneAndTalkButton = screen.getByRole('button', { name: 'TaskArea.Tasks.DoneAndTalkButton.doneAndTalk' })
+        let doneButton = screen.getByRole('button', { name: 'TaskArea.Tasks.DoneButton.done' })
         // mock task doesn't require an identified choice, so confirm the Done & Talk and Done buttons are enabled before selecting a choice
         expect(doneAndTalkButton.disabled).to.be.false()
         expect(doneButton.disabled).to.be.false()
 
-        const choiceButton = getByRole('menuitemcheckbox', { name: 'Aardvark' })
+        const choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Aardvark' })
         await user.click(choiceButton)
-        doneAndTalkButton = getByRole('button', { name: 'TaskArea.Tasks.DoneAndTalkButton.doneAndTalk' })
-        doneButton = getByRole('button', { name: 'TaskArea.Tasks.DoneButton.done' })
+        doneAndTalkButton = screen.getByRole('button', { name: 'TaskArea.Tasks.DoneAndTalkButton.doneAndTalk' })
+        doneButton = screen.getByRole('button', { name: 'TaskArea.Tasks.DoneButton.done' })
         // confirm the Done & Talk and Done buttons are disabled while a choice is selected
         expect(doneAndTalkButton.disabled).to.be.true()
         expect(doneButton.disabled).to.be.true()
@@ -366,45 +366,45 @@ describe('SurveyTask', function () {
     describe('when the Filter button is keyed with Enter', function () {
       it('should show characteristic filter sections', async function () {
         const user = userEvent.setup({ delay: null })
-        const { getAllByRole, getByRole } = render(<DefaultStory />)
+        render(<DefaultStory />)
         // tabbing to the Filter button
         await user.keyboard('[Tab]')
-        const filterButton = getByRole( 'button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+        const filterButton = screen.getByRole( 'button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
         expect(filterButton).to.equal(document.activeElement)
         
         // pressing the Enter key to open the Filter button
         await user.keyboard('[Enter]')
         // the filterSections are the characteristic filter sections, i.e. the sections for "Like", "Pattern", and "Color" for the mock task
-        const filterSections = getAllByRole('radiogroup')
+        const filterSections = screen.getAllByRole('radiogroup')
         expect(filterSections.length).to.equal(3)
       })
 
       describe('when filters are keyed', function () {
         it('should show the filter button with a remove filter button', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getByTestId, queryByTestId } = render(<DefaultStory />)
+          render(<DefaultStory />)
           // tabbing to and opening the Filter button
           await user.keyboard('[Tab][Enter]')
           // the solidFilterButton is the button to filter choices by "solid". Solid is a specific value of the "Pattern" characteristic.
-          const solidFilterButton = getByTestId('filter-PTTRN-SLD')
+          const solidFilterButton = screen.getByTestId('filter-PTTRN-SLD')
           expect(solidFilterButton).to.be.ok()
 
           // the solidFilterRemoveButton is the small x button that appears over a filter to remove the filter, after it is selected. The presence of this button indicates that the filter is selected. The absence of this button indicates that the filter is not selected.
-          let characteristicsSection = queryByTestId('characteristics')
+          let characteristicsSection = screen.queryByTestId('characteristics')
           let solidFilterRemoveButton = within(characteristicsSection).queryByTestId('remove-filter-PTTRN-SLD')
           expect(solidFilterRemoveButton).to.be.null()
           
           // tabbing to the pattern section that contains the solid filter and selecting the solid filter with space key
           await user.keyboard('[Tab][Tab][Space]')
-          characteristicsSection = queryByTestId('characteristics')
+          characteristicsSection = screen.queryByTestId('characteristics')
           solidFilterRemoveButton = within(characteristicsSection).getByTestId('remove-filter-PTTRN-SLD')
           expect(solidFilterRemoveButton).to.be.ok()
         })
 
         it('should show the choices that match the filter', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByText } = render(<DefaultStory />)
-          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
+          render(<DefaultStory />)
+          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
           // tabbing to and opening the Filter button
           await user.keyboard('[Tab][Enter]')
           // tabbing to the pattern section that contains the solid filter and selecting the solid filter with space key
@@ -412,7 +412,7 @@ describe('SurveyTask', function () {
           // close the filters
           await user.click(filterButton)
           // confirming that the choices are filtered by the solid filter
-          const choiceButtons = getAllByRole('menuitemcheckbox')
+          const choiceButtons = screen.getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(3)
           expect(choiceButtons[0]).to.have.text('Aardvark')
           expect(choiceButtons[1]).to.have.text('Elephant')
@@ -421,53 +421,53 @@ describe('SurveyTask', function () {
 
         it('should remove the filter on remove filter button keypress (within Characteristics)', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, queryByTestId, getByText } = render(<DefaultStory />)
-          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
+          render(<DefaultStory />)
+          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
           // tabbing to and opening the Filter button
           await user.keyboard('[Tab][Enter]')
           // tabbing to the pattern section that contains the solid filter and selecting the solid filter with space key
           await user.keyboard('[Tab][Tab][Space]')
           // confirm the solid filter is selected with existence of the related remove filter button
-          let characteristicsSection = queryByTestId('characteristics')
+          let characteristicsSection = screen.queryByTestId('characteristics')
           let solidFilterRemoveButton = within(characteristicsSection).getByTestId('remove-filter-PTTRN-SLD')
           expect(solidFilterRemoveButton).to.be.ok()
 
           // remove the solid filter with the "Remove solid filter" small x button
           await user.keyboard('[Tab][Tab][Space]')
           // confirm the solid filter is no longer selected with absence of the related remove filter button
-          solidFilterRemoveButton = queryByTestId('remove-filter-PTTRN-SLD')
+          solidFilterRemoveButton = screen.queryByTestId('remove-filter-PTTRN-SLD')
           expect(solidFilterRemoveButton).to.be.null()
           
           // close the filters
           await user.click(filterButton)
           // confirm the choices are the total 6 choices, not filtered by the solid filter
-          const choiceButtons = getAllByRole('menuitemcheckbox')
+          const choiceButtons = screen.getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(6)
         })
 
         it('should remove the filter on remove filter button keypress (within FilterStatus)', async function () {
           const user = userEvent.setup({ delay: null })
-          const { getAllByRole, getByTestId, getByText } = render(<DefaultStory />)
-          const filterButton = getByText('SurveyTask.CharacteristicsFilter.filter')
+          render(<DefaultStory />)
+          const filterButton = screen.getByText('SurveyTask.CharacteristicsFilter.filter')
           // tabbing to and opening the Filter button
           await user.keyboard('[Tab][Enter]')
           // tabbing to the pattern section that contains the solid filter and selecting the solid filter with space key
           await user.keyboard('[Tab][Tab][Space]')
           // confirm the solid filter is selected with existence of the related remove filter button
-          let filterStatusSection = getByTestId('filter-status')
+          let filterStatusSection = screen.getByTestId('filter-status')
           let solidFilterRemoveButton = within(filterStatusSection).getByTestId('remove-filter-PTTRN-SLD')
           expect(solidFilterRemoveButton).to.be.ok()
 
           // close the filters
           await user.click(filterButton)
           // confirm the solid filter is applied, of the total 6 choices only 1 choice (Kudu) matches the solid filter
-          let choiceButtons = getAllByRole('menuitemcheckbox')
+          let choiceButtons = screen.getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(3)
 
           // remove the solid filter with the "Remove solid filter" small x button in the Filter Status component
           await user.keyboard('[Tab][Space]')
           // confirm the choices are the total 6 choices, not filtered by the solid filter
-          choiceButtons = getAllByRole('menuitemcheckbox')
+          choiceButtons = screen.getAllByRole('menuitemcheckbox')
           expect(choiceButtons.length).to.equal(6)
         })
       })
@@ -476,82 +476,82 @@ describe('SurveyTask', function () {
     describe('when a choice is selected with Enter', function () {
       it('should show the choice heading', async function () {
         const user = userEvent.setup({ delay: null })
-        const { getByRole } = render(<NoFiltersStory />)
+        render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark)
         await user.keyboard('[Tab]')
-        const choiceButton = getByRole('menuitemcheckbox', { name: 'Aardvark' })
+        const choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Aardvark' })
         expect(choiceButton).to.equal(document.activeElement)
         // pressing Enter to open the choice (Aardvark)
         await user.keyboard('[Enter]')
-        const choiceHeading = getByRole('heading', { name: 'Aardvark' })
+        const choiceHeading = screen.getByRole('heading', { name: 'Aardvark' })
         expect(choiceHeading).to.be.ok()
       })
 
       it('should show choice images', async function () {
         const user = userEvent.setup({ delay: null })
-        const { getByTestId } = render(<NoFiltersStory />)
+        render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark) and pressing Enter to open the choice (Aardvark)
         await user.keyboard('[Tab][Enter]')
-        const choiceImages = getByTestId('choice-images')
+        const choiceImages = screen.getByTestId('choice-images')
         
         expect(choiceImages).to.be.ok()
       })
 
       it.skip('should show choices with recent choice as active choice when Not This button keyed with Enter', async function () {
         const user = userEvent.setup({ delay: null })
-        const { getAllByRole, getByRole, queryByRole } = render(<NoFiltersStory />)
+        render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark), arrowing up to the last choice (Nothing here), and pressing Enter to open the choice (Nothing here)
         await user.keyboard('[Tab]')
         await user.keyboard('[ArrowUp]')
         await user.keyboard('[Enter]')
-        let choiceHeading = getByRole('heading', { name: 'Nothing here' })
+        let choiceHeading = screen.getByRole('heading', { name: 'Nothing here' })
         expect(choiceHeading).to.be.ok()
         // tabbing to the "Not this" button
         await user.keyboard('[Tab][Tab]')
-        const notThisButton = getByRole('button', { name: 'SurveyTask.Choice.notThis' })
+        const notThisButton = screen.getByRole('button', { name: 'SurveyTask.Choice.notThis' })
         expect(notThisButton).to.equal(document.activeElement)
         // pressing Enter to close the choice (Nothing here)
         await user.keyboard('[Enter]')
         // confirm choice (Nothing here) heading, and therefore choice, is not shown
-        choiceHeading = queryByRole('heading', { name: 'Nothing here' })
+        choiceHeading = screen.queryByRole('heading', { name: 'Nothing here' })
         expect(choiceHeading).to.be.null()
         // confirm choices are shown
-        const choiceButtons = getAllByRole('menuitemcheckbox')
+        const choiceButtons = screen.getAllByRole('menuitemcheckbox')
         expect(choiceButtons.length).to.equal(6)
       })
 
       it.skip('should show choices with identified choice as active choice when Identify keyed with Enter', async function () {
         const user = userEvent.setup({ delay: null })
-        const { getAllByRole, getByRole, queryByRole } = render(<NoFiltersStory />)
+        render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark), arrowing up to the last choice (Nothing here), and pressing Enter to open the choice (Nothing here)
         await user.keyboard('[Tab]')
         await user.keyboard('[ArrowUp]')
         await user.keyboard('[Enter]')
-        let choiceHeading = getByRole('heading', { name: 'Nothing here' })
+        let choiceHeading = screen.getByRole('heading', { name: 'Nothing here' })
         expect(choiceHeading).to.be.ok()
         // tabbing to the "Identify" button
         await user.keyboard('[Tab][Tab][Tab]')
-        const identifyButton = getByRole('button', { name: 'SurveyTask.Choice.identify' })
+        const identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
         expect(identifyButton).to.equal(document.activeElement)
         // pressing Enter to identify and close the choice (Nothing here)
         await user.keyboard('[Enter]')
         // confirm choice (Nothing here) heading, and therefore choice, is not shown
-        choiceHeading = queryByRole('heading', { name: 'Fire' })
+        choiceHeading = screen.queryByRole('heading', { name: 'Fire' })
         expect(choiceHeading).to.be.null()
         // confirm choices are shown
-        const choiceButtons = getAllByRole('menuitemcheckbox')
+        const choiceButtons = screen.getAllByRole('menuitemcheckbox')
         expect(choiceButtons.length).to.equal(6)
         // confirm the identified choice (Nothing here) is the active choice
-        const nothingHereChoiceButton = getByRole('menuitemcheckbox', { name: 'Nothing here' })
+        const nothingHereChoiceButton = screen.getByRole('menuitemcheckbox', { name: 'Nothing here' })
         expect(nothingHereChoiceButton).to.equal(document.activeElement)
       })
 
       it.skip('should disable the Identify button until required questions are answered', async function () {
         const user = userEvent.setup({ delay: null })
-        const { getByRole } = render(<NoFiltersStory />)
+        render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark) and pressing Enter to open the choice (Aardvark)
         await user.keyboard('[Tab][Enter]')
-        let identifyButton = getByRole('button', { name: 'SurveyTask.Choice.identify' })
+        let identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
         // confirm the Identify button is disabled, pending required questions answered
         expect(identifyButton.disabled).to.be.true()
         // the required questions for Aardvark are "How many?" and "What behavior do you see?"
@@ -560,7 +560,7 @@ describe('SurveyTask', function () {
         // tabbing (x3) to the "How many?" question, selecting the "1" answer with space key, tabbing (x4) to the "What behavior do you see?" question, selecting the "Eating" answer with space key
         await user.keyboard('[Tab][Tab][Tab][Space][Tab][Tab][Tab][Tab][Space]')
         // confirm the Identify button is enabled, now that required questions are answered
-        identifyButton = getByRole('button', { name: 'SurveyTask.Choice.identify' })
+        identifyButton = screen.getByRole('button', { name: 'SurveyTask.Choice.identify' })
         // confirm the Identify button is enabled, now that required questions answered
         expect(identifyButton.disabled).to.be.false()
       })
@@ -568,18 +568,18 @@ describe('SurveyTask', function () {
 
     it.skip('should remove a previously identified choice with delete key', async function () {
       const user = userEvent.setup({ delay: null })
-      const { getAllByRole, getByRole, getByText } = render(<NoFiltersStory />)
-      let choiceButton = getByRole('menuitemcheckbox', { name: 'Fire' })
+      render(<NoFiltersStory />)
+      let choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
       await user.click(choiceButton)
-      const identifyButton = getByText('SurveyTask.Choice.identify')
+      const identifyButton = screen.getByText('SurveyTask.Choice.identify')
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
       // confirm choices showing
-      const choiceButtons = getAllByRole('menuitemcheckbox')
+      const choiceButtons = screen.getAllByRole('menuitemcheckbox')
       expect(choiceButtons.length).to.equal(6)
       
       // confirm choice Fire selected
-      choiceButton = getByRole('menuitemcheckbox', { name: 'Fire' })
+      choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
       expect(choiceButton.getAttribute('aria-checked')).to.equal('true')
       
       // confirm choice Fire active element
@@ -588,24 +588,24 @@ describe('SurveyTask', function () {
       // press delete key to remove choice (Fire)
       await user.keyboard('[Delete]')
       // confirm choice Fire not selected
-      choiceButton = getByRole('menuitemcheckbox', { name: 'Fire' })
+      choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
       expect(choiceButton.getAttribute('aria-checked')).to.equal('false')
     })
 
     it.skip('should remove a previously identified choice with backspace key', async function () {
       const user = userEvent.setup({ delay: null })
-      const { getAllByRole, getByRole, getByText } = render(<NoFiltersStory />)
-      let choiceButton = getByRole('menuitemcheckbox', { name: 'Fire' })
+      render(<NoFiltersStory />)
+      let choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
       await user.click(choiceButton)
-      const identifyButton = getByText('SurveyTask.Choice.identify')
+      const identifyButton = screen.getByText('SurveyTask.Choice.identify')
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
       // confirm choices showing
-      const choiceButtons = getAllByRole('menuitemcheckbox')
+      const choiceButtons = screen.getAllByRole('menuitemcheckbox')
       expect(choiceButtons.length).to.equal(6)
       
       // confirm choice Fire selected
-      choiceButton = getByRole('menuitemcheckbox', { name: 'Fire' })
+      choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
       expect(choiceButton.getAttribute('aria-checked')).to.equal('true')
       
       // confirm choice Fire active element
@@ -614,7 +614,7 @@ describe('SurveyTask', function () {
       // press backspace key to remove choice (Fire)
       await user.keyboard('[Backspace]')
       // confirm choice Fire not selected
-      choiceButton = getByRole('menuitemcheckbox', { name: 'Fire' })
+      choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
       expect(choiceButton.getAttribute('aria-checked')).to.equal('false')
     })
   })

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -277,7 +277,7 @@ describe('SurveyTask', function () {
       it('should show the choice heading', async function () {
         const user = userEvent.setup({ delay: null })
         render(<DefaultStory />)
-        const choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Aardvark' })
+        const choiceButton = screen.getByLabelText('Aardvark')
         await user.click(choiceButton)
         const choiceHeading = screen.getByRole('heading', { name: 'Aardvark' })
 
@@ -287,7 +287,7 @@ describe('SurveyTask', function () {
       it('should show choice images', async function () {
         const user = userEvent.setup({ delay: null })
         render(<DefaultStory />)
-        const choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
+        const choiceButton = screen.getByLabelText('Fire')
         await user.click(choiceButton)
         const choiceImages = screen.getByTestId('choice-images')
         
@@ -297,7 +297,7 @@ describe('SurveyTask', function () {
       it('should show choices when Not This button is clicked', async function () {
         const user = userEvent.setup({ delay: null })
         render(<DefaultStory />)
-        const choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
+        const choiceButton = screen.getByLabelText('Fire')
         await user.click(choiceButton)
         const notThisButton = screen.getByLabelText('SurveyTask.Choice.notThis Fire')
         // close choice (Fire) component
@@ -314,7 +314,7 @@ describe('SurveyTask', function () {
       it('should show choices with selected choice checked when Identify button is clicked', async function () {
         const user = userEvent.setup({ delay: null })
         render(<DefaultStory />)
-        const choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
+        const choiceButton = screen.getByLabelText('Fire')
         await user.click(choiceButton)
         const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Fire')
         // identify choice (Fire) and close choice (Fire) component
@@ -327,7 +327,7 @@ describe('SurveyTask', function () {
         const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
         expect(choiceButtons.length).to.equal(6)
         // confirm choice (Fire) is shown as checked
-        const fireChoiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
+        const fireChoiceButton = screen.getByLabelText('Fire')
         expect(fireChoiceButton.getAttribute('aria-checked')).to.equal('true')
       })
 
@@ -340,7 +340,7 @@ describe('SurveyTask', function () {
         expect(doneAndTalkButton.disabled).to.be.false()
         expect(doneButton.disabled).to.be.false()
 
-        const choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Aardvark' })
+        const choiceButton = screen.getByLabelText('Aardvark')
         await user.click(choiceButton)
         doneAndTalkButton = screen.getByRole('button', { name: 'TaskArea.Tasks.DoneAndTalkButton.doneAndTalk' })
         doneButton = screen.getByRole('button', { name: 'TaskArea.Tasks.DoneButton.done' })
@@ -361,7 +361,7 @@ describe('SurveyTask', function () {
         render(<DefaultStory />)
         // tabbing to the Filter button
         await user.keyboard('[Tab]')
-        const filterButton = screen.getByRole( 'button', { name: 'SurveyTask.CharacteristicsFilter.filter' })
+        const filterButton = screen.getByLabelText('SurveyTask.CharacteristicsFilter.filter')
         expect(filterButton).to.equal(document.activeElement)
         
         // pressing the Enter key to open the Filter button
@@ -467,7 +467,7 @@ describe('SurveyTask', function () {
         render(<NoFiltersStory />)
         // tabbing to the first choice (Aardvark)
         await user.keyboard('[Tab]')
-        const choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Aardvark' })
+        const choiceButton = screen.getByLabelText('Aardvark')
         expect(choiceButton).to.equal(document.activeElement)
         // pressing Enter to open the choice (Aardvark)
         await user.keyboard('[Enter]')
@@ -532,7 +532,7 @@ describe('SurveyTask', function () {
         const choiceButtons = within(choicesMenu).getAllByRole('menuitemcheckbox')
         expect(choiceButtons.length).to.equal(6)
         // confirm the identified choice (Nothing here) is the active choice
-        const nothingHereChoiceButton = screen.getByRole('menuitemcheckbox', { name: 'Nothing here' })
+        const nothingHereChoiceButton = screen.getByLabelText('Nothing here')
         expect(nothingHereChoiceButton).to.equal(document.activeElement)
       })
 
@@ -559,7 +559,7 @@ describe('SurveyTask', function () {
     it.skip('should remove a previously identified choice with delete key', async function () {
       const user = userEvent.setup({ delay: null })
       render(<NoFiltersStory />)
-      let choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
+      let choiceButton = screen.getByLabelText('Fire')
       await user.click(choiceButton)
       const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Fire')
       // identify choice (Fire) and close choice (Fire) component
@@ -570,7 +570,7 @@ describe('SurveyTask', function () {
       expect(choiceButtons.length).to.equal(6)
       
       // confirm choice Fire selected
-      choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
+      choiceButton = screen.getByLabelText('Fire')
       expect(choiceButton.getAttribute('aria-checked')).to.equal('true')
       
       // confirm choice Fire active element
@@ -579,14 +579,14 @@ describe('SurveyTask', function () {
       // press delete key to remove choice (Fire)
       await user.keyboard('[Delete]')
       // confirm choice Fire not selected
-      choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
+      choiceButton = screen.getByLabelText('Fire')
       expect(choiceButton.getAttribute('aria-checked')).to.equal('false')
     })
 
     it.skip('should remove a previously identified choice with backspace key', async function () {
       const user = userEvent.setup({ delay: null })
       render(<NoFiltersStory />)
-      let choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
+      let choiceButton = screen.getByLabelText('Fire')
       await user.click(choiceButton)
       const identifyButton = screen.getByLabelText('SurveyTask.Choice.identify Fire')
       // identify choice (Fire) and close choice (Fire) component
@@ -597,7 +597,7 @@ describe('SurveyTask', function () {
       expect(choiceButtons.length).to.equal(6)
       
       // confirm choice Fire selected
-      choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
+      choiceButton = screen.getByLabelText('Fire')
       expect(choiceButton.getAttribute('aria-checked')).to.equal('true')
       
       // confirm choice Fire active element
@@ -606,7 +606,7 @@ describe('SurveyTask', function () {
       // press backspace key to remove choice (Fire)
       await user.keyboard('[Backspace]')
       // confirm choice Fire not selected
-      choiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
+      choiceButton = screen.getByLabelText('Fire')
       expect(choiceButton.getAttribute('aria-checked')).to.equal('false')
     })
   })

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -25,9 +25,8 @@ describe('SurveyTask', function () {
       it('should show the choices', function () {
         render(<DefaultStory />)
         
-        const choicesMenu = document.querySelector('[role=menu]')
         // choiceButtons are the menu items / buttons for the various choices (i.e. for the mock task the various animals)
-        const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+        const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
         
         expect(choiceButtons.length).to.equal(6)
         expect(choiceButtons[0]).to.have.text('Aardvark')
@@ -78,9 +77,8 @@ describe('SurveyTask', function () {
       it('should show the choices', function () {
         render(<NoFiltersStory />)
         
-        const choicesMenu = document.querySelector('[role=menu]')
         // choiceButtons are the menu items / buttons for the various choices (i.e. for the mock task the various animals)
-        const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+        const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
         
         expect(choiceButtons.length).to.equal(6)
         expect(choiceButtons[0]).to.have.text('Aardvark')
@@ -161,8 +159,7 @@ describe('SurveyTask', function () {
 
           await user.click(redFilterButton)
           await user.click(filterButton)
-          const choicesMenu = document.querySelector('[role=menu]')
-          const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+          const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
           // confirm the choices are the 3 choices that match the red filter
           expect(choiceButtons.length).to.equal(3)
           expect(choiceButtons[0]).to.have.text('Aardvark')
@@ -182,8 +179,7 @@ describe('SurveyTask', function () {
           const identifyButton = screen.getByText('SurveyTask.Choice.identify')
           // identify the Fire choice
           await user.click(identifyButton)
-          const choicesMenu = document.querySelector('[role=menu]')
-          const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+          const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
           // confirm the remaining choices are the 3 choices that match the red filter
           expect(choiceButtons.length).to.equal(3)
           expect(choiceButtons[0]).to.have.text('Aardvark')
@@ -204,8 +200,7 @@ describe('SurveyTask', function () {
           await user.click(stripesFilterRemoveButton)
           // close the characteristics filters
           await user.click(filterButton)
-          const choicesMenu = document.querySelector('[role=menu]')
-          const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+          const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
           // confirm the choices are the total 6 choices, not filtered by the stripes filter
           expect(choiceButtons.length).to.equal(6)
         })
@@ -216,16 +211,14 @@ describe('SurveyTask', function () {
           await user.click(stripesFilterButton)
           await user.click(filterButton)
           // confirm the stripes filter is applied, of the total 6 choices only 1 choice (Kudu) matches the stripes filter
-          let choicesMenu = document.querySelector('[role=menu]')
-          let choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+          let choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
           expect(choiceButtons.length).to.equal(1)
 
           const filterStatusSection = screen.getByTestId('filter-status')
           const stripesFilterRemoveButton = within(filterStatusSection).getByTestId('remove-filter-PTTRN-STRPS')
           // remove the stripes filter
           await user.click(stripesFilterRemoveButton)
-          choicesMenu = document.querySelector('[role=menu]')
-          choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+          choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
           // confirm the choices are the total 6 choices, not filtered by the stripes filter
           expect(choiceButtons.length).to.equal(6)
         })
@@ -262,16 +255,14 @@ describe('SurveyTask', function () {
           // click/apply the color tan/yellow filter
           await user.click(tanYellowFilterButton)
           await user.click(filterButton)
-          let choicesMenu = document.querySelector('[role=menu]')
-          let choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+          let choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
           // confirm the choices remaining are the 1 choice (Kudu) that matches the cow/horse and tan/yellow filters
           expect(choiceButtons.length).to.equal(1)
 
           const clearFiltersButton = screen.getByText('SurveyTask.CharacteristicsFilter.clearFilters')
           // clear the filters
           await user.click(clearFiltersButton)
-          choicesMenu = document.querySelector('[role=menu]')
-          choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+          choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
           // confirm the choices are the total 6 choices, not filtered by the cow/horse and tan/yellow filters
           expect(choiceButtons.length).to.equal(6)
         })
@@ -311,8 +302,7 @@ describe('SurveyTask', function () {
         const choiceDescription = screen.queryByText('It\'s a fire. Pretty sure you know what this looks like.')
         expect(choiceDescription).to.be.null()
         // confirm choices are shown
-        const choicesMenu = document.querySelector('[role=menu]')
-        const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+        const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
         expect(choiceButtons.length).to.equal(6)
       })
 
@@ -328,11 +318,10 @@ describe('SurveyTask', function () {
         const choiceDescription = screen.queryByText('It\'s a fire. Pretty sure you know what this looks like.')
         expect(choiceDescription).to.be.null()
         // confirm choices are shown
-        const choicesMenu = document.querySelector('[role=menu]')
-        const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+        const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
         expect(choiceButtons.length).to.equal(6)
         // confirm choice (Fire) is shown as checked
-        const fireChoiceButton = screen.getByRole('menuitemcheckbox', { name: 'Fire' })
+        const fireChoiceButton = Array.from(choiceButtons).find(choiceButton => choiceButton.textContent === 'Fire')
         expect(fireChoiceButton.getAttribute('aria-checked')).to.equal('true')
       })
 
@@ -369,12 +358,11 @@ describe('SurveyTask', function () {
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
       // confirm choices showing
-      let choicesMenu = document.querySelector('[role=menu]')
-      const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+      const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
       expect(choiceButtons.length).to.equal(6)
       
       // confirm choice Fire selected
-      choiceButton = within(choicesMenu).getByRole('menuitemcheckbox', { name: 'Fire' })
+      choiceButton = Array.from(choiceButtons).find(choiceButton => choiceButton.textContent === 'Fire')
       expect(choiceButton.getAttribute('aria-checked')).to.equal('true')
       
       // confirm choice Fire active element
@@ -382,8 +370,7 @@ describe('SurveyTask', function () {
       
       // press delete key to remove choice (Fire)
       await user.keyboard('[Delete]')
-      choicesMenu = document.querySelector('[role=menu]')
-      choiceButton = within(choicesMenu).getByRole('menuitemcheckbox', { name: 'Fire' })
+      choiceButton = Array.from(choiceButtons).find(choiceButton => choiceButton.textContent === 'Fire')
       // confirm choice Fire not selected
       expect(choiceButton.getAttribute('aria-checked')).to.equal('false')
     })
@@ -397,12 +384,11 @@ describe('SurveyTask', function () {
       // identify choice (Fire) and close choice (Fire) component
       await user.click(identifyButton)
       // confirm choices showing
-      let choicesMenu = document.querySelector('[role=menu]')
-      const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+      const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
       expect(choiceButtons.length).to.equal(6)
       
       // confirm choice Fire selected
-      choiceButton = within(choicesMenu).getByRole('menuitemcheckbox', { name: 'Fire' })
+      choiceButton = Array.from(choiceButtons).find(choiceButton => choiceButton.textContent === 'Fire')
       expect(choiceButton.getAttribute('aria-checked')).to.equal('true')
       
       // confirm choice Fire active element
@@ -410,8 +396,7 @@ describe('SurveyTask', function () {
       
       // press backspace key to remove choice (Fire)
       await user.keyboard('[Backspace]')
-      choicesMenu = document.querySelector('[role=menu]')
-      choiceButton = within(choicesMenu).getByRole('menuitemcheckbox', { name: 'Fire' })
+      choiceButton = Array.from(choiceButtons).find(choiceButton => choiceButton.textContent === 'Fire')
       // confirm choice Fire not selected
       expect(choiceButton.getAttribute('aria-checked')).to.equal('false')
     })
@@ -467,8 +452,7 @@ describe('SurveyTask', function () {
           // close the filters
           await user.click(filterButton)
           // confirming that the choices are filtered by the solid filter
-          const choicesMenu = document.querySelector('[role=menu]')
-          const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+          const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
           expect(choiceButtons.length).to.equal(3)
           expect(choiceButtons[0]).to.have.text('Aardvark')
           expect(choiceButtons[1]).to.have.text('Elephant')
@@ -492,8 +476,7 @@ describe('SurveyTask', function () {
           // close the filters
           await user.click(filterButton)
           // confirm the choices are the total 6 choices, not filtered by the solid filter
-          const choicesMenu = document.querySelector('[role=menu]')
-          const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+          const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
           expect(choiceButtons.length).to.equal(6)
         })
 
@@ -508,15 +491,13 @@ describe('SurveyTask', function () {
           // close the filters
           await user.click(filterButton)
           // confirm the solid filter is applied, of the total 6 choices only 1 choice (Kudu) matches the solid filter
-          let choicesMenu = document.querySelector('[role=menu]')
-          let choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+          let choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
           expect(choiceButtons.length).to.equal(3)
 
           // remove the solid filter with the "Remove solid filter" small x button in the Filter Status component
           await user.keyboard('[Tab][Space]')
           // confirm the choices are the total 6 choices, not filtered by the solid filter
-          choicesMenu = document.querySelector('[role=menu]')
-          choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+          choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
           expect(choiceButtons.length).to.equal(6)
         })
       })
@@ -564,8 +545,7 @@ describe('SurveyTask', function () {
         choiceDescription = screen.queryByText('Don\'t tell the plant biologists we called vegetation \"nothing here\"!')
         expect(choiceDescription).to.be.null()
         // confirm choices are shown
-        const choicesMenu = document.querySelector('[role=menu]')
-        const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+        const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
         expect(choiceButtons.length).to.equal(6)
       })
 
@@ -588,11 +568,10 @@ describe('SurveyTask', function () {
         choiceDescription = screen.queryByText('Don\'t tell the plant biologists we called vegetation \"nothing here\"!')
         expect(choiceDescription).to.be.null()
         // confirm choices are shown
-        const choicesMenu = document.querySelector('[role=menu]')
-        const choiceButtons = choicesMenu.querySelectorAll('[role=menuitemcheckbox]')
+        const choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
         expect(choiceButtons.length).to.equal(6)
         // confirm the identified choice (Nothing here) is the active choice
-        const nothingHereChoiceButton = screen.getByRole('menuitemcheckbox', { name: 'Nothing here' })
+        const nothingHereChoiceButton = Array.from(choiceButtons).find(choiceButton => choiceButton.textContent === 'Nothing here')
         expect(nothingHereChoiceButton).to.equal(document.activeElement)
       })
 

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -92,11 +92,13 @@ export default function Choice({
         pad={{ top: 'small' }}
       >
         <Button
+          a11yTitle={`${t('SurveyTask.Choice.notThis')} ${choice.label}`}
           fill='horizontal'
           label={t('SurveyTask.Choice.notThis')}
           onClick={() => handleDelete(choiceId)}
         />
         <PrimaryButton
+          a11yTitle={`${t('SurveyTask.Choice.identify')} ${choice.label}`}
           disabled={!allowIdentify}
           fill='horizontal'
           label={t('SurveyTask.Choice.identify')}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -92,13 +92,11 @@ export default function Choice({
         pad={{ top: 'small' }}
       >
         <Button
-          a11yTitle={`${t('SurveyTask.Choice.notThis')} ${choice.label}`}
           fill='horizontal'
           label={t('SurveyTask.Choice.notThis')}
           onClick={() => handleDelete(choiceId)}
         />
         <PrimaryButton
-          a11yTitle={`${t('SurveyTask.Choice.identify')} ${choice.label}`}
           disabled={!allowIdentify}
           fill='horizontal'
           label={t('SurveyTask.Choice.identify')}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.js
@@ -97,6 +97,7 @@ export default function Choice({
           onClick={() => handleDelete(choiceId)}
         />
         <PrimaryButton
+          data-testid='choice-identify-button'
           disabled={!allowIdentify}
           fill='horizontal'
           label={t('SurveyTask.Choice.identify')}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/Choice.spec.js
@@ -84,4 +84,36 @@ describe('Component > Choice', function () {
       expect(screen.queryAllByRole('checkbox', { hidden: true })).to.have.lengthOf(0)
     })
   })
+
+  describe('with choice with required questions unanswered', function () {
+    // choice 'RDVRK' (Aardvark) has 2 required questions
+
+    it('should disable the Identify button', function () {
+      render(
+        <Choice
+          choiceId='RDVRK'
+          task={mockTask}
+        />
+      )
+      expect(screen.getByRole('button', { name: 'SurveyTask.Choice.identify' }).disabled).to.be.true()
+    })
+  })
+
+  describe('with choice with required questions answered', function () {
+    // choice 'RDVRK' (Aardvark) has 2 required questions
+
+    it('should enable the Identify button', function () {
+      render(
+        <Choice
+          answers={{
+            HWMN: '3',
+            WHTBHVRSDS: ['TNG', 'STNDNG']
+          }}
+          choiceId='RDVRK'
+          task={mockTask}
+        />
+      )
+      expect(screen.getByRole('button', { name: 'SurveyTask.Choice.identify' }).disabled).to.be.false()
+    })
+  })
 })

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
@@ -20,6 +20,10 @@ function Chooser ({
 }) {
   const [filterDropOpen, setFilterDropOpen] = useState(false)
 
+  function clearFilters() {
+    handleFilter()
+  }
+
   function handleFilterDropClose () {
     setFilterDropOpen(false)
   }
@@ -56,7 +60,7 @@ function Chooser ({
       />
       {showFilters
         ? (<ClearFilters
-            handleFilter={handleFilter}
+            onClick={clearFilters}
             showingChoices={filteredChoiceIds.length}
             totalChoices={task.choicesOrder?.length}
            />)

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/ClearFilters/ClearFilters.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/ClearFilters/ClearFilters.js
@@ -4,14 +4,17 @@ import PropTypes from 'prop-types'
 import { PlainButton, SpacedText } from '@zooniverse/react-components'
 import { useTranslation } from '@translations/i18n'
 
-export default function ClearFilters (props) {
-  const {
-    handleFilter,
-    showingChoices,
-    totalChoices
-  } = props
-
+const defaultHandler = () => true
+export default function ClearFilters ({
+  handleFilter = defaultHandler,
+  showingChoices = 0,
+  totalChoices = 0
+}) {
   const { t } = useTranslation('plugins')
+
+  function onClick() {
+    handleFilter()
+  }
 
   return (
     <Box
@@ -27,18 +30,12 @@ export default function ClearFilters (props) {
       </SpacedText>
       <PlainButton
         disabled={showingChoices === totalChoices}
-        icon={<Clear />}
-        onClick={() => handleFilter()}
+        icon={<Clear aria-hidden='true' />}
+        onClick={onClick}
         text={t('SurveyTask.CharacteristicsFilter.clearFilters')}
       />
     </Box>
   )
-}
-
-ClearFilters.defaultProps = {
-  handleFilter: () => {},
-  showingChoices: 0,
-  totalChoices: 0
 }
 
 ClearFilters.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/ClearFilters/ClearFilters.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/ClearFilters/ClearFilters.js
@@ -26,6 +26,7 @@ export default function ClearFilters (props) {
         {t('SurveyTask.CharacteristicsFilter.showing', { showing: showingChoices, total: totalChoices })}
       </SpacedText>
       <PlainButton
+        a11yTitle={t('SurveyTask.CharacteristicsFilter.clearFilters')}
         disabled={showingChoices === totalChoices}
         icon={<Clear />}
         onClick={() => handleFilter()}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/ClearFilters/ClearFilters.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/ClearFilters/ClearFilters.js
@@ -6,15 +6,11 @@ import { useTranslation } from '@translations/i18n'
 
 const defaultHandler = () => true
 export default function ClearFilters ({
-  handleFilter = defaultHandler,
+  onClick = defaultHandler,
   showingChoices = 0,
   totalChoices = 0
 }) {
   const { t } = useTranslation('plugins')
-
-  function onClick() {
-    handleFilter()
-  }
 
   return (
     <Box
@@ -39,7 +35,7 @@ export default function ClearFilters ({
 }
 
 ClearFilters.propTypes = {
-  handleFilter: PropTypes.func,
+  onClick: PropTypes.func,
   showingChoices: PropTypes.number,
   totalChoices: PropTypes.number
 }

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/ClearFilters/ClearFilters.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/ClearFilters/ClearFilters.js
@@ -26,7 +26,6 @@ export default function ClearFilters (props) {
         {t('SurveyTask.CharacteristicsFilter.showing', { showing: showingChoices, total: totalChoices })}
       </SpacedText>
       <PlainButton
-        a11yTitle={t('SurveyTask.CharacteristicsFilter.clearFilters')}
         disabled={showingChoices === totalChoices}
         icon={<Clear />}
         onClick={() => handleFilter()}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.js
@@ -85,6 +85,7 @@ export function Choices ({
 
   return (
     <StyledGrid
+      data-testid='choices-menu'
       role='menu'
       rowsCount={rowsCount}
     >

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/Choices.js
@@ -85,7 +85,6 @@ export function Choices ({
 
   return (
     <StyledGrid
-      data-testid='choices-menu'
       role='menu'
       rowsCount={rowsCount}
     >

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/components/ChoiceButton.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/components/ChoiceButton.js
@@ -55,7 +55,6 @@ function ChoiceButton({
     <Button
       ref={choiceButton}
       aria-checked={ariaChecked}
-      a11yTitle={choiceLabel}
       disabled={disabled}
       fill
       label={


### PR DESCRIPTION
## Package
- lib-classifier

## Describe your changes
- refactor survey task tests for when choice with required questions selected
- refactor some (not all, left at least one test with `getByRole` for related component) tests with `getByText` instead of `getByRole`
- improves `SurveyTask.spec.js` tests runtime by approximately 4 seconds

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected