### PR TITLE
ClassifierContainer: test the translations API

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.spec.js
@@ -858,7 +858,7 @@ describe('components > ClassifierContainer', function () {
         expect(radioButton.name).to.equal('T0')
         expect(radioButton.disabled).to.be.true()
       })
-      //expect(translationRequests.isDone()).to.be.true()
+      expect(translationRequests.isDone()).to.be.true()
     })
   })
 })


### PR DESCRIPTION
Uncomment an expectation that was accidentally left commented out in #5038. It tests that the Panoptes translations API is called for workflow translations.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## How to Review
The classifier tests should pass.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github

