### PR TITLE
Fix privacy policy links

### DIFF
--- a/packages/app-content-pages/src/shared/components/AuthModal/components/RegisterForm/components/Form/Form.js
+++ b/packages/app-content-pages/src/shared/components/AuthModal/components/RegisterForm/components/Form/Form.js
@@ -2,7 +2,6 @@ import counterpart from 'counterpart'
 import PropTypes from 'prop-types'
 import { Anchor, Box, Button, CheckBox, Grid, Text, FormField, TextInput } from 'grommet'
 import styled from 'styled-components'
-import Link from 'next/link'
 import FieldLabel from '../../../../shared/components/FieldLabel'
 import { withCustomFormik } from '@zooniverse/react-components'
 import en from '../../locales/en'
@@ -21,9 +20,7 @@ export const betaListSignUpFieldId = 'RegisterForm_beta_list_sign_up'
 export const underageWithParentFieldId = 'RegisterForm_underage_with_parent'
 
 const PrivacyPolicyLink = () => (
-  <Link href='/privacy' passHref>
-    <Anchor size='small'>{counterpart('RegisterForm.privacyLink')}</Anchor>
-  </Link>
+  <Anchor href='/privacy' size='small'>{counterpart('RegisterForm.privacyLink')}</Anchor>
 )
 
 const CheckBoxFormField = styled(FormField)`

--- a/packages/app-project/src/components/AuthModal/components/RegisterForm/components/Form/Form.js
+++ b/packages/app-project/src/components/AuthModal/components/RegisterForm/components/Form/Form.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import { Anchor, Box, Button, CheckBox, Grid, Text, FormField, TextInput } from 'grommet'
 import styled from 'styled-components'
-import Link from 'next/link'
 import FieldLabel from '../../../../shared/components/FieldLabel'
 import { withCustomFormik } from '@zooniverse/react-components'
 import { useTranslation } from 'next-i18next'
@@ -20,9 +19,7 @@ export const underageWithParentFieldId = 'RegisterForm_underage_with_parent'
 const PrivacyPolicyLink = () => {
   const { t } = useTranslation('components')
   return (
-    <Link href='/privacy' passHref>
-      <Anchor size='small'>{t('AuthModal.RegisterForm.privacyLink')}</Anchor>
-    </Link>
+    <Anchor href='/privacy' size='small'>{t('AuthModal.RegisterForm.privacyLink')}</Anchor>
   )
 }
 


### PR DESCRIPTION
Links to the privacy policy should be external links from the NextJS apps.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
app-content-pages
app-project

## How to Review
Open the registration form from each NextJS app and check that the link to the privacy policy goes to the correct URL now.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
