### PR TITLE
Image toolbar: use pointer events

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/Button/Button.js
@@ -49,16 +49,22 @@ const StyledButton = styled(GrommetButton)`
   }
 `
 
+function DEFAULT_HANDLER() {
+  return true
+}
+
 function Button({
   active = false,
   a11yTitle,
   disabled,
   icon,
-  onBlur = () => true,
-  onClick = () => true,
-  onFocus = () => true,
-  onMouseOver = () => true,
-  onMouseOut = () => true
+  onBlur = DEFAULT_HANDLER,
+  onClick = DEFAULT_HANDLER,
+  onFocus = DEFAULT_HANDLER,
+  onPointerDown = DEFAULT_HANDLER,
+  onPointerOut = DEFAULT_HANDLER,
+  onPointerOver = DEFAULT_HANDLER,
+  onPointerUp = DEFAULT_HANDLER
 }) {
   const eventHandlers = disabled
     ? {}
@@ -66,8 +72,10 @@ function Button({
         onBlur,
         onClick,
         onFocus,
-        onMouseOver,
-        onMouseOut
+        onPointerDown,
+        onPointerOut,
+        onPointerOver,
+        onPointerUp
       }
 
   return (
@@ -76,7 +84,6 @@ function Button({
       a11yTitle={a11yTitle}
       disabled={disabled}
       icon={icon}
-      title={a11yTitle}
       plain
       {...eventHandlers}
     />
@@ -88,8 +95,10 @@ Button.propTypes = {
   onBlur: func,
   onClick: func,
   onFocus: func,
-  onMouseOver: func,
-  onMouseOut: func
+  onPointerDown: func,
+  onPointerOut: func,
+  onPointerOver: func,
+  onPointerUp: func
 }
 
 export default Button

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.js
@@ -9,7 +9,9 @@ function DEFAULT_HANDLER() {
   return true
 }
 function ZoomInButton ({
-  onClick = DEFAULT_HANDLER
+  onClick = DEFAULT_HANDLER,
+  onPointerDown = DEFAULT_HANDLER,
+  onPointerUp = DEFAULT_HANDLER
 }) {
   const { t } = useTranslation('components')
   return (
@@ -17,6 +19,8 @@ function ZoomInButton ({
       a11yTitle={t('ImageToolbar.ZoomInButton.ariaLabel')}
       icon={<ZoomInIcon />}
       onClick={onClick}
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
     />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
@@ -1,7 +1,8 @@
+import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import { useState } from 'react'
 
-import { withStores } from '@helpers'
+import { useStores } from '@hooks'
 import ZoomInButton from './ZoomInButton'
 
 function storeMapper(classifierStore) {
@@ -12,12 +13,8 @@ function storeMapper(classifierStore) {
   }
 }
 
-function DEFAULT_HANDLER() {
-  console.log('zoom in')
-  return true
-}
-
-function ZoomInButtonContainer({ zoomIn = DEFAULT_HANDLER }) {
+function ZoomInButtonContainer() {
+  const { zoomIn } = useStores(storeMapper)
   const [timer, setTimer] = useState('')
 
   function onPointerDown(event) {
@@ -36,19 +33,12 @@ function ZoomInButtonContainer({ zoomIn = DEFAULT_HANDLER }) {
   }
 
   return (
-    <span
+    <ZoomInButton
+      onClick={zoomIn}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
-    >
-      <ZoomInButton
-        onClick={zoomIn}
-      />
-    </span>
+    />
   )
 }
 
-ZoomInButtonContainer.propTypes = {
-  zoomIn: PropTypes.func
-}
-
-export default withStores(ZoomInButtonContainer, storeMapper)
+export default observer(ZoomInButtonContainer)

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
@@ -1,5 +1,4 @@
 import { observer } from 'mobx-react'
-import PropTypes from 'prop-types'
 import { useState } from 'react'
 
 import { useStores } from '@hooks'

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.spec.js
@@ -1,11 +1,20 @@
-import { shallow } from 'enzyme'
+import zooTheme from '@zooniverse/grommet-theme'
+import { mount } from 'enzyme'
+import { Grommet } from 'grommet'
+import { Provider } from 'mobx-react'
 
 import mockStore from '@test/mockStore'
 import ZoomInButtonContainer from './ZoomInButtonContainer'
 
 describe('Component > ZoomInButtonContainer', function () {
   it('should render without crashing', function () {
-    const wrapper = shallow(<ZoomInButtonContainer store={mockStore()} />)
+    const wrapper = mount(
+      <Grommet theme={zooTheme}>
+        <Provider classifierStore={mockStore()}>
+          <ZoomInButtonContainer />
+        </Provider>
+      </Grommet>
+    )
     expect(wrapper).to.be.ok()
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.js
@@ -9,13 +9,19 @@ function DEFAULT_HANDLER() {
   return true
 }
 
-function ZoomOutButton({ onClick = DEFAULT_HANDLER }) {
+function ZoomOutButton({
+  onClick = DEFAULT_HANDLER,
+  onPointerDown = DEFAULT_HANDLER,
+  onPointerUp = DEFAULT_HANDLER
+}) {
   const { t } = useTranslation('components')
   return (
     <Button
       a11yTitle={t('ImageToolbar.ZoomOutButton.ariaLabel')}
       icon={<ZoomOutIcon />}
       onClick={onClick}
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
     />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
@@ -1,7 +1,8 @@
+import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import { useState } from 'react'
 
-import { withStores } from '@helpers'
+import { useStores } from '@hooks'
 import ZoomOutButton from './ZoomOutButton'
 
 function storeMapper(classifierStore) {
@@ -12,12 +13,8 @@ function storeMapper(classifierStore) {
   }
 }
 
-function DEFAULT_HANDLER() {
-  console.log('zoom out')
-  return true
-}
-
-function ZoomOutButtonContainer({ zoomOut = DEFAULT_HANDLER }) {
+function ZoomOutButtonContainer() {
+  const { zoomOut } = useStores(storeMapper)
   const [timer, setTimer] = useState('')
 
   function onPointerDown(event) {
@@ -36,19 +33,12 @@ function ZoomOutButtonContainer({ zoomOut = DEFAULT_HANDLER }) {
   }
 
   return (
-    <span
+    <ZoomOutButton
+      onClick={zoomOut}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
-    >
-      <ZoomOutButton
-        onClick={zoomOut}
-      />
-    </span>
+    />
   )
 }
 
-ZoomOutButtonContainer.propTypes = {
-  zoomOut: PropTypes.func
-}
-
-export default withStores(ZoomOutButtonContainer, storeMapper)
+export default observer(ZoomOutButtonContainer)

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
@@ -1,5 +1,4 @@
 import { observer } from 'mobx-react'
-import PropTypes from 'prop-types'
 import { useState } from 'react'
 
 import { useStores } from '@hooks'

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.spec.js
@@ -1,11 +1,20 @@
-import { shallow } from 'enzyme'
+import zooTheme from '@zooniverse/grommet-theme'
+import { mount } from 'enzyme'
+import { Grommet } from 'grommet'
+import { Provider } from 'mobx-react'
 
 import mockStore from '@test/mockStore'
 import ZoomOutButtonContainer from './ZoomOutButtonContainer'
 
 describe('Component > ZoomOutButtonContainer', function () {
   it('should render without crashing', function () {
-    const wrapper = shallow(<ZoomOutButtonContainer store={mockStore()} />)
+    const wrapper = mount(
+      <Grommet theme={zooTheme}>
+        <Provider classifierStore={mockStore()}>
+          <ZoomOutButtonContainer />
+        </Provider>
+      </Grommet>
+    )
     expect(wrapper).to.be.ok()
   })
 })


### PR DESCRIPTION
- Add pointer events to the base `Button` component.
- Remove extra `span` elements from the zoom controls.
- Remove mouse events.
- Replace HOC's with hooks in the zoom buttons.

This reverts #4315 and fixes #4314 by adding pointer events to the image toolbar's base `Button` component.

Closes #4351.

## Package
lib-classifier

## How to Review
#4314 shouldn't regress here, so continuous zoom should still work while the pointer is down. This should also fix styling bugs that were caught by @goplayoutside3.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser



## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
