### PR TITLE
Refactor TranscribedLines tests with RTL

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
@@ -150,7 +150,7 @@ function TranscribedLines({
                 aria-disabled={disabled.toString()}
                 aria-describedby={id}
                 aria-label={line.consensusText}
-                className="complete line"
+                className='complete line'
                 focusColor={focusColor}
                 pointerEvents={disabled ? 'none' : 'painted'}
                 tabIndex={disabled ? -1 : 0}
@@ -193,7 +193,7 @@ function TranscribedLines({
                 aria-describedby={id}
                 aria-disabled={disabled.toString()}
                 aria-label={line.consensusText}
-                className="transcribed line"
+                className='transcribed line'
                 focusColor={focusColor}
                 pointerEvents={disabled ? 'none' : 'painted'}
                 tabIndex={disabled ? -1 : 0}


### PR DESCRIPTION
Refactor the `TranscribedLines` tests with React Testing Library, instead of Enzyme.

Fixes a couple of evergreen tests that are broken but still pass.

Tests for tooltips are broken by #1705 so I've skipped them for the time being.
https://github.com/zooniverse/front-end-monorepo/blob/25fe1627fdc24e981c912cf10f36b535546c2c8f/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js#L506-L511

Companion PR to #4237.

## Package
lib-classifier


## How to Review
Run the tests.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
