### PR TITLE
Remove seenThisSession from ZooHeaderWrapper

### DIFF
--- a/packages/app-content-pages/src/shared/components/ZooHeaderWrapper/ZooHeaderWrapperContainer.js
+++ b/packages/app-content-pages/src/shared/components/ZooHeaderWrapper/ZooHeaderWrapperContainer.js
@@ -12,17 +12,6 @@ function useStore() {
 
 export function signOut(user) {
   user.clear()
-  // resetting the alreay seen subjects during the session tracking should move
-  // once we refactor the UPP and User resource tracking in the classifier
-  // Current implementation in classifier is possibly buggy (see discussion https://github.com/zooniverse/front-end-monorepo/discussions/2362)
-  // likely a user id prop will be passed to the classifier and that will be reacted to with an effect hook
-  /// which would reset the subject already seen tracking
-  // I needed to guarantee that this happened on sign out only so that's why this is here for now
-  const seenThisSession = (window) ? window.sessionStorage.getItem("subjectsSeenThisSession") : null
-
-  if (seenThisSession) {
-    window.sessionStorage.removeItem("subjectsSeenThisSession")
-  }
   auth.signOut()
 }
 

--- a/packages/app-content-pages/src/shared/components/ZooHeaderWrapper/ZooHeaderWrapperContainer.spec.js
+++ b/packages/app-content-pages/src/shared/components/ZooHeaderWrapper/ZooHeaderWrapperContainer.spec.js
@@ -77,12 +77,6 @@ describe('Component > ZooHeaderWrapperContainer', function () {
     expect(auth.signOut).to.have.been.calledOnce()
   })
 
-  it('should remove already seen subjects session storage', async function () {
-    expect(window.sessionStorage.getItem("subjectsSeenThisSession")).to.equal('["1234/5678"]')
-    signOut(store.user)
-    expect(window.sessionStorage.getItem("subjectsSeenThisSession")).to.be.null()
-  })
-
   describe('Sign In', function () {
     let signInButton
 

--- a/packages/app-project/src/components/ZooHeaderWrapper/ZooHeaderWrapperContainer.js
+++ b/packages/app-project/src/components/ZooHeaderWrapper/ZooHeaderWrapperContainer.js
@@ -12,17 +12,6 @@ function useStore() {
 
 export function signOut(user) {
   user.clear()
-  // resetting the alreay seen subjects during the session tracking should move
-  // once we refactor the UPP and User resource tracking in the classifier
-  // Current implementation in classifier is possibly buggy (see discussion https://github.com/zooniverse/front-end-monorepo/discussions/2362)
-  // likely a user id prop will be passed to the classifier and that will be reacted to with an effect hook
-  /// which would reset the subject already seen tracking
-  // I needed to guarantee that this happened on sign out only so that's why this is here for now
-  const seenThisSession = (window) ? window.sessionStorage.getItem("subjectsSeenThisSession") : null
-
-  if (seenThisSession) {
-    window.sessionStorage.removeItem("subjectsSeenThisSession")
-  }
   auth.signOut()
 }
 

--- a/packages/app-project/src/components/ZooHeaderWrapper/ZooHeaderWrapperContainer.spec.js
+++ b/packages/app-project/src/components/ZooHeaderWrapper/ZooHeaderWrapperContainer.spec.js
@@ -77,12 +77,6 @@ describe('Component > ZooHeaderWrapperContainer', function () {
     expect(auth.signOut).to.have.been.calledOnce()
   })
 
-  it('should remove already seen subjects session storage', async function () {
-    expect(window.sessionStorage.getItem("subjectsSeenThisSession")).to.equal('["1234/5678"]')
-    signOut(store.user)
-    expect(window.sessionStorage.getItem("subjectsSeenThisSession")).to.be.null()
-  })
-
   describe('Sign In', function () {
     let signInButton
 


### PR DESCRIPTION
`seenThisSession` is now handled by the classifier when you sign out.

See #4838. 

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-content-pages 
- app-project

## Linked Issue and/or Talk Post
- #4838. 

## How to Review
See the review for #4838. Seen subjects should be reset when the signed-in user changes. 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected