### PR TITLE
Remove query-string

### DIFF
--- a/packages/lib-classifier/dev/index.js
+++ b/packages/lib-classifier/dev/index.js
@@ -1,12 +1,15 @@
-import queryString from 'query-string'
-import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './components/App'
 
 function getQueryParams() {
-  if (window.location && window.location.search) {
-    const { language, subject, subjectSet, workflow } = queryString.parse(window.location.search)
-    return { language, subject, subjectSet, workflow }
+  if (window.location) {
+    const url = new URL(window.location)
+    const { searchParams } = url
+    const queryParams = {}
+    searchParams.forEach((value, key) => {
+      queryParams[key] = value
+    })
+    return queryParams
   }
 
   return {}

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -108,7 +108,6 @@
     "panoptes-client": "~4.2.0",
     "polished": "~4.2.2",
     "process": "~0.11.10",
-    "query-string": "~7.1.0",
     "react": "~17.0.2",
     "react-dom": "~17.0.2",
     "rosie": "~2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7648,7 +7648,7 @@ decimal.js@^10.4.2:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.2.tgz#0341651d1d997d86065a2ce3a441fbd0d8e8b98e"
   integrity sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==
 
-decode-uri-component@^0.2.0, decode-uri-component@^0.2.2:
+decode-uri-component@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
@@ -14497,16 +14497,6 @@ query-string@^6.13.8:
   integrity sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==
   dependencies:
     decode-uri-component "^0.2.0"
-    filter-obj "^1.1.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
-
-query-string@~7.1.0:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.3.tgz#a1cf90e994abb113a325804a972d98276fe02328"
-  integrity sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==
-  dependencies:
-    decode-uri-component "^0.2.2"
     filter-obj "^1.1.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"


### PR DESCRIPTION
Remove `query-string` from the dev classifier.

Replace [`query-string`](https://www.npmjs.com/package/query-string) with the native [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) interface.

## Package
lib-classifier

## How to Review
Run the standalone classifier on https://localhost:8080 with `yarn dev`.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## Maintenance
- [x] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
