### PR TITLE
Classifier: add onTouch handler for Highlighter task button

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/experimental/highlighter/components/HighlighterTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/highlighter/components/HighlighterTask.js
@@ -170,6 +170,10 @@ export function HighlighterTask ({
                 />}
               name='highlighter-label'
               onClick={(event) => handleClick(event, index)}
+              onTouchEnd={(event) => {
+                event.preventDefault()
+                handleClick(event, index)
+              }}
             />
           )
         }) : <span>{t('HighlighterTask.noLabels')}</span>


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #4498 

## Describe your changes
- add `onTouchEnd` handler to Highlighter task buttons for iOS text selection and highlighting
- ^ including `event.preventDefault()` to prevent `handleClick` from running twice on Android

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - use BrowserStack to test on iOS device and Android device
  - local - https://local.zooniverse.org:8080/?project=1952&workflow=3538
  - branch deploy - TBD
- What user actions should my reviewer step through to review this PR?
  1. highlight text
  2. click a Highlighter task button
  3. note the text becomes highlighted as per button clicked
  4. with BrowserStack, I could only get Android/Chrome to work, but can see dev console, if add console log to `handleClick` you can see it's is only called once per button click
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
