### PR TITLE
Refactor classifier user authentication

### DIFF
--- a/packages/lib-classifier/test/mockStore/mockStore.js
+++ b/packages/lib-classifier/test/mockStore/mockStore.js
@@ -21,7 +21,9 @@ export const defaultClient = {
 
 export const defaultAuthClient = {
   checkBearerToken: sinon.stub().callsFake(() => Promise.resolve(null)),
-  checkCurrent: sinon.stub().callsFake(() => Promise.resolve(null))
+  checkCurrent: sinon.stub().callsFake(() => Promise.resolve(null)),
+  listen: sinon.stub(),
+  stopListening: sinon.stub()
 }
 
 /** build a mock store, with a branching workflow, steps, tasks and subjects. */


### PR DESCRIPTION
Refactor the `usePanoptesUser` hook to subscribe to changes in the auth client session, which matches how PFE handles login and logout. Remove SWR for fetching user sessions from the Panoptes Auth API.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## Linked Issue and/or Talk Post
- Closes #4119

## How to Review
Sign in and sign out on a project's classify page. Signing in should enable personalisation features in the classifier eg. personalised subject queues, QuickTalk, collections and favourites. Signing out should turn personalisation features off and start an anonymous classification session.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
