### PR TITLE
ADRs 48 & 49: Flipbook Viewer and Separate Frames Viewer documentation

### DIFF
--- a/docs/arch/adr-48.md
+++ b/docs/arch/adr-48.md
@@ -1,0 +1,53 @@
+# ADR 48: Flipbook Viewer
+
+May 2023
+
+
+## Context
+
+To support non-transcription projects that use multi-image subjects, we built a flipbook viewer with the same features as the PFE frontend app. This subject viewer displays when `workflow.configuration.viewer` is undefined and a subject has more than one location and all locations are images.
+
+This viewer assumes all images (locations) in a subject have the same dimensions, and is catered toward landscape oriented or square images.
+
+There is a plan to add fine-grained choice of subject viewer to the project builder in the future, but any relevant changes to the flipbook viewer will be discussed in another ADR.
+
+
+## Features
+
+Configurable options in the project builder handled by the flipbook viewer are:
+- Number of play iterations 
+    - Defaults to 3
+    - `workflow.configuration.playIterations`
+- Autoplay (automatically start looping on page load)
+    - Defaults to false
+    - `workflow.configuration.flipbook_autoplay`
+- Allow volunteers to switch to a separate frames view
+    - Defaults to false
+    - `workflow.configuration.enable_switching_flipbook_and_separate`
+- Choose whether to clone drawn marks between all frames
+    - Defaults to false
+    - `workflow.configuration.multi_image_clone_markers`
+
+### Flipbook Controls
+
+- Thumbnails of each frame (ratio inputs) as navigation buttons
+- Next and previous buttons for navigation between frames
+- Play speed selection with five options: 0.25x, 0.5x, 1x, 2x, 4x
+- Play/Pause button
+- Button to switch to separate frames view
+
+### With Drawing Tasks
+
+When "Clone markers in all frames" is checked/enabled in the project builder:
+- A drawn mark such as a circle should appear on every frame of the flipbook viewer
+- The frame that the volunteer added the mark to should still be recorded in its annotation. To implement this feature, refactoring of InteractionLayer's handling of "current frame" is needed
+- If a volunteer drags a mark to a new position, that new position should display in all frames
+
+When "Clone markers in all frames" is unchecked/disabled in the project builder:
+- A drawn mark should appear only on the frame where it was initially drawn. 
+- The frame that the volunteer added the mark to should be recorded in its annotation (similar to MultiFrameViewer used for transcription projects)
+- If a volunteer drags a mark to a new position, that new position should only apply to the dragged mark
+
+
+## Status
+Accepted

--- a/docs/arch/adr-49.md
+++ b/docs/arch/adr-49.md
@@ -1,0 +1,43 @@
+# ADR 48: Separate Frames Viewer
+
+May 2023
+
+
+## Context
+
+To support non-transcription projects that use multi-image subjects, we built a separate frames viewer with the same features and some additional features as the PFE frontend app. This subject viewer displays when `workflow.configuration.multi_image_mode` is `separate`, or if `subjectViewer.separateFramesView` is toggled to `true` from the flipbook viewer. A subject should have more than one location and all locations are images.
+
+ There is a plan to add fine-grained choice of subject viewer to the project builder in the future, but any relevant changes to the separate frames viewer will be discussed in another ADR.
+
+
+## Features
+
+Configurable options in the project builder handled by the separate frames viewer are:
+- Layout
+    - Defaults to 1-column (`col`)
+    - All options are `col`, `grid2`, `grid3`, `row`
+- Choose whether to clone drawn marks between all frames
+    - Defaults to false
+    - `workflow.configuration.multi_image_clone_markers`
+
+Choosing the appropriate separate frames viewer layout is up to the project team. For instance, a subject with portrait-oriented images will easily be displayed in a 3-column grid in constrast to a subject with landscape-oreinted images which would work best in a 1-column layout.
+
+Regardless of the selected layout, the component code will switch to the 1-column layout when an individual frame's width in the browser is less than `minFrameWidth` as defined in SeparateFramesViewer.js.
+
+Note that `enable_switching_flipbook_and_separate` in WorkflowConfiguration store enables the "switch to separate frames view" in Flipbook Controls.
+
+### With Drawing Tasks
+
+When "Clone markers in all frames" is checked/enabled in the project builder:
+- A drawn mark such as a circle should appear on every frame of the flipbook viewer
+- The frame that the volunteer added the mark to should still be recorded in its annotation. To implement this feature, refactoring of InteractionLayer's handling of "current frame" is needed
+- If a volunteer drags a mark to a new position, that new position should display in all frames
+
+When "Clone markers in all frames" is unchecked/disabled in the project builder:
+- A drawn mark should appear only on the frame where it was initially drawn. 
+- The frame that the volunteer added the mark to should be recorded in its annotation (similar to MultiFrameViewer used for transcription projects)
+- If a volunteer drags a mark to a new position, that new position should only apply to the dragged mark
+
+
+## Status
+Accepted

