### PR TITLE
Maintenance Week: add tests for Tooltip's sub-components

### DIFF
--- a/packages/lib-react-components/src/Tooltip/components/Label/Label.spec.js
+++ b/packages/lib-react-components/src/Tooltip/components/Label/Label.spec.js
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import Triangle from '../Triangle'
 import { Label } from './Label'
 
 describe('Tooltip > Component > Label', function () {

--- a/packages/lib-react-components/src/Tooltip/components/Label/Label.spec.js
+++ b/packages/lib-react-components/src/Tooltip/components/Label/Label.spec.js
@@ -1,47 +1,41 @@
-import { shallow } from 'enzyme'
+import { render, screen } from '@testing-library/react'
 import Triangle from '../Triangle'
 import { Label } from './Label'
 
 describe('Tooltip > Component > Label', function () {
-  let wrapper
-  beforeEach(function () {
-    wrapper = shallow(<Label label='helpful tip' />)
-  })
-
-  it('renders without crashing', function () {
-    expect(wrapper).to.be.ok()
-  })
-
-  it('should render the label', function () {
-    expect(wrapper.contains('helpful tip')).to.be.true()
-  })
-
-  it('should set the animation of the wrapper Box', function () {
-    expect(wrapper.props().animation).to.equal('fadeIn')
-    wrapper.setProps({ animation: 'zoomIn' })
-    expect(wrapper.props().animation).to.equal('zoomIn')
-  })
-
-  describe('arrow', function () {
+  describe('with simple props', function () {
     beforeEach(function () {
-      wrapper = shallow(<Label data-position='top' label='helpful tip' />)
+      render(<Label label='helpful tip' />)
     })
 
-    it('should render an arrow based on the prop', function () {
-      expect(wrapper.find(Triangle)).to.have.lengthOf(1)
-      wrapper.setProps({ arrow: false })
-      expect(wrapper.find(Triangle)).to.have.lengthOf(0)
+    it('renders without crashing', function () {
+      expect(screen).to.be.ok()
     })
 
-    it('should position the arrow based on the data-position prop', function () {
-      let arrow = wrapper.find('Box').first().childAt(1)
-      expect(arrow).to.have.lengthOf(1)
-      expect(arrow.props().pointDirection).to.equal('down')
-      wrapper.setProps({ 'data-placement': 'bottom' })
-      arrow = wrapper.find('Box').first().childAt(0)
-      expect(arrow).to.have.lengthOf(1)
-      expect(arrow.props().pointDirection).to.equal('up')
+    it('should render the label', function () {
+      expect(screen.queryByText('helpful tip')).to.exist()
+    })
+  })
 
+  describe('with specific props', function () {
+    it('should render a triangle/arrow, by default', function () {
+      render(<Label label='helpful tip' />)
+      const triangle = document.querySelector('svg polygon')
+      expect(triangle).to.exist()
+      expect(triangle.getAttribute('points')).to.equal('5,0 10,10 0,10')
+    })
+
+    it('should render a triangle/arrow if arrow=true', function () {
+      render(<Label label='helpful tip' arrow={true} />)
+      const triangle = document.querySelector('svg polygon')
+      expect(triangle).to.exist()
+      expect(triangle.getAttribute('points')).to.equal('5,0 10,10 0,10')
+    })
+
+    it('should not render a triangle/arrow if arrow=false', function () {
+      render(<Label label='helpful tip' arrow={false} />)
+      const triangle = document.querySelector('svg polygon')
+      expect(triangle).to.not.exist()
     })
   })
 })

--- a/packages/lib-react-components/src/Tooltip/components/Label/Label.spec.js
+++ b/packages/lib-react-components/src/Tooltip/components/Label/Label.spec.js
@@ -37,5 +37,19 @@ describe('Tooltip > Component > Label', function () {
       const triangle = document.querySelector('svg polygon')
       expect(triangle).to.not.exist()
     })
+
+    it('should render an downward triangle/arrow if Tippy-defined placement = top', function () {
+      render(<Label label='helpful tip' arrow={true} data-placement='top' />)
+      const svg = document.querySelector('svg')
+      const svgStyle = window.getComputedStyle(svg)
+      expect(svgStyle.getPropertyValue('transform')).to.equal('rotate(180deg)')
+    })
+
+    it('should render an upward triangle/arrow if Tippy-defined placement = bottom', function () {
+      render(<Label label='helpful tip' arrow={true} data-placement='bottom' />)
+      const svg = document.querySelector('svg')
+      const svgStyle = window.getComputedStyle(svg)
+      expect(svgStyle.getPropertyValue('transform')).to.equal('rotate(0deg)')
+    })
   })
 })

--- a/packages/lib-react-components/src/Tooltip/components/Triangle/Triangle.spec.js
+++ b/packages/lib-react-components/src/Tooltip/components/Triangle/Triangle.spec.js
@@ -1,56 +1,40 @@
-import { shallow } from 'enzyme'
+import { render, screen } from '@testing-library/react'
 import zooTheme from '@zooniverse/grommet-theme'
-import { Triangle, SVG } from './Triangle'
+import { Triangle } from './Triangle'
 
 describe('Component > Triangle', function () {
-  let wrapper
-  beforeEach(function () {
-    wrapper = shallow(<Triangle theme={zooTheme} />)
-  })
-
   it('should render without crashing', function () {
-    expect(wrapper).to.be.ok()
+    render(<Triangle theme={zooTheme} />)
+    expect(screen).to.be.ok()
   })
 
-  it('should render the wrapper Box with the expected props', function () {
-    let props = wrapper.props()
-    expect(props.justify).to.equal('center')
-    expect(props.pad).to.deep.equal({ horizontal: 'small' })
-    wrapper.setProps({ justify: 'end', pad: 'none' })
-    props = wrapper.props()
-    expect(props.justify).to.equal('end')
-    expect(props.pad).to.equal('none')
+  describe('with color settings', function () {
+    it('should render theme colors, if specified', function () {
+      render(<Triangle theme={zooTheme} />)
+      const svg = document.querySelector('svg')
+      expect(svg.getAttribute('fill')).to.equal(zooTheme.global.colors['dark-2'])
+    })
+
+    it('should render specific colors, if specified', function () {
+      render(<Triangle theme={zooTheme} color='cyan' />)
+      const svg = document.querySelector('svg')
+      expect(svg.getAttribute('fill')).to.equal('cyan')
+    })
   })
 
-  it('should render the SVG with a fill color', function () {
-    expect(wrapper.find(SVG).props().fill).to.equal(zooTheme.global.colors['dark-2'])
-    wrapper.setProps({ theme: Object.assign({}, zooTheme, { dark: true })})
-    expect(wrapper.find(SVG).props().fill).equal(zooTheme.global.colors['neutral-6'])
-    wrapper.setProps({ color: 'blue' })
-    expect(wrapper.find(SVG).props().fill).equal('blue')
-  })
+  describe('with point direction settings', function () {
+    it('should point up, if specified', function () {
+      render(<Triangle theme={zooTheme} pointDirection='up' />)
+      const svg = document.querySelector('svg')
+      const svgStyle = window.getComputedStyle(svg)
+      expect(svgStyle.getPropertyValue('transform')).to.equal('rotate(0deg)')
+    })
 
-  it('should render the SVG at a certain width and height', function () {
-    let props = wrapper.find(SVG).props()
-    expect(props.width).to.equal(20)
-    expect(props.height).to.equal(20)
-    wrapper.setProps({ width: 10, height: 10 })
-    props = wrapper.find(SVG).props()
-    expect(props.width).to.equal(10)
-    expect(props.height).to.equal(10)
-  })
-
-  it('should set the rotation degrees based on the pointDirection prop', function () {
-    let rotation = wrapper.find(SVG).props().rotation
-    expect(rotation).to.equal('0deg')
-    wrapper.setProps({ pointDirection: 'down' })
-    rotation = wrapper.find(SVG).props().rotation
-    expect(rotation).to.equal('180deg')
-    wrapper.setProps({ pointDirection: 'left' })
-    rotation = wrapper.find(SVG).props().rotation
-    expect(rotation).to.equal('-90deg')
-    wrapper.setProps({ pointDirection: 'right' })
-    rotation = wrapper.find(SVG).props().rotation
-    expect(rotation).to.equal('90deg')
+    it('should point down, if specified', function () {
+      render(<Triangle theme={zooTheme} pointDirection='down' />)
+      const svg = document.querySelector('svg')
+      const svgStyle = window.getComputedStyle(svg)
+      expect(svgStyle.getPropertyValue('transform')).to.equal('rotate(180deg)')
+    })
   })
 })


### PR DESCRIPTION
## PR Overview

Follows #4107 
Package: lib-react-components
Part of: Maintenance Week

This PR adds React Testing Library tests for Tooltip's sub-components. They're pretty basic, honestly.

Ready for review