### PR TITLE
Refactor Markdownz's handling of custom image dimensions

### DIFF
--- a/packages/lib-react-components/src/Markdownz/Markdownz.js
+++ b/packages/lib-react-components/src/Markdownz/Markdownz.js
@@ -1,4 +1,4 @@
-import { Fragment, useCallback } from 'react';
+import { Fragment, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import {
   Anchor,

--- a/packages/lib-react-components/src/Markdownz/Markdownz.js
+++ b/packages/lib-react-components/src/Markdownz/Markdownz.js
@@ -41,9 +41,8 @@ export function renderMedia(nodeProps) {
 
   if (match && match.length > 0) {
     width = parseInt(match[1])
-    height = parseInt(match[3])
+    if (match[3]) height = parseInt(match[3])
     alt = alt.split(match[0])[0].trim()
-    if (width && !height) height = 'none'
   }
 
   if (src) return <Media alt={alt} height={height} src={src} width={width} />

--- a/packages/lib-react-components/src/Markdownz/Markdownz.spec.js
+++ b/packages/lib-react-components/src/Markdownz/Markdownz.spec.js
@@ -201,11 +201,11 @@ describe('<Markdownz />', function () {
       expect(returnedValue.props.height).to.equal(100)
     })
 
-    it('should set max height as none if only width is defined', function () {
+    it('height should be undefined if only width is defined', function () {
       const imagePropsMockWithWidth = { src, alt: `${altText} =100x`, children: undefined }
       const returnedValue = renderMedia(imagePropsMockWithWidth)
       expect(returnedValue.props.width).to.equal(100)
-      expect(returnedValue.props.height).to.equal('none')
+      expect(returnedValue.props.height).to.equal(undefined)
     })
 
     it('should remove the width and height declaration from the alt text before setting it on the rendered Image', function () {

--- a/packages/lib-react-components/src/Markdownz/markdownGridExample.md
+++ b/packages/lib-react-components/src/Markdownz/markdownGridExample.md
@@ -3,7 +3,7 @@ Lorem ipsum etc
 
 ![J1003351.36-003340.8_sdss_decals.gif](https://panoptes-uploads.zooniverse.org/production/project_attached_image/7656d42d-4d25-42e1-9014-6b8876a5641f.gif =100x) 
 ![J094402.93+004556.2_sdss_decals.gif](https://panoptes-uploads.zooniverse.org/production/project_attached_image/bb03674a-e03a-455b-9a4d-4aad7d718df1.gif =250x)
-*This is an image label. The above to gifs will not pass through the thumbnail service because they're gifs not img*
+*This is an image label. The above two gifs will not pass through the thumbnail service because they're gifs not img*
 
 ![alt](https://static.zooniverse.org/www.zooniverse.org/assets/home-video.mp4 =300x)
 

--- a/packages/lib-react-components/src/Markdownz/markdownGridExample.md
+++ b/packages/lib-react-components/src/Markdownz/markdownGridExample.md
@@ -1,11 +1,11 @@
 # This is a Header #
 Lorem ipsum etc
 
-![J1003351.36-003340.8_sdss_decals.gif](https://panoptes-uploads.zooniverse.org/production/project_attached_image/7656d42d-4d25-42e1-9014-6b8876a5641f.gif =250x) 
+![J1003351.36-003340.8_sdss_decals.gif](https://panoptes-uploads.zooniverse.org/production/project_attached_image/7656d42d-4d25-42e1-9014-6b8876a5641f.gif =100x) 
 ![J094402.93+004556.2_sdss_decals.gif](https://panoptes-uploads.zooniverse.org/production/project_attached_image/bb03674a-e03a-455b-9a4d-4aad7d718df1.gif =250x)
-*This is an image label*
+*This is an image label. The above to gifs will not pass through the thumbnail service because they're gifs not img*
 
-![alt](https://static.zooniverse.org/www.zooniverse.org/assets/home-video.mp4)
+![alt](https://static.zooniverse.org/www.zooniverse.org/assets/home-video.mp4 =300x)
 
 ![alt](https://panoptes-uploads.zooniverse.org/production/subject_location/1c93591f-5d7e-4129-a6da-a65419b88048.mpga)
 

--- a/packages/lib-react-components/src/Media/Media.stories.js
+++ b/packages/lib-react-components/src/Media/Media.stories.js
@@ -1,101 +1,72 @@
-import { withKnobs, text } from '@storybook/addon-knobs';
-import zooTheme from '@zooniverse/grommet-theme';
-import { Grommet, Box } from 'grommet';
+import zooTheme from '@zooniverse/grommet-theme'
+import { Grommet, Box, Text } from 'grommet'
 
-import Media from './Media';
-import readme from './README.md';
-import ZooniverseLogo from '../ZooniverseLogo';
-
-const config = {
-  docs: {
-    description: {
-      component: readme,
-    },
-  },
-};
-
-const AUDIO_URL =
-  'https://panoptes-uploads.zooniverse.org/production/subject_location/1c93591f-5d7e-4129-a6da-a65419b88048.mpga';
-const IMAGE_URL =
-  'https://panoptes-uploads.zooniverse.org/production/subject_location/66094a64-8823-4314-8ef4-1ee228e49470.jpeg';
-const VIDEO_URL = 'https://static.zooniverse.org/www.zooniverse.org/assets/home-video.mp4';
+import Media from './Media'
+import ZooniverseLogo from '../ZooniverseLogo'
 
 export default {
-  title: 'Components/Media',
-  decorators: [withKnobs],
-};
+  title: 'Components / Media',
+  component: Media,
+  args: {
+    dark: false
+  }
+}
 
-export const Image = () => (
-  <Grommet theme={zooTheme}>
+const AUDIO_URL =
+  'https://panoptes-uploads.zooniverse.org/production/subject_location/1c93591f-5d7e-4129-a6da-a65419b88048.mpga'
+const IMAGE_URL =
+  'https://panoptes-uploads.zooniverse.org/production/subject_location/66094a64-8823-4314-8ef4-1ee228e49470.jpeg'
+const VIDEO_URL =
+  'https://static.zooniverse.org/www.zooniverse.org/assets/home-video.mp4'
+
+export const Image = ({ dark }) => (
+  <Grommet
+    background={{
+      dark: 'dark-1',
+      light: 'light-1'
+    }}
+    theme={zooTheme}
+    themeMode={dark ? 'dark' : 'light'}
+  >
     <Box>
-      <Media
-        alt={text('Alt', 'A galaxy')}
-        height={200}
-        src={text('Image URL', IMAGE_URL)}
-        width={270}
-      />
-    </Box>
-  </Grommet>
-);
-
-Image.story = {
-  parameters: config,
-};
-
-export const ImageWithAPlaceholderWhileLoading = () => (
-  <Grommet theme={zooTheme}>
-    <Box margin={{ bottom: 'medium' }}>
-      Image with zooniverse logo placeholder and an added loading delay of 3 seconds so you can see
-      it...
+      <Text>Width set as 270</Text>
+      <Media alt='A galaxy' src={IMAGE_URL} width={270} />
     </Box>
     <Box>
+      <Text>Has a placeholder (delay 3sec). Width and height set as 200</Text>
       <Media
-        alt="A galaxy"
+        alt='A galaxy'
         delay={3000}
-        height={250}
-        placeholder={<ZooniverseLogo size="38%" />}
-        src={text('Image URL', IMAGE_URL)}
-        width={250}
+        height={200}
+        placeholder={<ZooniverseLogo id='Media storybook' size='38%' />}
+        src={IMAGE_URL}
+        width={200}
       />
     </Box>
+    <Box>
+      <Text>Specifying only a height will crop the image</Text>
+      <Media alt='A galaxy' src={IMAGE_URL} height={100} />
+    </Box>
+    <Box>
+      <Text>Not setting the dimensions props defaults them to 999px</Text>
+      <Media alt='A galaxy' src={IMAGE_URL} />
+    </Box>
   </Grommet>
-);
+)
 
-ImageWithAPlaceholderWhileLoading.story = {
-  name: 'Image with a placeholder while loading',
-  parameters: config,
-};
-
-export const Video = () => (
+export const Video = ({ dark }) => (
   <Grommet theme={zooTheme}>
     <Box>
-      <Media
-        alt={text('Alt', 'Zooniverse in a nutshell')}
-        height={200}
-        src={text('Video URL', VIDEO_URL)}
-        width={270}
-      />
+      <Text>Width set as 270</Text>
+      <Media alt='Zooniverse in a nutshell' src={VIDEO_URL} width={270} />
     </Box>
   </Grommet>
-);
+)
 
-Video.story = {
-  parameters: config,
-};
-
-export const Audio = () => (
+export const Audio = ({ dark }) => (
   <Grommet theme={zooTheme}>
     <Box>
-      <Media
-        alt={text('Alt', 'City noise')}
-        height={200}
-        src={text('Audio URL', AUDIO_URL)}
-        width={270}
-      />
+      <Media alt='City noise' src={AUDIO_URL} width={270} />
     </Box>
   </Grommet>
-);
-
-Audio.story = {
-  parameters: config,
-};
+)

--- a/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.js
+++ b/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.js
@@ -30,13 +30,13 @@ function stringifySize (size) {
 }
 
 export default function ThumbnailImage({
-  alt, // ''
-  delay, // 0
-  fit, // cover
-  flex, // grow
+  alt = defaultProps.alt,
+  delay = defaultProps.delay,
+  fit = defaultProps.fit,
+  flex = defaultProps.flex,
   height = DEFAULT_THUMBNAIL_DIMENSION,
-  origin, // https://thumbnails.zooniverse.org
-  placeholder, //  null
+  origin = defaultProps.origin,
+  placeholder = defaultProps.placeholder,
   src,
   width = DEFAULT_THUMBNAIL_DIMENSION,
   ...rest
@@ -81,8 +81,4 @@ export default function ThumbnailImage({
 
 ThumbnailImage.propTypes = {
   ...propTypes
-}
-
-ThumbnailImage.defaultProps = {
-  ...defaultProps
 }

--- a/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.js
+++ b/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.js
@@ -1,9 +1,8 @@
-import { useState } from 'react';
 import styled, { css } from 'styled-components'
 import { Box, Image } from 'grommet'
 import getThumbnailSrc from '../../helpers/getThumbnailSrc.js'
 import { propTypes, defaultProps } from '../../helpers/mediaPropTypes.js'
-import useProgressiveImage  from '../../../hooks/useProgressiveImage.js'
+import useProgressiveImage from '../../../hooks/useProgressiveImage.js'
 
 const DEFAULT_THUMBNAIL_DIMENSION = 999
 
@@ -31,19 +30,19 @@ function stringifySize (size) {
 }
 
 export default function ThumbnailImage({
-  alt,
-  delay,
-  fit,
-  flex,
-  height,
-  origin,
-  placeholder,
+  alt, // ''
+  delay, // 0
+  fit, // cover
+  flex, // grow
+  height = DEFAULT_THUMBNAIL_DIMENSION,
+  origin, // https://thumbnails.zooniverse.org
+  placeholder, //  null
   src,
-  width,
+  width = DEFAULT_THUMBNAIL_DIMENSION,
   ...rest
 }) {
   const thumbnailSrc = getThumbnailSrc({ height, origin, src, width })
-  const { img, error, loading } = useProgressiveImage({ delay, src: thumbnailSrc })
+  const { error, loading } = useProgressiveImage({ delay, src: thumbnailSrc })
 
   const imageSrc = error ? src : thumbnailSrc
   const stringHeight = stringifySize(height)
@@ -58,8 +57,8 @@ export default function ThumbnailImage({
       {loading ?
         <Placeholder height={stringHeight} flex={flex} width={stringWidth} {...rest}>{placeholder}</Placeholder> :
         <StyledBox
-          animation={loading ? undefined : "fadeIn"}
-          className="thumbnailImage"
+          animation={loading ? undefined : 'fadeIn'}
+          className='thumbnailImage'
           flex={flex}
           maxWidth={stringWidth}
           maxHeight={stringHeight}
@@ -85,7 +84,5 @@ ThumbnailImage.propTypes = {
 }
 
 ThumbnailImage.defaultProps = {
-  ...defaultProps,
-  height: DEFAULT_THUMBNAIL_DIMENSION,
-  width: DEFAULT_THUMBNAIL_DIMENSION
+  ...defaultProps
 }


### PR DESCRIPTION
## Package
lib-react-components

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/2554

## Describe your changes

- Allow `height` to be undefined when parsing markdown image strings that contain custom dimensions such as "=200x" or "=100x100".
- Refactored Media component's stories to have more explicit examples of images
- linting

## How to Review

This can be reviewed by looking at the Media or Markdownz stories in lib-react-components storybook.

You can also run app-project locally and visit Superwasp's [Team page](https://local.zooniverse.org:3000/projects/hughdickinson/superwasp-black-hole-hunters/about/team?env=production). The network requests should not error, and the images in the page's markdown should be source from thumbnails.zooniverse.org.

Note that I will follow up with a documented Issue and separate PR for addressing how field guide icons are incorrectly passing dimensions to the Media component.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
(https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).