### PR TITLE
Classifier: add workflow configuration pan_and_zoom functionality

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/SeparateFramesViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/SeparateFramesViewer.js
@@ -12,12 +12,14 @@ import ViewModeButton from './components/ViewModeButton/ViewModeButton.js'
 function storeMapper(store) {
   const {
     limit_subject_height: limitSubjectHeight,
-    multi_image_layout: multiImageLayout
+    multi_image_layout: multiImageLayout,
+    pan_and_zoom: panAndZoom
   } = store.workflows?.active?.configuration
 
   return {
     limitSubjectHeight,
-    multiImageLayout
+    multiImageLayout,
+    panAndZoom
   }
 }
 
@@ -30,9 +32,12 @@ function SeparateFramesViewer({
   onReady = DEFAULT_HANDLER,
   subject
 }) {
-  console.log(subject)
-  const { limitSubjectHeight, multiImageLayout } = useStores(storeMapper)
-
+  const {
+    limitSubjectHeight,
+    multiImageLayout,
+    panAndZoom
+  } = useStores(storeMapper)
+  
   const [forceColLayout, setForceColLayout] = useState(false)
   const [numFramesHorizontally, setNumFramesHorizontally] = useState(1)
 
@@ -88,6 +93,7 @@ function SeparateFramesViewer({
             limitSubjectHeight={limitSubjectHeight}
             onError={onError}
             onReady={onReady}
+            panAndZoom={panAndZoom}
           />
         ))}
       </Grid>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.js
@@ -22,7 +22,8 @@ const SeparateFrame = ({
   frameUrl = '',
   limitSubjectHeight = false,
   onError = DEFAULT_HANDLER,
-  onReady = DEFAULT_HANDLER
+  onReady = DEFAULT_HANDLER,
+  panAndZoom = true
 }) => {
   const { img, error, loading, subjectImage } = useSubjectImage({
     src: frameUrl,
@@ -218,38 +219,40 @@ const SeparateFrame = ({
           />
         </g>
       </SingleImageViewer>
-      <Box
-        background={{
-          dark: 'dark-3',
-          light: 'white'
-        }}
-        border={{
-          color: {
-            dark: 'dark-1',
-            light: 'light-3'
-          },
-          side: 'all'
-        }}
-        direction='column'
-        height='fit-content'
-        onKeyDown={onKeyDown}
-        pad='8px'
-        style={{ width: '3rem' }}
-      >
-        <AnnotateButton
-          separateFrameAnnotate={separateFrameAnnotate}
-          separateFrameEnableAnnotate={separateFrameEnableAnnotate}
-        />
-        <MoveButton
-          separateFrameMove={separateFrameMove}
-          separateFrameEnableMove={separateFrameEnableMove}
-        />
-        <ZoomInButton separateFrameZoomIn={separateFrameZoomIn} />
-        <ZoomOutButton separateFrameZoomOut={separateFrameZoomOut} />
-        <RotateButton separateFrameRotate={separateFrameRotate} />
-        <ResetButton separateFrameResetView={separateFrameResetView} />
-        <InvertButton separateFrameInvert={separateFrameInvert} />
-      </Box>
+      {panAndZoom && (
+        <Box
+          background={{
+            dark: 'dark-3',
+            light: 'white'
+          }}
+          border={{
+            color: {
+              dark: 'dark-1',
+              light: 'light-3'
+            },
+            side: 'all'
+          }}
+          direction='column'
+          height='fit-content'
+          onKeyDown={onKeyDown}
+          pad='8px'
+          style={{ width: '3rem' }}
+        >
+          <AnnotateButton
+            separateFrameAnnotate={separateFrameAnnotate}
+            separateFrameEnableAnnotate={separateFrameEnableAnnotate}
+          />
+          <MoveButton
+            separateFrameMove={separateFrameMove}
+            separateFrameEnableMove={separateFrameEnableMove}
+          />
+          <ZoomInButton separateFrameZoomIn={separateFrameZoomIn} />
+          <ZoomOutButton separateFrameZoomOut={separateFrameZoomOut} />
+          <RotateButton separateFrameRotate={separateFrameRotate} />
+          <ResetButton separateFrameResetView={separateFrameResetView} />
+          <InvertButton separateFrameInvert={separateFrameInvert} />
+        </Box>
+      )}
     </Box>
   )
 }

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -57,7 +57,10 @@ const SubjectViewer = types
       const frameLocation = subject?.locations[self.frame]
       const frameMimeType = frameLocation && Object.keys(frameLocation)[0]
 
-      if (self.separateFramesView || NO_IMAGE_TOOLBAR_MIME_TYPES.includes(frameMimeType)) {
+      const workflow = getRoot(self).workflows.active
+      const panAndZoom = workflow?.configuration?.pan_and_zoom
+
+      if (!panAndZoom || self.separateFramesView || NO_IMAGE_TOOLBAR_MIME_TYPES.includes(frameMimeType)) {
         return false
       }
       return true

--- a/packages/lib-classifier/src/store/WorkflowStore/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
@@ -9,6 +9,7 @@ const WorkflowConfiguration = types.snapshotProcessor(
     limit_subject_height: types.optional(types.boolean, false),
     multi_image_mode: types.optional(types.enumeration('multiImageMode', ['flipbook', 'separate']), 'flipbook'),
     multi_image_layout: types.optional(types.enumeration('multiImageLayout', ['col', 'grid2', 'grid3', 'row']), 'col'),
+    pan_and_zoom: types.optional(types.boolean, true),
     persist_annotations: types.optional(types.boolean, true),
     playIterations: types.optional(types.number, 3),
     subject_viewer: types.maybe(


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- iteration on #4532 

## Describe your changes
- refactors subject viewers per workflow configuration `pan_and_zoom` property

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
    - local - https://local.zooniverse.org:8080/?project=1693&workflow=3755
    - fe-project-branch - TBD
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)