### PR TITLE
Add missing CI env to deploy_storybook workflow

### DIFF
--- a/.github/workflows/deploy_storybook.yml
+++ b/.github/workflows/deploy_storybook.yml
@@ -20,4 +20,7 @@ jobs:
 
       - run: yarn install --production=false --frozen-lockfile
       - run: yarn workspace @zooniverse/react-components build:es6
-      - run: yarn deploy-storybook
+      - name: Deploy to GH Pages
+        run: yarn deploy-storybook -- --ci
+        env:
+          GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `deploy-storybook` script needs an extra `--ci` flag and `GH_TOKEN` environment variable when it's run by GitHub Actions. See https://github.com/storybook-eol/storybook-deployer/blob/master/README.md#deploying-storybook-to-github-pages-as-part-of-a-github-action

## Linked Issue and/or Talk Post
Follows on from #4463.

## How to Review
You should be able to deploy the storybook from this branch, under the Actions tab:
https://github.com/zooniverse/front-end-monorepo/actions/workflows/deploy_storybook.yml

Deploys fail on master, because of the missing `--ci` flag and GH token.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser
