### PR TITLE
Restore survey task focus tests

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.userClicks.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.userClicks.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { composeStory } from '@storybook/testing-react'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as globalConfig from '../../../../../.storybook/preview'
 
@@ -197,7 +197,7 @@ describe('SurveyTask with user clicks', function () {
       expect(choiceButtons.length).to.equal(6)
       const fireChoiceButton = Array.from(choiceButtons).find(choiceButton => choiceButton.textContent === 'Fire')
       // confirm choice (Fire) is focused
-      // expect(fireChoiceButton).to.equal(document.activeElement)
+      await waitFor(() => expect(fireChoiceButton).to.equal(document.activeElement))
     })
 
     it('should show choices with selected choice checked and focused when Identify button is clicked', async function () {
@@ -214,7 +214,7 @@ describe('SurveyTask with user clicks', function () {
       // confirm choice (Fire) is shown as checked
       expect(fireChoiceButton.getAttribute('aria-checked')).to.equal('true')
       // confirm choice (Fire) is shown as focused
-      // expect(fireChoiceButton).to.equal(document.activeElement)
+      await waitFor(() => expect(fireChoiceButton).to.equal(document.activeElement))
     })
     
     it('should disable "Done & Talk" and "Done" buttons', async function () {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.userKeystrokes.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.userKeystrokes.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { composeStory } from '@storybook/testing-react'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as globalConfig from '../../../../../.storybook/preview'
 
@@ -36,10 +36,9 @@ describe('SurveyTask with user keystrokes', function () {
       expect(choiceButton.getAttribute('aria-checked')).to.equal('true')
     
       // confirm choice Fire active element
-      // expect(choiceButton).to.equal(document.activeElement)
+      await waitFor(() => expect(choiceButton).to.equal(document.activeElement))
     
       // press delete key to remove choice (Fire)
-      choiceButton.focus()
       await user.keyboard('[Delete]')
       choiceButton = Array.from(choiceButtons).find(choiceButton => choiceButton.textContent === 'Fire')
       // confirm choice Fire not selected
@@ -54,10 +53,9 @@ describe('SurveyTask with user keystrokes', function () {
       expect(choiceButton.getAttribute('aria-checked')).to.equal('true')
     
       // confirm choice Fire active element
-      // expect(choiceButton).to.equal(document.activeElement)
+      await waitFor(() => expect(choiceButton).to.equal(document.activeElement))
     
       // press backspace key to remove choice (Fire)
-      choiceButton.focus()
       await user.keyboard('[Backspace]')
       choiceButtons = document.querySelector('[role=menu]').querySelectorAll('[role=menuitemcheckbox]')
       choiceButton = Array.from(choiceButtons).find(choiceButton => choiceButton.textContent === 'Fire')
@@ -181,7 +179,8 @@ describe('SurveyTask with user keystrokes', function () {
       expect(choiceImages).to.be.ok()
     })
 
-    it.skip('should close choice on Escape key', async function () {
+    it('should close choice on Escape key', async function () {
+      await waitFor(() => expect(document.activeElement === document.body).to.be.false())
       // pressing Escape to close the choice (Aardvark)
       await user.keyboard('[Escape]')
       // confirm choice (Aardvark) description, and therefore choice, is not visible


### PR DESCRIPTION
Survey task keyboard focus tests were skipped in order to pass with React Testing Library v9. This restores them, wrapped in `waitFor` so that each test waits for focus to change before running.

This PR reverts changes from #4395, where failing expectations were either commented out or skipped.
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## How to Review
Tests should pass on this branch, with the latest testing library.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser


## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
