### PR TITLE
WorkflowSelector: prevent container from squeezing/overlapping content

### DIFF
--- a/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelector.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelector.js
@@ -48,6 +48,7 @@ function WorkflowSelector ({
           gap='xsmall'
           margin={{ top: 'small' }}
           width={{ max: 'medium' }}
+          flex='grow'
         >
           <WorkflowSelectButtons
             assignedWorkflowID={assignedWorkflowID}


### PR DESCRIPTION
## PR Overview

Fixes #4806 
Package: `app-project`
Affects: Workflow Selector.

This PR fixes an issue where - if you have project that has both locked & unlocked workflows _and_ the browser height is too short - the Workflow Selector component starts "squeezing" its content, causing it to visually overlap one another.

This is usually only visible on the project's `/classify` path (with no Workflow selected), for projects with a sufficient amount of locked & unlocked workflows.

The problem:

<img width="923" alt="image" src="https://github.com/zooniverse/front-end-monorepo/assets/13952701/367b665b-7686-42e1-ac88-4b16952de0bf">

With fix applied:

<img width="924" alt="image" src="https://github.com/zooniverse/front-end-monorepo/assets/13952701/5f0190af-410e-4025-8ac9-c7e25c40d635">

The solution is to set flex="grow" to the Workflow Selector's container (see [4806's analysis;](https://github.com/zooniverse/front-end-monorepo/issues/4806#issuecomment-1593339650) the container is the div with the pink border) to prevent it from shrinking below the height necessary to contain its children.

### Testing

Expected UI behaviour of the Workflow Selector:
- should display all workflows available to the project
- workflow buttons shouldn't overlap one another, _no matter the window size_
- if amount of workflow buttons exceeds visual space available, the (vertical) scrollbars should kick in

Testing steps:
- Open browser window (e.g. Chrome Incognito), and set height to _something short,_ e.g. 520px
- View the baseline at https://frontend.preview.zooniverse.org:3000/projects/zooniverse/gravity-spy/classify
  - Observe that the "unlocked workflows" div and "locked workflow" div both overlap.
- Compare with https://local.zooniverse.org:3000/projects/zooniverse/gravity-spy/classify?env=production
  - Observe that the visual issue no longer occurs.

Additionally:
- Change the browser height to tall (say 800px) to confirm the list of workflows still displays properly
- Change the test project [(example)](https://local.zooniverse.org:3000/projects/darkeshard/test-project-2022/classify)
- Check the Workflow Selector continues to display all workflows normally, even on the _non-`/classify`_ pages.
  - [Example: project home page](https://local.zooniverse.org:3000/projects/zooniverse/gravity-spy?env=production), for both wide & narrow layouts

### Status

Ready for review