### PR TITLE
Classifier: Refactor and document Caesar hooks

### DIFF
--- a/packages/lib-classifier/src/hooks/Readme.md
+++ b/packages/lib-classifier/src/hooks/Readme.md
@@ -1,5 +1,13 @@
 # Classifier hooks
 
+## useCaesarReductions
+
+Get the stored Caesar reductions from the active subject, for a given reducer key.
+
+```js
+const { loaded, caesarReductions } = useCaesarReductions(reducerKey)
+```
+
 ## useClientRect
 
 Get the bounding client rectangle (`rect`) for a referenced DOM node (`ref`.)
@@ -17,6 +25,7 @@ Returns the new store when hydration is complete. Snapshots are stored in sessio
 ```js
 const classifierStore = useHydratedStore({ authClient, client }, cachePanoptesData = false, storageKey)
 ```
+
 ## usePanoptesAuth
 
 Asynchronously fetch an auth token, for a given user ID. A wrapper for `authClient.checkBearerToken()`.
@@ -56,7 +65,7 @@ Get the logged-in user's project roles, as an array of strings, or an empty arra
   const projectRoles = useProjectRoles(project.id, user.id)
 ```
 
-# useStores
+## useStores
   
 A custom hook which connects a component to the classifier store, or to a filtered list of store properties if a store  mapper function is provided.
 
@@ -70,6 +79,24 @@ function storeMapper(store) {
 function MyConnectedComponent(props) {
   const { workflows } = useStores(storeMapper)
 }
+```
+
+## useTranscriptionReductions
+
+A wrapper for `useCaesarReductions`, specific to the transcription task. Generates the props for the `TranscribedLines` component.
+
+Usage:
+```js
+const {
+  annotation,
+  frame,
+  invalidMark,
+  lines,
+  marks,
+  task,
+  visible,
+  workflow
+} = useTranscriptionReductions()
 ```
 
 ## useWorkflowSnapshot

--- a/packages/lib-classifier/src/hooks/index.js
+++ b/packages/lib-classifier/src/hooks/index.js
@@ -1,3 +1,4 @@
+export { default as useCaesarReductions } from './useCaesarReductions'
 export { default as useClientRect } from './useClientRect'
 export { default as useHydratedStore } from './useHydratedStore'
 export { default as usePanoptesAuth } from './usePanoptesAuth'

--- a/packages/lib-classifier/src/hooks/useCaesarReductions.js
+++ b/packages/lib-classifier/src/hooks/useCaesarReductions.js
@@ -1,0 +1,65 @@
+import { captureException } from '@sentry/browser'
+import { useEffect, useState } from 'react'
+
+import { useStores } from '@hooks'
+
+async function fetchReductions(caesarClient, reducerKey, subjectID, workflowID) {
+  if (reducerKey) {
+    try {
+      const query = `{
+        workflow(id: ${workflowID}) {
+          subject_reductions(subjectId: ${subjectID}, reducerKey:"${reducerKey}")
+          {
+            data
+          }
+        }
+      }`
+      const response = await caesarClient.request(query.replace(/\s+/g, ' '))
+      return response?.workflow?.subject_reductions
+    } catch (error) {
+      captureException(error)
+      console.error(error)
+      return []
+    }
+  }
+  return []
+}
+
+export default function useCaesarReductions(reducerKey) {
+  const [loaded, setLoaded] = useState(false)
+
+  const {
+    client: {
+      caesar
+    },
+    subjects: {
+      active: subject
+    },
+    workflows: {
+      active: workflow
+    }
+  } = useStores()
+
+  useEffect(function onSubjectChange() {
+    async function updateReductions(caesarClient, reducerKey, subject, workflow) {
+      const reductions = await fetchReductions(caesarClient, reducerKey, subject.id, workflow.id)
+      subject.setCaesarReductions({
+        reducer: reducerKey,
+        subjectId: subject.id,
+        workflowId: workflow.id,
+        reductions
+      })
+      setLoaded(true)
+    }
+
+    if (subject?.id && reducerKey) {
+      setLoaded(false)
+      updateReductions(caesar, reducerKey, subject, workflow)
+    }
+  }, [caesar, reducerKey, subject, workflow])
+
+  return {
+    loaded,
+    caesarReductions: subject.caesarReductions
+  }
+}


### PR DESCRIPTION
- extract `useCaesarReductions(reducerKey)` into its own hook.
- add error-handling to Caesar requests.
- add `useTranscriptionReductions` and `useCaesarReductions` to the hooks Readme.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## How to Review
- Check that previous transcriptions load from Caesar for a transcription workflow.
- Check that previous transcriptions load in the Transcribed Lines story.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