--- a/docs/arch/adr-49.md
+++ b/docs/arch/adr-49.md
@@ -26,6 +26,10 @@ Regardless of the selected layout, the component code will switch to the 1-colum
 
 Note that `enable_switching_flipbook_and_separate` in WorkflowConfiguration store enables the "switch to separate frames view" in Flipbook Controls.
 
+### SeparateFrame Component
+
+The separate frames viewer has a repeatable component that is designed to include an image toolbar affecting only one frame. This SeparateFrame component is in contrast to the generalized ImageToolbar in the classifier layout components, which relies on the subject viewer store to handle pan, zoom, rotate, and invert state. In SeparateFrame, local state is used for those features instead.
+
 ### With Drawing Tasks
 
 When "Clone markers in all frames" is checked/enabled in the project builder:

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
@@ -132,13 +132,17 @@ FlipbookViewer.propTypes = {
   /** Passed from Subject Viewer Store */
   invert: PropTypes.bool,
   /** Passed from Subject Viewer Store */
+  limit_subject_height: PropTypes.bool,
+  /** Passed from Subject Viewer Store */
   move: PropTypes.bool,
-  /** withKeyZoom in for using keyboard pan and zoom controls while focused on the subject image */
+  /** withKeyZoom() is for using keyboard pan and zoom controls while focused on the subject image */
   onKeyDown: PropTypes.func,
   /** Passed from Subject Viewer Store and called when default frame's src is loaded */
   onReady: PropTypes.func,
   /** Fetched from workflow configuration. Number preference for how many loops to play */
   playIterations: PropTypes.number,
+  /** Passed from the subject viewer store. Needed in SingleImageViewer to handle transforming (rotating) the image */
+  rotation: PropTypes.number,
   /** Passed from the Subject Viewer Store */
   setOnPan: PropTypes.func,
   /** Passed from the Subject Viewer Store */

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/README.md
@@ -4,11 +4,18 @@ The flipbook viewer displays subjects with multiple images in the `locations` ar
 
 This viewer assumes all images in one subject have the same dimensions, and is catered toward landscape oriented or square images. 
 
-?? The SVG drawing layer dimensions are determined once `defaultFrame` is loaded. Then, `onReady()` is called (corresponds to SubjecViewerStore's `onSubjectReady()`).
-
 ## Workflow Configuration
 
-The "Pan and Zoom" section and the "Multi-Image Options" section in the lab are relevant to the Flipbook Viewer.
+Configurable options in the project builder handled by the flipbook viewer are:
+- Number of play iterations 
+    - Defaults to 3
+    - `workflow.configuration.playIterations`
+- Autoplay (automatically start looping on page load)
+    - Defaults to false
+    - `workflow.configuration.flipbook_autoplay`
+- Allow volunteers to switch to a separate frames view
+    - Defaults to false
+    - `workflow.configuration.enable_switching_flipbook_and_separate`
 
 ## Features
 
@@ -19,19 +26,17 @@ FlipbookControls handles the following features:
 - Play/Pause button
 - Button to switch to separate frames view
 
-### Refs
-- `subjectImage`: Reference to svg layer for handling SVGPanZoom component.
-
 ### Props
 - `defaultFrame`: (number) Fetched from `metadata.default_frame` or initialized to zero in the subject viewer store.
-- `defaultFrameSrc`: (string) Either a placeholder or the subject image url.
 = `enableRotation`: (function) Passed from the subject viewer store and called once the first frame image is loaded.
+- `flipbookAutoplay`: (boolean) Fetched from `workflow.configuration.flipbook_autoplay` and defaults to false.
 - `invert`: (boolean) Whether the image colors are inverted. Passed from the subject viewer store.
+- `limitSubjectHeight`: (boolean) Fetch from `workflow.configuration.limit_subject_height` and passed to SingleImageViewer to handle CenteredLayout.
 - `move`: (boolean) Passed from subject viewer store and used during panning and zooming.
-- `naturalHeight`: (number) Height of the subject image.
-- `naturalWidth`: (number) Width of the subject image.
-- `onReady`: (function) Function is passed from SubjectViewer and  dimensions are added to classification metadata. Called after svg layers successfully load with `defaultFrameSrc`.
+- `onKeyDown`: (function) withKeyZoom() is for using keyboard pan and zoom controls while focused on the subject image.
+- `onReady`: (function) Function is passed from SubjectViewer and  dimensions are added to classification metadata.
 - `playIterations`: (string) Can be '', meaning infinite, or a number represented as a string. Set in the project builder and determines how many times to loop the flipbook.
+- `rotation`: (number) Passed from the subject viewer store. Needed in SingleImageViewer to handle transforming (rotating) the image.
 - `setOnPan`: (function) Passed from subject viewer store and used in SVGPanZoom.
 - `setOnZoom`: (function) Passed from subject viewer store and used in SVGPanZoom.
 - `subject`: (object) Passed from mobx store via SubjectViewer.

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/README.md
@@ -1,10 +1,10 @@
 # Flipbook Viewer
 
-The flipbook viewer will display subjects with multiple images in the `locations` array whose workflow configration does not include `multiFrame`. See SubjectStore > Subject > `getViewer()` and ADR 46 for more details.
+The flipbook viewer displays subjects with multiple images in the `locations` array whose workflow configration does not include `multiFrame`. See SubjectStore > Subject > `getViewer()` and ADR 46 for more details.
 
-This viewer assumes all images in one subject have the same dimensions, and is catered toward landscape oriented images. The SVG drawing layer dimensions are determined once `defaultFrame` is loaded. Then, `onReady()` is called (corresponds to SubjecViewerStore's `onSubjectReady()`).
+This viewer assumes all images in one subject have the same dimensions, and is catered toward landscape oriented or square images. 
 
-Unlike MultiFrameViewer, the currently viewed frame is saved as FlipbookViewer state rather than in SubjectViewerStore because the flipbook is designed for projects that do not intend to refresh pan, zoom, rotate, nor drawing marks between frames.
+?? The SVG drawing layer dimensions are determined once `defaultFrame` is loaded. Then, `onReady()` is called (corresponds to SubjecViewerStore's `onSubjectReady()`).
 
 ## Workflow Configuration
 
@@ -15,6 +15,9 @@ The "Pan and Zoom" section and the "Multi-Image Options" section in the lab are 
 FlipbookControls handles the following features:
 - Thumbnails of each frame (ratio inputs)
 - Next and previous buttons for navigation between frames
+- Play speed with five options: 0.25x, 0.5x, 1x, 2x, 4x
+- Play/Pause button
+- Button to switch to separate frames view
 
 ### Refs
 - `subjectImage`: Reference to svg layer for handling SVGPanZoom component.

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/README.md
@@ -1,0 +1,1 @@
+# Separate Frames Viewer

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/README.md
@@ -1,1 +1,23 @@
 # Separate Frames Viewer
+
+The separate frames viewer displays subjects with multiple images in the `locations` array. As of now, it can only be enabled if viewing the flipbook viewer first, and then switching to the separate frames view.
+
+## Features
+
+Configurable options in the project builder handled by the separate frames viewer are:
+- Layout
+    - Defaults to 1-column (`col`)
+    - All options are `col`, `grid2`, `grid3`, `row`
+
+Choosing the appropriate separate frames viewer layout is up to the project team. For instance, a subject with portrait-oriented images will easily be displayed in a 3-column grid in constrast to a subject with landscape-oreinted images which would work best in a 1-column layout.
+
+Regardless of the selected layout, the component code will switch to the 1-column layout when an individual frame's width in the browser is less than `minFrameWidth`.
+
+### Props
+- `onError`: (function) Function passed from SubjectViewer and called if `useSubjectImage()` hook fails.
+- `onReady`: (function) Function is passed from SubjectViewer and  dimensions are added to classification metadata.
+- `subject`: (object) Passed from mobx store via SubjectViewer.
+
+## SeparateFrame Component
+
+This repeatable component is designed to include an image toolbar that affects only one frame. This is in contrast to the generalized ImageToolbar in the classifier layout components that relies on the subject viewer store to handle pan, zoom, rotate, and invert state. In SeparateFrame, local state is used for those features instead.

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/SeparateFramesViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/SeparateFramesViewer.js
@@ -30,7 +30,6 @@ function SeparateFramesViewer({
   onReady = DEFAULT_HANDLER,
   subject
 }) {
-  console.log(subject)
   const { limitSubjectHeight, multiImageLayout } = useStores(storeMapper)
 
   const [forceColLayout, setForceColLayout] = useState(false)


### PR DESCRIPTION
## Package
lib-classifier

## Describe your changes

I added two ADRs - one for flipbook viewer features and one for separate frames viewer features.

I also updated the Readme files in the FlipbookViewer and SeparateFramesViewer folders.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected