### PR TITLE
Label approved pull requests

### DIFF
--- a/.github/workflows/label_approved.yml
+++ b/.github/workflows/label_approved.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Label when approved
-      uses: zooniverse/label-when-approved-action@v1.0.5
+      uses: pullreminders/label-when-approved-action@master
       env:
         APPROVALS: "1"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use the [`pullreminders/label-when-approved`](https://github.com/marketplace/actions/label-approved-pull-requests) action, rather than the Zooniverse fork, which has stopped running.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 
