### PR TITLE
Implement Custom 404 page for project pages

### DIFF
--- a/packages/app-project/pages/404.js
+++ b/packages/app-project/pages/404.js
@@ -1,14 +1,17 @@
+import { ThemeContext } from 'grommet'
 import { ZooHeaderWrapper } from '@components'
 import { ZooFooter } from '@zooniverse/react-components'
 import { Box, Image, Heading, Text, Paragraph, Anchor } from 'grommet'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
+import theme404 from './../src/helpers/404theme.js'
 import styled from 'styled-components'
 
 
 const ContainerBox = styled(Box)`
   position: relative;
   color: white;
+  background-color: #000;
   z-index: 1;
 `
 
@@ -47,30 +50,26 @@ export default function Error404({
   const { t } = useTranslation('components')
 
   return (
-    <>
+    <ThemeContext.Extend value={theme404}>
       <ZooHeaderWrapper locale={locale} />
       <ContainerBox
         width="100%"
-        height="50vh"
+        height="80vh"
         alignContent="center"
-        background="#1e1e1e"
         justify="center"
-        style={{ backgroundColor: '#000' }}
       >
         <Overlay
           background={`url("${backgroundURL}")`}
           width="100%"
-          height="50vh"
+          height="80vh"
           justify="center"
-          style={{ opacity: '50%' }}
         />
-
         <PageContent
           alignContent="center"
           justify="center"
           textAlign="center"
         >
-          <Paragraph textAlign="center">
+          <Paragraph textAlign="center" style={{ margin: 0 }}>
             <Image
               id="404-logo"
               fit="contain"
@@ -80,31 +79,37 @@ export default function Error404({
               src={`/projects/assets/logoWhite404.png`}
             />
           </Paragraph>
-          <Heading level="2" textAlign="center" style={{ maxWidth: '100%' }}>{t('404.heading')}</Heading>
+          <Heading
+            level="1"
+            textAlign="center"
+            margin={{ top: '20px', bottom: '20px' }}
+            style={{ maxWidth: '100%' }}
+          >{t('404.heading')}</Heading>
           <Paragraph textAlign="center">
-            {t('404.message')}
-            <br />
-            <Anchor
-              id="404-to-project-home"
-              color="white"
-              weight="bold"
-              href={`/`}
-              label={t('404.returnHome')}
-            />
-            <br />
-            {t('404.or')}
-            <br />
-            <Anchor
-              id="404-to-project-home"
-              color="white"
-              weight="bold"
-              href={`/projects`}
-              label={t('404.findNewProject')}
-            />
+            <Text style={{ fontStyle: 'italic', display: 'block', marginBottom: '30px' }}>{t('404.message')}</Text>
+            <Text style={{ display: 'block', marginTop: '30px', marginBottom: '15px' }}>• <Anchor
+                id="404-to-project-home"
+                color="white"
+                weight="bold"
+                href={`/`}
+                label={t('404.returnHome')}
+                style={{ textDecoration: 'underline' }}
+              />
+            </Text>
+            <Text style={{ display: 'block', marginTop: '15px' }}>•&nbsp;
+              <Anchor
+                id="404-to-project-home"
+                color="white"
+                weight="bold"
+                href={`/projects`}
+                label={t('404.findNewProject')}
+                style={{ textDecoration: 'underline' }}
+              />
+            </Text>
           </Paragraph>
         </PageContent>
       </ContainerBox>
       <ZooFooter locale={locale} />
-    </>
+    </ThemeContext.Extend>
   )
 }

--- a/packages/app-project/public/locales/en/components.json
+++ b/packages/app-project/public/locales/en/components.json
@@ -1,10 +1,9 @@
 {
   "404": {
-    "heading": "Nothing here",
+    "heading": "Nothing here.",
     "message": "The page you're looking for no longer exists.",
-    "returnHome": "Return to the home page",
-    "or": "or",
-    "findNewProject": "find a new project to explore"
+    "returnHome": "Return to the homepage",
+    "findNewProject": "Find a new project to explore"
   },
   "Announcements": {
     "AuthenticationInvitation": {

--- a/packages/app-project/src/helpers/404theme.js
+++ b/packages/app-project/src/helpers/404theme.js
@@ -1,0 +1,65 @@
+const theme = {
+  heading: {
+    level: {
+      1: {
+        small: {
+          size: '37.5px',
+        },
+        medium: {
+          size: '48px',
+        },
+        large: {
+          size: '80px',
+        },
+        xlarge: {
+          size: '100px',
+        }
+      },
+      2: {
+        small: {
+          size: '18px',
+        },
+        medium: {
+          size: '24px',
+        },
+        large: {
+          size: '37.5px',
+        },
+        xlarge: {
+          size: '48px',
+        }
+      },
+    },
+  },
+  // we're treating paragraph and text the same typographically
+  paragraph: {
+    small: {
+      size: '14px',
+    },
+    medium: {
+      size: '16px',
+    },
+    large: {
+      size: '18px',
+    },
+    xlarge: {
+      size: '20px',
+    }
+  },
+  text: {
+    small: {
+      size: '14px',
+    },
+    medium: {
+      size: '16px',
+    },
+    large: {
+      size: '18px',
+    },
+    xlarge: {
+      size: '20px',
+    }
+  }
+}
+
+export default theme


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package

## Linked Issue and/or Talk Post

Toward: https://github.com/zooniverse/front-end-monorepo/issues/4257

## Describe your changes
- Update default 404 page to incorporate changes
- Create custom 404 component to handle "project not found" errors
- Incorporates rotating background images and translations

## How to Review
_Helpful explanations that will make your reviewer happy:_
- General 404: https://local.zooniverse.org:3000/projects/test404
- Missing Classification Workflow: https://local.zooniverse.org:3000/projects/kieftrav/freehand-line-test/classify/workflow/403
- Existing Classification Workflow: https://local.zooniverse.org:3000/projects/kieftrav/freehand-line-test/classify/workflow/3691?env=staging

** Still working on test and various edge cases / permutations checking. Fully working POC

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).