### PR TITLE
Classifier: Remove legacy +tab+ formatter from MetadataModal

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.js
@@ -26,9 +26,6 @@ export function formatValue (value) {
   if (value) {
     const stringValue = value.toString()
     stringValue.trim()
-    if (stringValue.startsWith('http')) {
-      return `[${stringValue}](+tab+${stringValue})`
-    }
     return stringValue
   }
 

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.spec.js
@@ -33,12 +33,6 @@ describe('MetadataModal', function () {
     expect(wrapper.find('Styled(DataTable)').props().data).to.have.lengthOf(Object.keys(metadata).length - 2)
   })
 
-  it('should add the +tab+ prefix to metadata urls', function () {
-    const wrapper = shallow(<MetadataModal metadata={metadata} />)
-    const href = wrapper.find('Styled(DataTable)').props().data[1]
-    expect(href.value.props.children.includes('+tab+')).to.be.true()
-  })
-
   it('should not render metadata prefixed with # or !', function () {
     const wrapper = shallow(<MetadataModal metadata={metadata} />)
     wrapper.find('Styled(DataTable)').props().data.forEach((datum) => {


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Relevant [ADR](https://github.com/zooniverse/front-end-monorepo/blob/master/docs/arch/adr-11.md)
Related Slack [thread](https://zooniverse.slack.com/archives/C01TYAR0V43/p1661374475093859)

## Describe your changes

I removed the formatting intended to add `+tab+` to links in MetadataModal's `data`. That sequence would have worked in PFE's markdown handler, but is no longer supported in FEM's Markdownz.

## How to Review

This is best reviewed in storybook. There's a Metadata Modal story with data that includes a url. When displayed as a table, the url is rendered as a link that should open in a new tab. Previously, the link did not work at all.

There's much more refactoring of MetaTools coming in a future PR (on branch `metatools-refactor`).

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated