### PR TITLE
Refactor ScatterPlot components

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.spec.js
@@ -1,9 +1,34 @@
-import { shallow } from 'enzyme'
+import { render } from '@testing-library/react'
+import zooTheme from '@zooniverse/grommet-theme'
+import { Grommet } from 'grommet'
+import { Provider } from 'mobx-react'
+
+import mockStore from '@test/mockStore/mockStore.js'
 
 import ImageToolbar from './ImageToolbar'
 
 describe('Component > ImageToolbar', function () {
+  function withStore() {
+    return function Wrapper({
+      children = null,
+      store = mockStore()
+    }) {
+      return (
+        <Grommet theme={zooTheme}>
+          <Provider classifierStore={store}>
+            {children}
+          </Provider>
+        </Grommet>
+      )
+    }
+  }
+
   it('should render without crashing', function () {
-    shallow(<ImageToolbar />)
+    render(
+      <ImageToolbar />,
+      {
+        wrapper: withStore()
+      }
+    )
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Background/Background.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Background/Background.js
@@ -1,17 +1,18 @@
 import PropTypes from 'prop-types'
 
-function Background (props) {
-  const {
-    borderColor,
-    fill,
-    height,
-    underlayParameters,
-    width,
-    ...rest
-  } = props
+function Background ({
+  borderColor = '',
+  className = 'chartBackground',
+  fill = '',
+  height = '100%',
+  underlayParameters = [],
+  width = '100%',
+  ...rest
+}) {
   return (
     <>
       <rect
+        className={className}
         fill={fill}
         height={height}
         stroke={borderColor || ''}
@@ -24,6 +25,7 @@ function Background (props) {
           const { fill, left, width } = parameters
           return (
             <rect
+              className={`${className}-underlay`}
               key={Math.random()}
               fill={fill}
               height={height}
@@ -36,14 +38,6 @@ function Background (props) {
     </>
 
   )
-}
-
-Background.defaultProps = {
-  borderColor: '',
-  fill: '',
-  height: '100%',
-  underlayParameters: [],
-  width: '100%'
 }
 
 Background.propTypes = {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Background/Background.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/Background/Background.spec.js
@@ -1,38 +1,38 @@
-import { shallow } from 'enzyme'
+import { cleanup, render } from '@testing-library/react'
 
 import Background from './Background'
 
 describe('Component > Background', function () {
   it('should render without crashing', function () {
-    const wrapper = shallow(<Background />)
-    expect(wrapper).to.be.ok()
+    render(<svg><Background /></svg>)
   })
 
   it('should render a rect', function () {
-    const wrapper = shallow(<Background />)
-    expect(wrapper.find('rect')).to.have.lengthOf(1)
+    render(<svg><Background /></svg>)
+    expect(document.querySelectorAll('rect')).to.have.lengthOf(1)
   })
 
   it('should pass along any other props', function () {
-    const wrapper = shallow(<Background foo='bar' />)
-    expect(wrapper.find('rect').props().foo).to.equal('bar')
+    render(<svg><Background foo='bar' /></svg>)
+    expect(document.querySelector('rect').getAttribute('foo')).to.equal('bar')
   })
 
   it('should set the fill color by prop', function () {
-    const wrapper = shallow(<Background fill='black' />)
-    expect(wrapper.find('rect').props().fill).to.equal('black')
+    render(<svg><Background fill='black' /></svg>)
+    expect(document.querySelector('rect').getAttribute('fill')).to.equal('black')
   })
 
   it('should set the stroke properties if a borderColor is defined', function () {
     let rect
-    const wrapper = shallow(<Background fill='black' />)
-    rect = wrapper.find('rect')
-    expect(rect.props().stroke).to.be.empty()
-    expect(rect.props().strokeWidth).to.be.equal(0)
-    wrapper.setProps({ borderColor: '#ffffff' })
-    rect = wrapper.find('rect')
-    expect(rect.props().stroke).to.equal('#ffffff')
-    expect(rect.props().strokeWidth).to.be.equal(1)
+    render(<svg><Background fill='black' /></svg>)
+    rect = document.querySelector('rect')
+    expect(rect.getAttribute('stroke')).to.be.empty()
+    expect(rect.getAttribute('stroke-width')).to.equal('0')
+    cleanup()
+    render(<svg><Background fill='black' borderColor='#fff' /></svg>)
+    rect = document.querySelector('rect')
+    expect(rect.getAttribute('stroke')).to.equal('#fff')
+    expect(rect.getAttribute('stroke-width')).to.equal('1')
   })
 
   describe('when there are underlays', function () {
@@ -40,8 +40,8 @@ describe('Component > Background', function () {
       const underlayParameters = [
         { fill: '#000000', left: 5, width: 10 }
       ]
-      const wrapper = shallow(<Background fill='white' underlayParameters={underlayParameters} />)
-      expect(wrapper.find('rect')).to.have.lengthOf(2)
+      render(<svg><Background fill='white' underlayParameters={underlayParameters} /></svg>)
+      expect(document.querySelectorAll('rect')).to.have.lengthOf(2)
     })
 
     it('should render the underlay rects with the specified parameters', function () {
@@ -49,16 +49,17 @@ describe('Component > Background', function () {
       const underlayParameters = [
         { fill: '#000000', left: 5, width: 10 }
       ]
-      const wrapper = shallow(<Background fill='white' underlayParameters={underlayParameters} />)
-      underlayRect = wrapper.find('rect').last()
-      expect(underlayRect.props().fill).to.equal(underlayParameters[0].fill)
-      expect(underlayRect.props().transform).to.equal(`translate(${underlayParameters[0].left}, 0)`)
-      expect(underlayRect.props().width).to.equal(underlayParameters[0].width)
-      wrapper.setProps({ borderColor: 'blue' })
-      underlayRect = wrapper.find('rect').last()
-      expect(underlayRect.props().fill).to.equal(underlayParameters[0].fill)
-      expect(underlayRect.props().transform).to.equal(`translate(${underlayParameters[0].left}, 1)`)
-      expect(underlayRect.props().width).to.equal(underlayParameters[0].width)
+      render(<svg><Background fill='white' underlayParameters={underlayParameters} /></svg>)
+      underlayRect = document.querySelector('rect.chartBackground-underlay')
+      expect(underlayRect.getAttribute('fill')).to.equal(underlayParameters[0].fill)
+      expect(underlayRect.getAttribute('transform')).to.equal(`translate(${underlayParameters[0].left}, 0)`)
+      expect(underlayRect.getAttribute('width')).to.equal(underlayParameters[0].width.toString())
+      cleanup()
+      render(<svg><Background fill='white' borderColor='blue' underlayParameters={underlayParameters} /></svg>)
+      underlayRect = document.querySelector('rect.chartBackground-underlay')
+      expect(underlayRect.getAttribute('fill')).to.equal(underlayParameters[0].fill)
+      expect(underlayRect.getAttribute('transform')).to.equal(`translate(${underlayParameters[0].left}, 1)`)
+      expect(underlayRect.getAttribute('width')).to.equal(underlayParameters[0].width.toString())
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/ScatterPlotViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/ScatterPlotViewer.stories.js
@@ -4,7 +4,9 @@ import { darken } from 'polished'
 import ScatterPlotViewer from './ScatterPlotViewer'
 import ScatterPlotViewerConnector from './ScatterPlotViewerConnector'
 import { Provider } from 'mobx-react'
+
 import SubjectViewerStore from '@store/SubjectViewerStore'
+import mockStore from '@test/mockStore'
 import ImageToolbar from '../../../ImageToolbar'
 import {
   keplerMockDataWithOptions,
@@ -36,31 +38,11 @@ const transientObjectSubject = Factory.build('subject', {
   ]
 })
 
-const mockStore = {
-  classifications: {
-    active: {
-      annotations: new Map()
-    }
-  },
-  fieldGuide: {
-    setActiveItemIndex: () => {},
-    setModalVisibility: () => {}
-  },
-  subjects: {
-    active: transientObjectSubject
-  },
-  subjectViewer: SubjectViewerStore.create({}),
-  workflows: {
-    active: {}
-  },
-  workflowSteps: {
-    activeStepTasks: []
-  }
-}
+const store = mockStore({ subject: transientObjectSubject })
 
 function ViewerContext(props) {
   const { children } = props
-  return <Provider classifierStore={mockStore}>{children}</Provider>
+  return <Provider classifierStore={store}>{children}</Provider>
 }
 
 export default {
@@ -121,23 +103,25 @@ export function ErrorBars() {
   ]
 
   return (
-    <Box direction='row' height='medium' width='large'>
-      <ScatterPlotViewer
-        data={data}
-        panning
-        setOnZoom={setZoomCallback}
-        xAxisLabel='x-axis'
-        yAxisLabel='y-axis'
-        zooming
-        zoomConfiguration={{
-          direction: 'both',
-          minZoom: 1,
-          maxZoom: 10,
-          zoomInValue: 1.2,
-          zoomOutValue: 0.8
-        }}
-      />
-    </Box>
+    <ViewerContext>
+      <Box direction='row' height='medium' width='large'>
+        <ScatterPlotViewer
+          data={data}
+          panning
+          setOnZoom={setZoomCallback}
+          xAxisLabel='x-axis'
+          yAxisLabel='y-axis'
+          zooming
+          zoomConfiguration={{
+            direction: 'both',
+            minZoom: 1,
+            maxZoom: 10,
+            zoomInValue: 1.2,
+            zoomOutValue: 0.8
+          }}
+        />
+      </Box>
+    </ViewerContext>
   )
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
@@ -1,15 +1,13 @@
 import PropTypes from 'prop-types'
 import { Group } from '@visx/group'
 import cuid from 'cuid'
-import { lighten } from 'polished'
+
 import Background from '@viewers/components/SVGComponents/Background'
 import Chart from '@viewers/components/SVGComponents/Chart'
-import Axes from '../Axes'
-import getDataSeriesColor from '@viewers/helpers/getDataSeriesColor'
-import getDataSeriesSymbol from '@viewers/helpers/getDataSeriesSymbol'
-import isDataSeriesHighlighted from '@viewers/helpers/isDataSeriesHighlighted'
 import getZoomBackgroundColor from '@viewers/helpers/getZoomBackgroundColor'
 import sortDataPointsByHighlight from '@viewers/helpers/sortDataPointsByHighlight'
+import Axes from '../Axes'
+import { ScatterPlotSeries } from './components'
 
 import {
   getDataPoints,
@@ -47,7 +45,9 @@ const TRANSFORM_MATRIX = {
   translateY: 0
 }
 
-function ScatterPlot ({
+
+
+export default function ScatterPlot({
   axisColor = '',
   backgroundColor = '',
   children,
@@ -81,6 +81,7 @@ function ScatterPlot ({
   yScale = null,
   zooming = false
 }) {
+
   const rangeParameters = {
     invertAxes,
     margin,
@@ -138,6 +139,7 @@ function ScatterPlot ({
       return { fill, left, width }
     })
   }
+
   return (
     <Chart
       className='scatterPlot'
@@ -167,76 +169,20 @@ function ScatterPlot ({
             underlayParameters={underlayParameters}
             width={plotWidth}
           />}
-        {sortedDataPoints.map((series, seriesIndex) => {
-          const highlighted = isDataSeriesHighlighted({ highlightedSeries, seriesOptions: series?.seriesOptions })
-          const glyphColor = getDataSeriesColor({
-            defaultColors: Object.values(colors.drawingTools),
-            seriesOptions: series?.seriesOptions,
-            seriesIndex,
-            themeColors: colors,
-            highlighted
-          })
-
-          const errorBarColor = lighten(0.25, glyphColor)
-          const GlyphComponent = getDataSeriesSymbol({ seriesOptions: series?.seriesOptions, seriesIndex })
-
-          return series.seriesData.map((point, pointIndex) => {
-            let xErrorBarPoints, yErrorBarPoints
-            const { x, y, x_error, y_error } = point
-            const cx = xScaleTransformed(x)
-            const cy = yScaleTransformed(y)
-
-            if (x_error) {
-              xErrorBarPoints = {
-                x1: xScaleTransformed(x - x_error),
-                x2: xScaleTransformed(x + x_error)
-              }
-            }
-
-            if (y_error) {
-              yErrorBarPoints = {
-                y1: yScaleTransformed(y + y_error),
-                y2: yScaleTransformed(y - y_error)
-              }
-            }
-
-            return (
-              <g key={pointIndex}>
-                {x_error &&
-                  <line
-                    className='errorBar'
-                    stroke={errorBarColor}
-                    strokeWidth={2}
-                    x1={xErrorBarPoints.x1}
-                    x2={xErrorBarPoints.x2}
-                    y1={cy}
-                    y2={cy}
-                  />}
-                {y_error &&
-                  <line
-                    className='errorBar'
-                    stroke={errorBarColor}
-                    strokeWidth={2}
-                    x1={cx}
-                    x2={cx}
-                    y1={yErrorBarPoints.y1}
-                    y2={yErrorBarPoints.y2}
-                  />}
-                <GlyphComponent
-                  data-x={x}
-                  data-y={y}
-                  left={cx}
-                  size={dataPointSize}
-                  top={cy}
-                  fill={glyphColor}
-                  stroke={(highlighted) ? 'black' : colors['light-4']}
-                />
-              </g>
-            )
-          })
-        })}
+        {sortedDataPoints.map((series, seriesIndex) => (
+          <ScatterPlotSeries
+            key={`series-${seriesIndex}`}
+            colors={colors}
+            dataPointSize={dataPointSize}
+            highlightedSeries={highlightedSeries}
+            series={series}
+            seriesIndex={seriesIndex}
+            xScale={xScaleTransformed}
+            yScale={yScaleTransformed}
+          />
+        ))}
+        {children}
       </Group>
-      {children}
       <Group
         className='chartAxes'
         left={leftPosition}
@@ -323,5 +269,3 @@ ScatterPlot.propTypes = {
   yScale: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   zooming: PropTypes.bool
 }
-
-export default ScatterPlot

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
@@ -140,6 +140,7 @@ function ScatterPlot ({
   }
   return (
     <Chart
+      className='scatterPlot'
       height={parentHeight}
       width={parentWidth}
     >
@@ -151,6 +152,7 @@ function ScatterPlot ({
         />
       </clipPath>
       <Group
+        className='chartContent'
         clipPath={`url(#scatter-plot-${clipPathId})`}
         left={leftPosition}
         top={topPosition}
@@ -202,6 +204,7 @@ function ScatterPlot ({
               <g key={pointIndex}>
                 {x_error &&
                   <line
+                    className='errorBar'
                     stroke={errorBarColor}
                     strokeWidth={2}
                     x1={xErrorBarPoints.x1}
@@ -211,6 +214,7 @@ function ScatterPlot ({
                   />}
                 {y_error &&
                   <line
+                    className='errorBar'
                     stroke={errorBarColor}
                     strokeWidth={2}
                     x1={cx}
@@ -234,6 +238,7 @@ function ScatterPlot ({
       </Group>
       {children}
       <Group
+        className='chartAxes'
         left={leftPosition}
         top={margin.top}
       >

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.spec.js
@@ -1,14 +1,10 @@
 import { render, screen } from '@testing-library/react'
-import { Group } from '@visx/group'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
 
 import mockStore from '@test/mockStore/mockStore.js'
 
-import Axes from '../Axes'
-import Background from '../../../SVGComponents/Background'
-import Chart from '../../../SVGComponents/Chart'
 import ScatterPlot from './ScatterPlot'
 import { glyphComponents } from '../../../../helpers/getDataSeriesSymbol'
 import {
@@ -42,7 +38,6 @@ describe('Component > ScatterPlot', function () {
   }
 
   describe('render', function () {
-    let wrapper, chart
     beforeEach(function () {
       render(
         <ScatterPlot

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/ScatterPlotSeries/ScatterPlotPoint.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/ScatterPlotSeries/ScatterPlotPoint.js
@@ -1,0 +1,65 @@
+import { lighten } from 'polished'
+
+export default function ScatterPlotPoint({
+  dataPointSize,
+  glyphColor,
+  GlyphComponent,
+  highlighted,
+  point,
+  xScale,
+  yScale
+}) {
+  let xErrorBarPoints, yErrorBarPoints
+  const { x, y, x_error, y_error } = point
+  const cx = xScale(x)
+  const cy = yScale(y)
+  const errorBarColor = lighten(0.25, glyphColor)
+
+  if (x_error) {
+    xErrorBarPoints = {
+      x1: xScale(x - x_error),
+      x2: xScale(x + x_error)
+    }
+  }
+
+  if (y_error) {
+    yErrorBarPoints = {
+      y1: yScale(y + y_error),
+      y2: yScale(y - y_error)
+    }
+  }
+
+  return (
+    <g>
+      {x_error &&
+        <line
+          className='errorBar'
+          stroke={errorBarColor}
+          strokeWidth={2}
+          x1={xErrorBarPoints.x1}
+          x2={xErrorBarPoints.x2}
+          y1={cy}
+          y2={cy}
+        />}
+      {y_error &&
+        <line
+          className='errorBar'
+          stroke={errorBarColor}
+          strokeWidth={2}
+          x1={cx}
+          x2={cx}
+          y1={yErrorBarPoints.y1}
+          y2={yErrorBarPoints.y2}
+        />}
+      <GlyphComponent
+        data-x={x}
+        data-y={y}
+        left={cx}
+        size={dataPointSize}
+        top={cy}
+        fill={glyphColor}
+        stroke={(highlighted) ? 'black' : colors['light-4']}
+      />
+    </g>
+  )
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/ScatterPlotSeries/ScatterPlotSeries.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/ScatterPlotSeries/ScatterPlotSeries.js
@@ -1,0 +1,38 @@
+import ScatterPlotPoint from './ScatterPlotPoint'
+import getDataSeriesColor from '@viewers/helpers/getDataSeriesColor'
+import getDataSeriesSymbol from '@viewers/helpers/getDataSeriesSymbol'
+import isDataSeriesHighlighted from '@viewers/helpers/isDataSeriesHighlighted'
+
+export default function ScatterPlotSeries({
+  colors,
+  dataPointSize,
+  highlightedSeries,
+  series,
+  seriesIndex,
+  xScale,
+  yScale
+}) {
+  const highlighted = isDataSeriesHighlighted({ highlightedSeries, seriesOptions: series?.seriesOptions })
+  const glyphColor = getDataSeriesColor({
+    defaultColors: Object.values(colors.drawingTools),
+    seriesOptions: series?.seriesOptions,
+    seriesIndex,
+    themeColors: colors,
+    highlighted
+  })
+
+  const GlyphComponent = getDataSeriesSymbol({ seriesOptions: series?.seriesOptions, seriesIndex })
+
+  return series.seriesData.map((point, index) => (
+    <ScatterPlotPoint
+      key={`point-${index}`}
+      dataPointSize={dataPointSize}
+      glyphColor={glyphColor}
+      GlyphComponent={GlyphComponent}
+      highlighted={highlighted}
+      point={point}
+      xScale={xScale}
+      yScale={yScale}
+    />
+  ))
+}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/ScatterPlotSeries/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/ScatterPlotSeries/index.js
@@ -1,0 +1,1 @@
+export { default } from './ScatterPlotSeries'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/index.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/index.js
@@ -1,0 +1,1 @@
+export { default as ScatterPlotSeries } from './ScatterPlotSeries'

--- a/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
@@ -1,103 +1,24 @@
 import { MobXProviderContext } from 'mobx-react'
 import { Component, forwardRef } from 'react';
 
+import { useKeyZoom } from '@hooks'
+
+const DEFAULT_HANDLER = () => true
+
 function withKeyZoom (WrappedComponent) {
-  const ALLOWED_TAGS = ['svg', 'button', 'g', 'rect']
 
-  class KeyZoom extends Component {
-    constructor () {
-      super()
-      this.onKeyDown = this.onKeyDown.bind(this)
-    }
-
-    onKeyDown (e) {
-      const { classifierStore } = this.context
-      const {
-        panLeft,
-        panRight,
-        panUp,
-        panDown,
-        zoomIn,
-        zoomOut
-      } = classifierStore.subjectViewer
-      const htmlTag = e.target?.tagName.toLowerCase()
-      if (ALLOWED_TAGS.includes(htmlTag)) {
-        switch (e.key) {
-          case '+':
-          case '=': {
-            zoomIn()
-            return true
-          }
-          case '-':
-          case '_': {
-            zoomOut()
-            return true
-          }
-          case 'ArrowRight': {
-            e.preventDefault()
-            panRight()
-            return false
-          }
-          case 'ArrowLeft': {
-            e.preventDefault()
-            panLeft()
-            return false
-          }
-          case 'ArrowUp': {
-            e.preventDefault()
-            panUp()
-            return false
-          }
-          case 'ArrowDown': {
-            e.preventDefault()
-            panDown()
-            return false
-          }
-          default: {
-            return true
-          }
-        }
-      }
-
-      return true
-    }
-
-    render () {
-      const {
-        forwardedRef,
-        panLeft,
-        panRight,
-        panUp,
-        panDown,
-        zoomIn,
-        zoomOut,
-        ...props
-      } = this.props
-      return (
-        <WrappedComponent
-          ref={forwardedRef}
-          onKeyDown={this.onKeyDown}
-          {...props}
-        />
-      )
-    }
+  function KeyZoom(props, ref) {
+    const { onKeyZoom } = useKeyZoom()
+    return (
+      <WrappedComponent
+        ref={ref}
+        onKeyDown={onKeyZoom}
+        {...props}
+      />
+    )
   }
 
-  KeyZoom.contextType = MobXProviderContext
-
-  KeyZoom.defaultProps = {
-    forwardedRef: null,
-    panLeft: () => true,
-    panRight: () => true,
-    panUp: () => true,
-    panDown: () => true,
-    zoomIn: () => true,
-    zoomOut: () => true
-  }
-
-  const DecoratedKeyZoom = forwardRef(function (props, ref) {
-    return <KeyZoom {...props} forwardedRef={ref} />
-  })
+  const DecoratedKeyZoom = forwardRef(KeyZoom)
   const name = WrappedComponent.displayName || WrappedComponent.name
   DecoratedKeyZoom.displayName = `withKeyZoom(${name})`
   DecoratedKeyZoom.wrappedComponent = WrappedComponent

--- a/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
@@ -1,9 +1,7 @@
-import { MobXProviderContext } from 'mobx-react'
-import { Component, forwardRef } from 'react';
+import { forwardRef } from 'react'
 
 import { useKeyZoom } from '@hooks'
 
-const DEFAULT_HANDLER = () => true
 
 function withKeyZoom (WrappedComponent) {
 

--- a/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.spec.js
@@ -1,5 +1,5 @@
 import { Component, createRef } from 'react';
-import { mount } from 'enzyme'
+import { render } from '@testing-library/react'
 import { expect } from 'chai'
 import sinon from 'sinon'
 import { Provider } from 'mobx-react'
@@ -24,8 +24,8 @@ describe('withKeyZoom', function () {
   subjectViewer.setOnZoom(onZoom)
   let wrappedComponent
 
-  before(function () {
-    mount(
+  beforeEach(function () {
+    render(
       <Provider classifierStore={classifierStore}>
         <WithZoom ref={zoomStub} />
       </Provider>

--- a/packages/lib-classifier/src/hooks/Readme.md
+++ b/packages/lib-classifier/src/hooks/Readme.md
@@ -26,6 +26,16 @@ Returns the new store when hydration is complete. Snapshots are stored in sessio
 const classifierStore = useHydratedStore({ authClient, client }, cachePanoptesData = false, storageKey)
 ```
 
+## useKeyZoom
+
+Add keyboard zoom controls to a component
+
+```js
+const onKeyZoom = useKeyZoom()
+
+<ComponentWithZoom onKeyDown={onKeyZoom} />
+```
+
 ## usePanoptesAuth
 
 Asynchronously fetch an auth token, for a given user ID. A wrapper for `authClient.checkBearerToken()`.

--- a/packages/lib-classifier/src/hooks/index.js
+++ b/packages/lib-classifier/src/hooks/index.js
@@ -1,6 +1,7 @@
 export { default as useCaesarReductions } from './useCaesarReductions'
 export { default as useClientRect } from './useClientRect'
 export { default as useHydratedStore } from './useHydratedStore'
+export { default as useKeyZoom } from './useKeyZoom'
 export { default as usePanoptesAuth } from './usePanoptesAuth'
 export { default as usePanoptesTranslations } from './usePanoptesTranslations'
 export { default as usePanoptesUser } from './usePanoptesUser'

--- a/packages/lib-classifier/src/hooks/useKeyZoom.js
+++ b/packages/lib-classifier/src/hooks/useKeyZoom.js
@@ -1,0 +1,81 @@
+import { useStores } from '@hooks'
+
+const ALLOWED_TAGS = ['svg', 'button', 'g', 'rect']
+
+function storeMapper(classifierStore) {
+  const {
+    subjectViewer: {
+      panLeft,
+      panRight,
+      panUp,
+      panDown,
+      zoomIn,
+      zoomOut
+    }
+  } = classifierStore
+    
+  return {
+    panLeft,
+    panRight,
+    panUp,
+    panDown,
+    zoomIn,
+    zoomOut
+  }
+}
+
+export default function useKeyZoom() {
+  const {
+    panLeft,
+    panRight,
+    panUp,
+    panDown,
+    zoomIn,
+    zoomOut
+  } = useStores(storeMapper)
+
+  function onKeyZoom(event) {
+      const htmlTag = event.target?.tagName.toLowerCase()
+      if (ALLOWED_TAGS.includes(htmlTag)) {
+        switch (event.key) {
+          case '+':
+          case '=': {
+            zoomIn()
+            return true
+          }
+          case '-':
+          case '_': {
+            zoomOut()
+            return true
+          }
+          case 'ArrowRight': {
+            event.preventDefault()
+            panRight()
+            return false
+          }
+          case 'ArrowLeft': {
+            event.preventDefault()
+            panLeft()
+            return false
+          }
+          case 'ArrowUp': {
+            event.preventDefault()
+            panUp()
+            return false
+          }
+          case 'ArrowDown': {
+            event.preventDefault()
+            panDown()
+            return false
+          }
+          default: {
+            return true
+          }
+        }
+      }
+
+      return true
+    }
+    
+    return { onKeyZoom }
+}


### PR DESCRIPTION
Refactor `ScatterPlot` in preparation for adding new features in #4482.
- Extract a `useKeyZoom` hook from `withKeyZoom`.
- Rewrite `ScatterPlot`, `withKeyZoom`, `ImageToolbar` and `Background` tests using RTL.
- Extract data series logic into `ScatterPlotSeries` and `ScatterPlotPoint`.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## How to Review
The easiest way to test changes to the scatter plot viewer is to take a look at the storybook. Note that internal components from the `ScatterPlotViewer` package are imported into `DataImageViewer` and `VariableStarViewer`, so check those stories too. Nothing should have changed.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
