### PR TITLE
Classifier: preserve pending classifications

### DIFF
--- a/packages/lib-classifier/src/store/Classification/Classification.js
+++ b/packages/lib-classifier/src/store/Classification/Classification.js
@@ -54,9 +54,6 @@ const Classification = types
   })
   .postProcessSnapshot(snapshot => {
     const newSnapshot = Object.assign({}, snapshot)
-    // remove temporary classification IDs
-    // TODO: leave the ID if it came from Panoptes
-    delete newSnapshot.id
     // convert annotations to an array
     newSnapshot.annotations = Object.values(snapshot.annotations)
     return newSnapshot

--- a/packages/lib-classifier/src/store/Classification/Classification.spec.js
+++ b/packages/lib-classifier/src/store/Classification/Classification.spec.js
@@ -86,8 +86,9 @@ describe('Model > Classification', function () {
       snapshot = classification.toSnapshot()
     })
 
-    it('should not have an ID', function () {
-      expect(snapshot.id).to.be.undefined()
+    it('should have an ID', function () {
+      expect(snapshot.id).to.exist()
+      expect(snapshot.id).to.be.a('string')
     })
 
     it('should have an annotations array', function () {

--- a/packages/lib-classifier/src/store/utils/ClassificationQueue.js
+++ b/packages/lib-classifier/src/store/utils/ClassificationQueue.js
@@ -10,44 +10,69 @@ export const FAILED_CLASSIFICATION_QUEUE_NAME = 'failed-classifications'
 export const MAX_RECENTS = 10
 export const RETRY_INTERVAL = 5 * 60 * 1000
 
+const DEFAULT_HANDLER = () => true
 class ClassificationQueue {
-  constructor (api, onClassificationSaved, authClient) {
+  constructor(
+    api = panoptes,
+    onClassificationSaved = DEFAULT_HANDLER,
+    authClient
+  ) {
     this.storage = window.localStorage
-    this.apiClient = api || panoptes
+    this.apiClient = api
     this.authClient = authClient
+    this.onClassificationSaved = onClassificationSaved
     this.recents = []
+    this.sending = []
     this.flushTimeout = null
-    this.onClassificationSaved = onClassificationSaved || function () { return true }
     this.endpoint = '/classifications'
     this.flushToBackend = this.flushToBackend.bind(this)
+
+    // flush any pending classifications from previous sessions.
+    this.flushToBackend()
   }
 
-  add (classification) {
+  add(classification) {
     this.store(classification)
     return this.flushToBackend()
   }
 
-  store (classification) {
+  store(classification) {
     const queue = this._loadQueue()
     queue.push(classification)
 
     try {
       this._saveQueue(queue)
-      if (process.env.NODE_ENV !== 'test') console.info('Queued classifications:', queue.length)
+      console.info('Queued classifications:', queue.length)
     } catch (error) {
-      if (process.env.NODE_ENV !== 'test') console.error('Failed to queue classification:', error)
+      console.error('Failed to queue classification:', error.message)
       Sentry.withScope((scope) => {
+        scope.setTag('classificationQueue', 'storeFailed')
         scope.setExtra('classification', JSON.stringify(classification))
         Sentry.captureException(error)
       })
     }
   }
 
-  length () {
+  remove(classification) {
+    const queue = this._loadQueue()
+    try {
+      const newQueue = queue.filter(c => c.id !== classification.id)
+      this._saveQueue(newQueue)
+    } catch (error) {
+      console.error(error.message)
+      Sentry.withScope((scope) => {
+        scope.setTag('classificationQueue', 'removeFailed')
+        scope.setExtra('classification', JSON.stringify(classification))
+        Sentry.captureException(error)
+      })
+    }
+  }
+
+  length() {
     return this._loadQueue().length
   }
 
-  addRecent (classification) {
+  addRecent(classification) {
     if (this.recents.length > MAX_RECENTS) {
       const droppedClassification = this.recents.pop()
       droppedClassification.destroy()
@@ -56,40 +81,43 @@ class ClassificationQueue {
     this.recents.unshift(classification)
   }
 
-  async flushToBackend () {
+  async flushToBackend() {
     const pendingClassifications = this._loadQueue()
-    const failedClassifications = []
-    this._saveQueue(failedClassifications)
     if (this.flushTimeout) {
       clearTimeout(this.flushTimeout)
       this.flushTimeout = null
     }
 
-    if (process.env.NODE_ENV !== 'test') console.log('Saving queued classifications:', pendingClassifications.length)
+    console.log('Saving queued classifications:', pendingClassifications.length)
     const authorization = await getBearerToken(this.authClient)
     // generate an array of promises, one for each classification
-    const awaitSaveClassifications = pendingClassifications.map((classificationData) => {
-      this._saveClassification(classificationData, authorization)
-    })
+    const saveClassification = classificationData => this._saveClassification(classificationData, authorization)
+    const awaitSaveClassifications = pendingClassifications
+      .filter(c => !this.sending.includes(c.id))
+      .map(saveClassification)
     return Promise.all(awaitSaveClassifications)
   }
 
   async _saveClassification(classificationData, authorization) {
-    let response
     try {
-      response = await this.apiClient.post(this.endpoint, { classifications: classificationData }, { authorization })
+      const { id, ...classificationToSave } = classificationData
+      this.sending.push(id)
+      const response = await this.apiClient.post(this.endpoint, { classifications: classificationToSave }, { authorization })
       if (response.ok) {
-        const savedClassification = response.body.classifications[0]
-        if (process.env.NODE_ENV !== 'test') console.log('Saved classification', savedClassification.id)
+        this.remove(classificationData)
+        const [savedClassification] = response.body.classifications
+        console.log('Saved classification', savedClassification.id)
         this.onClassificationSaved(savedClassification)
         this.addRecent(savedClassification)
       }
+      this.sending = this.sending.filter(id => id !== classificationData.id)
+      return response
     } catch (error) {
-      if (process.env.NODE_ENV !== 'test') console.error('Failed to save a queued classification:', error)
+      console.error('Failed to save a queued classification:', error.message)
+      this.sending = this.sending.filter(id => id !== classificationData.id)
 
       if (error.status !== 422) {
         try {
-          this.store(classificationData)
           if (!this.flushTimeout) {
             this.flushTimeout = setTimeout(this.flushToBackend, RETRY_INTERVAL)
           }
@@ -98,16 +126,18 @@ class ClassificationQueue {
         }
       } else {
         console.error('Dropping malformed classification permanently', classificationData)
-        Sentry.withScope((scope) => {
-          scope.setExtra('classification', JSON.stringify(classificationData))
-          Sentry.captureException(error)
-        })
+        this.remove(classificationData)
       }
+      Sentry.withScope((scope) => {
+        scope.setTag('classificationError', error.status)
+        scope.setExtra('classification', JSON.stringify(classificationData))
+        Sentry.captureException(error)
+      })
+      return error
     }
-    return response
   }
 
-  _loadQueue () {
+  _loadQueue() {
     let queue = JSON.parse(this.storage.getItem(FAILED_CLASSIFICATION_QUEUE_NAME))
 
     if (queue === undefined || queue === null) {
@@ -117,7 +147,7 @@ class ClassificationQueue {
     return queue
   }
 
-  _saveQueue (queue) {
+  _saveQueue(queue) {
     this.storage.setItem(FAILED_CLASSIFICATION_QUEUE_NAME, JSON.stringify(queue))
   }
 }

--- a/packages/lib-classifier/src/store/utils/ClassificationQueue.spec.js
+++ b/packages/lib-classifier/src/store/utils/ClassificationQueue.spec.js
@@ -150,18 +150,17 @@ describe('ClassificationQueue', function () {
   })
 
   describe('with a slow network connection', function () {
+    this.timeout(5000)
     let firstRequest, secondRequest, thirdRequest
 
-    before(function () {
+    before(async function () {
       firstRequest = nock('https://panoptes-staging.zooniverse.org/api')
       .post('/classifications')
+      .delayBody(3000)
       .query(true)
       .reply(201, {
         classifications: [{ id: '1' }]
       })
-
-      classificationQueue = new ClassificationQueue()
-      classificationQueue.add({ id: '1', annotations: [], metadata: {} })
 
       secondRequest = nock('https://panoptes-staging.zooniverse.org/api')
       .post('/classifications')
@@ -169,6 +168,7 @@ describe('ClassificationQueue', function () {
       .reply(201, {
         classifications: [{ id: '2' }]
       })
+
       thirdRequest = nock('https://panoptes-staging.zooniverse.org/api')
       .post('/classifications')
       .query(true)
@@ -176,7 +176,11 @@ describe('ClassificationQueue', function () {
         classifications: [{ id: '3' }]
       })
 
-      classificationQueue.add({ id: '2', annotations: [], metadata: {} })
+      classificationQueue = new ClassificationQueue()
+      await Promise.all([
+        classificationQueue.add({ id: '1', annotations: [], metadata: {} }),
+        classificationQueue.add({ id: '2', annotations: [], metadata: {} })
+      ])
     })
 
     it('saves each classification once', function () {

--- a/packages/lib-classifier/src/store/utils/ClassificationQueue.spec.js
+++ b/packages/lib-classifier/src/store/utils/ClassificationQueue.spec.js
@@ -1,34 +1,32 @@
 import { expect } from 'chai'
+import nock from 'nock'
 import sinon from 'sinon'
 import ClassificationQueue, { RETRY_INTERVAL } from './ClassificationQueue'
 
-// TODO: migrate this to use panoptes js stub and factories
 describe('ClassificationQueue', function () {
-  let apiClient
   let classificationQueue
-  let classificationData = { annotations: [], metadata: {} }
+  let classificationData = { id: '1', annotations: [], metadata: {} }
 
   afterEach(function () {
     classificationQueue._saveQueue([])
   })
 
   describe('sends classifications to the backend', function () {
-    let postSpy
 
     beforeEach(function () {
-      apiClient = {
-        post: () => Promise.resolve({ body: { classifications: [{ id: '1' }] }, status: 201, ok: true })
-      }
-      postSpy = sinon.spy(apiClient, 'post')
-      classificationQueue = new ClassificationQueue(apiClient)
+      nock('https://panoptes-staging.zooniverse.org/api')
+      .post('/classifications')
+      .query(true)
+      .reply(201, {
+        classifications: [{ id: '1' }]
+      })
+      classificationQueue = new ClassificationQueue()
     })
 
     it('saves classifications to the API', async function () {
+      expect(nock.isDone()).to.be.false()
       await classificationQueue.add(classificationData)
-      expect(postSpy).to.have.been.called()
-      postSpy.returnValues[0].then((response) => {
-        expect(response.ok).to.be.true()
-      })
+      expect(nock.isDone()).to.be.true()
     })
 
     it('does not store saved classifications', async function () {
@@ -44,7 +42,6 @@ describe('ClassificationQueue', function () {
 
   describe('keeps classifications in localStorage if backend fails', function () {
     let clock
-    let postSpy
 
     before(function () {
       clock = sinon.useFakeTimers({ global })
@@ -55,40 +52,35 @@ describe('ClassificationQueue', function () {
     })
 
     beforeEach(function () {
-      apiClient = { 
-        post: () => {
-          const error = new Error('Stubbing error response')
-          error.status = 504
-          return Promise.reject(error)
-        }
-      }
-      postSpy = sinon.spy(apiClient, 'post')
-      classificationData = { annotations: [], metadata: {} }
-      classificationQueue = new ClassificationQueue(apiClient)
+      nock('https://panoptes-staging.zooniverse.org/api')
+      .persist()
+      .post('/classifications')
+      .query(true)
+      .reply(504, {
+        error: 'something went wrong on the server'
+      })
+
+      classificationQueue = new ClassificationQueue()
+    })
+
+    afterEach(function () {
+      nock.cleanAll()
     })
 
     it('should not save failed classifications', async function () {
-      try {
-        await classificationQueue.add(classificationData)
-        expect(postSpy).to.have.been.called()
-        postSpy.returnValues[0].then((response) => {
-          expect(response.ok).to.be.false()
-        })
-      } catch (error) {}
+      expect(nock.isDone()).to.be.false()
+      await classificationQueue.add(classificationData)
+      expect(nock.isDone()).to.be.true()
     })
 
     it('should queue failed classifications to retry', async function () {
-      try {
-        await classificationQueue.add(classificationData)
-        expect(classificationQueue.length()).to.equal(1)
-      } catch (e) {}
+      await classificationQueue.add(classificationData)
+      expect(classificationQueue.length()).to.equal(1)
     })
 
     it('should not add failed classifications to recents', async function () {
-      try {
-        await classificationQueue.add(classificationData)
-        expect(classificationQueue.recents).to.have.lengthOf(0)
-      } catch (e) {}
+      await classificationQueue.add(classificationData)
+      expect(classificationQueue.recents).to.have.lengthOf(0)
     })
 
     it('should set a timer to retry failed classifications', async function () {
@@ -107,7 +99,6 @@ describe('ClassificationQueue', function () {
 
   describe('with invalid classifications', function () {
     let clock
-    let postSpy
 
     before(function () {
       clock = sinon.useFakeTimers({ global })
@@ -118,40 +109,30 @@ describe('ClassificationQueue', function () {
     })
 
     beforeEach(function () {
-      apiClient = { 
-        post: () => {
-          const error = new Error('Stubbing error response')
-          error.status = 422
-          return Promise.reject(error)
-        }
-      }
-      postSpy = sinon.spy(apiClient, 'post')
-      classificationData = { annotations: [], metadata: {} }
-      classificationQueue = new ClassificationQueue(apiClient)
+      nock('https://panoptes-staging.zooniverse.org/api')
+      .post('/classifications')
+      .query(true)
+      .reply(422, {
+        error: 'invalid classification'
+      })
+
+      classificationQueue = new ClassificationQueue()
     })
 
     it('should not save failed classifications', async function () {
-      try {
-        await classificationQueue.add(classificationData)
-        expect(postSpy).to.have.been.called()
-        postSpy.returnValues[0].then((response) => {
-          expect(response.ok).to.be.false()
-        })
-      } catch (error) {}
+      expect(nock.isDone()).to.be.false()
+      await classificationQueue.add(classificationData)
+      expect(nock.isDone()).to.be.true()
     })
 
     it('should not queue failed classifications to retry', async function () {
-      try {
-        await classificationQueue.add(classificationData)
-        expect(classificationQueue.length()).to.equal(0)
-      } catch (e) {}
+      await classificationQueue.add(classificationData)
+      expect(classificationQueue.length()).to.equal(0)
     })
 
     it('should not add failed classifications to recents', async function () {
-      try {
-        await classificationQueue.add(classificationData)
-        expect(classificationQueue.recents).to.have.lengthOf(0)
-      } catch (e) {}
+      await classificationQueue.add(classificationData)
+      expect(classificationQueue.recents).to.have.lengthOf(0)
     })
 
     it('should not set a timer to retry failed classifications', async function () {
@@ -169,20 +150,39 @@ describe('ClassificationQueue', function () {
   })
 
   describe('with a slow network connection', function () {
-    let apiClient
-    let postSpy
+    let firstRequest, secondRequest, thirdRequest
+
     before(function () {
-      apiClient = { post: () => {} }
-      postSpy = sinon.stub(apiClient, 'post').callsFake(() => new Promise(function (resolve, reject) { }))
-      classificationQueue = new ClassificationQueue(apiClient)
-      classificationQueue.add({ annotations: [], metadata: {} })
-      classificationQueue.add({ annotations: [], metadata: {} })
+      firstRequest = nock('https://panoptes-staging.zooniverse.org/api')
+      .post('/classifications')
+      .query(true)
+      .reply(201, {
+        classifications: [{ id: '1' }]
+      })
+
+      classificationQueue = new ClassificationQueue()
+      classificationQueue.add({ id: '1', annotations: [], metadata: {} })
+
+      secondRequest = nock('https://panoptes-staging.zooniverse.org/api')
+      .post('/classifications')
+      .query(true)
+      .reply(201, {
+        classifications: [{ id: '2' }]
+      })
+      thirdRequest = nock('https://panoptes-staging.zooniverse.org/api')
+      .post('/classifications')
+      .query(true)
+      .reply(201, {
+        classifications: [{ id: '3' }]
+      })
+
+      classificationQueue.add({ id: '2', annotations: [], metadata: {} })
     })
-    after(function () {
-      postSpy.restore()
-    })
+
     it('saves each classification once', function () {
-      expect(postSpy.callCount).to.equal(2)
+      expect(firstRequest.isDone()).to.be.true()
+      expect(secondRequest.isDone()).to.be.true()
+      expect(thirdRequest.isDone()).to.be.false()
     })
   })
 })


### PR DESCRIPTION
- Rewrite the `ClassificationQueue` tests to mock the Panoptes API with 'nock'.
- Add tags to Sentry logs.
- Use `classification.id` to uniquely identify classifications.
- Fix a broken map in `classificationQueue.flushToBackend()`.
- Remove successful classifications from the queue, rather than deleting the whole queue then rebuilding it.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## Linked Issue and/or Talk Post
- may close #4725.
- may close #3016.

## How to Review
The easiest way to check this in a browser is probably with the dev classifier. Verify (in the Network tab) that Done & Talk aborts your classification before it can be saved, but that the classification is kept in local storage, to be retried the next time that you load the classifier or press Done.
https://local.zooniverse.org:8080/?project=908&workflow=3223

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [ ] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
