### PR TITLE
Fix button icon sizing

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.js
@@ -146,13 +146,18 @@ const LineControls = forwardRef(function LineControls({
               onKeyDown={(ev) => { onEnterOrSpace(ev, action) }}
             ></StyledPath>
           </Tooltip>
-          <IconComponent
-            color='white'
-            size={`${icon.size}px`}
+          <svg
+            height={icon.size}
+            width={icon.size}
             x={icon.x}
             y={icon.y}
-            focusable='false'
-          />
+          >
+            <IconComponent
+              color='white'
+              size={`${icon.size}px`}
+              focusable='false'
+            />
+          </svg>
         </g>
       })}
     </g>


### PR DESCRIPTION
Wrap nested Grommet icons inside an SVG element. Nested SVG elements inherit their size and position from their nearest parent SVG. https://www.sarasoueidan.com/blog/nesting-svgs/#nesting-svgs

![Screenshot of the freehand line tools in Firefox 111. The icons for the line controls are sized normally.](https://user-images.githubusercontent.com/59547/231829910-47936f90-51ca-4e13-bfd5-062a1fdc1a75.png)
