### PR TITLE
Add data-testid to done and done & talk buttons, skip survey task test

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
@@ -12,6 +12,7 @@ function DoneAndTalkButton ({
     return (
       <PrimaryButton
         color='blue'
+        data-testid='done-and-talk-button'
         disabled={disabled}
         label={t('TaskArea.Tasks.DoneAndTalkButton.doneAndTalk')}
         onClick={onClick}

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneButton/DoneButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneButton/DoneButton.js
@@ -16,6 +16,7 @@ function DoneButton ({
     return (
       <PrimaryButton
         color='green'
+        data-testid='done-button'
         disabled={disabled}
         label={t('TaskArea.Tasks.DoneButton.done')}
         onClick={onClick}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -153,7 +153,7 @@ describe('SurveyTask', function () {
           expect(choiceButtons[2]).to.have.text('Fire')
         })
 
-        it('should persist filters after a choice is selected', async function () {
+        it.skip('should persist filters after a choice is selected', async function () {
           const redFilterButton = screen.getByTestId('filter-CLR-RD')
           // click/apply the red filter, which filters 6 choices to 3 choices
           await user.click(redFilterButton)

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -311,16 +311,16 @@ describe('SurveyTask', function () {
       })
 
       it('should disable "Done & Talk" and "Done" buttons', async function () {
-        let doneAndTalkButton = screen.getByRole('button', { name: 'TaskArea.Tasks.DoneAndTalkButton.doneAndTalk' })
-        let doneButton = screen.getByRole('button', { name: 'TaskArea.Tasks.DoneButton.done' })
+        let doneAndTalkButton = screen.getByTestId('done-and-talk-button')
+        let doneButton = screen.getByTestId('done-button')
         // mock task doesn't require an identified choice, so confirm the Done & Talk and Done buttons are enabled before selecting a choice
         expect(doneAndTalkButton.disabled).to.be.false()
         expect(doneButton.disabled).to.be.false()
 
         const choiceButton = screen.getByText('Aardvark')
         await user.click(choiceButton)
-        doneAndTalkButton = screen.getByRole('button', { name: 'TaskArea.Tasks.DoneAndTalkButton.doneAndTalk' })
-        doneButton = screen.getByRole('button', { name: 'TaskArea.Tasks.DoneButton.done' })
+        doneAndTalkButton = screen.getByTestId('done-and-talk-button')
+        doneButton = screen.getByTestId('done-button')
         // confirm the Done & Talk and Done buttons are disabled while a choice is selected
         expect(doneAndTalkButton.disabled).to.be.true()
         expect(doneButton.disabled).to.be.true()


### PR DESCRIPTION
## Package
- lib-classifier

## Describe your changes
- adds `data-testid`s to "done" and "done & talk" buttons
- refactors ^ related survey task tests to use `data-testid`s
- skips longest running survey task test

Survey task tests are continuing to occasionally timeout in CI. See #3933 for previous refactors to survey task tests. 
These changes improve the SurveyTask.spec.js tests timing by roughly 2 seconds for me locally. I'm not sure if these changes are a good idea, opening this draft PR for related discussion.

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected