### PR TITLE
Fix data image viewer stories

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/BarChartViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/BarChartViewer.stories.js
@@ -1,4 +1,3 @@
-import { withKnobs, text, number, object } from '@storybook/addon-knobs';
 import zooTheme from '@zooniverse/grommet-theme';
 import { Box, Grommet, base as baseTheme } from 'grommet';
 import BarChartViewer from './BarChartViewer';
@@ -17,12 +16,11 @@ const config = {
   },
 };
 
-const darkThemeConfig = Object.assign({}, config, { backgrounds: backgrounds.darkDefault });
+const darkThemeConfig = { ...config, backgrounds: backgrounds.darkDefault };
 
 export default {
   title: 'Subject Viewers / BarChartViewer',
-  component: BarChartViewer,
-  decorators: [withKnobs]
+  component: BarChartViewer
 }
 
 export const LightTheme = () => {
@@ -33,21 +31,16 @@ export const LightTheme = () => {
   return (
     <Grommet theme={zooTheme}>
       <Box
-        background={text('container background', 'white')}
+        background='white'
         height="medium"
         pad="small"
         width="large"
       >
         <BarChartViewer
-          data={object('data', data)}
-          margin={{
-            bottom: number('bottom margin', margin.bottom),
-            left: number('left margin', margin.left),
-            right: number('right margin', margin.right),
-            top: number('top margin', margin.top),
-          }}
-          xAxisLabel={text('x axis label', xAxisLabel)}
-          yAxisLabel={text('y axis label', yAxisLabel)}
+          data={data}
+          margin={margin}
+          xAxisLabel={xAxisLabel}
+          yAxisLabel={yAxisLabel}
         />
       </Box>
     </Grommet>
@@ -64,11 +57,11 @@ export const DarkTheme = () => {
     data,
     chartOptions: { margin, xAxisLabel, yAxisLabel },
   } = mockData;
-  const darkZooTheme = Object.assign({}, zooTheme, { dark: true });
+  const darkZooTheme = { ...zooTheme, dark: true };
   return (
     <Grommet theme={darkZooTheme}>
       <Box
-        background={text('container background', darkZooTheme.global.colors['dark-3'])}
+        background={darkZooTheme.global.colors['dark-3']}
         height="medium"
         pad="small"
         width="large"
@@ -76,8 +69,8 @@ export const DarkTheme = () => {
         <BarChartViewer
           data={data}
           margin={margin}
-          xAxisLabel={text('x axis label', xAxisLabel)}
-          yAxisLabel={text('y axis label', yAxisLabel)}
+          xAxisLabel={xAxisLabel}
+          yAxisLabel={yAxisLabel}
         />
       </Box>
     </Grommet>
@@ -112,8 +105,8 @@ export const CustomThemeAndBarColor = () => {
         <BarChartViewer
           data={data}
           margin={margin}
-          xAxisLabel={text('x axis label', xAxisLabel)}
-          yAxisLabel={text('y axis label', yAxisLabel)}
+          xAxisLabel={xAxisLabel}
+          yAxisLabel={yAxisLabel}
         />
       </Box>
     </Grommet>
@@ -129,64 +122,24 @@ export const VariableStarPeriodBarCharts = () => {
   return (
     <Grommet theme={zooTheme}>
       <Box
-        background={text('container background', '#ffffff')}
+        background='#ffffff'
         direction="row"
-        height={text('parent container height', '300px')}
+        height='300px'
         gap="small"
         pad="small"
-        width={text('parent container width', '300px')}
+        width='300px'
       >
         <BarChartViewer
-          data={object('period data', variableStarPeriodMockData.data)}
-          margin={{
-            bottom: number(
-              'period bottom margin',
-              variableStarPeriodMockData.chartOptions.margin.bottom
-            ),
-            left: number('period left margin', variableStarPeriodMockData.chartOptions.margin.left),
-            right: number(
-              'period right margin',
-              variableStarPeriodMockData.chartOptions.margin.right
-            ),
-            top: number('period top margin', variableStarPeriodMockData.chartOptions.margin.top),
-          }}
-          xAxisLabel={text(
-            'period x-axis label',
-            variableStarPeriodMockData.chartOptions.xAxisLabel
-          )}
-          yAxisLabel={text(
-            'period y-axis label',
-            variableStarPeriodMockData.chartOptions.yAxisLabel
-          )}
+          data={variableStarPeriodMockData.data}
+          margin={variableStarPeriodMockData.chartOptions.margin}
+          xAxisLabel={variableStarPeriodMockData.chartOptions.xAxisLabel}
+          yAxisLabel={variableStarPeriodMockData.chartOptions.yAxisLabel}
         />
         <BarChartViewer
-          data={object('amplitude data', variableStarAmplitudeMockData.data)}
-          margin={{
-            bottom: number(
-              'amplitude bottom margin',
-              variableStarAmplitudeMockData.chartOptions.margin.bottom
-            ),
-            left: number(
-              'amplitude left margin',
-              variableStarAmplitudeMockData.chartOptions.margin.left
-            ),
-            right: number(
-              'amplitude right margin',
-              variableStarAmplitudeMockData.chartOptions.margin.right
-            ),
-            top: number(
-              'amplitude top margin',
-              variableStarAmplitudeMockData.chartOptions.margin.top
-            ),
-          }}
-          xAxisLabel={text(
-            'amplitude x-axis label',
-            variableStarAmplitudeMockData.chartOptions.xAxisLabel
-          )}
-          yAxisLabel={text(
-            'amplitude y-axis label',
-            variableStarAmplitudeMockData.chartOptions.yAxisLabel
-          )}
+          data={variableStarAmplitudeMockData.data}
+          margin={variableStarAmplitudeMockData.chartOptions.margin}
+          xAxisLabel={variableStarAmplitudeMockData.chartOptions.xAxisLabel}
+          yAxisLabel={variableStarAmplitudeMockData.chartOptions.yAxisLabel}
         />
       </Box>
     </Grommet>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/mockData.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/BarChartViewer/mockData.js
@@ -34,8 +34,8 @@ const dataWithVariableBarColor = letterFrequency.map((datum) => {
   return { color: '#1cc6b7', label: datum.letter, value: datum.frequency }
 })
 
-const mockData = Object.assign({}, { data: dataInZooFormat }, optionsMock)
-const mockDataWithColor = Object.assign({}, { data: dataWithVariableBarColor }, optionsMock)
+const mockData = { data: dataInZooFormat, ...optionsMock }
+const mockDataWithColor = { data: dataWithVariableBarColor, ...optionsMock }
 
 const xScale = scaleBand({
   domain: dataInZooFormat.map(datum => datum.label),

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.js
@@ -58,6 +58,11 @@ const DataImageViewer = forwardRef(function DataImageViewer(props, ref) {
     setAllowPanZoom('')
   }
 
+  /*
+    PH-TESS light curves use JSONData.x and JSONData.y.
+    SuperWASP Black Hole Hunters use JSONData.data.x and JSONData.data.y
+  */
+  const data = JSONData.data ? JSONData.data : JSONData
   return (
     <Grid
       areas={areas}
@@ -74,7 +79,7 @@ const DataImageViewer = forwardRef(function DataImageViewer(props, ref) {
         height='500px'
       >
         <ScatterPlotViewer
-          data={JSONData.data}
+          data={data}
           margin={{
             bottom: 50,
             left: 70,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/DataImageViewer/DataImageViewer.stories.js
@@ -1,12 +1,10 @@
 import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Grommet } from 'grommet'
-import { withKnobs, boolean, text, object } from '@storybook/addon-knobs'
 import { Factory } from 'rosie'
 import { Provider } from 'mobx-react'
 import asyncStates from '@zooniverse/async-states'
-import DataImageViewerContainer from './DataImageViewerContainer'
-import DataImageViewerConnector from './DataImageViewerConnector'
+import DataImageViewer from './index.js'
 import ImageToolbar from '../../../ImageToolbar'
 import SubjectViewerStore from '@store/SubjectViewerStore'
 import readme from './README.md'
@@ -68,27 +66,18 @@ const { colors } = zooTheme.global
 
 export default {
   title: 'Subject Viewers / DataImageViewer',
-  component: DataImageViewerContainer,
-  decorators: [withKnobs]
+  component: DataImageViewer
 }
 
 export function LightTheme() {
   return (
-    <Grommet
-      background={{
-        dark: 'dark-1',
-        light: 'light-1'
-      }}
-      theme={zooTheme}
-      themeMode='light'
-    >
+    <ViewerContext mode='light' theme={zooTheme}>
       <Box width='large'>
-        <DataImageViewerContainer
+        <DataImageViewer
           loadingState={asyncStates.success}
-          subject={subject}
         />
       </Box>
-    </Grommet>
+    </ViewerContext>
   )
 }
 
@@ -98,23 +87,15 @@ LightTheme.story = {
 }
 
 export function DarkTheme() {
-  const darkZooTheme = Object.assign({}, zooTheme, { dark: true })
+  const darkZooTheme = { ...zooTheme, dark: true }
   return (
-    <Grommet
-      background={{
-        dark: 'dark-1',
-        light: 'light-1'
-      }}
-      theme={darkZooTheme}
-      themeMode='dark'
-    >
+    <ViewerContext mode='dark' theme={zooTheme}>
       <Box width='large'>
-        <DataImageViewerContainer
+        <DataImageViewer
           loadingState={asyncStates.success}
-          subject={subject}
         />
       </Box>
-    </Grommet>
+    </ViewerContext>
   )
 }
 
@@ -131,21 +112,13 @@ DarkTheme.story = {
 
 export function NarrowView() {
   return (
-    <Grommet
-      background={{
-        dark: 'dark-1',
-        light: 'light-1'
-      }}
-      theme={zooTheme}
-      themeMode='light'
-    >
+    <ViewerContext mode='light' theme={zooTheme}>
       <Box width='large'>
-        <DataImageViewerContainer
+        <DataImageViewer
           loadingState={asyncStates.success}
-          subject={subject}
         />
       </Box>
-    </Grommet>
+    </ViewerContext>
   )
 }
 
@@ -163,10 +136,10 @@ export function PanZoom() {
   return (
     <ViewerContext mode='light' theme={zooTheme}>
       <Box direction='row' width='large'>
-        <DataImageViewerConnector
+        <DataImageViewer
           loadingState={asyncStates.success}
         />
-        <ImageToolbar />
+        <ImageToolbar width='4rem' />
       </Box>
     </ViewerContext>
   )

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/ScatterPlotViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/ScatterPlotViewer.stories.js
@@ -2,7 +2,6 @@ import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Grommet } from 'grommet'
 import { darken } from 'polished'
-import { withKnobs, boolean, text, number, object } from '@storybook/addon-knobs'
 import ScatterPlotViewer from './ScatterPlotViewer'
 import ScatterPlotViewerConnector from './ScatterPlotViewerConnector'
 import { Provider } from 'mobx-react'
@@ -94,7 +93,6 @@ function ViewerContext(props) {
 export default {
   title: 'Subject Viewers / ScatterPlotViewer',
   component: ScatterPlotViewer,
-  decorators: [withKnobs],
   parameters: {
     viewport: {
       defaultViewport: 'responsive'
@@ -114,13 +112,9 @@ export function LightTheme() {
     >
       <Box height='medium' width='large'>
         <ScatterPlotViewer
-          data={object('data', data)}
-          panning={boolean('panning', false)}
-          xAxisLabel={text('x axis label', 'x-axis')}
-          xAxisLabelOffset={number('x axis label offset', undefined)}
-          yAxisLabel={text('y axis label', 'y-axis')}
-          yAxisLabelOffset={number('y axis label offset', undefined)}
-          zooming={boolean('zooming', false)}
+          data={data}
+          xAxisLabel='x-axis'
+          yAxisLabel='y-axis'
         />
       </Box>
     </Grommet>
@@ -133,7 +127,7 @@ LightTheme.story = {
 }
 
 export function DarkTheme() {
-  const darkZooTheme = Object.assign({}, zooTheme, { dark: true })
+  const darkZooTheme = { ...zooTheme, dark: true }
 
   return (
     <Grommet
@@ -146,13 +140,9 @@ export function DarkTheme() {
     >
       <Box height='medium' width='large'>
         <ScatterPlotViewer
-          data={object('data', data)}
-          panning={boolean('panning', false)}
-          xAxisLabel={text('x axis label', 'x-axis')}
-          xAxisLabelOffset={number('x axis label offset', undefined)}
-          yAxisLabel={text('y axis label', 'y-axis')}
-          yAxisLabelOffset={number('y axis label offset', undefined)}
-          zooming={boolean('zooming', false)}
+          data={data}
+          xAxisLabel='x-axis'
+          yAxisLabel='y-axis'
         />
       </Box>
     </Grommet>
@@ -171,7 +161,7 @@ DarkTheme.story = {
 }
 
 export function NarrowView() {
-  const darkZooTheme = Object.assign({}, zooTheme, { dark: true })
+  const darkZooTheme = { ...zooTheme, dark: true }
   return (
     <Grommet
       background={{
@@ -183,13 +173,9 @@ export function NarrowView() {
     >
       <Box height='medium' width='large'>
         <ScatterPlotViewer
-          data={object('data', data)}
-          panning={boolean('panning', false)}
-          xAxisLabel={text('x axis label', 'x-axis')}
-          xAxisLabelOffset={number('x axis label offset', undefined)}
-          yAxisLabel={text('y axis label', 'y-axis')}
-          yAxisLabelOffset={number('y axis label offset', undefined)}
-          zooming={boolean('zooming', false)}
+          data={data}
+          xAxisLabel='x-axis'
+          yAxisLabel='y-axis'
         />
       </Box>
     </Grommet>
@@ -238,20 +224,18 @@ export function ErrorBars() {
     >
       <Box direction='row' height='medium' width='large'>
         <ScatterPlotViewer
-          data={object('data', data)}
-          panning={boolean('panning', true)}
+          data={data}
+          panning
           setOnZoom={setZoomCallback}
-          xAxisLabel={text('x axis label', 'x-axis')}
-          xAxisLabelOffset={number('x axis label offset', undefined)}
-          yAxisLabelOffset={number('y axis label offset', undefined)}
-          yAxisLabel={text('y axis label', 'y-axis')}
-          zooming={boolean('zooming', true)}
+          xAxisLabel='x-axis'
+          yAxisLabel='y-axis'
+          zooming
           zoomConfiguration={{
-            direction: text('zoom direction', 'both'),
-            minZoom: number('min zoom', 1),
-            maxZoom: number('max zoom', 10),
-            zoomInValue: number('zoom in scale', 1.2),
-            zoomOutValue: number('zoom out scale', 0.8)
+            direction: 'both',
+            minZoom: 1,
+            maxZoom: 10,
+            zoomInValue: 1.2,
+            zoomOutValue: 0.8
           }}
         />
       </Box>
@@ -275,23 +259,21 @@ export function KeplerLightCurve() {
     >
       <Box height='medium' width='large'>
         <ScatterPlotViewer
-          axisColor={text('axis color', colors['light-1'])}
-          backgroundColor={text('background color', darken(0.08, colors['neutral-1']))}
-          data={object('data', keplerMockDataWithOptions.data)}
+          axisColor={colors['light-1']}
+          backgroundColor={darken(0.08, colors['neutral-1'])}
+          data={keplerMockDataWithOptions.data}
           glyphColors={[colors['light-1']]}
           margin={keplerMockDataWithOptions.chartOptions.margin}
           padding={keplerMockDataWithOptions.chartOptions.padding}
-          panning={boolean('panning', false)}
           tickDirection='inner'
-          xAxisLabel={text('x axis label', keplerMockDataWithOptions.chartOptions.xAxisLabel)}
-          yAxisLabel={text('y axis label', keplerMockDataWithOptions.chartOptions.yAxisLabel)}
-          zooming={boolean('zooming', false)}
+          xAxisLabel={keplerMockDataWithOptions.chartOptions.xAxisLabel}
+          yAxisLabel={keplerMockDataWithOptions.chartOptions.yAxisLabel}
           zoomConfiguration={{
-            direction: text('zoom direction', 'both'),
-            minZoom: number('min zoom', 1),
-            maxZoom: number('max zoom', 10),
-            zoomInValue: number('zoom in scale', 1.2),
-            zoomOutValue: number('zoom out scale', 0.8)
+            direction: 'both',
+            minZoom: 1,
+            maxZoom: 10,
+            zoomInValue: 1.2,
+            zoomOutValue: 0.8
           }}
         />
       </Box>
@@ -310,14 +292,14 @@ export function PanAndZoom() {
       <Box direction='row' height='medium' width='large'>
         <ScatterPlotViewerConnector
           zoomConfiguration={{
-            direction: text('zoom direction', 'both'),
-            minZoom: number('min zoom', 1),
-            maxZoom: number('max zoom', 10),
-            zoomInValue: number('zoom in scale', 1.2),
-            zoomOutValue: number('zoom out scale', 0.8)
+            direction: 'both',
+            minZoom: 1,
+            maxZoom: 10,
+            zoomInValue: 1.2,
+            zoomOutValue: 0.8
           }}
         />
-        <ImageToolbar />
+        <ImageToolbar width='4rem' />
       </Box>
     </ViewerContext>
   )
@@ -333,7 +315,7 @@ export function MultipleSeries() {
     <ViewerContext theme={zooTheme}>
       <Box direction='row' height='medium' width='large'>
         <ScatterPlotViewerConnector />
-        <ImageToolbar />
+        <ImageToolbar width='4rem' />
       </Box>
     </ViewerContext>
   )

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/SubjectGroupViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SubjectGroupViewer/SubjectGroupViewer.stories.js
@@ -118,7 +118,7 @@ export const WithZoomControls = () => {
   const Toolbar = withKeyZoom(Box);
   return (
     <ViewerContext theme={zooTheme}>
-      <Toolbar direction="row">
+      <Toolbar direction="row" height='4rem'>
         <AnnotateButton />
         <MoveButton />
         <ZoomInButton />

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.stories.js
@@ -1,7 +1,5 @@
-import { storiesOf } from '@storybook/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Box, Grommet } from 'grommet'
-import { withKnobs, boolean, text, object } from '@storybook/addon-knobs'
 import { Factory } from 'rosie'
 import VariableStarViewer from './VariableStarViewerContainer'
 import VariableStarViewerConnector from './VariableStarViewerConnector'
@@ -152,7 +150,7 @@ export function PanZoom() {
         <VariableStarViewerConnector
           loadingState={asyncStates.success}
         />
-        <ImageToolbar />
+        <ImageToolbar width='4rem' />
       </Box>
     </ViewerContext>
   )


### PR DESCRIPTION
- fix `DataImageViewer` stories when the light curve data is in the `{ x, y }` format used by PH-TESS and the mock data.
- replace `Object.assign()` with spread operators in a few places.
- update `DataImageViewer` stories to use a mock store.
- limit the size of image toolbars in stories that use them.
- remove `addon-knobs`.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## Linked Issue and/or Talk Post
- towards #2370.
- fixes an issue where the [`DataImageViewer` stories](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/story/subject-viewers-dataimageviewer--light-theme&globals=locale:en;locales.en:English;locales.test:Test+Language) are showing `data is undefined`. 
<img width="978" alt="Screenshot of a 'data is undefined' error, and stack trace, showing in place of the data image viewer stories." src="https://user-images.githubusercontent.com/59547/212727420-a0fca50c-ec69-4e05-b7e5-d50723292317.png">

- removing `addon-knobs` also fixes an issue where the viewer crashes if you look at `ScatterPlotViewer` after loading `BarChartViewer`, or vice versa. 

## How to Review
Start the classifier storybook and try the stories for the various data subject viewers.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [ ] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated
