### PR TITLE
Add DataVisAnnotation task to scatter plot viewer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
@@ -187,11 +187,10 @@ export default function ScatterPlot({
         ))}
         {children}
         {experimentalSelectionTool && <Selections
-          colors={colors}
           disabled={disabled || interactionMode !== 'annotate'}
           height={plotHeight}
-          initialSelections={initialSelections}
           margin={margin}
+          transformMatrix={transformMatrix}
           width={plotWidth}
           xScale={xScaleTransformed}
           yScale={yScaleTransformed}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.spec.js
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
+import { Factory } from 'rosie'
 
 import mockStore from '@test/mockStore/mockStore.js'
 
@@ -24,7 +25,28 @@ describe('Component > ScatterPlot', function () {
   const { variableStar } = lightCurveMockData
   const { data, dataPoints } = randomSingleSeriesData
   const defaultColors = Object.values(zooTheme.global.colors.drawingTools)
-  const store = mockStore()
+
+  const dataSelectionWorkflow = Factory.build('workflow', {
+    tasks: {
+      T0: {
+        help: "",
+        instruction: "If you spot a transit? If so, mark it!",
+        required: false,
+        tools: [
+          {
+            type: "graph2dRangeX",
+            label: "Transit?"
+          },
+          {
+            type: "graph2dRangeX",
+            label: "Something else"
+          }
+        ],
+        type: "dataVisAnnotation"
+      }
+    }
+  })
+  const store = mockStore({ workflow: dataSelectionWorkflow })
 
   function withStore() {
     return function Wrapper({ children }) {
@@ -304,16 +326,28 @@ describe('Component > ScatterPlot', function () {
 
     describe('with selections', function () {
       beforeEach(function () {
-        const initialSelections = [
-          { x0: 250, x1: 300 },
-          { x0: 495, x1: 505 }
-        ]
+        const [task] = store.workflowSteps.active.tasks
+        store.classifications.addAnnotation(task, [
+          {
+            tool: 0,
+            toolType: 'graph2dRangeX',
+            x: 275,
+            width: 50,
+            zoomLevelOnCreation: 0
+          },
+          {
+            tool: 0,
+            toolType: 'graph2dRangeX',
+            x: 500,
+            width: 10,
+            zoomLevelOnCreation: 0
+          }
+        ])
 
         render(
           <ScatterPlot
             data={variableStar.scatterPlot.data}
             experimentalSelectionTool
-            initialSelections={initialSelections}
             parentHeight={parentHeight}
             parentWidth={parentWidth}
             theme={zooTheme}
@@ -350,17 +384,29 @@ describe('Component > ScatterPlot', function () {
 
     describe('with selections but disabled', function () {
       beforeEach(function () {
-        const initialSelections = [
-          { x0: 250, x1: 300 },
-          { x0: 495, x1: 505 }
-        ]
+        const [task] = store.workflowSteps.active.tasks
+        store.classifications.addAnnotation(task, [
+          {
+            tool: 0,
+            toolType: 'graph2dRangeX',
+            x: 275,
+            width: 50,
+            zoomLevelOnCreation: 0
+          },
+          {
+            tool: 0,
+            toolType: 'graph2dRangeX',
+            x: 500,
+            width: 10,
+            zoomLevelOnCreation: 0
+          }
+        ])
 
         render(
           <ScatterPlot
             data={variableStar.scatterPlot.data}
             disabled
             experimentalSelectionTool
-            initialSelections={initialSelections}
             parentHeight={parentHeight}
             parentWidth={parentWidth}
             theme={zooTheme}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/Selections/Selection.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/Selections/Selection.js
@@ -6,8 +6,8 @@ export default function Selection({
   onSelect,
   xScale
 }) {
-  const x = xScale(selection.x0)
-  const width = xScale(selection.x1) - x
+  const x = xScale(selection.x - selection.width / 2)
+  const width = xScale(selection.x + selection.width / 2) - x
 
   function onClick() {
     if (!disabled) {
@@ -23,6 +23,7 @@ export default function Selection({
       focusable={disabled ? 'false' : 'true'}
       height='100%'
       onClick={onClick}
+      onFocus={onClick}
       opacity={0.5}
       pointerEvents={disabled ? 'none' : 'all'}
       tabIndex={disabled ? '-1' : '0'}


### PR DESCRIPTION
- Add a hook to inject any active `dataVisAnnotation` task into the `Selections` component.
- Render selection colours based on the active tool index, using the theme's highlighter colours.
- Refactor the storybook to show selections with a couple of different coloured tools.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## Linked Issue and/or Talk Post
- towards #4302.

## How to Review
You can use the 'X Range Selection' and 'Selected X Range' stories to review this, in the classifier storybook. They have a data selection workflow set up, with two data selection tools.

'X Range Selection' has two steps, so you can try out the viewer with and without an active data selection task. When the selection task isn't active, selections should be visible but not editable.


https://github.com/zooniverse/front-end-monorepo/assets/59547/8a137bb6-353b-4967-ae01-6b791a467867


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
