### PR TITLE
Remove drop-down icon from hamburger menu

### DIFF
--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.4.1] 2023-01-28
+
+### Fixed
+- Removed the default drop-down menu icon from the hamburger menu button on small screens.
+
 ## [1.4.0] 2023-01-13
 
 ### Changed

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -3,7 +3,7 @@
   "description": "Zooniverse React Components",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": {

--- a/packages/lib-react-components/src/ZooHeader/components/NarrowMainNavMenu/NarrowMainNavMenu.js
+++ b/packages/lib-react-components/src/ZooHeader/components/NarrowMainNavMenu/NarrowMainNavMenu.js
@@ -31,6 +31,7 @@ export default function NarrowMainNavMenu({
 
   return (
     <NarrowMenu
+      icon={false}
       items={menuListItems}
       label={<StyledMenuIcon color='#B2B2B2' text='Main Navigation' />}
     />


### PR DESCRIPTION
Remove the default Grommet menu icon from the hamburger menu button on small screens.

## Package
lib-react-components 

## Linked Issue and/or Talk Post
- closes #4207. 

## How to Review
Look at the Zooniverse Header in the storybook with the viewport set to a phone screen size. 


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed