### PR TITLE
Correct the app-content-pages production assetPrefix to bypass CDN

### DIFF
--- a/packages/app-content-pages/next.config.js
+++ b/packages/app-content-pages/next.config.js
@@ -8,7 +8,6 @@ const withSourceMaps = require('@zeit/next-source-maps')()
 const assetPrefixes = {
   development: '/about',
   branch: 'https://fe-project-branch.preview.zooniverse.org/about',
-  staging: 'https://frontend.preview.zooniverse.org/about',
   static: 'https://fe-static.zooniverse.org/about',
   production: 'https://fe-content-pages.zooniverse.org/about/'
 }

--- a/packages/app-content-pages/next.config.js
+++ b/packages/app-content-pages/next.config.js
@@ -10,7 +10,7 @@ const assetPrefixes = {
   branch: 'https://fe-project-branch.preview.zooniverse.org/about',
   staging: 'https://frontend.preview.zooniverse.org/about',
   static: 'https://fe-static.zooniverse.org/about',
-  production : 'https://fe-project.zooniverse.org/about'
+  production: 'https://fe-content-pages.zooniverse.org/about/'
 }
 
 function commitID () {

--- a/packages/app-project/next.config.js
+++ b/packages/app-project/next.config.js
@@ -12,7 +12,7 @@ const assetPrefixes = {
   development: '/projects',
   branch: 'https://fe-project-branch.preview.zooniverse.org/projects',
   static: 'https://fe-static.zooniverse.org/projects',
-  production : 'https://fe-project.zooniverse.org/projects'
+  production: 'https://fe-project.zooniverse.org/projects'
 }
 
 function commitID () {


### PR DESCRIPTION
## Package
app-content-pages

## Linked Issue and/or Talk Post
Follow-up to https://github.com/zooniverse/front-end-monorepo/pull/4238

## Describe your changes

Per [ADR 36](https://github.com/zooniverse/front-end-monorepo/blob/master/docs/arch/adr-36.md), use root URL  https://fe-content-pages.zooniverse.org/about/ for app-content-pages production site to bypass the CDN while debugging intermittent page loading issues.

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)