### PR TITLE
Remove @babel/plugin-proposal-decorators

### DIFF
--- a/packages/lib-classifier/.babelrc
+++ b/packages/lib-classifier/.babelrc
@@ -3,9 +3,6 @@
     ["@babel/plugin-transform-runtime", {
       "helpers": false
     }],
-    ["@babel/plugin-proposal-decorators", {
-      "legacy": true
-    }],
     "@babel/plugin-proposal-logical-assignment-operators",
     ["transform-imports", {
       "lodash": {

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -61,7 +61,6 @@
   "devDependencies": {
     "@babel/cli": "~7.20.7",
     "@babel/core": "~7.20.2",
-    "@babel/plugin-proposal-decorators": "~7.20.0",
     "@babel/plugin-proposal-logical-assignment-operators": "~7.20.7",
     "@babel/plugin-transform-runtime": "~7.19.1",
     "@babel/preset-env": "~7.20.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -415,7 +415,7 @@
     "@babel/helper-plugin-utils" "^7.18.6"
     "@babel/plugin-syntax-class-static-block" "^7.14.5"
 
-"@babel/plugin-proposal-decorators@^7.12.12", "@babel/plugin-proposal-decorators@~7.20.0":
+"@babel/plugin-proposal-decorators@^7.12.12":
   version "7.20.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.20.13.tgz#b6bea3b18e88443688fa7ed2cc06d2c60da9f4a7"
   integrity sha512-7T6BKHa9Cpd7lCueHBBzP0nkXNina+h5giOZw+a8ZpMfPFY19VjJAjIxyFHuWkhCWgL6QMqRiY/wB1fLXzm6Mw==


### PR DESCRIPTION
We don't use class decorators any more, so the Babel plugin isn't being used.

## Package
lib-classifier

## Linked Issue and/or Talk Post
- #2712.

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Maintenance
- [x] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
