### PR TITLE
Add storybook docs pages for documented components

### DIFF
--- a/packages/app-project/src/components/AuthModal/components/LoginForm/LoginFormContainer.spec.js
+++ b/packages/app-project/src/components/AuthModal/components/LoginForm/LoginFormContainer.spec.js
@@ -98,7 +98,7 @@ describe('Component > LoginFormContainer', function () {
         expect.fail()
       } catch (error) {
         expect(INVALID_SIGN_IN).to.have.been.calledWith(MOCK_FORM_VALUES)
-        /** The translation function t is set to simply return keys in a testing environment **/
+        /* The translation function t is set to simply return keys in a testing environment **/
         expect(MOCK_FORMIK.setFieldError).to.have.been.calledWith('login', 'AuthModal.LoginForm.error')
         expect(MOCK_FORMIK.setFieldError).to.have.been.calledWith('password', 'AuthModal.LoginForm.error')
         expect(MOCK_FORMIK.setSubmitting).to.have.been.calledWith(false)

--- a/packages/app-project/src/components/AuthModal/components/RegisterForm/RegisterFormContainer.spec.js
+++ b/packages/app-project/src/components/AuthModal/components/RegisterForm/RegisterFormContainer.spec.js
@@ -79,7 +79,7 @@ describe('Component > RegisterFormContainer', function () {
 
     it('should return an error when there are invalid values', function () {
       const errors = wrapper.instance().validate(MOCK_INVALID_FORM_VALUES)
-      /** The translation function t is set to simply return keys in a testing environment **/
+      /* The translation function t is set to simply return keys in a testing environment **/
       expect(errors.passwordConfirm).to.equal('AuthModal.RegisterForm.passwordConfirmError')
       expect(errors.emailConfirm).to.equal('AuthModal.RegisterForm.emailConfirmError')
       expect(errors.privacyAgreement).to.equal('AuthModal.RegisterForm.privacyAgreementError')
@@ -153,7 +153,7 @@ describe('Component > RegisterFormContainer', function () {
           await validWrapper.instance().onSubmit(MOCK_FORM_VALUES, MOCK_FORMIK)
           expect(Object.keys(synchronousErrors)).to.have.lengthOf(0)
           expect(INVALID_REGISTRATION).to.have.been.calledOnceWith(MOCK_SUBMISSION_VALUES)
-          /** The translation function t is set to simply return keys in a testing environment **/
+          /* The translation function t is set to simply return keys in a testing environment **/
           expect(MOCK_FORMIK.setFieldError.withArgs('username', 'AuthModal.RegisterForm.usernameConflict')).to.have.been.calledOnce()
           expect(MOCK_FORMIK.setFieldError.withArgs('email', 'AuthModal.RegisterForm.emailConflict')).to.have.been.calledOnce()
           expect(MOCK_FORMIK.setSubmitting).to.have.been.calledOnceWith(false)

--- a/packages/app-project/src/components/AuthModal/components/RegisterForm/components/Form/Form.spec.js
+++ b/packages/app-project/src/components/AuthModal/components/RegisterForm/components/Form/Form.spec.js
@@ -217,7 +217,7 @@ describe('RegisterForm > Component > Form', function () {
         <Form />,
         shallowOptions
       )
-      /** The translation function t is set to simply return keys in a testing environment **/
+      /* The translation function t is set to simply return keys in a testing environment **/
       expect(wrapper.find({ htmlFor: userNameFieldId }).props().help).equal('AuthModal.RegisterForm.usernameHelp')
       expect(wrapper.find({ id: privacyAgreementFieldId }).props().label.props.children[0]).equal('AuthModal.RegisterForm.privacyAgreement')
       expect(wrapper.find({ id: emailListSignUpFieldId }).props().label.props.children).equal('AuthModal.RegisterForm.emailListSignUp')
@@ -231,7 +231,7 @@ describe('RegisterForm > Component > Form', function () {
       )
       wrapper.setProps({ values: { underageWithParent: true } })
 
-      /** The translation function t is set to simply return keys in a testing environment **/
+      /* The translation function t is set to simply return keys in a testing environment **/
       expect(wrapper.find({ htmlFor: userNameFieldId }).props().help).equal('AuthModal.RegisterForm.underageNotRealName')
       expect(wrapper.find({ id: privacyAgreementFieldId }).props().label.props.children[0]).equal('AuthModal.RegisterForm.underageConsent')
       expect(wrapper.find({ id: emailListSignUpFieldId }).props().label.props.children).equal('AuthModal.RegisterForm.underageEmailSignUp')

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.js
@@ -43,7 +43,7 @@ function ProjectHeader({
   const gap = width < maxColumnWidth ? 'small' : 'medium'
   const useDropdownNav = width < maxColumnWidth + 200
 
-  /** Widths were determined visually and can be updated as needed if ProjectHeader components are refactored */
+  /* Widths were determined visually and can be updated as needed if ProjectHeader components are refactored */
   const maxTitleWidth = (hasTranslations && width >= 1200) ? '560px' : '600px'
 
   return (

--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.stories.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.stories.js
@@ -28,7 +28,8 @@ const ORGANIZATION = {
 
 export default {
   title: 'Project App / Shared / Project Header',
-  component: ProjectHeader
+  component: ProjectHeader,
+  tags: ['autodocs']
 }
 
 export function NotLoggedIn({ adminMode, className, project }) {

--- a/packages/app-project/src/helpers/localeMenu.js
+++ b/packages/app-project/src/helpers/localeMenu.js
@@ -1,4 +1,4 @@
-/** This locale menu matches next-18next.config.js and PFE's app/locales */
+/* This locale menu matches next-18next.config.js and PFE's app/locales */
 
 const localeMenu = {
   ar: 'العربية',

--- a/packages/app-project/src/screens/ClassifyPage/components/RecentSubjects/RecentSubjects.stories.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/RecentSubjects/RecentSubjects.stories.js
@@ -144,7 +144,8 @@ export default {
   component: RecentSubjects,
   args: {
     isLoggedIn: true
-  }
+  },
+  tags: ['autodocs']
 }
 
 export function Plain({ isLoggedIn }) {

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenuModal/WorkflowMenuModal.stories.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowMenuModal/WorkflowMenuModal.stories.js
@@ -94,7 +94,8 @@ export default {
     docs: {
       inlineStories: false
     }
-  }
+  },
+  tags: ['autodocs']
 }
 
 export function ChooseAWorkflow({ headingBackground, titleColor, workflows }) {

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChart.stories.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChart.stories.js
@@ -47,7 +47,8 @@ export default {
     counts: MOCK_TOTALS,
     projectName: 'Snapshot Serengeti',
     thisWeek: MOCK_DAILY_COUNTS
-  }
+  },
+  tags: ['autodocs']
 }
 
 export function Plain({ counts, projectName, thisWeek }) {

--- a/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/ProjectAboutPage.js
@@ -3,7 +3,7 @@ import { arrayOf, bool, object, shape, string } from 'prop-types'
 import styled, { withTheme } from 'styled-components'
 import { useTranslation } from 'next-i18next'
 
-/** Components */
+/* Components */
 import StandardLayout from '@shared/components/StandardLayout'
 import {
   SpacedHeading,

--- a/packages/app-project/src/screens/ProjectAboutPage/components/AboutDropdownNav/AboutDropdownNav.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/components/AboutDropdownNav/AboutDropdownNav.js
@@ -3,7 +3,7 @@ import { arrayOf, object, string } from 'prop-types'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 
-/** Components */
+/* Components */
 import { Box, DropButton, Nav } from 'grommet'
 import { FormDown } from 'grommet-icons'
 import { SpacedText } from '@zooniverse/react-components'

--- a/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink/AboutNavLink.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink/AboutNavLink.js
@@ -2,7 +2,7 @@ import { string, object, shape } from 'prop-types'
 import styled from 'styled-components'
 import addQueryParams from '@helpers/addQueryParams'
 
-/** Components */
+/* Components */
 import NavLink from '@shared/components/NavLink'
 import { Anchor, Box } from 'grommet'
 

--- a/packages/app-project/src/screens/ProjectHomePage/components/AboutProject/AboutProject.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/AboutProject/AboutProject.spec.js
@@ -19,7 +19,7 @@ describe('Component > AboutProject', function () {
   it('should show the title', function () {
     const titleWrapper = wrapper.find('h2')
     expect(titleWrapper.text()).to.equal('Home.AboutProject.title')
-    /** The translation function will simply return keys in a testing env */
+    /* The translation function will simply return keys in a testing env */
   })
 
   it('should show the description', function () {

--- a/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.stories.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/Hero/Hero.stories.js
@@ -84,7 +84,8 @@ export default {
   component: Hero,
   args: {
     isWide: true
-  }
+  },
+  tags: ['autodocs']
 }
 
 const snapshot = {

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjects.stories.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjects.stories.js
@@ -137,7 +137,8 @@ const DATA_SUBJECTS = [
 
 export default {
   title: 'Project App / Screens / Project Home / Recent Subjects',
-  component: RecentSubjects
+  component: RecentSubjects,
+  tags: ['autodocs']
 }
 
 export function Plain() {

--- a/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.stories.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/SubjectPicker.stories.js
@@ -12,7 +12,8 @@ function DecoratedStory(Story) {
 export default {
   title: 'Project App / Shared / Subject Picker',
   component: SubjectPicker,
-  decorators: [DecoratedStory]
+  decorators: [DecoratedStory],
+  tags: ['autodocs']
 }
 
 export function Default(args) {

--- a/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.stories.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.stories.js
@@ -62,7 +62,8 @@ const store = Store.create(snapshot)
 
 export default {
   title: 'Project App / Shared / Subject Preview',
-  component: SubjectPreview
+  component: SubjectPreview,
+  tags: ['autodocs']
 }
 
 export function Plain({ isLoggedIn, subject, slug }) {

--- a/packages/app-project/src/shared/components/SubjectSetPicker/SubjectSetPicker.stories.js
+++ b/packages/app-project/src/shared/components/SubjectSetPicker/SubjectSetPicker.stories.js
@@ -17,7 +17,8 @@ export default {
   decorators: [DecoratedStory],
   args: {
     workflow: mockWorkflow
-  }
+  },
+  tags: ['autodocs']
 }
 
 export function Default({ workflow }) {

--- a/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelector.spec.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelector.spec.js
@@ -27,7 +27,7 @@ describe('Component > WorkflowSelector', function () {
 
   const WORKFLOW_DESCRIPTION = 'Sit nulla mi metus tellus aenean lobortis litora'
   const DEFAULT_WORKFLOW_DESCRIPTION = 'WorkflowSelector.message'
-  /** The translation function will simply return keys in a testing env */
+  /* The translation function will simply return keys in a testing env */
 
   it('should render without crashing', function () {
     const wrapper = shallow(

--- a/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelector.stories.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelector.stories.js
@@ -88,7 +88,8 @@ export default {
         options: asyncStates
       }
     }
-  }
+  },
+  tags: ['autodocs']
 }
 
 export function Default({

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.spec.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.spec.js
@@ -30,7 +30,7 @@ describe('Component > WorkflowSelector > WorkflowSelectButton', function () {
     const wrapper = shallow(<WorkflowSelectButton theme={zooTheme} workflow={WORKFLOW} />)
     const label = shallow(wrapper.find(ThemedButton).prop('label')).render()
     expect(label.text()).to.equal('WorkflowSelector.WorkflowSelectButton.completeWorkflow name')
-    /** The translation function will simply return keys in a testing env */
+    /* The translation function will simply return keys in a testing env */
   })
 
   describe('when used with a default workflow', function () {
@@ -70,7 +70,7 @@ describe('Component > WorkflowSelector > WorkflowSelectButton', function () {
     it('should add "set selection" to the label', function () {
       const label = shallow(wrapper.find(ThemedButton).prop('label')).render()
       expect(label.text()).to.equal('WorkflowSelector.WorkflowSelectButton.complete·WorkflowSelector.WorkflowSelectButton.setSelectionWorkflow name')
-      /** The translation function will simply return keys in a testing env */
+      /* The translation function will simply return keys in a testing env */
     })
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/AlreadySeenBanner/AlreadySeenBanner.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/AlreadySeenBanner/AlreadySeenBanner.stories.js
@@ -19,7 +19,8 @@ export default {
         component: readme
       }
     }
-  }
+  },
+  tags: ['autodoc']
 }
 
 export function Default({ subject }) {

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/RetiredBanner/RetiredBanner.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/RetiredBanner/RetiredBanner.stories.js
@@ -19,7 +19,8 @@ export default {
         component: readme
       }
     }
-  }
+  },
+  tags: ['autodocs']
 }
 
 export function Default({ subject }) {

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/SubjectSetProgressBanner/SubjectSetProgressBanner.stories.js
@@ -37,7 +37,8 @@ function buildMocks({
 
 export default {
   title: 'Banners / Subject Set Progress Banner',
-  component: SubjectSetProgressBanner
+  component: SubjectSetProgressBanner,
+  tags: ['autodocs']
   // parameters: {
   //   docs: {
   //     description: {

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/UserHasFinishedWorkflowBanner/UserHasFinishedWorkflowBanner.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/UserHasFinishedWorkflowBanner/UserHasFinishedWorkflowBanner.stories.js
@@ -19,7 +19,8 @@ export default {
         component: readme
       }
     }
-  }
+  },
+  tags: ['autodocs']
 }
 
 export function Default({ subject }) {

--- a/packages/lib-classifier/src/components/Classifier/components/Banners/components/WorkflowIsFinishedBanner/WorkflowIsFinishedBanner.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Banners/components/WorkflowIsFinishedBanner/WorkflowIsFinishedBanner.stories.js
@@ -19,7 +19,8 @@ export default {
         component: readme
       }
     }
-  }
+  },
+  tags: ['autodocs']
 }
 
 export function Default({ subject }) {

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuideButton/FieldGuideButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuideButton/FieldGuideButton.js
@@ -45,7 +45,7 @@ export function ColumnButtonLabel() {
       <StyledSpacedText size='xsmall' color='white' textAlign='center'>
         {t('FieldGuide.FieldGuideButton.buttonLabel')}
       </StyledSpacedText>
-      {/** Same styling as ImageToolbar > Button */}
+      {/* Same styling as ImageToolbar > Button */}
       <StyledHelpIcon fill='white' />
     </Box>
   )

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.stories.js
@@ -51,7 +51,8 @@ export default {
     steps,
     stepWithMedium,
     width: '40vw'
-  }
+  },
+  tags: ['autodocs']
 }
 
 export function Default({

--- a/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorialContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorialContainer.spec.js
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme'
 import { Paragraph } from 'grommet'
 import { SlideTutorialContainer } from './SlideTutorialContainer'
-/** useTranslation will simply return the translation key in a test environment */
+/* useTranslation will simply return the translation key in a test environment */
 
 describe('SlideTutorialContainer', function () {
   it('should render without crashing', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
@@ -31,7 +31,7 @@ const FlipbookViewer = ({
   const [currentFrame, setCurrentFrame] = useState(defaultFrame)
   const [playing, setPlaying] = useState(false)
   const [dragMove, setDragMove] = useState()
-  /** This initializes an image element from the subject's defaultFrame src url.
+  /* This initializes an image element from the subject's defaultFrame src url.
    * We do this so the SVGPanZoom has dimensions of the subject image.
    * We're assuming all frames in one subject have the same dimensions. */
   const defaultFrameLocation = subject ? subject.locations[defaultFrame] : null

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.spec.js
@@ -110,7 +110,7 @@ describe('Component > FlipbookViewer', function () {
       const selectedSpeed = await findByRole('option', { name: '1x' })
       expect(selectedSpeed.selected).to.be.true()
 
-      /** The following is the correct way to test with RTL
+      /* The following is the correct way to test with RTL
        *  but Grommet does not render Select as a <select>
        *  so selectOptions() will not find the speed options
        */

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.stories.js
@@ -8,7 +8,8 @@ import FlipbookViewerContainer from './FlipbookViewerContainer'
 
 export default {
   title: 'Subject Viewers / FlipbookViewer',
-  component: FlipbookViewerContainer
+  component: FlipbookViewerContainer,
+  tags: ['autodocs']
 }
 
 const mockSubject = SubjectFactory.build({

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/components/ImageAndTextControls.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/components/ImageAndTextControls.js
@@ -60,7 +60,7 @@ const ImageAndTextControls = ({
 }) => {
   const { t } = useTranslation('components')
   
-  /** DefaultLayout for classify page styling has breakpoints at 768px and 1160px
+  /* DefaultLayout for classify page styling has breakpoints at 768px and 1160px
    * In ImageAndTextControls we're simply checking for when this component is < 450px
    * which happens both before and after the 768px layout breakpoint
    */

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/SubTaskPopup/SubTaskPopup.spec.js
@@ -113,7 +113,7 @@ describe('SubTaskPopup', function () {
         expect(requiredSubtask.prop('border').size).to.equal('small')
         expect(requiredSubtask.prop('border').color).to.equal('tomato')
         expect(requiredSubtask.find('strong').text()).to.equal('SubjectViewer.InteractionLayer.SubTaskPopup.required')
-        /** The translation function will simply return keys in a testing environment */
+        /* The translation function will simply return keys in a testing environment */
       })
     })
   })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.spec.js
@@ -36,7 +36,7 @@ describe('TranscribedLines > Component > ConsensusPopup', function () {
         { selector: 'p' }
       )
       expect(firstParagraph).to.exist()
-      /** The translation function will simply return keys in a testing env */
+      /* The translation function will simply return keys in a testing env */
     })
 
     it('should render the consensus text with explanation', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/components/ConsensusPopup/ConsensusPopup.stories.js
@@ -11,7 +11,8 @@ export default {
     docs: {
       inlineStories: false
     }
-  }
+  },
+  tags: ['autodocs']
 }
 
 function ConsensusPopupStory(props) {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/SeparateFramesViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/SeparateFramesViewer.stories.js
@@ -7,7 +7,8 @@ import SeparateFramesViewer from './SeparateFramesViewer'
 
 export default {
   title: 'Subject Viewers / SeparateFramesViewer / Layouts',
-  component: SeparateFramesViewer
+  component: SeparateFramesViewer,
+  tags: ['autodocs']
 }
 
 const mockSubject = SubjectFactory.build({

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.stories.js
@@ -19,7 +19,8 @@ const workflow = WorkflowFactory.build('workflow', {
 
 export default {
   title: 'Subject Viewers / SingleImageViewer',
-  component: SingleImageViewer
+  component: SingleImageViewer,
+  tags: ['autodocs']
 }
 
 export function Default() {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewer.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleTextViewer/SingleTextViewer.stories.js
@@ -19,7 +19,8 @@ export default {
       options: Object.values(asyncStates),
       type: 'select'
     }
-  }
+  },
+  tags: ['autodocs']
 }
 
 const subjectSnapshot = SubjectFactory.build({

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleVideoViewer/SingleVideoViewerContainer.js
@@ -228,7 +228,7 @@ function SingleVideoViewerContainer({
           <Box>{t('SubjectViewer.SingleVideoViewerContainer.error')}</Box>
           )}
 
-      {/** See ADR 45 for notes on custom video controls */}
+      {/* See ADR 45 for notes on custom video controls */}
       {enableDrawing && (
         <VideoController
           duration={duration}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/VariableStarViewer/VariableStarViewer.spec.js
@@ -96,7 +96,7 @@ describe('Component > VariableStarViewer', function () {
     })
 
     it('should set the x-axis and y-axis labels', function () {
-      /** The translation function will simply return keys in a testing environment */
+      /* The translation function will simply return keys in a testing environment */
       expect(phasedScatterPlot.props().xAxisLabel).to.equal('SubjectViewer.VariableStarViewer.phase')
       expect(phasedScatterPlot.props().yAxisLabel).to.equal(phasedJSONMock.chartOptions.yAxisLabel)
     })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ZoomControlButton/ZoomControlButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ZoomControlButton/ZoomControlButton.spec.js
@@ -16,7 +16,7 @@ describe('Component > ZoomControlButton', function () {
   })
 
   it('should label text the button according to the zooming prop', function () {
-    /** The translation function simply return keys in a testing env */
+    /* The translation function simply return keys in a testing env */
     expect(wrapper.find(MetaToolsButton).props().text).to.equal('SubjectViewer.ZoomControlButton.enable')
     wrapper.setProps({ zooming: true })
     expect(wrapper.find(MetaToolsButton).props().text).to.equal('SubjectViewer.ZoomControlButton.disable')

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskArea.js
@@ -8,7 +8,6 @@ import { useTranslation } from '@translations/i18n'
 import { DisabledTaskPopup, Tasks } from './components'
 import SlideTutorial from '../SlideTutorial'
 
-// TODO: add autofocus for the first tab/task area
 /**
 The tabbed tasks area of the classifier, with tabs for the tutorial and active tasks.
 */

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/TaskAreaConnector.spec.js
@@ -48,7 +48,7 @@ describe('TaskAreaConnector', function () {
           wrapper: withStore(store)
         }
       )
-      /** The translation function will simply return keys in a testing environment */
+      /* The translation function will simply return keys in a testing environment */
       finishedMessage = screen.queryByText('TaskArea.DisabledTaskPopup.body')
       selectButton = screen.queryByText('TaskArea.DisabledTaskPopup.select')
       nextButton = screen.queryByText('TaskArea.DisabledTaskPopup.next')
@@ -132,7 +132,7 @@ describe('TaskAreaConnector', function () {
             wrapper: withStore(store)
           }
         )
-        /** The translation function will simply return keys in a testing environment */
+        /* The translation function will simply return keys in a testing environment */
         finishedMessage = screen.queryByText('TaskArea.DisabledTaskPopup.body')
         selectButton = screen.queryByText('TaskArea.DisabledTaskPopup.options.select')
         nextButton = screen.queryByText('TaskArea.DisabledTaskPopup.options.next')
@@ -182,7 +182,7 @@ describe('TaskAreaConnector', function () {
             wrapper: withStore(store)
           }
         )
-        /** The translation function will simply return keys in a testing environment */
+        /* The translation function will simply return keys in a testing environment */
         finishedMessage = screen.queryByText('TaskArea.DisabledTaskPopup.body')
         selectButton = screen.queryByText('TaskArea.DisabledTaskPopup.options.select')
         nextButton = screen.queryByText('TaskArea.DisabledTaskPopup.options.next')
@@ -230,7 +230,7 @@ describe('TaskAreaConnector', function () {
             wrapper: withStore(store)
           }
         )
-        /** The translation function will simply return keys in a testing environment */
+        /* The translation function will simply return keys in a testing environment */
         finishedMessage = screen.queryByText('TaskArea.DisabledTaskPopup.body')
         selectButton = screen.queryByText('TaskArea.DisabledTaskPopup.options.select')
         nextButton = screen.queryByText('TaskArea.DisabledTaskPopup.options.next')

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/DisabledTaskPopup/DisabledTaskPopup.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/DisabledTaskPopup/DisabledTaskPopup.stories.js
@@ -28,7 +28,8 @@ export default {
     docs: {
       inlineStories: false
     }
-  }
+  },
+  tags: ['autodocs']
 }
 
 export function Default({ isOpen, nextAvailable, onClose, reset }) {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.spec.js
@@ -58,7 +58,7 @@ describe('Tasks', function () {
       it('should render an error message when there is a loading error', function () {
         const wrapper = shallow(<Tasks loadingState={asyncStates.error} />)
         expect(wrapper.contains('TaskArea.Tasks.error')).to.be.true()
-        /** The translation function will simply return keys in a testing environment */
+        /* The translation function will simply return keys in a testing environment */
       })
 
       it('should render null if the workflow is loaded but has no tasks', function () {
@@ -139,7 +139,7 @@ describe('Tasks', function () {
       it('should not render the demo mode messaging', function () {
         const wrapper = shallow(<Tasks />)
         expect(wrapper.contains('TaskArea.Tasks.demoMode')).to.be.false()
-        /** The translation function will simply return keys in a testing environment */
+        /* The translation function will simply return keys in a testing environment */
       })
 
       it('should render the demo mode messaging when enabled', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/Tasks.stories.js
@@ -23,7 +23,8 @@ export default {
         options: asyncStates
       }
     }
-  }
+  },
+  tags: ['autodocs']
 }
 
 export function Loading() {

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Circle/Circle.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Circle/Circle.stories.js
@@ -79,7 +79,8 @@ const stores = setupStores()
 
 export default {
   title: 'Drawing tools / Circle',
-  component: Circle
+  component: Circle,
+  tags: ['autodocs']
 }
 
 export function Complete(args) {

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Polygon/Polygon.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Polygon/Polygon.stories.js
@@ -81,7 +81,8 @@ const stores = setupStores()
 
 export default {
   title: 'Drawing tools / Polygon',
-  component: Polygon
+  component: Polygon,
+  tags: ['autodocs']
 }
 
 export function Complete(args) {

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.stories.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/FreehandLine.stories.js
@@ -99,7 +99,8 @@ export default {
     viewport: {
       defaultViewport: 'responsive'
     }
-  }
+  },
+  tags: ['autodocs']
 }
 
 export const Drawing = (args) => {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.stories.js
@@ -17,7 +17,8 @@ export default {
       type: 'select',
       options: Object.keys(asyncStates)
     }
-  }
+  },
+  tags: ['autodocs']
 }
 
 const Template = ({

--- a/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/text/components/TextTask/components/TextTaskWithSuggestions/TextTaskWithSuggestions.spec.js
@@ -96,7 +96,7 @@ describe('TextTask > Components > TextTaskWithSuggestions', function () {
   })
 })
 
-/**
+/*
 UI to test in lib-classifier storybook:
 - ?path=/story/tasks-text--with-suggestions
 - ?path=/story/drawing-tools-transcribedlines--default

--- a/packages/lib-classifier/src/translations/i18n.js
+++ b/packages/lib-classifier/src/translations/i18n.js
@@ -6,7 +6,7 @@ import {
 
 const namespaces = ['components', 'plugins']
 
-/** supportedLngs array matches app-project's next-i18next.config.js */
+/* supportedLngs array matches app-project's next-i18next.config.js */
 const supportedLngs = [
   'ar',
   'cs',

--- a/packages/lib-react-components/src/Media/Media.stories.js
+++ b/packages/lib-react-components/src/Media/Media.stories.js
@@ -3,7 +3,7 @@ import { Box, Text } from 'grommet'
 import Media from './Media'
 import ZooniverseLogo from '../ZooniverseLogo'
 
-/** This will not work with @storybook/react composeStory function */
+/* This will not work with @storybook/react composeStory function */
 // import readme from './README.md'
 
 export default {

--- a/packages/lib-react-components/src/Modal/Modal.stories.js
+++ b/packages/lib-react-components/src/Modal/Modal.stories.js
@@ -32,7 +32,8 @@ export default {
         component: readme
       }
     }
-  }
+  },
+  tags: ['autodocs']
 }
 
 export function Default({

--- a/packages/lib-react-components/src/PlainButton/PlainButton.stories.js
+++ b/packages/lib-react-components/src/PlainButton/PlainButton.stories.js
@@ -3,7 +3,7 @@ import { Add } from 'grommet-icons'
 
 import PlainButton from './PlainButton'
 
-/** This will not work with @storybook/react composeStory function */
+/* This will not work with @storybook/react composeStory function */
 // import readme from './README.md'
 
 export default {
@@ -28,7 +28,8 @@ export default {
     onClick: {
       action: 'clicked'
     }
-  }
+  },
+  tags: ['autodocs']
   // parameters: {
   //   docs: {
   //     description: {

--- a/packages/lib-react-components/src/PrimaryButton/PrimaryButton.stories.js
+++ b/packages/lib-react-components/src/PrimaryButton/PrimaryButton.stories.js
@@ -1,7 +1,7 @@
 import { Box } from 'grommet'
 import PrimaryButton from './PrimaryButton'
 
-/** This will not work with @storybook/react composeStory function */
+/* This will not work with @storybook/react composeStory function */
 // import readme from './README.md'
 
 export default {
@@ -21,7 +21,8 @@ export default {
     onClick: {
       action: 'clicked'
     }
-  }
+  },
+  tags: ['autodocs']
   // parameters: {
   //   docs: {
   //     description: {

--- a/packages/lib-react-components/src/SpacedHeading/SpacedHeading.stories.js
+++ b/packages/lib-react-components/src/SpacedHeading/SpacedHeading.stories.js
@@ -1,7 +1,7 @@
 import { Box } from 'grommet'
 import SpacedHeading from './SpacedHeading'
 
-/** This will not work with @storybook/react composeStory function */
+/* This will not work with @storybook/react composeStory function */
 // import readme from './README.md'
 
 export default {
@@ -27,7 +27,8 @@ export default {
       options: ['normal', 'bold'],
       control: { type: 'radio' }
     }
-  }
+  },
+  tags: ['autodocs']
   // parameters: {
   //   docs: {
   //     description: {

--- a/packages/lib-react-components/src/SpacedText/SpacedText.stories.js
+++ b/packages/lib-react-components/src/SpacedText/SpacedText.stories.js
@@ -1,7 +1,7 @@
 import { Box } from 'grommet'
 import SpacedText from './SpacedText'
 
-/** This will not work with @storybook/react composeStory function */
+/* This will not work with @storybook/react composeStory function */
 // import readme from './README.md'
 
 export default {
@@ -27,7 +27,8 @@ export default {
       options: ['normal', 'bold'],
       control: { type: 'radio' }
     }
-  }
+  },
+  tags: ['autodocs']
   // parameters: {
   //   docs: {
   //     description: {

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.stories.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.stories.js
@@ -27,7 +27,7 @@ export function SignedOut({ signIn, signOut }) {
   return <ZooHeader signIn={signIn} signOut={signOut} user={{}} />
 }
 
-/** You can also see this using the 'Viewports' button in Storybook's toolbar */
+/* You can also see this using the 'Viewports' button in Storybook's toolbar */
 export function SignedOutNarrowWindowView({ signIn, signOut }) {
   return (
     <Box width='400px'>
@@ -49,7 +49,7 @@ export function SignedIn({ signIn, signOut }) {
   )
 }
 
-/** You can also see this using the 'Viewports' button in Storybook's toolbar */
+/* You can also see this using the 'Viewports' button in Storybook's toolbar */
 export function SignedInNarrowWindowView({
   signIn,
   signOut,

--- a/packages/lib-react-components/src/translations/i18n.js
+++ b/packages/lib-react-components/src/translations/i18n.js
@@ -1,7 +1,7 @@
 import i18n from 'i18next'
 import { initReactI18next, useTranslation as useBaseTranslation } from 'react-i18next'
 
-/** supportedLngs array matches app-project's next-i18next.config.js */
+/* supportedLngs array matches app-project's next-i18next.config.js */
 const supportedLngs = [
   'ar',
   'cs',


### PR DESCRIPTION
- Add `tags: ['autodocs']` to any component that has prop types with docgen comments. Bonus points for any that also have a component description!
- Correct any inline JS comments, `/*`, that were incorrectly written as docgen descriptions, `/**`. That makes components with docgen documentation easier to find.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project
- lib-classifier
- lib-react-components

## How to Review
Open up the storybooks. Components that have docgen comments should now have Docs pages with those comments describing the components and, in some cases, a description for the component too.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate


## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
