### PR TITLE
Specify dimensions for Media images

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/FinishedForTheDay/components/ProjectImage/ProjectImage.js
@@ -16,6 +16,7 @@ function ProjectImage ({ imageSrc, projectName, theme }) {
           size='38%'
         />
       }
+      width={400}
     />
   )
 }

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/components/Confusion.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/components/Confusion.js
@@ -39,6 +39,7 @@ export default function Confusion({
               key={filename}
               alt={`${confusion.label}-image${index}`}
               src={images[filename]}
+              width={400}
             />
           ))}
         </Carousel>

--- a/packages/lib-react-components/src/Media/Media.js
+++ b/packages/lib-react-components/src/Media/Media.js
@@ -5,28 +5,32 @@ import { propTypes, defaultProps } from './helpers/mediaPropTypes'
 export default function Media(props) {
   const mimeType = mime.getType(props.src)
   const [ type ] = mimeType ? mimeType.split('/') : []
+  const componentProps = {
+    ...defaultProps,
+    ...props
+  }
 
   if (type === 'image') {
     return (
-      <Viewers.ThumbnailImage {...props} />
+      <Viewers.ThumbnailImage {...componentProps} />
     )
   }
 
   if (type === 'video') {
     return (
-      <Viewers.Video {...props} />
+      <Viewers.Video {...componentProps} />
     )
   }
 
   if (type === 'audio') {
     return (
-      <Viewers.Audio {...props} />
+      <Viewers.Audio {...componentProps} />
     )
   }
 
   if (type === 'application') {
     return (
-      <Viewers.Data {...props} />
+      <Viewers.Data {...componentProps} />
     )
   }
 
@@ -35,8 +39,4 @@ export default function Media(props) {
 
 Media.propTypes = {
   ...propTypes
-}
-
-Media.defaultProps = {
-  ...defaultProps
 }

--- a/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.js
+++ b/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.js
@@ -3,8 +3,6 @@ import getThumbnailSrc from '../../helpers/getThumbnailSrc.js'
 import { propTypes, defaultProps } from '../../helpers/mediaPropTypes.js'
 import useProgressiveImage from '../../../hooks/useProgressiveImage.js'
 
-const DEFAULT_THUMBNAIL_DIMENSION = ''
-
 export function Placeholder({ children, flex, ...props}) {
   return (
     <Box background='brand' flex={flex} justify='center' align='center' {...props}>
@@ -18,11 +16,11 @@ export default function ThumbnailImage({
   delay = defaultProps.delay,
   fit = defaultProps.fit,
   flex = defaultProps.flex,
-  height = DEFAULT_THUMBNAIL_DIMENSION,
+  height,
   origin = defaultProps.origin,
   placeholder = defaultProps.placeholder,
   src,
-  width = DEFAULT_THUMBNAIL_DIMENSION,
+  width,
   ...rest
 }) {
   const thumbnailSrc = getThumbnailSrc({ height, origin, src, width })

--- a/packages/lib-react-components/src/Media/helpers/getThumbnailSrc.js
+++ b/packages/lib-react-components/src/Media/helpers/getThumbnailSrc.js
@@ -1,6 +1,4 @@
-const DEFAULT_THUMBNAIL_DIMENSION = ''
-
-export default function getThumbnailSrc({ height = DEFAULT_THUMBNAIL_DIMENSION, origin, src, width = DEFAULT_THUMBNAIL_DIMENSION }) {
+export default function getThumbnailSrc({ height = '', origin, src, width = 999 }) {
   if (!src) return undefined
 
   if (src.endsWith('.gif')) return src


### PR DESCRIPTION
`Media` components must specify either a width or a height. This sets the width of the `ProjectImage` and survey task 'confused with' images to 400px. Embedded images in markdown text use a default width of 999px, as before.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project
- lib-classifier
- lib-react-components

## Linked Issue and/or Talk Post
- Closes #4862

## How to Review
Image thumbnails should have valid URLs, which don't error.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated
