### PR TITLE
Scatter plot viewer: add x-range selection

### DIFF
--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "~7.21.0",
     "@sentry/browser": "~7.51.0",
     "@visx/axis": "~2.18.0",
+    "@visx/brush": "~3.0.1",
     "@visx/event": "~3.0.0",
     "@visx/glyph": "~3.0.0",
     "@visx/group": "~3.0.0",

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/ScatterPlotViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/ScatterPlotViewer.stories.js
@@ -38,10 +38,19 @@ const transientObjectSubject = Factory.build('subject', {
   ]
 })
 
-const store = mockStore({ subject: transientObjectSubject })
+const storeWithTransientSubject = mockStore({ subject: transientObjectSubject })
 
-function ViewerContext(props) {
-  const { children } = props
+const superWaspSubject = Factory.build('subject', {
+  locations: [
+    { 'application/json': 'https://panoptes-uploads.zooniverse.org/subject_location/f311cd2a-f6c7-4cc2-a411-0e32c5ff55e3.json'}
+  ]
+})
+
+
+function ViewerContext({
+  store = storeWithTransientSubject,
+  children
+}) {
   return <Provider classifierStore={store}>{children}</Provider>
 }
 
@@ -179,3 +188,51 @@ export function MultipleSeries() {
     </ViewerContext>
   )
 }
