### PR TITLE
Remove redundant asset prefixes

### DIFF
--- a/packages/app-content-pages/next.config.js
+++ b/packages/app-content-pages/next.config.js
@@ -6,9 +6,6 @@ const path = require('path')
 const withSourceMaps = require('@zeit/next-source-maps')()
 
 const assetPrefixes = {
-  development: '/about',
-  branch: 'https://fe-project-branch.preview.zooniverse.org/about',
-  static: 'https://fe-static.zooniverse.org/about',
   production: 'https://fe-content-pages.zooniverse.org/about/'
 }
 

--- a/packages/app-project/next.config.js
+++ b/packages/app-project/next.config.js
@@ -9,9 +9,6 @@ const { i18n } = require('./next-i18next.config')
 
 const talkHosts = require('./config/talkHosts')
 const assetPrefixes = {
-  development: '/projects',
-  branch: 'https://fe-project-branch.preview.zooniverse.org/projects',
-  static: 'https://fe-static.zooniverse.org/projects',
   production: 'https://fe-project.zooniverse.org/projects'
 }
 


### PR DESCRIPTION
[`assetPrefix`](https://nextjs.org/docs/api-reference/next.config.js/cdn-support-with-asset-prefix) shouldn't be used as a replacement for `basePath`. It should only be set when static assets are hosted on a different domain than the NextJS app.

