### PR TITLE
Defer Done & Talk until classification has saved

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
@@ -1,20 +1,29 @@
+import { useState } from 'react'
 import { PrimaryButton } from '@zooniverse/react-components'
 import PropTypes from 'prop-types'
 import { useTranslation } from '@translations/i18n'
 
+const DEFAULT_HANDLER = () => true
 function DoneAndTalkButton ({
   disabled = false,
-  onClick = () => {},
+  onClick = DEFAULT_HANDLER,
   visible = false
 }) {
   const { t } = useTranslation('components')
+  const [saving, setSaving] = useState(false)
+
+  function handleClick(event) {
+    setSaving(true)
+    return onClick(event)
+  }
+
   if (visible) {
     return (
       <PrimaryButton
         color='blue'
-        disabled={disabled}
+        disabled={disabled || saving}
         label={t('TaskArea.Tasks.DoneAndTalkButton.doneAndTalk')}
-        onClick={onClick}
+        onClick={handleClick}
         style={{ flex: '1 0', marginRight: '1ch', textTransform: 'capitalize' }}
       />
     )

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneButton/DoneButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneButton/DoneButton.js
@@ -1,7 +1,9 @@
+import { useState } from 'react'
 import { PrimaryButton } from '@zooniverse/react-components'
 import PropTypes from 'prop-types'
 import { useTranslation } from '@translations/i18n'
 
+const DEFAULT_HANDLER = () => true
 // TODO add back gold standard and demo buttons using grommet Button icon prop
 // {props.demoMode && <i className="fa fa-trash fa-fw" />}
 // {props.goldStandardMode && <i className="fa fa-star fa-fw" />}
@@ -9,16 +11,23 @@ function DoneButton ({
   completed = false,
   disabled = false,
   hasNextStep = false,
-  onClick = () => true
+  onClick = DEFAULT_HANDLER
 }) {
   const { t } = useTranslation('components')
+  const [saving, setSaving] = useState(false)
+
+  function handleClick(event) {
+    setSaving(true)
+    return onClick(event)
+  }
+
   if (!hasNextStep) {
     return (
       <PrimaryButton
         color='green'
-        disabled={disabled}
+        disabled={disabled || saving}
         label={t('TaskArea.Tasks.DoneButton.done')}
-        onClick={onClick}
+        onClick={handleClick}
         style={{ flex: '1 0', textTransform: 'capitalize' }}
       />
     )

--- a/packages/lib-classifier/src/store/ClassificationStore.js
+++ b/packages/lib-classifier/src/store/ClassificationStore.js
@@ -172,11 +172,10 @@ const ClassificationStore = types
     }
 
     function * submitClassification (classification) {
-      self.loadingState = asyncStates.posting
-
       // Service worker isn't working right now, so let's use the fallback queue for all browsers
       try {
         yield self.classificationQueue.add(classification)
+        self.loadingState = asyncStates.posting
       } catch (error) {
         console.error(error)
         self.loadingState = asyncStates.error


### PR DESCRIPTION
Wait until `classificationQueue.add(classification)` has resolved before updating the classification store state and advancing the subject queue. This should prevent the window from navigating away from the classifier until the new classification is either saved in local storage or posted to Panoptes.

Disable both Done and Done & Talk after one click, to avoid duplicate classification submissions.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## Linked Issue and/or Talk Post
- https://github.com/zooniverse/front-end-monorepo/issues/3016#issuecomment-1098849554
- Closes #4772.

## How to Review
This should prevent a race condition where the page can unload before a classification has saved, when you press Done & Talk. I've been able to reproduce the original issue reliably by using Done & Talk after every identification on [Gravity Spy level 1](https://frontend.preview.zooniverse.org/projects/zooniverse/gravity-spy/classify/workflow/1610).

To test it, you may need to hard-code a subject's `talkURL` to use `https://www.zooniverse.org` as the origin.

You can try out the changes here too:
https://fe-project-branch.preview.zooniverse.org/projects/zooniverse/gravity-spy/classify/workflow/1610

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated
