### PR TITLE
Log errors from prioritised subject queues

### DIFF
--- a/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
+++ b/packages/lib-classifier/src/store/SubjectStore/SubjectStore.js
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser'
 import asyncStates from '@zooniverse/async-states'
 import { autorun } from 'mobx'
 import { addDisposer, addMiddleware, flow, getRoot, isValidReference, tryReference, types } from 'mobx-state-tree'
@@ -173,6 +174,9 @@ const SubjectStore = types
             // subject metadata in the API response are strings, not numbers.
             const priority = metadataPriority ? parseFloat(metadataPriority) : -1
             const lastPriority = self.last?.priority || -1
+            if (priority === -1) {
+              throw new Error(`Subject ${subject.id}: missing priority field for prioritised workflow.`)
+            }
             notSeen = priority > lastPriority
           }
           if (notSeen && !alreadyStored) {
@@ -180,6 +184,7 @@ const SubjectStore = types
             self.queue.push(subject.id)
           }
         } catch (error) {
+          Sentry.captureException(error)
           console.error(`Subject ${subject.id} is not a valid subject.`)
           console.error(error)
         }


### PR DESCRIPTION
- Throw an error if subjects are missing the `priority` field in a prioritised workflow.
- Log subject queue errors to Sentry, so that we can debug them.

## Package
lib-classifier

## Linked Issue and/or Talk Post
- closes #4272.

## How to Review
Load a prioritised workflow with a subject that doesn't have the `priority` field set in its metadata. The classifier will fail, but the error should be logged in the console and recorded by Sentry.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
