### PR TITLE
lib-classifier: Add fallback url false to dev webpack

### DIFF
--- a/packages/lib-classifier/webpack.dev.js
+++ b/packages/lib-classifier/webpack.dev.js
@@ -52,6 +52,9 @@ module.exports = {
       '@test': path.resolve(__dirname, 'test'),
       '@translations': path.resolve(__dirname, 'src/translations'),
       '@viewers': path.resolve(__dirname, 'src/components/Classifier/components/SubjectViewer')
+    },
+    fallback: {
+      "url": false,
     }
   },
   module: {

--- a/packages/lib-classifier/webpack.dev.js
+++ b/packages/lib-classifier/webpack.dev.js
@@ -33,7 +33,6 @@ module.exports = {
       'localhost',
       '.zooniverse.org'
     ],
-    host: process.env.HOST || 'localhost',
     server: 'https'
   },
   entry: [
@@ -54,7 +53,7 @@ module.exports = {
       '@viewers': path.resolve(__dirname, 'src/components/Classifier/components/SubjectViewer')
     },
     fallback: {
-      "url": false,
+      url: false,
     }
   },
   module: {


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- `HOST=local.zooniverse.org yarn dev` errors with "Can’t resolve ‘url’ in ‘/Users/markbouslog/zooniverse/front-end-monorepo/node_modules/normalizeurl/lib"

## Describe your changes
- as per additional information logged in noted Error message, adds `fallback: { "url": false }` to dev webpack

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What user actions should my reviewer step through to review this PR?
  - run `HOST=local.zooniverse.org yarn dev` and https://local.zooniverse.org:8080/?project=335 loads
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed