### PR TITLE
Workflow Assignment Modal: check for session storage item on every render

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.js
@@ -26,10 +26,6 @@ function useStore() {
   }
 }
 
-/** Check if user has dismissed the modal, but only in the browser */
-const isBrowser = typeof window !== 'undefined'
-const storedDismissedForSession = isBrowser ? window.sessionStorage.getItem('workflowAssignmentModalDismissed') : false
-
 function WorkflowAssignmentModal({ currentWorkflowID = '' }) {
   const { assignedWorkflowID, promptAssignment } = useStore()
 
@@ -38,6 +34,10 @@ function WorkflowAssignmentModal({ currentWorkflowID = '' }) {
   const owner = router?.query?.owner
   const project = router?.query?.project
   const url = `/${owner}/${project}/classify/workflow/${assignedWorkflowID}`
+
+  /** Check if user has dismissed the modal, but only in the browser */
+  const isBrowser = typeof window !== 'undefined'
+  const storedDismissedForSession = isBrowser ? window.sessionStorage.getItem('workflowAssignmentModalDismissed') : false
 
   /** Modal active state*/
   const [active, setActive] = useState(false)


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/4804

## Describe your changes

Move the check for `workfowAssignmentModalDismissed` (session storage) to inside WorkflowAssignmentModal's functional component. Previously, defining the constant outside of the component was resulting in it being sudo cached as `false` and not accurately checked again when needed.

## How to Review

To test on a live project, login to zootester1 account and visit [Gravity Spy](https://localhost.zooniverse.org:3000/projects/zooniverse/gravity-spy/classify/workflow/1610?env=production) locally. The modal should appear when viewing Level 1 workflow. Check the checkbox, dismiss the modal, and navigate to the project's home page. Go back to Level 1 workflow and the modal should stay hidden.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed