### PR TITLE
Transcription task: catch duplicate subjects

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.spec.js
@@ -2,6 +2,7 @@ import { within } from '@testing-library/dom'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import zooTheme from '@zooniverse/grommet-theme'
+import { auth } from '@zooniverse/panoptes-js'
 import { Grommet } from 'grommet'
 import { when } from 'mobx'
 import { Provider } from 'mobx-react'
@@ -691,6 +692,31 @@ describe('Component > TranscribedLines', function () {
           expect(line.tabIndex).to.equal(-1)
         })
       })
+    })
+  })
+
+  describe('previously transcribed subjects', function () {
+    let subject
+
+    before(async function () {
+      sinon.stub(auth, 'verify').resolves({
+        data: { id: 1, login: 'testUser', dname: 'Test User', admin: false }
+      })
+      const authClient = {
+        checkBearerToken: sinon.stub().resolves('fakeToken')
+      }
+      const store = mockStore({ authClient, client, workflow: workflowSnapshot })
+      render(<TranscribedLines />, { wrapper: withStore(store) })
+      subject = store.subjects.active
+      await when(() => subject.caesarReductions?.reductions.length > 0)
+    })
+
+    after(function () {
+      auth.verify.restore()
+    })
+
+    it('should be marked as already seen', function () {
+      expect(subject.already_seen).to.be.true()
     })
   })
 })

--- a/packages/lib-classifier/src/hooks/useTranscriptionReductions.js
+++ b/packages/lib-classifier/src/hooks/useTranscriptionReductions.js
@@ -1,16 +1,27 @@
-import { getType } from 'mobx-state-tree'
-import { useEffect, useState } from 'react'
+import { auth } from '@zooniverse/panoptes-js'
+import { getSnapshot, getType } from 'mobx-state-tree'
+import { useEffect } from 'react'
+import * as Sentry from '@sentry/browser'
 
 import SHOWN_MARKS from '@helpers/shownMarks'
 import { useStores } from '@hooks'
+import { getBearerToken } from '@store/utils'
 import { useCaesarReductions } from './'
+
+async function checkUser(userIDs = [], authorization) {
+  if (authorization) {
+    const token = authorization.replace('Bearer ', '')
+    const { data } = await auth.verify(token)
+    return data && userIDs.includes(data.id)
+  }
+  return false
+}
 
 export default function useTranscriptionReductions() {
   const {
+    authClient,
     subjects: {
-      active: {
-        stepHistory
-      }
+      active: subject
     },
     subjectViewer: {
       frame
@@ -26,8 +37,26 @@ export default function useTranscriptionReductions() {
 
   const { loaded, caesarReductions } = useCaesarReductions(workflow.caesarReducer)
 
+  useEffect(function checkTranscriptionUsers() {
+    async function checkSubject() {
+      const authorization = await getBearerToken(authClient)
+      const alreadySeen = await checkUser(caesarReductions?.userIDs, authorization)
+      if (alreadySeen) {
+        subject.markAsSeen()
+        const subjectError = new Error(`Duplicate transcription subject: ${subject.id}`)
+        const subjectSnapshot = getSnapshot(subject)
+        Sentry.withScope((scope) => {
+          scope.setTag('subjectError', 'duplicate')
+          scope.setExtra('subject', JSON.stringify(subjectSnapshot))
+          Sentry.captureException(subjectError)
+        })
+      }
+    }
+    checkSubject()
+  }, [caesarReductions, subject])
+
   let lines = []
-  const activeStepAnnotations = stepHistory?.latest.annotations
+  const activeStepAnnotations = subject?.stepHistory?.latest.annotations
   // We expect there to only be one
   const [task] = findTasksByType('transcription')
   // We want to observe the marks array for changes, so pass that as a separate prop.

--- a/packages/lib-classifier/src/store/subjects/Subject/TranscriptionReductions/TranscriptionReductions.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/TranscriptionReductions/TranscriptionReductions.js
@@ -57,6 +57,33 @@ const TranscriptionReductions = types
       }
     }
 
+    /**
+    Unique users from all the lines of a single frame.
+    */
+    function frameUsers(frame) {
+      // A frame is an array of line transcriptions.
+      // Each line has a list of user IDs that contributed to the transcription.
+      const users = frame.map(line => line.user_ids)
+      const uniqueUsers = [...new Set(users.flat())]
+      return uniqueUsers
+    }
+
+    /**
+    Get the frames from a single reduction.
+    */
+    function reductionFrames(reduction) {
+      return Object.entries(reduction.data).filter(([key, value]) => key.startsWith('frame'))
+    }
+
+    /** 
+    Unique user IDs for a single Caesar reduction
+    */ 
+    function reductionUsers(reduction) {
+      const users = reductionFrames(reduction).map(([key, frame]) => frameUsers(frame))
+      const uniqueUsers = new Set(users.flat())
+      return [ ...uniqueUsers]
+    }
+
     return {
       consensusLines(frame) {
         const { reductions } = self
@@ -75,6 +102,12 @@ const TranscriptionReductions = types
           consensusLines = consensusLines.concat(currentFrameConsensus)
         })
         return consensusLines
+      },
+
+      get userIDs() {
+        const users = self.reductions.map(reductionUsers)
+        const uniqueUsers = new Set(users.flat())
+        return [...uniqueUsers]
       }
     }
   })


### PR DESCRIPTION
- Add `subject.caesarReductions.userIDs`, a list of unique users who have contributed transcriptions to a subject.
- Update `useTranscriptionReductions` to check the logged-in user against the list of previous users from Caesar.
- Mark subjects as seen if you've previously transcribed them.
- Log an error to Sentry for duplicate subjects.
- Refactor `TranscriptionReductions` for readability.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## How to Review
Caesar reductions for the transcription task include a list of user IDs for each transcribed line. This PR reduces those arrays down to an array of unique user IDs for each previously transcribed subject, then checks the logged-in user against that array. If you've already transcribed this subject, then it is marked as already seen and an error is logged to Sentry.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
