### PR TITLE
Increase popup tutorial size

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ModalTutorial/ModalTutorial.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types'
 import { ResponsiveContext } from 'grommet'
 import { Modal } from '@zooniverse/react-components'
@@ -27,6 +27,7 @@ function ModalTutorial ({
   ...props
 }) {
   const [active, setActive] = useState(false)
+  const size = useContext(ResponsiveContext)
   const { t } = useTranslation('components')
 
   useEffect(() => {
@@ -40,6 +41,8 @@ function ModalTutorial ({
     tutorial.setSeenTime()
   }
 
+  const width = (size === 'small') ? '100%' : '400px'
+
   if (tutorial) {
     return (
       <Modal
@@ -48,18 +51,11 @@ function ModalTutorial ({
         closeFn={onClose}
         title={t('ModalTutorial.title')}
       >
-        <ResponsiveContext.Consumer>
-          {size => {
-            const width = (size === 'small') ? '100%' : '330px'
-            return (
-              <SlideTutorial
-                onClick={onClose}
-                pad='none'
-                width={width}
-              />
-            )
-          }}
-        </ResponsiveContext.Consumer>
+        <SlideTutorial
+          onClick={onClose}
+          pad='none'
+          width={width}
+        />
       </Modal>
     )
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js
@@ -76,14 +76,10 @@ function SlideTutorial({
         {isThereMedia &&
           <Media
             alt={t('SlideTutorial.alt', { activeStep: stepIndex })}
-            fit='cover'
+            fit='contain'
             height={200}
             src={medium.src}
           />}
-        {isFirstStep &&
-          <Heading level='3' margin={{ bottom: 'xsmall', top: 'small' }}>
-            {t('SlideTutorial.heading', { projectDisplayName })}
-          </Heading>}
         <Markdownz>{strings[`steps.${stepIndex}.content`]}</Markdownz>
       </StyledMarkdownWrapper>
       <StepNavigation

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.spec.js
@@ -52,30 +52,6 @@ describe('SlideTutorial', function () {
     expect(wrapper.find(Media)).to.have.lengthOf(1)
   })
 
-  it('should render the Heading on the first step', function () {
-    const wrapper = shallow(
-      <SlideTutorial
-        activeStep={0}
-        stepWithMedium={() => ({ step, medium })}
-        steps={[{ step, medium }, { step, medium }]}
-        strings={strings}
-      />
-    )
-    expect(wrapper.find(Heading)).to.have.lengthOf(1)
-  })
-
-  it('should not render the Heading on the second step', function () {
-    const wrapper = shallow(
-      <SlideTutorial
-        activeStep={1}
-        stepWithMedium={() => ({ step, medium })}
-        steps={[{ step, medium }, { step, medium }]}
-        strings={strings}
-      />
-    )
-    expect(wrapper.find(Heading)).to.have.lengthOf(0)
-  })
-
   it('should render the Get Started button on the last step', function () {
     const wrapper = shallow(
       <SlideTutorial

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorialContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorialContainer.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import { ResponsiveContext } from 'grommet'
+import { useContext } from 'react'
 
 import { withStores } from '@helpers'
 import { usePanoptesTranslations } from '@hooks'
@@ -47,26 +48,21 @@ function SlideTutorialContainer({
     translated_id: tutorial?.id,
     language: locale
   })
+  const size = useContext(ResponsiveContext)
   const strings = tutorialTranslation?.strings
   const { activeStep, steps, stepWithMedium } = tutorial
+  const height = (size === 'small') ? '100%' : '73vh'
   return (
-    <ResponsiveContext.Consumer>
-      {size => {
-        const height = (size === 'small') ? '100%' : '53vh'
-        return (
-          <SlideTutorial
-            activeStep={activeStep}
-            height={height}
-            pad={pad}
-            projectDisplayName={projectDisplayName}
-            steps={steps}
-            stepWithMedium={stepWithMedium}
-            strings={strings}
-            {...props}
-          />
-        )
-      }}
-    </ResponsiveContext.Consumer>
+    <SlideTutorial
+      activeStep={activeStep}
+      height={height}
+      pad={pad}
+      projectDisplayName={projectDisplayName}
+      steps={steps}
+      stepWithMedium={stepWithMedium}
+      strings={strings}
+      {...props}
+    />
   )
 }
 


### PR DESCRIPTION
- increase the height to `73vh`.
- increase the width to `400px`.
- remove the first heading to allow for more text on the first slide.
- change the slide image from `cover` to `contain`.
- includes #4639. Check the deployed branch with the DOM inspector. 
<img width="300" alt="Page metadata in the DOM inspector, showing that the deployed ref is 'tutorial-sizing'." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/a3d3d98a-c54a-4e3a-889f-68e4eb8b41a0">


<img width="1278" alt="The Daily Minor Planet poup tutorial with a wider (400px), taller (73vh) box, and the header image constrained to be square, with larger white margins to its left and right." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/062eadc4-8e29-4207-9d7e-4bd15e8af9ee">


_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## Linked Issue and/or Talk Post
- towards #4558.

## How to Review
I think best to try out the popup and inline slide tutorial on a range of projects, to see how the size changes work with a variety of images and text.

Some random projects with a variety of tutorial content:
- Daily Minor Planet: https://local.zooniverse.org:3000/projects/fulsdavid/the-daily-minor-planet/classify/workflow/22354?env=production
- Beyond Borders: https://local.zooniverse.org:3000/projects/mainehistory/beyond-borders-transcribing-historic-maine-land-documents/classify/workflow/18383?env=production
- Planet Hunters Tess: https://local.zooniverse.org:3000/projects/nora-dot-eisner/planet-hunters-tess/classify/workflow/11235?env=production
- Deciphering Secrets: https://local.zooniverse.org:3000/projects/profdrrogerlouismartinez-davila/deciphering-secrets-unlocking-the-manuscripts-of-medieval-spain/classify/workflow/19276/subject-set/106993/subject/79761817?env=production
- SuperWASP: Black Hole Hunters: https://local.zooniverse.org:3000/projects/hughdickinson/superwasp-black-hole-hunters/classify/workflow/17386?env=production

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
