### PR TITLE
app-project: Remove google+ link from Connect With Project

### DIFF
--- a/packages/app-project/public/locales/en/components.json
+++ b/packages/app-project/public/locales/en/components.json
@@ -78,7 +78,6 @@
         "instagram": "Instagram",
         "medium": "Medium",
         "pinterest": "Pinterest",
-        "googleplus": "Google+",
         "reddit": "Reddit",
         "tumblr": "Tumblr",
         "twitter": "Twitter",

--- a/packages/app-project/public/locales/es/components.json
+++ b/packages/app-project/public/locales/es/components.json
@@ -74,7 +74,6 @@
         "bitbucket": "Bitbucket",
         "facebook": "Facebook",
         "github": "GitHub",
-        "googleplus": "Google+",
         "instagram": "Instagram",
         "medium": "Medium",
         "pinterest": "Pinterest",

--- a/packages/app-project/public/locales/test/components.json
+++ b/packages/app-project/public/locales/test/components.json
@@ -74,7 +74,6 @@
         "bitbucket": "Translated",
         "facebook": "Translated",
         "github": "Translated",
-        "googleplus": "Translated",
         "instagram": "Translated",
         "medium": "Translated",
         "pinterest": "Translated",

--- a/packages/app-project/public/locales/tr/components.json
+++ b/packages/app-project/public/locales/tr/components.json
@@ -74,7 +74,6 @@
         "bitbucket": "Bitbucket",
         "facebook": "Facebook",
         "github": "GitHub",
-        "googleplus": "Google+",
         "instagram": "Instagram",
         "medium": "Medium",
         "pinterest": "Pinterest",

--- a/packages/app-project/src/shared/components/ConnectWithProject/ConnectWithProject.stories.js
+++ b/packages/app-project/src/shared/components/ConnectWithProject/ConnectWithProject.stories.js
@@ -35,11 +35,6 @@ const mockUrls = [
   {
     label: '',
     path: 'test-project',
-    site: 'plus.google.com'
-  },
-  {
-    label: '',
-    path: 'test-project',
     site: 'reddit.com'
   },
   {

--- a/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/helpers/formatUrlObject/formatUrlObject.js
+++ b/packages/app-project/src/shared/components/ConnectWithProject/components/ProjectLink/helpers/formatUrlObject/formatUrlObject.js
@@ -2,7 +2,6 @@ import {
   Facebook as FacebookIcon,
   Github as GitHubIcon,
   Language as GlobeIcon,
-  GooglePlus as GooglePlusIcon,
   Instagram as InstagramIcon,
   Medium as MediumIcon,
   Pinterest as PinterestIcon,
@@ -56,11 +55,6 @@ function formatUrlObject (obj, t) {
   if (obj.site && obj.site.includes('pinterest')) {
     formattedObject.IconComponent = PinterestIcon
     formattedObject.type = t('ConnectWithProject.ProjectLink.types.pinterest')
-  }
-
-  if (obj.site && obj.site.includes('plus.google')) {
-    formattedObject.IconComponent = GooglePlusIcon
-    formattedObject.type = t('ConnectWithProject.ProjectLink.types.googleplus')
   }
 
   if (obj.site && obj.site.includes('reddit')) {


### PR DESCRIPTION
## Package
app-project


## Describe your changes

Google Plus doesn't exist anymore, so this PR removes the link from ConnectWithProject. I also deleted the translation key from Lokalise.


## How to Review

- View the ConnectWithProject component's story: http://localhost:9001/?path=/story/project-app-shared-connectwithproject--default
- View TESS locally to see the Connect With Project section: https://local.zooniverse.org:3000/projects/nora-dot-eisner/planet-hunters-tess?env=production&demo=true

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook