### PR TITLE
ESLint: Add eslint-plugin-react

### DIFF
--- a/packages/app-content-pages/.eslintrc
+++ b/packages/app-content-pages/.eslintrc
@@ -1,5 +1,8 @@
 {
-  "extends": "next",
+  "extends": [
+    "next/core-web-vitals",
+    "plugin:jsx-a11y/recommended"
+  ],
   "overrides": [
       {
         "files": [

--- a/packages/app-content-pages/.eslintrc
+++ b/packages/app-content-pages/.eslintrc
@@ -3,6 +3,9 @@
     "next/core-web-vitals",
     "plugin:jsx-a11y/recommended"
   ],
+  "rules": {
+    "consistent-return": "error"
+  },
   "overrides": [
       {
         "files": [

--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -63,6 +63,7 @@
     "dirty-chai": "~2.0.1",
     "enzyme": "~3.11.0",
     "eslint-config-next": "~12.3.0",
+    "eslint-plugin-jsx-a11y": "~6.7.0",
     "jsdom": "~22.1.0",
     "mocha": "~10.2.0",
     "proxyquire": "~2.1.0",

--- a/packages/app-content-pages/pages/_app.js
+++ b/packages/app-content-pages/pages/_app.js
@@ -35,8 +35,8 @@ function MyApp({ Component, initialState, pageProps }) {
   makeInspectable(store)
 
   useEffect(() => {
-    store?.user.checkCurrent()
-  }, [])
+    store.user.checkCurrent()
+  }, [store.user])
 
   try {
     if (pageProps.statusCode) {

--- a/packages/app-content-pages/src/api/publications/buildResponse.js
+++ b/packages/app-content-pages/src/api/publications/buildResponse.js
@@ -6,7 +6,7 @@ export default function buildResponse(publications, projectAvatarsMap) {
     // Draft items are returned in the Contentful response, but have no
     // fields, so we skip them.
     if (!publication.fields) {
-      return
+      return acc
     }
 
     const publicationData = {

--- a/packages/app-content-pages/src/shared/components/AuthModal/components/RegisterForm/components/Form/Form.js
+++ b/packages/app-content-pages/src/shared/components/AuthModal/components/RegisterForm/components/Form/Form.js
@@ -69,7 +69,6 @@ function Form ({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, v
             required
           >
             <TextInput
-              autoFocus
               disabled={isSubmitting}
               id={userNameFieldId}
               name='username'

--- a/packages/app-project/.eslintignore
+++ b/packages/app-project/.eslintignore
@@ -1,1 +1,0 @@
-**/*.stories.js

--- a/packages/app-project/.eslintrc
+++ b/packages/app-project/.eslintrc
@@ -1,3 +1,16 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": [
+    "next/core-web-vitals",
+    "plugin:jsx-a11y/recommended"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "src/**/*.stories.js"
+      ],
+      "rules": {
+        "import/no-anonymous-default-export": "off"
+      }
+    }
+  ]
 }

--- a/packages/app-project/.eslintrc
+++ b/packages/app-project/.eslintrc
@@ -3,6 +3,9 @@
     "next/core-web-vitals",
     "plugin:jsx-a11y/recommended"
   ],
+  "rules": {
+    "consistent-return": "error"
+  },
   "overrides": [
     {
       "files": [

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -78,6 +78,7 @@
     "dirty-chai": "~2.0.1",
     "enzyme": "~3.11.0",
     "eslint-config-next": "~12.3.0",
+    "eslint-plugin-jsx-a11y": "~6.7.0",
     "jsdom": "~22.1.0",
     "mocha": "~10.2.0",
     "nock": "~13.3.0",

--- a/packages/app-project/pages/_document.js
+++ b/packages/app-project/pages/_document.js
@@ -92,6 +92,7 @@ export default class MyDocument extends Document {
           {isProduction && (
             <noscript>
               <iframe
+                title='Google Tag Manager'
                 height='0'
                 src={`https://www.googletagmanager.com/ns.html?id=${GA_TRACKING_ID}`}
                 style={{ display: 'none', visibility: 'hidden' }}

--- a/packages/app-project/src/components/AuthModal/components/RegisterForm/components/Form/Form.js
+++ b/packages/app-project/src/components/AuthModal/components/RegisterForm/components/Form/Form.js
@@ -71,7 +71,6 @@ function Form ({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, v
             required
           >
             <TextInput
-              autoFocus
               disabled={isSubmitting}
               id={userNameFieldId}
               name='username'

--- a/packages/app-project/src/helpers/fetchProjectPageTitles/fetchProjectPageTitles.js
+++ b/packages/app-project/src/helpers/fetchProjectPageTitles/fetchProjectPageTitles.js
@@ -18,6 +18,7 @@ export default async function fetchProjectPageTitles(project, env) {
           url_key: page.url_key
         })
       }
+      return null
     }).filter(Boolean)
   } catch (error) {
     logToSentry(error)

--- a/packages/app-project/src/hooks/useAdminMode.js
+++ b/packages/app-project/src/hooks/useAdminMode.js
@@ -10,8 +10,8 @@ export default function useAdminMode() {
   const adminMode = store?.user.isAdmin && adminState
 
   useEffect(function onUserChange() {
-    const user = store?.user
-    if (user?.isAdmin) {
+    const isAdmin = store?.user.isAdmin
+    if (isAdmin) {
       const adminFlag = !!localStorage?.getItem('adminFlag')
       setAdminState(adminFlag)
     } else {

--- a/packages/app-project/src/hooks/useSugarProject.js
+++ b/packages/app-project/src/hooks/useSugarProject.js
@@ -14,5 +14,6 @@ export default function useSugarProject(project) {
         sugarClient.unsubscribeFrom(channel)
       }
     }
+    return null
   }, [projectID])
 }

--- a/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.js
@@ -87,11 +87,12 @@ export default function SubjectPicker({ baseUrl, subjectSet, workflow }) {
   function sort(data) {
     const { property: sortField, direction: sortOrder } = data
     if (sortField === 'status') {
-      return true;
+      return true
     }
     setRows([])
     setSortField(sortField)
     setSortOrder(sortOrder)
+    return true
   }
 
   const background = {

--- a/packages/lib-classifier/.eslintrc
+++ b/packages/lib-classifier/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "parser": "babel-eslint"
-}

--- a/packages/lib-classifier/eslint.config.js
+++ b/packages/lib-classifier/eslint.config.js
@@ -1,0 +1,35 @@
+const babelParser = require('@babel/eslint-parser')
+const jsxA11y = require('eslint-plugin-jsx-a11y')
+const reactRecommended = require('eslint-plugin-react/configs/recommended')
+const jsxRuntime = require('eslint-plugin-react/configs/jsx-runtime')
+
+module.exports = [
+  {
+    settings: {
+      react: {
+        version: 'detect'
+      }
+    },
+    ...reactRecommended
+  },
+  jsxRuntime,
+  {
+    files: [
+      'src/**/*.js'
+    ],
+    ignores: [
+      'src/**/*.spec.js',
+      'src/**/*.stories.js'
+    ],
+    languageOptions: {
+      parser: babelParser,
+      ...reactRecommended.languageOptions
+    },
+    plugins: {
+      'jsx-a11y': jsxA11y
+    },
+    rules: {
+      ...jsxA11y.configs.recommended.rules
+    }
+  }
+]

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -125,18 +125,5 @@
   },
   "engines": {
     "node": ">=18.13"
-  },
-  "eslintConfig": {
-    "extends": [
-      "plugin:react/recommended",
-      "plugin:jsx-a11y/recommended",
-      "plugin:react/jsx-runtime"
-    ],
-    "parser": "@babel/eslint-parser",
-    "settings": {
-      "react": {
-        "version": "detect"
-      }
-    }
   }
 }

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -17,6 +17,7 @@
     "build:es6": "BABEL_ENV=es6 babel ./src/ --out-dir ./dist/esm --copy-files --no-copy-ignored --ignore 'src/**/*.spec.js' --ignore 'src/**/*.stories.js'",
     "dev": "BABEL_ENV=es6 webpack serve --config webpack.dev.js",
     "lint": "zoo-standard --fix | snazzy",
+    "eslint": "eslint ./src --fix | snazzy",
     "start": "PANOPTES_ENV=production npm run dev",
     "test": "NODE_PATH=. NODE_ENV=test mocha --exit --config ./test/.mocharc.json \"./{src,test}/**/*.spec.js\"",
     "test:ci": "NODE_PATH=. NODE_ENV=test mocha --exit --config ./test/.mocharc.json --reporter=min \"./{src,test}/**/*.spec.js\"",
@@ -62,6 +63,7 @@
   "devDependencies": {
     "@babel/cli": "~7.22.5",
     "@babel/core": "~7.22.0",
+    "@babel/eslint-parser": "~7.21.8",
     "@babel/plugin-transform-runtime": "~7.22.0",
     "@babel/preset-env": "~7.22.0",
     "@babel/preset-react": "~7.22.0",
@@ -88,6 +90,8 @@
     "css-loader": "~6.8.1",
     "dirty-chai": "~2.0.1",
     "enzyme": "~3.11.0",
+    "eslint-plugin-jsx-a11y": "~6.7.0",
+    "eslint-plugin-react": "~7.32.2",
     "grommet": "~2.32.0",
     "grommet-icons": "~4.11.0",
     "html-webpack-plugin": "~5.5.0",
@@ -119,24 +123,20 @@
     "webpack-cli": "~5.1.0",
     "webpack-dev-server": "~4.15.0"
   },
+  "engines": {
+    "node": ">=18.13"
+  },
   "eslintConfig": {
     "extends": [
-      "plugin:jsx-a11y/recommended"
-    ]
-  },
-  "standardx": {
-    "env": {
-      "mocha": true
-    },
-    "globals": [
-      "before",
-      "describe",
-      "expect",
-      "it"
+      "plugin:react/recommended",
+      "plugin:jsx-a11y/recommended",
+      "plugin:react/jsx-runtime"
     ],
-    "parser": "babel-eslint",
-    "engines": {
-      "node": ">=18.13"
+    "parser": "@babel/eslint-parser",
+    "settings": {
+      "react": {
+        "version": "detect"
+      }
     }
   }
 }

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -15,7 +15,7 @@
     "build": "yarn build:cjs && yarn build:es6",
     "build:cjs": "babel ./src/ --out-dir ./dist/cjs --copy-files --no-copy-ignored --ignore 'src/**/*.spec.js' --ignore 'src/**/*.stories.js'",
     "build:es6": "BABEL_ENV=es6 babel ./src/ --out-dir ./dist/esm --copy-files --no-copy-ignored --ignore 'src/**/*.spec.js' --ignore 'src/**/*.stories.js'",
-    "lint": "zoo-standard --fix {.storybook,src,stories,test}/**/*.{js,jsx} | snazzy",
+    "lint": "zoo-standard --fix | snazzy",
     "prepare": "yarn build",
     "start": "start-storybook -p 6007",
     "test": "mocha --config ./test/.mocharc.json \"./src/**/*.spec.js\"",

--- a/packages/tools-standard/options.js
+++ b/packages/tools-standard/options.js
@@ -16,7 +16,8 @@ const opts = {
       },
       extends: [
         'plugin:react/recommended',
-        'plugin:jsx-a11y/recommended'
+        'plugin:jsx-a11y/recommended',
+        'plugin:react/jsx-runtime'
       ],
       globals: {
         'expect': true

--- a/packages/tools-standard/options.js
+++ b/packages/tools-standard/options.js
@@ -14,12 +14,17 @@ const opts = {
       env: {
         'mocha': true
       },
+      extends: [
+        'plugin:react/recommended',
+        'plugin:jsx-a11y/recommended'
+      ],
       globals: {
         'expect': true
       },
       parser: '@babel/eslint-parser',
       plugins: [
-        'jsx-a11y'
+        'jsx-a11y',
+        'react'
       ],
       rules: {
         "consistent-return": "error"

--- a/packages/tools-standard/package.json
+++ b/packages/tools-standard/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@babel/eslint-parser": "~7.22.5",
     "eslint-plugin-jsx-a11y": "~6.7.0",
+    "eslint-plugin-react": "~7.32.2",
     "standard": "~17.1.0",
     "standard-engine": "^15.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8766,7 +8766,7 @@ eslint-plugin-react-hooks@^4.5.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
-eslint-plugin-react@^7.31.7, eslint-plugin-react@^7.32.2:
+eslint-plugin-react@^7.31.7, eslint-plugin-react@^7.32.2, eslint-plugin-react@~7.32.2:
   version "7.32.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz#e71f21c7c265ebce01bcbc9d0955170c55571f10"
   integrity sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==


### PR DESCRIPTION
- Add the [ESLint React plugin](https://www.npmjs.com/package/eslint-plugin-react) to `@zooniverse/standard`. 
- Enable the recommended React rules and JSX a11y rules when running `zoo-standard`.
- Upgrade the classifier to the new `eslint.config.js`, with the recommended React rules and JSX accessibility rules.
- Add the JSX accessibility rules to both NextJS apps.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-content-pages
- app-project
- lib-classifier
- tools-standard

## How to Review
You can lint the classifier with `zoo-standard` by running `yarn lint`. It will probably generate a lot of errors and warnings, as it hasn't been linted for a while. I've also added a `yarn eslint` script, which runs ESLint with the React and JSX accessibility rules, but without StandardJS.

With the React plugin, the linter should catch errors specific to React components, such as missing prop type declarations, or missing dependency declarations in `useEffect` hooks. 

I get ~1200 warnings after linting the classifier with `zoo-standard`, but most of them seem to be missing prop type declarations in React components. I haven't committed the linted code, because that would be a huge change for this PR.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
