### PR TITLE
Refactor ZooHeaderWrapperContainer signOut with await on auth.signOut

### DIFF
--- a/packages/app-project/src/components/ZooHeaderWrapper/ZooHeaderWrapperContainer.js
+++ b/packages/app-project/src/components/ZooHeaderWrapper/ZooHeaderWrapperContainer.js
@@ -10,8 +10,11 @@ function useStore() {
   return { user }
 }
 
-export function signOut(user) {
+export async function signOut(user) {
+  await auth.signOut()
+  
   user.clear()
+  
   // resetting the alreay seen subjects during the session tracking should move
   // once we refactor the UPP and User resource tracking in the classifier
   // Current implementation in classifier is possibly buggy (see discussion https://github.com/zooniverse/front-end-monorepo/discussions/2362)
@@ -23,7 +26,6 @@ export function signOut(user) {
   if (seenThisSession) {
     window.sessionStorage.removeItem("subjectsSeenThisSession")
   }
-  auth.signOut()
 }
 
 function ZooHeaderWrapperContainer(props) {

--- a/packages/app-project/src/components/ZooHeaderWrapper/ZooHeaderWrapperContainer.spec.js
+++ b/packages/app-project/src/components/ZooHeaderWrapper/ZooHeaderWrapperContainer.spec.js
@@ -66,28 +66,28 @@ describe('Component > ZooHeaderWrapperContainer', function () {
     expect(siteMenu).to.exist()
   })
 
-  it('should clear the stored user on sign out', function () {
+  it('should clear the stored user on sign out', async function () {
     expect(store.user.isLoggedIn).to.be.true()
-    signOut(store.user)
+    await signOut(store.user)
     expect(store.user.isLoggedIn).to.be.false()
   })
 
-  it('should sign out of Panoptes', function () {
-    signOut(store.user)
+  it('should sign out of Panoptes', async function () {
+    await signOut(store.user)
     expect(auth.signOut).to.have.been.calledOnce()
   })
 
   it('should remove already seen subjects session storage', async function () {
     expect(window.sessionStorage.getItem("subjectsSeenThisSession")).to.equal('["1234/5678"]')
-    signOut(store.user)
+    await signOut(store.user)
     expect(window.sessionStorage.getItem("subjectsSeenThisSession")).to.be.null()
   })
 
   describe('Sign In', function () {
     let signInButton
 
-    beforeEach(function () {
-      signOut(store.user)
+    beforeEach(async function () {
+      await signOut(store.user)
     })
 
     it('should navigate to ./?login=true', async function () {
@@ -101,8 +101,8 @@ describe('Component > ZooHeaderWrapperContainer', function () {
   describe('Register', function () {
     let registerButton
 
-    beforeEach(function () {
-      signOut(store.user)
+    beforeEach(async function () {
+      await signOut(store.user)
     })
 
     it('should navigate to ./?register=true', async function () {


### PR DESCRIPTION
## Package
- app-project

## Linked Issue and/or Talk Post
- closes #4119 

## Describe your changes
- user state is clearing from app-project, causing nav, recents, and stats to show as signed-out, before it's clearing from the panoptes-client
- lib-classifier is updating per an app-project with signed out user state but checking user state from the panoptes-client that still has user state, causing UPP to load/persist

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- What user actions should my reviewer step through to review this PR?
  - sign in, go to Classify
  - note subject metatools (Add to Favorites, Add to Collection) enabled
  - sign out
  - nav, stats, recents (previously worked as expected) and metatools (previously didn't work as expected) should show as disabled/signed-out
- Which storybook stories should be reviewed? N/A
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated