### PR TITLE
Project App: Remove max-width on Classify Page

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -38,7 +38,7 @@ function ClassifyPage({
   const responsiveColumns = (screenSize === 'small')
     ? ['auto']
     : ['1em', 'auto', '1em']
-  const [classifierProps, setClassifierProps]  = useState({})
+  const [classifierProps, setClassifierProps] = useState({})
   const [showTutorial, setShowTutorial] = useState(false)
 
   let subjectSetFromUrl
@@ -80,7 +80,7 @@ function ClassifyPage({
         pad={{ horizontal: 'small', vertical: 'medium' }}
       >
 
-        <Box as='main' fill='horizontal' width={{ min: 'none', max: 'xxlarge' }}>
+        <Box as='main' fill='horizontal'>
           {!canClassify && appLoadingState === asyncStates.success && (
             <WorkflowMenuModal
               subjectSetFromUrl={subjectSetFromUrl}


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Re-opens Issue https://github.com/zooniverse/front-end-monorepo/issues/3958 for now
Reverts PR https://github.com/zooniverse/front-end-monorepo/pull/3961

## Describe your changes

Per @snblickhan and I’s suggestion, we’re going to remove the max-width constraint on the classify page today - primarily because the projects that benefit from a max-width are not launched on FEM yet. Volunteers working on transcription projects have reported on more than one occasion that the ability to increase subject width in relation to task area (via browser zoom) is crucial to their ability to make a classification.

## How to Review

Load I Fancy Cats and zoom out to simulate an extra-wide display. Or view the Classify page on an extra-wide monitor, if you have one available.

Load a transcription project such as [Poets & Lovers](https://local.zooniverse.org:3000/projects/pmlogan/poets-and-lovers/classify/workflow/21362/subject-set/104809?env=production), and change the browser zoom. The subject area should increase and decrease.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed