### PR TITLE
Require selfsigned in local development

### DIFF
--- a/packages/app-content-pages/server/server.js
+++ b/packages/app-content-pages/server/server.js
@@ -4,8 +4,6 @@ if (process.env.NEWRELIC_LICENSE_KEY) {
 
 const express = require('express')
 const next = require('next')
-const https = require('https')
-const selfsigned = require('selfsigned')
 
 const setLogging = require('./set-logging')
 const setCacheHeaders = require('./set-cache-headers')
@@ -37,6 +35,9 @@ app.prepare().then(() => {
   })
 
   if (APP_ENV === 'development') {
+    const https = require('https')
+    const selfsigned = require('selfsigned')
+
     const attrs = [{ name: 'commonName', value: hostname }];
     const { cert, private: key } = selfsigned.generate(attrs, { days: 365 })
     return https.createServer({ cert, key }, server)

--- a/packages/app-project/server/server.js
+++ b/packages/app-project/server/server.js
@@ -4,8 +4,6 @@ if (process.env.NEWRELIC_LICENSE_KEY) {
 
 const express = require('express')
 const next = require('next')
-const https = require('https')
-const selfsigned = require('selfsigned')
 
 const setLogging = require('./set-logging')
 const setCacheHeaders = require('./set-cache-headers')
@@ -37,6 +35,9 @@ app.prepare().then(() => {
   })
 
   if (APP_ENV === 'development') {
+    const https = require('https')
+    const selfsigned = require('selfsigned')
+
     const attrs = [{ name: 'commonName', value: hostname }];
     const { cert, private: key } = selfsigned.generate(attrs, { days: 365 })
     return https.createServer({ cert, key }, server)


### PR DESCRIPTION
Only load `https` and `selfsigned` in local development.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-content-pages
- app-project

## Linked Issue and/or Talk Post
- docker builds erroring with "Error: Cannot find module 'selfsigned'"

## Describe your changes
- in both app's `server.js` - moves `https` and `selfsigned` (selfsigned is a dev dependency) within if block that checks `APP_ENV` = "development" environment

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed