### PR TITLE
Classifier: fix FieldGuide story

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuide.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/FieldGuide.stories.js
@@ -117,7 +117,10 @@ const mockStore = {
     active: fieldGuide.id,
     attachedMedia: { [medium.id]: medium },
     resources: { [fieldGuide.id]: fieldGuide }
-  })
+  }),
+  subjectViewer: {
+    separateFramesView: false
+  }
 }
 
 export default {


### PR DESCRIPTION
## Package
lib-classifier

## Describe your changes

The FieldGuide component's mock store was missing a `separateFramesView` property in storybook. This PR fixes that bug.

## How to Review

Run the classifier package's storybook and check that the Field Guide story loads as expected.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed