### PR TITLE
Disable real HTTP requests in tests

### DIFF
--- a/packages/app-content-pages/test/create-global-document.js
+++ b/packages/app-content-pages/test/create-global-document.js
@@ -1,6 +1,10 @@
 // Creates a global document object using jsdom to allow the use of the
 // `mount` method in enzyme.
 import { JSDOM } from 'jsdom'
+import nock from 'nock'
+
+// require all net requests to be mocked.
+nock.disableNetConnect()
 
 const jsdom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://localhost' })
 const { window } = jsdom

--- a/packages/app-project/test/create-global-document.js
+++ b/packages/app-project/test/create-global-document.js
@@ -2,6 +2,10 @@
 // `mount` method in enzyme.
 import { JSDOM } from 'jsdom'
 import fetch from 'node-fetch'
+import nock from 'nock'
+
+// require all net requests to be mocked.
+nock.disableNetConnect()
 
 const jsdom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://localhost' })
 const { window } = jsdom

--- a/packages/lib-classifier/test/setup.js
+++ b/packages/lib-classifier/test/setup.js
@@ -4,10 +4,14 @@ import sinonChai from 'sinon-chai'
 import dirtyChai from 'dirty-chai'
 import { JSDOM } from 'jsdom'
 import fetch from 'node-fetch'
+import nock from 'nock'
 
 chai.use(chaiDom)
 chai.use(dirtyChai)
 chai.use(sinonChai)
+
+// require all net requests to be mocked.
+nock.disableNetConnect()
 
 const jsdom = new JSDOM('<!doctype html><html><body></body></html>', {
   pretendToBeVisual: true, // See: https://github.com/jsdom/jsdom#pretending-to-be-a-visual-browser


### PR DESCRIPTION
Set [`nock.disableNetConnect()`](https://github.com/nock/nock#enabledisable-real-http-requests) for all tests. Any requests and responses that are required for tests must be mocked.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
app-content-pages
app-project
lib-classifier

## Linked Issue and/or Talk Post
- towards #4105.

## How to Review
Run the tests.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
