### PR TITLE
Add filters default value to MetadataModal

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.js
@@ -37,7 +37,7 @@ export function formatValue (value) {
 export default function MetadataModal ({
   active = false,
   closeFn = () => true,
-  filters,
+  filters = defaultFilters,
   metadata,
   prefixes = defaultFilters
 }) {

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.spec.js
@@ -13,4 +13,19 @@ describe('MetadataModal', function () {
     const rows = within(tableBody).getAllByRole('row')
     expect(rows).to.have.lengthOf(3)
   })
+
+  describe('with undefined filters', function () {
+    it('should render the correct number of table rows', function () {
+      render(
+        <DefaultStory
+          filters={undefined}
+        />
+      )
+      const tableBody = document.querySelector('tbody')
+      const rows = within(tableBody).getAllByRole('row')
+
+      // the DefaultStory mock subject metadata includes 5 items, 2 of which should be filtered/hidden per default filters, leaving 3 rows rendered
+      expect(rows).to.have.lengthOf(3)
+    })
+  })
 })


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #4210 

## Describe your changes
- adds default value per `filterByLabel` helper of `['#', '!']` to `filters` prop of MetadataModal

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - https://local.zooniverse.org:8080/?project=1862&workflow=3317
- What user actions should my reviewer step through to review this PR?
  - click "Subject Info" button, note ID and Target at minimum shouldn't show, or any subject metadata field that starts with `#` or `!`
- Which storybook stories should be reviewed?
  - no changes to, but http://localhost:6006/?path=/story/meta-tools-metadatamodal--default&args=filters:!null&globals=locale:en;locales.en:English;locales.test:Test+Language will continue to work
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated - the current MetadataModal test uses the DefaultStory which defines `filters` causing the bug linked not to be caught, but I think the story is preferable with the defined `filters`, so I haven't updated the story, just added a test, though I'm not really sure the additional test is necessary, open to suggestion 