### PR TITLE
Set classification userLanguage from locale

### DIFF
--- a/packages/lib-classifier/src/store/Classification/ClassificationMetadata.js
+++ b/packages/lib-classifier/src/store/Classification/ClassificationMetadata.js
@@ -1,4 +1,5 @@
-import { types } from 'mobx-state-tree'
+import { autorun } from 'mobx'
+import { addDisposer, getRoot, types } from 'mobx-state-tree'
 
 const ClassificationMetadata = types.model('ClassificationMetadata', {
   classifier_version: types.literal('2.0'),
@@ -33,14 +34,23 @@ const ClassificationMetadata = types.model('ClassificationMetadata', {
   workflowVersion: types.string
 })
   .actions(self => ({
+    afterAttach() {
+      function _onLocaleChange() {
+        self.update({
+          userLanguage: getRoot(self)?.locale
+        })
+      }
+      addDisposer(self, autorun(_onLocaleChange))
+    },
+
     afterCreate() {
       const now = new Date()
       self.startedAt = now.toISOString()
     },
 
     update(newMetadata) {
-      Object.keys(newMetadata).forEach(key => {
-        self[key] = newMetadata[key]
+      Object.entries(newMetadata).forEach(([key, value]) => {
+        self[key] = value
       })
     }
   }))

--- a/packages/lib-classifier/src/store/Classification/ClassificationMetadata.spec.js
+++ b/packages/lib-classifier/src/store/Classification/ClassificationMetadata.spec.js
@@ -1,5 +1,8 @@
 import { getSnapshot } from 'mobx-state-tree'
 import sinon from 'sinon'
+
+import mockStore from '@test/mockStore'
+
 import ClassificationMetadata from './ClassificationMetadata'
 
 describe('Model > ClassificationMetadata', function () {
@@ -61,6 +64,15 @@ describe('Model > ClassificationMetadata', function () {
 
     it('should ignore unknown keys', function () {
       expect(snapshot.unknownKey).to.be.undefined()
+    })
+  })
+
+  describe('user language', function () {
+    it('should match the locale', function () {
+      const store = mockStore()
+      expect(store.classifications.active.metadata.userLanguage).to.equal('en')
+      store.setLocale('de')
+      expect(store.classifications.active.metadata.userLanguage).to.equal('de')
     })
   })
 })


### PR DESCRIPTION
Add an `_onLocaleChange` listener to `ClassificationMetadata`, which sets `metadata.userLanguage` from the root store locale.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## Linked Issue and/or Talk Post
- closes #4521.

## How to Review
If you change language during a classification, the classification metadata should update to match the current language.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated
