### PR TITLE
Use constant callbacks in the dev classifier

### DIFF
--- a/packages/lib-classifier/dev/components/App/App.js
+++ b/packages/lib-classifier/dev/components/App/App.js
@@ -8,6 +8,9 @@ import React from 'react'
 import Classifier from '../../../src/components/Classifier'
 import localeMenu from './localeMenu.js'
 
+const onAddToCollection = (subjectId) => console.log(subjectId)
+const onCompleteClassification = (classification, subject) => console.log('onComplete', classification, subject)
+
 class App extends React.Component {
   constructor(props) {
     super(props)
@@ -219,8 +222,8 @@ class App extends React.Component {
               authClient={oauth}
               cachePanoptesData={this.state.cachePanoptesData}
               locale={locale}
-              onAddToCollection={(subjectId) => console.log(subjectId)}
-              onCompleteClassification={(classification, subject) => console.log('onComplete', classification, subject)}
+              onAddToCollection={onAddToCollection}
+              onCompleteClassification={onCompleteClassification}
               onError={this.onError}
               project={this.state.project}
               showTutorial


### PR DESCRIPTION
The dev classifier stubbed callback functions are constants, but the `App` component generates new `onAddToCollection` and `onCompleteClassification` callback functions on each render. This declares them once, so that they are only set once.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## How to Review
This is a small change, but you shouldn't see console logs warning that the dev classifier's callbacks have been reset on every render eg. when toggling the theme from dark to light.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
