### PR TITLE
app-content-pages: only check for user on app mount

### DIFF
--- a/packages/app-content-pages/pages/_app.js
+++ b/packages/app-content-pages/pages/_app.js
@@ -6,7 +6,7 @@ import { Provider } from 'mobx-react'
 import { createGlobalStyle } from 'styled-components'
 import merge from 'lodash/merge'
 import Error from 'next/error'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { appWithTranslation } from 'next-i18next'
 
 import { initializeLogger, logReactError } from '../src/helpers/logger'
@@ -34,7 +34,10 @@ function MyApp({ Component, initialState, pageProps }) {
   const mergedThemes = merge({}, base, zooTheme)
   const store = useStore(initialState)
   makeInspectable(store)
-  store?.user.checkCurrent()
+
+  useEffect(() => {
+    store?.user.checkCurrent()
+  }, [])
 
   try {
     if (pageProps.statusCode) {


### PR DESCRIPTION
## Package
app-content-pages

## Linked Issue and/or Talk Post
Follow-up to https://github.com/zooniverse/front-end-monorepo/pull/4643

## Describe your changes

Call `store.user.checkCurrent()` in a useEffect so that app-content-pages doesn't try to check for user during build.

## How to Review

Run `yarn bootstrap` on this branch locally, and check that https://local.zooniverse.org:3000/about/team?env=production loads. When building with `yarn build`, there should be no console logs of "checking for user".

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] Can sign-in and sign-out

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed