### PR TITLE
Restore continuous zoom in and out

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.js
@@ -4,8 +4,12 @@ import { useTranslation } from '@translations/i18n'
 import ZoomInIcon from './ZoomInIcon'
 import Button from '../Button'
 
+function DEFAULT_HANDLER() {
+  console.log('zoom in')
+  return true
+}
 function ZoomInButton ({
-  onClick = () => console.log('Zoom in')
+  onClick = DEFAULT_HANDLER
 }) {
   const { t } = useTranslation('components')
   return (

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
@@ -12,7 +12,12 @@ function storeMapper(classifierStore) {
   }
 }
 
-function ZoomInButtonContainer({ zoomIn = () => console.log('zoom in') }) {
+function DEFAULT_HANDLER() {
+  console.log('zoom in')
+  return true
+}
+
+function ZoomInButtonContainer({ zoomIn = DEFAULT_HANDLER }) {
   const [timer, setTimer] = useState('')
 
   function onPointerDown(event) {
@@ -31,11 +36,14 @@ function ZoomInButtonContainer({ zoomIn = () => console.log('zoom in') }) {
   }
 
   return (
-    <ZoomInButton
-      onClick={zoomIn}
+    <span
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
-    />
+    >
+      <ZoomInButton
+        onClick={zoomIn}
+      />
+    </span>
   )
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.js
@@ -4,7 +4,12 @@ import { useTranslation } from '@translations/i18n'
 import ZoomOutIcon from './ZoomOutIcon'
 import Button from '../Button'
 
-function ZoomOutButton({ onClick = () => console.log('Zoom out') }) {
+function DEFAULT_HANDLER() {
+  console.log('zoom out')
+  return true
+}
+
+function ZoomOutButton({ onClick = DEFAULT_HANDLER }) {
   const { t } = useTranslation('components')
   return (
     <Button

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
@@ -12,7 +12,12 @@ function storeMapper(classifierStore) {
   }
 }
 
-function ZoomOutButtonContainer({ zoomOut = () => console.log('zoom out') }) {
+function DEFAULT_HANDLER() {
+  console.log('zoom out')
+  return true
+}
+
+function ZoomOutButtonContainer({ zoomOut = DEFAULT_HANDLER }) {
   const [timer, setTimer] = useState('')
 
   function onPointerDown(event) {
@@ -31,11 +36,14 @@ function ZoomOutButtonContainer({ zoomOut = () => console.log('zoom out') }) {
   }
 
   return (
-    <ZoomOutButton
-      onClick={zoomOut}
+    <span
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
-    />
+    >
+      <ZoomOutButton
+        onClick={zoomOut}
+      />
+    </span>
   )
 }
 


### PR DESCRIPTION
Zoom continuously in or out while the pointer is down on the zoom in and zoom out buttons in the image toolbar.


## Package
lib-classifier

## Linked Issue and/or Talk Post
- closes #4314.
- reverts changes from #4008 that broke the zoom buttons.


## How to Review
Use a pointing device to press the zoom buttons on any image subject. The subject should zoom continuously while the button is pressed.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

