### PR TITLE
Remove @next/bundle-analyzer

### DIFF
--- a/packages/app-content-pages/README.md
+++ b/packages/app-content-pages/README.md
@@ -47,14 +47,6 @@ yarn storybook
 
 Starts a Storybook server on port 9001 by default.
 
-### Bundle Analyser
-
-```sh
-yarn analyse
-```
-
-Run a build with [`@next/bundle-analyzer`](https://www.npmjs.com/package/@next/bundle-analyzer) enabled. It generates two reports on bundle sizes: the browser bundle and the server bundle.
-
 ## Running in production
 
 ### Docker

--- a/packages/app-content-pages/next.config.js
+++ b/packages/app-content-pages/next.config.js
@@ -4,9 +4,6 @@ const { execSync } = require('child_process')
 const Dotenv = require('dotenv-webpack')
 const path = require('path')
 const withSourceMaps = require('@zeit/next-source-maps')()
-const withBundleAnalyzer = require('@next/bundle-analyzer')({
-  enabled: process.env.ANALYSE === 'true',
-})
 
 const assetPrefixes = {
   development: '/about',
@@ -35,7 +32,7 @@ console.info({ APP_ENV, PANOPTES_ENV, assetPrefix })
 
 const nextConfig = {
   assetPrefix,
-  basePath: '/about', 
+  basePath: '/about',
 
   compiler: {
     styledComponents: true,
@@ -72,5 +69,4 @@ const nextConfig = {
   }
 }
 
-module.exports = withBundleAnalyzer(withSourceMaps(nextConfig))
-
+module.exports = withSourceMaps(nextConfig)

--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -6,7 +6,6 @@
   "version": "0.0.1",
   "main": "index.js",
   "scripts": {
-    "analyse": "ANALYSE=true next build",
     "build": "APP_ENV=${APP_ENV:-development} NODE_ENV=${NODE_ENV:-production} PANOPTES_ENV=${PANOPTES_ENV:-production} next build",
     "dev": "APP_ENV=${APP_ENV:-development} PANOPTES_ENV=${PANOPTES_ENV:-production} node server/server.js",
     "lint": "next lint",
@@ -16,7 +15,6 @@
     "test:ci": "BABEL_ENV=test mocha --config ./test/.mocharc.json --reporter=min \"./{src,server,test}/**/*.spec.js\""
   },
   "dependencies": {
-    "@next/bundle-analyzer": "~13.0.4",
     "@sentry/browser": "~7.34.0",
     "@sentry/node": "~7.34.0",
     "@zeit/next-source-maps": "0.0.4-canary.1",

--- a/packages/app-project/README.md
+++ b/packages/app-project/README.md
@@ -31,13 +31,6 @@ yarn storybook
 
 If you want to run the app using a node inspect mode, run `yarn dev:inspect`. Then you can [connect your preferred debugger](https://nextjs.org/docs/advanced-features/debugging#step-2-connect-to-the-debugger) to be able to see the server logs and debug.
 
-### Bundle Analyser
-```sh
-yarn analyse
-```
-
-Run a build with [`@next/bundle-analyzer`](https://www.npmjs.com/package/@next/bundle-analyzer) enabled. It generates two reports on bundle sizes: the browser bundle and the server bundle.
-
 ## Running in production
 
 Next.js [treats the build and serve tasks as separate steps](https://github.com/zeit/next.js/#production-deployment) when running in production.

--- a/packages/app-project/next.config.js
+++ b/packages/app-project/next.config.js
@@ -6,9 +6,6 @@ const { execSync } = require('child_process')
 const path = require('path')
 const withSourceMaps = require('@zeit/next-source-maps')()
 const { i18n } = require('./next-i18next.config')
-const withBundleAnalyzer = require('@next/bundle-analyzer')({
-  enabled: process.env.ANALYSE === 'true',
-})
 
 const talkHosts = require('./config/talkHosts')
 const assetPrefixes = {
@@ -110,4 +107,4 @@ const nextConfig = {
   }
 }
 
-module.exports = withBundleAnalyzer(withSourceMaps(nextConfig))
+module.exports = withSourceMaps(nextConfig)

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -6,7 +6,6 @@
   "version": "0.0.1",
   "main": "index.js",
   "scripts": {
-    "analyse": "ANALYSE=true next build",
     "build": "APP_ENV=${APP_ENV:-development} NODE_ENV=${NODE_ENV:-production} PANOPTES_ENV=${PANOPTES_ENV:-production} next build",
     "build-storybook": "build-storybook -s public",
     "dev": "APP_ENV=${APP_ENV:-development} PANOPTES_ENV=${PANOPTES_ENV:-staging} node server/server.js",
@@ -19,7 +18,6 @@
   },
   "dependencies": {
     "@artsy/fresnel": "~6.1.0",
-    "@next/bundle-analyzer": "~13.0.4",
     "@sentry/browser": "~7.34.0",
     "@sentry/node": "~7.34.0",
     "@sindresorhus/string-hash": "~1.2.0",


### PR DESCRIPTION
## PR Overview

Packages: app-project, app-content-pages
Essentially reverts: #3905

At the moment, we're investigating an issue where JS files on FEM pages are encountering a bottleneck on the server. (See [Slack](https://zooniverse.slack.com/archives/CANKLB50E/p1675257413579159)) This PR is an experimental fix suggested by Jim - since it's _only_ the JS bundles that are encountering issues, perhaps we should explore anything on the FEM code that might be affecting those bundles.

As Jim noted, this is unlikely, since 3905 was introduced in early December, and the issues we're encountering are recent. Still, it's worth a shot.

Ready for review