### PR TITLE
Refactor Panoptes authentication in all packages 

### DIFF
--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -19,7 +19,7 @@
     "@sentry/nextjs": "~7.57.0",
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/grommet-theme": "~3.1.0",
-    "@zooniverse/panoptes-js": "~0.3.0",
+    "@zooniverse/panoptes-js": "~0.4.0",
     "@zooniverse/react-components": "~1.5.0",
     "contentful": "~10.3.0",
     "dotenv": "~16.3.0",

--- a/packages/app-content-pages/src/shared/stores/User/User.js
+++ b/packages/app-content-pages/src/shared/stores/User/User.js
@@ -7,28 +7,11 @@ import numberString from '../types/numberString'
 
 import UserPersonalization from './UserPersonalization'
 
-async function decodeJWT(token) {
-  let user = null
-  let error = null
-  const decodedToken = await panoptesJS.auth.verify(token)
-  const { data } = decodedToken
-  error = decodedToken.error
-  if (data) {
-    user = {
-      id: data.id.toString(),
-      login: data.login,
-      display_name: data.dname,
-      admin: data.admin
-    }
-  }
-  return { user, error }
-}
-
 async function fetchPanoptesUser() {
   try {
     const token = await auth.checkBearerToken()
     if (token) {
-      const { user, error } = await decodeJWT(token)
+      const { user, error } = await panoptesJS.auth.decodeJWT(token)
       if (user) {
         return user
       }

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -28,7 +28,7 @@
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/classifier": "^0.0.1",
     "@zooniverse/grommet-theme": "~3.1.0",
-    "@zooniverse/panoptes-js": "~0.3.0",
+    "@zooniverse/panoptes-js": "~0.4.0",
     "@zooniverse/react-components": "~1.5.0",
     "cookie": "~0.5.0",
     "d3": "~6.7.0",

--- a/packages/app-project/src/hooks/usePanoptesUser.js
+++ b/packages/app-project/src/hooks/usePanoptesUser.js
@@ -1,3 +1,4 @@
+import * as panoptesJS from '@zooniverse/panoptes-js'
 import auth from 'panoptes-client/lib/auth'
 import useSWR from 'swr'
 
@@ -9,8 +10,35 @@ const SWRoptions = {
   refreshInterval: 0
 }
 
+async function decodeJWT(token) {
+  let user = null
+  let error = null
+  const decodedToken = await panoptesJS.auth.verify(token)
+  const { data } = decodedToken
+  error = decodedToken.error
+  if (data) {
+    user = {
+      id: data.id.toString(),
+      login: data.login,
+      display_name: data.dname,
+      admin: data.admin
+    }
+  }
+  return { user, error }
+}
+
 async function fetchPanoptesUser() {
   try {
+    const token = await auth.checkBearerToken()
+    if (token) {
+      const { user, error } = await decodeJWT(token)
+      if (user) {
+        return user
+      }
+      if (error) {
+        throw error
+      }
+    }
     return await auth.checkCurrent()
   } catch (error) {
     console.log(error)
@@ -18,7 +46,7 @@ async function fetchPanoptesUser() {
   }
 }
 
-export default function usePanoptesUser(key) {
+export default function usePanoptesUser(key = 'no-user') {
   const { data } = useSWR(key, fetchPanoptesUser, SWRoptions)
   return data
 }

--- a/packages/app-project/src/hooks/usePanoptesUser.js
+++ b/packages/app-project/src/hooks/usePanoptesUser.js
@@ -10,28 +10,11 @@ const SWRoptions = {
   refreshInterval: 0
 }
 
-async function decodeJWT(token) {
-  let user = null
-  let error = null
-  const decodedToken = await panoptesJS.auth.verify(token)
-  const { data } = decodedToken
-  error = decodedToken.error
-  if (data) {
-    user = {
-      id: data.id.toString(),
-      login: data.login,
-      display_name: data.dname,
-      admin: data.admin
-    }
-  }
-  return { user, error }
-}
-
 async function fetchPanoptesUser() {
   try {
     const token = await auth.checkBearerToken()
     if (token) {
-      const { user, error } = await decodeJWT(token)
+      const { user, error } = await panoptesJS.auth.decodeJWT(token)
       if (user) {
         return user
       }

--- a/packages/app-project/stores/User/User.js
+++ b/packages/app-project/stores/User/User.js
@@ -1,5 +1,5 @@
 import asyncStates from '@zooniverse/async-states'
-import { applySnapshot, flow, types } from 'mobx-state-tree'
+import { applySnapshot, flow, getSnapshot, types } from 'mobx-state-tree'
 import auth from 'panoptes-client/lib/auth'
 
 import Collections from './Collections'
@@ -53,7 +53,10 @@ const User = types
     },
 
     set(user) {
+      const newUser = self.id !== user?.id
+      const { personalization } = getSnapshot(self)
       const userSnapshot = {
+        personalization,
         ...user,
         loadingState: asyncStates.success
       }
@@ -64,7 +67,7 @@ const User = types
         current_user_roles: 'owner,collaborator,contributor'
       })
       if (self.id) {
-        self.personalization.load()
+        self.personalization.load(newUser)
       }
     }
   }))

--- a/packages/app-project/stores/User/User.spec.js
+++ b/packages/app-project/stores/User/User.spec.js
@@ -1,21 +1,80 @@
 import asyncStates from '@zooniverse/async-states'
+import * as client from '@zooniverse/panoptes-js'
 import { expect } from 'chai'
+import { when } from 'mobx'
 import { getSnapshot } from 'mobx-state-tree'
+import nock from 'nock'
 import sinon from 'sinon'
 
 import Store from '@stores/Store'
 import initStore from '@stores/initStore'
-import placeholderEnv from '@stores/helpers/placeholderEnv'
-
-const user = {
-  display_name: 'Jean-Luc Picard',
-  id: '1',
-  login: 'zootester1'
-}
 
 describe('stores > User', function () {
-  let rootStore = Store.create({}, placeholderEnv)
-  let userStore = rootStore.user
+  const user = {
+    display_name: 'Jean-Luc Picard',
+    id: '1',
+    login: 'zootester1'
+  }
+  let rootStore
+  let userStore
+
+  beforeEach(function () {
+    nock('https://panoptes-staging.zooniverse.org/api')
+    .persist()
+    .get('/users/1/recents')
+    .query(true)
+    .reply(200, { recents: [] })
+    .get('/users/2/recents')
+    .query(true)
+    .reply(200, { recents: [] })
+    .get('/collections')
+    .query(true)
+    .reply(200, { collections: [] })
+
+    nock('https://panoptes-staging.zooniverse.org/api')
+    .get('/project_preferences?project_id=1&user_id=1&http_cache=true')
+    .reply(200, {
+      project_preferences: [
+        { activity_count: 23 }
+      ]
+    })
+    .get('/project_preferences?project_id=1&user_id=1&http_cache=true')
+    .reply(200, {
+      project_preferences: [
+        { activity_count: 25 }
+      ]
+    })
+    .get('/project_preferences?project_id=1&user_id=2&http_cache=true')
+    .reply(200, {
+      project_preferences: [
+        { activity_count: 27 }
+      ]
+    })
+
+    nock('https://talk-staging.zooniverse.org')
+    .persist()
+    .get('/conversations')
+    .query(true)
+    .reply(200, { conversations: [] })
+    .get('/notifications')
+    .query(true)
+    .reply(200, { notifications: [] })
+
+    nock('https://graphql-stats.zooniverse.org')
+    .persist()
+    .post('/graphql')
+    .reply(200, { data: { statsCount: [] }})
+
+    rootStore = Store.create({ project: {
+      id: '1',
+      loadingState: asyncStates.success
+    }}, { client })
+    userStore = rootStore.user
+  })
+
+  afterEach(function () {
+    nock.cleanAll()
+  })
 
   it('should exist', function () {
     expect(userStore).to.be.ok()
@@ -33,15 +92,48 @@ describe('stores > User', function () {
     expect(userStore.display_name).to.equal(user.display_name)
   })
 
-  it('should clear the user', function () {
+  it('should clear the user', async function () {
+    userStore.set(user)
     expect(userStore.id).to.equal(user.id)
     expect(userStore.login).to.equal(user.login)
     expect(userStore.display_name).to.equal(user.display_name)
+    await when(() => userStore.loadingState === asyncStates.success)
 
     userStore.clear()
 
     expect(userStore.id).to.be.null()
     expect(userStore.login).to.be.null()
     expect(userStore.display_name).to.be.null()
+  })
+
+  describe('with an existing user session', function () {
+    
+    it('should refresh project preferences for the same user', async function () {
+      userStore.set(user)
+      const { personalization } = userStore
+
+      expect(userStore.id).to.equal(user.id)
+      await when(() => personalization.projectPreferences.loadingState === asyncStates.success)
+
+      userStore.set(user)
+      expect(userStore.personalization.projectPreferences.loadingState).to.equal(asyncStates.success)
+      expect(rootStore.appLoadingState).to.equal(asyncStates.success)
+    })
+
+    it('should load project preferences for new users', async function () {
+      userStore.set(user)
+      const { personalization } = userStore
+
+      expect(userStore.id).to.equal(user.id)
+      await when(() => personalization.projectPreferences.loadingState === asyncStates.success)
+
+      userStore.set({
+        display_name: 'Worf',
+        id: '2',
+        login: 'zootester2'
+      })
+      expect(userStore.personalization.projectPreferences.loadingState).to.equal(asyncStates.loading)
+      expect(rootStore.appLoadingState).to.equal(asyncStates.loading)
+    })
   })
 })

--- a/packages/app-project/stores/User/User.spec.js
+++ b/packages/app-project/stores/User/User.spec.js
@@ -2,12 +2,9 @@ import asyncStates from '@zooniverse/async-states'
 import * as client from '@zooniverse/panoptes-js'
 import { expect } from 'chai'
 import { when } from 'mobx'
-import { getSnapshot } from 'mobx-state-tree'
 import nock from 'nock'
-import sinon from 'sinon'
 
 import Store from '@stores/Store'
-import initStore from '@stores/initStore'
 
 describe('stores > User', function () {
   const user = {

--- a/packages/app-project/stores/User/UserPersonalization/UserPersonalization.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserPersonalization.js
@@ -66,10 +66,14 @@ const UserPersonalization = types
         }
       },
 
-      load() {
+      load(newUser = true) {
         self.notifications.fetchAndSubscribe()
-        self.projectPreferences.fetchResource()
         self.stats.fetchDailyCounts()
+        if (newUser) {
+          self.projectPreferences.fetchResource()
+        } else {
+          self.projectPreferences.refreshSettings()
+        }
       },
 
       reset() {

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "@zooniverse/grommet-theme": "3.x.x",
-    "@zooniverse/panoptes-js": "~0.3.0",
+    "@zooniverse/panoptes-js": "~0.4.0",
     "@zooniverse/react-components": "~1.x.x",
     "grommet": "~2.x.x",
     "grommet-icons": "~4.x.x",
@@ -79,7 +79,7 @@
     "@visx/mock-data": "~3.0.0",
     "@wojtekmaj/enzyme-adapter-react-17": "~0.8.0",
     "@zooniverse/grommet-theme": "~3.1.0",
-    "@zooniverse/panoptes-js": "~0.3.0",
+    "@zooniverse/panoptes-js": "~0.4.0",
     "@zooniverse/react-components": "~1.5.0",
     "@zooniverse/standard": "~2.0.0",
     "babel-loader": "~9.1.0",

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -9,13 +9,12 @@ import Layout from './components/Layout'
 import ModalTutorial from './components/ModalTutorial'
 
 function Classifier({
-  canPreviewWorkflows = false,
   locale,
   onError = () => true,
   showTutorial = false,
   subjectID,
   subjectSetID,
-  workflowSnapshot,
+  workflowSnapshot = null,
 }) {
   const classifierStore = useStores()
   const { workflows, projects } = classifierStore
@@ -57,9 +56,9 @@ function Classifier({
     if (workflowID) {
       console.log('starting new subject queue', { workflowID, subjectSetID, subjectID })
       workflows.setResources([workflowSnapshot])
-      workflows.selectWorkflow(workflowID, subjectSetID, subjectID, canPreviewWorkflows)
+      workflows.selectWorkflow(workflowID, subjectSetID, subjectID)
     }
-  }, [canPreviewWorkflows, subjectID, subjectSetID, workflowID, workflows])
+  }, [subjectID, subjectSetID, workflowID, workflows])
 
   useEffect(function onWorkflowStringsChange() {
     if (workflowStrings) {
@@ -86,7 +85,6 @@ function Classifier({
 }
 
 Classifier.propTypes = {
-  canPreviewWorkflows: PropTypes.bool,
   locale: PropTypes.string,
   onError: PropTypes.func,
   showTutorial: PropTypes.bool,

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -17,8 +17,7 @@ function Classifier({
   workflowSnapshot = null,
 }) {
   const classifierStore = useStores()
-  const { workflows, projects } = classifierStore
-  const project = projects.active
+  const { workflows } = classifierStore
   const workflowID = workflowSnapshot?.id
   const workflowStrings = workflowSnapshot?.strings
   let workflowVersionChanged = false

--- a/packages/lib-classifier/src/components/Classifier/Classifier.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { useEffect } from 'react';
 import i18n from '../../translations/i18n'
 
-import { usePanoptesUser, useProjectPreferences, useProjectRoles } from '@hooks'
+import { useProjectPreferences, useProjectRoles } from '@hooks'
 import Layout from './components/Layout'
 import ModalTutorial from './components/ModalTutorial'
 
@@ -16,14 +16,14 @@ export default function Classifier({
   showTutorial = false,
   subjectID,
   subjectSetID,
+  userID,
   workflowSnapshot,
 }) {
 
   const project = classifierStore.projects.active
   const workflowID = workflowSnapshot?.id
   const workflowStrings = workflowSnapshot?.strings
-  const user = usePanoptesUser()
-  const projectRoles = useProjectRoles(project?.id, user?.id)
+  const projectRoles = useProjectRoles(project?.id, userID)
   let workflowVersionChanged = false
 
   if (workflowSnapshot) {
@@ -49,7 +49,7 @@ export default function Classifier({
     }
   }
 
-  const upp = useProjectPreferences(project?.id, user?.id)
+  const upp = useProjectPreferences(project?.id, userID)
 
   const uppLoading = upp === undefined
   const { userProjectPreferences } = classifierStore
@@ -68,7 +68,7 @@ export default function Classifier({
     }
   }
 
-  const canPreviewWorkflows = adminMode && user?.admin ||
+  const canPreviewWorkflows = adminMode ||
     projectRoles.indexOf('owner') > -1 ||
     projectRoles.indexOf('collaborator') > -1 ||
     projectRoles.indexOf('tester') > -1
@@ -122,8 +122,10 @@ Classifier.propTypes = {
   showTutorial: PropTypes.bool,
   subjectSetID: PropTypes.string,
   subjectID: PropTypes.string,
+  userID: PropTypes.string,
   workflowSnapshot: PropTypes.shape({
     id: PropTypes.string,
+    strings: PropTypes.object,
     version: PropTypes.string
   })
 }

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -69,13 +69,11 @@ describe('Components > Classifier', function () {
       sinon.replace(window, 'Image', MockSlowImage)
       const subject = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
       const store = mockStore({ subject })
-      const project = store.projects.active
       workflow = store.workflows.active
       const workflowSnapshot = { ...getSnapshot(workflow) }
       workflowSnapshot.strings = workflowStrings
       render(
         <Classifier
-          classifierStore={store}
           workflowSnapshot={workflowSnapshot}
         />,
         {
@@ -139,7 +137,6 @@ describe('Components > Classifier', function () {
       workflowSnapshot.strings = workflowStrings
       render(
         <Classifier
-          classifierStore={store}
           workflowSnapshot={workflowSnapshot}
         />,
         {
@@ -241,7 +238,6 @@ describe('Components > Classifier', function () {
 
       const { rerender } = render(
         <Classifier
-          classifierStore={store}
           locale='en'
           workflowSnapshot={workflowSnapshot}
         />,
@@ -397,7 +393,6 @@ describe('Components > Classifier', function () {
       }, { authClient, client })
       const { rerender } = render(
         <Classifier
-          classifierStore={store}
           workflowSnapshot={workflowSnapshot}
         />,
         {
@@ -544,7 +539,6 @@ describe('Components > Classifier', function () {
           }, { authClient, client })
           render(
             <Classifier
-              classifierStore={store}
               workflowSnapshot={workflowSnapshot}
             />,
             {
@@ -634,7 +628,6 @@ describe('Components > Classifier', function () {
       }, { authClient, client })
       render(
         <Classifier
-          classifierStore={store}
           workflowSnapshot={workflowSnapshot}
         />,
         {
@@ -696,7 +689,6 @@ describe('Components > Classifier', function () {
       workflowSnapshot.strings = workflowStrings
       render(
         <Classifier
-          classifierStore={store}
           locale='en'
           showTutorial
           workflowSnapshot={workflowSnapshot}
@@ -736,7 +728,6 @@ describe('Components > Classifier', function () {
       workflowSnapshot.strings = workflowStrings
       render(
         <Classifier
-          classifierStore={store}
           locale='en'
           workflowSnapshot={workflowSnapshot}
         />,
@@ -814,7 +805,6 @@ describe('Components > Classifier', function () {
       }, { authClient, client })
       const { rerender } = render(
         <Classifier
-          classifierStore={store}
           subjectSetID='1'
           workflowSnapshot={workflowSnapshot}
         />,
@@ -926,7 +916,6 @@ describe('Components > Classifier', function () {
       render(
         <Classifier
           adminMode
-          classifierStore={store}
           workflowSnapshot={workflowSnapshot}
         />,
         {
@@ -1003,7 +992,6 @@ describe('Components > Classifier', function () {
       }, { authClient, client })
       render(
         <Classifier
-          classifierStore={store}
           workflowSnapshot={workflowSnapshot}
         />,
         {

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -1,6 +1,7 @@
 import { within } from '@testing-library/dom'
 import { render, screen } from '@testing-library/react'
 import asyncStates from '@zooniverse/async-states'
+import { auth } from '@zooniverse/panoptes-js'
 import zooTheme from '@zooniverse/grommet-theme'
 import { panoptes } from '@zooniverse/panoptes-js'
 import { Grommet } from 'grommet'
@@ -207,9 +208,9 @@ describe('Components > Classifier', function () {
         .query(true)
         .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
 
-      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
-      const checkCurrent = sinon.stub().callsFake(() => Promise.resolve({ id: 123, login: 'mockUser' }))
-      const authClient = { ...defaultAuthClient, checkBearerToken, checkCurrent }
+      sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockUser' } })
+      const checkBearerToken = sinon.stub().resolves('mockAuth')
+      const authClient = { ...defaultAuthClient, checkBearerToken }
       const client = { ...defaultClient, panoptes }
 
       const workflowSnapshot = branchingWorkflow
@@ -368,9 +369,9 @@ describe('Components > Classifier', function () {
       sinon.stub(panoptes, 'post').callsFake((...args) => {
         return Promise.resolve({ headers: {}, body: { project_preferences: []}})
       })
-      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
-      const checkCurrent = sinon.stub().callsFake(() => Promise.resolve({ id: 123, login: 'mockUser' }))
-      const authClient = { ...defaultAuthClient, checkBearerToken, checkCurrent }
+      sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockUser' } })
+      const checkBearerToken = sinon.stub().resolves('mockAuth')
+      const authClient = { ...defaultAuthClient, checkBearerToken }
       const client = { ...defaultClient, panoptes }
       const store = RootStore.create({
         projects: {
@@ -508,9 +509,9 @@ describe('Components > Classifier', function () {
           sinon.stub(panoptes, 'post').callsFake((...args) => {
             return Promise.resolve({ headers: {}, body: { project_preferences: []}})
           })
-          const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
-          const checkCurrent = sinon.stub().callsFake(() => Promise.resolve({ id: 123, login: 'mockUser' }))
-          const authClient = { ...defaultAuthClient, checkBearerToken, checkCurrent }
+          sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockUser' } })
+          const checkBearerToken = sinon.stub().resolves('mockAuth')
+          const authClient = { ...defaultAuthClient, checkBearerToken }
           const client = { ...defaultClient, panoptes }
           const store = RootStore.create({
             projects: {
@@ -599,9 +600,9 @@ describe('Components > Classifier', function () {
         .query(true)
         .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
 
-      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
-      const checkCurrent = sinon.stub().callsFake(() => Promise.resolve({ id: 123, login: 'mockUser' }))
-      const authClient = { ...defaultAuthClient, checkBearerToken, checkCurrent }
+      sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockUser' } })
+      const checkBearerToken = sinon.stub().resolves('mockAuth')
+      const authClient = { ...defaultAuthClient, checkBearerToken }
       const client = { ...defaultClient, panoptes }
       const store = RootStore.create({
         projects: {
@@ -769,9 +770,9 @@ describe('Components > Classifier', function () {
         .query(true)
         .reply(200, { subject_sets: [SubjectSetFactory.build({ id: '2' })] })
 
-      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
-      const checkCurrent = sinon.stub().callsFake(() => Promise.resolve({ id: 123, login: 'mockUser' }))
-      const authClient = { ...defaultAuthClient, checkBearerToken, checkCurrent }
+      sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockUser' } })
+      const checkBearerToken = sinon.stub().resolves('mockAuth')
+      const authClient = { ...defaultAuthClient, checkBearerToken }
       const client = { ...defaultClient, panoptes }
       const store = RootStore.create({
         projects: {
@@ -872,9 +873,9 @@ describe('Components > Classifier', function () {
           workflows: [workflowSnapshot.id]
         }
       })
-      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
-      const checkCurrent = sinon.stub().callsFake(() => Promise.resolve({ id: 123, login: 'mockAdmin', admin: true }))
-      const authClient = { ...defaultAuthClient, checkBearerToken, checkCurrent }
+      sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockAdmin', admin: true } })
+      const checkBearerToken = sinon.stub().resolves('mockAuth')
+      const authClient = { ...defaultAuthClient, checkBearerToken }
       const client = { ...defaultClient, panoptes }
       const store = RootStore.create({
         projects: {
@@ -942,9 +943,9 @@ describe('Components > Classifier', function () {
           workflows: [workflowSnapshot.id]
         }
       })
-      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
-      const checkCurrent = sinon.stub().callsFake(() => Promise.resolve({ id: 123, login: 'mockAdmin', admin: true }))
-      const authClient = { ...defaultAuthClient, checkBearerToken, checkCurrent }
+      sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockAdmin', admin: true } })
+      const checkBearerToken = sinon.stub().resolves('mockAuth')
+      const authClient = { ...defaultAuthClient, checkBearerToken }
       const client = { ...defaultClient, panoptes }
       const store = RootStore.create({
         projects: {

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -1,9 +1,8 @@
 import { within } from '@testing-library/dom'
 import { render, screen } from '@testing-library/react'
 import asyncStates from '@zooniverse/async-states'
-import { auth } from '@zooniverse/panoptes-js'
 import zooTheme from '@zooniverse/grommet-theme'
-import { panoptes } from '@zooniverse/panoptes-js'
+import { auth, panoptes } from '@zooniverse/panoptes-js'
 import { Grommet } from 'grommet'
 import { when } from 'mobx'
 import { Provider } from 'mobx-react'
@@ -208,7 +207,15 @@ describe('Components > Classifier', function () {
         .query(true)
         .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
 
-      sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockUser' } })
+      const mockUser = { id: 123, login: 'mockUser' }
+      sinon.stub(auth, 'decodeJWT').resolves({
+        user: mockUser,
+        error: null
+      })
+      sinon.stub(auth, 'verify').resolves({
+        data: mockUser
+      })
+
       const checkBearerToken = sinon.stub().resolves('mockAuth')
       const authClient = { ...defaultAuthClient, checkBearerToken }
       const client = { ...defaultClient, panoptes }
@@ -369,7 +376,14 @@ describe('Components > Classifier', function () {
       sinon.stub(panoptes, 'post').callsFake((...args) => {
         return Promise.resolve({ headers: {}, body: { project_preferences: []}})
       })
-      sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockUser' } })
+      const mockUser = { id: 123, login: 'mockUser' }
+      sinon.stub(auth, 'decodeJWT').resolves({
+        user: mockUser,
+        error: null
+      })
+      sinon.stub(auth, 'verify').resolves({
+        data: mockUser
+      })
       const checkBearerToken = sinon.stub().resolves('mockAuth')
       const authClient = { ...defaultAuthClient, checkBearerToken }
       const client = { ...defaultClient, panoptes }
@@ -509,7 +523,14 @@ describe('Components > Classifier', function () {
           sinon.stub(panoptes, 'post').callsFake((...args) => {
             return Promise.resolve({ headers: {}, body: { project_preferences: []}})
           })
-          sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockUser' } })
+          const mockUser = { id: 123, login: 'mockUser' }
+          sinon.stub(auth, 'decodeJWT').resolves({
+            user: mockUser,
+            error: null
+          })
+          sinon.stub(auth, 'verify').resolves({
+            data: mockUser
+          })
           const checkBearerToken = sinon.stub().resolves('mockAuth')
           const authClient = { ...defaultAuthClient, checkBearerToken }
           const client = { ...defaultClient, panoptes }
@@ -600,7 +621,6 @@ describe('Components > Classifier', function () {
         .query(true)
         .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
 
-      sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockUser' } })
       const checkBearerToken = sinon.stub().resolves('mockAuth')
       const authClient = { ...defaultAuthClient, checkBearerToken }
       const client = { ...defaultClient, panoptes }
@@ -669,6 +689,7 @@ describe('Components > Classifier', function () {
       ]
       const workflowTutorial = TutorialFactory.build({ steps })
       const store = mockStore({ subject })
+      store.userProjectPreferences.clear()
       store.tutorials.setResources([workflowTutorial])
       store.tutorials.setActive(workflowTutorial.id)
       const workflowSnapshot = { ...getSnapshot(store.workflows.active) }
@@ -708,6 +729,7 @@ describe('Components > Classifier', function () {
       ]
       const workflowTutorial = TutorialFactory.build({ steps })
       const store = mockStore({ subject })
+      store.userProjectPreferences.clear()
       store.tutorials.setResources([workflowTutorial])
       store.tutorials.setActive(workflowTutorial.id)
       const workflowSnapshot = { ...getSnapshot(store.workflows.active) }
@@ -770,7 +792,15 @@ describe('Components > Classifier', function () {
         .query(true)
         .reply(200, { subject_sets: [SubjectSetFactory.build({ id: '2' })] })
 
-      sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockUser' } })
+      const mockUser = { id: 123, login: 'mockUser' }
+      sinon.stub(auth, 'decodeJWT').resolves({
+        user: mockUser,
+        error: null
+      })
+      sinon.stub(auth, 'verify').resolves({
+        data: mockUser
+      })
+
       const checkBearerToken = sinon.stub().resolves('mockAuth')
       const authClient = { ...defaultAuthClient, checkBearerToken }
       const client = { ...defaultClient, panoptes }
@@ -865,6 +895,15 @@ describe('Components > Classifier', function () {
         .query(true)
         .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
 
+      const mockUser = { id: 123, login: 'mockUser', admin: true }
+      sinon.stub(auth, 'decodeJWT').resolves({
+        user: mockUser,
+        error: null
+      })
+      sinon.stub(auth, 'verify').resolves({
+        data: mockUser
+      })
+
       const workflowSnapshot = branchingWorkflow
       workflowSnapshot.strings = workflowStrings
       const projectSnapshot = ProjectFactory.build({
@@ -873,7 +912,6 @@ describe('Components > Classifier', function () {
           workflows: [workflowSnapshot.id]
         }
       })
-      sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockAdmin', admin: true } })
       const checkBearerToken = sinon.stub().resolves('mockAuth')
       const authClient = { ...defaultAuthClient, checkBearerToken }
       const client = { ...defaultClient, panoptes }
@@ -935,6 +973,15 @@ describe('Components > Classifier', function () {
         .query(true)
         .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
 
+      const mockUser = { id: 123, login: 'mockUser', admin: true }
+      sinon.stub(auth, 'decodeJWT').resolves({
+        user: mockUser,
+        error: null
+      })
+      sinon.stub(auth, 'verify').resolves({
+        data: mockUser
+      })
+
       const workflowSnapshot = branchingWorkflow
       workflowSnapshot.strings = workflowStrings
       const projectSnapshot = ProjectFactory.build({
@@ -943,7 +990,6 @@ describe('Components > Classifier', function () {
           workflows: [workflowSnapshot.id]
         }
       })
-      sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockAdmin', admin: true } })
       const checkBearerToken = sinon.stub().resolves('mockAuth')
       const authClient = { ...defaultAuthClient, checkBearerToken }
       const client = { ...defaultClient, panoptes }

--- a/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.spec.js
@@ -471,112 +471,6 @@ describe('Components > Classifier', function () {
     })
   })
 
-  describe('with permission to view an inactive workflow', function () {
-    let subjectImage, tabPanel, taskAnswers, taskTab, tutorialTab, workflow
-
-    before(async function () {
-      sinon.replace(window, 'Image', class MockImage {
-        constructor () {
-          this.naturalHeight = 1000
-          this.naturalWidth = 500
-          setTimeout(() => this.onload(), 500)
-        }
-      })
-      const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
-      const workflowSnapshot = branchingWorkflow
-      workflowSnapshot.strings = workflowStrings
-      const projectSnapshot = ProjectFactory.build({
-        links: {
-          active_workflows: [],
-          workflows: [workflowSnapshot.id]
-        }
-      })
-      sinon.stub(panoptes, 'get').callsFake((endpoint, query, headers) => {
-        switch (endpoint) {
-          case '/field_guides': {
-            const field_guides = []
-            return Promise.resolve({ body: { field_guides }})
-          }
-          case '/subjects/queued': {
-            const subjects = [subjectSnapshot, ...Factory.buildList('subject', 9)]
-            return Promise.resolve({ body: { subjects }})
-          }
-        }
-      })
-      const mockUser = { id: 123, login: 'mockUser' }
-      sinon.stub(auth, 'decodeJWT').resolves({
-        user: mockUser,
-        error: null
-      })
-      sinon.stub(auth, 'verify').resolves({
-        data: mockUser
-      })
-      const checkBearerToken = sinon.stub().resolves('mockAuth')
-      const authClient = { ...defaultAuthClient, checkBearerToken }
-      const client = { ...defaultClient, panoptes }
-      const store = RootStore.create({
-        projects: {
-          active: projectSnapshot.id,
-          resources: {
-            [projectSnapshot.id]: projectSnapshot
-          }
-        }
-      }, { authClient, client })
-      render(
-        <Classifier
-          canPreviewWorkflows
-          workflowSnapshot={workflowSnapshot}
-        />,
-        {
-          wrapper: withStore(store)
-        }
-      )
-      await when(() => store.subjectViewer.loadingState === asyncStates.success)
-      workflow = store.workflows.active
-      taskTab = screen.getByRole('tab', { name: 'TaskArea.task'})
-      tutorialTab = screen.getByRole('tab', { name: 'TaskArea.tutorial'})
-      subjectImage = screen.queryByRole('img', { name: `Subject ${subjectSnapshot.id}` })
-      tabPanel = screen.getByRole('tabpanel', { name: '1 Tab Contents'})
-      const task = workflowSnapshot.tasks.T0
-      const getAnswerInput = answer => within(tabPanel).getByRole('radio', { name: answer.label })
-      taskAnswers = task.answers.map(getAnswerInput)
-    })
-
-    after(function () {
-      sinon.restore()
-    })
-
-    it('should have a task tab', function () {
-      expect(taskTab).to.be.ok()
-    })
-
-    it('should have a tutorial tab', function () {
-      expect(tutorialTab).to.be.ok()
-    })
-
-    it('should have a subject image', function () {
-      expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
-    })
-
-    describe('task answers', function () {
-      it('should be displayed', function () {
-        expect(taskAnswers).to.have.lengthOf(workflow.tasks.T0.answers.length)
-      })
-
-      it('should be linked to the task', function () {
-        taskAnswers.forEach(radioButton => {
-          expect(radioButton.name).to.equal('T0')
-        })
-      })
-
-      it('should be enabled', function () {
-        taskAnswers.forEach(radioButton => {
-          expect(radioButton.disabled).to.be.false()
-        })
-      })
-    })
-  })
-
   describe('without permission to view an inactive workflow', function () {
     let subjectImage, tabPanel, taskAnswers, taskTab, tutorialTab, workflow
 
@@ -609,7 +503,7 @@ describe('Components > Classifier', function () {
       }, { authClient, client })
       render(
         <Classifier
-          workflowSnapshot={workflowSnapshot}
+          workflowSnapshot={null}
         />,
         {
           wrapper: withStore(store)

--- a/packages/lib-classifier/src/components/Classifier/Classifier.workflows.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.workflows.spec.js
@@ -1,6 +1,7 @@
 import { within } from '@testing-library/dom'
 import { render, screen } from '@testing-library/react'
 import asyncStates from '@zooniverse/async-states'
+import { auth } from '@zooniverse/panoptes-js'
 import zooTheme from '@zooniverse/grommet-theme'
 import { panoptes } from '@zooniverse/panoptes-js'
 import { Grommet } from 'grommet'
@@ -106,9 +107,9 @@ function testWorkflow(workflowSnapshot, workflowStrings) {
     .query(true)
     .reply(200, { project_preferences: [] })
 
-    const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
-    const checkCurrent = sinon.stub().callsFake(() => Promise.resolve({ id: 123, login: 'mockUser' }))
-    const authClient = { ...defaultAuthClient, checkBearerToken, checkCurrent }
+    sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockUser' } })
+    const checkBearerToken = sinon.stub().resolves('mockAuth')
+    const authClient = { ...defaultAuthClient, checkBearerToken }
     const client = { ...defaultClient, panoptes }
     const store = RootStore.create({
       projects: {

--- a/packages/lib-classifier/src/components/Classifier/Classifier.workflows.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.workflows.spec.js
@@ -127,7 +127,6 @@ function testWorkflow(workflowSnapshot, workflowStrings) {
     }, { authClient, client })
     render(
       <Classifier
-        classifierStore={store}
         workflowSnapshot={workflowSnapshot}
       />,
       {

--- a/packages/lib-classifier/src/components/Classifier/Classifier.workflows.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/Classifier.workflows.spec.js
@@ -1,9 +1,8 @@
 import { within } from '@testing-library/dom'
 import { render, screen } from '@testing-library/react'
 import asyncStates from '@zooniverse/async-states'
-import { auth } from '@zooniverse/panoptes-js'
 import zooTheme from '@zooniverse/grommet-theme'
-import { panoptes } from '@zooniverse/panoptes-js'
+import { auth, panoptes } from '@zooniverse/panoptes-js'
 import { Grommet } from 'grommet'
 import { when } from 'mobx'
 import { Provider } from 'mobx-react'
@@ -107,7 +106,14 @@ function testWorkflow(workflowSnapshot, workflowStrings) {
     .query(true)
     .reply(200, { project_preferences: [] })
 
-    sinon.stub(auth, 'verify').resolves({ data: { id: 123, login: 'mockUser' } })
+    const mockUser = { id: 123, login: 'mockUser' }
+    sinon.stub(auth, 'decodeJWT').resolves({
+      user: mockUser,
+      error: null
+    })
+    sinon.stub(auth, 'verify').resolves({
+      data: mockUser
+    })
     const checkBearerToken = sinon.stub().resolves('mockAuth')
     const authClient = { ...defaultAuthClient, checkBearerToken }
     const client = { ...defaultClient, panoptes }

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
@@ -80,7 +80,10 @@ export default function ClassifierContainer({
     projectRoles?.indexOf('collaborator') > -1 ||
     projectRoles?.indexOf('tester') > -1
 
-  const workflowSnapshot = useWorkflowSnapshot(workflowID)
+  const allowedWorkflows = canPreviewWorkflows ? project?.links.workflows : project?.links.active_workflows
+  const allowedWorkflowID = allowedWorkflows.includes(workflowID) ? workflowID : null
+
+  const workflowSnapshot = useWorkflowSnapshot(allowedWorkflowID)
   const workflowTranslation = usePanoptesTranslations({
     translated_id: workflowID,
     translated_type: 'workflow',
@@ -139,7 +142,6 @@ export default function ClassifierContainer({
         <StrictMode>
           <Provider classifierStore={classifierStore}>
             <Classifier
-              canPreviewWorkflows={canPreviewWorkflows}
               locale={locale}
               onError={onError}
               project={project}

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
@@ -11,7 +11,7 @@ import {
   tutorials as tutorialsClient
 } from '@zooniverse/panoptes-js'
 
-import { useHydratedStore, usePanoptesTranslations, useWorkflowSnapshot } from '@hooks'
+import { useHydratedStore, usePanoptesTranslations, usePanoptesUser, useWorkflowSnapshot } from '@hooks'
 import { unregisterWorkers } from '../../workers'
 import Classifier from './Classifier'
 
@@ -63,6 +63,7 @@ export default function ClassifierContainer({
   workflowID
 }) {
   const storeEnvironment = { authClient, client }
+  const { user, loading } = usePanoptesUser(authClient)
 
   const workflowSnapshot = useWorkflowSnapshot(workflowID)
   const workflowTranslation = usePanoptesTranslations({
@@ -103,13 +104,13 @@ export default function ClassifierContainer({
   }, [])
 
   try {
-    if (classifierStore) {
+    if (!loading && classifierStore) {
 
       return (
         <StrictMode>
           <Provider classifierStore={classifierStore}>
             <Classifier
-              adminMode={adminMode}
+              adminMode={user?.admin && adminMode}
               classifierStore={classifierStore}
               locale={locale}
               onError={onError}
@@ -117,6 +118,7 @@ export default function ClassifierContainer({
               showTutorial={showTutorial}
               subjectSetID={subjectSetID}
               subjectID={subjectID}
+              userID={user?.id}
               workflowSnapshot={workflowSnapshot}
             />
           </Provider>
@@ -143,11 +145,15 @@ ClassifierContainer.propTypes = {
   onAddToCollection: PropTypes.func,
   onCompleteClassification: PropTypes.func,
   onError: PropTypes.func,
+  onSubjectChange: PropTypes.func,
   onSubjectReset: PropTypes.func,
   onToggleFavourite: PropTypes.func,
   project: PropTypes.shape({
     id: PropTypes.string.isRequired
   }).isRequired,
   showTutorial: PropTypes.bool,
-  theme: PropTypes.object
+  subjectID: PropTypes.string,
+  subjectSetID: PropTypes.string,
+  theme: PropTypes.object,
+  workflowID: PropTypes.string
 }

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
@@ -165,7 +165,6 @@ ClassifierContainer.propTypes = {
   authClient: PropTypes.object.isRequired,
   cachePanoptesData: PropTypes.bool,
   locale: PropTypes.string,
-  mode: PropTypes.string,
   onAddToCollection: PropTypes.func,
   onCompleteClassification: PropTypes.func,
   onError: PropTypes.func,
@@ -178,6 +177,5 @@ ClassifierContainer.propTypes = {
   showTutorial: PropTypes.bool,
   subjectID: PropTypes.string,
   subjectSetID: PropTypes.string,
-  theme: PropTypes.object,
   workflowID: PropTypes.string
 }

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
@@ -15,11 +15,10 @@ import {
 import {
   useHydratedStore,
   usePanoptesTranslations,
-  usePanoptesUser,
-  useProjectPreferences,
-  useProjectRoles,
   useWorkflowSnapshot
 } from '@hooks'
+
+import usePanoptesUserSession from './hooks/usePanoptesUserSession'
 import { unregisterWorkers } from '../../workers'
 import Classifier from './Classifier'
 
@@ -71,10 +70,7 @@ export default function ClassifierContainer({
   workflowID
 }) {
   const storeEnvironment = { authClient, client }
-  const { user, loading } = usePanoptesUser(authClient)
-  const upp = useProjectPreferences({ authClient, projectID: project?.id, userID: user?.id })
-  const projectRoles = useProjectRoles({ authClient, projectID: project?.id, userID: user?.id })
-
+  const { user, upp, projectRoles, userHasLoaded } = usePanoptesUserSession({ authClient, projectID: project?.id })
   const canPreviewWorkflows = adminMode ||
     projectRoles?.indexOf('owner') > -1 ||
     projectRoles?.indexOf('collaborator') > -1 ||
@@ -136,7 +132,7 @@ export default function ClassifierContainer({
   }, [upp, userProjectPreferences])
 
   try {
-    if (!loading && classifierStore) {
+    if (userHasLoaded && classifierStore) {
 
       return (
         <StrictMode>

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
@@ -1,4 +1,3 @@
-import asyncStates from '@zooniverse/async-states'
 import { GraphQLClient } from 'graphql-request'
 import { Paragraph } from 'grommet'
 import { Provider } from 'mobx-react'

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.spec.js
@@ -1,0 +1,715 @@
+import { within } from '@testing-library/dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import zooTheme from '@zooniverse/grommet-theme'
+import { auth } from '@zooniverse/panoptes-js'
+import { Grommet } from 'grommet'
+import nock from 'nock'
+import { Factory } from 'rosie'
+import sinon from 'sinon'
+import { SWRConfig } from 'swr'
+
+import { cleanStore } from '@hooks/useHydratedStore.js'
+import { ProjectFactory, SubjectFactory } from '@test/factories'
+import { defaultAuthClient } from '@test/mockStore/mockStore.js'
+import branchingWorkflow, { workflowStrings } from '@test/mockStore/branchingWorkflow.js'
+
+import ClassifierContainer from './'
+
+describe('components > ClassifierContainer', function () {
+  // Allow time for workflows and subjects to load before running the tests.
+  this.timeout(5000)
+
+  function mockPanoptesAPI() {
+    return nock('https://panoptes-staging.zooniverse.org/api')
+      .persist()
+      .get('/field_guides')
+      .reply(200, { field_guides: [] })
+      .get('/tutorials')
+      .query(true)
+      .reply(200, { tutorials: [] })
+  }
+
+  class MockSubjectImage {
+    constructor () {
+      this.naturalHeight = 1000
+      this.naturalWidth = 500
+      setTimeout(() => {
+        this.onload()
+      }, 500)
+    }
+  }
+
+  function withGrommet(store) {
+    /*
+    The Classifier uses Grommet but isn't wrapped in the Grommet context,
+    so add that here.
+    Also reset the SWR cache between tests.
+    https://swr.vercel.app/docs/advanced/cache#reset-cache-between-test-cases
+    */
+    return function Wrapper({ children }) {
+      return (
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <Grommet theme={zooTheme}>
+            {children}
+          </Grommet>
+        </SWRConfig>
+      )
+    }
+  }
+
+  describe('anonymous volunteers', function () {
+    let taskAnswers, subjectsRequest, workflowRequest
+    const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+    const workflowSnapshot = branchingWorkflow
+    workflowSnapshot.strings = workflowStrings
+    const projectSnapshot = ProjectFactory.build({
+      links: {
+        active_workflows: [workflowSnapshot.id],
+        workflows: [workflowSnapshot.id]
+      }
+    })
+
+    beforeEach(async function () {
+      cleanStore()
+      sinon.replace(window, 'Image', MockSubjectImage)
+      const roles = []
+      nock('https://panoptes-staging.zooniverse.org/oauth')
+        .post('/token')
+        .reply(401,{ error: 'invalid_grant' })
+
+      mockPanoptesAPI()
+        .get('/project_preferences')
+        .query(true)
+        .reply(200, { project_preferences: [] })
+        .get('/project_roles')
+        .query(true)
+        .reply(200, { project_roles: [] })
+
+      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get(`/workflows/${workflowSnapshot.id}`)
+        .query(true)
+        .reply(200, { workflows: [workflowSnapshot] })
+
+      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve(''))
+      const authClient = { ...defaultAuthClient, checkBearerToken }
+      render(
+        <ClassifierContainer
+          authClient={authClient}
+          project={projectSnapshot}
+          workflowID={workflowSnapshot.id}
+        />,
+        {
+          wrapper: withGrommet()
+        }
+      )
+      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
+      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
+      const tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const task = workflowSnapshot.tasks.T0
+      const getAnswerInput = answer => within(tabPanel).findByRole('radio', { name: answer.label })
+      taskAnswers = await Promise.all(task.answers.map(getAnswerInput))
+    })
+
+    afterEach(function () {
+      sinon.restore()
+      nock.cleanAll()
+      cleanStore()
+    })
+
+    it('should be able to view active workflows', async function () {
+      await waitFor(() => {
+        const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
+        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+      })
+      expect(workflowRequest.isDone()).to.be.true()
+      expect(subjectsRequest.isDone()).to.be.true()
+      expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
+      taskAnswers.forEach(radioButton => {
+        expect(radioButton.name).to.equal('T0')
+        expect(radioButton.disabled).to.be.true()
+      })
+    })
+  })
+
+  describe('signed-in volunteers without a stored Panoptes session', function () {
+    let taskAnswers, subjectsRequest, workflowRequest
+    const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+    const workflowSnapshot = branchingWorkflow
+    workflowSnapshot.strings = workflowStrings
+    const projectSnapshot = ProjectFactory.build({
+      links: {
+        active_workflows: [workflowSnapshot.id],
+        workflows: [workflowSnapshot.id]
+      }
+    })
+
+    beforeEach(async function () {
+      cleanStore()
+      sinon.replace(window, 'Image', MockSubjectImage)
+      const roles = []
+      const mockUser = { id: 1, login: 'mockUser' }
+      nock('https://panoptes-staging.zooniverse.org/oauth')
+        .post('/token')
+        .reply(200,{ access_token: 'mockToken', refresh_token: 'mockRefresh' })
+
+      mockPanoptesAPI()
+        .get('/project_preferences')
+        .query(true)
+        .reply(200, { project_preferences: [{
+          activity_count: 24
+        }] })
+        .get('/project_roles')
+        .query(true)
+        .reply(200, { project_roles: [{ roles }] })
+        .get('/me')
+        .reply(200, { users: [mockUser] })
+
+      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get(`/workflows/${workflowSnapshot.id}`)
+        .query(true)
+        .reply(200, { workflows: [workflowSnapshot] })
+
+      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve(''))
+      const authClient = { ...defaultAuthClient, checkBearerToken }
+      render(
+        <ClassifierContainer
+          authClient={authClient}
+          project={projectSnapshot}
+          workflowID={workflowSnapshot.id}
+        />,
+        {
+          wrapper: withGrommet()
+        }
+      )
+      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
+      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
+      const tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const task = workflowSnapshot.tasks.T0
+      const getAnswerInput = answer => within(tabPanel).findByRole('radio', { name: answer.label })
+      taskAnswers = await Promise.all(task.answers.map(getAnswerInput))
+    })
+
+    afterEach(function () {
+      sinon.restore()
+      nock.cleanAll()
+      cleanStore()
+    })
+
+    it('should be able to view active workflows', async function () {
+      await waitFor(() => {
+        const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
+        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+      })
+      expect(workflowRequest.isDone()).to.be.true()
+      expect(subjectsRequest.isDone()).to.be.true()
+      expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
+      taskAnswers.forEach(radioButton => {
+        expect(radioButton.name).to.equal('T0')
+        expect(radioButton.disabled).to.be.true()
+      })
+    })
+  })
+
+  describe('signed-in volunteers with a stored Panoptes session', function () {
+    let taskAnswers, subjectsRequest, workflowRequest
+    const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+    const workflowSnapshot = branchingWorkflow
+    workflowSnapshot.strings = workflowStrings
+    const projectSnapshot = ProjectFactory.build({
+      links: {
+        active_workflows: [workflowSnapshot.id],
+        workflows: [workflowSnapshot.id]
+      }
+    })
+
+    beforeEach(async function () {
+      cleanStore()
+      sinon.replace(window, 'Image', MockSubjectImage)
+      const roles = []
+      mockPanoptesAPI()
+        .get('/project_preferences')
+        .query(true)
+        .reply(200, { project_preferences: [{
+          activity_count: 24
+        }] })
+        .get('/project_roles')
+        .query(true)
+        .reply(200, { project_roles: [{ roles }] })
+
+      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get(`/workflows/${workflowSnapshot.id}`)
+        .query(true)
+        .reply(200, { workflows: [workflowSnapshot] })
+
+      const mockUser = { id: 1, login: 'mockUser' }
+      sinon.stub(auth, 'decodeJWT').resolves({
+        user: mockUser,
+        error: null
+      })
+      sinon.stub(auth, 'verify').resolves({
+        data: mockUser
+      })
+      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
+      const authClient = { ...defaultAuthClient, checkBearerToken }
+      render(
+        <ClassifierContainer
+          authClient={authClient}
+          project={projectSnapshot}
+          workflowID={workflowSnapshot.id}
+        />,
+        {
+          wrapper: withGrommet()
+        }
+      )
+      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
+      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
+      const tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const task = workflowSnapshot.tasks.T0
+      const getAnswerInput = answer => within(tabPanel).findByRole('radio', { name: answer.label })
+      taskAnswers = await Promise.all(task.answers.map(getAnswerInput))
+    })
+
+    afterEach(function () {
+      sinon.restore()
+      nock.cleanAll()
+      cleanStore()
+    })
+
+    it('should be able to view active workflows', async function () {
+      await waitFor(() => {
+        const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
+        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+      })
+      expect(workflowRequest.isDone()).to.be.true()
+      expect(subjectsRequest.isDone()).to.be.true()
+      expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
+      taskAnswers.forEach(radioButton => {
+        expect(radioButton.name).to.equal('T0')
+        expect(radioButton.disabled).to.be.true()
+      })
+    })
+  })
+
+  describe('Project owner', function () {
+    let taskAnswers, subjectsRequest, workflowRequest
+    const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+    const workflowSnapshot = branchingWorkflow
+    workflowSnapshot.strings = workflowStrings
+    const projectSnapshot = ProjectFactory.build({
+      links: {
+        active_workflows: [],
+        workflows: [workflowSnapshot.id]
+      }
+    })
+
+    beforeEach(async function () {
+      cleanStore()
+      sinon.replace(window, 'Image', MockSubjectImage)
+      const roles = ['owner']
+      mockPanoptesAPI()
+        .get('/project_preferences')
+        .query(true)
+        .reply(200, { project_preferences: [{
+          activity_count: 24
+        }] })
+        .get('/project_roles')
+        .query(true)
+        .reply(200, { project_roles: [{ roles }] })
+
+      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get(`/workflows/${workflowSnapshot.id}`)
+        .query(true)
+        .reply(200, { workflows: [workflowSnapshot] })
+
+      const mockUser = { id: 2, login: 'mockUser' }
+      sinon.stub(auth, 'decodeJWT').resolves({
+        user: mockUser,
+        error: null
+      })
+      sinon.stub(auth, 'verify').resolves({
+        data: mockUser
+      })
+      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
+      const authClient = { ...defaultAuthClient, checkBearerToken }
+      render(
+        <ClassifierContainer
+          authClient={authClient}
+          project={projectSnapshot}
+          workflowID={workflowSnapshot.id}
+        />,
+        {
+          wrapper: withGrommet()
+        }
+      )
+      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
+      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
+      const tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const task = workflowSnapshot.tasks.T0
+      const getAnswerInput = answer => within(tabPanel).findByRole('radio', { name: answer.label })
+      taskAnswers = await Promise.all(task.answers.map(getAnswerInput))
+    })
+
+    after(function () {
+      sinon.restore()
+      nock.cleanAll()
+      cleanStore()
+    })
+
+    it('should be able to view inactive workflows', async function () {
+      await waitFor(() => {
+        const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
+        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+      })
+      expect(workflowRequest.isDone()).to.be.true()
+      expect(subjectsRequest.isDone()).to.be.true()
+      expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
+      taskAnswers.forEach(radioButton => {
+        expect(radioButton.name).to.equal('T0')
+        expect(radioButton.disabled).to.be.true()
+      })
+    })
+  })
+
+  describe('Project collaborator', function () {
+    let taskAnswers, subjectsRequest, workflowRequest
+    const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+    const workflowSnapshot = branchingWorkflow
+    workflowSnapshot.strings = workflowStrings
+    const projectSnapshot = ProjectFactory.build({
+      links: {
+        active_workflows: [],
+        workflows: [workflowSnapshot.id]
+      }
+    })
+
+    beforeEach(async function () {
+      cleanStore()
+      sinon.replace(window, 'Image', MockSubjectImage)
+      const roles = ['collaborator']
+      mockPanoptesAPI()
+        .get('/project_preferences')
+        .query(true)
+        .reply(200, { project_preferences: [{
+          activity_count: 24
+        }] })
+        .get('/project_roles')
+        .query(true)
+        .reply(200, { project_roles: [{ roles }] })
+
+      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get(`/workflows/${workflowSnapshot.id}`)
+        .query(true)
+        .reply(200, { workflows: [workflowSnapshot] })
+
+      const mockUser = { id: 3, login: 'mockUser' }
+      sinon.stub(auth, 'decodeJWT').resolves({
+        user: mockUser,
+        error: null
+      })
+      sinon.stub(auth, 'verify').resolves({
+        data: mockUser
+      })
+      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
+      const authClient = { ...defaultAuthClient, checkBearerToken }
+      render(
+        <ClassifierContainer
+          authClient={authClient}
+          project={projectSnapshot}
+          workflowID={workflowSnapshot.id}
+        />,
+        {
+          wrapper: withGrommet()
+        }
+      )
+      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
+      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
+      const tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const task = workflowSnapshot.tasks.T0
+      const getAnswerInput = answer => within(tabPanel).findByRole('radio', { name: answer.label })
+      taskAnswers = await Promise.all(task.answers.map(getAnswerInput))
+    })
+
+    after(function () {
+      sinon.restore()
+      nock.cleanAll()
+      cleanStore()
+    })
+
+    it('should be able to view inactive workflows', async function () {
+      await waitFor(() => {
+        const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
+        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+      })
+      expect(workflowRequest.isDone()).to.be.true()
+      expect(subjectsRequest.isDone()).to.be.true()
+      expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
+      taskAnswers.forEach(radioButton => {
+        expect(radioButton.name).to.equal('T0')
+        expect(radioButton.disabled).to.be.true()
+      })
+    })
+  })
+
+  describe('Project tester', function () {
+    let taskAnswers, subjectsRequest, workflowRequest
+    const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+    const workflowSnapshot = branchingWorkflow
+    workflowSnapshot.strings = workflowStrings
+    const projectSnapshot = ProjectFactory.build({
+      links: {
+        active_workflows: [],
+        workflows: [workflowSnapshot.id]
+      }
+    })
+
+    beforeEach(async function () {
+      cleanStore()
+      sinon.replace(window, 'Image', MockSubjectImage)
+      const roles = ['tester']
+      mockPanoptesAPI()
+        .get('/project_preferences')
+        .query(true)
+        .reply(200, { project_preferences: [{
+          activity_count: 24
+        }] })
+        .get('/project_roles')
+        .query(true)
+        .reply(200, { project_roles: [{ roles }] })
+
+      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get(`/workflows/${workflowSnapshot.id}`)
+        .query(true)
+        .reply(200, { workflows: [workflowSnapshot] })
+
+      const mockUser = { id: 4, login: 'mockUser' }
+      sinon.stub(auth, 'decodeJWT').resolves({
+        user: mockUser,
+        error: null
+      })
+      sinon.stub(auth, 'verify').resolves({
+        data: mockUser
+      })
+      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
+      const authClient = { ...defaultAuthClient, checkBearerToken }
+      render(
+        <ClassifierContainer
+          authClient={authClient}
+          project={projectSnapshot}
+          workflowID={workflowSnapshot.id}
+        />,
+        {
+          wrapper: withGrommet()
+        }
+      )
+      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
+      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
+      const tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const task = workflowSnapshot.tasks.T0
+      const getAnswerInput = answer => within(tabPanel).findByRole('radio', { name: answer.label })
+      taskAnswers = await Promise.all(task.answers.map(getAnswerInput))
+    })
+
+    after(function () {
+      sinon.restore()
+      nock.cleanAll()
+      cleanStore()
+    })
+
+    it('should be able to view inactive workflows', async function () {
+      await waitFor(() => {
+        const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
+        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+      })
+      expect(workflowRequest.isDone()).to.be.true()
+      expect(subjectsRequest.isDone()).to.be.true()
+      expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
+      taskAnswers.forEach(radioButton => {
+        expect(radioButton.name).to.equal('T0')
+        expect(radioButton.disabled).to.be.true()
+      })
+    })
+  })
+
+  describe('admins: in admin mode', function () {
+    let taskAnswers, subjectsRequest, workflowRequest
+    const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+    const workflowSnapshot = branchingWorkflow
+    workflowSnapshot.strings = workflowStrings
+    const projectSnapshot = ProjectFactory.build({
+      links: {
+        active_workflows: [],
+        workflows: [workflowSnapshot.id]
+      }
+    })
+
+    beforeEach(async function () {
+      cleanStore()
+      sinon.replace(window, 'Image', MockSubjectImage)
+      const roles = []
+      mockPanoptesAPI()
+        .get('/project_preferences')
+        .query(true)
+        .reply(200, { project_preferences: [{
+          activity_count: 24
+        }] })
+        .get('/project_roles')
+        .query(true)
+        .reply(200, { project_roles: [{ roles }] })
+
+      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get(`/workflows/${workflowSnapshot.id}`)
+        .query(true)
+        .reply(200, { workflows: [workflowSnapshot] })
+
+      const mockUser = { id: 5, login: 'mockUser', admin: true }
+      sinon.stub(auth, 'decodeJWT').resolves({
+        user: mockUser,
+        error: null
+      })
+      sinon.stub(auth, 'verify').resolves({
+        data: mockUser
+      })
+      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
+      const authClient = { ...defaultAuthClient, checkBearerToken }
+      render(
+        <ClassifierContainer
+          adminMode
+          authClient={authClient}
+          project={projectSnapshot}
+          workflowID={workflowSnapshot.id}
+        />,
+        {
+          wrapper: withGrommet()
+        }
+      )
+      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
+      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
+      const tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const task = workflowSnapshot.tasks.T0
+      const getAnswerInput = answer => within(tabPanel).findByRole('radio', { name: answer.label })
+      taskAnswers = await Promise.all(task.answers.map(getAnswerInput))
+    })
+
+    afterEach(function () {
+      sinon.restore()
+      nock.cleanAll()
+      cleanStore()
+    })
+
+    it('should be able to view inactive workflows', async function () {
+      await waitFor(() => {
+        const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
+        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+      })
+      expect(workflowRequest.isDone()).to.be.true()
+      expect(subjectsRequest.isDone()).to.be.true()
+      expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
+      taskAnswers.forEach(radioButton => {
+        expect(radioButton.name).to.equal('T0')
+        expect(radioButton.disabled).to.be.true()
+      })
+    })
+  })
+
+  describe('admins: not in admin mode', function () {
+    let taskAnswers, subjectsRequest, workflowRequest
+    const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
+    const workflowSnapshot = branchingWorkflow
+    workflowSnapshot.strings = workflowStrings
+    const projectSnapshot = ProjectFactory.build({
+      links: {
+        active_workflows: [],
+        workflows: [workflowSnapshot.id]
+      }
+    })
+
+    beforeEach(async function () {
+      cleanStore()
+      sinon.replace(window, 'Image', MockSubjectImage)
+      const roles = []
+      mockPanoptesAPI()
+        .get('/project_preferences')
+        .query(true)
+        .reply(200, { project_preferences: [{
+          activity_count: 24
+        }] })
+        .get('/project_roles')
+        .query(true)
+        .reply(200, { project_roles: [{ roles }] })
+
+      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get(`/workflows/${workflowSnapshot.id}`)
+        .query(true)
+        .reply(200, { workflows: [workflowSnapshot] })
+
+      const mockUser = { id: 6, login: 'mockUser', admin: true }
+      sinon.stub(auth, 'decodeJWT').resolves({
+        user: mockUser,
+        error: null
+      })
+      sinon.stub(auth, 'verify').resolves({
+        data: mockUser
+      })
+      const checkBearerToken = sinon.stub().callsFake(() => Promise.resolve('mockAuth'))
+      const authClient = { ...defaultAuthClient, checkBearerToken }
+      render(
+        <ClassifierContainer
+          authClient={authClient}
+          project={projectSnapshot}
+          workflowID={workflowSnapshot.id}
+        />,
+        {
+          wrapper: withGrommet()
+        }
+      )
+      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
+      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
+    })
+
+    afterEach(function () {
+      sinon.restore()
+      nock.cleanAll()
+      cleanStore()
+    })
+
+    it('should not request a workflow', function () {
+      expect(workflowRequest.isDone()).to.be.false()
+    })
+
+    it('should not load the subject queue', function () {
+      expect(subjectsRequest.isDone()).to.be.false()
+    })
+  })
+})

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.spec.js
@@ -58,7 +58,7 @@ describe('components > ClassifierContainer', function () {
   }
 
   describe('anonymous volunteers', function () {
-    let taskAnswers, subjectsRequest, workflowRequest
+    let taskAnswers, firstSubjectsRequest, secondSubjectsRequest, workflowRequest
     const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
     const workflowSnapshot = branchingWorkflow
     workflowSnapshot.strings = workflowStrings
@@ -85,10 +85,14 @@ describe('components > ClassifierContainer', function () {
         .query(true)
         .reply(200, { project_roles: [] })
 
-      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+      firstSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get('/subjects/queued')
         .query(true)
         .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      secondSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [...Factory.buildList('subject', 10)] })
       workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get(`/workflows/${workflowSnapshot.id}`)
         .query(true)
@@ -106,9 +110,7 @@ describe('components > ClassifierContainer', function () {
           wrapper: withGrommet()
         }
       )
-      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
-      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
-      const tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const tabPanel = await screen.findByRole('tabpanel', { name: '1 Tab Contents'})
       const task = workflowSnapshot.tasks.T0
       const getAnswerInput = answer => within(tabPanel).findByRole('radio', { name: answer.label })
       taskAnswers = await Promise.all(task.answers.map(getAnswerInput))
@@ -126,7 +128,8 @@ describe('components > ClassifierContainer', function () {
         expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
       })
       expect(workflowRequest.isDone()).to.be.true()
-      expect(subjectsRequest.isDone()).to.be.true()
+      expect(firstSubjectsRequest.isDone()).to.be.true()
+      expect(secondSubjectsRequest.isDone()).to.be.false()
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
@@ -136,7 +139,7 @@ describe('components > ClassifierContainer', function () {
   })
 
   describe('signed-in volunteers without a stored Panoptes session', function () {
-    let taskAnswers, subjectsRequest, workflowRequest
+    let taskAnswers, firstSubjectsRequest, secondSubjectsRequest, workflowRequest
     const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
     const workflowSnapshot = branchingWorkflow
     workflowSnapshot.strings = workflowStrings
@@ -168,10 +171,14 @@ describe('components > ClassifierContainer', function () {
         .get('/me')
         .reply(200, { users: [mockUser] })
 
-      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+      firstSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get('/subjects/queued')
         .query(true)
         .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      secondSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [...Factory.buildList('subject', 10)] })
       workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get(`/workflows/${workflowSnapshot.id}`)
         .query(true)
@@ -189,9 +196,7 @@ describe('components > ClassifierContainer', function () {
           wrapper: withGrommet()
         }
       )
-      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
-      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
-      const tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const tabPanel = await screen.findByRole('tabpanel', { name: '1 Tab Contents'})
       const task = workflowSnapshot.tasks.T0
       const getAnswerInput = answer => within(tabPanel).findByRole('radio', { name: answer.label })
       taskAnswers = await Promise.all(task.answers.map(getAnswerInput))
@@ -209,7 +214,8 @@ describe('components > ClassifierContainer', function () {
         expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
       })
       expect(workflowRequest.isDone()).to.be.true()
-      expect(subjectsRequest.isDone()).to.be.true()
+      expect(firstSubjectsRequest.isDone()).to.be.true()
+      expect(secondSubjectsRequest.isDone()).to.be.false()
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
@@ -219,7 +225,7 @@ describe('components > ClassifierContainer', function () {
   })
 
   describe('signed-in volunteers with a stored Panoptes session', function () {
-    let taskAnswers, subjectsRequest, workflowRequest
+    let taskAnswers, firstSubjectsRequest, secondSubjectsRequest, workflowRequest
     const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
     const workflowSnapshot = branchingWorkflow
     workflowSnapshot.strings = workflowStrings
@@ -244,10 +250,14 @@ describe('components > ClassifierContainer', function () {
         .query(true)
         .reply(200, { project_roles: [{ roles }] })
 
-      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+      firstSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get('/subjects/queued')
         .query(true)
         .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      secondSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [...Factory.buildList('subject', 10)] })
       workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get(`/workflows/${workflowSnapshot.id}`)
         .query(true)
@@ -273,9 +283,7 @@ describe('components > ClassifierContainer', function () {
           wrapper: withGrommet()
         }
       )
-      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
-      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
-      const tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const tabPanel = await screen.findByRole('tabpanel', { name: '1 Tab Contents'})
       const task = workflowSnapshot.tasks.T0
       const getAnswerInput = answer => within(tabPanel).findByRole('radio', { name: answer.label })
       taskAnswers = await Promise.all(task.answers.map(getAnswerInput))
@@ -293,7 +301,8 @@ describe('components > ClassifierContainer', function () {
         expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
       })
       expect(workflowRequest.isDone()).to.be.true()
-      expect(subjectsRequest.isDone()).to.be.true()
+      expect(firstSubjectsRequest.isDone()).to.be.true()
+      expect(secondSubjectsRequest.isDone()).to.be.false()
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
@@ -303,7 +312,7 @@ describe('components > ClassifierContainer', function () {
   })
 
   describe('Project owner', function () {
-    let taskAnswers, subjectsRequest, workflowRequest
+    let taskAnswers, firstSubjectsRequest, secondSubjectsRequest, workflowRequest
     const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
     const workflowSnapshot = branchingWorkflow
     workflowSnapshot.strings = workflowStrings
@@ -328,10 +337,14 @@ describe('components > ClassifierContainer', function () {
         .query(true)
         .reply(200, { project_roles: [{ roles }] })
 
-      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+      firstSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get('/subjects/queued')
         .query(true)
         .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      secondSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [...Factory.buildList('subject', 10)] })
       workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get(`/workflows/${workflowSnapshot.id}`)
         .query(true)
@@ -357,9 +370,7 @@ describe('components > ClassifierContainer', function () {
           wrapper: withGrommet()
         }
       )
-      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
-      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
-      const tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const tabPanel = await screen.findByRole('tabpanel', { name: '1 Tab Contents'})
       const task = workflowSnapshot.tasks.T0
       const getAnswerInput = answer => within(tabPanel).findByRole('radio', { name: answer.label })
       taskAnswers = await Promise.all(task.answers.map(getAnswerInput))
@@ -377,7 +388,8 @@ describe('components > ClassifierContainer', function () {
         expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
       })
       expect(workflowRequest.isDone()).to.be.true()
-      expect(subjectsRequest.isDone()).to.be.true()
+      expect(firstSubjectsRequest.isDone()).to.be.true()
+      expect(secondSubjectsRequest.isDone()).to.be.false()
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
@@ -387,7 +399,7 @@ describe('components > ClassifierContainer', function () {
   })
 
   describe('Project collaborator', function () {
-    let taskAnswers, subjectsRequest, workflowRequest
+    let taskAnswers, firstSubjectsRequest, secondSubjectsRequest, workflowRequest
     const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
     const workflowSnapshot = branchingWorkflow
     workflowSnapshot.strings = workflowStrings
@@ -412,10 +424,14 @@ describe('components > ClassifierContainer', function () {
         .query(true)
         .reply(200, { project_roles: [{ roles }] })
 
-      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+      firstSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get('/subjects/queued')
         .query(true)
         .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      secondSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [...Factory.buildList('subject', 10)] })
       workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get(`/workflows/${workflowSnapshot.id}`)
         .query(true)
@@ -441,9 +457,7 @@ describe('components > ClassifierContainer', function () {
           wrapper: withGrommet()
         }
       )
-      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
-      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
-      const tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const tabPanel = await screen.findByRole('tabpanel', { name: '1 Tab Contents'})
       const task = workflowSnapshot.tasks.T0
       const getAnswerInput = answer => within(tabPanel).findByRole('radio', { name: answer.label })
       taskAnswers = await Promise.all(task.answers.map(getAnswerInput))
@@ -461,7 +475,8 @@ describe('components > ClassifierContainer', function () {
         expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
       })
       expect(workflowRequest.isDone()).to.be.true()
-      expect(subjectsRequest.isDone()).to.be.true()
+      expect(firstSubjectsRequest.isDone()).to.be.true()
+      expect(secondSubjectsRequest.isDone()).to.be.false()
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
@@ -471,7 +486,7 @@ describe('components > ClassifierContainer', function () {
   })
 
   describe('Project tester', function () {
-    let taskAnswers, subjectsRequest, workflowRequest
+    let taskAnswers, firstSubjectsRequest, secondSubjectsRequest, workflowRequest
     const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
     const workflowSnapshot = branchingWorkflow
     workflowSnapshot.strings = workflowStrings
@@ -496,10 +511,14 @@ describe('components > ClassifierContainer', function () {
         .query(true)
         .reply(200, { project_roles: [{ roles }] })
 
-      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+      firstSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get('/subjects/queued')
         .query(true)
         .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      secondSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [...Factory.buildList('subject', 10)] })
       workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get(`/workflows/${workflowSnapshot.id}`)
         .query(true)
@@ -525,9 +544,7 @@ describe('components > ClassifierContainer', function () {
           wrapper: withGrommet()
         }
       )
-      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
-      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
-      const tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const tabPanel = await screen.findByRole('tabpanel', { name: '1 Tab Contents'})
       const task = workflowSnapshot.tasks.T0
       const getAnswerInput = answer => within(tabPanel).findByRole('radio', { name: answer.label })
       taskAnswers = await Promise.all(task.answers.map(getAnswerInput))
@@ -545,7 +562,8 @@ describe('components > ClassifierContainer', function () {
         expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
       })
       expect(workflowRequest.isDone()).to.be.true()
-      expect(subjectsRequest.isDone()).to.be.true()
+      expect(firstSubjectsRequest.isDone()).to.be.true()
+      expect(secondSubjectsRequest.isDone()).to.be.false()
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
@@ -555,7 +573,7 @@ describe('components > ClassifierContainer', function () {
   })
 
   describe('admins: in admin mode', function () {
-    let taskAnswers, subjectsRequest, workflowRequest
+    let taskAnswers, firstSubjectsRequest, secondSubjectsRequest, workflowRequest
     const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
     const workflowSnapshot = branchingWorkflow
     workflowSnapshot.strings = workflowStrings
@@ -580,10 +598,14 @@ describe('components > ClassifierContainer', function () {
         .query(true)
         .reply(200, { project_roles: [{ roles }] })
 
-      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+      firstSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get('/subjects/queued')
         .query(true)
         .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      secondSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [...Factory.buildList('subject', 10)] })
       workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get(`/workflows/${workflowSnapshot.id}`)
         .query(true)
@@ -610,9 +632,7 @@ describe('components > ClassifierContainer', function () {
           wrapper: withGrommet()
         }
       )
-      const taskTab = await screen.findByRole('tab', { name: 'TaskArea.task'})
-      const tutorialTab = screen.queryByRole('tab', { name: 'TaskArea.tutorial'})
-      const tabPanel = screen.queryByRole('tabpanel', { name: '1 Tab Contents'})
+      const tabPanel = await screen.findByRole('tabpanel', { name: '1 Tab Contents'})
       const task = workflowSnapshot.tasks.T0
       const getAnswerInput = answer => within(tabPanel).findByRole('radio', { name: answer.label })
       taskAnswers = await Promise.all(task.answers.map(getAnswerInput))
@@ -630,7 +650,8 @@ describe('components > ClassifierContainer', function () {
         expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
       })
       expect(workflowRequest.isDone()).to.be.true()
-      expect(subjectsRequest.isDone()).to.be.true()
+      expect(firstSubjectsRequest.isDone()).to.be.true()
+      expect(secondSubjectsRequest.isDone()).to.be.false()
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
@@ -640,7 +661,7 @@ describe('components > ClassifierContainer', function () {
   })
 
   describe('admins: not in admin mode', function () {
-    let taskAnswers, subjectsRequest, workflowRequest
+    let taskAnswers, firstSubjectsRequest, secondSubjectsRequest, workflowRequest
     const subjectSnapshot = SubjectFactory.build({ locations: [{ 'image/png': 'https://foo.bar/example.png' }] })
     const workflowSnapshot = branchingWorkflow
     workflowSnapshot.strings = workflowStrings
@@ -665,10 +686,14 @@ describe('components > ClassifierContainer', function () {
         .query(true)
         .reply(200, { project_roles: [{ roles }] })
 
-      subjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+      firstSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get('/subjects/queued')
         .query(true)
         .reply(200, { subjects: [subjectSnapshot, ...Factory.buildList('subject', 9)] })
+      secondSubjectsRequest = nock('https://panoptes-staging.zooniverse.org/api')
+        .get('/subjects/queued')
+        .query(true)
+        .reply(200, { subjects: [...Factory.buildList('subject', 10)] })
       workflowRequest = nock('https://panoptes-staging.zooniverse.org/api')
         .get(`/workflows/${workflowSnapshot.id}`)
         .query(true)
@@ -709,7 +734,8 @@ describe('components > ClassifierContainer', function () {
     })
 
     it('should not load the subject queue', function () {
-      expect(subjectsRequest.isDone()).to.be.false()
+      expect(firstSubjectsRequest.isDone()).to.be.false()
+      expect(secondSubjectsRequest.isDone()).to.be.false()
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
@@ -18,12 +18,14 @@ import postTalkDiscussion from './helpers/postTalkDiscussion'
 
 function storeMapper(store) {
   const {
+    authClient,
     subjects: {
       active: subject
     }
   } = store
 
   return {
+    authClient,
     subject
   }
 }
@@ -39,8 +41,8 @@ const SWROptions = {
 function QuickTalkContainer () {
 
   const { t } = useTranslation()
-  const { subject } = useStores(storeMapper)
-  const user = usePanoptesUser()
+  const { authClient, subject } = useStores(storeMapper)
+  const { user } = usePanoptesUser(authClient)
   const userId = user?.id
   const authorization = usePanoptesAuth(userId)
   const { data: comments } = useSWR(subject, getTalkComments, SWROptions)

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
@@ -44,7 +44,7 @@ function QuickTalkContainer () {
   const { authClient, subject } = useStores(storeMapper)
   const { user } = usePanoptesUser(authClient)
   const userId = user?.id
-  const authorization = usePanoptesAuth(userId)
+  const authorization = usePanoptesAuth({ authClient, userID: userId })
   const { data: comments } = useSWR(subject, getTalkComments, SWROptions)
 
   let author_ids = comments?.map(comment => comment.user_id)

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalkContainer.js
@@ -42,7 +42,7 @@ function QuickTalkContainer () {
 
   const { t } = useTranslation()
   const { authClient, subject } = useStores(storeMapper)
-  const { user } = usePanoptesUser(authClient)
+  const { data: user } = usePanoptesUser(authClient)
   const userId = user?.id
   const authorization = usePanoptesAuth({ authClient, userID: userId })
   const { data: comments } = useSWR(subject, getTalkComments, SWROptions)

--- a/packages/lib-classifier/src/components/Classifier/hooks/usePanoptesUserSession.js
+++ b/packages/lib-classifier/src/components/Classifier/hooks/usePanoptesUserSession.js
@@ -1,0 +1,19 @@
+import {
+  usePanoptesUser,
+  useProjectPreferences,
+  useProjectRoles
+} from '@hooks'
+
+export default function usePanoptesUserSession({ authClient, projectID }) {
+  const { user, loading: userLoading } = usePanoptesUser(authClient)
+  const userID = !userLoading && user?.id
+  const { data: upp, isLoading: uppLoading } = useProjectPreferences({ authClient, projectID, userID })
+  const { data: projectRoles, isLoading: rolesLoading } = useProjectRoles({ authClient, projectID, userID })
+  const userHasLoaded = userID ?
+    // logged-in user is loaded once we have user, preferences and roles.
+    !!userID && !!upp && !!projectRoles :
+    // anonymous user's are always falsy but ready once all API checks have resolved.
+    !userLoading && !uppLoading && !rolesLoading
+
+  return { user, upp, projectRoles, userHasLoaded }
+}

--- a/packages/lib-classifier/src/components/Classifier/hooks/usePanoptesUserSession.js
+++ b/packages/lib-classifier/src/components/Classifier/hooks/usePanoptesUserSession.js
@@ -5,7 +5,7 @@ import {
 } from '@hooks'
 
 export default function usePanoptesUserSession({ authClient, projectID }) {
-  const { user, loading: userLoading } = usePanoptesUser(authClient)
+  const { data: user, isLoading: userLoading } = usePanoptesUser(authClient)
   const userID = !userLoading && user?.id
   const { data: upp, isLoading: uppLoading } = useProjectPreferences({ authClient, projectID, userID })
   const { data: projectRoles, isLoading: rolesLoading } = useProjectRoles({ authClient, projectID, userID })

--- a/packages/lib-classifier/src/hooks/Readme.md
+++ b/packages/lib-classifier/src/hooks/Readme.md
@@ -58,7 +58,7 @@ Get the logged-in user, or null if no one is logged in. `loading` will be true w
 
 ```js
   const { authClient } = useStores()
-  const { loading, user } = usePanoptesUser(authClient)
+  const { data: user, error, isLoading } = usePanoptesUser(authClient)
 ```
 
 ## useProjectPreferences

--- a/packages/lib-classifier/src/hooks/Readme.md
+++ b/packages/lib-classifier/src/hooks/Readme.md
@@ -64,16 +64,21 @@ Get the logged-in user, or null if no one is logged in. `loading` will be true w
 ## useProjectPreferences
 
 Get project preferences for a user and project, or null if there's no one logged in.
+
+Returns a `useSWR` hook. See the [`useSWR` API](https://swr.vercel.app/docs/api) for all returned properties.
+
 ```js
-  const upp = useProjectPreferences({ authClient, projectID, userID })
+  const { data: upp, isLoading } = useProjectPreferences({ authClient, projectID, userID })
 ```
 
 ## useProjectRoles
 
 Get the logged-in user's project roles, as an array of strings, or an empty array if no one is logged in.
 
+Returns a `useSWR` hook. See the [`useSWR` API](https://swr.vercel.app/docs/api) for all returned properties.
+
 ```js
-  const projectRoles = useProjectRoles({ authClient, projectID, userID })
+  const { data: projectRoles, isLoading } = useProjectRoles({ authClient, projectID, userID })
 ```
 
 ## useStores

--- a/packages/lib-classifier/src/hooks/Readme.md
+++ b/packages/lib-classifier/src/hooks/Readme.md
@@ -54,10 +54,11 @@ const translations = usePanoptesTranslations({ translated_id, translated_type, l
 
 ## usePanoptesUser
 
-Get the logged-in user, or null if no one is logged in.
+Get the logged-in user, or null if no one is logged in. `loading` will be true while new user state is being fetched from Panoptes.
 
 ```js
-  const user = usePanoptesUser()
+  const { authClient } = useStores()
+  const { loading, user } = usePanoptesUser(authClient)
 ```
 
 ## useProjectPreferences

--- a/packages/lib-classifier/src/hooks/Readme.md
+++ b/packages/lib-classifier/src/hooks/Readme.md
@@ -41,7 +41,7 @@ const onKeyZoom = useKeyZoom()
 Asynchronously fetch an auth token, for a given user ID. A wrapper for `authClient.checkBearerToken()`.
 
 ```js
-  const authorization = usePanoptesAuth(user.id)
+  const authorization = usePanoptesAuth({ authClient, userID })
 ```
 
 ## usePanoptesTranslations
@@ -65,7 +65,7 @@ Get the logged-in user, or null if no one is logged in. `loading` will be true w
 
 Get project preferences for a user and project, or null if there's no one logged in.
 ```js
-  const upp = useProjectPreferences(project.id, user.id)
+  const upp = useProjectPreferences({ authClient, projectID, userID })
 ```
 
 ## useProjectRoles
@@ -73,7 +73,7 @@ Get project preferences for a user and project, or null if there's no one logged
 Get the logged-in user's project roles, as an array of strings, or an empty array if no one is logged in.
 
 ```js
-  const projectRoles = useProjectRoles(project.id, user.id)
+  const projectRoles = useProjectRoles({ authClient, projectID, userID })
 ```
 
 ## useStores

--- a/packages/lib-classifier/src/hooks/useHydratedStore.js
+++ b/packages/lib-classifier/src/hooks/useHydratedStore.js
@@ -70,8 +70,10 @@ function initStore({ cachePanoptesData, storageKey, storeEnv }) {
 }
 
 export function cleanStore() {
-  destroy(store)
-  store = null
+  if (store) {
+    destroy(store)
+    store = null
+  }
 }
 
 export default function useHydratedStore(storeEnv = {}, cachePanoptesData = false, storageKey) {

--- a/packages/lib-classifier/src/hooks/useHydratedStore.spec.js
+++ b/packages/lib-classifier/src/hooks/useHydratedStore.spec.js
@@ -12,6 +12,7 @@ describe('Hooks > useHydratedStore', function () {
     let store
 
     beforeEach(function () {
+      cleanStore()
       const { authClient, client } = mockStore()
       const { result } = renderHook(() => useHydratedStore({ authClient, client }, false, 'test-key'))
       store = result.current
@@ -33,6 +34,7 @@ describe('Hooks > useHydratedStore', function () {
     let newStore
 
     beforeEach(function () {
+      cleanStore()
       const { authClient, client } = mockStore()
       const { result: firstRun } = renderHook(() => useHydratedStore({ authClient, client }, false, 'test-key'))
       store = firstRun.current

--- a/packages/lib-classifier/src/hooks/usePanoptesAuth.js
+++ b/packages/lib-classifier/src/hooks/usePanoptesAuth.js
@@ -3,8 +3,7 @@ import { useEffect, useState } from 'react'
 import { useStores } from '@hooks'
 import { getBearerToken } from '@store/utils'
 
-export default function usePanoptesAuth(userID) {
-  const { authClient } = useStores()
+export default function usePanoptesAuth({ authClient, userID }) {
   const [authorization, setAuthorization] = useState()
   async function checkAuth() {
     const token = await getBearerToken(authClient)
@@ -13,7 +12,7 @@ export default function usePanoptesAuth(userID) {
 
   useEffect(function onUserChange() {
     checkAuth()
-  }, [userID])
+  }, [authClient, userID])
 
   return authorization
 }

--- a/packages/lib-classifier/src/hooks/usePanoptesAuth.js
+++ b/packages/lib-classifier/src/hooks/usePanoptesAuth.js
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 
-import { useStores } from '@hooks'
 import { getBearerToken } from '@store/utils'
 
 export default function usePanoptesAuth({ authClient, userID }) {

--- a/packages/lib-classifier/src/hooks/usePanoptesUser.js
+++ b/packages/lib-classifier/src/hooks/usePanoptesUser.js
@@ -1,7 +1,6 @@
 import { auth } from '@zooniverse/panoptes-js'
 import { useEffect, useState } from 'react'
 
-import { useStores } from '@hooks'
 import { getBearerToken } from '@store/utils'
 
 async function decodeJWT(token) {
@@ -41,14 +40,16 @@ async function fetchPanoptesUser(authClient) {
   }
 }
 
-export default function usePanoptesUser() {
-  const { authClient } = useStores()
+export default function usePanoptesUser(authClient) {
   const [user, setUser] = useState(null)
+  const [loading, setLoading] = useState(true)
 
   useEffect(function () {
     async function checkUserSession() {
+      setLoading(true)
       const panoptesUser = await fetchPanoptesUser(authClient)
       setUser(panoptesUser)
+      setLoading(false)
     }
 
     checkUserSession()
@@ -59,5 +60,5 @@ export default function usePanoptesUser() {
     }
   }, [authClient])
 
-  return user
+  return { user, loading }
 }

--- a/packages/lib-classifier/src/hooks/usePanoptesUser.js
+++ b/packages/lib-classifier/src/hooks/usePanoptesUser.js
@@ -1,6 +1,45 @@
+import { auth } from '@zooniverse/panoptes-js'
 import { useEffect, useState } from 'react'
 
 import { useStores } from '@hooks'
+import { getBearerToken } from '@store/utils'
+
+async function decodeJWT(token) {
+  let user = null
+  let error = null
+  const decodedToken = await auth.verify(token)
+  const { data } = decodedToken
+  error = decodedToken.error
+  if (data) {
+    user = {
+      id: data.id.toString(),
+      login: data.login,
+      display_name: data.dname,
+      admin: data.admin
+    }
+  }
+  return { user, error }
+}
+
+async function fetchPanoptesUser(authClient) {
+  try {
+    const authorization = await getBearerToken(authClient)
+    if (authorization) {
+      const token = authorization.replace('Bearer ', '')
+      const { user, error } = await decodeJWT(token)
+      if (user) {
+        return user
+      }
+      if (error) {
+        throw error
+      }
+    }
+    return await authClient.checkCurrent()
+  } catch (error) {
+    console.log(error)
+    return null
+  }
+}
 
 export default function usePanoptesUser() {
   const { authClient } = useStores()
@@ -8,7 +47,7 @@ export default function usePanoptesUser() {
 
   useEffect(function () {
     async function checkUserSession() {
-      const panoptesUser = await authClient.checkCurrent()
+      const panoptesUser = await fetchPanoptesUser(authClient)
       setUser(panoptesUser)
     }
 

--- a/packages/lib-classifier/src/hooks/usePanoptesUser.js
+++ b/packages/lib-classifier/src/hooks/usePanoptesUser.js
@@ -3,29 +3,11 @@ import { useEffect, useState } from 'react'
 
 import { getBearerToken } from '@store/utils'
 
-async function decodeJWT(token) {
-  let user = null
-  let error = null
-  const decodedToken = await auth.verify(token)
-  const { data } = decodedToken
-  error = decodedToken.error
-  if (data) {
-    user = {
-      id: data.id.toString(),
-      login: data.login,
-      display_name: data.dname,
-      admin: data.admin
-    }
-  }
-  return { user, error }
-}
-
 async function fetchPanoptesUser(authClient) {
   try {
     const authorization = await getBearerToken(authClient)
     if (authorization) {
-      const token = authorization.replace('Bearer ', '')
-      const { user, error } = await decodeJWT(token)
+      const { user, error } = await auth.decodeJWT(authorization)
       if (user) {
         return user
       }

--- a/packages/lib-classifier/src/hooks/usePanoptesUser.js
+++ b/packages/lib-classifier/src/hooks/usePanoptesUser.js
@@ -23,14 +23,19 @@ async function fetchPanoptesUser(authClient) {
 }
 
 export default function usePanoptesUser(authClient) {
+  const [error, setError] = useState(null)
   const [user, setUser] = useState(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(function () {
     async function checkUserSession() {
       setLoading(true)
-      const panoptesUser = await fetchPanoptesUser(authClient)
-      setUser(panoptesUser)
+      try {
+        const panoptesUser = await fetchPanoptesUser(authClient)
+        setUser(panoptesUser)
+      } catch (error) {
+        setError(error)
+      }
       setLoading(false)
     }
 
@@ -42,5 +47,5 @@ export default function usePanoptesUser(authClient) {
     }
   }, [authClient])
 
-  return { user, loading }
+  return { data: user, error, isLoading: loading }
 }

--- a/packages/lib-classifier/src/hooks/useProjectPreferences.js
+++ b/packages/lib-classifier/src/hooks/useProjectPreferences.js
@@ -48,6 +48,6 @@ async function fetchOrCreateProjectPreferences({ endpoint, projectID, userID, au
 export default function useProjectPreferences({ authClient, projectID, userID }) {
   const authorization = usePanoptesAuth({ authClient, userID })
   const endpoint = '/project_preferences'
-  const { data } = useSWR({ endpoint, projectID, userID, authorization }, fetchOrCreateProjectPreferences, SWRoptions)
-  return data
+  const key = userID && authorization ? { endpoint, projectID, userID, authorization } : null
+  return useSWR(key, fetchOrCreateProjectPreferences, SWRoptions)
 }

--- a/packages/lib-classifier/src/hooks/useProjectPreferences.js
+++ b/packages/lib-classifier/src/hooks/useProjectPreferences.js
@@ -11,9 +11,9 @@ const SWRoptions = {
   refreshInterval: 0
 }
 
-async function createProjectPreferences({ endpoint, project_id, authorization }) {
+async function createProjectPreferences({ endpoint, projectID, authorization }) {
   const data = {
-    links: { project: project_id },
+    links: { project: projectID },
     preferences: {}
   }
   const { body } = await panoptes.post(endpoint, { project_preferences: data }, { authorization })
@@ -21,33 +21,33 @@ async function createProjectPreferences({ endpoint, project_id, authorization })
   return projectPreferences
 }
 
-async function fetchProjectPreferences({ endpoint, project_id, user_id, authorization }) {
-  const { body } = await panoptes.get(endpoint, { project_id, user_id }, { authorization })
+async function fetchProjectPreferences({ endpoint, projectID, userID, authorization }) {
+  const { body } = await panoptes.get(endpoint, { project_id: projectID, user_id: userID }, { authorization })
   const [projectPreferences] = body.project_preferences
   return projectPreferences
 }
 
-async function fetchOrCreateProjectPreferences({ endpoint, project_id, user_id, authorization }) {
+async function fetchOrCreateProjectPreferences({ endpoint, projectID, userID, authorization }) {
   // auth is undefined while loading
   if (authorization === undefined) {
     return undefined
   }
   // logged-in
   if (authorization) {
-    const projectPreferences = await fetchProjectPreferences({ endpoint, project_id, user_id, authorization })
+    const projectPreferences = await fetchProjectPreferences({ endpoint, projectID, userID, authorization })
     if (projectPreferences) {
       return projectPreferences
     } else {
-      return await createProjectPreferences({ endpoint, project_id, authorization })
+      return await createProjectPreferences({ endpoint, projectID, authorization })
     }
   }
   // not logged-in
   return null
 }
 
-export default function useProjectPreferences(project_id, user_id) {
-  const authorization = usePanoptesAuth(user_id)
+export default function useProjectPreferences({ authClient, projectID, userID }) {
+  const authorization = usePanoptesAuth({ authClient, userID })
   const endpoint = '/project_preferences'
-  const { data } = useSWR({ endpoint, project_id, user_id, authorization }, fetchOrCreateProjectPreferences, SWRoptions)
+  const { data } = useSWR({ endpoint, projectID, userID, authorization }, fetchOrCreateProjectPreferences, SWRoptions)
   return data
 }

--- a/packages/lib-classifier/src/hooks/useProjectRoles.js
+++ b/packages/lib-classifier/src/hooks/useProjectRoles.js
@@ -15,7 +15,7 @@ async function fetchProjectRoles({ endpoint, projectID, userID, authorization })
   if (authorization) {
     const { body } = await panoptes.get(endpoint, { project_id: projectID, user_id: userID }, { authorization })
     const [projectRoles] = body.project_roles
-    return projectRoles.roles
+    return projectRoles.roles || []
   }
   return []
 }
@@ -24,5 +24,5 @@ export default function useProjectRoles({ authClient, projectID, userID }) {
   const authorization = usePanoptesAuth({ authClient, userID })
   const endpoint = '/project_roles'
   const { data } = useSWR({ endpoint, projectID, userID, authorization }, fetchProjectRoles, SWRoptions)
-  return data ?? []
+  return data
 }

--- a/packages/lib-classifier/src/hooks/useProjectRoles.js
+++ b/packages/lib-classifier/src/hooks/useProjectRoles.js
@@ -11,18 +11,18 @@ const SWRoptions = {
   refreshInterval: 0
 }
 
-async function fetchProjectRoles({ endpoint, project_id, user_id, authorization }) {
+async function fetchProjectRoles({ endpoint, projectID, userID, authorization }) {
   if (authorization) {
-    const { body } = await panoptes.get(endpoint, { project_id, user_id }, { authorization })
+    const { body } = await panoptes.get(endpoint, { project_id: projectID, user_id: userID }, { authorization })
     const [projectRoles] = body.project_roles
     return projectRoles.roles
   }
   return []
 }
 
-export default function useProjectRoles(project_id, user_id) {
-  const authorization = usePanoptesAuth(user_id)
+export default function useProjectRoles({ authClient, projectID, userID }) {
+  const authorization = usePanoptesAuth({ authClient, userID })
   const endpoint = '/project_roles'
-  const { data } = useSWR({ endpoint, project_id, user_id, authorization }, fetchProjectRoles, SWRoptions)
+  const { data } = useSWR({ endpoint, projectID, userID, authorization }, fetchProjectRoles, SWRoptions)
   return data ?? []
 }

--- a/packages/lib-classifier/src/hooks/useProjectRoles.js
+++ b/packages/lib-classifier/src/hooks/useProjectRoles.js
@@ -15,7 +15,7 @@ async function fetchProjectRoles({ endpoint, projectID, userID, authorization })
   if (authorization) {
     const { body } = await panoptes.get(endpoint, { project_id: projectID, user_id: userID }, { authorization })
     const [projectRoles] = body.project_roles
-    return projectRoles.roles || []
+    return projectRoles?.roles || []
   }
   return []
 }
@@ -23,6 +23,6 @@ async function fetchProjectRoles({ endpoint, projectID, userID, authorization })
 export default function useProjectRoles({ authClient, projectID, userID }) {
   const authorization = usePanoptesAuth({ authClient, userID })
   const endpoint = '/project_roles'
-  const { data } = useSWR({ endpoint, projectID, userID, authorization }, fetchProjectRoles, SWRoptions)
-  return data
+  const key = userID && authorization ? { endpoint, projectID, userID, authorization } : null
+  return useSWR(key, fetchProjectRoles, SWRoptions)
 }

--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -81,7 +81,6 @@ const RootStore = types
       await self.authClient?.checkCurrent()
       window.sessionStorage.removeItem('subjectsSeenThisSession')
       self.subjects.reset()
-      self.subjects.populateQueue()
     }
 
     // Public actions

--- a/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
+++ b/packages/lib-classifier/src/store/SubjectViewerStore/SubjectViewerStore.js
@@ -1,6 +1,6 @@
 import asyncStates from '@zooniverse/async-states'
 import { autorun } from 'mobx'
-import { addDisposer, getRoot, isValidReference, types } from 'mobx-state-tree'
+import { addDisposer, getRoot, isValidReference, tryReference, types } from 'mobx-state-tree'
 
 const SubjectViewer = types
   .model('SubjectViewer', {
@@ -39,7 +39,7 @@ const SubjectViewer = types
 
   .views(self => ({
     get disableImageToolbar () {
-      const subject = getRoot(self).subjects.active
+      const subject = tryReference(() => getRoot(self).subjects?.active)
       const frameType = subject?.locations[self.frame].type
       if (frameType === 'text' || frameType === 'video') {
         return true

--- a/packages/lib-classifier/src/store/WorkflowStore/WorkflowStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/WorkflowStore.js
@@ -24,13 +24,11 @@ const WorkflowStore = types
 
   .actions(self => {
 
-    function * selectWorkflow(id = self.defaultWorkflowID, subjectSetID, subjectID, canPreviewWorkflows = false) {
+    function * selectWorkflow(id = self.defaultWorkflowID, subjectSetID, subjectID) {
       if (!id) {
         throw new ReferenceError('No workflow ID available')
       }
-      const availableWorkflows = canPreviewWorkflows ?
-        self.project?.links?.workflows :
-        self.project?.links?.active_workflows
+      const availableWorkflows = self.project?.links?.workflows
 
       const { subjects } = getRoot(self)
       const activeWorkflow = tryReference(() => self.active)

--- a/packages/lib-panoptes-js/docs/CHANGELOG.md
+++ b/packages/lib-panoptes-js/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.4.0] 2023-07-04
+- add `auth.decodeJWT(token)` to get a Panoptes user from a token.
+- allow `auth` methods to accept Authorization headers (which are used in the Classifier) as well as tokens.
+
 ## [0.3.0] 2023-05-25
 - add JWT verification as `auth.verify(token)`.
 

--- a/packages/lib-panoptes-js/package.json
+++ b/packages/lib-panoptes-js/package.json
@@ -3,7 +3,7 @@
   "description": "A Javascript client for Panoptes API using Superagent",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "src/index.js",
   "repository": {
     "type": "git",

--- a/packages/lib-panoptes-js/src/auth.js
+++ b/packages/lib-panoptes-js/src/auth.js
@@ -9,7 +9,7 @@ async function verify(token) {
   try {
     const pemKey = env === 'production' ? productionKey : stagingKey
     const publicKey = await importSPKI(pemKey, 'RS512')
-    const { payload } = await jwtVerify(token, publicKey)
+    const { payload } = await jwtVerify(token.replace('Bearer ', ''), publicKey)
     data = payload.data
   } catch (e) {
     error = e
@@ -17,6 +17,21 @@ async function verify(token) {
   return { data, error }
 }
 
+async function decodeJWT(token) {
+  let user = null
+  const { data, error } = await verify(token)
+  if (data) {
+    user = {
+      id: data.id.toString(),
+      login: data.login,
+      display_name: data.dname,
+      admin: data.admin
+    }
+  }
+  return { user, error }
+}
+
 module.exports = {
+  decodeJWT,
   verify
 }


### PR DESCRIPTION
Refactor `usePanoptesUser` to get the current user from the stored Panoptes JWT (#4766.) Fall back to `auth.checkCurrent()`, which gets a new session and token from the Panoptes API, if we don't have a stored token.

Refactor the classifier to authenticate in `ClassifierContainer`, waiting until sign-in is complete and all user data has loaded before rendering the `Classifier` component (#4845 and #4875.) Move all the workflow validation up to `ClassifierContainer`, so that we validate the workflow ID (from the URL) when the user has loaded, then pass down null to `Classifier` if they don't have permission to view that workflow.

Test `ClassifierContainer`, checking that:
- inactive workflows only load when you have permission to view them.
- the mock API for `/subjects/queued` is only called once.

Fix a bug, in the project app, where updating the project user in the project app's store will unmount and mount the classifier (#4946.)

Fix a bug where a `project_roles` request is continually made (closes #4975).

The `Classifier` component uses MobX observable data, but isn't wrapped in `observer`, so I've also fixed that here.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-content-pages
- app-project
- lib-classifier

## Linked Issue and/or Talk Post
- Closes #4766.
- Closes #4845.
- Closes #4875.
- Closes #4946.
- Closes #4975.
- https://github.com/zooniverse/panoptes-javascript-client/issues/53 

## How to Review
This PR reflects on the Panoptes JSON Web Token to get the logged-in user for the project app, the content pages app and the classifier, which should be faster than pinging the API for the current user session and won’t ask Panoptes OAuth to generate a new token (https://github.com/zooniverse/panoptes-javascript-client/issues/53.) If there's no stored token yet, it falls back to `auth.checkCurrent()`, which is currently used for all user checks.

You should be able to use any project, logged-in or not, and continue to use Admin Mode without any changes to the app's behaviour.

On page load, there should only be one request to `/api/me` to get the user resource. 

Subjects should only be fetched once, with your access token, after you log in (#4875.)

Apps will still lose your stored session when they unload eg. when going from PFE to FEM on the same origin, or when going from the project app to the content pages app. That can be tested in staging, on the `https://frontend.preview.zooniverse.org` origin, after this PR merges. 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
