### PR TITLE
lib-react-components: update .npmignore

### DIFF
--- a/packages/lib-react-components/.npmignore
+++ b/packages/lib-react-components/.npmignore
@@ -9,3 +9,6 @@ test
 .editorconfig
 .travis.yml
 webpack.dist.js
+
+**/mockLightCurves/*
+**/screenshot.png

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.5.1] 2023-03-29
+
+### Changed
+- Ignore mock data and screenshots in the published package.
+
 ## [1.5.0] 2023-03-20
 
 ### Added

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -3,7 +3,7 @@
   "description": "Zooniverse React Components",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": {


### PR DESCRIPTION
- Ignore mock light curves and screenshots in `@zooniverse/react-components`. That removes ~500k of unused files from the published package.
- Update the changelog.
- Bump the version to 1.5.1.

## Package
lib-react-components


## How to Review
`npm publish --dry-run` to check which files are included in the published package.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out

## Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
