### PR TITLE
Classifier: Disable both Done&Talk and Done buttons while classification is saving

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/TaskNavButtons.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import { Box } from 'grommet'
+import { useState } from 'react'
 
 import NextButton from './components/NextButton'
 import DoneButton from './components/DoneButton'
@@ -10,6 +11,8 @@ import ExpertOptions from './components/ExpertOptions'
 export default function TaskNavButtons({
   disabled = false
 }) {
+  const [saving, setSaving] = useState(false)
+
   return (
     <Box direction='row'>
       <BackButton />
@@ -19,11 +22,13 @@ export default function TaskNavButtons({
       />
       <DoneAndTalkButton
         flex='grow'
-        disabled={disabled}
+        disabled={disabled || saving}
+        setSaving={setSaving}
       />
       <DoneButton
         flex='grow'
-        disabled={disabled}
+        disabled={disabled || saving}
+        setSaving={setSaving}
       />
       <ExpertOptions />
     </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneAndTalkButton/DoneAndTalkButton.js
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { PrimaryButton } from '@zooniverse/react-components'
 import PropTypes from 'prop-types'
 import { useTranslation } from '@translations/i18n'
@@ -7,10 +6,10 @@ const DEFAULT_HANDLER = () => true
 function DoneAndTalkButton ({
   disabled = false,
   onClick = DEFAULT_HANDLER,
+  setSaving = DEFAULT_HANDLER,
   visible = false
 }) {
   const { t } = useTranslation('components')
-  const [saving, setSaving] = useState(false)
 
   function handleClick(event) {
     setSaving(true)
@@ -21,7 +20,7 @@ function DoneAndTalkButton ({
     return (
       <PrimaryButton
         color='blue'
-        disabled={disabled || saving}
+        disabled={disabled}
         label={t('TaskArea.Tasks.DoneAndTalkButton.doneAndTalk')}
         onClick={handleClick}
         style={{ flex: '1 0', marginRight: '1ch', textTransform: 'capitalize' }}
@@ -34,6 +33,7 @@ function DoneAndTalkButton ({
 DoneAndTalkButton.propTypes = {
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
+  setSaving: PropTypes.func,
   visible: PropTypes.bool
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneButton/DoneButton.js
+++ b/packages/lib-classifier/src/components/Classifier/components/TaskArea/components/Tasks/components/TaskNavButtons/components/DoneButton/DoneButton.js
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { PrimaryButton } from '@zooniverse/react-components'
 import PropTypes from 'prop-types'
 import { useTranslation } from '@translations/i18n'
@@ -11,10 +10,10 @@ function DoneButton ({
   completed = false,
   disabled = false,
   hasNextStep = false,
-  onClick = DEFAULT_HANDLER
+  onClick = DEFAULT_HANDLER,
+  setSaving = DEFAULT_HANDLER
 }) {
   const { t } = useTranslation('components')
-  const [saving, setSaving] = useState(false)
 
   function handleClick(event) {
     setSaving(true)
@@ -25,7 +24,7 @@ function DoneButton ({
     return (
       <PrimaryButton
         color='green'
-        disabled={disabled || saving}
+        disabled={disabled}
         label={t('TaskArea.Tasks.DoneButton.done')}
         onClick={handleClick}
         style={{ flex: '1 0', textTransform: 'capitalize' }}
@@ -41,7 +40,8 @@ DoneButton.propTypes = {
   demoMode: PropTypes.bool,
   disabled: PropTypes.bool,
   hasNextStep: PropTypes.bool,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  setSaving: PropTypes.func
 }
 
 export default DoneButton


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Follow-up to https://github.com/zooniverse/front-end-monorepo/pull/4767

## Describe your changes

The Done and Done&Talk buttons should be disabled while a classification is being posted to panoptes. This PR moves the local `saving` state into TaskNavButtons so that both buttons can listen to it and be disabled at the same time.

## How to Review

Test a classification on any test project. I used this transcription project: https://local.zooniverse.org:3000/projects/blicksam/transcription-task-testing/classify/workflow/13898?env=production

Check that the Done and Done&Talk buttons appear in storybook: http://localhost:6006/?path=/story/tasks-simple-dropdown--default

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed