### PR TITLE
Classifier: fix offset in VisXZoom's "zoom-layer"

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -123,7 +123,6 @@ function VisXZoom({
 
 
   const ZoomingComponent = zoomingComponent
-  console.log('+++ ZoomingComponent', ZoomingComponent)
   return (
     <Zoom
       constrain={constrain}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.js
@@ -123,6 +123,7 @@ function VisXZoom({
 
 
   const ZoomingComponent = zoomingComponent
+  console.log('+++ ZoomingComponent', ZoomingComponent)
   return (
     <Zoom
       constrain={constrain}
@@ -148,7 +149,6 @@ function VisXZoom({
             <ZoomEventLayer
               focusable
               height={height}
-              left={left}
               onDoubleClick={onDoubleClick}
               onKeyDown={onKeyDown}
               onPointerDown={panning ? _zoom.dragStart : DEFAULT_HANDLER}
@@ -159,7 +159,6 @@ function VisXZoom({
               onWheel={onWheel}
               panning={panning}
               tabIndex={0}
-              top={top}
               width={width}
             />
           </ZoomingComponent>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/VisXZoom/VisXZoom.spec.js
@@ -177,21 +177,17 @@ describe('Component > VisXZoom', function () {
         expect(wrapper.find(StubComponent).find(ZoomEventLayer)).to.have.lengthOf(1)
       })
 
-      it('should set the height, width, and left and top positions by props', function () {
+      it('should set the height and width by props', function () {
         const wrapper = mount(
           <VisXZoom
             data={mockData}
-            left={20}
             height={height}
             width={width}
-            top={40}
             zoomingComponent={StubComponent}
           />
         )
 
         const zoomEventLayer = wrapper.find(StubComponent).find(ZoomEventLayer)
-        expect(zoomEventLayer.props().left).to.equal(20)
-        expect(zoomEventLayer.props().top).to.equal(40)
         expect(zoomEventLayer.props().height).to.equal(height)
         expect(zoomEventLayer.props().width).to.equal(width)
       })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
@@ -168,8 +168,6 @@ export default function ScatterPlot({
             borderColor={(dark) ? colors['light-5'] : colors['dark-5']}
             fill={(dark) ? colors['light-3'] : colors['neutral-6']}
             height={plotHeight}
-            left={leftPosition}
-            top={topPosition}
             underlayParameters={underlayParameters}
             width={plotWidth}
           />}


### PR DESCRIPTION
## PR Overview

Package: lib-classifier
Affects: ScatterPlotViewer (and theoretically any component that would use VisXZoom)
Follows: #4482's review
Fixes #4593 

At the moment, the "zoom layer" (the invisible rectangle that's supposed to cover a scatterplot chart, and listen for pan/zoom actions from the mouse) has an odd offset.

_Screenshot: (before fix, [SuperWASP Blackhole on lib-classifier](https://localhost:8080/?env=production&project=hughdickinson/superwasp-black-hole-hunters&workflow=17386)) : The visible "zoom layer", marked by a focus-outline on Chrome, is offset to the bottom-right. This means if a user's mouse is on the far left or top edge of the chart, they can't use the mouse to pan & zoom._
<img width="498" alt="Screenshot 2023-05-08 at 21 32 44" src="https://user-images.githubusercontent.com/13952701/236960088-8241f236-6e63-419f-8e47-de64bc19d218.png">

This fix removes that offset.

_Screenshot (after fix, [ScatterPlotViewer -> X Range Selection on Storybook](http://localhost:6006/?path=/story/subject-viewers-scatterplotviewer--x-range-selection&globals=locale:en;locales.en:English;locales.test:Test+Language)) : Now, the "zoom layer" is correctly covering all the visible data points._
<img width="522" alt="Screenshot 2023-05-09 at 00 46 14" src="https://user-images.githubusercontent.com/13952701/236961082-cd440b01-9455-4814-8966-41706cb109ce.png">

### Dev Notes

From the DOM, I can see...
```
<g class="chartContent" transform="translate(60, 10)">
  <rect class="chartBackground" left="60" top="10">
  <g> // 1st data point
  <g> // 2nd data point
  (etc)
  <rect data-testId="zoom-layer" transform="translate(60, 10)">
```

The chartContent parent has an x-offset of 60px to compensate for the width of the y-axis, and a y-offset of 10px (for aesthetic reasons, I think?). These offsets are then replicated by the "zoom layer" rect, which unfortunately introduced and extra unwanted offset of wonkiness. (Side note: the chartBackground's [top & left are invalid and ignored.](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/rect#attributes))

Digging into the code, I see that the unnecessary `left` and `top` are added in `VisXZoom.js`:
```
left = 60 // padding to compensate for the width of the y-axis's markers
top = 10 // padding to compensate for the height of the (bottom?) y-axis's markers
<Zoom left={left} top={top} ...>  // Hey, left and top are already used here
  <ZoomingComponent ...>
    <ZoomEventLayer
      left={left} top={top}  // Yeah, now you're just offsetting an element whose parent already has the same offset.
    >
```

Removing top/left from `<ZoomEventLayer>` seems like the most sensible thing to do.

UPDATE: I'm now not 100% sure if `<Zoom/>` even uses [left & top,](https://airbnb.io/visx/docs/zoom) so maybe I can remove those two params from `VisXZoom.js` altogether. 🤷 Ping me if you think I should.

### Status

Ready for review. I'd be particularly interested in knowing of any scenarios that I might have missed, e.g. _"actually, a current/future component WILL require left/top offsets to be passed to the VisXZoom, so you can't just delete those params",_ etc