### PR TITLE
Classifier: Specify no download for video subject viewer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
@@ -170,6 +170,7 @@ function SingleVideoViewerContainer({
       config={{
         file: { // styling the <video> element
           attributes: {
+            controlsList: ['nodownload'],
             style: {
               display: 'block',
               height: '100%',


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Follow-up to video subject viewer dev: https://github.com/zooniverse/front-end-monorepo/projects/13

## Describe your changes

This PR adds the [controlslist](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-controlslist) attribute 'nodownload' to the video element of the video subject viewer because [PFE](https://www.zooniverse.org/projects/elwest/woodpecker-cavity-cam/classify)'s video subject viewer does not allow downoads.

## How to Review

Load the classifier's storybook to view the SingleVideoViewer story, or view a video project such as [Woodpecker Cavity Cam](https://local.zooniverse.org:3000/projects/elwest/woodpecker-cavity-cam?env=production) while running this branch locally.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)