### PR TITLE
React-components: add cuid

### DIFF
--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.5.4] 2023-06-01
+
+### Fixed
+- Add missing `cuid` dependency for JSON data media.
+
 ## [1.5.3] 2023-05-25
 
 ### Fixed

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -3,7 +3,7 @@
   "description": "Zooniverse React Components",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "repository": {
@@ -31,6 +31,7 @@
     "@visx/group": "~3.0.0",
     "@visx/responsive": "~3.0.0",
     "@visx/shape": "~3.0.0",
+    "cuid": "~3.0.0",
     "formik": "~2.4.0",
     "i18next": "~22.5.0",
     "mime": "~3.0.0",


### PR DESCRIPTION
- Add `cuid` to `@zooniverse/react-components`. It's used by the `DataSeriesPlot` model.
- Bump the version to 1.5.4.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-react-components
