### PR TITLE
Stronger checking for classifier data fetching 

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.js
@@ -136,7 +136,9 @@ export default function ClassifierContainer({
   - the workflow has loaded.
   - the project has been added to the store.
   */
-  const classifierIsReady = userHasLoaded && !!workflowSnapshot && !!classifierStore.projects.active
+  const workflowIsReady = !!workflowSnapshot?.strings
+  const projectIsReady = !!classifierStore.projects.active
+  const classifierIsReady = userHasLoaded && workflowIsReady && projectIsReady
   try {
     if (classifierIsReady) {
 

--- a/packages/lib-classifier/src/components/Classifier/hooks/usePanoptesUserSession.js
+++ b/packages/lib-classifier/src/components/Classifier/hooks/usePanoptesUserSession.js
@@ -6,7 +6,7 @@ import {
 
 export default function usePanoptesUserSession({ authClient, projectID }) {
   const { data: user, isLoading: userLoading } = usePanoptesUser(authClient)
-  const userID = !userLoading && user?.id
+  const userID = userLoading ? undefined : (user?.id || null)
   const { data: upp } = useProjectPreferences({ authClient, projectID, userID })
   const { data: projectRoles } = useProjectRoles({ authClient, projectID, userID })
   const userHasLoaded = userID ?

--- a/packages/lib-classifier/src/hooks/useProjectPreferences.js
+++ b/packages/lib-classifier/src/hooks/useProjectPreferences.js
@@ -28,12 +28,12 @@ async function fetchProjectPreferences({ endpoint, projectID, userID, authorizat
 }
 
 async function fetchOrCreateProjectPreferences({ endpoint, projectID, userID, authorization }) {
-  // auth is undefined while loading
-  if (authorization === undefined) {
+  // userID and auth are undefined while loading
+  if (userID === undefined || authorization === undefined) {
     return undefined
   }
   // logged-in
-  if (authorization) {
+  if (projectID && userID && authorization) {
     const projectPreferences = await fetchProjectPreferences({ endpoint, projectID, userID, authorization })
     if (projectPreferences) {
       return projectPreferences

--- a/packages/lib-classifier/src/hooks/useProjectRoles.js
+++ b/packages/lib-classifier/src/hooks/useProjectRoles.js
@@ -12,11 +12,17 @@ const SWRoptions = {
 }
 
 async function fetchProjectRoles({ endpoint, projectID, userID, authorization }) {
-  if (authorization) {
+  // userID and auth are undefined while loading
+  if (userID === undefined || authorization === undefined) {
+    return undefined
+  }
+  // logged in
+  if (projectID && userID && authorization) {
     const { body } = await panoptes.get(endpoint, { project_id: projectID, user_id: userID }, { authorization })
     const [projectRoles] = body.project_roles
     return projectRoles?.roles || []
   }
+  // logged out
   return null
 }
 


### PR DESCRIPTION
Set the current `userID` to undefined while the user is loading. Check that in both `useProjectPreferences` and `useProjectRoles` so that the possible return values are:
- undefined (resource is loading.)
- null (user isn't logged in.)
- a Panoptes resource (user is logged in.)

Wait until workflow translations have loaded before rendering the classifier (closes #5015.)
 
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## How to Review
I checked this in the dev classifier. With these changes, you shouldn't see any requests made for either project preferences or project roles until the user is authenticated, and set to either null or a Panoptes user resource.

You shouldn't see GET requests like this, where the user ID is `false` because the user session hasn't authenticated yet.
https://panoptes-staging.zooniverse.org/api/project_preferences?project_id=335&user_id=false&http_cache=true

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
