### PR TITLE
Add Grommet theme to scatter plot points

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/ScatterPlot.js
@@ -176,7 +176,6 @@ export default function ScatterPlot({
           <ScatterPlotSeries
             key={`series-${seriesIndex}`}
             color={color}
-            colors={colors}
             dataPointSize={dataPointSize}
             highlightedSeries={highlightedSeries}
             series={series}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/ScatterPlotSeries/ScatterPlotPoint.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/ScatterPlotSeries/ScatterPlotPoint.js
@@ -1,4 +1,5 @@
 import { lighten } from 'polished'
+import { useTheme } from 'styled-components'
 
 export default function ScatterPlotPoint({
   dataPointSize,
@@ -9,6 +10,11 @@ export default function ScatterPlotPoint({
   xScale,
   yScale
 }) {
+  const {
+    global: {
+      colors = {}
+    }
+  } = useTheme()
   let xErrorBarPoints, yErrorBarPoints
   const { x, y, x_error, y_error } = point
   const cx = xScale(x)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/ScatterPlotSeries/ScatterPlotSeries.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/ScatterPlotSeries/ScatterPlotSeries.js
@@ -1,3 +1,5 @@
+import { useTheme } from 'styled-components'
+
 import ScatterPlotPoint from './ScatterPlotPoint'
 import getDataSeriesColor from '@viewers/helpers/getDataSeriesColor'
 import getDataSeriesSymbol from '@viewers/helpers/getDataSeriesSymbol'
@@ -5,7 +7,6 @@ import isDataSeriesHighlighted from '@viewers/helpers/isDataSeriesHighlighted'
 
 export default function ScatterPlotSeries({
   color,
-  colors,
   dataPointSize,
   highlightedSeries,
   series,
@@ -13,6 +14,11 @@ export default function ScatterPlotSeries({
   xScale,
   yScale
 }) {
+  const {
+    global: {
+      colors = {}
+    }
+  } = useTheme()
   const highlighted = isDataSeriesHighlighted({ highlightedSeries, seriesOptions: series?.seriesOptions })
   const glyphColor = color || getDataSeriesColor({
     defaultColors: Object.values(colors.drawingTools),

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomingScatterPlot/ZoomingScatterPlot.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ZoomingScatterPlot/ZoomingScatterPlot.spec.js
@@ -1,9 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import zooTheme from '@zooniverse/grommet-theme'
+import { Grommet } from 'grommet'
 import sinon from 'sinon'
 import { Provider } from 'mobx-react'
+
 import SubjectViewerStore from '@store/SubjectViewerStore'
 import ZoomingScatterPlot from './ZoomingScatterPlot'
-import zooTheme from '@zooniverse/grommet-theme'
 import {
   parentHeight as height,
   parentWidth as width
@@ -47,32 +49,36 @@ describe('Component > ZoomingScatterPlot', function() {
 
   it('should render without crashing', function() {
     const output = render(
-      <Provider classifierStore={mockStore}>
-        <ZoomingScatterPlot
-          data={mockData}
-          parentHeight={height}
-          parentWidth={width}
-          theme={zooTheme}
-          xAxisLabelOffset={10}
-          yAxisLabelOffset={10}
-        />
-      </Provider>
+      <Grommet theme={zooTheme}>
+        <Provider classifierStore={mockStore}>
+          <ZoomingScatterPlot
+            data={mockData}
+            parentHeight={height}
+            parentWidth={width}
+            theme={zooTheme}
+            xAxisLabelOffset={10}
+            yAxisLabelOffset={10}
+          />
+        </Provider>
+      </Grommet>
     )
     expect(output).to.be.ok()
   })
 
   it('should render a scatter plot', function () {
     const output = render(
-      <Provider classifierStore={mockStore}>
-        <ZoomingScatterPlot
-          data={mockData}
-          parentHeight={height}
-          parentWidth={width}
-          theme={zooTheme}
-          xAxisLabelOffset={10}
-          yAxisLabelOffset={10}
-        />
-      </Provider>
+      <Grommet theme={zooTheme}>
+        <Provider classifierStore={mockStore}>
+          <ZoomingScatterPlot
+            data={mockData}
+            parentHeight={height}
+            parentWidth={width}
+            theme={zooTheme}
+            xAxisLabelOffset={10}
+            yAxisLabelOffset={10}
+          />
+        </Provider>
+      </Grommet>
     )
 
     expect(output.getAllByTestId('data-vis-chart')).to.have.lengthOf(1)
@@ -82,16 +88,18 @@ describe('Component > ZoomingScatterPlot', function() {
     describe('with the default configuration of allowing zoom in both directions', function () {
       it('should scale both axes and transform data points', function () {
         const { container, getByTestId } = render(
-          <Provider classifierStore={mockStore}>
-            <ZoomingScatterPlot
-              data={mockData}
-              parentHeight={height}
-              parentWidth={width}
-              theme={zooTheme}
-              xAxisLabelOffset={10}
-              yAxisLabelOffset={10}
-            />
+          <Grommet theme={zooTheme}>
+            <Provider classifierStore={mockStore}>
+              <ZoomingScatterPlot
+                data={mockData}
+                parentHeight={height}
+                parentWidth={width}
+                theme={zooTheme}
+                xAxisLabelOffset={10}
+                yAxisLabelOffset={10}
+              />
           </Provider>
+          </Grommet>
         )
 
         // Original transform position and axes labels
@@ -111,16 +119,18 @@ describe('Component > ZoomingScatterPlot', function() {
 
       it('should scale both axes out and and transform data points', function () {
         const { container, getByTestId } = render(
-          <Provider classifierStore={mockStore}>
-            <ZoomingScatterPlot
-              data={mockData}
-              parentHeight={height}
-              parentWidth={width}
-              theme={zooTheme}
-              xAxisLabelOffset={10}
-              yAxisLabelOffset={10}
-            />
-          </Provider>
+          <Grommet theme={zooTheme}>
+            <Provider classifierStore={mockStore}>
+              <ZoomingScatterPlot
+                data={mockData}
+                parentHeight={height}
+                parentWidth={width}
+                theme={zooTheme}
+                xAxisLabelOffset={10}
+                yAxisLabelOffset={10}
+              />
+            </Provider>
+          </Grommet>
         )
 
         // Original transform position and axes labels
@@ -151,16 +161,18 @@ describe('Component > ZoomingScatterPlot', function() {
 
       it('should reset the scale when zooming out beyond the minimum scale', function () {
         const { container, getByTestId } = render(
-          <Provider classifierStore={mockStore}>
-            <ZoomingScatterPlot
-              data={mockData}
-              parentHeight={height}
-              parentWidth={width}
-              theme={zooTheme}
-              xAxisLabelOffset={10}
-              yAxisLabelOffset={10}
-            />
-          </Provider>
+          <Grommet theme={zooTheme}>
+            <Provider classifierStore={mockStore}>
+              <ZoomingScatterPlot
+                data={mockData}
+                parentHeight={height}
+                parentWidth={width}
+                theme={zooTheme}
+                xAxisLabelOffset={10}
+                yAxisLabelOffset={10}
+              />
+            </Provider>
+          </Grommet>
         )
 
         // Original transform position and axes labels
@@ -203,17 +215,19 @@ describe('Component > ZoomingScatterPlot', function() {
 
       it('should scale the x-axis in', function () {
         const { container, getByTestId } = render(
-          <Provider classifierStore={mockStore}>
-            <ZoomingScatterPlot
-              data={mockData}
-              parentHeight={height}
-              parentWidth={width}
-              theme={zooTheme}
-              xAxisLabelOffset={10}
-              yAxisLabelOffset={10}
-              zoomConfiguration={zoomConfig}
-            />
-          </Provider>
+          <Grommet theme={zooTheme}>
+            <Provider classifierStore={mockStore}>
+              <ZoomingScatterPlot
+                data={mockData}
+                parentHeight={height}
+                parentWidth={width}
+                theme={zooTheme}
+                xAxisLabelOffset={10}
+                yAxisLabelOffset={10}
+                zoomConfiguration={zoomConfig}
+              />
+            </Provider>
+          </Grommet>
         )
 
         // Original transform position and axes labels
@@ -233,17 +247,19 @@ describe('Component > ZoomingScatterPlot', function() {
 
       it('should scale the x-axis out', function () {
         const { container, getByTestId } = render(
-          <Provider classifierStore={mockStore}>
-            <ZoomingScatterPlot
-              data={mockData}
-              parentHeight={height}
-              parentWidth={width}
-              theme={zooTheme}
-              xAxisLabelOffset={10}
-              yAxisLabelOffset={10}
-              zoomConfiguration={zoomConfig}
-            />
-          </Provider>
+          <Grommet theme={zooTheme}>
+            <Provider classifierStore={mockStore}>
+              <ZoomingScatterPlot
+                data={mockData}
+                parentHeight={height}
+                parentWidth={width}
+                theme={zooTheme}
+                xAxisLabelOffset={10}
+                yAxisLabelOffset={10}
+                zoomConfiguration={zoomConfig}
+              />
+            </Provider>
+          </Grommet>
         )
 
         // Original transform position and axes labels
@@ -274,17 +290,19 @@ describe('Component > ZoomingScatterPlot', function() {
 
       it('should reset the x-scale when zooming out beyond the minimum', function () {
         const { container, getByTestId } = render(
-          <Provider classifierStore={mockStore}>
-            <ZoomingScatterPlot
-              data={mockData}
-              parentHeight={height}
-              parentWidth={width}
-              theme={zooTheme}
-              xAxisLabelOffset={10}
-              yAxisLabelOffset={10}
-              zoomConfiguration={zoomConfig}
-            />
-          </Provider>
+          <Grommet theme={zooTheme}>
+            <Provider classifierStore={mockStore}>
+              <ZoomingScatterPlot
+                data={mockData}
+                parentHeight={height}
+                parentWidth={width}
+                theme={zooTheme}
+                xAxisLabelOffset={10}
+                yAxisLabelOffset={10}
+                zoomConfiguration={zoomConfig}
+              />
+            </Provider>
+          </Grommet>
         )
 
         // Original transform position and axes labels
@@ -327,17 +345,19 @@ describe('Component > ZoomingScatterPlot', function() {
 
       it('should scale the y-axis in', function () {
         const { container, getByTestId } = render(
-          <Provider classifierStore={mockStore}>
-            <ZoomingScatterPlot
-              data={mockData}
-              parentHeight={height}
-              parentWidth={width}
-              theme={zooTheme}
-              xAxisLabelOffset={10}
-              yAxisLabelOffset={10}
-              zoomConfiguration={zoomConfig}
-            />
-          </Provider>
+          <Grommet theme={zooTheme}>
+            <Provider classifierStore={mockStore}>
+              <ZoomingScatterPlot
+                data={mockData}
+                parentHeight={height}
+                parentWidth={width}
+                theme={zooTheme}
+                xAxisLabelOffset={10}
+                yAxisLabelOffset={10}
+                zoomConfiguration={zoomConfig}
+              />
+            </Provider>
+          </Grommet>
         )
 
         // Original transform position and axes labels
@@ -357,17 +377,19 @@ describe('Component > ZoomingScatterPlot', function() {
 
       it('should scale the y-axis out', function () {
         const { container, getByTestId } = render(
-          <Provider classifierStore={mockStore}>
-            <ZoomingScatterPlot
-              data={mockData}
-              parentHeight={height}
-              parentWidth={width}
-              theme={zooTheme}
-              xAxisLabelOffset={10}
-              yAxisLabelOffset={10}
-              zoomConfiguration={zoomConfig}
-            />
-          </Provider>
+          <Grommet theme={zooTheme}>
+            <Provider classifierStore={mockStore}>
+              <ZoomingScatterPlot
+                data={mockData}
+                parentHeight={height}
+                parentWidth={width}
+                theme={zooTheme}
+                xAxisLabelOffset={10}
+                yAxisLabelOffset={10}
+                zoomConfiguration={zoomConfig}
+              />
+            </Provider>
+          </Grommet>
         )
 
         // Original transform position and axes labels
@@ -398,17 +420,19 @@ describe('Component > ZoomingScatterPlot', function() {
 
       it('should reset the y-scale when zooming out beyond the minimum', function () {
         const { container, getByTestId } = render(
-          <Provider classifierStore={mockStore}>
-            <ZoomingScatterPlot
-              data={mockData}
-              parentHeight={height}
-              parentWidth={width}
-              theme={zooTheme}
-              xAxisLabelOffset={10}
-              yAxisLabelOffset={10}
-              zoomConfiguration={zoomConfig}
-            />
-          </Provider>
+          <Grommet theme={zooTheme}>
+            <Provider classifierStore={mockStore}>
+              <ZoomingScatterPlot
+                data={mockData}
+                parentHeight={height}
+                parentWidth={width}
+                theme={zooTheme}
+                xAxisLabelOffset={10}
+                yAxisLabelOffset={10}
+                zoomConfiguration={zoomConfig}
+              />
+            </Provider>
+          </Grommet>
         )
 
         // Original transform position and axes labels
@@ -442,17 +466,19 @@ describe('Component > ZoomingScatterPlot', function() {
     describe('when panning is disabled', function () {
       it('should not translate the SVG position', function () {
         render(
-          <Provider classifierStore={mockStore}>
-            <ZoomingScatterPlot
-              data={mockData}
-              panning={false}
-              parentHeight={height}
-              parentWidth={width}
-              theme={zooTheme}
-              xAxisLabelOffset={10}
-              yAxisLabelOffset={10}
-            />
-          </Provider>
+          <Grommet theme={zooTheme}>
+            <Provider classifierStore={mockStore}>
+              <ZoomingScatterPlot
+                data={mockData}
+                panning={false}
+                parentHeight={height}
+                parentWidth={width}
+                theme={zooTheme}
+                xAxisLabelOffset={10}
+                yAxisLabelOffset={10}
+              />
+            </Provider>
+          </Grommet>
         )
 
         const eventMock = {
@@ -485,16 +511,18 @@ describe('Component > ZoomingScatterPlot', function() {
       describe('with the default configuration allowing pan in both directions', function () {
         it('should transform the data points and scale the axes', function () {
           render(
-            <Provider classifierStore={mockStore}>
-              <ZoomingScatterPlot
-                data={mockData}
-                parentHeight={height}
-                parentWidth={width}
-                theme={zooTheme}
-                xAxisLabelOffset={10}
-                yAxisLabelOffset={10}
-              />
-            </Provider>
+            <Grommet theme={zooTheme}>
+              <Provider classifierStore={mockStore}>
+                <ZoomingScatterPlot
+                  data={mockData}
+                  parentHeight={height}
+                  parentWidth={width}
+                  theme={zooTheme}
+                  xAxisLabelOffset={10}
+                  yAxisLabelOffset={10}
+                />
+              </Provider>
+            </Grommet>
           )
 
           const glyph = document.querySelector('.visx-glyph')
@@ -539,17 +567,19 @@ describe('Component > ZoomingScatterPlot', function() {
           }
 
           render(
-            <Provider classifierStore={mockStore}>
-              <ZoomingScatterPlot
-                data={mockData}
-                parentHeight={height}
-                parentWidth={width}
-                theme={zooTheme}
-                xAxisLabelOffset={10}
-                yAxisLabelOffset={10}
-                zoomConfiguration={zoomConfiguration}
-              />
-            </Provider>
+            <Grommet theme={zooTheme}>
+              <Provider classifierStore={mockStore}>
+                <ZoomingScatterPlot
+                  data={mockData}
+                  parentHeight={height}
+                  parentWidth={width}
+                  theme={zooTheme}
+                  xAxisLabelOffset={10}
+                  yAxisLabelOffset={10}
+                  zoomConfiguration={zoomConfiguration}
+                />
+              </Provider>
+            </Grommet>
           )
 
           const glyph = document.querySelector('.visx-glyph')
@@ -593,17 +623,19 @@ describe('Component > ZoomingScatterPlot', function() {
             zoomOutValue: 0.8
           }
           render(
-            <Provider classifierStore={mockStore}>
-              <ZoomingScatterPlot
-                data={mockData}
-                parentHeight={height}
-                parentWidth={width}
-                theme={zooTheme}
-                xAxisLabelOffset={10}
-                yAxisLabelOffset={10}
-                zoomConfiguration={zoomConfiguration}
-              />
+            <Grommet theme={zooTheme}>
+              <Provider classifierStore={mockStore}>
+                <ZoomingScatterPlot
+                  data={mockData}
+                  parentHeight={height}
+                  parentWidth={width}
+                  theme={zooTheme}
+                  xAxisLabelOffset={10}
+                  yAxisLabelOffset={10}
+                  zoomConfiguration={zoomConfiguration}
+                />
             </Provider>
+            </Grommet>
           )
 
           const glyph = document.querySelector('.visx-glyph')
@@ -654,17 +686,19 @@ describe('Component > ZoomingScatterPlot', function() {
 
       it('should not zoom in beyond maximum zoom configuration', function () {
         const { container, getByTestId } = render(
-          <Provider classifierStore={mockStore}>
-            <ZoomingScatterPlot
-              data={mockData}
-              parentHeight={height}
-              parentWidth={width}
-              theme={zooTheme}
-              xAxisLabelOffset={10}
-              yAxisLabelOffset={10}
-              zoomConfiguration={zoomConfig}
-            />
-          </Provider>
+          <Grommet theme={zooTheme}>
+            <Provider classifierStore={mockStore}>
+              <ZoomingScatterPlot
+                data={mockData}
+                parentHeight={height}
+                parentWidth={width}
+                theme={zooTheme}
+                xAxisLabelOffset={10}
+                yAxisLabelOffset={10}
+                zoomConfiguration={zoomConfig}
+              />
+            </Provider>
+          </Grommet>
         )
 
         // The position and labels prior to zooming
@@ -703,17 +737,19 @@ describe('Component > ZoomingScatterPlot', function() {
 
       it('should not zoom out beyond the minimum zoom configuration and reset the zoom', function () {
         const { container, getByTestId } = render(
-          <Provider classifierStore={mockStore}>
-            <ZoomingScatterPlot
-              data={mockData}
-              parentHeight={height}
-              parentWidth={width}
-              theme={zooTheme}
-              xAxisLabelOffset={10}
-              yAxisLabelOffset={10}
-              zoomConfiguration={zoomConfig}
-            />
-          </Provider>
+          <Grommet theme={zooTheme}>
+            <Provider classifierStore={mockStore}>
+              <ZoomingScatterPlot
+                data={mockData}
+                parentHeight={height}
+                parentWidth={width}
+                theme={zooTheme}
+                xAxisLabelOffset={10}
+                yAxisLabelOffset={10}
+                zoomConfiguration={zoomConfig}
+              />
+            </Provider>
+          </Grommet>
         )
 
         // The position and labels prior to zooming
@@ -754,16 +790,18 @@ describe('Component > ZoomingScatterPlot', function() {
       describe('in the x-axis direction', function () {
         it('should not pan beyond the data extent minimum', function () {
           const { container, getByTestId } = render(
-            <Provider classifierStore={mockStore}>
-              <ZoomingScatterPlot
-                data={mockData}
-                parentHeight={height}
-                parentWidth={width}
-                theme={zooTheme}
-                xAxisLabelOffset={10}
-                yAxisLabelOffset={10}
-              />
-            </Provider>
+            <Grommet theme={zooTheme}>
+              <Provider classifierStore={mockStore}>
+                <ZoomingScatterPlot
+                  data={mockData}
+                  parentHeight={height}
+                  parentWidth={width}
+                  theme={zooTheme}
+                  xAxisLabelOffset={10}
+                  yAxisLabelOffset={10}
+                />
+              </Provider>
+            </Grommet>
           )
 
           // The position and labels prior to panning
@@ -799,16 +837,18 @@ describe('Component > ZoomingScatterPlot', function() {
 
         it('should not pan beyond the data extent maximum', function () {
           const { container, getByTestId } = render(
-            <Provider classifierStore={mockStore}>
-              <ZoomingScatterPlot
-                data={mockData}
-                parentHeight={height}
-                parentWidth={width}
-                theme={zooTheme}
-                xAxisLabelOffset={10}
-                yAxisLabelOffset={10}
-              />
-            </Provider>
+            <Grommet theme={zooTheme}>
+              <Provider classifierStore={mockStore}>
+                <ZoomingScatterPlot
+                  data={mockData}
+                  parentHeight={height}
+                  parentWidth={width}
+                  theme={zooTheme}
+                  xAxisLabelOffset={10}
+                  yAxisLabelOffset={10}
+                />
+              </Provider>
+            </Grommet>
           )
 
           // The position and labels prior to panning
@@ -846,16 +886,18 @@ describe('Component > ZoomingScatterPlot', function() {
       describe('in the y-axis direction', function () {
         it('should not pan beyond the data extent minimum', function () {
           const { container, getByTestId } = render(
-            <Provider classifierStore={mockStore}>
-              <ZoomingScatterPlot
-                data={mockData}
-                parentHeight={height}
-                parentWidth={width}
-                theme={zooTheme}
-                xAxisLabelOffset={10}
-                yAxisLabelOffset={10}
-              />
-            </Provider>
+            <Grommet theme={zooTheme}>
+              <Provider classifierStore={mockStore}>
+                <ZoomingScatterPlot
+                  data={mockData}
+                  parentHeight={height}
+                  parentWidth={width}
+                  theme={zooTheme}
+                  xAxisLabelOffset={10}
+                  yAxisLabelOffset={10}
+                />
+              </Provider>
+            </Grommet>
           )
 
           // The position and labels prior to panning
@@ -891,16 +933,18 @@ describe('Component > ZoomingScatterPlot', function() {
 
         it('should not pan beyond the data extent maximum', function () {
           const { container, getByTestId } = render(
-            <Provider classifierStore={mockStore}>
-              <ZoomingScatterPlot
-                data={mockData}
-                parentHeight={height}
-                parentWidth={width}
-                theme={zooTheme}
-                xAxisLabelOffset={10}
-                yAxisLabelOffset={10}
-              />
-            </Provider>
+            <Grommet theme={zooTheme}>
+              <Provider classifierStore={mockStore}>
+                <ZoomingScatterPlot
+                  data={mockData}
+                  parentHeight={height}
+                  parentWidth={width}
+                  theme={zooTheme}
+                  xAxisLabelOffset={10}
+                  yAxisLabelOffset={10}
+                />
+              </Provider>
+            </Grommet>
           )
 
           // The position and labels prior to panning


### PR DESCRIPTION
Add the Grommet theme to scatter plot data series and points. Make sure that `colors` is defined in both components.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## Linked Issue and/or Talk Post
- fixes #4620.

## How to Review
Change the 'Highlight' checkboxes in the variable star viewer controls, either in the storybook or in Zwicky's Stellar Sleuths.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
