### PR TITLE
Classifier: remove image toolbar for not applicable mime types

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideConnector.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideConnector.js
@@ -9,7 +9,7 @@ function storeMapper(classifierStore) {
       attachedMedia: icons
     },
     subjectViewer: {
-      separateFramesView
+      showImageToolbar
     }
   } = classifierStore
 
@@ -17,7 +17,7 @@ function storeMapper(classifierStore) {
     locale,
     fieldGuide,
     icons,
-    separateFramesView
+    showImageToolbar
   }
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideConnector.spec.js
@@ -21,7 +21,7 @@ const mockStoreSnapshot = {
       showModal: false
     },
     subjectViewer: {
-      separateFramesView: false
+      showImageToolbar: true
     }
   }
 }

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideWrapper.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuideWrapper.js
@@ -10,7 +10,7 @@ import FieldGuide from './components/FieldGuide'
 function FieldGuideWrapper ({
   fieldGuide = null,
   locale,
-  separateFramesView = false,
+  showImageToolbar = true,
   ...props
 }) {
   const [showModal, setModalVisibility] = useState(false)
@@ -23,7 +23,11 @@ function FieldGuideWrapper ({
 
   return (
     <>
-      <FieldGuideButton fieldGuide={fieldGuide} onClick={() => setModalVisibility(true)} separateFramesView={separateFramesView} />
+      <FieldGuideButton
+        fieldGuide={fieldGuide}
+        onClick={() => setModalVisibility(true)}
+        showImageToolbar={showImageToolbar}
+      />
       {showModal &&
         <ResponsiveContext.Consumer>
           {size => (

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuideButton/FieldGuideButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuideButton/FieldGuideButton.js
@@ -63,14 +63,14 @@ function RowButtonLabel() {
 function FieldGuideButton({
   fieldGuide = null,
   onClick = () => true,
-  separateFramesView = false,
+  showImageToolbar = true,
   theme
 }) {
   const disabled = !fieldGuide || fieldGuide.items.length === 0
 
   return (
     <StyledButton
-      label={separateFramesView ? <RowButtonLabel /> : <ColumnButtonLabel />}
+      label={showImageToolbar ? <ColumnButtonLabel /> : <RowButtonLabel />}
       disabled={disabled}
       onClick={onClick}
       plain

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/Layout.js
@@ -7,19 +7,19 @@ function storeMapper(classifierStore) {
   const workflow = classifierStore.workflows.active
   const limitSubjectHeight = workflow?.configuration?.limit_subject_height
   const layout = limitSubjectHeight ? 'centered' : workflow?.layout
-  const separateFramesView = classifierStore.subjectViewer.separateFramesView
+  const showImageToolbar = classifierStore.subjectViewer.showImageToolbar
 
   return {
     layout,
-    separateFramesView
+    showImageToolbar
   }
 }
 
 function Layout() {
   // `getLayout()` will always return the default layout as a fallback
-  const { layout, separateFramesView } = useStores(storeMapper)
+  const { layout, showImageToolbar } = useStores(storeMapper)
   const CurrentLayout = getLayout(layout)
-  return <CurrentLayout separateFramesView={separateFramesView} />
+  return <CurrentLayout showImageToolbar={showImageToolbar} />
 }
 
 export default observer(Layout)

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
@@ -38,7 +38,7 @@ export const horizontalLayout = {
   justify: 'center'
 }
 
-export default function CenteredLayout({ separateFramesView = false }) {
+export default function CenteredLayout({ showImageToolbar = true }) {
   const size = useContext(ResponsiveContext)
   const containerProps = size === 'small' ? verticalLayout : horizontalLayout
 
@@ -55,7 +55,7 @@ export default function CenteredLayout({ separateFramesView = false }) {
             <SubjectViewer />
             <MetaTools />
           </Box>
-          {!separateFramesView && (
+          {showImageToolbar && (
             <Box width='3rem' fill='vertical' style={{ minWidth: '3rem' }}>
               <StickyImageToolbar />
             </Box>
@@ -67,7 +67,7 @@ export default function CenteredLayout({ separateFramesView = false }) {
         >
           <StickyTaskArea>
             <TaskArea />
-            {separateFramesView && <FieldGuide />}
+            {!showImageToolbar && <FieldGuide />}
           </StickyTaskArea>
         </Box>
       </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.stories.js
@@ -9,7 +9,7 @@ export default {
   component: CenteredLayout,
   excludeStories: ['mockTask'],
   args: {
-    separateFramesView: false
+    showImageToolbar: true
   }
 }
 
@@ -56,10 +56,10 @@ const workflowSnapshot = WorkflowFactory.build({
   tasks: mockTask
 })
 
-export function Default({ separateFramesView }) {
+export function Default({ showImageToolbar }) {
   return (
     <Provider classifierStore={Default.store}>
-      <CenteredLayout separateFramesView={separateFramesView} />
+      <CenteredLayout showImageToolbar={showImageToolbar} />
     </Provider>
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
@@ -72,7 +72,7 @@ export const horizontalLayout = {
 
 export default function MaxWidth({
   className = '',
-  separateFramesView = false
+  showImageToolbar = true
 }) {
   const size = useContext(ResponsiveContext)
   const containerGridProps =
@@ -80,13 +80,7 @@ export default function MaxWidth({
 
   return (
     <ContainerGrid className={className} {...containerGridProps}>
-      {separateFramesView ? (
-        <Box>
-          <Banners />
-          <SubjectViewer />
-          <MetaTools />
-        </Box>
-      ) : (
+      {showImageToolbar ? (
         <ViewerGrid>
           <Box gridArea='subject'>
             <Banners />
@@ -97,11 +91,17 @@ export default function MaxWidth({
             <StyledImageToolbar />
           </StyledImageToolbarContainer>
         </ViewerGrid>
+      ) : (
+        <Box>
+          <Banners />
+          <SubjectViewer />
+          <MetaTools />
+        </Box>
       )}
       <StyledTaskAreaContainer>
         <StyledTaskArea>
           <TaskArea />
-          {separateFramesView && <FieldGuide />}
+          {!showImageToolbar && <FieldGuide />}
         </StyledTaskArea>
       </StyledTaskAreaContainer>
       <FeedbackModal />

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.stories.js
@@ -9,7 +9,7 @@ export default {
   component: MaxWidth,
   excludeStories: ['mockTask'],
   args: {
-    separateFramesView: false
+    showImageToolbar: true
   }
 }
 
@@ -55,10 +55,10 @@ const workflowSnapshot = WorkflowFactory.build({
   tasks: mockTask
 })
 
-export function Default({ separateFramesView }) {
+export function Default({ showImageToolbar }) {
   return (
     <Provider classifierStore={Default.store}>
-      <MaxWidth separateFramesView={separateFramesView} />
+      <MaxWidth showImageToolbar={showImageToolbar} />
     </Provider>
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.js
@@ -56,7 +56,7 @@ export function ViewerGrid({ children }) {
 
 export default function NoMaxWidth({
   className = '',
-  separateFramesView = false
+  showImageToolbar = true
 }) {
   const size = useContext(ResponsiveContext)
   const verticalLayout = {
@@ -77,13 +77,7 @@ export default function NoMaxWidth({
 
   return (
     <ContainerGrid className={className} {...containerGridProps}>
-      {separateFramesView ? (
-        <Box>
-          <Banners />
-          <SubjectViewer />
-          <MetaTools />
-        </Box>
-      ) : (
+      {showImageToolbar ? (
         <ViewerGrid>
           <Box gridArea='subject'>
             <Banners />
@@ -94,11 +88,17 @@ export default function NoMaxWidth({
             <StyledImageToolbar />
           </StyledImageToolbarContainer>
         </ViewerGrid>
+      ) : (
+        <Box>
+          <Banners />
+          <SubjectViewer />
+          <MetaTools />
+        </Box>
       )}
       <StyledTaskAreaContainer>
         <StyledTaskArea>
           <TaskArea />
-          {separateFramesView && <FieldGuide />}
+          {showImageToolbar && <FieldGuide />}
         </StyledTaskArea>
       </StyledTaskAreaContainer>
       <FeedbackModal />

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.stories.js
@@ -9,7 +9,7 @@ export default {
   component: NoMaxWidth,
   excludeStories: ['mockTask'],
   args: {
-    separateFramesView: false
+    showImageToolbar: true
   }
 }
 
@@ -55,10 +55,10 @@ const workflowSnapshot = WorkflowFactory.build({
   tasks: mockTask
 })
 
-export function Default({ separateFramesView }) {
+export function Default({ showImageToolbar }) {
   return (
     <Provider classifierStore={Default.store}>
-      <NoMaxWidth separateFramesView={separateFramesView} />
+      <NoMaxWidth showImageToolbar={showImageToolbar} />
     </Provider>
   )
 }

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -2,6 +2,16 @@ import asyncStates from '@zooniverse/async-states'
 import { autorun } from 'mobx'
 import { addDisposer, getRoot, isValidReference, types } from 'mobx-state-tree'
 
+const NO_IMAGE_TOOLBAR_MIME_TYPES = [
+  'audio/mp3',
+  'audio/m4a',
+  'audio/mpeg',
+  'text/plain',
+  'video/mp4',
+  'video/mpeg',
+  'video/x-m4v'
+]
+
 const SubjectViewer = types
   .model('SubjectViewer', {
     annotate: types.optional(types.boolean, true),
@@ -41,6 +51,16 @@ const SubjectViewer = types
     get interactionMode () {
       // Default interaction mode is 'annotate'
       return (!self.annotate && self.move) ? 'move' : 'annotate'
+    },
+    get showImageToolbar () {
+      const subject = getRoot(self).subjects.active
+      const frameLocation = subject?.locations[self.frame]
+      const frameMimeType = frameLocation && Object.keys(frameLocation)[0]
+
+      if (self.separateFramesView || NO_IMAGE_TOOLBAR_MIME_TYPES.includes(frameMimeType)) {
+        return false
+      }
+      return true
     }
   }))
 


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #3093

## Describe your changes
- adds `showImageToolbar` view to SubjectViewerStore based on frame location mime type
- refactors FieldGuide components per ^
- refactors layouts per ^

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - local - https://local.zooniverse.org:8080/?project=1693&workflow=3755
  - fe-project-branch - TBD
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)