### PR TITLE
lib-classifier: Add survey task instruction

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.js
@@ -60,7 +60,12 @@ function Task ({
   }
 
   return (
-    <Box key={annotation.id} basis='auto'>
+    <Box
+      key={annotation.id}
+      as='fieldset'
+      basis='auto'
+      style={{ border: 'none' }}
+    >
       <TaskComponent
         {...props}
         autoFocus={autoFocus}

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/Task/Task.js
@@ -60,12 +60,7 @@ function Task ({
   }
 
   return (
-    <Box
-      key={annotation.id}
-      as='fieldset'
-      basis='auto'
-      style={{ border: 'none' }}
-    >
+    <Box key={annotation.id} basis='auto'>
       <TaskComponent
         {...props}
         autoFocus={autoFocus}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -9,7 +9,7 @@ describe('SurveyTask', function () {
   describe('when choices are showing / without a selected choice', function () {
     describe('with task instruction', function () {
       it('should show the instruction', function () {
-        const DefaultStory = composeStory(Default, Meta)
+        const DefaultStory = composeStory(Default, Meta, globalConfig)
         render(<DefaultStory />)
 
         const instruction = screen.findByText('Select the animals you see in the image.')

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -3,10 +3,21 @@ import { composeStory } from '@storybook/testing-react'
 import { render, screen } from '@testing-library/react'
 import * as globalConfig from '../../../../../.storybook/preview'
 
-import Meta, { Default, NoFilters } from './SurveyTask.stories'
+import Meta, { Default, NoFiltersNoInstruction } from './SurveyTask.stories'
 
 describe('SurveyTask', function () {
   describe('when choices are showing / without a selected choice', function () {
+    describe('with task instruction', function () {
+      it('should show the instruction', function () {
+        const DefaultStory = composeStory(Default, Meta)
+        render(<DefaultStory />)
+
+        const instruction = screen.findByText('Select the animals you see in the image.')
+
+        expect(instruction).to.be.ok()
+      })
+    })
+    
     describe('with characteristic filters', function () {
       let filterButton, choiceButtons, choicesShowingCount, clearFiltersButton
 
@@ -54,8 +65,8 @@ describe('SurveyTask', function () {
       let filterButton, choiceButtons, choicesShowingCount, clearFiltersButton
 
       before(function () {
-        const NoFiltersStory = composeStory(NoFilters, Meta, globalConfig)
-        render(<NoFiltersStory />)
+        const NoFiltersNoInstructionStory = composeStory(NoFiltersNoInstruction, Meta, globalConfig)
+        render(<NoFiltersNoInstructionStory />)
         // filterButton is the Filter button above the choices
         filterButton = screen.queryByLabelText('SurveyTask.CharacteristicsFilter.filter')
         const choiceMenu = document.querySelector('[role=menu]')

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.stories.js
@@ -45,8 +45,13 @@ Default.args = {
   task
 }
 
-const taskWithoutCharacteristics = { ...task, characteristics: {} }
-export const NoFilters = Template.bind({})
-NoFilters.args = {
-  task: taskWithoutCharacteristics
+const taskWithoutInstructionStrings = { ...task.strings }
+delete taskWithoutInstructionStrings.instruction
+
+const taskWithoutCharacteristicsOrInstruction = { ...task, characteristics: {}, strings: taskWithoutInstructionStrings }
+delete taskWithoutCharacteristicsOrInstruction.instruction
+
+export const NoFiltersNoInstruction = Template.bind({})
+NoFiltersNoInstruction.args = {
+  task: taskWithoutCharacteristicsOrInstruction
 }

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.userKeystrokes.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.userKeystrokes.spec.js
@@ -4,21 +4,20 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as globalConfig from '../../../../../.storybook/preview'
 
-import Meta, { Default, NoFilters } from './SurveyTask.stories'
+import Meta, { Default, NoFiltersNoInstruction } from './SurveyTask.stories'
 
 describe('SurveyTask with user keystrokes', function () {
   // this turns off Mocha's time limit for slow tests
   this.timeout(0)
-
   const DefaultStory = composeStory(Default, Meta, globalConfig)
-  const NoFiltersStory = composeStory(NoFilters, Meta, globalConfig)
+  const NoFiltersNoInstructionStory = composeStory(NoFiltersNoInstruction, Meta, globalConfig)
 
   describe('without filters', function() {
     let user, choiceButton, choiceButtons
 
     beforeEach(async function () {
       user = userEvent.setup({ delay: null })
-      render(<NoFiltersStory />)
+      render(<NoFiltersNoInstructionStory />)
       choiceButton = screen.getByText('Fire')
       await user.click(choiceButton)
       const identifyButton = screen.getByText('SurveyTask.Choice.identify')
@@ -162,7 +161,7 @@ describe('SurveyTask with user keystrokes', function () {
 
     beforeEach(async function () {
       user = userEvent.setup({ delay: null })
-      render(<NoFiltersStory />)
+      render(<NoFiltersNoInstructionStory />)
       // tabbing to the first choice (Aardvark)
       await user.keyboard('[Tab]')
       // pressing Enter to open the choice (Aardvark)

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
@@ -20,6 +20,18 @@ const StyledText = styled(Text)`
   }
 `
 
+const components = {
+  a: Text,
+  h1: Text,
+  h2: Text,
+  h3: Text,
+  h4: Text,
+  h5: Text,
+  h6: Text,
+  p: Text,
+  span: Text
+}
+
 function Chooser ({
   disabled = false,
   filters = {},
@@ -54,7 +66,7 @@ function Chooser ({
     >
       {task.instruction 
         ? <StyledText as='legend' size='small'>
-            <Markdownz>
+            <Markdownz components={components}>
               {task.instruction}
             </Markdownz>
           </StyledText>

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
@@ -48,7 +48,10 @@ function Chooser ({
   const filteredChoiceIds = getFilteredChoiceIds(filters, task)
   
   return (
-    <Box>
+    <Box
+      as={task.instruction ? 'fieldset' : 'div'}
+      style={{ border: 'none' }}
+    >
       {task.instruction 
         ? <StyledText as='legend' size='small'>
             <Markdownz>

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
@@ -1,12 +1,19 @@
-import { Box } from 'grommet'
+import { Box, Text } from 'grommet'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import { useState } from 'react';
+import styled from 'styled-components'
+import { Markdownz } from '@zooniverse/react-components'
 
 import FilterStatus from './components/CharacteristicsFilter/FilterStatus'
 import Choices from './components/Choices'
 import ClearFilters from './components/CharacteristicsFilter/ClearFilters'
 import getFilteredChoiceIds from './helpers/getFilteredChoiceIds'
+
+const StyledText = styled(Text)`
+  display: block;
+  margin: 10px 0;
+`
 
 function Chooser ({
   disabled = false,
@@ -32,11 +39,26 @@ function Chooser ({
     setFilterDropOpen(true)
   }
 
+  const components = {
+    a: StyledText,
+    h1: StyledText,
+    h2: StyledText,
+    h3: StyledText,
+    h4: StyledText,
+    h5: StyledText,
+    h6: StyledText,
+    p: StyledText,
+    span: Text
+  }
+
   const showFilters = Object.keys(task.characteristics).length > 0
   const filteredChoiceIds = getFilteredChoiceIds(filters, task)
   
   return (
     <Box>
+      {task.instruction 
+        ? <Markdownz components={components}>{task.instruction}</Markdownz>
+        : null}
       {showFilters
         ? (<FilterStatus
             disabled={disabled}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/Chooser.js
@@ -11,8 +11,13 @@ import ClearFilters from './components/CharacteristicsFilter/ClearFilters'
 import getFilteredChoiceIds from './helpers/getFilteredChoiceIds'
 
 const StyledText = styled(Text)`
-  display: block;
-  margin: 10px 0;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+
+  > *:first-child {
+    margin-top: 0;
+  }
 `
 
 function Chooser ({
@@ -39,25 +44,17 @@ function Chooser ({
     setFilterDropOpen(true)
   }
 
-  const components = {
-    a: StyledText,
-    h1: StyledText,
-    h2: StyledText,
-    h3: StyledText,
-    h4: StyledText,
-    h5: StyledText,
-    h6: StyledText,
-    p: StyledText,
-    span: Text
-  }
-
   const showFilters = Object.keys(task.characteristics).length > 0
   const filteredChoiceIds = getFilteredChoiceIds(filters, task)
   
   return (
     <Box>
       {task.instruction 
-        ? <Markdownz components={components}>{task.instruction}</Markdownz>
+        ? <StyledText as='legend' size='small'>
+            <Markdownz>
+              {task.instruction}
+            </Markdownz>
+          </StyledText>
         : null}
       {showFilters
         ? (<FilterStatus

--- a/packages/lib-classifier/src/plugins/tasks/survey/mock-data/task.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/mock-data/task.js
@@ -2,6 +2,7 @@ const task = {
   'taskKey': 'T0',
   'required': false,
   'type': 'survey',
+  'instruction': 'Select the animals you see in the image.',
   'characteristics': {
     'LK': {
       'label': 'Like',
@@ -348,7 +349,7 @@ const task = {
   'questionsOrder': ['HWMN', 'WHTBHVRSDS', 'RTHRNNGPRSNT']
 }
 
-const strings = {}
+const strings = { instruction: task.instruction }
 
 Object.entries(task.characteristics).forEach(([characteristicID, characteristic]) => {
   const prefix = `characteristics.${characteristicID}`


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #2437 
- linked to https://github.com/zooniverse/Panoptes-Front-End/pull/6460

## Describe your changes
- conditionally show survey task instruction
- update stories, tests, and mock task accordingly

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - survey task with instruction - https://local.zooniverse.org:8080/?project=1634&workflow=3729
  - survey task without instruction - https://local.zooniverse.org:8080/?project=1634&workflow=2434
- What user actions should my reviewer step through to review this PR?
  - note task instruction
- Which storybook stories should be reviewed?
  - http://localhost:6006/?path=/story/tasks-survey--default&globals=locale:en;locales.en:English;locales.test:Test+Language
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)