### PR TITLE
Trace page performance with Sentry

### DIFF
--- a/packages/app-content-pages/next.config.js
+++ b/packages/app-content-pages/next.config.js
@@ -15,9 +15,10 @@ function commitID () {
   }
 }
 
+const isDevelopment = process.env.NODE_ENV === 'development'
 const PANOPTES_ENV = process.env.PANOPTES_ENV || 'staging'
 const webpackConfig = require('./webpack.config')
-const SENTRY_CONTENT_DSN = 'https://1f0126a750244108be76957b989081e8@sentry.io/1492498'
+const SENTRY_CONTENT_DSN = isDevelopment ? '' : 'https://1f0126a750244108be76957b989081e8@sentry.io/1492498'
 const APP_ENV = process.env.APP_ENV || 'development'
 const COMMIT_ID = process.env.COMMIT_ID || commitID()
 const assetPrefix = assetPrefixes[APP_ENV]

--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@sentry/browser": "~7.45.0",
     "@sentry/node": "~7.45.0",
+    "@sentry/tracing": "~7.45.0",
     "@zeit/next-source-maps": "0.0.4-canary.1",
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/grommet-theme": "~3.1.0",

--- a/packages/app-content-pages/pages/publications.js
+++ b/packages/app-content-pages/pages/publications.js
@@ -1,5 +1,5 @@
 import PublicationsAPI from '../src/api/publications'
