### PR TITLE
Classifier: disable image toolbar for not applicable mime types

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/MoveButton/MoveButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/MoveButton/MoveButton.js
@@ -6,6 +6,7 @@ import Button from '../Button'
 
 function MoveButton({
   active = false,
+  disabled = false,
   onClick = () => console.log('Move Button')
 }) {
   const { t } = useTranslation('components')
@@ -13,6 +14,7 @@ function MoveButton({
     <Button
       a11yTitle={t('ImageToolbar.MoveButton.ariaLabel')}
       active={active}
+      disabled={disabled}
       icon={<MoveIcon />}
       onClick={onClick}
     />
@@ -21,6 +23,7 @@ function MoveButton({
 
 MoveButton.propTypes = {
   active: PropTypes.bool,
+  disabled: PropTypes.bool,
   onClick: PropTypes.func
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/MoveButton/MoveButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/MoveButton/MoveButtonContainer.js
@@ -6,15 +6,19 @@ import MoveButton from './MoveButton'
 
 function storeMapper(classifierStore) {
   const {
-    move,
+    disableImageToolbar,
     enableMove,
+    move,
     separateFramesView
   } = classifierStore.subjectViewer
 
+  const disabled = disableImageToolbar
+
   return {
-    move,
+    disabled,
     enableMove,
-    separateFramesView
+    move,
+    separateFramesView,
   }
 }
 
@@ -22,11 +26,17 @@ function MoveButtonContainer({
   separateFrameMove = false,
   separateFrameEnableMove = () => true
 }) {
-  const { move, enableMove, separateFramesView } = useStores(storeMapper)
+  const { 
+    disabled,
+    enableMove,
+    move, 
+    separateFramesView
+  } = useStores(storeMapper)
 
   return (
     <MoveButton
       active={separateFramesView ? separateFrameMove : move}
+      disabled={disabled}
       onClick={separateFramesView ? separateFrameEnableMove : enableMove}
     />
   )

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButtonContainer.js
@@ -6,21 +6,30 @@ import ResetButton from './ResetButton'
 
 function storeMapper(classifierStore) {
   const {
-    separateFramesView,
-    resetView
+    disableImageToolbar,
+    resetView,
+    separateFramesView
   } = classifierStore.subjectViewer
 
+  const disabled = disableImageToolbar
+
   return {
+    disabled,
     resetView,
     separateFramesView
   }
 }
 
 function ResetButtonContainer({ separateFrameResetView = () => true }) {
-  const { separateFramesView, resetView } = useStores(storeMapper)
+  const {
+    disabled,
+    resetView,
+    separateFramesView
+  } = useStores(storeMapper)
 
   return (
     <ResetButton
+      disabled={disabled}
       onClick={separateFramesView ? separateFrameResetView : resetView}
     />
   )

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButtonContainer.js
@@ -5,26 +5,37 @@ import { useStores } from '@hooks'
 import RotateButton from './RotateButton'
 
 function storeMapper (classifierStore) {
-  const { rotate, rotationEnabled, separateFramesView } =
+  const {
+    disableImageToolbar,
+    rotate,
+    rotationEnabled,
+    separateFramesView
+  } =
     classifierStore.subjectViewer
 
-  const disabled = !rotationEnabled
+  const disabled = disableImageToolbar
+  const hidden = !rotationEnabled
+  
   return {
     disabled,
+    hidden,
     rotate,
     separateFramesView
   }
 }
 
 function RotateButtonContainer({ separateFrameRotate = () => true }) {
-  const { disabled, rotate, separateFramesView } = useStores(storeMapper)
+  const { disabled, hidden, rotate, separateFramesView } = useStores(storeMapper)
 
-  if (disabled) {
+  if (hidden) {
     return null
   }
 
   return (
-    <RotateButton onClick={separateFramesView ? separateFrameRotate : rotate} />
+    <RotateButton
+      disabled={disabled}
+      onClick={separateFramesView ? separateFrameRotate : rotate}
+    />
   )
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.js
@@ -8,7 +8,9 @@ function DEFAULT_HANDLER() {
   console.log('zoom in')
   return true
 }
+
 function ZoomInButton ({
+  disabled = false,
   onClick = DEFAULT_HANDLER,
   onPointerDown = DEFAULT_HANDLER,
   onPointerUp = DEFAULT_HANDLER
@@ -17,6 +19,7 @@ function ZoomInButton ({
   return (
     <Button
       a11yTitle={t('ImageToolbar.ZoomInButton.ariaLabel')}
+      disabled={disabled}
       icon={<ZoomInIcon />}
       onClick={onClick}
       onPointerDown={onPointerDown}
@@ -26,6 +29,7 @@ function ZoomInButton ({
 }
 
 ZoomInButton.propTypes = {
+  disabled: PropTypes.bool,
   onClick: PropTypes.func
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
@@ -6,16 +6,27 @@ import { useStores } from '@hooks'
 import ZoomInButton from './ZoomInButton'
 
 function storeMapper(classifierStore) {
-  const { separateFramesView, zoomIn } = classifierStore.subjectViewer
+  const {
+    disableImageToolbar,
+    separateFramesView,
+    zoomIn
+  } = classifierStore.subjectViewer
+
+  const disabled = disableImageToolbar
 
   return {
+    disabled,
     separateFramesView,
     zoomIn
   }
 }
 
 function ZoomInButtonContainer({ separateFrameZoomIn = () => true }) {
-  const { separateFramesView, zoomIn } = useStores(storeMapper)
+  const {
+    disabled,
+    separateFramesView,
+    zoomIn
+  } = useStores(storeMapper)
   const [timer, setTimer] = useState('')
 
   function onPointerDown(event) {
@@ -35,6 +46,7 @@ function ZoomInButtonContainer({ separateFrameZoomIn = () => true }) {
 
   return (
     <ZoomInButton
+      disabled={disabled}
       onClick={separateFramesView ? separateFrameZoomIn : zoomIn}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.js
@@ -10,6 +10,7 @@ function DEFAULT_HANDLER() {
 }
 
 function ZoomOutButton({
+  disabled = false,
   onClick = DEFAULT_HANDLER,
   onPointerDown = DEFAULT_HANDLER,
   onPointerUp = DEFAULT_HANDLER
@@ -18,6 +19,7 @@ function ZoomOutButton({
   return (
     <Button
       a11yTitle={t('ImageToolbar.ZoomOutButton.ariaLabel')}
+      disabled={disabled}
       icon={<ZoomOutIcon />}
       onClick={onClick}
       onPointerDown={onPointerDown}
@@ -27,6 +29,7 @@ function ZoomOutButton({
 }
 
 ZoomOutButton.propTypes = {
+  disabled: PropTypes.bool,
   onClick: PropTypes.func
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
@@ -6,16 +6,27 @@ import { useStores } from '@hooks'
 import ZoomOutButton from './ZoomOutButton'
 
 function storeMapper(classifierStore) {
-  const { separateFramesView, zoomOut } = classifierStore.subjectViewer
+  const {
+    disableImageToolbar,
+    separateFramesView,
+    zoomOut
+  } = classifierStore.subjectViewer
+
+  const disabled = disableImageToolbar
 
   return {
+    disabled,
     separateFramesView,
     zoomOut
   }
 }
 
 function ZoomOutButtonContainer({ separateFrameZoomOut = () => true }) {
-  const { separateFramesView, zoomOut } = useStores(storeMapper)
+  const {
+    disabled,
+    separateFramesView,
+    zoomOut
+  } = useStores(storeMapper)
   const [timer, setTimer] = useState('')
 
   function onPointerDown(event) {
@@ -35,6 +46,7 @@ function ZoomOutButtonContainer({ separateFrameZoomOut = () => true }) {
 
   return (
     <ZoomOutButton
+      disabled={disabled}
       onClick={separateFramesView ? separateFrameZoomOut : zoomOut}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -2,6 +2,16 @@ import asyncStates from '@zooniverse/async-states'
 import { autorun } from 'mobx'
 import { addDisposer, getRoot, isValidReference, types } from 'mobx-state-tree'
 
+const NO_IMAGE_TOOLBAR_MIME_TYPES = [
+  'audio/mp3',
+  'audio/m4a',
+  'audio/mpeg',
+  'text/plain',
+  'video/mp4',
+  'video/mpeg',
+  'video/x-m4v'
+]
+
 const SubjectViewer = types
   .model('SubjectViewer', {
     annotate: types.optional(types.boolean, true),
@@ -41,6 +51,16 @@ const SubjectViewer = types
     get interactionMode () {
       // Default interaction mode is 'annotate'
       return (!self.annotate && self.move) ? 'move' : 'annotate'
+    },
+    get disableImageToolbar () {
+      const subject = getRoot(self).subjects.active
+      const frameLocation = subject?.locations[self.frame]
+      const frameMimeType = frameLocation && Object.keys(frameLocation)[0]
+
+      if (NO_IMAGE_TOOLBAR_MIME_TYPES.includes(frameMimeType)) {
+        return true
+      }
+      return false
     }
   }))
 


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- related to #3093 and #4532

## Describe your changes
- adds `disableImageToolbar` view to subject viewer store
- disables ImageToolbar buttons per ^

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - local - https://local.zooniverse.org:8080/?project=1693&workflow=3755
  - fe-project-branch - TBD
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)