### PR TITLE
Panoptes-js: add organization to projects getWithLinkedResources

### DIFF
--- a/packages/lib-panoptes-js/docs/CHANGELOG.md
+++ b/packages/lib-panoptes-js/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- linked organization to projects getWithLinkedResources request.
+
 ## [0.2.3] 2022-12-05
 - require `superagent` 8.0.6 or higher.
 

--- a/packages/lib-panoptes-js/src/README.md
+++ b/packages/lib-panoptes-js/src/README.md
@@ -134,7 +134,7 @@ panoptes.get('/projects', { page: 2 }).then((response) => {
 Get a single project:
 
 ``` javascript
-panoptes.get('/projects/1104', { include: 'avatar,background,owners' }).then((response) => {
+panoptes.get('/projects/1104', { include: 'avatar,background,organization,owners' }).then((response) => {
   // Do something with the response
 });
 ```

--- a/packages/lib-panoptes-js/src/resources/projects/README.md
+++ b/packages/lib-panoptes-js/src/resources/projects/README.md
@@ -180,6 +180,7 @@ projects.getBySlug({ slug: 'zooniverse/galaxy-zoo' }).then((response) => {
 A project get request that automatically includes the following linked resources with the `includes` query param:
 - avatar
 - background
+- organization
 - owners
 - pages
 
@@ -223,6 +224,7 @@ projects.getWithLinkedResources({ slug: 'zooniverse/galaxy-zoo' }).then((respons
   this.setState({
     avatar: response.body.linked.avatar[0],
     background: response.body.linked.background[0],
+    organization: response.body.linked.organization[0],
     owner: response.body.linked.owners[0],
     pages: response.body.linked.pages,
     project: response.body.projects[0]
@@ -236,6 +238,7 @@ projects.getWithLinkedResources().then((response) => {
   this.setState({
     avatar: response.body.linked.avatar[0],
     background: response.body.linked.background[0],
+    organization: response.body.linked.organization[0],
     owner: response.body.linked.owners[0],
     pages: response.body.linked.pages,
     project: response.body.projects[0]
@@ -252,6 +255,7 @@ For your convenience, the mocks used in testing are exported and made available 
 - resources
   - projectAvatar - `projects.mocks.resources.projectAvatar`
   - projectBackground - `projects.mocks.resources.projectBackground`
+  - projectOrganization - `projects.mocks.resources.projectOrganization`
   - projectOne - `projects.mocks.resources.projectOne`
   - projectTwo - `projects.mocks.resources.projectTwo`
   - projectPages

--- a/packages/lib-panoptes-js/src/resources/projects/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/projects/commonRequests.js
@@ -19,7 +19,7 @@ function getBySlug (params) {
 }
 
 function getWithLinkedResources (params) {
-  const include = { include: 'avatar,background,owners' }
+  const include = { include: 'avatar,background,organization,owners' }
   const projectId = (params && params.id) ? params.id : ''
   const authorization = (params && params.authorization) ? params.authorization : ''
 

--- a/packages/lib-panoptes-js/src/resources/projects/mocks.js
+++ b/packages/lib-panoptes-js/src/resources/projects/mocks.js
@@ -85,6 +85,20 @@ const projectTwo = {
   workflow_description: ''
 }
 
+const projectOrganization = {
+  description: 'A short description of the organization',
+  display_name: 'Untitled organization 1',
+  href: '/organizations/1',
+  id: '1',
+  introduction: 'A more in-depth introduction to your organization...',
+  links: { projects: ['2'] },
+  listed: true,
+  listed_at: '2018-05-10T16:53:33.328Z',
+  primary_language: 'en',
+  slug: 'user/untitled-organization-1',
+  title: 'Untitled organization 1',
+}
+
 const projectPages = {
   team: {
     content: '',
@@ -132,6 +146,7 @@ const resources = {
   projectBackground,
   projectOne,
   projectTwo,
+  projectOrganization,
   projectPages,
   projectRoles
 }
@@ -157,6 +172,7 @@ const projectPagesResponse = buildResponse('get', 'project_pages', [resources.pr
 const projectWithLinkedResources = buildResponse('get', 'projects', [resources.projectTwo], {
   avatars: [resources.projectAvatar],
   backgrounds: [resources.projectBackground],
+  organizations: [resources.projectOrganization],
   owners: users.mocks.resources.user,
   project_pages: [resources.projectPages]
 })


### PR DESCRIPTION
## Package
- lib-panoptes-js

## Linked Issue and/or Talk Post
- towards #3579 

## Describe your changes
- adds `organization` to projects `getWithLinkedResources` request
- updates READMEs and CHANGELOG per ^

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? yes, related PRs will all be linked to #3579 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected