### PR TITLE
Classifier: Fix build warning about workflow assignment modal

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.js
@@ -56,7 +56,7 @@ function WorkflowAssignmentModal({ currentWorkflowID = '' }) {
       const isActive = (showPrompt && !dismissedForSession)
       setActive(isActive)
     },
-    [assignedWorkflowID, dismissedForSession, router]
+    [assignedWorkflowID, currentWorkflowID, dismissedForSession, promptAssignment]
   )
 
   function handleChange(event) {


### PR DESCRIPTION
## Package
app-content

## Linked Issue and/or Talk Post
Closes: #4860 

## Describe your changes

Added `currentWorkflowID` and `promptAssignment` to useEffect. Removed `router` as a dependency because that was the initial solution to telling the modal the workflow id had changed.

## How to Review

In app-project storybook, the Workflow Assignment Modal [story](http://localhost:9001/?path=/story/project-app-screens-classify-workflow-assignment-assignment-modal--default) should show the modal. If you check the checkbox and close the modal, workflowAssignmentModalDismissed will appear in your session storage. There should be a message in storybook that tells you that too. Open storybook in a fresh browser tab and the modal will reappear.

To test on a live project, login to zootester1 account and visit [Gravity Spy](https://localhost.zooniverse.org:3000/projects/zooniverse/gravity-spy/classify/workflow/1610?env=production) locally. The modal should appear when viewing Level 1 workflow. Check the checkbox, dismiss the modal, and refresh the page. The modal should stay hidden.

Other checks: The modal should not show when viewing a different workflow in Gravity Spy (such as [1934](https://localhost.zooniverse.org:3000/projects/zooniverse/gravity-spy/classify/workflow/1934?env=production)). The modal should not show when viewing a different project like i-fancy-cats. The modal should not show on Gravity Spy Level 1 when logged into your personal Zooniverse account, unless your account has been promoted to Level 2 for that project.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed