### PR TITLE
Refactor text viewer font

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewer.js
@@ -1,5 +1,6 @@
 import { Box } from 'grommet'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
 
 /**
 The Single Text Viewer is a variant of the Subject Viewer that's used to display text media.
@@ -13,6 +14,22 @@ The `height` is defined in the ImageAndTextViewerContainer as the clientHeight p
 ```
 */
 
+const StyledPre = styled.pre`
+  white-space: pre-wrap;
+  font-family: 'Anonymous Pro', monospace;
+  @font-face {
+    font-family: 'Anonymous Pro';
+    font-style: normal;
+    font-weight: 400;
+    src:
+      local('Anonymous Pro'),
+      local('Anonymous Pro-Regular'),
+      url(https://fonts.gstatic.com/s/anonymouspro/v21/rP2Bp2a15UIB7Un-bOeISG3pHls29QP-4Ks.woff2) 
+      format('woff2');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  }
+`
+
 function SingleTextViewer ({
   content = '',
   height = ''
@@ -23,9 +40,9 @@ function SingleTextViewer ({
       height={{ min: height }}
       pad='xsmall'
     >
-      <pre style={{ whiteSpace: 'pre-wrap' }}>
+      <StyledPre>
         {content}
-      </pre>
+      </StyledPre>
     </Box>
   )
 }


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- iteration on #4195 

## Describe your changes
- as detailed in the linked issue, volunteers should to be able to distinguish between 1, l, and I, which is crucial to transcription work
- the font "Anonymous Pro" differentiates well between the noted (and other) commonly confused characters/glyphs
- this PR adds "Anonymous Pro" font to the subject single text viewer
- #4310 also uses "Anonymous Pro"

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - local lib-classifier - https://local.zooniverse.org:8080/?project=1952&workflow=3602
  - local app-project  - https://local.zooniverse.org:3000/projects/markb-panoptes/digileap-testing-staging/classify/workflow/3602
- What user actions should my reviewer step through to review this PR?
  - note characters like 1/uppercase i/ lowercase L and the letter o vs the number zero
  - load a project that doesn't use the text viewer (like [I Fancy Cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)), note the new font isn't requested in network activity
- Which storybook stories should be reviewed?
  - [local textFromSubject task story](http://localhost:6006/?path=/story/subject-viewers-singletextviewer--default&globals=locale:en;locales.en:English;locales.test:Test+Language)
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected