### PR TITLE
Add undo, redo, and tests to the freehand line tool.

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -6,6 +6,7 @@ import DrawingToolMarks from './components/DrawingToolMarks'
 import TranscribedLines from './components/TranscribedLines'
 import SubTaskPopup from './components/SubTaskPopup'
 import getFixedNumber from '../../helpers/getFixedNumber'
+import locationValidator from '../../helpers/locationValidator'
 
 const DrawingCanvas = styled('rect')`
   ${(props) =>
@@ -33,8 +34,9 @@ function InteractionLayer({
   height,
   marks = [],
   move,
-  setActiveMark = () => {},
+  setActiveMark = () => { },
   scale = 1,
+  subject,
   width,
   played,
   duration
@@ -46,7 +48,7 @@ function InteractionLayer({
     setCreating(false)
   }
 
-  if(activeMark?.finished && !activeMark.isValid) {
+  if (activeMark?.finished && !activeMark.isValid) {
     activeTool.deleteMark(activeMark)
     setActiveMark(undefined)
   }
@@ -204,12 +206,15 @@ InteractionLayer.propTypes = {
     taskType: PropTypes.string,
     value: PropTypes.array
   }).isRequired,
-  frame: PropTypes.number,
-  marks: PropTypes.array,
-  setActiveMark: PropTypes.func,
-  height: PropTypes.number.isRequired,
   disabled: PropTypes.bool,
+  frame: PropTypes.number,
+  height: PropTypes.number.isRequired,
+  marks: PropTypes.array,
   scale: PropTypes.number,
+  setActiveMark: PropTypes.func,
+  subject: PropTypes.shape({
+    locations: PropTypes.arrayOf(locationValidator)
+  }),
   width: PropTypes.number.isRequired
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -5,6 +5,7 @@ import InteractionLayer from './InteractionLayer'
 import PreviousMarks from './components/PreviousMarks'
 import SHOWN_MARKS from '@helpers/shownMarks'
 import { withStores } from '@helpers'
+import locationValidator from '../../helpers/locationValidator'
 
 function storeMapper(classifierStore) {
   const activeStepAnnotations = classifierStore.subjects.active?.stepHistory?.latest?.annotations
@@ -57,9 +58,11 @@ export function InteractionLayerContainer({
   marks = [],
   move = false,
   scale = 1,
-  setActiveMark = () => {},
+  setActiveMark = () => { },
   shownMarks = SHOWN_MARKS.ALL,
+  subject,
   taskKey = '',
+  viewBox,
   width,
   played,
   duration
@@ -80,15 +83,17 @@ export function InteractionLayerContainer({
           activeToolIndex={activeToolIndex}
           annotation={annotation}
           disabled={disabled}
+          duration={duration}
           frame={frame}
           height={height}
           key={taskKey}
           marks={visibleMarksPerFrame}
           move={move}
-          scale={scale}
           played={played}
-          duration={duration}
           setActiveMark={setActiveMark}
+          scale={scale}
+          subject={subject}
+          viewBox={viewBox}
           width={width}
         />
       )}
@@ -111,6 +116,9 @@ InteractionLayerContainer.propTypes = {
   scale: PropTypes.number,
   setActiveMark: PropTypes.func,
   shownMarks: PropTypes.string,
+  subject: PropTypes.shape({
+    locations: PropTypes.arrayOf(locationValidator)
+  }),
   taskKey: PropTypes.string,
   width: PropTypes.number.isRequired
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
@@ -1,12 +1,13 @@
 import { useContext } from 'react';
 import PropTypes from 'prop-types'
 import { DeleteButton, Mark } from '@plugins/drawingTools/components'
+import { LineControls } from '@plugins/drawingTools/experimental/components'
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 
 function DrawingToolMarks({
   activeMark = {
     id: '',
-    setSubTaskVisibility: () => {}
+    setSubTaskVisibility: () => { }
   },
   marks = [],
   onDelete = () => true,
@@ -14,9 +15,9 @@ function DrawingToolMarks({
   onFinish = () => true,
   onMove = () => true,
   onSelectMark = () => true,
-  pointerEvents='painted',
+  pointerEvents = 'painted',
   scale = 1,
-  played
+  played,
 }) {
   const { canvas } = useContext(SVGContext)
 
@@ -25,6 +26,7 @@ function DrawingToolMarks({
     mark.tool: the tool definition (e.g. "small red Point")
     mark.videoTime: indicates when the mark was created. Only relevant to certain time-based tools, otherwise undefined.
      */
+
     const { tool, videoTime } = mark
     const MarkingComponent = mark.toolComponent
     const isActive = mark.id === activeMark?.id
@@ -94,13 +96,20 @@ function DrawingToolMarks({
           scale={scale}
           played={played}
         />
-        {isActive && (
+        {isActive && mark.tool.type !== 'freehandLine' && (
           <DeleteButton
             label={`Delete ${tool.type}`}
             mark={mark}
             scale={scale}
             onDelete={deleteMark}
             onDeselect={deselectMark}
+          />
+        )}
+        {isActive && mark.tool.type == 'freehandLine' && (
+          <LineControls
+            mark={mark}
+            scale={scale}
+            onDelete={deleteMark}
           />
         )}
       </Mark>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGImage/SVGImage.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGImage/SVGImage.js
@@ -20,7 +20,7 @@ const INVERT =
     </defs>
   </svg>`
 
