### PR TITLE
Classifier: mute liveliness warnings in tests

### DIFF
--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -7,7 +7,7 @@ import {
   onPatch,
   tryReference,
   types,
-  setLivelynessChecking
+  setLivelinessChecking
 } from 'mobx-state-tree'
 
 import ClassificationStore from './ClassificationStore'
@@ -136,6 +136,8 @@ const RootStore = types
 
 // Forces MST warnings to throw as errors instead with full stack trace
 // Easier for debugging...
-if (process.env.NODE_ENV === 'development') setLivelynessChecking('error')
+if (process.env.NODE_ENV === 'development') setLivelinessChecking('error')
+// mute liveliness warnings in the test logs.
+if (process.env.NODE_ENV === 'test') setLivelinessChecking('ignore')
 
 export default RootStore


### PR DESCRIPTION
Mute MobX State Tree liveliness warnings, to make the test logs less noisy.

## Package
lib-classifier

## Linked Issue and/or Talk Post
- towards #4136.

## How to Review
The test logs should ignore [livelieness warnings](https://mobx-state-tree.js.org/API/#livelinessmode), which might make them easier to read.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser
