### PR TITLE
Wait before refreshing the subject queue

### DIFF
--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -77,7 +77,8 @@ const RootStore = types
       }
     }
 
-    function _onUserChange() {
+    async function _onUserChange() {
+      await self.authClient?.checkCurrent()
       window.sessionStorage.removeItem('subjectsSeenThisSession')
       self.subjects.reset()
       self.subjects.populateQueue()


### PR DESCRIPTION
Wait for sign-in to complete before refreshing the subject queue, when the auth'ed user changes.

<img width="500" alt="Screenshot of the dev console for Gravity Spy, after a new sign-in, showing that the first new subject loads after the new user is signed in." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/34f8e731-65d9-4c9a-8428-44825bbe2504">

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## Linked Issue and/or Talk Post
- closes #4847.

## How to Review
Load the Classify page while signed out, then sign in. The first request for queued subjects should be made with your Authorization header.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