-import { logNodeError } from '../src/helpers/logger'
+import logNodeError from '../src/helpers/logger/logNodeError.js'
 export { default } from '../src/screens/Publications'
 
 export async function getStaticProps() {

--- a/packages/app-content-pages/pages/team.js
+++ b/packages/app-content-pages/pages/team.js
@@ -1,5 +1,5 @@
 import TeamAPI from '../src/api/team'
-import { logNodeError } from '../src/helpers/logger'
+import logNodeError from '../src/helpers/logger/logNodeError.js'
 export { default } from '../src/screens/Team'
 
 export async function getStaticProps() {

--- a/packages/app-content-pages/src/helpers/logger/initializeSentry.js
+++ b/packages/app-content-pages/src/helpers/logger/initializeSentry.js
@@ -1,9 +1,13 @@
 import * as Sentry from '@sentry/node'
+import { Integrations } from '@sentry/tracing'
 
 export default function initializeSentry () {
+  const isBrowser = typeof window !== 'undefined'
   const dsn = process.env.SENTRY_CONTENT_DSN
   const release = process.env.COMMIT_ID
   const environment = process.env.APP_ENV
+  const integrations = isBrowser ? [new Integrations.BrowserTracing()] : [new Integrations.Express()]
+  const tracesSampleRate = 1.0
   const ignoreErrors = [
     'ResizeObserver loop limit exceeded' // Ignore benign error: https://github.com/WICG/resize-observer/issues/38
   ]
@@ -11,8 +15,10 @@ export default function initializeSentry () {
   if (dsn) {
     Sentry.init({
       dsn,
-      release,
       environment,
+      integrations,
+      release,
+      tracesSampleRate,
       ignoreErrors
     })
   }

--- a/packages/app-content-pages/src/helpers/logger/initializeSentry.js
+++ b/packages/app-content-pages/src/helpers/logger/initializeSentry.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/node'
 import { Integrations } from '@sentry/tracing'
 
-export default function initializeSentry () {
+export default function initializeSentry() {
   const isBrowser = typeof window !== 'undefined'
   const dsn = process.env.SENTRY_CONTENT_DSN
   const release = process.env.COMMIT_ID

--- a/packages/app-content-pages/src/helpers/logger/logNodeError.js
+++ b/packages/app-content-pages/src/helpers/logger/logNodeError.js
@@ -1,10 +1,10 @@
-import * as Sentry from '@sentry/node'
+import { captureException } from '@sentry/node'
 
 export default function logNodeError (error) {
   const dsn = process.env.SENTRY_CONTENT_DSN
 
   if (dsn) {
-    Sentry.captureException(error)
+    captureException(error)
   }
 
   return null

--- a/packages/app-content-pages/src/helpers/logger/logReactError.js
+++ b/packages/app-content-pages/src/helpers/logger/logReactError.js
@@ -1,14 +1,14 @@
-import * as Sentry from '@sentry/node'
+import { withScope, captureException} from '@sentry/node'
 
 export default function logReactError (error, errorInfo) {
   const dsn = process.env.SENTRY_CONTENT_DSN
 
   if (dsn) {
-    Sentry.withScope((scope) => {
+    withScope((scope) => {
       Object.keys(errorInfo).forEach((key) => {
         scope.setExtra(key, errorInfo[key])
       });
-      Sentry.captureException(error)
+      captureException(error)
     })
   }
 

--- a/packages/app-project/next.config.js
+++ b/packages/app-project/next.config.js
@@ -18,9 +18,10 @@ function commitID () {
   }
 }
 
+const isDevelopment = process.env.NODE_ENV === 'development'
 const PANOPTES_ENV = process.env.PANOPTES_ENV || 'staging'
 const webpackConfig = require('./webpack.config')
-const SENTRY_PROJECT_DSN = 'https://2a50683835694829b4bc3cccc9adcc1b@sentry.io/1492691'
+const SENTRY_PROJECT_DSN = isDevelopment ? '' : 'https://2a50683835694829b4bc3cccc9adcc1b@sentry.io/1492691'
 const APP_ENV = process.env.APP_ENV || 'development'
 const COMMIT_ID = process.env.COMMIT_ID || commitID()
 const assetPrefix = assetPrefixes[APP_ENV]

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -20,6 +20,7 @@
     "@artsy/fresnel": "~6.1.0",
     "@sentry/browser": "~7.45.0",
     "@sentry/node": "~7.45.0",
+    "@sentry/tracing": "~7.45.0",
     "@sindresorhus/string-hash": "~1.2.0",
     "@visx/axis": "~2.18.0",
     "@visx/group": "~3.0.0",

--- a/packages/app-project/pages/_document.js
+++ b/packages/app-project/pages/_document.js
@@ -15,19 +15,21 @@ const ERROR_LOGGING_SCRIPT = `
     Sentry.init({
       dsn: '${process.env.SENTRY_PROJECT_DSN}',
       environment: '${process.env.APP_ENV}',
-      release: '${process.env.COMMIT_ID}'
+      release: '${process.env.COMMIT_ID}',
+      integrations: [new Sentry.BrowserTracing()],
+      tracesSampleRate: 1.0
     });
     console.log('Sentry init: ${process.env.SENTRY_PROJECT_DSN} ${process.env.APP_ENV}');
   }
 
   function onError(e) {
-    console.log('errored', e.srcElement.src);
     const error = new Error('External script failed to load');
     Sentry.withScope((scope) => {
       scope.setTag('ScriptError', 'loadFailed');
       scope.setExtra('scriptSrc', e.srcElement.src);
       Sentry.captureException(error);
     });
+    console.log('errored', e.srcElement.src);
   };
 
   const scripts = document.querySelectorAll('script');
@@ -78,8 +80,8 @@ export default class MyDocument extends Document {
             <script dangerouslySetInnerHTML={{ __html: GA_TRACKING_SCRIPT }} />
           )}
           <script
-            src="https://browser.sentry-cdn.com/7.44.2/bundle.min.js"
-            integrity="sha384-DKvNAjtV829X/OfXiq539qMBQjm0X+mzgpSoEbPd0CUa6jU62Z7Y23By/A4oLgqB"
+            src="https://browser.sentry-cdn.com/7.45.0/bundle.tracing.min.js"
+            integrity="sha384-3eSp2mmX0+DiH727hyDCiJsV+21D7/8YtcsQuhzpNTUTKJsYa16mVS5qfrdYjkoe"
             crossorigin="anonymous"
             defer
             id='sentryScript'

--- a/packages/app-project/src/helpers/fetchProjectData/fetchProjectData.js
+++ b/packages/app-project/src/helpers/fetchProjectData/fetchProjectData.js
@@ -3,7 +3,7 @@ import asyncStates from '@zooniverse/async-states'
 import { projects } from '@zooniverse/panoptes-js'
 
 import getServerSideAPIHost from '@helpers/getServerSideAPIHost'
-import { logToSentry } from '@helpers/logger'
+import logToSentry from '@helpers/logger/logToSentry.js'
 
 export default async function fetchProjectData(slug, params) {
   const { headers, host } = getServerSideAPIHost(params?.env)

--- a/packages/app-project/src/helpers/fetchProjectPage/fetchProjectPage.js
+++ b/packages/app-project/src/helpers/fetchProjectPage/fetchProjectPage.js
@@ -1,6 +1,6 @@
 import fetchTranslations from '@helpers/fetchTranslations'
 import getServerSideAPIHost from '@helpers/getServerSideAPIHost'
-import { logToSentry } from '@helpers/logger'
+import logToSentry from '@helpers/logger/logToSentry.js'
 
 export default async function fetchProjectPage(project, locale, key, env) {
   const { headers, host } = getServerSideAPIHost(env)

--- a/packages/app-project/src/helpers/fetchProjectPageTitles/fetchProjectPageTitles.js
+++ b/packages/app-project/src/helpers/fetchProjectPageTitles/fetchProjectPageTitles.js
@@ -1,6 +1,6 @@
 import { panoptes } from '@zooniverse/panoptes-js'
 import getServerSideAPIHost from '@helpers/getServerSideAPIHost'
-import { logToSentry } from '@helpers/logger'
+import logToSentry from '@helpers/logger/logToSentry.js'
 
 export default async function fetchProjectPageTitles(project, env) {
   try {

--- a/packages/app-project/src/helpers/fetchSubjectSets/fetchSubjectSets.js
+++ b/packages/app-project/src/helpers/fetchSubjectSets/fetchSubjectSets.js
@@ -1,7 +1,7 @@
 import { panoptes } from '@zooniverse/panoptes-js'
 
 import getServerSideAPIHost from '@helpers/getServerSideAPIHost'
-import { logToSentry } from '@helpers/logger'
+import logToSentry from '@helpers/logger/logToSentry.js'
 
 async function fetchSubjectSetData(subjectSetIDs, env) {
   const { headers, host } = getServerSideAPIHost(env)

--- a/packages/app-project/src/helpers/fetchTeam/fetchTeam.js
+++ b/packages/app-project/src/helpers/fetchTeam/fetchTeam.js
@@ -1,6 +1,6 @@
 import { panoptes } from '@zooniverse/panoptes-js'
 import getServerSideAPIHost from '@helpers/getServerSideAPIHost'
-import { logToSentry } from '@helpers/logger'
+import logToSentry from '@helpers/logger/logToSentry.js'
 
 export default async function fetchTeam(project, env) {
   const { headers, host } = getServerSideAPIHost(env)

--- a/packages/app-project/src/helpers/fetchTranslations/fetchTranslations.js
+++ b/packages/app-project/src/helpers/fetchTranslations/fetchTranslations.js
@@ -1,7 +1,7 @@
 import { panoptes } from '@zooniverse/panoptes-js'
 
 import getServerSideAPIHost from '@helpers/getServerSideAPIHost'
-import { logToSentry } from '@helpers/logger'
+import logToSentry from '@helpers/logger/logToSentry.js'
 
 export default async function fetchTranslations({
   translated_id,

--- a/packages/app-project/src/helpers/fetchWorkflowsHelper/fetchWorkflowsHelper.js
+++ b/packages/app-project/src/helpers/fetchWorkflowsHelper/fetchWorkflowsHelper.js
@@ -1,7 +1,7 @@
 import { panoptes } from '@zooniverse/panoptes-js'
 
 import getServerSideAPIHost from '@helpers/getServerSideAPIHost'
-import { logToSentry } from '@helpers/logger'
+import logToSentry from '@helpers/logger/logToSentry.js'
 
 async function fetchWorkflowData(workflows, env) {
   const { headers, host } = getServerSideAPIHost(env)

--- a/packages/app-project/src/helpers/logger/initializeSentry.js
+++ b/packages/app-project/src/helpers/logger/initializeSentry.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/node'
 import { Integrations } from '@sentry/tracing'
 
-export default function initializeSentry () {
+export default function initializeSentry() {
   const isBrowser = typeof window !== 'undefined'
   const dsn = process.env.SENTRY_PROJECT_DSN
   const environment = process.env.APP_ENV

--- a/packages/app-project/src/helpers/logger/initializeSentry.js
+++ b/packages/app-project/src/helpers/logger/initializeSentry.js
@@ -1,9 +1,13 @@
 import * as Sentry from '@sentry/node'
+import { Integrations } from '@sentry/tracing'
 
 export default function initializeSentry () {
+  const isBrowser = typeof window !== 'undefined'
   const dsn = process.env.SENTRY_PROJECT_DSN
   const environment = process.env.APP_ENV
   const release = process.env.COMMIT_ID
+  const integrations = isBrowser ? [new Integrations.BrowserTracing()] : [new Integrations.Express()]
+  const tracesSampleRate = 1.0
   const ignoreErrors = [
     'ResizeObserver loop limit exceeded' // Ignore benign error: https://github.com/WICG/resize-observer/issues/38
   ]
@@ -13,7 +17,9 @@ export default function initializeSentry () {
     Sentry.init({
       dsn,
       environment,
+      integrations,
       release,
+      tracesSampleRate,
       ignoreErrors
     })
   }

--- a/packages/app-project/src/helpers/logger/logToSentry.js
+++ b/packages/app-project/src/helpers/logger/logToSentry.js
@@ -1,14 +1,14 @@
-import * as Sentry from '@sentry/node'
+import { withScope, captureException } from '@sentry/node'
 
 export default function logToSentry(error, errorInfo = {}) {
   const dsn = process.env.SENTRY_PROJECT_DSN
 
   if (dsn) {
-    Sentry.withScope((scope) => {
+    withScope((scope) => {
       Object.keys(errorInfo).forEach((key) => {
         scope.setExtra(key, errorInfo[key])
       })
-      Sentry.captureException(error)
+      captureException(error)
     })
   }
 

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -6,7 +6,7 @@ import asyncStates from '@zooniverse/async-states'
 
 import { useAdminMode } from '@hooks'
 import addQueryParams from '@helpers/addQueryParams'
-import { logToSentry } from '@helpers/logger'
+import logToSentry from '@helpers/logger/logToSentry.js'
 import ErrorMessage from './components/ErrorMessage'
 import Loader from '@shared/components/Loader'
 

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/checkRetiredStatus.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/checkRetiredStatus.js
@@ -1,6 +1,6 @@
 import { env, panoptes } from '@zooniverse/panoptes-js'
 import auth from 'panoptes-client/lib/auth'
-import { logToSentry } from '@helpers/logger'
+import logToSentry from '@helpers/logger/logToSentry.js'
 
 export default async function checkRetiredStatus(ids, workflow) {
   const token = await auth.checkBearerToken()

--- a/packages/app-project/stores/Store.js
+++ b/packages/app-project/stores/Store.js
@@ -1,7 +1,7 @@
 import asyncStates from '@zooniverse/async-states'
 import { addDisposer, addMiddleware, getEnv, onAction, types } from 'mobx-state-tree'
 import { autorun } from 'mobx'
-import { logToSentry } from '../src/helpers/logger'
+import logToSentry from '../src/helpers/logger/logToSentry.js'
 
 import Project from './Project'
 import UI from './UI'

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
@@ -2,7 +2,7 @@ import { applySnapshot, flow, getRoot, types } from 'mobx-state-tree'
 import auth from 'panoptes-client/lib/auth'
 import asyncStates from '@zooniverse/async-states'
 
-import { logToSentry } from '@helpers/logger'
+import logToSentry from '@helpers/logger/logToSentry.js'
 import numberString from '@stores/types/numberString'
 
 const Preferences = types

--- a/yarn.lock
+++ b/yarn.lock
@@ -2286,6 +2286,13 @@
     "@sentry/types" "7.45.0"
     "@sentry/utils" "7.45.0"
 
+"@sentry/tracing@~7.45.0":
+  version "7.45.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.45.0.tgz#77fe1075b3fdfd5026bf8d816a855bbe992b64a3"
+  integrity sha512-FsoFmZPzTBGvWeJH73NxSF1ot61Zw3aIZo5XolengiKnRmcrQOFxebtMKBiZ61QBRYGqsm5uT7QB7zITU6Ikgg==
+  dependencies:
+    "@sentry-internal/tracing" "7.45.0"
+
 "@sentry/types@7.45.0":
   version "7.45.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.45.0.tgz#b5e2db7a421f6090398565b0a72fb3bbdc94233a"


### PR DESCRIPTION
- install `@sentry/tracing` in both NextJS apps.
- enable performance tracing in Express and in the browser.
- turn off Sentry in local development mode (`NODE_ENV = 'development'`) so that Sentry isn't spammed with empty development releases.

## Package
app-project
app-content-pages

## How to Review
There are a few options. Pick the one you're most comfortable with:
- [Build and start both NextJS apps locally in Node](https://github.com/zooniverse/front-end-monorepo/#with-node-and-yarn) to verify that they still build and run.
- [Build and start a Docker image](https://github.com/zooniverse/front-end-monorepo/#docker), then check both NextJS apps on localhost. This will verify that a production install (no dev dependencies) starts and runs in a container.
- [Build and deploy a Docker image of this branch](https://github.com/zooniverse/front-end-monorepo/actions/workflows/deploy_branch.yml), then check the project app on https://fe-project-branch.preview.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess. There's no branch preview on kubernetes for the content pages app.

Production builds will log performance tracing information to Sentry, while you are browsing a project (except in Brave, which blocks all tracking.) Local development mode (`yarn dev`) won't log to Sentry at all.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
