### PR TITLE
Project: fix collections search

### DIFF
--- a/packages/app-project/src/shared/components/CollectionsModal/components/SelectCollection/SelectCollection.js
+++ b/packages/app-project/src/shared/components/CollectionsModal/components/SelectCollection/SelectCollection.js
@@ -1,4 +1,5 @@
 import { Box, Button, FormField, Grid, Select } from 'grommet'
+import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import { useTranslation } from 'next-i18next'
 
@@ -38,7 +39,7 @@ function SelectCollection ({
           onSearch={searchText => onSearch({
             favorite: false,
             current_user_roles: 'owner,collaborator,contributor',
-            search: searchText
+            search: searchText ? searchText : undefined
           })}
           options={collections}
           valueKey='id'
@@ -70,4 +71,4 @@ SelectCollection.defaultProps = {
   selected: {}
 }
 
-export default SelectCollection
+export default observer(SelectCollection)

--- a/packages/app-project/src/shared/components/CollectionsModal/components/SelectCollection/SelectCollection.js
+++ b/packages/app-project/src/shared/components/CollectionsModal/components/SelectCollection/SelectCollection.js
@@ -2,6 +2,7 @@ import { Box, Button, FormField, Grid, Select } from 'grommet'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
 import { useTranslation } from 'next-i18next'
+import { useState } from 'react'
 
 function SelectCollection ({
   collections,
@@ -11,10 +12,23 @@ function SelectCollection ({
   onSubmit,
   selected
 }) {
+  const [searchText, setSearchText] = useState('')
   const { t } = useTranslation('components')
   const dropProps = {
     trapFocus: false
   }
+  function onTextChange(text) {
+    onSearch({
+      favorite: false,
+      current_user_roles: 'owner,collaborator,contributor',
+      search: text.length > 3 ? text : undefined
+    })
+    setSearchText(text)
+  }
+  const options = searchText.length > 3 ?
+    collections :
+    collections.filter(collection => collection.display_name.includes(searchText))
+
   return (
     <Grid
       as='form'
@@ -36,12 +50,8 @@ function SelectCollection ({
           labelKey='display_name'
           name='display_name'
           onChange={onSelect}
-          onSearch={searchText => onSearch({
-            favorite: false,
-            current_user_roles: 'owner,collaborator,contributor',
-            search: searchText ? searchText : undefined
-          })}
-          options={collections}
+          onSearch={onTextChange}
+          options={options}
           valueKey='id'
           value={selected}
         />

--- a/packages/app-project/src/shared/components/CollectionsModal/components/SelectCollection/SelectCollection.js
+++ b/packages/app-project/src/shared/components/CollectionsModal/components/SelectCollection/SelectCollection.js
@@ -27,7 +27,7 @@ function SelectCollection ({
   }
   const options = searchText.length > 3 ?
     collections :
-    collections.filter(collection => collection.display_name.includes(searchText))
+    collections.filter(collection => collection.display_name.toLowerCase().includes(searchText.toLowerCase()))
 
   return (
     <Grid

--- a/packages/app-project/src/shared/components/CollectionsModal/components/SelectCollection/SelectCollection.js
+++ b/packages/app-project/src/shared/components/CollectionsModal/components/SelectCollection/SelectCollection.js
@@ -17,17 +17,30 @@ function SelectCollection ({
   const dropProps = {
     trapFocus: false
   }
+
+  /*
+  Panoptes collections search uses Postgres full-text search, which needs at least 4 characters.
+  For shorter strings, we request all your collections then filter the display names.
+  */
+
   function onTextChange(text) {
+    const search = text.trim()
     onSearch({
       favorite: false,
       current_user_roles: 'owner,collaborator,contributor',
-      search: text.length > 3 ? text : undefined
+      search: search.length > 3 ? search : undefined
     })
-    setSearchText(text)
+    setSearchText(search.toLowerCase())
   }
-  const options = searchText.length > 3 ?
-    collections :
-    collections.filter(collection => collection.display_name.toLowerCase().includes(searchText.toLowerCase()))
+
+  const ignorePanoptesFullTextSearch = searchText.length < 4
+
+  function collectionNameFilter(collection) {
+    const displayNameLowerCase = collection.display_name.toLowerCase()
+    return displayNameLowerCase.includes(searchText)
+  }
+
+  const options = ignorePanoptesFullTextSearch ? collections.filter(collectionNameFilter) : collections
 
   return (
     <Grid

--- a/packages/app-project/src/shared/components/CollectionsModal/components/SelectCollection/SelectCollection.spec.js
+++ b/packages/app-project/src/shared/components/CollectionsModal/components/SelectCollection/SelectCollection.spec.js
@@ -49,7 +49,7 @@ describe('Component > SelectCollection', function () {
     })
 
     it('should list collections', function () {
-      expect(select.prop('options')).to.equal(collections)
+      expect(select.prop('options')).to.eql(collections)
     })
 
     it('should call the onSearch callback', function () {


### PR DESCRIPTION
- the `search` parameter should not be included in the API call when the text box is empty.
- the `SelectCollections` component should observe the project store for changes.
- Use Postgres full text search for long search strings. Otherwise, filter collection display names by short search strings. 


https://github.com/zooniverse/front-end-monorepo/assets/59547/34022d1d-b3bb-4dd4-9f1a-fc492e50b6b0






_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
app-project

## Linked Issue and/or Talk Post
- closes #4865.

## How to Review
While logged in, search your collections from the 'Add to collection' button underneath any subject on the Classify page (including subject previews.) You should be able to search both collections that you own, and collections that have been shared with you.

Clearing the text box should send an API query without the `search` parameter, which will list all your collections (up to a limit of the current page size, max. 100 in Panoptes.)

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated
