### PR TITLE
Deploy storybooks from production-release

### DIFF
--- a/.github/workflows/deploy_storybook.yml
+++ b/.github/workflows/deploy_storybook.yml
@@ -1,0 +1,24 @@
+name: deploy storybooks
+
+on:
+  push:
+    tags:
+      - production-release
+  workflow_dispatch:
+
+jobs:
+  build_storybooks:
+    name: Build storybooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
+        with:
+         node-version: 'lts/hydrogen'
+         cache: 'yarn'
+
+      - run: yarn install --production=false --frozen-lockfile
+      - run: yarn workspace @zooniverse/react-components build:es6
+      - run: yarn workspace @zooniverse/classifier build:es6
+      - run: yarn deploy-storybook

--- a/.github/workflows/deploy_storybook.yml
+++ b/.github/workflows/deploy_storybook.yml
@@ -20,5 +20,4 @@ jobs:
 
       - run: yarn install --production=false --frozen-lockfile
       - run: yarn workspace @zooniverse/react-components build:es6
-      - run: yarn workspace @zooniverse/classifier build:es6
       - run: yarn deploy-storybook


### PR DESCRIPTION
Build the libraries and run `yarn deploy-storybook` when the `production-release` tag changes. Allow deploys to be run manually too, via `workflow_dispatch`.