-export default function SVGImage ({
+export default function SVGImage({
   invert = false,
   move = false,
   naturalHeight,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -5,8 +5,9 @@ import { useRef } from 'react'
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import InteractionLayer from '../InteractionLayer'
 import ZoomControlButton from '../ZoomControlButton'
+import locationValidator from '../../helpers/locationValidator'
 
-function SingleImageViewer (props) {
+function SingleImageViewer(props) {
   const {
     children,
     enableInteractionLayer = true,
@@ -16,6 +17,7 @@ function SingleImageViewer (props) {
     rotate = 0,
     scale = 1,
     svgMaxHeight = null,
+	subject,
     title = {},
     viewBox,
     width,
@@ -27,7 +29,7 @@ function SingleImageViewer (props) {
   const transform = `rotate(${rotate} ${width / 2} ${height / 2})`
 
   return (
-    <SVGContext.Provider value={{ canvas }}>
+    <SVGContext.Provider value={{ canvas, viewBox, rotate, width, height }}>
       {zoomControlFn && (
         <ZoomControlButton
           onClick={zoomControlFn}
@@ -65,6 +67,7 @@ function SingleImageViewer (props) {
                 scale={scale}
                 height={height}
                 width={width}
+                subject={subject}
               />
             )}
           </g>
@@ -88,6 +91,9 @@ SingleImageViewer.propTypes = {
   /** Calculated in SVGPanZoom component */
   svgMaxHeight: PropTypes.string,
   /** Passed from container */
+  subject: PropTypes.shape({
+    locations: PropTypes.arrayOf(locationValidator)
+  }),
   title: PropTypes.shape({
     id: PropTypes.string,
     text: PropTypes.string

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -12,7 +12,7 @@ import SingleImageViewer from './SingleImageViewer'
 
 const DEFAULT_HANDLER = () => true
 
-function SingleImageViewerContainer ({
+function SingleImageViewerContainer({
   enableInteractionLayer = true,
   enableRotation = DEFAULT_HANDLER,
   frame = 0,
@@ -40,15 +40,15 @@ function SingleImageViewerContainer ({
     onError
   })
 
-  useEffect(function onMount () {
+  useEffect(function onMount() {
     enableRotation()
   }, [])
 
-  function setOnDrag (callback) {
+  function setOnDrag(callback) {
     setDragMove(() => callback)
   }
 
-  function onDrag (event, difference) {
+  function onDrag(event, difference) {
     dragMove?.(event, difference)
   }
 
@@ -61,6 +61,7 @@ function SingleImageViewerContainer ({
 
   if (loadingState !== asyncStates.initialized) {
     const subjectID = subject?.id || 'unknown'
+
     return (
       <SVGPanZoom
         img={subjectImage.current}
@@ -86,6 +87,7 @@ function SingleImageViewerContainer ({
           width={img.naturalWidth}
           zoomControlFn={zoomControlFn}
           zooming={zooming}
+          subject={subject}
         >
           <g ref={subjectImage}>
             <SVGImage

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
@@ -10,18 +10,18 @@ const SELECTED_STROKE_WIDTH = 4
 const StyledGroup = styled('g')`
   &:focus {
     ${(props) =>
-      css`
+    css`
         outline: solid 4px ${props.focusColor};
       `}
   }
 
   :hover {
     ${(props) =>
-      props.dragging
-        ? css`
+    props.dragging
+      ? css`
             cursor: grabbing;
           `
-        : css`
+      : css`
             cursor: grab;
           `}
   }
@@ -149,6 +149,7 @@ const Mark = forwardRef(function Mark(
   return (
     <StyledGroup
       {...mainStyle}
+      data-testid="mark-mark"
       aria-label={label}
       dragging={dragging}
       focusable

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.stories.js
@@ -1,9 +1,7 @@
-import zooTheme from '@zooniverse/grommet-theme'
 import mockStore from '@test/mockStore'
 import {
   DrawingStory,
   subject,
-  subTasksSnapshot,
   subtaskStrings,
   updateStores
 } from '@plugins/drawingTools/stories/helpers.js'
@@ -15,9 +13,7 @@ const drawingTaskSnapshot = DrawingTaskFactory.build({
   taskKey: 'T1',
   tools: [
     {
-      color: zooTheme.global.colors['drawing-red'],
       type: 'freehandLine',
-      details: subTasksSnapshot
     }
   ],
   type: 'drawing'
@@ -33,8 +29,6 @@ drawingTaskSnapshot.strings = {
   ...taskSubtaskStrings
 }
 
-// should think of a better way to do create bounds for the story
-// this is a rough approximation of what the positioning is like now
 const mockBounds = {
   x: 100,
   y: 100,
@@ -45,6 +39,8 @@ const mockBounds = {
   bottom: 0,
   left: 0
 }
+
+let freehandLineTool
 
 function setupStores() {
   try {
@@ -66,30 +62,25 @@ function setupStores() {
     const mockStores = mockStore({ subject, workflow })
     const [drawingTask] = mockStores.workflowSteps.active.tasks
     drawingTask.setActiveTool(0)
-    const freehandLine = drawingTask.activeTool.createMark()
-    freehandLine.initialPosition({ x: 125, y: 125 })
-    freehandLine.setCoordinates([
+    freehandLineTool = drawingTask.activeTool.createMark({}, [
+      { x: 200, y: 100 },
+      { x: 175, y: 75 },
+      { x: 150, y: 75 },
+      { x: 125, y: 100 },
       { x: 125, y: 125 },
-      { x: 128, y: 128 },
-      { x: 138, y: 157 },
-      { x: 175, y: 183 },
-      { x: 198, y: 195 },
-      { x: 202, y: 205 },
-      { x: 215, y: 215 },
-      { x: 239, y: 225 },
-      { x: 265, y: 235 },
-      { x: 286, y: 200 },
-      { x: 318, y: 163 },
-      { x: 323, y: 168 },
-      { x: 333, y: 157 },
-      { x: 228, y: 158 },
-      { x: 175, y: 202 },
-      { x: 170, y: 180 },
-      { x: 160, y: 170 },
-      { x: 150, y: 160 },
-      { x: 140, y: 150 },
-      { x: 135, y: 145 },
-      { x: 130, y: 140 }
+      { x: 150, y: 150 },
+      { x: 175, y: 150 },
+      { x: 200, y: 125 },
+      { x: 201, y: 101 },
+    ])
+
+    freehandLineTool = drawingTask.activeTool.createMark({}, [
+      { x: 400, y: 100 },
+      { x: 375, y: 75 },
+      { x: 350, y: 75 },
+      { x: 325, y: 100 },
+      { x: 325, y: 125 },
+      { x: 350, y: 150 },
     ])
 
     return mockStores
@@ -103,35 +94,15 @@ const stores = setupStores()
 
 export default {
   title: 'Drawing tools / Freehand line',
-  component: FreehandLine
+  component: FreehandLine,
+  parameters: {
+    viewport: {
+      defaultViewport: 'responsive'
+    }
+  }
 }
 
-export function Complete(args) {
+export const Drawing = (args) => {
   updateStores(args, mockBounds, stores)
   return <DrawingStory stores={stores} />
-}
-Complete.args = {
-  activeMark: false,
-  finished: false,
-  subtask: false
-}
-
-export function Active(args) {
-  updateStores(args, mockBounds, stores)
-  return <DrawingStory stores={stores} />
-}
-Active.args = {
-  activeMark: true,
-  finished: false,
-  subtask: false
-}
-
-export function Subtask(args) {
-  updateStores(args, mockBounds, stores)
-  return <DrawingStory stores={stores} />
-}
-Subtask.args = {
-  activeMark: true,
-  finished: true,
-  subtask: true
 }

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/README.md
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/README.md
@@ -1,70 +1,182 @@
 # Freehand Line Drawing Tool
 
-The `Freehand Line` tool is an svg element using the `<path>` element. The `<path>` element is defined by one parameter: `d`. The `d` attribute can be made of up several different commands and parameters. See [Path Reference](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths) for a full list.
+The `Freehand Line` tool is an svg element using the `<path>` element. See [Path Reference](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths) if unfamiliar. The intention of the tool is to draw one or more partial or completed irregular circles - the `<path>` - on an image subject. Additionally, the user is able to splice/edit their `<path>` to correct an irregularity, which could come from a machine annotation or accidental user input. The complexity of this tool is in maintaining a full undo/redo internal state while creating, extending, editing, and closing the path. The most complex aspect is in maintaining a true undo/redo history while splicing a closed `<path>` and the potential removal of the existing start and end points of the `<path>`. All of this complexity in state is constrained to the `Freehand Line Model`.
 
-## Path Commands used in Freehand Line tool
+## Goals
+- User is able to start drawing a `<path>` anywhere on the subject
+- User is able to extend an existing, unclosed `<path>`
+- User is able to close an unclosed `<path>`
+- User is able to edit/splice an existing, unclosed or closed `<path>` to correct part of the path
+- User is able to undo all actions performed on the `<path>`
+- User is able to redo all undone actions performed on the `<path>` until a new action is performed and destroys the redo saved state
 
-M - `Move To`: This is the starting point and will be the first x and y coordinate for a `<path>`.
+## Configuration
+- User is able to configure the line resolution to accomodate preferred `<path>` thickness
+- User is able to configure the minimum points a `<path>` should have to be considered a valid `<path>`
+- User is able to configure the minimum poitns to create a new Undo action
 
-L - `Line To`: This takes an x and y coordinate and draws a line from the current position to a new position. As a user draws with the `Freehand Line` tool, many x and y coordinates will be appended to this `L` command.
+## Initial Drawing Path Model
 
-Z - `Close Path`: We append `Z` to the end of the `<path>` when a user draws a line that returns to the starting point. Once a user's drawing path is within 10px of the starting point, the `Z` will be appended and the path will be closed.
-
-The final composition of the `<path>` is of type `string`.
-
-An example:
-
+### External Model State
 ```javascript
-<path d='M 342,252 L 343,252 344,252 345,252 346,252 Z' />
+{
+	pathX: types.array(FixedNumber),
+  pathY: types.array(FixedNumber),
+}
 ```
 
-## Initial Drawing Path
+When the `<path>` is considered complete and sent to the API, it is sent as an array of x coordinates and an array of y coordinates.
+
+### Internal, Volatile Model State
+```javascript
+{
+  scale: types.number,
+  lineResolution: types.optional(types.number, 0.5),
+  minimumPoints: types.optional(types.number, 20),
+  undoActionPointThreshold: types.optional(types.number, 20),
+
+  points: types.array(SingleCoord),
+  dragPoint: types.maybeNull(SingleCoord),
+  closePoint: types.maybeNull(SingleCoord),
+  pathIsClosed: types.boolean,
+  isDragging: false,
+
+  spliceActive: types.boolean,
+  spliceReverse: types.boolean,
+  spliceThroughBeginning: types.boolean,
+  spliceDragPointIndex: types.maybeNull(types.number),
+  spliceClosePointIndex: types.maybeNull(types.number),
+  splicePoints: types.array(SingleCoord),
+
+  drawActions: types.array(ActionType),
+  redoActions: types.array(ActionType),
+}
+```
+
+Internally, the `<path>` details are stored as an array of `{ x, y }` coordinate objects in the `points` object property. The `dragPoint` indicates the point from which a `<path>` can be extended, or in the case of splicing, is the starting point for the splice. The `closePoint` is the point for which a `<path>` will close which, when unclosed, is the starting point. In the case of splicing, the `closePoint` is the desired end point for the splice action and is proactively chosen by the user. The `pathIsClosed` property is used internally by the model to determine if a `dragPoint` or `closePoint` should be set and displayed. The `isDragging` parameter is used for managing `<path>` extension, specifically tracking `mousedown` and `mouseup` user actions.
+
+The `spliceActive`, `spliceReverse`, `spliceThroughBeginning`, `spliceDragPointIndex`, `spliceClosePointIndex`, and `splicePoints` properties are used to manage active splice state across any undo/redo action state.
+
+The `drawActions` and `redoActions` are an array of objects that contain the successive series of actions that a user has performed. If given an array of valid `drawActions`, the `Freehand Line Model` could successfully draw the user's path. This is used extensively within the tests for this tool.
 
 ### Methods
 
-- `path()`
+- `afterCreate()`
+
+Automatically invoked on mark creation. This checks to see if points were passed into the model on creation, and if so, it invokes `initialize()` to setup the model with those points.
+
+- `initialize(points=[])`
+
+When the tool's model is initiliazed, this method is invoked to setup the internal state. It is passed an array of `{ x, y }` coordinate objects and sets up the `dragPoint`, `closePoint`, and `pathIsClosed` attributes along with sane defaults for all other state properties.
+
 - `isValid()`
 
-When a user clicks and drags, a `<path>` is created.
+A path is only created if a user has clicked and dragged long enough to add the minimum number of coordinates set in the `minimumPoints` property. By default this is 20.
 
-At the starting point, one will see a solid handle which has a stroke and fill matching the `currentColor`. If the user releases the mouse button before closing the path, a handle will appear at the last drawing point. The handle will have a stroke matching the `currentColor` and no fill. This transparent handle is an indicator to the user that they can continue drawing!
+- `closeDistance()`
 
-NOTE: A path is only created if a user has clicked and dragged long enough to add 20 coordinates to the `<path>`.
-This is verified using `isValid()`.
-
-## Continue Drawing
-
-### Methods
-
-- `appendPath()`
-
-A user can continue drawing by clicking and dragging on the transparent handle. All coordinates will be appended to the active path via the `appendPath()` method.
-
-## Close Path
-
-### Methods
+A path or splice action will autoclose when the `dragPoint` is within 10 scale-adjusted pixels of the `closePoint`. 
 
 - `isCloseToStart()`
 
-When a user's drawing path returns to the starting point and is within 10px, the path will close and both handles will no longer be visible. This is done by simply appending `Z` to the end of the `<path>`.
+This method performs the mathematical calculation for `closeDistance()`
 
-## Undo
+- `pointDistance(p1, p2)`
 
-### Methods
+Calculates the distance between the points `p1` and `p2`
 
-- `shortenPath()`
+- `findClosestPathPointIndex({ x, y })`
 
-Near the starting point is an `Undo` button. When a user clicks this button, 20 coordinates will be removed from the end of the `<path>`. This will be the 20 most recently drawn coordinates.
+Finds the closest existing `<path>` point to a given `{ x, y }` pair.
 
-A user can use the `Undo` feature after a path has been closed!
+- `visiblePathsRender()`
 
-## Path Classification Data Structure
+The model translates its internal state into potentially three arrays of `{ x, y }` points for svg rendering. The three potential paths are:
 
-When a `<path>` is sent to our api, its sent as an array of x coordinates and an array of y coordinates.
+1. Path start point to splice start point or end point
+2. Splice start point or end point to path end point
+3. Splice start point to splice dragPoint
 
-```json
-{
-  "pathX": "[ 345, 350, 355… ]",
-  "pathY": "[ 160, 165, 170… ]"
-}
-```
+- `splicePathRender()`
+
+If in a splicing state, this method returns the to-be-removed partial path of points.
+
+- `toData()`
+
+Returns the existing volatile model state object and is used for debugging purposes in the model tests.
+
+- `setDragPoint(point)`, `setClosePoint(point)`, `setScale(scale)`, `setLineResolution(lineResolution)`, `setMinimumPoints(minimumPoints)`, `setUndoActionPointThreshold(undoActionPointThreshold)`,
+
+All of the above are convenience methods describing their intended purpose.
+
+- `initialPosition(event)`
+
+When a user clicks and drags, this is the first method invoked by the parent component and kicks off internal state build and managing/watching for user drag events. It is a required/expected method.
+
+- `initialDrag(point)`
+
+When a user drags after the initial click to create a new `<path>` is invoked, this method handles all drag events. It is a required/expected method invoked by the parent component.
+
+- `close()`
+
+Method that proxies externally-initiated requests to close the existing, unfinished `<path>`.
+
+- `appendPathStart()`
+
+This method is invoked on the `mouseDown` event to extend an existing `<path>` or extend a path in a splice state.
+
+- `appendPath({ x, y })`
+
+This method is invoked on the `mouseMove` event after the `appendPathStart()` method has been invoked. It remains active until the path is closed, the `dragPoint` is within closing distance to the `closePoint` or the user releases the mouse button.
+
+- `appendPathEnd()`
+
+This method is invoked on the `mouseUp` event and ends the current user append or edit activity.
+
+- `closePath()`
+
+Manages the internal model state when either the splice path is closed or when the base `<path>` is closed. Proxies to `closeSplice()` for splices.
+
+- `closeSplice()`
+
+Manages the internal model state upon completion of a splice. Very complex in that the spliced portion of the `<path>` has to handled for all cases: open/closed paths, forward/reverse direction, and removal of existing start/end points in the closed path state.
+
+`undo()`
+
+Performs complementary model state change to each action to return it to a former state. Each undo action object is moved to the `redoActions` property once completed.
+
+`redo()`
+
+Undo the undo. Each redo action is moved to the `undoActions` property once completed.
+
+- `redoActionsClear()`
+
+After several actions have been undone, there is the ability to redo those actions. This method destroys those actions upon new drawing/splicing actions.
+
+`splicePathDragPoint(point)`
+
+Manages the internal model state changes when the user double clicks to create a `spliceDragPoint`.
+
+- `splicePathClosePoint(point)`
+
+Manages the internal model state changes when the user clicks to create a `spliceClosePoint`.
+
+- `splicePathSetup()`
+
+Sets up the internal model state for splicing after `splicePathDragPoint()` and `splicePathClosePoint()` have been invoked.
+
+- `spliceReset()`
+
+Clears internal model splice state.
+
+- `move()`
+
+Required method from parent component that is unused. It is not desired to be able to move/translate the `<path>` in this context.
+
+- `inactive()`
+
+When the user clicks outside of an active path, particularly while in a splicing state, this method undoes all incomplete splicing activity.
+
+- `finish()`
+
+This method is invoked twice - once upon the initial path `mouseup` event and when the user clicks to complete the subject classification entirely. In the first scenario, we ensure the `<path>` is a valid path otherwise it is destroyed. In the second scenario, we convert the internal `{ x, y }` representation to the final model `{ pathX: [], pathY: [] }` data structure for API ingestion.

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.js
@@ -1,0 +1,176 @@
+import React, { forwardRef, useState, useContext } from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { Tooltip } from '@zooniverse/react-components'
+import SVGContext from '@plugins/drawingTools/shared/SVGContext'
+import { useTranslation } from '@translations/i18n'
+import { Pan, Radial, Redo, Trash, Undo } from 'grommet-icons'
+
+const LineControls = forwardRef(function LineControls({
+  mark,
+  scale = 1,
+  onDelete
+},
+  ref
+) {
+  let [activePosition, setActivePosition] = useState('tr')
+  const { t } = useTranslation('plugins')
+
+  const ARROW_STROKE_COLOR = 'white'
+  const FILL_COLOR = 'black'
+  const HOVER_COLOR = 'grey'
+  const STROKE_WIDTH = 0.5 / scale
+  const OUTER_RADIUS = 40 / scale
+  const INNER_RADIUS = 20 / scale
+
+  const { viewBox, rotate, width, height } = useContext(SVGContext)
+  const [x, y, w, h] = viewBox.split(' ').map(n => parseInt(n, 10))
+  const p = (activePosition == 'tr')
+    ? { x: x + (50 / scale), y: y + (50 / scale) }
+    : { x: x + w - (50 / scale), y: y + (50 / scale) }
+
+  const StyledPath = styled('path')`
+    fill: ${FILL_COLOR}
+    &:hover {
+      cursor: pointer;
+      fill: ${HOVER_COLOR};
+    }
+  `
+
+  function onEnterOrSpace(ev, func) {
+    if (ev.keyCode === 13 || ev.keyCode === 32) func()
+  }
+
+  const buttons = [
+    {
+      label: t('LineControls.undo'),
+      action: mark.undo,
+      icon: {
+        type: Undo,
+        size: (10 / scale),
+        x: p.x - (27 / scale),
+        y: p.y - (27 / scale),
+      },
+      path: `M ${p.x - OUTER_RADIUS} ${p.y}
+        A ${OUTER_RADIUS} ${OUTER_RADIUS} 0 0 1 ${p.x} ${p.y - OUTER_RADIUS}
+        L ${p.x} ${p.y - INNER_RADIUS}
+        A ${INNER_RADIUS} ${INNER_RADIUS} 0 0 0 ${p.x - INNER_RADIUS} ${p.y}
+        Z`
+    },
+    {
+      label: t('LineControls.redo'),
+      action: mark.redo,
+      icon: {
+        type: Redo,
+        size: (10 / scale),
+        x: p.x + (17 / scale),
+        y: p.y - (27 / scale),
+      },
+      path: `M ${p.x + OUTER_RADIUS} ${p.y}
+        A ${OUTER_RADIUS} ${OUTER_RADIUS} 0 0 0 ${p.x} ${p.y - OUTER_RADIUS}
+        L ${p.x} ${p.y - INNER_RADIUS}
+        A ${INNER_RADIUS} ${INNER_RADIUS} 0 0 1 ${p.x + INNER_RADIUS} ${p.y}
+        Z`
+    },
+    {
+      label: t('LineControls.close'),
+      action: mark.close,
+      icon: {
+        type: Radial,
+        size: (10 / scale),
+        x: p.x - (27 / scale),
+        y: p.y + (17 / scale),
+      },
+      path: `M ${p.x - OUTER_RADIUS} ${p.y}
+        A ${OUTER_RADIUS} ${OUTER_RADIUS} 0 0 0 ${p.x} ${p.y + OUTER_RADIUS}
+        L ${p.x} ${p.y + INNER_RADIUS}
+        A ${INNER_RADIUS} ${INNER_RADIUS} 0 0 1 ${p.x - INNER_RADIUS} ${p.y}
+        Z`
+    },
+    {
+      label: t('LineControls.delete'),
+      action: onDelete,
+      icon: {
+        type: Trash,
+        size: (10 / scale),
+        x: p.x + (17 / scale),
+        y: p.y + (17 / scale),
+      },
+      path: `M ${p.x + OUTER_RADIUS} ${p.y}
+        A ${OUTER_RADIUS} ${OUTER_RADIUS} 0 0 1 ${p.x} ${p.y + OUTER_RADIUS}
+        L ${p.x} ${p.y + INNER_RADIUS}
+        A ${INNER_RADIUS} ${INNER_RADIUS} 0 0 0 ${p.x + INNER_RADIUS} ${p.y}
+        Z`
+    },
+    {
+      label: t('LineControls.move'),
+      action: () => {
+        setActivePosition((activePosition == 'tl') ? 'tr' : 'tl')
+      },
+      icon: {
+        type: Pan,
+        size: (20 / scale),
+        x: p.x - (10 / scale),
+        y: p.y - (10 / scale),
+      },
+      path: `M ${p.x - INNER_RADIUS} ${p.y}
+        A ${INNER_RADIUS} ${INNER_RADIUS} 0 0 0 ${p.x + INNER_RADIUS} ${p.y}
+        A ${INNER_RADIUS} ${INNER_RADIUS} 0 0 0 ${p.x - INNER_RADIUS} ${p.y}
+        Z`
+    },
+  ]
+
+  return (
+    <g
+      ref={ref}
+      role='group'
+      aria-label={t('lineControls.lineControls')}
+      focusable='false'
+      transform={`rotate(${-rotate} ${width / 2} ${height / 2})`}
+	  fill={FILL_COLOR}
+    >
+      {buttons.map(({ label, path, action, icon }, index) => {
+        const IconComponent = icon.type
+        return <g focusable='false' key={index}>
+          <Tooltip label={label}>
+            <StyledPath
+              role='button'
+              aria-label={label}
+              focusable='true'
+              tabIndex='0'
+
+              d={path}
+              stroke={ARROW_STROKE_COLOR}
+              strokeWidth={STROKE_WIDTH}
+              onPointerDown={action}
+              onKeyDown={(ev) => { onEnterOrSpace(ev, action) }}
+            ></StyledPath>
+          </Tooltip>
+          <svg
+            height={icon.size}
+            width={icon.size}
+            x={icon.x}
+            y={icon.y}
+          >
+            <IconComponent
+              color='white'
+              size={`${icon.size}px`}
+              focusable='false'
+            />
+          </svg>
+        </g>
+      })}
+    </g>
+  )
+})
+
+LineControls.propTypes = {
+  mark: PropTypes.shape({
+    id: PropTypes.string,
+    setSubTaskVisibility: PropTypes.func
+  }),
+  scale: PropTypes.number,
+  onDelete: PropTypes.func,
+}
+
+export default LineControls

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/index.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/index.js
@@ -1,0 +1,1 @@
+export { default } from './LineControls'

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/index.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/index.js
@@ -1,2 +1,3 @@
 export { default as FreehandLine } from './FreehandLine'
+export { default as LineControls } from './LineControls'
 export { default as TranscriptionLine } from './TranscriptionLine'

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/FreehandLine/FreehandLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/FreehandLine/FreehandLine.js
@@ -4,277 +4,636 @@ import { Mark } from '@plugins/drawingTools/models/marks'
 import { FreehandLineTool } from '@plugins/drawingTools/models/tools'
 import { FixedNumber } from '@plugins/drawingTools/types/'
 
-const LINE_RESOLUTION = 0.5
-const MINIMUM_POINTS = 20
-
 const SingleCoord = types.model('SingleCoord', {
   x: FixedNumber,
   y: FixedNumber
 })
 
+const ActionType = types.model('ActionType', {
+  type: types.enumeration([
+    'append',
+    'end',
+    'start',
+    'splice-append',
+    'splice-close-point',
+    'splice-drag-point',
+    'splice-end'
+  ]),
+  pointIndexDrag: types.number,
+  pointIndexClose: types.number,
+  pointsFromDrag: types.array(SingleCoord),
+  pointsFromClose: types.array(SingleCoord),
+  pointsSpliceCount: types.number,
+  isReversed: types.boolean,
+  throughBeginning: types.boolean,
+})
+
 const FreehandLineModel = types
   .model('FreehandLineModel', {
     pathX: types.array(FixedNumber),
-    pathY: types.array(FixedNumber)
+    pathY: types.array(FixedNumber),
   })
   .views((self) => ({
-    get coords() {
-      const [x] = self.pathX
-      const [y] = self.pathY
-      return { x, y }
-    },
-
-    deleteButtonPosition(scale) {
-      const BUFFER = 16
-      const x = self.pathX[0] - BUFFER / scale
-      const y = self.pathY[0] - BUFFER / scale
-      return { x, y }
-    },
-
     get isValid() {
-      return self.pathX.length > MINIMUM_POINTS
+      return true
     },
 
     get tool() {
       return getParentOfType(self, FreehandLineTool)
     },
 
-    get initialPoint() {
-      const [x] = self.pathX
-      const [y] = self.pathY
-      if (!x) {
-        return null
-      }
-      return { x, y }
-    },
-
-    get lastPoint() {
-      const x = self.pathX.at(-1)
-      const y = self.pathY.at(-1)
-      if (!x) {
-        return null
-      }
-      return { x, y }
-    },
-
-    get points() {
-      return self.pathX.map((x, index) => {
-        const y = self.pathY[index]
-        return { x, y }
-      })
-    },
-
-    get isClosed() {
-      const firstPoint = self.initialPoint
-      const lastPoint = self.lastPoint
-      if (firstPoint && lastPoint) {
-        const dist = self.getDistance(firstPoint.x, firstPoint.y, lastPoint.x, lastPoint.y)
-        return dist < 10
-      }
-      return false
-    },
-
-    // this determines if drawing point is close to initial point
-    get isCloseToStart() {
-      const { dragPoint, targetPoint } = self
-      if (dragPoint && targetPoint) {
-        const dist = self.getDistance(dragPoint.x, dragPoint.y, targetPoint.x, targetPoint.y)
-        return dist < 10
-      }
-      return false
-    },
-
     get toolComponent() {
       return FreehandLineComponent
     },
 
-    selectPoint({ x, y }) {
-      const distances = self.points.map(point => self.getDistance(x, y, point.x, point.y))
+    get closeDistance() {
+      return Math.ceil(10 / self.scale)
+    },
+
+    get isCloseToStart() {
+      if (self.dragPoint && self.closePoint) {
+        return self.pointDistance(self.dragPoint, self.closePoint) < self.closeDistance
+      }
+      return false
+    },
+
+    pointDistance(p1, p2) {
+      return self.getDistance(p1.x, p1.y, p2.x, p2.y)
+    },
+
+    findClosestPathPointIndex({ x, y }) {
+      const distances = self.points.map(point => self.pointDistance({ x: x, y: y }, point))
       const minDistance = Math.min(...distances)
-      const selectedIndex = distances.indexOf(minDistance)
-      return self.points[selectedIndex]
-    }
+      return distances.indexOf(minDistance)
+    },
+
+    get visiblePathsRender() {
+      // There are up to 3 paths
+      // 1) Start point to splice start/end
+      // 2) Splice start/end to end point
+      // 3) Splice start to splice drag
+
+      let paths = []
+
+      if (self.spliceActive) {
+        if (self.spliceThroughBeginning) {
+          // Because it's closed we can draw 1 path
+          let startIndex = (self.spliceReverse)
+            ? self.spliceDragPointIndex
+            : self.spliceClosePointIndex
+          let endIndex = (self.spliceReverse)
+            ? self.spliceClosePointIndex
+            : self.spliceDragPointIndex
+
+          paths.push(self.points.slice(startIndex, endIndex + 1))
+        } else {
+          // Scenarion #1 and #2
+          let endIndex = (self.spliceReverse)
+            ? self.spliceClosePointIndex
+            : self.spliceDragPointIndex
+
+          paths.push(self.points.slice(0, endIndex + 1))
+
+          let startIndex = (self.spliceReverse)
+            ? self.spliceDragPointIndex
+            : self.spliceClosePointIndex
+
+          paths.push(self.points.slice(startIndex, self.points.length))
+        }
+      } else {
+        paths.push(self.points)
+      }
+
+      paths.push(self.splicePoints)
+
+      return paths
+    },
+
+    get splicePathRender() {
+      // Dashed line path when splicing
+      if (!self.spliceActive) {
+        return []
+      }
+
+      let pnts = []
+      let startIndex = (self.spliceReverse)
+        ? self.spliceClosePointIndex
+        : self.spliceDragPointIndex
+      let endIndex = (self.spliceReverse)
+        ? self.spliceDragPointIndex
+        : self.spliceClosePointIndex
+
+      if (self.spliceThroughBeginning) {
+        pnts = pnts.concat(self.points.slice(endIndex, self.points.length))
+        pnts = pnts.concat(self.points.slice(0, startIndex + 1))
+      } else {
+        pnts = pnts.concat(self.points.slice(startIndex, endIndex + 1))
+      }
+
+      return pnts
+    },
+
+    get toData() {
+      return {
+        scale: self.scale,
+        points: self.points,
+        dragPoint: self.dragPoint,
+        closePoint: self.closePoint,
+        pathIsClosed: self.pathIsClosed,
+        isDragging: self.isDragging,
+
+        spliceActive: self.spliceActive,
+        spliceReverse: self.spliceReverse,
+        spliceThroughBeginning: self.spliceThroughBeginning,
+        spliceDragPointIndex: self.spliceDragPointIndex,
+        spliceClosePointIndex: self.spliceClosePointIndex,
+        splicePoints: self.splicePoints,
+
+        drawActions: self.drawActions,
+        redoActions: self.redoActions,
+      }
+    },
   }))
   .volatile(self => ({
-    clipPath: types.array(SingleCoord),
+    scale: types.number,
+    lineResolution: types.optional(types.number, 0.5),
+    minimumPoints: types.optional(types.number, 20),
+    undoActionPointThreshold: types.optional(types.number, 20),
+
+    points: types.array(SingleCoord),
     dragPoint: types.maybeNull(SingleCoord),
-    originalPath: types.array(SingleCoord),
-    targetPoint: types.maybeNull(SingleCoord)
+    closePoint: types.maybeNull(SingleCoord),
+    pathIsClosed: types.boolean,
+    isDragging: false,
+
+    spliceActive: types.boolean,
+    spliceReverse: types.boolean,
+    spliceThroughBeginning: types.boolean,
+    spliceDragPointIndex: types.maybeNull(types.number),
+    spliceClosePointIndex: types.maybeNull(types.number),
+    splicePoints: types.array(SingleCoord),
+
+    drawActions: types.array(ActionType),
+    redoActions: types.array(ActionType),
   }))
   .actions((self) => ({
-    initialPosition({ x, y }) {
-      self.pathX.push(x)
-      self.pathY.push(y)
-      self.dragPoint = null
-      self.targetPoint = null
-      self.clipPath = []
-    },
+    afterCreate: () => {
+      // points assumes [{ x, y }, { x, y }]
+      let points = self.points || []
 
-    initialDrag({ x, y }) {
-      const dist = self.getDistance(x, y, self.lastPoint.x, self.lastPoint.y)
-      if (dist > LINE_RESOLUTION) {
-        self.pathX.push(x)
-        self.pathY.push(y)
+      if (self.pathX && self.pathY) {
+        points = self.pathX.map((x, i) => {
+          return { x: self.pathX[i], y: self.pathY[i] }
+        })
       }
+
+      self.initialize(points)
     },
 
-    setCoordinates(points) {
-      self.pathX = points.map(({ x, y }) => x)
-      self.pathY = points.map(({ x, y }) => y)
-    },
+    initialize(points = []) {
+      self.scale = 1
+      self.lineResolution = isNaN(self.lineResolution) ? 0.5 : self.lineResolution
+      self.minimumPoints = isNaN(self.minimumPoints) ? 20 : self.minimumPoints
+      self.undoActionPointThreshold = isNaN(self.undoActionPointThreshold) ? 20 : self.undoActionPointThreshold
+      self.pathIsClosed = false
+    	self.points = [...points]
 
-    move() {
-      return
-    },
+      self.setClosePoint(self.points.at(0))
+      self.setDragPoint(self.points.at(-1))
 
-    appendPath({ x, y }) {
-      const dist = self.getDistance(x, y, self.lastPoint.x, self.lastPoint.y)
-      if (dist > LINE_RESOLUTION && !self.isClosed) {
-        self.pathX.push(x)
-        self.pathY.push(y)
+      if (self.isCloseToStart && self.points.length > self.minimumPoints) {
+        self.setClosePoint(null)
+        self.setDragPoint(null)
+        self.pathIsClosed = true
       }
-      if (self.isClosed) {
-        self.clipPath = []
-      }
-    },
 
-    splicePath({ x, y }) {
-      if (!self.targetPoint) {
-        return true
-      }
-      const dist = self.getDistance(x, y, self.dragPoint.x, self.dragPoint.y)
-      if (dist > LINE_RESOLUTION) {
-        const dragIndex = self.points.indexOf(self.dragPoint)
-        const nextPoint = dragIndex + 1
-        self.pathX.splice(nextPoint, 0, x)
-        self.pathY.splice(nextPoint, 0, y)
-        self.dragPoint = self.points[nextPoint]
-        if (self.isCloseToStart) {
-          self.clipPath = []
-        }
-      }
-    },
+      self.splicePoints = []
+      self.spliceDragPointIndex = null
+      self.spliceClosePointIndex = null
+      self.spliceActive = false
+      self.spliceReverse = false
+      self.spliceThroughBeginning = false
 
-    cancelClipPath() {
-      self.setCoordinates(self.originalPath)
-      self.setClipPath([])
-    },
-
-    cutSegment(startPoint, endPoint) {
-      /*
-        If the line has already been cut into subpaths, restore the original path.
-        Note that this will overwrite both dragPoint and targetPoint.
-      */
-      if (self.clipPath.length > 0) {
-        self.setCoordinates(self.originalPath)
-      } else {
-        self.originalPath = self.points.map(({ x, y }) => ({ x, y }))
-      }
-      const dragPoint = self.selectPoint(startPoint)
-      let startIndex = self.points.indexOf(dragPoint)
-      const targetPoint = self.selectPoint(endPoint)
-      let endIndex = self.points.indexOf(targetPoint)
-      let spansStartPoint = false
-      if (self.isClosed) {
-        const firstPoint = Math.min(startIndex, endIndex)
-        const lastPoint = Math.max(startIndex, endIndex)
-        const deleteCount = lastPoint - firstPoint - 1
-        const distFromEnd = self.points.length - lastPoint - 1
-        const distFromStart = firstPoint
-        spansStartPoint = (distFromEnd + distFromStart) < deleteCount
-      }
-      if (!spansStartPoint) {
-        /*
-        Segment lies entirely within the line path, so splice points
-        from dragIndex to targetIndex.
-        */
-        self.splice(startIndex, endIndex)
-      } else {
-        /*
-        Segment spans the start point of a closed loop, so
-        trim the ends of the line back to dragIndex and targetIndex.
-        */
-        self.trim(startIndex, endIndex)
-      }
-    },
-
-    revertEdits() {
-      self.cancelClipPath()
-      self.dragPoint = null
-      self.targetPoint = null
-    },
-
-    setClipPath(points = []) {
-      self.clipPath = points
+      self.drawActions = []
+      self.redoActions = []
     },
 
     setDragPoint(point) {
-      self.dragPoint = point ? self.selectPoint(point) : null
+      self.dragPoint = point
     },
 
-    setTargetPoint(point) {
-      self.targetPoint = point ? self.selectPoint(point) : null
+    setClosePoint(point) {
+      self.closePoint = point
     },
 
-    shortenPath() {
-      let lengthToRemove = 20
-      while (lengthToRemove--) {
-        self.pathX.pop()
-        self.pathY.pop()
+    setScale(scale) {
+      self.scale = scale
+    },
+
+    setLineResolution(lineResolution) {
+      self.lineResolution = lineResolution
+    },
+
+    setMinimumPoints(minimumPoints) {
+      self.minimumPoints = minimumPoints
+    },
+
+    setUndoActionPointThreshold(undoActionPointThreshold) {
+      self.undoActionPointThreshold = undoActionPointThreshold
+    },
+
+    initialPosition(event) {
+      self.initialize([{ x: event.x, y: event.y }])
+      self.appendPathStart()
+    },
+
+    initialDrag(point) {
+      self.appendPath(point)
+    },
+
+    close() {
+      self.closePath()
+    },
+
+    appendPathStart() {
+      self.isDragging = true
+
+      self.drawActions.push({
+        type: (self.spliceActive) ? 'splice-append' : 'append',
+        pointIndexDrag: self.spliceDragPointIndex,
+        pointIndexClose: self.spliceClosePointIndex,
+        pointsFromDrag: [],
+        pointsFromClose: [],
+        pointsSpliceCount: 0,
+        isReversed: self.spliceReverse,
+        throughBeginning: self.spliceThroughBeginning
+      })
+
+      // Helps with where to set the dragPoint
+      if (self.spliceActive && self.splicePoints.length == 0) {
+        self.splicePoints = [self.points[self.spliceDragPointIndex]]
+      }
+
+      self.redoActionsClear()
+    },
+
+    appendPath({ x, y }) {
+      if (!self.isDragging) return
+
+      const pathPoints = (self.spliceActive)
+        ? self.splicePoints
+        : self.points
+      const newPoint = { x: x, y: y }
+
+      if (self.pointDistance(newPoint, pathPoints.at(-1)) < self.lineResolution) {
+        return
+      }
+
+      pathPoints.push(newPoint)
+
+      // Create new undo-able action 
+      if (self.drawActions.at(-1).pointsFromDrag.length > self.undoActionPointThreshold) {
+        self.appendPathStart()
+      }
+
+      self.drawActions.at(-1).pointsFromDrag.push(newPoint)
+      self.setDragPoint(newPoint)
+
+      if (self.isCloseToStart && (self.spliceActive || (!self.spliceActive && self.points.length > self.minimumPoints))) {
+        self.isDragging = false
+        self.closePath()
       }
     },
 
-    splice(startIndex, endIndex) {
-      let firstPoint = Math.min(startIndex, endIndex)
-      let lastPoint = Math.max(startIndex, endIndex)
-      /*
-        Reverse the path, if necessary, so that the first point clicked
-        is always the draggable point.
-      */
-      if (firstPoint === endIndex) {
-        const lastIndex = self.points.length - 1
-        self.pathX.reverse()
-        self.pathY.reverse()
-        firstPoint = lastIndex - startIndex
-        lastPoint = lastIndex - endIndex
+    appendPathEnd() {
+      self.isDragging = false
+      if (self.drawActions.at(-1).pointsFromDrag.length == 0) {
+        self.drawActions.pop()
       }
-      const deleteCount = lastPoint - firstPoint - 1
-      const clippedPoints = self.points.slice(firstPoint, lastPoint + 1)
-      self.clipPath = clippedPoints.map(({ x, y }) => ({ x, y }))
-      self.pathX.splice(firstPoint + 1, deleteCount)
-      self.pathY.splice(firstPoint + 1, deleteCount)
-      // Make the ends of the spliced section draggable.
-      self.dragPoint = self.points[firstPoint]
-      self.targetPoint = self.points[firstPoint + 1]
     },
 
-    trim(startIndex, endIndex) {
-      let firstPoint = Math.min(startIndex, endIndex)
-      let lastPoint = Math.max(startIndex, endIndex)
-      /*
-        Reverse the path, if necessary, so that the first point clicked
-        is always at the end of the new line. The end of an open line
-        is the draggable point.
-      */
-      if (lastPoint === endIndex) {
-        const lastIndex = self.points.length - 1
-        self.pathX.reverse()
-        self.pathY.reverse()
-        lastPoint = lastIndex - startIndex
-        firstPoint = lastIndex - endIndex
+    closePath() {
+      if (!self.spliceActive) {
+        self.drawActions.push({
+          type: 'end',
+          pointIndexDrag: -1,
+          pointIndexClose: -1,
+          pointsFromDrag: [
+            {
+              x: self.points.at(0).x,
+              y: self.points.at(0).y
+            }
+          ],
+          pointsFromClose: [],
+          pointsSpliceCount: 0,
+          isReversed: false,
+          throughBeginning: false
+        })
+        self.points.push(self.points.at(0))
+        self.setDragPoint(null)
+        self.setClosePoint(null)
+        self.pathIsClosed = true
+      } else {
+        let spliceEndAction = self.closeSplice()
+        self.drawActions.push(spliceEndAction)
       }
-      const clippedPoints = [ ...self.points.slice(lastPoint), ...self.points.slice(0, firstPoint + 1)]
-      self.clipPath = clippedPoints.map(({ x, y }) => ({ x, y }))
-      // Move the end of the line back to lastPoint.
-      self.pathX.splice(lastPoint + 1)
-      self.pathY.splice(lastPoint + 1)
-      // Move the start of the line forward to firstPoint.
-      self.pathX.splice(0, firstPoint)
-      self.pathY.splice(0, firstPoint)
-      // Make the ends of the new, open line draggable.
-      self.dragPoint = null
-      self.targetPoint = null
-    }
+    },
+
+    closeSplice() {
+      // remove our splice starting point 
+      self.splicePoints.shift()
+
+      let closeSpliceAction = {
+        type: 'splice-end',
+        pointIndexDrag: self.spliceDragPointIndex,
+        pointIndexClose: self.spliceClosePointIndex,
+        pointsFromDrag: [],
+        pointsFromClose: [],
+        pointsSpliceCount: self.splicePoints.length,
+        isReversed: self.spliceReverse,
+        throughBeginning: self.spliceThroughBeginning,
+      }
+
+      let startIndex = (self.spliceReverse)
+        ? self.spliceClosePointIndex
+        : self.spliceDragPointIndex
+      let endIndex = (self.spliceReverse)
+        ? self.spliceDragPointIndex
+        : self.spliceClosePointIndex
+
+      // we don't want to remove the start index but everything in between
+      startIndex++
+
+      if (self.spliceThroughBeginning) {
+        // When we remove our spliced points we start the path at the lowest-indexed end
+        if (self.spliceReverse) self.splicePoints = self.splicePoints.reverse()
+        self.splicePoints.push(self.points.at(endIndex))
+
+        closeSpliceAction.pointsFromClose = closeSpliceAction.pointsFromClose.concat(self.points.slice(startIndex, self.points.length))
+        closeSpliceAction.pointsFromDrag = closeSpliceAction.pointsFromDrag.concat(self.points.slice(0, endIndex))
+
+        self.points.splice(startIndex, self.points.length - startIndex)
+        self.points.splice(0, endIndex)
+        self.points.splice(self.points.length, 0, ...self.splicePoints)
+      } else {
+        closeSpliceAction.pointsFromDrag = closeSpliceAction.pointsFromDrag.concat(self.points.slice(startIndex, endIndex))
+
+        if (self.spliceReverse) {
+          self.splicePoints = self.splicePoints.reverse()
+        }
+
+        self.points.splice(startIndex, endIndex - startIndex, ...self.splicePoints)
+      }
+
+      self.spliceReset()
+      self.setDragPoint(self.pathIsClosed ? null : self.points.at(-1))
+      self.setClosePoint(self.pathIsClosed ? null : self.points.at(0))
+
+      return closeSpliceAction
+    },
+
+    undo() {
+      if (self.drawActions.length == 0) {
+        // remove a mark that was created, not loaded
+        if (self.points.length == 1) {
+          self.finish()
+        }
+        return
+      }
+      const action = self.drawActions.at(-1)
+
+
+      if (action.type == 'start') {
+        self.drawActions.pop()
+        self.tool.deleteMark(self)
+      } else if (action.type == 'end') {
+        self.points.pop()
+        self.setDragPoint(self.points.at(-1))
+        self.setClosePoint(self.points.at(0))
+        self.drawActions.pop()
+      } else if (action.type == 'append') {
+        let indexStart = self.points.length - action.pointsFromDrag.length
+        self.points.splice(indexStart, action.pointsFromDrag.length)
+        self.setDragPoint(self.points.at(-1))
+        self.drawActions.pop()
+      } else if (action.type == 'splice-drag-point') {
+        self.spliceDragPointIndex = null
+        self.setDragPoint((self.pathIsClosed) ? null : self.points.at(-1))
+        self.setClosePoint((self.pathIsClosed) ? null : self.points.at(0))
+        self.drawActions.pop()
+      } else if (action.type == 'splice-close-point') {
+        self.splicePoints.length = 0
+        self.setClosePoint(null)
+        self.spliceReverse = false
+        self.spliceThroughBeginning = false
+        self.spliceActive = false
+        self.spliceClosePointIndex = null
+        self.drawActions.pop()
+      } else if (action.type == 'splice-append') {
+        let indexStart = self.splicePoints.length - action.pointsFromDrag.length
+        self.splicePoints.splice(indexStart, action.pointsFromDrag.length)
+        self.setDragPoint(self.splicePoints.at(-1))
+        self.drawActions.pop()
+      } else if (action.type == 'splice-end') {
+        if (action.throughBeginning) {
+          let spliceIndex = Math.abs(action.pointIndexDrag - action.pointIndexClose)
+
+          self.splicePoints = self.splicePoints.concat(self.points.slice(spliceIndex, self.points.length - 1));
+
+          if (action.isReversed) {
+            self.splicePoints = self.splicePoints.reverse()
+          }
+
+          // we add 1 because we don't splice out either drag/close point
+          self.points.splice(spliceIndex + 1, self.points.length - spliceIndex, ...action.pointsFromClose)
+          self.points.splice(0, 0, ...action.pointsFromDrag)
+        } else {
+          let spliceIndex = (action.isReversed)
+            ? action.pointIndexClose
+            : action.pointIndexDrag
+
+          self.splicePoints = self.splicePoints.concat(self.points.slice(spliceIndex, (spliceIndex + action.pointsSpliceCount + 1)));
+
+          if (action.isReversed) {
+            self.splicePoints = self.splicePoints.reverse()
+          }
+
+          // we add 1 because we don't splice out either drag/close point
+          self.points.splice(spliceIndex + 1, action.pointsSpliceCount, ...action.pointsFromDrag)
+        }
+        self.spliceActive = true
+        self.spliceReverse = action.isReversed
+        self.spliceThroughBeginning = action.throughBeginning
+        self.spliceDragPointIndex = action.pointIndexDrag
+        self.spliceClosePointIndex = action.pointIndexClose
+
+        self.setDragPoint(self.splicePoints.at(-1))
+        self.setClosePoint(self.points[self.spliceClosePointIndex])
+
+        self.drawActions.pop()
+      }
+
+      self.redoActions.push(action)
+    },
+
+    redo() {
+      if (self.redoActions.length == 0) return
+
+      const action = self.redoActions.at(-1)
+
+      if (action.type == 'end') {
+        self.closePath()
+      } else if (action.type == 'append') {
+        self.points.splice(self.points.length, 0, ...action.pointsFromDrag)
+        self.setDragPoint(self.points.at(-1))
+        self.drawActions.push(action)
+      } else if (action.type == 'splice-drag-point') {
+        self.spliceDragPointIndex = action.pointIndexDrag
+        self.setDragPoint(self.points[action.pointIndexDrag])
+        self.setClosePoint(null)
+        self.drawActions.push(action)
+      } else if (action.type == 'splice-close-point') {
+        self.setClosePoint(self.points[action.pointIndexDrag])
+        self.drawActions.push(action)
+        self.splicePathSetup()
+      } else if (action.type == 'splice-append') {
+        // complement the redo of appendPathStart
+        if (self.splicePoints.length == 0) {
+          self.splicePoints.push(self.dragPoint)
+        }
+
+        self.splicePoints.splice(self.splicePoints.length, 0, ...action.pointsFromDrag)
+        self.setDragPoint(self.splicePoints.at(-1))
+        self.drawActions.push(action)
+      } else if (action.type == 'splice-end') {
+        self.closeSplice()
+        self.drawActions.push(action)
+      }
+
+      self.redoActions.pop()
+    },
+
+    redoActionsClear() {
+      self.redoActions.length = 0
+    },
+
+    splicePathDragPoint(point) {
+      if (self.spliceDragPointIndex) {
+        return
+      }
+
+      let closestPointIndex = self.findClosestPathPointIndex(point)
+
+      self.drawActions.push({
+        type: 'splice-drag-point',
+        pointIndexDrag: closestPointIndex,
+        pointIndexClose: -1,
+        pointsFromDrag: [],
+        pointsFromClose: [],
+        pointsSpliceCount: 0,
+        isReversed: false,
+        throughBeginning: false
+      })
+
+      self.spliceDragPointIndex = closestPointIndex
+      self.setDragPoint(self.points.at(closestPointIndex))
+      self.setClosePoint(null)
+      self.redoActionsClear()
+    },
+
+    splicePathClosePoint(point) {
+      if (!self.spliceDragPointIndex || self.spliceClosePointIndex) {
+        return
+      }
+
+      // Four splicing scenarios ALWAYS choosing shortest splicing path
+      // 1) Splice does path through path start going forward
+      // 2) Splice does path through path start going reverse
+      // 3) Splice does not pass through path start going forward
+      // 4) Splice does not pass through path start going reverse 
+      let dragPointIndex = self.spliceDragPointIndex
+      let closePointIndex = self.findClosestPathPointIndex(point)
+      let spliceSpan = Math.abs(closePointIndex - dragPointIndex)
+      let spliceReverse = closePointIndex < dragPointIndex
+      let spliceThroughBeginning = false
+
+      if (self.pathIsClosed) {
+        if (spliceSpan > self.points.length / 2) {
+          spliceSpan = Math.abs(dragPointIndex - closePointIndex)
+          spliceReverse = dragPointIndex < closePointIndex
+        }
+
+        if (spliceReverse && dragPointIndex < spliceSpan) {
+          spliceThroughBeginning = true
+        } else if (!spliceReverse && (dragPointIndex + spliceSpan) > self.points.length) {
+          spliceThroughBeginning = true
+        }
+      }
+
+      self.drawActions.push({
+        type: 'splice-close-point',
+        pointIndexDrag: dragPointIndex,
+        pointIndexClose: closePointIndex,
+        pointsFromDrag: [],
+        pointsFromClose: [],
+        pointsSpliceCount: 0,
+        isReversed: spliceReverse,
+        throughBeginning: spliceThroughBeginning
+      })
+
+      self.splicePathSetup()
+      self.redoActionsClear()
+    },
+
+    splicePathSetup() {
+      // for purposes of undo/redo we use the action to set these properties
+      const action = self.drawActions.at(-1)
+      self.spliceClosePointIndex = action.pointIndexClose
+      self.spliceReverse = action.isReversed
+      self.spliceThroughBeginning = action.throughBeginning
+      self.spliceActive = true
+      self.setClosePoint(self.points[action.pointIndexClose])
+    },
+
+    spliceReset() {
+      self.splicePoints.length = 0
+      self.spliceActive = false
+      self.spliceReverse = false
+      self.spliceThroughBeginning = false
+      self.spliceDragPointIndex = null
+      self.spliceClosePointIndex = null
+    },
+
+    move() {
+      // do nothing... tool required but not used in this context
+    },
+
+    inactive() {
+      if (self.drawActions.length === 0) return // comes up in stories
+
+      while (['splice-drag-point', 'splice-close-point', 'splice-append'].indexOf(self.drawActions.at(-1).type) > -1) {
+        self.undo()
+        self.redoActionsClear()
+      }
+    },
+
+    finish() {
+      if (self.points.length < self.minimumPoints) {
+        return self.tool.deleteMark(self)
+      }
+
+      if (self.isDragging) {
+        self.appendPathEnd()
+        self.finished = true
+      } else {
+        self.pathX = []
+        self.pathY = []
+        self.points.forEach(point => {
+          self.pathX.push(point.x)
+          self.pathY.push(point.y)
+        })
+      }
+    },
   }))
 
 const FreehandLine = types.compose('FreehandLine', Mark, FreehandLineModel)

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/FreehandLineTool/FreehandLineTool.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/FreehandLineTool/FreehandLineTool.js
@@ -10,14 +10,16 @@ const FreehandLineTool = types
   .actions((self) => ({
     createMark(mark) {
       const newMark = FreehandLine.create(
-        Object.assign({}, mark, { toolType: self.type })
+        { ...mark, toolType: self.type }
       )
+
       self.marks.put(newMark)
+
       return newMark
     },
 
     handlePointerMove(event, mark) {
-      mark.initialDrag(event)
+      mark.initialDrag({ x: event.x, y: event.y })
     },
 
     handlePointerUp(event, mark) {

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/FreehandLineTool/FreehandLineTool.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/tools/FreehandLineTool/FreehandLineTool.spec.js
@@ -1,0 +1,1578 @@
+import FreehandLineTool from './FreehandLineTool'
+
+const markDataOpen = {
+  frame: 0,
+  id: "clewjkjz800033b6bz45c3uq7",
+  toolIndex: 0
+}
+
+const markDataClosed = {
+  frame: 0,
+  id: "clewjkjz800033b6bz45c3uq7",
+  toolIndex: 0
+}
+
+const toolData = {
+  type: 'freehandLine'
+}
+
+const dragIndex = 3
+const dragIndexFail = 4
+const dragIndexThroughBeginning = 13
+const dragIndexThroughBeginningReverse = 1
+const closeIndexForward = 4
+const closeIndexReverse = 2
+const closeIndexFail = 5
+const closeIndexThroughBeginning = 1
+const closeIndexThroughBeginningReverse = 11
+
+const points = [
+  { x: 200, y: 100 },
+  { x: 175, y: 75 },
+  { x: 150, y: 75 },
+  { x: 125, y: 100 },
+  { x: 125, y: 125 },
+  { x: 150, y: 150 },
+  { x: 175, y: 150 },
+  { x: 200, y: 125 },
+  { x: 201, y: 101 },
+]
+
+const pointsOpen = [
+  { x: 200, y: 100 },
+  { x: 175, y: 75 },
+  { x: 150, y: 75 },
+  { x: 125, y: 100 },
+  { x: 125, y: 125 },
+  { x: 150, y: 150 },
+  { x: 175, y: 150 },
+]
+
+const appendForward = [
+  { x: 110, y: 100 },
+  { x: 110, y: 115 },
+  { x: 110, y: 125 },
+  { x: 120, y: 125 }, // will close
+]
+
+const pointsAppendForward = [
+  { x: 200, y: 100 },
+  { x: 175, y: 75 },
+  { x: 150, y: 75 },
+  { x: 125, y: 100 },
+  { x: 110, y: 100 },
+  { x: 110, y: 115 },
+  { x: 110, y: 125 },
+  { x: 120, y: 125 },
+  { x: 125, y: 125 },
+  { x: 150, y: 150 },
+  { x: 175, y: 150 },
+  { x: 200, y: 125 },
+  { x: 201, y: 101 }
+]
+
+const pointsOpenAppendForward = [
+  { x: 200, y: 100 },
+  { x: 175, y: 75 },
+  { x: 150, y: 75 },
+  { x: 125, y: 100 },
+  { x: 110, y: 100 },
+  { x: 110, y: 115 },
+  { x: 110, y: 125 },
+  { x: 120, y: 125 },
+  { x: 125, y: 125 },
+  { x: 150, y: 150 },
+  { x: 175, y: 150 },
+]
+
+const appendReverse = [
+  { x: 135, y: 100 },
+  { x: 135, y: 85 },
+  { x: 145, y: 80 }, // will close
+]
+
+const pointsAppendForwardReverse = [
+  { x: 200, y: 100 },
+  { x: 175, y: 75 },
+  { x: 150, y: 75 },
+  { x: 145, y: 80 },
+  { x: 135, y: 85 },
+  { x: 135, y: 100 },
+  { x: 125, y: 100 },
+  { x: 110, y: 100 },
+  { x: 110, y: 115 },
+  { x: 110, y: 125 },
+  { x: 120, y: 125 },
+  { x: 125, y: 125 },
+  { x: 150, y: 150 },
+  { x: 175, y: 150 },
+  { x: 200, y: 125 },
+  { x: 201, y: 101 },
+]
+
+const pointsOpenAppendForwardReverse = [
+  { x: 200, y: 100 },
+  { x: 175, y: 75 },
+  { x: 150, y: 75 },
+  { x: 145, y: 80 },
+  { x: 135, y: 85 },
+  { x: 135, y: 100 },
+  { x: 125, y: 100 },
+  { x: 110, y: 100 },
+  { x: 110, y: 115 },
+  { x: 110, y: 125 },
+  { x: 120, y: 125 },
+  { x: 125, y: 125 },
+  { x: 150, y: 150 },
+  { x: 175, y: 150 },
+]
+
+const pointsOpenAppendForwardReverseClose = [
+  { x: 200, y: 100 },
+  { x: 175, y: 75 },
+  { x: 150, y: 75 },
+  { x: 145, y: 80 },
+  { x: 135, y: 85 },
+  { x: 135, y: 100 },
+  { x: 125, y: 100 },
+  { x: 110, y: 100 },
+  { x: 110, y: 115 },
+  { x: 110, y: 125 },
+  { x: 120, y: 125 },
+  { x: 125, y: 125 },
+  { x: 150, y: 150 },
+  { x: 175, y: 150 },
+  { x: 200, y: 125 },
+  { x: 201, y: 101 },
+  { x: 200, y: 100 }
+]
+
+// 13 (175,150) => 1 (175,75)
+const appendThroughBeginning = [
+  { x: 175, y: 140 },
+  { x: 175, y: 120 },
+  { x: 175, y: 100 },
+  { x: 175, y: 80 }, // will close
+]
+
+// pointsAppendForwardReverse gets 0, 14, 15 cut
+const pointsAppendForwardReverseThroughBeginning = [
+  { x: 175, y: 75 },
+  { x: 150, y: 75 },
+  { x: 145, y: 80 },
+  { x: 135, y: 85 },
+  { x: 135, y: 100 },
+  { x: 125, y: 100 },
+  { x: 110, y: 100 },
+  { x: 110, y: 115 },
+  { x: 110, y: 125 },
+  { x: 120, y: 125 },
+  { x: 125, y: 125 },
+  { x: 150, y: 150 },
+  { x: 175, y: 150 },
+  { x: 175, y: 140 },
+  { x: 175, y: 120 },
+  { x: 175, y: 100 },
+  { x: 175, y: 80 },
+  { x: 175, y: 75 },
+]
+
+// 1 (150,75) => 11 (150,150)
+const appendThroughBeginningReverse = [
+  { x: 150, y: 85 },
+  { x: 150, y: 95 },
+  { x: 150, y: 105 },
+  { x: 150, y: 115 },
+  { x: 150, y: 125 },
+  { x: 150, y: 135 },
+  { x: 150, y: 145 }, // will close
+]
+
+// pointsAppendForwardReverseThroughBeginning gets 0, 12-17 cut
+const pointsAppendForwardReverseThroughBeginningReverse = [
+  { x: 150, y: 75 },
+  { x: 145, y: 80 },
+  { x: 135, y: 85 },
+  { x: 135, y: 100 },
+  { x: 125, y: 100 },
+  { x: 110, y: 100 },
+  { x: 110, y: 115 },
+  { x: 110, y: 125 },
+  { x: 120, y: 125 },
+  { x: 125, y: 125 },
+  { x: 150, y: 150 },
+  { x: 150, y: 145 },
+  { x: 150, y: 135 },
+  { x: 150, y: 125 },
+  { x: 150, y: 115 },
+  { x: 150, y: 105 },
+  { x: 150, y: 95 },
+  { x: 150, y: 85 },
+  { x: 150, y: 75 },
+]
+
+describe('FreehandLineTool', () => {
+  let tool
+
+  before(() => {
+    tool = FreehandLineTool.create(toolData)
+  })
+
+  it('should exist', () => {
+    expect(tool).to.exist()
+    expect(tool).to.be.an('object')
+  })
+
+  it('should create a valid mark', () => {
+    expect(tool.marks.size).to.equal(0)
+    tool.createMark(markDataClosed, points)
+    expect(tool.marks.size).to.equal(1)
+  })
+
+  describe('manipulating an open mark', () => {
+    let tool, mark
+
+    before(() => {
+      tool = FreehandLineTool.create(toolData)
+      mark = tool.createMark(markDataOpen)
+      mark.setMinimumPoints(5)
+      mark.initialize(pointsOpen)
+    })
+
+    it('should be valid as open', () => {
+      expect(mark.points).to.deep.equal(pointsOpen)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.scale).to.equal(1)
+      expect(mark.closePoint).to.deep.equal(pointsOpen.at(0))
+      expect(mark.dragPoint).to.deep.equal(pointsOpen.at(-1))
+      expect(mark.pathIsClosed).to.be.false()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(0)
+      expect(mark.redoActions.length).to.equal(0)
+    })
+
+    // drag point
+    it('should create splicePathDragPoint', () => {
+      mark.splicePathDragPoint(pointsOpen[dragIndex])
+
+      expect(mark.points).to.deep.equal(pointsOpen)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.equal(null)
+      expect(mark.dragPoint).to.deep.equal(pointsOpen[dragIndex])
+      expect(mark.pathIsClosed).to.be.false()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(1)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[0]
+      expect(action.type).to.equal('splice-drag-point')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(-1)
+      expect(action.pointsFromDrag.length).to.equal(0)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    it('should create splicePathClosePoint', () => {
+      mark.splicePathClosePoint(pointsOpen[closeIndexForward])
+
+      expect(mark.points).to.deep.equal(pointsOpen)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.deep.equal(pointsOpen[closeIndexForward])
+      expect(mark.dragPoint).to.deep.equal(pointsOpen[dragIndex])
+      expect(mark.pathIsClosed).to.be.false()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.equal(closeIndexForward)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(2)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[1]
+
+      expect(action.type).to.equal('splice-close-point')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(closeIndexForward)
+      expect(action.pointsFromDrag.length).to.equal(0)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    it('should start splicing with appendPathStart', () => {
+      mark.appendPathStart()
+
+      expect(mark.points).to.deep.equal(pointsOpen)
+      expect(mark.isDragging).to.be.true()
+      expect(mark.closePoint).to.deep.equal(pointsOpen[closeIndexForward])
+      expect(mark.dragPoint).to.deep.equal(pointsOpen[dragIndex])
+      expect(mark.pathIsClosed).to.be.false()
+      expect(mark.splicePoints.length).to.equal(1)
+      expect(mark.splicePoints[0]).to.deep.equal(mark.points[dragIndex])
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.equal(closeIndexForward)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(3)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[2]
+      expect(action.type).to.equal('splice-append')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(closeIndexForward)
+      expect(action.pointsFromDrag.length).to.equal(0)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    it('should append path with appendPath', () => {
+      mark.appendPath(appendForward[0])
+
+      expect(mark.points).to.deep.equal(pointsOpen)
+      expect(mark.isDragging).to.be.true()
+      expect(mark.closePoint).to.deep.equal(pointsOpen[closeIndexForward])
+      expect(mark.dragPoint).to.deep.equal(appendForward[0])
+      expect(mark.pathIsClosed).to.be.false()
+      expect(mark.splicePoints.length).to.equal(2)
+
+      expect(mark.splicePoints[0]).to.deep.equal(mark.points[dragIndex])
+      expect(mark.splicePoints[1]).to.deep.equal(appendForward[0])
+
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.equal(closeIndexForward)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(3)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[2]
+      expect(action.type).to.equal('splice-append')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(closeIndexForward)
+      expect(action.pointsFromDrag.length).to.equal(1)
+      expect(action.pointsFromDrag[0]).to.deep.equal(appendForward[0])
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    it('should close the path with the rest of appendPath', () => {
+      mark.appendPath(appendForward[1])
+      mark.appendPath(appendForward[2])
+      mark.appendPath(appendForward[3])
+
+      expect(mark.points).to.deep.equal(pointsOpenAppendForward)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.deep.equal(pointsOpen.at(0))
+      expect(mark.dragPoint).to.deep.equal(pointsOpen.at(-1))
+      expect(mark.pathIsClosed).to.be.false()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(4)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[3]
+      expect(action.type).to.equal('splice-end')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(closeIndexForward)
+      expect(action.pointsFromDrag.length).to.equal(closeIndexForward - dragIndex - 1)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.pointsSpliceCount).to.equal(appendForward.length)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    it('should undo and redo all actions', () => {
+      for (let i = 0; i < 4; i++) {
+        mark.undo()
+      }
+      for (let i = 0; i < 4; i++) {
+        mark.redo()
+      }
+
+      expect(mark.points).to.deep.equal(pointsOpenAppendForward)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.deep.equal(pointsOpen.at(0))
+      expect(mark.dragPoint).to.deep.equal(pointsOpen.at(-1))
+      expect(mark.pathIsClosed).to.be.false()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(4)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[3]
+      expect(action.type).to.equal('splice-end')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(closeIndexForward)
+      expect(action.pointsFromDrag.length).to.equal(closeIndexForward - dragIndex - 1)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.pointsSpliceCount).to.equal(appendForward.length)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    // append path reverse on top of existing appended path
+    it('should create reverse instance of splicePathDragPoint & splicePathClosePoint', () => {
+      mark.splicePathDragPoint(pointsOpenAppendForward[dragIndex])
+      mark.splicePathClosePoint(pointsOpenAppendForward[closeIndexReverse])
+
+      expect(mark.points).to.deep.equal(pointsOpenAppendForward)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.deep.equal(pointsOpenAppendForward[closeIndexReverse])
+      expect(mark.dragPoint).to.deep.equal(pointsOpenAppendForward[dragIndex])
+      expect(mark.pathIsClosed).to.be.false()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.equal(closeIndexReverse)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.true()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(6)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let spliceDragPointAction = mark.drawActions[4]
+      expect(spliceDragPointAction.type).to.equal('splice-drag-point')
+      expect(spliceDragPointAction.pointIndexDrag).to.equal(dragIndex)
+      expect(spliceDragPointAction.pointIndexClose).to.equal(-1)
+      expect(spliceDragPointAction.pointsFromDrag.length).to.equal(0)
+      expect(spliceDragPointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceDragPointAction.isReversed).to.be.false()
+      expect(spliceDragPointAction.throughBeginning).to.be.false()
+
+      let spliceClosePointAction = mark.drawActions[5]
+      expect(spliceClosePointAction.type).to.equal('splice-close-point')
+      expect(spliceClosePointAction.pointIndexDrag).to.equal(dragIndex)
+      expect(spliceClosePointAction.pointIndexClose).to.equal(closeIndexReverse)
+      expect(spliceClosePointAction.pointsFromDrag.length).to.equal(0)
+      expect(spliceClosePointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceClosePointAction.isReversed).to.be.true()
+      expect(spliceClosePointAction.throughBeginning).to.be.false()
+    })
+
+    it('should appendPath and appendPathEnd for reverse instance', () => {
+      mark.appendPathStart()
+      mark.appendPath(appendReverse[0])
+      mark.appendPath(appendReverse[1])
+      mark.appendPath(appendReverse[2])
+
+      expect(mark.points.length).to.equal(pointsOpenAppendForwardReverse.length)
+      expect(mark.points).to.deep.equal(pointsOpenAppendForwardReverse)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.deep.equal(pointsOpen.at(0))
+      expect(mark.dragPoint).to.deep.equal(pointsOpen.at(-1))
+      expect(mark.pathIsClosed).to.be.false()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(8)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let spliceDragPointAction = mark.drawActions[6]
+      expect(spliceDragPointAction.type).to.equal('splice-append')
+      expect(spliceDragPointAction.pointIndexDrag).to.equal(dragIndex)
+      expect(spliceDragPointAction.pointIndexClose).to.equal(closeIndexReverse)
+      expect(spliceDragPointAction.pointsFromDrag.length).to.equal(appendReverse.length)
+      expect(spliceDragPointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceDragPointAction.isReversed).to.be.true()
+      expect(spliceDragPointAction.throughBeginning).to.be.false()
+
+      let spliceClosePointAction = mark.drawActions[7]
+      expect(spliceClosePointAction.type).to.equal('splice-end')
+      expect(spliceClosePointAction.pointIndexDrag).to.equal(dragIndex)
+      expect(spliceClosePointAction.pointIndexClose).to.equal(closeIndexReverse)
+      expect(spliceClosePointAction.pointsFromDrag.length).to.equal(0)
+      expect(spliceClosePointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceClosePointAction.pointsSpliceCount).to.equal(appendReverse.length)
+      expect(spliceClosePointAction.isReversed).to.be.true()
+      expect(spliceClosePointAction.throughBeginning).to.be.false()
+    })
+
+    it('should undo/redo all actions for reverse instance', () => {
+      for (let i = 0; i < 8; i++) {
+        mark.undo()
+      }
+      for (let i = 0; i < 8; i++) {
+        mark.redo()
+      }
+
+      expect(mark.points.length).to.equal(pointsOpenAppendForwardReverse.length)
+      expect(mark.points).to.deep.equal(pointsOpenAppendForwardReverse)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.deep.equal(pointsOpen.at(0))
+      expect(mark.dragPoint).to.deep.equal(pointsOpen.at(-1))
+      expect(mark.pathIsClosed).to.be.false()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(8)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let spliceDragPointAction = mark.drawActions[6]
+      expect(spliceDragPointAction.type).to.equal('splice-append')
+      expect(spliceDragPointAction.pointIndexDrag).to.equal(dragIndex)
+      expect(spliceDragPointAction.pointIndexClose).to.equal(closeIndexReverse)
+      expect(spliceDragPointAction.pointsFromDrag.length).to.equal(appendReverse.length)
+      expect(spliceDragPointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceDragPointAction.isReversed).to.be.true()
+      expect(spliceDragPointAction.throughBeginning).to.be.false()
+
+      let spliceClosePointAction = mark.drawActions[7]
+      expect(spliceClosePointAction.type).to.equal('splice-end')
+      expect(spliceClosePointAction.pointIndexDrag).to.equal(dragIndex)
+      expect(spliceClosePointAction.pointIndexClose).to.equal(closeIndexReverse)
+      expect(spliceClosePointAction.pointsFromDrag.length).to.equal(0)
+      expect(spliceClosePointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceClosePointAction.pointsSpliceCount).to.equal(appendReverse.length)
+      expect(spliceClosePointAction.isReversed).to.be.true()
+      expect(spliceClosePointAction.throughBeginning).to.be.false()
+    })
+
+    it('should close the path instance', () => {
+      mark.appendPathStart()
+      mark.appendPath(points[7])
+      mark.appendPath(points[8])
+
+      expect(mark.points.length).to.equal(pointsOpenAppendForwardReverseClose.length)
+      expect(mark.points).to.deep.equal(pointsOpenAppendForwardReverseClose)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.be.null()
+      expect(mark.dragPoint).to.be.null()
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(10)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let appendAction = mark.drawActions[8]
+      expect(appendAction.type).to.equal('append')
+      expect(appendAction.pointIndexDrag).to.be.null()
+      expect(appendAction.pointIndexClose).to.be.null()
+      expect(appendAction.pointsFromDrag.length).to.equal(2)
+      expect(appendAction.pointsFromDrag[0]).to.deep.equal(points[7])
+      expect(appendAction.pointsFromDrag[1]).to.deep.equal(points[8])
+      expect(appendAction.pointsFromClose.length).to.equal(0)
+      expect(appendAction.isReversed).to.be.false()
+      expect(appendAction.throughBeginning).to.be.false()
+
+      let endAction = mark.drawActions[9]
+      expect(endAction.type).to.equal('end')
+      expect(endAction.pointIndexDrag).to.equal(-1)
+      expect(endAction.pointIndexClose).to.equal(-1)
+      expect(endAction.pointsFromDrag.length).to.equal(1)
+      expect(endAction.pointsFromDrag[0]).to.deep.equal(pointsOpenAppendForwardReverseClose[0])
+      expect(endAction.pointsFromClose.length).to.equal(0)
+      expect(endAction.pointsSpliceCount).to.equal(0)
+      expect(endAction.isReversed).to.be.false()
+      expect(endAction.throughBeginning).to.be.false()
+    })
+
+    it('should undo/redo the complete path instance', () => {
+      for (let i = 0; i < 10; i++) {
+        mark.undo()
+      }
+      for (let i = 0; i < 10; i++) {
+        mark.redo()
+      }
+
+      expect(mark.points.length).to.equal(pointsOpenAppendForwardReverseClose.length)
+      expect(mark.points).to.deep.equal(pointsOpenAppendForwardReverseClose)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.be.null()
+      expect(mark.dragPoint).to.be.null()
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(10)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let appendAction = mark.drawActions[8]
+      expect(appendAction.type).to.equal('append')
+      expect(appendAction.pointIndexDrag).to.be.null()
+      expect(appendAction.pointIndexClose).to.be.null()
+      expect(appendAction.pointsFromDrag.length).to.equal(2)
+      expect(appendAction.pointsFromDrag[0]).to.deep.equal(points[7])
+      expect(appendAction.pointsFromDrag[1]).to.deep.equal(points[8])
+      expect(appendAction.pointsFromClose.length).to.equal(0)
+      expect(appendAction.isReversed).to.be.false()
+      expect(appendAction.throughBeginning).to.be.false()
+
+      let endAction = mark.drawActions[9]
+      expect(endAction.type).to.equal('end')
+      expect(endAction.pointIndexDrag).to.equal(-1)
+      expect(endAction.pointIndexClose).to.equal(-1)
+      expect(endAction.pointsFromDrag.length).to.equal(1)
+      expect(endAction.pointsFromDrag[0]).to.deep.equal(pointsOpenAppendForwardReverseClose[0])
+      expect(endAction.pointsFromClose.length).to.equal(0)
+      expect(endAction.pointsSpliceCount).to.equal(0)
+      expect(endAction.isReversed).to.be.false()
+      expect(endAction.throughBeginning).to.be.false()
+    })
+  })
+
+  describe('manipulating a closed mark', () => {
+    let tool, mark
+
+    before(() => {
+      tool = FreehandLineTool.create(toolData)
+      mark = tool.createMark(markDataClosed)
+      mark.setMinimumPoints(5)
+      mark.initialize(points)
+    })
+
+    it('should be valid as closed', () => {
+      expect(mark.points).to.deep.equal(points)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.scale).to.equal(1)
+      expect(mark.closePoint).to.equal(null)
+      expect(mark.dragPoint).to.equal(null)
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(0)
+      expect(mark.redoActions.length).to.equal(0)
+    })
+
+    // drag point
+    it('should create splicePathDragPoint', () => {
+      mark.splicePathDragPoint(points[dragIndex])
+
+      expect(mark.points).to.deep.equal(points)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.equal(null)
+      expect(mark.dragPoint).to.deep.equal(points[dragIndex])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(1)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[0]
+      expect(action.type).to.equal('splice-drag-point')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(-1)
+      expect(action.pointsFromDrag.length).to.equal(0)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    it('should not create a second splicePathDragPoint', () => {
+      mark.splicePathDragPoint(points[dragIndexFail])
+
+      expect(mark.points).to.deep.equal(points)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.equal(null)
+      expect(mark.dragPoint).to.not.deep.equal(points[dragIndexFail])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.not.equal(dragIndexFail)
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(1)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[0]
+      expect(action.type).to.equal('splice-drag-point')
+      expect(action.pointIndexDrag).to.not.equal(dragIndexFail)
+      expect(action.pointIndexClose).to.equal(-1)
+      expect(action.pointsFromDrag.length).to.equal(0)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    it('should undo splicePathDragPoint', () => {
+      mark.undo()
+
+      expect(mark.points).to.deep.equal(points)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.be.null()
+      expect(mark.dragPoint).to.be.null()
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(0)
+      expect(mark.redoActions.length).to.equal(1)
+
+      let action = mark.redoActions[0]
+      expect(action.type).to.equal('splice-drag-point')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(-1)
+      expect(action.pointsFromDrag.length).to.equal(0)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    it('should redo splicePathDragPoint', () => {
+      mark.redo()
+
+      expect(mark.points).to.deep.equal(points)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.equal(null)
+      expect(mark.dragPoint).to.deep.equal(points[dragIndex])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(1)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[0]
+      expect(action.type).to.equal('splice-drag-point')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(-1)
+      expect(action.pointsFromDrag.length).to.equal(0)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    // close point
+    it('should create splicePathClosePoint', () => {
+      mark.splicePathClosePoint(points[closeIndexForward])
+
+      expect(mark.points).to.deep.equal(points)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.deep.equal(points[closeIndexForward])
+      expect(mark.dragPoint).to.deep.equal(points[dragIndex])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.equal(closeIndexForward)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(2)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[1]
+
+      expect(action.type).to.equal('splice-close-point')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(closeIndexForward)
+      expect(action.pointsFromDrag.length).to.equal(0)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    it('should not create a second splicePathClosePoint', () => {
+      mark.splicePathClosePoint(points[closeIndexFail])
+
+      expect(mark.points).to.deep.equal(points)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.not.equal(points[closeIndexFail])
+      expect(mark.dragPoint).to.deep.equal(points[dragIndex])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.not.equal(closeIndexFail)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(2)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[1]
+      expect(action.type).to.equal('splice-close-point')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.not.equal(closeIndexFail)
+      expect(action.pointsFromDrag.length).to.equal(0)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    it('should undo splicePathClosePoint', () => {
+      mark.undo()
+
+      expect(mark.points).to.deep.equal(points)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.equal(null)
+      expect(mark.dragPoint).to.deep.equal(points[dragIndex])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(1)
+      expect(mark.redoActions.length).to.equal(1)
+
+      let action = mark.redoActions[0]
+      expect(action.type).to.equal('splice-close-point')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(closeIndexForward)
+      expect(action.pointsFromDrag.length).to.equal(0)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    it('should redo splicePathClosePoint', () => {
+      mark.redo()
+
+      expect(mark.points).to.deep.equal(points)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.deep.equal(points[closeIndexForward])
+      expect(mark.dragPoint).to.deep.equal(points[dragIndex])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.equal(closeIndexForward)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(2)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[1]
+      expect(action.type).to.equal('splice-close-point')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(closeIndexForward)
+      expect(action.pointsFromDrag.length).to.equal(0)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    // append path
+    it('should start splicing with appendPathStart', () => {
+      mark.appendPathStart()
+
+      expect(mark.points).to.deep.equal(points)
+      expect(mark.isDragging).to.be.true()
+      expect(mark.closePoint).to.deep.equal(points[closeIndexForward])
+      expect(mark.dragPoint).to.deep.equal(points[dragIndex])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(1)
+      expect(mark.splicePoints[0]).to.deep.equal(mark.points[dragIndex])
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.equal(closeIndexForward)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(3)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[2]
+      expect(action.type).to.equal('splice-append')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(closeIndexForward)
+      expect(action.pointsFromDrag.length).to.equal(0)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    it('should append path with appendPath', () => {
+      mark.appendPath(appendForward[0])
+
+      expect(mark.points).to.deep.equal(points)
+      expect(mark.isDragging).to.be.true()
+      expect(mark.closePoint).to.deep.equal(points[closeIndexForward])
+      expect(mark.dragPoint).to.deep.equal(appendForward[0])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(2)
+
+      expect(mark.splicePoints[0]).to.deep.equal(mark.points[dragIndex])
+      expect(mark.splicePoints[1]).to.deep.equal(appendForward[0])
+
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.equal(closeIndexForward)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(3)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[2]
+      expect(action.type).to.equal('splice-append')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(closeIndexForward)
+      expect(action.pointsFromDrag.length).to.equal(1)
+      expect(action.pointsFromDrag[0]).to.deep.equal(appendForward[0])
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    it('should close the path with the rest of appendPath', () => {
+      mark.appendPath(appendForward[1])
+      mark.appendPath(appendForward[2])
+      mark.appendPath(appendForward[3])
+
+      expect(mark.points).to.deep.equal(pointsAppendForward)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.be.null()
+      expect(mark.dragPoint).to.be.null()
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(4)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[3]
+      expect(action.type).to.equal('splice-end')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(closeIndexForward)
+      expect(action.pointsFromDrag.length).to.equal(closeIndexForward - dragIndex - 1)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.pointsSpliceCount).to.equal(appendForward.length)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    it('should undo closePath', () => {
+      mark.undo()
+
+      expect(mark.points).to.deep.equal(points)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.deep.equal(points[closeIndexForward])
+      expect(mark.dragPoint).to.deep.equal(appendForward[3])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(appendForward.length + 1)
+
+      expect(mark.splicePoints[0]).to.deep.equal(mark.points[dragIndex])
+      expect(mark.splicePoints[1]).to.deep.equal(appendForward[0])
+
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.equal(closeIndexForward)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(3)
+      expect(mark.redoActions.length).to.equal(1)
+
+      let action = mark.drawActions[2]
+      expect(action.type).to.equal('splice-append')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(closeIndexForward)
+      expect(action.pointsFromDrag.length).to.equal(appendForward.length)
+      expect(action.pointsFromDrag).to.deep.equal(appendForward)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+
+      let redoAction = mark.redoActions[0]
+      expect(redoAction.type).to.equal('splice-end')
+      expect(redoAction.pointIndexDrag).to.equal(dragIndex)
+      expect(redoAction.pointIndexClose).to.equal(closeIndexForward)
+      expect(redoAction.pointsFromDrag.length).to.equal(closeIndexForward - dragIndex - 1)
+      expect(redoAction.pointsFromClose.length).to.equal(0)
+      expect(redoAction.isReversed).to.be.false()
+      expect(redoAction.throughBeginning).to.be.false()
+    })
+
+    it('should undo appendPath', () => {
+      mark.undo()
+
+      expect(mark.points).to.deep.equal(points)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.deep.equal(points[closeIndexForward])
+      expect(mark.dragPoint).to.deep.equal(points[dragIndex])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(1)
+      expect(mark.splicePoints[0]).to.deep.equal(points[dragIndex])
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.equal(closeIndexForward)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(2)
+      expect(mark.redoActions.length).to.equal(2)
+
+      let action = mark.drawActions[1]
+      expect(action.type).to.equal('splice-close-point')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(closeIndexForward)
+      expect(action.pointsFromDrag.length).to.equal(0)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+
+      let redoActionEnd = mark.redoActions[0]
+      expect(redoActionEnd.type).to.equal('splice-end')
+      expect(redoActionEnd.pointIndexDrag).to.equal(dragIndex)
+      expect(redoActionEnd.pointIndexClose).to.equal(closeIndexForward)
+      expect(redoActionEnd.pointsFromDrag.length).to.equal(0)
+      expect(redoActionEnd.pointsFromClose.length).to.equal(0)
+      expect(redoActionEnd.isReversed).to.be.false()
+      expect(redoActionEnd.throughBeginning).to.be.false()
+
+      let redoActionAppend = mark.redoActions[1]
+      expect(redoActionAppend.type).to.equal('splice-append')
+      expect(redoActionAppend.pointIndexDrag).to.equal(dragIndex)
+      expect(redoActionAppend.pointIndexClose).to.equal(closeIndexForward)
+      expect(redoActionAppend.pointsFromDrag.length).to.equal(appendForward.length)
+      expect(redoActionAppend.pointsFromDrag).to.deep.equal(appendForward)
+      expect(redoActionAppend.pointsFromClose.length).to.equal(0)
+      expect(redoActionAppend.isReversed).to.be.false()
+      expect(redoActionAppend.throughBeginning).to.be.false()
+    })
+
+    it('should redo appendPath', () => {
+      mark.redo()
+
+      expect(mark.points).to.deep.equal(points)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.deep.equal(points[closeIndexForward])
+      expect(mark.dragPoint).to.deep.equal(appendForward[3])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(appendForward.length + 1)
+
+      expect(mark.splicePoints[0]).to.deep.equal(points[dragIndex])
+      expect(mark.splicePoints[1]).to.deep.equal(appendForward[0])
+      expect(mark.splicePoints[3]).to.deep.equal(appendForward[2])
+
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.equal(closeIndexForward)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(3)
+      expect(mark.redoActions.length).to.equal(1)
+
+      let redoActionAppend = mark.drawActions[2]
+      expect(redoActionAppend.type).to.equal('splice-append')
+      expect(redoActionAppend.pointIndexDrag).to.equal(dragIndex)
+      expect(redoActionAppend.pointIndexClose).to.equal(closeIndexForward)
+      expect(redoActionAppend.pointsFromDrag.length).to.equal(appendForward.length)
+      expect(redoActionAppend.pointsFromDrag).to.deep.equal(appendForward)
+      expect(redoActionAppend.pointsFromClose.length).to.equal(0)
+      expect(redoActionAppend.isReversed).to.be.false()
+      expect(redoActionAppend.throughBeginning).to.be.false()
+
+      let redoActionEnd = mark.redoActions[0]
+      expect(redoActionEnd.type).to.equal('splice-end')
+      expect(redoActionEnd.pointIndexDrag).to.equal(dragIndex)
+      expect(redoActionEnd.pointIndexClose).to.equal(closeIndexForward)
+      expect(redoActionEnd.pointsFromDrag.length).to.equal(0)
+      expect(redoActionEnd.pointsFromClose.length).to.equal(0)
+      expect(redoActionEnd.isReversed).to.be.false()
+      expect(redoActionEnd.throughBeginning).to.be.false()
+    })
+
+    it('should redo appendPathEnd', () => {
+      mark.redo()
+
+      expect(mark.points).to.deep.equal(pointsAppendForward)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.be.null()
+      expect(mark.dragPoint).to.be.null()
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(4)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let action = mark.drawActions[3]
+      expect(action.type).to.equal('splice-end')
+      expect(action.pointIndexDrag).to.equal(dragIndex)
+      expect(action.pointIndexClose).to.equal(closeIndexForward)
+      expect(action.pointsFromDrag.length).to.equal(closeIndexForward - dragIndex - 1)
+      expect(action.pointsFromClose.length).to.equal(0)
+      expect(action.pointsSpliceCount).to.equal(appendForward.length)
+      expect(action.isReversed).to.be.false()
+      expect(action.throughBeginning).to.be.false()
+    })
+
+    // append path reverse on top of existing appended path
+    it('should create reverse instance of splicePathDragPoint & splicePathClosePoint', () => {
+      mark.splicePathDragPoint(points[dragIndex])
+      mark.splicePathClosePoint(points[closeIndexReverse])
+
+      expect(mark.points).to.deep.equal(pointsAppendForward)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.deep.equal(points[closeIndexReverse])
+      expect(mark.dragPoint).to.deep.equal(points[dragIndex])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.equal(dragIndex)
+      expect(mark.spliceClosePointIndex).to.equal(closeIndexReverse)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.true()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(6)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let spliceDragPointAction = mark.drawActions[4]
+      expect(spliceDragPointAction.type).to.equal('splice-drag-point')
+      expect(spliceDragPointAction.pointIndexDrag).to.equal(dragIndex)
+      expect(spliceDragPointAction.pointIndexClose).to.equal(-1)
+      expect(spliceDragPointAction.pointsFromDrag.length).to.equal(0)
+      expect(spliceDragPointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceDragPointAction.isReversed).to.be.false()
+      expect(spliceDragPointAction.throughBeginning).to.be.false()
+
+      let spliceClosePointAction = mark.drawActions[5]
+      expect(spliceClosePointAction.type).to.equal('splice-close-point')
+      expect(spliceClosePointAction.pointIndexDrag).to.equal(dragIndex)
+      expect(spliceClosePointAction.pointIndexClose).to.equal(closeIndexReverse)
+      expect(spliceClosePointAction.pointsFromDrag.length).to.equal(0)
+      expect(spliceClosePointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceClosePointAction.isReversed).to.be.true()
+      expect(spliceClosePointAction.throughBeginning).to.be.false()
+    })
+
+    it('should appendPath and appendPathEnd for reverse instance', () => {
+      mark.appendPathStart()
+      mark.appendPath(appendReverse[0])
+      mark.appendPath(appendReverse[1])
+      mark.appendPath(appendReverse[2])
+
+      expect(mark.points.length).to.equal(pointsAppendForwardReverse.length)
+      expect(mark.points).to.deep.equal(pointsAppendForwardReverse)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.be.null()
+      expect(mark.dragPoint).to.be.null()
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(8)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let spliceDragPointAction = mark.drawActions[6]
+      expect(spliceDragPointAction.type).to.equal('splice-append')
+      expect(spliceDragPointAction.pointIndexDrag).to.equal(dragIndex)
+      expect(spliceDragPointAction.pointIndexClose).to.equal(closeIndexReverse)
+      expect(spliceDragPointAction.pointsFromDrag.length).to.equal(appendReverse.length)
+      expect(spliceDragPointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceDragPointAction.isReversed).to.be.true()
+      expect(spliceDragPointAction.throughBeginning).to.be.false()
+
+      let spliceClosePointAction = mark.drawActions[7]
+      expect(spliceClosePointAction.type).to.equal('splice-end')
+      expect(spliceClosePointAction.pointIndexDrag).to.equal(dragIndex)
+      expect(spliceClosePointAction.pointIndexClose).to.equal(closeIndexReverse)
+      expect(spliceClosePointAction.pointsFromDrag.length).to.equal(0)
+      expect(spliceClosePointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceClosePointAction.pointsSpliceCount).to.equal(appendReverse.length)
+      expect(spliceClosePointAction.isReversed).to.be.true()
+      expect(spliceClosePointAction.throughBeginning).to.be.false()
+    })
+
+    it('should undo and redo all of the reverse path successfully', () => {
+      for (let i = 0; i < 4; i++) {
+        mark.undo()
+      }
+      for (let i = 0; i < 4; i++) {
+        mark.redo()
+      }
+
+      expect(mark.points.length).to.equal(pointsAppendForwardReverse.length)
+      expect(mark.points).to.deep.equal(pointsAppendForwardReverse)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.be.null()
+      expect(mark.dragPoint).to.be.null()
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(8)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let spliceDragPointAction = mark.drawActions[6]
+      expect(spliceDragPointAction.type).to.equal('splice-append')
+      expect(spliceDragPointAction.pointIndexDrag).to.equal(dragIndex)
+      expect(spliceDragPointAction.pointIndexClose).to.equal(closeIndexReverse)
+      expect(spliceDragPointAction.pointsFromDrag.length).to.equal(appendReverse.length)
+      expect(spliceDragPointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceDragPointAction.isReversed).to.be.true()
+      expect(spliceDragPointAction.throughBeginning).to.be.false()
+
+      let spliceClosePointAction = mark.drawActions[7]
+      expect(spliceClosePointAction.type).to.equal('splice-end')
+      expect(spliceClosePointAction.pointIndexDrag).to.equal(dragIndex)
+      expect(spliceClosePointAction.pointIndexClose).to.equal(closeIndexReverse)
+      expect(spliceClosePointAction.pointsFromDrag.length).to.equal(0)
+      expect(spliceClosePointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceClosePointAction.pointsSpliceCount).to.equal(appendReverse.length)
+      expect(spliceClosePointAction.isReversed).to.be.true()
+      expect(spliceClosePointAction.throughBeginning).to.be.false()
+    })
+
+    it('should undo and redo all action successfully', () => {
+      for (let i = 0; i < 8; i++) {
+        mark.undo()
+      }
+      for (let i = 0; i < 8; i++) {
+        mark.redo()
+      }
+
+      expect(mark.points.length).to.equal(pointsAppendForwardReverse.length)
+      expect(mark.points).to.deep.equal(pointsAppendForwardReverse)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.be.null()
+      expect(mark.dragPoint).to.be.null()
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(8)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let spliceDragPointAction = mark.drawActions[6]
+      expect(spliceDragPointAction.type).to.equal('splice-append')
+      expect(spliceDragPointAction.pointIndexDrag).to.equal(dragIndex)
+      expect(spliceDragPointAction.pointIndexClose).to.equal(closeIndexReverse)
+      expect(spliceDragPointAction.pointsFromDrag.length).to.equal(appendReverse.length)
+      expect(spliceDragPointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceDragPointAction.isReversed).to.be.true()
+      expect(spliceDragPointAction.throughBeginning).to.be.false()
+
+      let spliceClosePointAction = mark.drawActions[7]
+      expect(spliceClosePointAction.type).to.equal('splice-end')
+      expect(spliceClosePointAction.pointIndexDrag).to.equal(dragIndex)
+      expect(spliceClosePointAction.pointIndexClose).to.equal(closeIndexReverse)
+      expect(spliceClosePointAction.pointsFromDrag.length).to.equal(0)
+      expect(spliceClosePointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceClosePointAction.pointsSpliceCount).to.equal(appendReverse.length)
+      expect(spliceClosePointAction.isReversed).to.be.true()
+      expect(spliceClosePointAction.throughBeginning).to.be.false()
+    })
+
+    // append path through the start point
+    it('should create instance of splicePathDragPoint & splicePathClosePoint through beginning', () => {
+      mark.splicePathDragPoint(pointsAppendForwardReverse[dragIndexThroughBeginning])
+      mark.splicePathClosePoint(pointsAppendForwardReverse[closeIndexThroughBeginning])
+
+      expect(mark.points.length).to.equal(pointsAppendForwardReverse.length)
+      expect(mark.points).to.deep.equal(pointsAppendForwardReverse)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.deep.equal(pointsAppendForwardReverse[closeIndexThroughBeginning])
+      expect(mark.dragPoint).to.deep.equal(pointsAppendForwardReverse[dragIndexThroughBeginning])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.equal(dragIndexThroughBeginning)
+      expect(mark.spliceClosePointIndex).to.equal(closeIndexThroughBeginning)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.true()
+      expect(mark.drawActions.length).to.equal(10)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let spliceDragPointAction = mark.drawActions[8]
+      expect(spliceDragPointAction.type).to.equal('splice-drag-point')
+      expect(spliceDragPointAction.pointIndexDrag).to.equal(dragIndexThroughBeginning)
+      expect(spliceDragPointAction.pointIndexClose).to.equal(-1)
+      expect(spliceDragPointAction.pointsFromDrag.length).to.equal(0)
+      expect(spliceDragPointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceDragPointAction.isReversed).to.be.false()
+      expect(spliceDragPointAction.throughBeginning).to.be.false()
+
+      let spliceClosePointAction = mark.drawActions[9]
+      expect(spliceClosePointAction.type).to.equal('splice-close-point')
+      expect(spliceClosePointAction.pointIndexDrag).to.equal(dragIndexThroughBeginning)
+      expect(spliceClosePointAction.pointIndexClose).to.equal(closeIndexThroughBeginning)
+      expect(spliceClosePointAction.pointsFromDrag.length).to.equal(0)
+      expect(spliceClosePointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceClosePointAction.pointsSpliceCount).to.equal(0)
+      expect(spliceClosePointAction.isReversed).to.be.false()
+      expect(spliceClosePointAction.throughBeginning).to.be.true()
+    })
+
+    it('should appendPath and appendPathEnd through beginning', () => {
+      mark.appendPathStart()
+      appendThroughBeginning.forEach(pnt => {
+        mark.appendPath(pnt)
+      })
+
+      expect(mark.points.length).to.equal(pointsAppendForwardReverseThroughBeginning.length)
+      expect(mark.points).to.deep.equal(pointsAppendForwardReverseThroughBeginning)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.be.null()
+      expect(mark.dragPoint).to.be.null()
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(12)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let spliceAppendAction = mark.drawActions[10]
+      expect(spliceAppendAction.type).to.equal('splice-append')
+      expect(spliceAppendAction.pointIndexDrag).to.equal(dragIndexThroughBeginning)
+      expect(spliceAppendAction.pointIndexClose).to.equal(closeIndexThroughBeginning)
+      expect(spliceAppendAction.pointsFromDrag.length).to.equal(appendThroughBeginning.length)
+      expect(spliceAppendAction.pointsFromClose.length).to.equal(0)
+      expect(spliceAppendAction.isReversed).to.be.false()
+      expect(spliceAppendAction.throughBeginning).to.be.true()
+
+      let spliceEndAction = mark.drawActions[11]
+      expect(spliceEndAction.type).to.equal('splice-end')
+      expect(spliceEndAction.pointIndexDrag).to.equal(dragIndexThroughBeginning)
+      expect(spliceEndAction.pointIndexClose).to.equal(closeIndexThroughBeginning)
+      expect(spliceEndAction.pointsFromDrag.length).to.equal(1)
+      expect(spliceEndAction.pointsFromDrag[0]).to.deep.equal(pointsAppendForwardReverse[0])
+      expect(spliceEndAction.pointsFromClose.length).to.equal(2)
+      expect(spliceEndAction.pointsFromClose[0]).to.deep.equal(pointsAppendForwardReverse[14])
+      expect(spliceEndAction.pointsFromClose[1]).to.deep.equal(pointsAppendForwardReverse[15])
+      expect(spliceEndAction.pointsSpliceCount).to.equal(appendThroughBeginning.length)
+      expect(spliceEndAction.isReversed).to.be.false()
+      expect(spliceEndAction.throughBeginning).to.be.true()
+    })
+
+    it('should undo/redo path through beginning successfully', () => {
+      for (let i = 0; i < 4; i++) {
+        mark.undo()
+      }
+      for (let i = 0; i < 4; i++) {
+        mark.redo()
+      }
+
+      expect(mark.points.length).to.equal(pointsAppendForwardReverseThroughBeginning.length)
+      expect(mark.points).to.deep.equal(pointsAppendForwardReverseThroughBeginning)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.be.null()
+      expect(mark.dragPoint).to.be.null()
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(12)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let spliceAppendAction = mark.drawActions[10]
+      expect(spliceAppendAction.type).to.equal('splice-append')
+      expect(spliceAppendAction.pointIndexDrag).to.equal(dragIndexThroughBeginning)
+      expect(spliceAppendAction.pointIndexClose).to.equal(closeIndexThroughBeginning)
+      expect(spliceAppendAction.pointsFromDrag.length).to.equal(appendThroughBeginning.length)
+      expect(spliceAppendAction.pointsFromClose.length).to.equal(0)
+      expect(spliceAppendAction.isReversed).to.be.false()
+      expect(spliceAppendAction.throughBeginning).to.be.true()
+
+      let spliceEndAction = mark.drawActions[11]
+      expect(spliceEndAction.type).to.equal('splice-end')
+      expect(spliceEndAction.pointIndexDrag).to.equal(dragIndexThroughBeginning)
+      expect(spliceEndAction.pointIndexClose).to.equal(closeIndexThroughBeginning)
+      expect(spliceEndAction.pointsFromDrag.length).to.equal(1)
+      expect(spliceEndAction.pointsFromDrag[0]).to.deep.equal(pointsAppendForwardReverse[0])
+      expect(spliceEndAction.pointsFromClose.length).to.equal(2)
+      expect(spliceEndAction.pointsFromClose[0]).to.deep.equal(pointsAppendForwardReverse[14])
+      expect(spliceEndAction.pointsFromClose[1]).to.deep.equal(pointsAppendForwardReverse[15])
+      expect(spliceEndAction.pointsSpliceCount).to.equal(appendThroughBeginning.length)
+      expect(spliceEndAction.isReversed).to.be.false()
+      expect(spliceEndAction.throughBeginning).to.be.true()
+    })
+
+    // append path through the start point in reverse
+    it('should create instance of splicePathDragPoint & splicePathClosePoint through beginning in reverse', () => {
+      mark.splicePathDragPoint(pointsAppendForwardReverseThroughBeginning[dragIndexThroughBeginningReverse])
+      mark.splicePathClosePoint(pointsAppendForwardReverseThroughBeginning[closeIndexThroughBeginningReverse])
+
+      expect(mark.points.length).to.equal(pointsAppendForwardReverseThroughBeginning.length)
+      expect(mark.points).to.deep.equal(pointsAppendForwardReverseThroughBeginning)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.deep.equal(pointsAppendForwardReverseThroughBeginning[closeIndexThroughBeginningReverse])
+      expect(mark.dragPoint).to.deep.equal(pointsAppendForwardReverseThroughBeginning[dragIndexThroughBeginningReverse])
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.equal(dragIndexThroughBeginningReverse)
+      expect(mark.spliceClosePointIndex).to.equal(closeIndexThroughBeginningReverse)
+      expect(mark.spliceActive).to.be.true()
+      expect(mark.spliceReverse).to.be.true()
+      expect(mark.spliceThroughBeginning).to.be.true()
+      expect(mark.drawActions.length).to.equal(14)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let spliceDragPointAction = mark.drawActions[12]
+      expect(spliceDragPointAction.type).to.equal('splice-drag-point')
+      expect(spliceDragPointAction.pointIndexDrag).to.equal(dragIndexThroughBeginningReverse)
+      expect(spliceDragPointAction.pointIndexClose).to.equal(-1)
+      expect(spliceDragPointAction.pointsFromDrag.length).to.equal(0)
+      expect(spliceDragPointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceDragPointAction.isReversed).to.be.false()
+      expect(spliceDragPointAction.throughBeginning).to.be.false()
+
+      let spliceClosePointAction = mark.drawActions[13]
+      expect(spliceClosePointAction.type).to.equal('splice-close-point')
+      expect(spliceClosePointAction.pointIndexDrag).to.equal(dragIndexThroughBeginningReverse)
+      expect(spliceClosePointAction.pointIndexClose).to.equal(closeIndexThroughBeginningReverse)
+      expect(spliceClosePointAction.pointsFromDrag.length).to.equal(0)
+      expect(spliceClosePointAction.pointsFromClose.length).to.equal(0)
+      expect(spliceClosePointAction.pointsSpliceCount).to.equal(0)
+      expect(spliceClosePointAction.isReversed).to.be.true()
+      expect(spliceClosePointAction.throughBeginning).to.be.true()
+    })
+
+    it('should appendPath and appendPathEnd through beginning', () => {
+      mark.appendPathStart()
+      appendThroughBeginningReverse.forEach(pnt => {
+        mark.appendPath(pnt)
+      })
+
+      expect(mark.points.length).to.equal(pointsAppendForwardReverseThroughBeginningReverse.length)
+      expect(mark.points).to.deep.equal(pointsAppendForwardReverseThroughBeginningReverse)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.be.null()
+      expect(mark.dragPoint).to.be.null()
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(16)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let spliceAppendAction = mark.drawActions[14]
+      expect(spliceAppendAction.type).to.equal('splice-append')
+      expect(spliceAppendAction.pointIndexDrag).to.equal(dragIndexThroughBeginningReverse)
+      expect(spliceAppendAction.pointIndexClose).to.equal(closeIndexThroughBeginningReverse)
+      expect(spliceAppendAction.pointsFromDrag.length).to.equal(appendThroughBeginningReverse.length)
+      expect(spliceAppendAction.pointsFromClose.length).to.equal(0)
+      expect(spliceAppendAction.isReversed).to.be.true()
+      expect(spliceAppendAction.throughBeginning).to.be.true()
+
+      let spliceEndAction = mark.drawActions[15]
+      expect(spliceEndAction.type).to.equal('splice-end')
+      expect(spliceEndAction.pointIndexDrag).to.equal(dragIndexThroughBeginningReverse)
+      expect(spliceEndAction.pointIndexClose).to.equal(closeIndexThroughBeginningReverse)
+      expect(spliceEndAction.pointsFromDrag.length).to.equal(1)
+      expect(spliceEndAction.pointsFromDrag[0]).to.deep.equal(pointsAppendForwardReverseThroughBeginning[0])
+      expect(spliceEndAction.pointsFromClose.length).to.equal(6)
+      expect(spliceEndAction.pointsFromClose[0]).to.deep.equal(pointsAppendForwardReverseThroughBeginning[12])
+      expect(spliceEndAction.pointsFromClose[1]).to.deep.equal(pointsAppendForwardReverseThroughBeginning[13])
+      expect(spliceEndAction.pointsFromClose[2]).to.deep.equal(pointsAppendForwardReverseThroughBeginning[14])
+      expect(spliceEndAction.pointsFromClose[3]).to.deep.equal(pointsAppendForwardReverseThroughBeginning[15])
+      expect(spliceEndAction.pointsFromClose[4]).to.deep.equal(pointsAppendForwardReverseThroughBeginning[16])
+      expect(spliceEndAction.pointsFromClose[5]).to.deep.equal(pointsAppendForwardReverseThroughBeginning[17])
+      expect(spliceEndAction.pointsSpliceCount).to.equal(appendThroughBeginningReverse.length)
+      expect(spliceEndAction.isReversed).to.be.true()
+      expect(spliceEndAction.throughBeginning).to.be.true()
+    })
+
+    it('should undo/redo path through beginning successfully', () => {
+      for (let i = 0; i < 16; i++) {
+        mark.undo()
+      }
+      for (let i = 0; i < 16; i++) {
+        mark.redo()
+      }
+
+      expect(mark.points.length).to.equal(pointsAppendForwardReverseThroughBeginningReverse.length)
+      expect(mark.points).to.deep.equal(pointsAppendForwardReverseThroughBeginningReverse)
+      expect(mark.isDragging).to.be.false()
+      expect(mark.closePoint).to.be.null()
+      expect(mark.dragPoint).to.be.null()
+      expect(mark.pathIsClosed).to.be.true()
+      expect(mark.splicePoints.length).to.equal(0)
+      expect(mark.spliceDragPointIndex).to.be.null()
+      expect(mark.spliceClosePointIndex).to.be.null()
+      expect(mark.spliceActive).to.be.false()
+      expect(mark.spliceReverse).to.be.false()
+      expect(mark.spliceThroughBeginning).to.be.false()
+      expect(mark.drawActions.length).to.equal(16)
+      expect(mark.redoActions.length).to.equal(0)
+
+      let spliceAppendAction = mark.drawActions[14]
+      expect(spliceAppendAction.type).to.equal('splice-append')
+      expect(spliceAppendAction.pointIndexDrag).to.equal(dragIndexThroughBeginningReverse)
+      expect(spliceAppendAction.pointIndexClose).to.equal(closeIndexThroughBeginningReverse)
+      expect(spliceAppendAction.pointsFromDrag.length).to.equal(appendThroughBeginningReverse.length)
+      expect(spliceAppendAction.pointsFromClose.length).to.equal(0)
+      expect(spliceAppendAction.isReversed).to.be.true()
+      expect(spliceAppendAction.throughBeginning).to.be.true()
+
+      let spliceEndAction = mark.drawActions[15]
+      expect(spliceEndAction.type).to.equal('splice-end')
+      expect(spliceEndAction.pointIndexDrag).to.equal(dragIndexThroughBeginningReverse)
+      expect(spliceEndAction.pointIndexClose).to.equal(closeIndexThroughBeginningReverse)
+      expect(spliceEndAction.pointsFromDrag.length).to.equal(1)
+      expect(spliceEndAction.pointsFromDrag[0]).to.deep.equal(pointsAppendForwardReverseThroughBeginning[0])
+      expect(spliceEndAction.pointsFromClose.length).to.equal(6)
+      expect(spliceEndAction.pointsFromClose[0]).to.deep.equal(pointsAppendForwardReverseThroughBeginning[12])
+      expect(spliceEndAction.pointsFromClose[1]).to.deep.equal(pointsAppendForwardReverseThroughBeginning[13])
+      expect(spliceEndAction.pointsFromClose[2]).to.deep.equal(pointsAppendForwardReverseThroughBeginning[14])
+      expect(spliceEndAction.pointsFromClose[3]).to.deep.equal(pointsAppendForwardReverseThroughBeginning[15])
+      expect(spliceEndAction.pointsFromClose[4]).to.deep.equal(pointsAppendForwardReverseThroughBeginning[16])
+      expect(spliceEndAction.pointsFromClose[5]).to.deep.equal(pointsAppendForwardReverseThroughBeginning[17])
+      expect(spliceEndAction.pointsSpliceCount).to.equal(appendThroughBeginningReverse.length)
+      expect(spliceEndAction.isReversed).to.be.true()
+      expect(spliceEndAction.throughBeginning).to.be.true()
+    })
+  })
+})

--- a/packages/lib-classifier/src/translations/en/plugins.json
+++ b/packages/lib-classifier/src/translations/en/plugins.json
@@ -10,7 +10,7 @@
     "otherLabel": "Other...",
     "selectPlaceholder": "Choose an answer"
   },
-  "SurveyTask":{
+  "SurveyTask": {
     "CharacteristicsFilter": {
       "clearFilters": "Clear filters",
       "filter": "Filter",
@@ -38,5 +38,20 @@
   "TranscriptionLine": {
     "editing": "Editing transcription",
     "created": "Created transcription"
+  },
+  "FreehandLine": {
+    "inactive": "Click to edit this line",
+    "active": "Click and drag from the open point to the close point or double click anywhere on the line to create a splice point",
+    "splicePoint": "Double click anywhere on the line to create a splice point",
+    "closePoint": "Click anywhere on the line to set the close point",
+    "spliceDrag": "Click and drag from the open point to the close point"
+  },
+  "LineControls": {
+    "lineControls": "Line Controls",
+    "close": "Close",
+    "delete": "Delete",
+    "move": "Move",
+    "redo": "Redo",
+    "undo": "Undo"
   }
 }


### PR DESCRIPTION
Changes to the Freehand Line tool as its used for annotating images with svg paths.

## Package
lib-classifier

## Linked Issue and/or Talk Post

## Describe your changes

## How to Review
In the staging environment I have a project called "kieftrav/freehand-line-test" that preloads a very basic drawing from Caesar and allows the user to change the path. Experiment with modifying the path and exploring any edge cases that could cause failure to draw an enclosed path.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [freehand-line-test](https://local.zooniverse.org:3000/projects/kieftrav/freehand-line-test)
- [x] Can extend an existing path
- [x] Can close an existing path
- [x] Can undo a recent change
- [x] Can redo an undone change
- [x] Can auto-close an unfinished path
- [x] Can splice a path to make a change
- [ ] Zooming in and out changes the path width to be visually consistent between zoom levels
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
