### PR TITLE
Remove refs from withKeyZoom

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/withKeyZoom/withKeyZoom.js
@@ -1,27 +1,22 @@
-import { forwardRef } from 'react'
-
 import { useKeyZoom } from '@hooks'
-
 
 function withKeyZoom (WrappedComponent) {
 
-  function KeyZoom(props, ref) {
+  function KeyZoom(props) {
     const { onKeyZoom } = useKeyZoom()
     return (
       <WrappedComponent
-        ref={ref}
         onKeyDown={onKeyZoom}
         {...props}
       />
     )
   }
 
-  const DecoratedKeyZoom = forwardRef(KeyZoom)
   const name = WrappedComponent.displayName || WrappedComponent.name
-  DecoratedKeyZoom.displayName = `withKeyZoom(${name})`
-  DecoratedKeyZoom.wrappedComponent = WrappedComponent
+  KeyZoom.displayName = `withKeyZoom(${name})`
+  KeyZoom.wrappedComponent = WrappedComponent
 
-  return DecoratedKeyZoom
+  return KeyZoom
 }
 
 export default withKeyZoom


### PR DESCRIPTION
Remove `forwardRef` from `withKeyZoom`, so that a component wrapped in `withKeyZoom` will now error if you pass a ref to it.

- See the discussion in #4503.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## How to Review
Check the dev classifier with a variety of subject viewers (similar to #4538.) None of them should error, but if any are using refs then React should warn (or error) in the console, as refs can't be passed to functional components.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
