### PR TITLE
Continuous zooming in separate frames mode

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButton.spec.js
@@ -57,6 +57,6 @@ describe('Component > ZoomInButton', function () {
 
     await user.click(screen.getByRole('button', { name: 'ImageToolbar.ZoomInButton.ariaLabel' }))
 
-    expect(zoomSpy).to.have.been.calledWith("zoomin", 1)
+    expect(zoomSpy).to.have.been.calledOnceWith("zoomin", 1)
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
@@ -21,15 +21,15 @@ function storeMapper(classifierStore) {
   }
 }
 
-function ZoomInButtonContainer({ separateFrameZoomIn = () => true }) {
-  const { disabled, separateFramesView, zoomIn } = useStores(storeMapper)
+function ZoomInButtonContainer({ separateFrameZoomIn }) {
+  const { disabled, zoomIn } = useStores(storeMapper)
   const [timer, setTimer] = useState('')
+  const zoomCallback = separateFrameZoomIn || zoomIn
 
   function onPointerDown(event) {
     const { currentTarget, pointerId } = event
-    zoomIn()
     clearInterval(timer)
-    const newTimer = setInterval(zoomIn, 100)
+    const newTimer = setInterval(zoomCallback, 100)
     setTimer(newTimer)
     currentTarget.setPointerCapture(pointerId)
   }
@@ -43,7 +43,7 @@ function ZoomInButtonContainer({ separateFrameZoomIn = () => true }) {
   return (
     <ZoomInButton
       disabled={disabled}
-      onClick={separateFramesView ? separateFrameZoomIn : zoomIn}
+      onClick={zoomCallback}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
     />

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
@@ -26,6 +26,11 @@ function ZoomInButtonContainer({ separateFrameZoomIn }) {
   const [timer, setTimer] = useState('')
   const zoomCallback = separateFrameZoomIn || zoomIn
 
+  function onClick() {
+    clearInterval(timer)
+    zoomCallback()
+  }
+
   function onPointerDown(event) {
     const { currentTarget, pointerId } = event
     clearInterval(timer)
@@ -36,14 +41,13 @@ function ZoomInButtonContainer({ separateFrameZoomIn }) {
 
   function onPointerUp(event) {
     const { currentTarget, pointerId } = event
-    clearInterval(timer)
     currentTarget.releasePointerCapture(pointerId)
   }
 
   return (
     <ZoomInButton
       disabled={disabled}
-      onClick={zoomCallback}
+      onClick={onClick}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
     />

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomInButton/ZoomInButtonContainer.js
@@ -8,15 +8,11 @@ import ZoomInButton from './ZoomInButton'
 function storeMapper(classifierStore) {
   const {
     disableImageToolbar,
-    separateFramesView,
     zoomIn
   } = classifierStore.subjectViewer
 
-  const disabled = disableImageToolbar
-
   return {
-    disabled,
-    separateFramesView,
+    disabled: disableImageToolbar,
     zoomIn
   }
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButton.spec.js
@@ -57,6 +57,6 @@ describe('Component > ZoomOutButton', function () {
 
     await user.click(screen.getByRole('button', { name: 'ImageToolbar.ZoomOutButton.ariaLabel' }))
 
-    expect(zoomSpy).to.have.been.calledWith("zoomout", -1)
+    expect(zoomSpy).to.have.been.calledOnceWith("zoomout", -1)
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
@@ -26,6 +26,11 @@ function ZoomOutButtonContainer({ separateFrameZoomOut }) {
   const [timer, setTimer] = useState('')
   const zoomCallback = separateFrameZoomOut || zoomOut
 
+  function onClick() {
+    clearInterval(timer)
+    zoomCallback()
+  }
+
   function onPointerDown(event) {
     const { currentTarget, pointerId } = event
     clearInterval(timer)
@@ -36,14 +41,13 @@ function ZoomOutButtonContainer({ separateFrameZoomOut }) {
 
   function onPointerUp(event) {
     const { currentTarget, pointerId } = event
-    clearInterval(timer)
     currentTarget.releasePointerCapture(pointerId)
   }
 
   return (
     <ZoomOutButton
       disabled={disabled}
-      onClick={zoomCallback}
+      onClick={onClick}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
     />

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
@@ -21,15 +21,15 @@ function storeMapper(classifierStore) {
   }
 }
 
-function ZoomOutButtonContainer({ separateFrameZoomOut = () => true }) {
-  const { disabled, separateFramesView, zoomOut } = useStores(storeMapper)
+function ZoomOutButtonContainer({ separateFrameZoomOut }) {
+  const { disabled, zoomOut } = useStores(storeMapper)
   const [timer, setTimer] = useState('')
+  const zoomCallback = separateFrameZoomOut || zoomOut
 
   function onPointerDown(event) {
     const { currentTarget, pointerId } = event
-    zoomOut()
     clearInterval(timer)
-    const newTimer = setInterval(zoomOut, 100)
+    const newTimer = setInterval(zoomCallback, 100)
     setTimer(newTimer)
     currentTarget.setPointerCapture(pointerId)
   }
@@ -43,7 +43,7 @@ function ZoomOutButtonContainer({ separateFrameZoomOut = () => true }) {
   return (
     <ZoomOutButton
       disabled={disabled}
-      onClick={separateFramesView ? separateFrameZoomOut : zoomOut}
+      onClick={zoomCallback}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
     />

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ZoomOutButton/ZoomOutButtonContainer.js
@@ -8,15 +8,11 @@ import ZoomOutButton from './ZoomOutButton'
 function storeMapper(classifierStore) {
   const {
     disableImageToolbar,
-    separateFramesView,
     zoomOut
   } = classifierStore.subjectViewer
 
-  const disabled = disableImageToolbar
-
   return {
-    disabled,
-    separateFramesView,
+    disabled: disableImageToolbar,
     zoomOut
   }
 }


### PR DESCRIPTION
Separate frames mode uses its own callback functions for zoom, so they need to be called continuously while the zoom buttons are pressed.

I've also updated the tests to expect each zoom callback to run once on button click (see #5043.)

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## Linked Issue and/or Talk Post
- closes #5049.

## How to Review
You can test this on Daily Minor Planet in the standalone classifier:
https://localhost:8080/?project=fulsdavid/the-daily-minor-planet&env=production

Pressing the +/- buttons next to each frame, with either a pointing device or the keyboard, should continuously zoom while each button is pressed.

- [x] tests are passing.
- [x] the subject zooms continuously when the buttons are pressed with pointerdown.
- [x] the subject zooms continuously when the buttons are pressed with the keyboard.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
