### PR TITLE
Update README with better publishing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,11 @@ When publishing an individual package to [npm](https://www.npmjs.com/), first cd
 1. Merge branch
 1. Checkout master, pull for latest
 1. Build the package with `yarn build` from the package dir, where available
-1. `yarn publish --new-version <version> --access public` from the package dir
-    - yarn v1 `publish` command tries to version bump with the publish command. You can specify the exact same version from step two with the `--new-version` variable. 
-    - `--access public` publishes the package publicly
-    - You can optionally login in to npm prior to this using `npm login` and storing an auth token in an `.npmrc` file
+1. Publish using `npm`:
+    - Sanity check: if you're using `nvm` (Node Version Manager), make sure you've switched to the latest version of node/npm
+    - Check that you're publishing the new version by running `npm publish --dry-run` from the package dir
+    - When you're happy, run `npm publish` from the package dir
+    - You can optionally login to npm prior to this using `npm login` and store an auth token in a `.npmrc` file
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ When publishing an individual package to [npm](https://www.npmjs.com/), first cd
 1. Build the package with `yarn build` from the package dir, where available
 1. Publish using `npm`:
     - Sanity check: if you're using `nvm` (Node Version Manager), make sure you've switched to the latest version of node/npm
-    - Check that you're publishing the new version by running `npm publish --dry-run` from the package dir
+    - Check that you're publishing the correct version by running `npm publish --dry-run` from the package dir
     - When you're happy, run `npm publish` from the package dir
     - You can optionally login to npm prior to this using `npm login` and store an auth token in a `.npmrc` file
 


### PR DESCRIPTION
## PR Overview

Package: root

This PR updates the README with better(?) publishing instructions. I haven't tried the old `yarn publish` method myself TBH, but I _can_ attest to the fact that `npm publish` worked correctly for me when publishing `@zooniverse/react-components` [v1.3.2](https://www.npmjs.com/package/@zooniverse/react-components) today.