### PR TITLE
Restore drawing tool disabled state

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -30,12 +30,14 @@ function storeMapper(classifierStore) {
   } = activeInteractionTask || {}
 
   const activeMark = tryReference(() => activeInteractionTask?.activeMark)
+  const disabled = activeTool?.disabled
 
   return {
     activeMark,
     activeTool,
     activeToolIndex,
     annotation,
+    disabled,
     frame,
     hidingIndex,
     marks,


### PR DESCRIPTION
Restore `activeTool.disabled` to the drawing canvas. It checks whether a tool has reached its maximum allowed marks. I think it was removed in #2415.

## Package
lib-classifier

## Linked Issue and/or Talk Post
- closes #4905.

## How to Review
Try adding marks with a drawing tool, until you reach the maximum configured in the project builder for that tool.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated
