### PR TITLE
lib-classifier: Refactor styling for text viewer, highlighter task selection, and TextFromSubject task

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewer.js
@@ -1,6 +1,6 @@
 import { Box } from 'grommet'
 import PropTypes from 'prop-types'
-import styled, { withTheme } from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 
 /**
 The Single Text Viewer is a variant of the Subject Viewer that's used to display text media.
@@ -37,8 +37,8 @@ function SingleTextViewer ({
   content = [''],
   height = '',
   subjectId = '',
-  theme = { dark: false }
 }) {
+  const theme = useTheme()
   return (
     <Box
       a11yTitle={`Subject ${subjectId} text`}
@@ -62,10 +62,6 @@ SingleTextViewer.propTypes = {
   height: PropTypes.string,
   /** Subject ID */
   subjectId: PropTypes.string,
-  /** Theme */
-  theme: PropTypes.shape({
-    dark: PropTypes.bool
-  })
 }
 
-export default withTheme(SingleTextViewer)
+export default SingleTextViewer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewer.js
@@ -1,6 +1,6 @@
 import { Box } from 'grommet'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled, { withTheme } from 'styled-components'
 
 /**
 The Single Text Viewer is a variant of the Subject Viewer that's used to display text media.
@@ -18,6 +18,7 @@ The `subjectId` is defined by the subject ID.
 
 const StyledPre = styled.pre`
   white-space: pre-wrap;
+  color: ${props => props.theme.dark ? 'inherit' : 'black'};
   font-family: 'Anonymous Pro', monospace;
   @font-face {
     font-family: 'Anonymous Pro';
@@ -35,7 +36,8 @@ const StyledPre = styled.pre`
 function SingleTextViewer ({
   content = [''],
   height = '',
-  subjectId = ''
+  subjectId = '',
+  theme = { dark: false }
 }) {
   return (
     <Box
@@ -46,7 +48,7 @@ function SingleTextViewer ({
       pad='xsmall'
       tabIndex='0'
     >
-      <StyledPre>
+      <StyledPre theme={theme}>
         {content}
       </StyledPre>
     </Box>
@@ -59,7 +61,11 @@ SingleTextViewer.propTypes = {
   /** Minimum height of the text viewer in CSS units eg. '400px', '0.25vh', '20rem' etc. */
   height: PropTypes.string,
   /** Subject ID */
-  subjectId: PropTypes.string
+  subjectId: PropTypes.string,
+  /** Theme */
+  theme: PropTypes.shape({
+    dark: PropTypes.bool
+  })
 }
 
-export default SingleTextViewer
+export default withTheme(SingleTextViewer)

--- a/packages/lib-classifier/src/plugins/tasks/experimental/highlighter/components/components/Selection.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/highlighter/components/components/Selection.js
@@ -1,21 +1,13 @@
 import PropTypes from 'prop-types'
-import styled, { withTheme } from 'styled-components'
+import styled from 'styled-components'
 import { useTranslation } from '@translations/i18n'
-
-const defaultTheme = {
-  dark: false,
-  global: {
-    colors: {
-      text: {}
-    }
-  }
-}
 
 const StyledSpan = styled.span`
   background-color: ${props => props.color};
   border-radius: 8px;
-  color: ${props => props.theme.global.colors.text.light};
-  padding: .1em .4em .2em;
+  color: black;
+  margin-right: .2em;
+  padding: .1em .3em;
 `
 
 const StyledDeleteButton = styled.button`
@@ -36,8 +28,7 @@ function DEFAULT_HANDLER() {
 function Selection ({
   color,
   handleDelete = DEFAULT_HANDLER,
-  text,
-  theme = defaultTheme
+  text
 }) {
   const { t } = useTranslation('plugins')
 
@@ -54,7 +45,6 @@ function Selection ({
       color={color}
       onKeyDown={onKeyDown}
       tabIndex='0'
-      theme={theme}
     >
       {text}
       {' '}
@@ -75,4 +65,4 @@ Selection.propTypes = {
   text: PropTypes.string.isRequired
 }
 
-export default withTheme(Selection)
+export default Selection

--- a/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/components/TextFromSubjectTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/components/TextFromSubjectTask.js
@@ -66,7 +66,7 @@ export default function TextFromSubjectTask ({
           autoFocus={autoFocus}
           disabled={disabled}
           id={`${task.taskKey}-${task.type}`}
-          rows={value?.split(/\r\n|\r|\n/).length + 1}
+          rows={value?.split(/\r\n|\r|\n/).length + 3}
           value={value}
           onChange={onChange}
         />


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- towards #3663 
- per Slack discussion

## Describe your changes
- change text viewer and highlighter task selection font color for proper contrast
- increase TextFromSubject task rows per feedback

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - https://local.zooniverse.org:3000/projects/markb-panoptes/digileap-testing-staging
- What user actions should my reviewer step through to review this PR?
  - go to Highlighter Task Testing workflow, make a few highlights in light and dark mode
  - go to TextFromSubject Task Testing workflow, note increased rows of TextFromSubject task input
- Which storybook stories should be reviewed?
  - [Text viewer with highlighter task selections](http://localhost:6006/?path=/story/subject-viewers-singletextviewer--with-labeled-text&globals=theme:dark)
  - [TextFromSubject task](http://localhost:6006/?path=/story/tasks-textfromsubject--default&globals=theme:dark)
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected