### PR TITLE
Classifier: limit subject width in extra-wide viewports

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.stories.js
@@ -9,7 +9,7 @@ import {
   WorkflowFactory
 } from '@test/factories'
 import mockStore from '@test/mockStore'
-import { ViewerGrid } from '../Layout/components/DefaultLayout/DefaultLayout'
+import { ViewerGrid } from '../Layout/components/NoMaxWidth/NoMaxWidth'
 import MultiFrameViewer from '../SubjectViewer/components/MultiFrameViewer'
 import SingleImageViewer from '../SubjectViewer/components/SingleImageViewer'
 import ImageToolbar from './ImageToolbar'

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.js
@@ -1,24 +1,23 @@
+import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 
-import { withStores } from '@helpers'
+import { useStores } from '@hooks'
 import getLayout from './helpers/getLayout'
 
 function storeMapper(classifierStore) {
-  const { layout } = classifierStore.subjectViewer
-  return { layout }
+  const workflow = classifierStore.workflows.active
+
+  return {
+    layout: workflow?.layout
+  }
 }
 
 
-function Layout({
-  layout = 'default'
-}) {
+function Layout() {
   // `getLayout()` will always return the default layout as a fallback
+  const { layout } = useStores(storeMapper)
   const CurrentLayout = getLayout(layout)
   return <CurrentLayout />
 }
 
-Layout.propTypes = {
-  layout: PropTypes.string
-}
-
-export default withStores(Layout, storeMapper)
+export default observer(Layout)

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.js
@@ -1,5 +1,4 @@
 import { observer } from 'mobx-react'
-import PropTypes from 'prop-types'
 
 import { useStores } from '@hooks'
 import getLayout from './helpers/getLayout'

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/DefaultLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/DefaultLayout.js
@@ -13,10 +13,10 @@ import TaskArea from '@components/Classifier/components/TaskArea'
 const ContainerGrid = styled(Grid)`
   position: relative;
 
-  // proportional 9/5 subject/task sizing up to a maximum task width of 25.333rem.
-  @media screen and (min-width: 769px) and (max-width: 70.666rem) {
+  // proportional 45/25 subject/task sizing up to a maximum subject/task width of 45rem/25rem.
+  @media screen and (min-width: 769px) and (max-width: 70rem) {
     grid-gap: 1.75rem;
-    grid-template-columns: 45.333fr 25.333fr;
+    grid-template-columns: 45fr 25fr;
   }
 `
 
@@ -70,7 +70,7 @@ export default function DefaultLayout({ className = '' }) {
     areas: [
       ['viewer', 'task']
     ],
-    columns: ['auto', '25.333rem'],
+    columns: ['auto', '25rem'],
     gap: 'medium'
   }
   const containerGridProps = size === 'small' ? verticalLayout : horizontalLayout

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/DefaultLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/DefaultLayout.js
@@ -48,6 +48,7 @@ export function ViewerGrid({ children }) {
       columns={['auto', 'clamp(3rem, 10%, 4.5rem)']}
       gridArea='viewer'
       height='fit-content'
+      rows={['auto']}
     >
       {children}
     </Grid>
@@ -71,7 +72,8 @@ export default function DefaultLayout({ className = '' }) {
       ['viewer', 'task']
     ],
     columns: ['auto', '25rem'],
-    gap: 'medium'
+    gap: 'medium',
+    rows: ['auto']
   }
   const containerGridProps = size === 'small' ? verticalLayout : horizontalLayout
 

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/DefaultLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/DefaultLayout.js
@@ -1,5 +1,6 @@
+import { useContext } from 'react'
 import styled from 'styled-components'
-import { Box } from 'grommet'
+import { Box, Grid, ResponsiveContext } from 'grommet'
 
 import Banners from '@components/Classifier/components/Banners'
 import FeedbackModal from '@components/Classifier/components/Feedback'
@@ -9,25 +10,13 @@ import QuickTalk from '@components/Classifier/components/QuickTalk'
 import SubjectViewer from '@components/Classifier/components/SubjectViewer'
 import TaskArea from '@components/Classifier/components/TaskArea'
 
-const ContainerGrid = styled.div`
-  display: grid;
-  grid-gap: 30px;
-  grid-template-areas: "viewer task";
-  grid-template-columns: auto 25.333rem;
+const ContainerGrid = styled(Grid)`
   position: relative;
 
-  @media screen and (max-width: 1160px) {
+  // proportional 9/5 subject/task sizing up to a maximum task width of 25.333rem.
+  @media screen and (min-width: 769px) and (max-width: 70.666rem) {
     grid-gap: 1.75rem;
     grid-template-columns: 45.333fr 25.333fr;
-  }
-
-  // this breakpoint matches Grommet's ResponsiveContext component
-  @media screen and (max-width: 768px) {
-    grid-template-columns: 100%;
-    grid-template-rows: auto auto;
-    grid-auto-flow: column;
-    grid-gap: 20px;
-    grid-template-areas: "viewer" "task";
   }
 `
 
@@ -40,14 +29,6 @@ const StyledTaskArea = styled(TaskArea)`
   top: 10px;
 `
 
-export const ViewerGrid = styled.section`
-  display: grid;
-  grid-area: viewer;
-  grid-template-areas: "subject toolbar";
-  grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
-  height: fit-content;
-`
-
 const StyledImageToolbarContainer = styled.div`
   grid-area: toolbar;
 `
@@ -57,9 +38,48 @@ const StyledImageToolbar = styled(ImageToolbar)`
   top: 10px;
 `
 
-export default function DefaultLayout({ className = '' }) {
+export function ViewerGrid({ children }) {
   return (
-    <ContainerGrid className={className}>
+    <Grid
+      as='section'
+      areas={[
+        ['subject', 'toolbar']
+      ]}
+      columns={['auto', 'clamp(3rem, 10%, 4.5rem)']}
+      gridArea='viewer'
+      height='fit-content'
+    >
+      {children}
+    </Grid>
+  )
+}
+
+export default function DefaultLayout({ className = '' }) {
+  const size = useContext(ResponsiveContext)
+  const verticalLayout = {
+    areas: [
+      ['viewer'],
+      ['task']
+    ],
+    columns: ['100%'],
+    gap: 'small',
+    margin: 'none',
+    rows: ['auto', 'auto']
+  }
+  const horizontalLayout = {
+    areas: [
+      ['viewer', 'task']
+    ],
+    columns: ['auto', '25.333rem'],
+    gap: 'medium'
+  }
+  const containerGridProps = size === 'small' ? verticalLayout : horizontalLayout
+
+  return (
+    <ContainerGrid
+      className={className}
+      {...containerGridProps}
+    >
       <ViewerGrid>
         <Box gridArea='subject'>
           <Banners />

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/DefaultLayout.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/DefaultLayout.spec.js
@@ -3,7 +3,7 @@ import { composeStory } from '@storybook/testing-react'
 
 import Meta, { Default, mockTask } from './DefaultLayout.stories.js'
 
-describe('Component > DefaultLayout', function () {
+describe('Component > Layouts > DefaultLayout', function () {
   const DefaultStory = composeStory(Default, Meta)
 
   it('should render a subject and a task', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/DefaultLayout/index.js
@@ -1,1 +1,0 @@
-export { default } from './DefaultLayout'

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
@@ -48,6 +48,7 @@ export function ViewerGrid({ children }) {
       columns={['auto', 'clamp(3rem, 10%, 4.5rem)']}
       gridArea='viewer'
       height='fit-content'
+      rows={['auto']}
     >
       {children}
     </Grid>
@@ -72,7 +73,8 @@ export default function MaxWidth({ className = '' }) {
     ],
     columns: ['minmax(auto,100rem)', '25rem'],
     gap: 'medium',
-    margin: 'auto'
+    margin: 'auto',
+    rows: ['auto']
   }
   const containerGridProps = size === 'small' ? verticalLayout : horizontalLayout
 

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
@@ -13,10 +13,10 @@ import TaskArea from '@components/Classifier/components/TaskArea'
 const ContainerGrid = styled(Grid)`
   position: relative;
 
-  // proportional 9/5 subject/task sizing up to a maximum task width of 25.333rem.
-  @media screen and (min-width: 769px) and (max-width: 70.666rem) {
+  // proportional 45/25 subject/task sizing up to a maximum subject/task width of 45rem/25rem.
+  @media screen and (min-width: 769px) and (max-width: 70rem) {
     grid-gap: 1.75rem;
-    grid-template-columns: 45.333fr 25.333fr;
+    grid-template-columns: 45fr 25fr;
   }
 `
 
@@ -70,7 +70,7 @@ export default function MaxWidth({ className = '' }) {
     areas: [
       ['viewer', 'task']
     ],
-    columns: ['minmax(auto,100rem)', '25.333rem'],
+    columns: ['minmax(auto,100rem)', '25rem'],
     gap: 'medium',
     margin: 'auto'
   }

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
@@ -1,0 +1,101 @@
+import { useContext } from 'react'
+import styled from 'styled-components'
+import { Box, Grid, ResponsiveContext } from 'grommet'
+
+import Banners from '@components/Classifier/components/Banners'
+import FeedbackModal from '@components/Classifier/components/Feedback'
+import ImageToolbar from '@components/Classifier/components/ImageToolbar'
+import MetaTools from '@components/Classifier/components/MetaTools'
+import QuickTalk from '@components/Classifier/components/QuickTalk'
+import SubjectViewer from '@components/Classifier/components/SubjectViewer'
+import TaskArea from '@components/Classifier/components/TaskArea'
+
+const ContainerGrid = styled(Grid)`
+  position: relative;
+
+  // proportional 9/5 subject/task sizing up to a maximum task width of 25.333rem.
+  @media screen and (min-width: 769px) and (max-width: 70.666rem) {
+    grid-gap: 1.75rem;
+    grid-template-columns: 45.333fr 25.333fr;
+  }
+`
+
+const StyledTaskAreaContainer = styled.div`
+  grid-area: task;
+`
+
+const StyledTaskArea = styled(TaskArea)`
+  position: sticky;
+  top: 10px;
+`
+
+export const StyledImageToolbarContainer = styled.div`
+  grid-area: toolbar;
+`
+
+export const StyledImageToolbar = styled(ImageToolbar)`
+  position: sticky;
+  top: 10px;
+`
+
+export function ViewerGrid({ children }) {
+  return (
+    <Grid
+      as='section'
+      areas={[
+        ['subject', 'toolbar']
+      ]}
+      columns={['auto', 'clamp(3rem, 10%, 4.5rem)']}
+      gridArea='viewer'
+      height='fit-content'
+    >
+      {children}
+    </Grid>
+  )
+}
+
+export default function MaxWidth({ className = '' }) {
+  const size = useContext(ResponsiveContext)
+  const verticalLayout = {
+    areas: [
+      ['viewer'],
+      ['task']
+    ],
+    columns: ['100%'],
+    gap: 'small',
+    margin: 'none',
+    rows: ['auto', 'auto']
+  }
+  const horizontalLayout = {
+    areas: [
+      ['viewer', 'task']
+    ],
+    columns: ['minmax(auto,100rem)', '25.333rem'],
+    gap: 'medium',
+    margin: 'auto'
+  }
+  const containerGridProps = size === 'small' ? verticalLayout : horizontalLayout
+
+  return (
+    <ContainerGrid
+      className={className}
+      {...containerGridProps}
+    >
+      <ViewerGrid>
+        <Box gridArea='subject'>
+          <Banners />
+          <SubjectViewer />
+          <MetaTools />
+        </Box>
+        <StyledImageToolbarContainer>
+          <StyledImageToolbar />
+        </StyledImageToolbarContainer>
+      </ViewerGrid>
+      <StyledTaskAreaContainer>
+        <StyledTaskArea />
+      </StyledTaskAreaContainer>
+      <FeedbackModal />
+      <QuickTalk />
+    </ContainerGrid>
+  )
+}

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.spec.js
@@ -4,14 +4,14 @@ import { Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
 
 import mockStore from '@test/mockStore'
-import Layout from './Layout'
+import MaxWidth from './MaxWidth'
 
-describe('Component > Layout', function () {
+describe('Component > MaxWidth', function () {
   it('should render without crashing', function () {
     render(
       <Grommet theme={zooTheme}>
         <Provider classifierStore={mockStore()}>
-          <Layout />
+          <MaxWidth />
         </Provider>
       </Grommet>
     )

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.spec.js
@@ -4,9 +4,9 @@ import { composeStory } from '@storybook/testing-react'
 import Meta, { Default, mockTask } from './MaxWidth.stories.js'
 
 describe('Component > Layouts > MaxWidth', function () {
-  const DefaultStory = composeStory(Default, Meta)
 
   it('should render a subject and a task', function () {
+    const DefaultStory = composeStory(Default, Meta)
     render(<DefaultStory />)
     expect(screen.getByLabelText('Subject 1')).exists() // img aria-label from SVGImage
     expect(screen.getByText(mockTask.init.strings.question)).exists() // task question paragraph

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.spec.js
@@ -1,19 +1,14 @@
-import { render } from '@testing-library/react'
-import zooTheme from '@zooniverse/grommet-theme'
-import { Grommet } from 'grommet'
-import { Provider } from 'mobx-react'
+import { render, screen } from '@testing-library/react'
+import { composeStory } from '@storybook/testing-react'
 
-import mockStore from '@test/mockStore'
-import MaxWidth from './MaxWidth'
+import Meta, { Default, mockTask } from './MaxWidth.stories.js'
 
-describe('Component > MaxWidth', function () {
-  it('should render without crashing', function () {
-    render(
-      <Grommet theme={zooTheme}>
-        <Provider classifierStore={mockStore()}>
-          <MaxWidth />
-        </Provider>
-      </Grommet>
-    )
+describe('Component > Layouts > MaxWidth', function () {
+  const DefaultStory = composeStory(Default, Meta)
+
+  it('should render a subject and a task', function () {
+    render(<DefaultStory />)
+    expect(screen.getByLabelText('Subject 1')).exists() // img aria-label from SVGImage
+    expect(screen.getByText(mockTask.init.strings.question)).exists() // task question paragraph
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.stories.js
@@ -4,11 +4,11 @@ import zooTheme from '@zooniverse/grommet-theme'
 import { SubjectFactory, WorkflowFactory } from '@test/factories'
 import mockStore from '@test/mockStore'
 
-import DefaultLayout from './DefaultLayout'
+import MaxWidth from './MaxWidth'
 
 export default {
-  title: 'Layouts / Default Layout',
-  component: DefaultLayout,
+  title: 'Layouts / Maximum Width',
+  component: MaxWidth,
   excludeStories: ['mockTask'],
   args: {
     dark: false
@@ -16,6 +16,7 @@ export default {
 }
 
 const subjectSnapshot = SubjectFactory.build({
+  id: '1',
   locations: [
     {
       'image/jpeg':
@@ -67,7 +68,7 @@ export function Default({ dark }) {
       themeMode={dark ? 'dark' : 'light'}
     >
       <Provider classifierStore={Default.store}>
-        <DefaultLayout />
+        <MaxWidth />
       </Provider>
     </Grommet>
   )

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/index.js
@@ -1,0 +1,1 @@
+export { default } from './MaxWidth'

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.js
@@ -55,7 +55,7 @@ export function ViewerGrid({ children }) {
   )
 }
 
-export default function DefaultLayout({ className = '' }) {
+export default function NoMaxWidth({ className = '' }) {
   const size = useContext(ResponsiveContext)
   const verticalLayout = {
     areas: [

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.spec.js
@@ -1,9 +1,9 @@
 import { render, screen } from '@testing-library/react'
 import { composeStory } from '@storybook/testing-react'
 
-import Meta, { Default, mockTask } from './DefaultLayout.stories.js'
+import Meta, { Default, mockTask } from './NoMaxWidth.stories.js'
 
-describe('Component > Layouts > DefaultLayout', function () {
+describe('Component > Layouts > NoMaxWidth', function () {
   const DefaultStory = composeStory(Default, Meta)
 
   it('should render a subject and a task', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.spec.js
@@ -4,9 +4,8 @@ import { composeStory } from '@storybook/testing-react'
 import Meta, { Default, mockTask } from './NoMaxWidth.stories.js'
 
 describe('Component > Layouts > NoMaxWidth', function () {
-  const DefaultStory = composeStory(Default, Meta)
-
   it('should render a subject and a task', function () {
+    const DefaultStory = composeStory(Default, Meta)
     render(<DefaultStory />)
     expect(screen.getByLabelText('Subject 1')).exists() // img aria-label from SVGImage
     expect(screen.getByText(mockTask.init.strings.question)).exists() // task question paragraph

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.stories.js
@@ -4,7 +4,7 @@ import zooTheme from '@zooniverse/grommet-theme'
 import { SubjectFactory, WorkflowFactory } from '@test/factories'
 import mockStore from '@test/mockStore'
 
-import NoMaxWidth from './NoMaxWidthLayout'
+import NoMaxWidth from './NoMaxWidth'
 
 export default {
   title: 'Layouts / No Max Width',

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.stories.js
@@ -16,6 +16,7 @@ export default {
 }
 
 const subjectSnapshot = SubjectFactory.build({
+  id: '1',
   locations: [
     {
       'image/jpeg':

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.stories.js
@@ -4,11 +4,11 @@ import zooTheme from '@zooniverse/grommet-theme'
 import { SubjectFactory, WorkflowFactory } from '@test/factories'
 import mockStore from '@test/mockStore'
 
-import DefaultLayout from './DefaultLayout'
+import NoMaxWidth from './NoMaxWidthLayout'
 
 export default {
-  title: 'Layouts / Default Layout',
-  component: DefaultLayout,
+  title: 'Layouts / No Max Width',
+  component: NoMaxWidth,
   excludeStories: ['mockTask'],
   args: {
     dark: false
@@ -67,7 +67,7 @@ export function Default({ dark }) {
       themeMode={dark ? 'dark' : 'light'}
     >
       <Provider classifierStore={Default.store}>
-        <DefaultLayout />
+        <NoMaxWidth />
       </Provider>
     </Grommet>
   )

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/index.js
@@ -1,0 +1,1 @@
+export { default } from './NoMaxWidth'

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/index.js
@@ -1,0 +1,2 @@
+export { default as DefaultLayout } from './DefaultLayout'
+export { default as MaxWidth } from './MaxWidth'

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/index.js
@@ -1,2 +1,2 @@
-export { default as DefaultLayout } from './DefaultLayout'
 export { default as MaxWidth } from './MaxWidth'
+export { default as NoMaxWidth } from './NoMaxWidth'

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.js
@@ -1,7 +1,9 @@
 import DefaultLayout from '../../components/DefaultLayout'
+import MaxWidth from '../../components/MaxWidth'
 
 const layoutsMap = {
-  default: DefaultLayout
+  default: DefaultLayout,
+  maxWidth: MaxWidth
 }
 
 function getLayout (layout) {

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.js
@@ -1,4 +1,4 @@
-import { MaxWidth. NoMaxWidth } from '../../components/'
+import { MaxWidth, NoMaxWidth } from '../../components/'
 
 const layoutsMap = {
   default: MaxWidth,

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.js
@@ -2,8 +2,9 @@ import DefaultLayout from '../../components/DefaultLayout'
 import MaxWidth from '../../components/MaxWidth'
 
 const layoutsMap = {
-  default: DefaultLayout,
-  maxWidth: MaxWidth
+  default: MaxWidth,
+  maxWidth: MaxWidth,
+  noMaxWidth: DefaultLayout
 }
 
 function getLayout (layout) {

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.js
@@ -1,13 +1,12 @@
-import DefaultLayout from '../../components/DefaultLayout'
-import MaxWidth from '../../components/MaxWidth'
+import { MaxWidth. NoMaxWidth } from '../../components/'
 
 const layoutsMap = {
   default: MaxWidth,
   maxWidth: MaxWidth,
-  noMaxWidth: DefaultLayout
+  noMaxWidth: NoMaxWidth
 }
 
-function getLayout (layout) {
+export default function getLayout(layout) {
   if (layoutsMap[layout]) {
     return layoutsMap[layout]
   } else {
@@ -15,5 +14,3 @@ function getLayout (layout) {
     return layoutsMap.default
   }
 }
-
-export default getLayout

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.spec.js
@@ -1,17 +1,17 @@
 import getLayout from './getLayout'
 
-import { DefaultLayout, MaxWidth } from '../../components'
+import { NoMaxWidth, MaxWidth } from '../../components'
 
 describe('Helpers > getLayout', function () {
-  it('should return the `MaxWidth` component if passed `default`', function () {
+  it('should return the `MaxWidth` component if passed `maxWidth`', function () {
     expect(getLayout('default')).to.equal(MaxWidth)
   })
 
-  it('should return the old `DefaultLayout` component if passed `noMaxWidth`', function () {
-    expect(getLayout('noMaxWidth')).to.equal(DefaultLayout)
+  it('should return the `NoMaxWidth` component if passed `noMaxWidth`', function () {
+    expect(getLayout('noMaxWidth')).to.equal(NoMaxWidth)
   })
 
-  it('should return the default layout if it can\'t match a layout', function () {
+  it('should return the `MaxWidth` layout if it can\'t match a layout', function () {
     expect(getLayout('foobar')).to.equal(MaxWidth)
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.spec.js
@@ -1,13 +1,17 @@
 import getLayout from './getLayout'
 
-import DefaultLayout from '../../components/DefaultLayout'
+import { DefaultLayout, MaxWidth } from '../../components'
 
 describe('Helpers > getLayout', function () {
-  it('should return the `DefaultLayout` component if passed `default`', function () {
-    expect(getLayout('default')).to.equal(DefaultLayout)
+  it('should return the `MaxWidth` component if passed `default`', function () {
+    expect(getLayout('default')).to.equal(MaxWidth)
+  })
+
+  it('should return the old `DefaultLayout` component if passed `noMaxWidth`', function () {
+    expect(getLayout('noMaxWidth')).to.equal(DefaultLayout)
   })
 
   it('should return the default layout if it can\'t match a layout', function () {
-    expect(getLayout('foobar')).to.equal(DefaultLayout)
+    expect(getLayout('foobar')).to.equal(MaxWidth)
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.spec.js
@@ -4,7 +4,7 @@ import { NoMaxWidth, MaxWidth } from '../../components'
 
 describe('Helpers > getLayout', function () {
   it('should return the `MaxWidth` component if passed `maxWidth`', function () {
-    expect(getLayout('default')).to.equal(MaxWidth)
+    expect(getLayout('maxWidth')).to.equal(MaxWidth)
   })
 
   it('should return the `NoMaxWidth` component if passed `noMaxWidth`', function () {

--- a/packages/lib-classifier/src/store/WorkflowStore/Workflow/Workflow.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/Workflow/Workflow.js
@@ -58,7 +58,10 @@ const Workflow = types
 
     get layout() {
       if (self.usesTranscriptionTask) {
-        return 'default'
+        return 'noMaxWidth'
+      }
+      if (self.configuration.layout) {
+        return self.configuration.layout
       }
       return 'maxWidth'
     },

--- a/packages/lib-classifier/src/store/WorkflowStore/Workflow/Workflow.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/Workflow/Workflow.js
@@ -56,6 +56,13 @@ const Workflow = types
       return self.grouped && !!activeSet?.isIndexed
     },
 
+    get layout() {
+      if (self.usesTranscriptionTask) {
+        return 'default'
+      }
+      return 'maxWidth'
+    },
+
     get subjectSetId() {
       const activeSet = tryReference(() => self.subjectSet)
       return activeSet?.id

--- a/packages/lib-classifier/test/mockStore/mockStore.js
+++ b/packages/lib-classifier/test/mockStore/mockStore.js
@@ -48,10 +48,11 @@ export default function mockStore({
     activeWorkflowId: workflowSnapshot.id
   })
 
-  const subjectResources = { [subjectSnapshot.id]: subjectSnapshot }
+  const subjectResources = {}
   Factory
     .buildList('subject', 9)
     .forEach(subject => subjectResources[subject.id] = subject)
+  subjectResources[subjectSnapshot.id] = subjectSnapshot
 
   const { panoptes } = stubPanoptesJs({
     field_guides: [],


### PR DESCRIPTION
Add a layout with a restricted maximum subject width to the classifier. Keep the existing default layout for transcription workflows.

Grommet-ify the container and viewer grids, including using [`Grid`](https://v2.grommet.io/grid) for layout and adding a [responsive context](https://v2.grommet.io/responsivecontext) so that we can use themed breakpoints and sizing.

**Accessibility bug:** I've also fixed the 1160px breakpoint so that it works for base font sizes other than 16px. Here's I Fancy Cats with 'Larger Text' enabled in MacOS 11.7.2. The text is bigger but the subject and task still use a 9:5 column width ratio.

<img width="1022" alt="A screenshot of the I Fancy Cats Classify page in Firefox on MacOS, with Larger Text enabled for the display." src="https://user-images.githubusercontent.com/59547/215320209-a42c346b-3d85-477f-abeb-45462aea4cb0.png">

This should fix #3958 without changing the current behaviour of transcription projects. Here's I Fancy Cats zoomed out to an effective screen width of around 3600px. The classifier is centred, with the subject still completely visible in the viewport. The subject expands out beyond the original 9:5 width ratio, but only to a maximum width of 1600px (for a font size of 16px.)

<img width="1022" alt="Screenshot of I Fancy Cats zoomed out to 30% in Firefox on a 1200px Mac Retina display." src="https://user-images.githubusercontent.com/59547/215320702-c80b2b2a-f801-4d0c-aa37-920d713d5d1d.png">


## Package
lib-classifier

## Linked Issue and/or Talk Post
- Closes #3958.

## How to Review
The original bug was noticed on Superluminous Supernovae:
https://frontend.preview.zooniverse.org/projects/mrniaboc/superluminous-supernovae/classify/workflow/13193

However, you should be able to reproduce it on any workflow that uses images as classification subjects.

On this branch, the original classifier layout should still work on any workflow that uses the transcription task. Other workflows will limit the subject image width to 100rem/1600px. Sizing is proportional to base font size, so the layout should respect the minimum font size set in either your browser or operating system settings. If you have larger text set in your OS, you should be able to get larger subject images too.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
