### PR TITLE
Quick and dirty script error logging

### DIFF
--- a/packages/app-project/pages/_document.js
+++ b/packages/app-project/pages/_document.js
@@ -10,6 +10,32 @@ const GA_TRACKING_SCRIPT = `
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${GA_TRACKING_ID}');
 `
 
+const ERROR_LOGGING_SCRIPT = `
+  function setUpLogging() {
+    Sentry.init({
+      dsn: '${process.env.SENTRY_PROJECT_DSN}'
+    });
+    console.log('Sentry init: ${process.env.SENTRY_PROJECT_DSN}');
+  }
+
+  function onError(e) {
+    console.log('errored', e.srcElement.src);
+    const error = new Error('External script failed to load');
+    Sentry.withScope((scope) => {
+      scope.setTag('ScriptError', 'loadFailed');
+      scope.setExtra('scriptSrc', e.srcElement.src);
+      Sentry.captureException(error);
+    });
+  };
+
+  const scripts = document.querySelectorAll('script');
+  scripts.forEach(scriptNode => {
+    scriptNode.onload = e => console.log('loaded', e.srcElement.src);
+    scriptNode.onerror = onError;
+  });
+  const sentryScript = document.querySelector('#sentryScript');
+  sentryScript.onload = setUpLogging;
+`
 const isProduction = process.env.NODE_ENV === 'production'
 
 process.on('unhandledRejection', logToSentry)
@@ -49,6 +75,13 @@ export default class MyDocument extends Document {
           {isProduction && (
             <script dangerouslySetInnerHTML={{ __html: GA_TRACKING_SCRIPT }} />
           )}
+          <script
+            src="https://browser.sentry-cdn.com/7.44.2/bundle.min.js"
+            integrity="sha384-DKvNAjtV829X/OfXiq539qMBQjm0X+mzgpSoEbPd0CUa6jU62Z7Y23By/A4oLgqB"
+            crossorigin="anonymous"
+            defer
+            id='sentryScript'
+          ></script>
         </Head>
         <body>
           {isProduction && (
@@ -63,6 +96,7 @@ export default class MyDocument extends Document {
           )}
           <Main />
           <NextScript />
+          <script dangerouslySetInnerHTML={{ __html: ERROR_LOGGING_SCRIPT }} />
         </body>
       </Html>
     )


### PR DESCRIPTION
- Add Sentry to the page head, so that it's available before scripts load.
- Add `onload` and `onerror` handlers to each script tag in the downloaded page.

## Package
app-project
