### PR TITLE
Fix Field Guide icon width

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuideButton/FieldGuideButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuideButton/FieldGuideButton.js
@@ -7,6 +7,10 @@ import { useTranslation } from '@translations/i18n'
 
 import HelpIcon from './HelpIcon'
 
+const StyledHelpIcon = styled(HelpIcon)`
+  width: min(50%, 1.2rem);
+`
+
 export const StyledButton = styled(Button)`
   width: 100%;
   ${props =>
@@ -42,7 +46,7 @@ export function ColumnButtonLabel() {
         {t('FieldGuide.FieldGuideButton.buttonLabel')}
       </StyledSpacedText>
       {/** Same styling as ImageToolbar > Button */}
-      <HelpIcon fill='white' width='min(50%, 1.2rem)' />
+      <StyledHelpIcon fill='white' />
     </Box>
   )
 }


### PR DESCRIPTION
Fix an invalid `width` attribute, on the Field Guide's SVG help icon, by replacing it with a CSS style.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## Linked Issue and/or Talk Post
- closes #4604.

## How to Review
The image toolbar shouldn't warn about an unexpected `width` attribute now.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
