### PR TITLE
Default Sentry tag for classification errors

### DIFF
--- a/packages/lib-classifier/src/store/utils/ClassificationQueue.js
+++ b/packages/lib-classifier/src/store/utils/ClassificationQueue.js
@@ -143,7 +143,8 @@ class ClassificationQueue {
         this.remove(classificationData)
       }
       Sentry.withScope((scope) => {
-        scope.setTag('classificationError', error.status)
+        const errorTag = error.status || 'saveFailed'
+        scope.setTag('classificationError', errorTag)
         scope.setExtra('classification', JSON.stringify(classificationData))
         Sentry.captureException(error)
       })


### PR DESCRIPTION
Set `saveFailed` as the default tag for classification errors, so that we can group and count Sentry errors, even when there was no API response eg. when a request terminated before completion.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## How to Review
At the moment, we can't search for failed classifications in Sentry except when there was an API response, with an error status eg. [`classificationError: 503`](https://zooniverse-27.sentry.io/issues/?project=1492691&query=is%3Aunresolved+classificationError%3A503&referrer=issue-list&sort=date&statsPeriod=14d&stream_index=2).

This PR should tag errors with `classificationError: saveFailed` when there's no response from Panoptes eg. when a request is terminated before completion.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
