### PR TITLE
Remove @babel/plugin-proposal-logical-assignment-operators

### DIFF
--- a/packages/lib-classifier/.babelrc
+++ b/packages/lib-classifier/.babelrc
@@ -3,7 +3,6 @@
     ["@babel/plugin-transform-runtime", {
       "helpers": false
     }],
-    "@babel/plugin-proposal-logical-assignment-operators",
     ["transform-imports", {
       "lodash": {
         "transform": "lodash/${member}"

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -62,7 +62,6 @@
   "devDependencies": {
     "@babel/cli": "~7.21.0",
     "@babel/core": "~7.21.0",
-    "@babel/plugin-proposal-logical-assignment-operators": "~7.20.7",
     "@babel/plugin-transform-runtime": "~7.21.0",
     "@babel/preset-env": "~7.21.4",
     "@babel/preset-react": "~7.18.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -457,7 +457,7 @@
     "@babel/helper-plugin-utils" "^7.18.6"
     "@babel/plugin-syntax-json-strings" "^7.8.3"
 
-"@babel/plugin-proposal-logical-assignment-operators@^7.20.7", "@babel/plugin-proposal-logical-assignment-operators@~7.20.7":
+"@babel/plugin-proposal-logical-assignment-operators@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.20.7.tgz#dfbcaa8f7b4d37b51e8bfb46d94a5aea2bb89d83"
   integrity sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==


### PR DESCRIPTION
This plugin is included in `@babel/preset-env`. Logical assignment operators have been part of standard JavaScript since 2021.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Maintenance
- [x] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
