### PR TITLE
app-project: Add OrganizationLink to Hero component

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.js
+++ b/packages/app-project/src/screens/ProjectHomePage/ProjectHomePage.js
@@ -77,7 +77,10 @@ function ProjectHomePage ({
           />
           <Announcements />
         </header>
-        <Hero workflows={workflows} />
+        <Hero
+          workflows={workflows}
+          organization={organization}
+        />
         <Box margin='small' gap='small'>
           <ThemeModeToggle />
           <ZooniverseTalk />
@@ -99,7 +102,11 @@ function ProjectHomePage ({
             <Announcements />
           </header>
           <RemainingHeightBox>
-            <Hero workflows={workflows} isWide={true} />
+            <Hero
+              isWide={true}
+              organization={organization}
+              workflows={workflows}
+            />
           </RemainingHeightBox>
         </FullHeightBox>
         <Box

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.js
@@ -1,6 +1,4 @@
 import { arrayOf, bool, shape, string } from 'prop-types'
-import { Component } from 'react';
-import asyncStates from '@zooniverse/async-states'
 
 import WideLayout from './components/WideLayout'
 import NarrowLayout from './components/NarrowLayout'
@@ -10,16 +8,21 @@ import NarrowLayout from './components/NarrowLayout'
 */
 function Hero ({
   isWide = false,
+  organization = {},
   workflows = []
 }) {
   return isWide
-    ? <WideLayout workflows={workflows} />
-    : <NarrowLayout workflows={workflows} />
+    ? <WideLayout organization={organization} workflows={workflows} />
+    : <NarrowLayout organization={organization} workflows={workflows} />
 }
 
 Hero.propTypes = {
   /** SSR flag to render either the wide or narrow screen layout. */
   isWide: bool,
+  /** The project's organization. */
+  organization: shape({
+    id: string
+  }),
   /** An array of workflows for the workflow menu. */
   workflows: arrayOf(shape({
     id: string.isRequired

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.stories.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.stories.js
@@ -112,3 +112,22 @@ SmallScreen.parameters = {
     defaultViewport: 'iphone5'
   }
 }
+
+const ORGANIZATION = {
+  id: '1',
+  listed: true,
+  slug: 'brbcornell/nest-quest-go',
+  title: 'Nest Quest Go'
+}
+
+export function WithOrganization({ isWide }) {
+  return (
+    <MockProjectContext>
+      <Hero
+        isWide={isWide}
+        organization={ORGANIZATION}
+        workflows={WORKFLOWS}
+      />
+    </MockProjectContext>
+  )
+}

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/NarrowLayout/NarrowLayout.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/NarrowLayout/NarrowLayout.js
@@ -3,12 +3,14 @@ import { arrayOf, shape, string } from 'prop-types'
 
 import Background from '../Background'
 import Introduction from '../Introduction'
+import OrganizationLink from '../OrganizationLink'
 import WorkflowSelector from '@shared/components/WorkflowSelector'
 import ContentBox from '@shared/components/ContentBox'
 
-function NarrowLayout (props) {
-  const { workflows } = props
-
+function NarrowLayout ({
+  organization = {},
+  workflows = []
+}) {
   return (
     <Box
       align='stretch'
@@ -23,6 +25,12 @@ function NarrowLayout (props) {
       <Grid margin={{ top: 'medium-neg', horizontal: 'medium' }}>
         <ContentBox gap='medium' >
           <Introduction />
+          {organization?.id ? (
+            <OrganizationLink
+              slug={organization.slug}
+              title={organization.strings?.title || organization.title}
+            />
+          ) : null}
           <WorkflowSelector
             workflows={workflows}
           />
@@ -32,11 +40,12 @@ function NarrowLayout (props) {
   )
 }
 
-NarrowLayout.defaultProps = {
-  workflows: []
-}
-
 NarrowLayout.propTypes = {
+  organization: shape({
+    id: string,
+    slug: string,
+    title: string
+  }),
   workflows: arrayOf(shape({
     id: string.isRequired
   }))

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/OrganizationLink/OrganizationLink.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/OrganizationLink/OrganizationLink.js
@@ -1,0 +1,38 @@
+import { Anchor, Box } from 'grommet'
+import { useTranslation } from 'next-i18next'
+import { string } from 'prop-types'
+import { SpacedText } from '@zooniverse/react-components'
+
+function OrganizationLink({
+  slug = '',
+  title = ''
+}) {
+  const { t } = useTranslation('components')
+
+  return (
+    <Box
+      alignContent='start'
+      wrap={true}
+    >
+      <SpacedText>
+        {t('ProjectHeader.organization')}
+      </SpacedText>
+      <Anchor
+        href={`https://www.zooniverse.org/organizations/${slug}`}
+      >
+        <SpacedText
+          weight='bold'
+        >
+          {title}
+        </SpacedText>
+      </Anchor>
+    </Box>
+  )
+}
+
+OrganizationLink.propTypes = {
+  slug: string,
+  title: string
+}
+
+export default OrganizationLink

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/OrganizationLink/OrganizationLink.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/OrganizationLink/OrganizationLink.spec.js
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react'
+
+import OrganizationLink from './OrganizationLink'
+
+const SLUG = 'zooniverse/test-organization'
+const TITLE = 'Test Organization'
+
+describe('Component > Hero > OrganizationLink', function () {
+  it('should render a link to the organization page', function () {
+    render(<OrganizationLink slug={SLUG} title={TITLE} />)
+    expect(screen.getByRole('link', { name: TITLE })).to.exist()
+  })
+})

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/OrganizationLink/index.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/OrganizationLink/index.js
@@ -1,0 +1,1 @@
+export { default } from './OrganizationLink'

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WideLayout/WideLayout.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/components/WideLayout/WideLayout.js
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 
 import Background from '../Background'
 import Introduction from '../Introduction'
+import OrganizationLink from '../OrganizationLink'
 import WorkflowSelector from '@shared/components/WorkflowSelector'
 import ContentBox from '@shared/components/ContentBox'
 
@@ -15,11 +16,16 @@ const StyledContentBox = styled(ContentBox)`
   border-color: transparent;
 `
 
-function WideLayout (props) {
-  const { workflows } = props
-
+function WideLayout ({
+  organization = {},
+  workflows = []
+}) {
   return (
-    <GrowBox align='stretch' direction='row' justify='between'>
+    <GrowBox
+      align='stretch'
+      direction='row'
+      justify='between'
+    >
       <Box width='62%'>
         <Background />
       </Box>
@@ -30,6 +36,12 @@ function WideLayout (props) {
         width='38%'
       >
         <Introduction />
+        {organization?.id ? (
+          <OrganizationLink
+            slug={organization.slug}
+            title={organization.strings?.title || organization.title}
+          />
+        ) : null}
         <WorkflowSelector
           workflows={workflows}
         />
@@ -38,11 +50,12 @@ function WideLayout (props) {
   )
 }
 
-WideLayout.defaultProps = {
-  workflows: []
-}
-
 WideLayout.propTypes = {
+  organization: shape({
+    id: string,
+    slug: string,
+    title: string
+  }),
   workflows: arrayOf(shape({
     id: string.isRequired
   }))


### PR DESCRIPTION
## Package
- app-project

## Linked Issue and/or Talk Post
- towards #3579 

## Describe your changes
- adds organization link to project hero section

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).