### PR TITLE
Add pull request branch to CodeQL workflow config

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
+    branches: [ "master" ]
   schedule:
     - cron: '0 23 * * 3'
 


### PR DESCRIPTION
CodeQL is warning that the `on.push` branch config should match the `on.pull_request` branch config.

Closes #4382.