### PR TITLE
Remove source maps from webpack builds

### DIFF
--- a/packages/lib-classifier/webpack.dist.js
+++ b/packages/lib-classifier/webpack.dist.js
@@ -20,7 +20,6 @@ const EnvironmentWebpackPlugin = new webpack.EnvironmentPlugin({
 })
 
 module.exports = {
-  devtool: 'source-map',
   entry: './src/components/Classifier/index.js',
   externals: [
     '@zooniverse/grommet-theme',

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.1] 2022-12-05
+
+### Removed
+- Removed source maps from webpack builds.
+
 ## [1.3.0] 2022-12-01
 
 ### Added

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -3,7 +3,7 @@
   "description": "Zooniverse React Components",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "dist/main.js",
   "module": "dist/es6/index.js",
   "repository": {

--- a/packages/lib-react-components/webpack.dist.js
+++ b/packages/lib-react-components/webpack.dist.js
@@ -2,7 +2,6 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const path = require('path')
 
 module.exports = {
-  devtool: 'source-map',
   entry: './src/index.js',
   mode: 'production',
   module: {


### PR DESCRIPTION
- Remove source maps from production webpack builds.
- Bump `@zooniverse/react-components` to 1.3.1.

## Package
lib-react-components
lib-classifier

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
