### PR TITLE
Experiment: remove session caching

### DIFF
--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -38,7 +38,7 @@
     "next": "~12.3.0",
     "next-absolute-url": "~1.2.2",
     "next-i18next": "~14.0.0",
-    "panoptes-client": "~5.3.0",
+    "panoptes-client": "zooniverse/panoptes-javascript-client#remove-session-caching",
     "path-match": "~1.2.4",
     "react": "~17.0.2",
     "react-dom": "~17.0.2",

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -49,7 +49,7 @@
     "newrelic": "~10.3.0",
     "next": "~12.3.0",
     "next-i18next": "~14.0.0",
-    "panoptes-client": "~5.3.0",
+    "panoptes-client": "zooniverse/panoptes-javascript-client#remove-session-caching",
     "path-match": "~1.2.4",
     "polished": "~4.2.2",
     "react": "~17.0.2",

--- a/packages/app-project/src/hooks/usePanoptesUser.js
+++ b/packages/app-project/src/hooks/usePanoptesUser.js
@@ -11,7 +11,9 @@ const SWRoptions = {
 
 async function fetchPanoptesUser() {
   try {
-    return await auth.checkCurrent()
+    const user = await auth.checkCurrent()
+    console.log({ user })
+    return user
   } catch (error) {
     console.log(error)
     return null
@@ -20,5 +22,6 @@ async function fetchPanoptesUser() {
 
 export default function usePanoptesUser(key) {
   const { data } = useSWR(key, fetchPanoptesUser, SWRoptions)
+  console.log({ data })
   return data
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13448,10 +13448,9 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
-panoptes-client@~5.3.0:
+panoptes-client@zooniverse/panoptes-javascript-client#remove-session-caching, panoptes-client@~5.3.0:
   version "5.3.0"
-  resolved "https://registry.yarnpkg.com/panoptes-client/-/panoptes-client-5.3.0.tgz#df3a870de7766d97df6837d87e5660799c5efe2f"
-  integrity sha512-1XemHMGtMB4adyyewOkn962v2rcx/8eQ7IJkDUK+48L3tadibOlWJvkeRqWxul5L8pvVODjktDfvksYyIwxlWA==
+  resolved "https://codeload.github.com/zooniverse/panoptes-javascript-client/tar.gz/c903c7e0b7e1b2e7100872305b422c358d5e86cc"
   dependencies:
     local-storage "^2.0.0"
     normalizeurl "~1.0.0"


### PR DESCRIPTION
This is an experimental build, using an API client that doesn't cache Panoptes user sessions.

- See https://github.com/zooniverse/panoptes-javascript-client/pull/208.

## Package
- app-content-pages
- app-project

## Linked Issue and/or Talk Post
 - #4892.

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