+
+export function XRangeSelection() {
+  return (
+    <ViewerContext store={XRangeSelection.store}>
+      <Box direction='row' height='medium' width='large'>
+        <ScatterPlotViewerConnector
+          experimentalSelectionTool
+          zoomConfiguration={{
+            direction: 'x',
+            minZoom: 1,
+            maxZoom: 10,
+            zoomInValue: 1.2,
+            zoomOutValue: 0.8
+          }}
+        />
+        <ImageToolbar width='4rem' />
+      </Box>
+    </ViewerContext>
+  )
+}
+XRangeSelection.store = mockStore({ subject: superWaspSubject })
+
+export function SelectedXRanges() {
+  const initialSelections = [
+    { x0: 95, x1: 101 },
+    { x0: 114, x1: 118 }
+  ]
+  return (
+    <ViewerContext store={SelectedXRanges.store}>
+      <Box direction='row' height='medium' width='large'>
+        <ScatterPlotViewerConnector
+          disabled
+          experimentalSelectionTool
+          initialSelections={initialSelections}
+          zoomConfiguration={{
+            direction: 'x',
+            minZoom: 1,
+            maxZoom: 10,
+            zoomInValue: 1.2,
+            zoomOutValue: 0.8
+          }}
+        />
+        <ImageToolbar width='4rem' />
+      </Box>
+    </ViewerContext>
+  )
+}
+SelectedXRanges.store = mockStore({ subject: superWaspSubject })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/ScatterPlotViewerConnector.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/ScatterPlotViewerConnector.js
@@ -7,12 +7,14 @@ function storeMapper(classifierStore) {
       active: subject
     },
     subjectViewer: {
+      interactionMode,
       setOnZoom,
       setOnPan
     }
   } = classifierStore
 
   return {
+    interactionMode,
     setOnZoom,
     setOnPan,
     subject

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
@@ -7,7 +7,7 @@ import Chart from '@viewers/components/SVGComponents/Chart'
 import getZoomBackgroundColor from '@viewers/helpers/getZoomBackgroundColor'
 import sortDataPointsByHighlight from '@viewers/helpers/sortDataPointsByHighlight'
 import Axes from '../Axes'
-import { ScatterPlotSeries } from './components'
+import { ScatterPlotSeries, Selections } from './components'
 
 import {
   getDataPoints,
@@ -53,7 +53,11 @@ export default function ScatterPlot({
   children,
   data,
   dataPointSize = 25,
+  disabled = false,
+  experimentalSelectionTool = false,
   highlightedSeries,
+  initialSelections = [],
+  interactionMode = 'annotate',
   invertAxes = INVERT_AXES,
   margin = MARGIN,
   padding = PADDING,
@@ -182,6 +186,16 @@ export default function ScatterPlot({
           />
         ))}
         {children}
+        {experimentalSelectionTool && <Selections
+          colors={colors}
+          disabled={disabled || interactionMode !== 'annotate'}
+          height={plotHeight}
+          initialSelections={initialSelections}
+          margin={margin}
+          width={plotWidth}
+          xScale={xScaleTransformed}
+          yScale={yScaleTransformed}
+        />}
       </Group>
       <Group
         className='chartAxes'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.spec.js
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
@@ -271,6 +272,118 @@ describe('Component > ScatterPlot', function () {
       underlays.forEach(({ fill }) => {
         const underlay = document.querySelector(`.chartBackground-underlay[fill="${fill}"]`)
         expect(underlay).to.exist()
+      })
+    })
+  })
+
+  describe('with selection enabled', function () {
+    let brushLayer, user
+
+    describe('without any selections', function () {
+      beforeEach(function () {
+        render(
+          <ScatterPlot
+            data={variableStar.scatterPlot.data}
+            experimentalSelectionTool
+            parentHeight={parentHeight}
+            parentWidth={parentWidth}
+            theme={zooTheme}
+            transformMatrix={transformMatrix}
+          />,
+          {
+            wrapper: withStore()
+          }
+        )
+        brushLayer = document.querySelector('.chartContent .brushLayer')
+      })
+
+      it('should render a visx brush layer', function () {
+        expect(brushLayer.querySelector('.visx-brush-overlay')).to.exist()
+      })
+    })
+
+    describe('with selections', function () {
+      beforeEach(function () {
+        const initialSelections = [
+          { x0: 250, x1: 300 },
+          { x0: 495, x1: 505 }
+        ]
+
+        render(
+          <ScatterPlot
+            data={variableStar.scatterPlot.data}
+            experimentalSelectionTool
+            initialSelections={initialSelections}
+            parentHeight={parentHeight}
+            parentWidth={parentWidth}
+            theme={zooTheme}
+            transformMatrix={transformMatrix}
+          />,
+          {
+            wrapper: withStore()
+          }
+        )
+        brushLayer = document.querySelector('.chartContent .brushLayer')
+      })
+
+      it('should render a visx brush layer', function () {
+        expect(brushLayer.querySelector('.visx-brush-overlay')).to.exist()
+      })
+
+      it('should render the selections', function () {
+        expect(brushLayer.querySelectorAll('.selection')).to.have.lengthOf(2)
+      })
+
+      it('should render delete buttons', function () {
+        const user = userEvent.setup()
+        const buttons = brushLayer.querySelectorAll('[role="button"]')
+        expect(buttons).to.have.lengthOf(2)
+        buttons.forEach(async (button, index) => {
+          const label = button.getAttribute('aria-label')
+          expect(label).to.equal('SubjectViewer.ScatterPlotViewer.Selection.delete')
+          expect(brushLayer.querySelectorAll('.selection')).to.have.lengthOf(2 - index)
+          await user.click(button)
+          expect(brushLayer.querySelectorAll('.selection')).to.have.lengthOf(1 - index)
+        })
+      })
+    })
+
+    describe('with selections but disabled', function () {
+      beforeEach(function () {
+        const initialSelections = [
+          { x0: 250, x1: 300 },
+          { x0: 495, x1: 505 }
+        ]
+
+        render(
+          <ScatterPlot
+            data={variableStar.scatterPlot.data}
+            disabled
+            experimentalSelectionTool
+            initialSelections={initialSelections}
+            parentHeight={parentHeight}
+            parentWidth={parentWidth}
+            theme={zooTheme}
+            transformMatrix={transformMatrix}
+          />,
+          {
+            wrapper: withStore()
+          }
+        )
+        brushLayer = document.querySelector('.chartContent .brushLayer')
+      })
+
+      it('should not render a visx brush layer', function () {
+        expect(brushLayer.querySelector('.visx-brush-overlay')).not.to.exist()
+      })
+
+      it('should render the selections', function () {
+        expect(brushLayer.querySelectorAll('.selection')).to.have.lengthOf(2)
+      })
+
+      it('should not show delete buttons', function () {
+        const buttons = brushLayer.querySelectorAll('[role="button"]')
+        expect(buttons).to.have.lengthOf(0)
       })
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/Selections/DeleteButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/Selections/DeleteButton.js
@@ -40,7 +40,7 @@ export default function DeleteButton({
     switch (event.key) {
       case 'Enter':
       case ' ': {
-        return onPointerDown(event)
+        return onPointerUp(event)
       }
       default: {
         return true

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/Selections/DeleteButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/Selections/DeleteButton.js
@@ -1,0 +1,92 @@
+import PropTypes from 'prop-types'
+import styled, { css } from 'styled-components'
+
+const StyledGroup = styled('g')`
+  &:focus {
+    ${props => css`outline: solid 4px ${props.focusColor};`}
+  }
+
+  &:hover {
+    cursor: pointer;
+  }
+`
+const DEFAULT_HANDLER = () => true
+  
+export default function DeleteButton({
+  colors,
+  cx,
+  cy,
+  fill = 'black',
+  label,
+  onDelete = DEFAULT_HANDLER,
+  opacity = 1,
+  rotate = 0,
+  stroke = 'white',
+  strokeWidth = 1.5
+}) {
+  const focusColor = colors.focus
+  const RADIUS = (screen.width < 900) ? 11 : 8
+  const CROSS_PATH = `
+    M ${-1 * RADIUS * 0.7} 0
+    L ${RADIUS * 0.7} 0
+    M 0 ${-1 * RADIUS * 0.7}
+    L 0 ${RADIUS * 0.7}
+  `
+  const transform = `
+    translate(${cx}, ${cy})
+    rotate(${rotate})
+  `
+  function onKeyDown(event) {
+    switch (event.key) {
+      case 'Enter':
+      case ' ': {
+        return onPointerDown(event)
+      }
+      default: {
+        return true
+      }
+    }
+  }
+
+  function onPointerUp(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    onDelete()
+    return false
+  }
+
+  return (
+    <StyledGroup
+      aria-label={label}
+      focusable
+      focusColor={focusColor}
+      onKeyDown={onKeyDown}
+      onPointerUp={onPointerUp}
+      opacity={opacity}
+      role='button'
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+      tabIndex='-1'
+      transform={transform}
+    >
+      <circle
+        fill={fill}
+        r={RADIUS}
+      />
+      <path
+        d={CROSS_PATH}
+        transform='rotate(45)'
+      />
+    </StyledGroup>
+  )
+}
+
+DeleteButton.propTypes = {
+  label: PropTypes.string.isRequired,
+  mark: PropTypes.object.isRequired,
+  onDelete: PropTypes.func,
+  onDeselect: PropTypes.func,
+  rotate: PropTypes.number,
+  scale: PropTypes.number,
+  theme: PropTypes.object
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/Selections/Selection.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/Selections/Selection.js
@@ -1,0 +1,33 @@
+export default function Selection({
+  active = false,
+  disabled = false,
+  fill,
+  selection,
+  onSelect,
+  xScale
+}) {
+  const x = xScale(selection.x0)
+  const width = xScale(selection.x1) - x
+
+  function onClick() {
+    if (!disabled) {
+      return onSelect(selection)
+    }
+    return true
+  }
+
+  return (
+    <rect
+      className='selection'
+      fill={fill}
+      focusable={disabled ? 'false' : 'true'}
+      height='100%'
+      onClick={onClick}
+      opacity={0.5}
+      pointerEvents={disabled ? 'none' : 'all'}
+      tabIndex={disabled ? '-1' : '0'}
+      width={width}
+      x={x}
+    />
+  )
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/Selections/Selections.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/Selections/Selections.js
@@ -1,0 +1,180 @@
+import { useEffect, useRef, useState } from 'react'
+import { Brush } from '@visx/brush'
+
+import { useKeyZoom } from '@hooks'
+import { useTranslation } from '@translations/i18n'
+
+import DeleteButton from './DeleteButton'
+import Selection from './Selection'
+
+const HANDLE_SIZE = 10
+
+export default function Selections({
+  colors,
+  disabled,
+  height,
+  initialSelections = [],
+  margin,
+  width,
+  xScale,
+  yScale
+}) {
+  const { t } = useTranslation('components')
+  const { onKeyZoom } = useKeyZoom()
+  const eventRoot = useRef()
+  const [selections, setSelections] = useState(initialSelections)
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const [createNewBrush, setCreateNewBrush] = useState(true)
+  const activeSelection = selections[activeIndex]
+  const brushStyle = {
+    fill: colors['highlighter-blue'],
+    fillOpacity: 0.2,
+    stroke: colors['dark-3'],
+    strokeOpacity: 0.2
+  }
+
+  let key = 'new-brush'
+  let initialBrushPosition
+  if (activeSelection) {
+    const start = xScale(activeSelection.x0)
+    const end = xScale(activeSelection.x1)
+    initialBrushPosition = {
+      start: { x: start },
+      end: { x: end }
+    }
+    key = `active-selection-${start}-${end}`
+  }
+
+  if (disabled && activeSelection) {
+    setActiveIndex(-1)
+    setCreateNewBrush(true)
+  }
+
+  function deleteSelection(index) {
+    const newSelections = selections.filter((selection, i) => i !== index)
+    setSelections(newSelections)
+    if (index === activeIndex) {
+      setActiveIndex(-1)
+      setCreateNewBrush(true)
+    }
+  }
+
+  function onKeyDown(event) {
+    switch (event.key) {
+      case 'Backspace': {
+        if (activeIndex > -1) {
+          event.preventDefault()
+          deleteSelection(activeIndex)
+          return false
+        }
+      }
+    }
+    return onKeyZoom(event)
+  }
+
+  function onStartNewBrush() {
+    setCreateNewBrush(true)
+  }
+
+  function onSelectBrush(index) {
+    setActiveIndex(index)
+    setCreateNewBrush(false)
+  }
+
+  function onStartSelection({ x }) {
+    let index = -1
+    selections.forEach((selection, i) => {
+      const lower = xScale(selection.x0) - HANDLE_SIZE
+      const upper = xScale(selection.x1) + HANDLE_SIZE
+      const click = xScale(x)
+      const isSelection = (click > lower) && (click < upper)
+      if (isSelection) {
+        index = i
+      }
+    })
+    if (index > -1) {
+      onSelectBrush(index)
+    } else {
+      onStartNewBrush()
+    }
+  }
+
+  function createNewSelection(selection) {
+    if (selection) {
+      const newSelections = [...selections, selection]
+      setSelections(newSelections)
+      return newSelections.length - 1
+    } else {
+      return -1
+    }
+  }
+
+  function replaceActiveSelection(selection) {
+    if (selection) {
+      const newSelections = [...selections]
+      newSelections[activeIndex] = selection
+      setSelections(newSelections)
+      return activeIndex
+    } else {
+      setCreateNewBrush(true)
+      return -1
+    }
+  }
+
+  function onEndSelection(selection) {
+    const newSelection = createNewBrush ? createNewSelection(selection) : replaceActiveSelection(selection)
+    setActiveIndex(newSelection)
+    eventRoot?.current.focus()
+  }
+
+  return (
+    <g
+      ref={eventRoot}
+      className='brushLayer'
+      focusable='true'
+      onKeyDown={onKeyDown}
+      tabIndex='-1'
+    >
+      {selections.map((selection, index) => (
+        <Selection
+          key={`selection-${index}`}
+          active={!createNewBrush && selection === activeSelection}
+          disabled={disabled}
+          fill={colors['highlighter-blue']}
+          height={height}
+          onSelect={() => onSelectBrush(index)}
+          selection={selection}
+          xScale={xScale}
+        />
+      ))}
+      {!disabled && (
+        <Brush
+          key={key}
+          handleSize={HANDLE_SIZE}
+          height={height}
+          initialBrushPosition={initialBrushPosition}
+          margin={margin}
+          onBrushStart={onStartSelection}
+          onBrushEnd={onEndSelection}
+          selectedBoxStyle={brushStyle}
+          width={width}
+          xScale={xScale}
+          yScale={yScale}
+        />
+      )}
+      {!disabled && selections.map((selection, index) => (
+        <DeleteButton
+          key={`delete-selection-${index}`}
+          colors={colors}
+          cx={xScale((selection.x0 + selection.x1) / 2)}
+          cy={10}
+          fill={colors['accent-1']}
+          label={t('SubjectViewer.ScatterPlotViewer.Selection.delete', { index: index + 1 })}
+          onDelete={() => deleteSelection(index)}
+          opacity={0.8}
+          stroke={colors['dark-3']}
+        />
+      ))}
+    </g>
+  )
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/Selections/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/Selections/index.js
@@ -1,0 +1,1 @@
+export { default } from './Selections'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/index.js
@@ -1,1 +1,2 @@
 export { default as ScatterPlotSeries } from './ScatterPlotSeries'
+export { default as Selections } from './Selections'

--- a/packages/lib-classifier/src/translations/en/components.json
+++ b/packages/lib-classifier/src/translations/en/components.json
@@ -198,6 +198,11 @@
         "nextFrameLabel": "Next"
       }
     },
+    "ScatterPlotViewer": {
+      "Selection": {
+        "delete": "Delete selection {{index}}"
+      }
+    },
     "SeparateFramesViewer": {
       "ViewModeButton": {
         "switchToSeparateFrames": "Switch to separate frames view",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3937,6 +3937,19 @@
     classnames "^2.3.1"
     prop-types "^15.6.0"
 
+"@visx/brush@~3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@visx/brush/-/brush-3.0.1.tgz#23d550530443504380c9ae39cf31af6f49b66e58"
+  integrity sha512-5pZ5poFy3roi5bWAhqp6PNxQaWA23TKVjUHFDrWO7+szxx4bML2lHDxWalkaYeRbhpu84eqPXo0cU4pVOk2P+Q==
+  dependencies:
+    "@visx/drag" "3.0.1"
+    "@visx/event" "3.0.1"
+    "@visx/group" "3.0.0"
+    "@visx/scale" "3.0.0"
+    "@visx/shape" "3.0.0"
+    classnames "^2.3.1"
+    prop-types "^15.6.1"
+
 "@visx/curve@2.17.0":
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/@visx/curve/-/curve-2.17.0.tgz#9b4c87dd0d10a62a0f85d5a72e4c0400316df9bf"
@@ -3952,6 +3965,16 @@
   dependencies:
     "@types/d3-shape" "^1.3.1"
     d3-shape "^1.0.6"
+
+"@visx/drag@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@visx/drag/-/drag-3.0.1.tgz#753d5f471d4e31679ca4fddcb476cf2d5c7eb6e4"
+  integrity sha512-yi2AB/unUfNYBRKS4pmUOuz8MjaAAYjsQGYcD/s4LqeQjd+lBZF7CuNcYZ/maGNQAEUfgLr2czIzADanOMtMaw==
+  dependencies:
+    "@types/react" "*"
+    "@visx/event" "3.0.1"
+    "@visx/point" "3.0.1"
+    prop-types "^15.5.10"
 
 "@visx/event@3.0.1", "@visx/event@~3.0.0":
   version "3.0.1"
@@ -4061,7 +4084,7 @@
     lodash "^4.17.21"
     prop-types "^15.5.10"
 
-"@visx/shape@~3.0.0":
+"@visx/shape@3.0.0", "@visx/shape@~3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@visx/shape/-/shape-3.0.0.tgz#a1d4bd0e12cc94c164252f175997932a09c24652"
   integrity sha512-t6lpP9bIA1vwChDwiOUWl92ro29XF/M8IVNWRA0pm4LGxGGTACvxG3Agfcdi3JprahUVqPpnRCwuR36PDanq3Q==


### PR DESCRIPTION
Add x-range selection to the scatter plot viewer, using [`@visx/brush`](https://airbnb.io/visx/docs/brush). When annotation is selected in the image toolbar, the brush event layer overrides the zoom event layer, and clicking and dragging selects an x-range.

- add `Selections` and `Selection` components, which handle pointer interaction (when annotation is enabled) and data selection.
- add an `experimentalSelectionTool` flag, which is off by default.
- add an 'X Range Selection' story, which renders `ScatterPlotViewer` with `experimentalSelectionTool` set.
- add a 'Selected X Ranges' story, which renders `ScatterPlotViewer` with `experimentalSelectionTool` set and some data already selected, but selection itself disabled.

https://user-images.githubusercontent.com/59547/234002462-f1ca76a5-2d74-4e2d-9e8a-21ab4f963a77.mov


_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## Linked Issue and/or Talk Post
- towards #4302.


## How to Review
I've added an 'X Range Selection' story to the storybook, which shows a SuperWASP subject with the `experimentalSelectionTool` flag set. You can use that to test out selecting data on an example subject.

Ranges use [d3 brushes](https://d3-graph-gallery.com/graph/interactivity_brush.html), limited to movement in the x-axis. You should be able to select multiple ranges then resize them, drag them into new positions or even delete them again.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).