### PR TITLE
Refactor survey task choice button labels

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/components/ChoiceButton.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/components/ChoiceButton.js
@@ -69,7 +69,7 @@ function ChoiceButton({
         >
           {thumbnailSize !== 'none' && src &&
             <Image
-              alt={`${choiceLabel} media`}
+              alt=''
               height='fill'
               margin={{ right: '1ch' }}
               src={thumbnailSrc}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/components/ChoiceButton.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/Choices/components/ChoiceButton.js
@@ -1,11 +1,12 @@
 import {
   Box,
   Button,
+  Image,
   Text
 } from 'grommet'
 import PropTypes from 'prop-types'
 import { useCallback, useEffect, useRef } from 'react';
-import { Media, withThemeContext } from '@zooniverse/react-components'
+import { withThemeContext } from '@zooniverse/react-components'
 
 import theme from './theme'
 
@@ -51,6 +52,8 @@ function ChoiceButton({
     thumbnailHeight = 84
   }
 
+  const thumbnailWidth = Math.round(thumbnailHeight * THUMBNAIL_ASPECT_RATIO)
+  const thumbnailSrc = `https://thumbnails.zooniverse.org/${thumbnailWidth}x${thumbnailHeight}/${src.slice(8)}`
   return (
     <Button
       ref={choiceButton}
@@ -59,17 +62,18 @@ function ChoiceButton({
       fill
       label={
         <Box
+          as='span'
           direction='row'
           fill
           align='center'
         >
           {thumbnailSize !== 'none' && src &&
-            <Media
+            <Image
               alt={`${choiceLabel} media`}
-              height={thumbnailHeight}
+              height='fill'
               margin={{ right: '1ch' }}
-              src={src}
-              width={Math.round(thumbnailHeight * THUMBNAIL_ASPECT_RATIO)}
+              src={thumbnailSrc}
+              width={thumbnailWidth}
             />}
           <Text
             wordBreak='break-word'


### PR DESCRIPTION
Refactor choice button labels to use the Grommet `Image` component and fix invalid HTML inside the `<button>` element.

## Package
lib-classifier

## How to Review
You can check the changes here with the Survey Task story in the storybook. It shouldn't have changed, except that the layout shift when choices first load should now be fixed.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
