### PR TITLE
Organisations: small fixes

### DIFF
--- a/packages/app-project/src/helpers/fetchOrganization/fetchOrganization.js
+++ b/packages/app-project/src/helpers/fetchOrganization/fetchOrganization.js
@@ -18,6 +18,7 @@ async function fetchOrganizationData(organizationID, env) {
   } catch (error) {
     logToSentry(error)
     console.log('Error loading organization:', error)
+    return null
   }
 }
 

--- a/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.js
+++ b/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.js
@@ -92,7 +92,10 @@ export default async function getStaticPageProps({ locale, params }) {
 
   if (project.links.organization) {
     const organization = await fetchOrganization(project.links.organization, locale, env)
-    props.organization = organization
+    if (organization) {
+      applySnapshot(store.organization, organization)
+      props.organization = getSnapshot(store.organization)
+    }
   }  
 
   return { props }

--- a/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.spec.js
+++ b/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.spec.js
@@ -63,7 +63,7 @@ describe('Helpers > getStaticPageProps', function () {
     display_name: 'Test Organization',
     listed: true,
     primary_language: 'en',
-    title: 'Test Organization',
+    slug: 'test-owner/test-organization'
   }
 
   const TRANSLATION = {
@@ -349,8 +349,8 @@ describe('Helpers > getStaticPageProps', function () {
         props = response.props
       })
 
-      it('should return the project\'s organization as null', async function () {
-        expect(props.organization).to.be.null()
+      it('should not return the project\'s organization', async function () {
+        expect(props.organization).to.be.undefined()
       })
     })
 
@@ -518,8 +518,8 @@ describe('Helpers > getStaticPageProps', function () {
         props = response.props
       })
 
-      it('should return the project\'s organization as null', async function () {
-        expect(props.organization).to.be.null()
+      it('should not return the project\'s organization', async function () {
+        expect(props.organization).to.be.undefined()
       })
     })
 

--- a/packages/app-project/stores/Organization.js
+++ b/packages/app-project/stores/Organization.js
@@ -2,6 +2,8 @@ import { types } from 'mobx-state-tree'
 
 import numberString from './types/numberString'
 
+const TranslationStrings = types.map(types.maybeNull(types.string))
+
 const Organization = types
   .model('Organization', {
     id: types.maybeNull(numberString),
@@ -9,12 +11,12 @@ const Organization = types
     listed: types.optional(types.boolean, false),
     primary_language: types.optional(types.string, 'en'),
     slug: types.optional(types.string, ''),
-    strings: types.frozen({})
+    strings: TranslationStrings
   })
 
   .views(self => ({
     get title () {
-      return self.strings?.title
+      return self.strings.get('title')
     },
   }))
 

--- a/packages/app-project/stores/Organization.js
+++ b/packages/app-project/stores/Organization.js
@@ -5,9 +5,11 @@ import numberString from './types/numberString'
 const Organization = types
   .model('Organization', {
     id: types.maybeNull(numberString),
+    display_name: types.optional(types.string, ''),
+    listed: types.optional(types.boolean, false),
     primary_language: types.optional(types.string, 'en'),
     slug: types.optional(types.string, ''),
-    strings: types.frozen({}),
+    strings: types.frozen({})
   })
 
   .views(self => ({

--- a/packages/app-project/stores/Project.js
+++ b/packages/app-project/stores/Project.js
@@ -3,6 +3,8 @@ import { getRoot, types } from 'mobx-state-tree'
 
 import numberString from './types/numberString'
 
+const TranslationStrings = types.map(types.maybeNull(types.string))
+
 const Project = types
   .model('Project', {
     about_pages: types.frozen([]),
@@ -25,7 +27,7 @@ const Project = types
     owners: types.frozen([]),
     retired_subjects_count: types.optional(types.number, 0),
     slug: types.optional(types.string, ''),
-    strings: types.frozen({}),
+    strings: TranslationStrings,
     subjects_count: types.optional(types.number, 0),
     urls: types.frozen([])
   })
@@ -45,11 +47,11 @@ const Project = types
     },
 
     get description () {
-      return self.strings?.description
+      return self.strings.get('description')
     },
 
     get display_name () {
-      return self.strings?.display_name
+      return self.strings.get('display_name')
     },
 
     get displayName () {
@@ -57,7 +59,7 @@ const Project = types
     },
 
     get introduction () {
-      return self.strings?.introduction
+      return self.strings.get('introduction')
     },
 
     get isComplete () {
@@ -69,15 +71,15 @@ const Project = types
     },
 
     get researcher_quote () {
-      return self.strings?.researcher_quote
+      return self.strings.get('researcher_quote')
     },
 
     get title () {
-      return self.strings?.title
+      return self.strings.get('title')
     },
 
     get workflow_description () {
-      return self.strings?.workflow_description
+      return self.strings.get('workflow_description')
     },
 
     workflowIsActive(workflowId) {

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
@@ -330,6 +330,7 @@ describe('Stores > UserProjectPreferences', function () {
       before(function () {
         const project = {
           id: '2',
+          slug: 'test/project',
           links: {
             active_workflows: ['555']
           }


### PR DESCRIPTION
- add `organization` to the store during SSR, and pass a snapshot to the browser.
- return null when organisations aren't found eg. they exist but are not public.
- model translation strings as a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of nullable strings.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
app-project

## How to Review
Try this out with projects that are part of public organisations, eg. Snapshot Serengeti or Notes from Nature, and projects that are part of private organisations, eg. Galaxy Zoo or Gravity Spy.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
