### PR TITLE
Image Toolbar: change button callbacks to match zoom callback pattern

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/InvertButton/InvertButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/InvertButton/InvertButtonContainer.js
@@ -9,8 +9,7 @@ function storeMapper (classifierStore) {
     subjectViewer: {
       disableImageToolbar,
       invert,
-      invertView,
-      separateFramesView
+      invertView
     },
     workflows: {
       active: workflow
@@ -25,21 +24,19 @@ function storeMapper (classifierStore) {
     active,
     disabled,
     invertView,
-    separateFramesView,
     show
   }
 }
 
-function InvertButtonContainer ({
-  separateFrameInvert
-}) {
+function InvertButtonContainer ({ separateFrameInvert }) {
   const {
     active,
     disabled,
     invertView,
-    separateFramesView,
     show
   } = useStores(storeMapper)
+
+  const invertCallback = separateFrameInvert || invertView
 
   if (!show) {
     return null
@@ -49,7 +46,7 @@ function InvertButtonContainer ({
     <InvertButton
       active={active}
       disabled={disabled}
-      onClick={separateFramesView ? separateFrameInvert : invertView}
+      onClick={invertCallback}
     />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/ResetButton/ResetButtonContainer.js
@@ -7,7 +7,6 @@ import ResetButton from './ResetButton'
 function storeMapper(classifierStore) {
   const {
     disableImageToolbar,
-    separateFramesView,
     resetView
   } = classifierStore.subjectViewer
 
@@ -15,18 +14,19 @@ function storeMapper(classifierStore) {
 
   return {
     disabled,
-    resetView,
-    separateFramesView
+    resetView
   }
 }
 
-function ResetButtonContainer({ separateFrameResetView = () => true }) {
-  const { disabled, separateFramesView, resetView } = useStores(storeMapper)
+function ResetButtonContainer({ separateFrameResetView }) {
+  const { disabled, resetView } = useStores(storeMapper)
+
+  const resetCallback = separateFrameResetView || resetView
 
   return (
     <ResetButton
       disabled={disabled}
-      onClick={separateFramesView ? separateFrameResetView : resetView}
+      onClick={resetCallback}
     />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/RotateButton/RotateButtonContainer.js
@@ -8,8 +8,7 @@ function storeMapper (classifierStore) {
   const {
     disableImageToolbar,
     rotate,
-    rotationEnabled,
-    separateFramesView
+    rotationEnabled
   } = classifierStore.subjectViewer
 
   const disabled = disableImageToolbar
@@ -18,13 +17,14 @@ function storeMapper (classifierStore) {
   return {
     disabled,
     rotate,
-    separateFramesView,
     show
   }
 }
 
-function RotateButtonContainer({ separateFrameRotate = () => true }) {
-  const { disabled, rotate, separateFramesView, show } = useStores(storeMapper)
+function RotateButtonContainer({ separateFrameRotate }) {
+  const { disabled, rotate, show } = useStores(storeMapper)
+
+  const rotateCallback = separateFrameRotate || rotate
 
   if (!show) {
     return null
@@ -33,7 +33,7 @@ function RotateButtonContainer({ separateFrameRotate = () => true }) {
   return (
     <RotateButton
       disabled={disabled}
-      onClick={separateFramesView ? separateFrameRotate : rotate}
+      onClick={rotateCallback}
     />
   )
 }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/SeparateFramesViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/SeparateFramesViewer.js
@@ -30,7 +30,6 @@ function SeparateFramesViewer({
   onReady = DEFAULT_HANDLER,
   subject
 }) {
-  console.log(subject)
   const { limitSubjectHeight, multiImageLayout } = useStores(storeMapper)
 
   const [forceColLayout, setForceColLayout] = useState(false)


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Follow-up to #5050 

## Describe your changes

Separate frames mode uses its own callback functions for invert, rotate, and reset so the existence of those custom callbacks can be used instead of looking for `separateFramesMode` in the store. This PR doesn't have any affect on functionality, it just matches the same callback pattern as PR #5050's refactoring of the zoom buttons.

Note that the Move and Annotate buttons cannot use this pattern because they also involve a move or annotate "mode" from the store.

## How to Review

Review the SeparateFramesViewer in the lib-classifier storybook.

Use Daily Minor Planet, or this test flipbook project to check that all image toolbar buttons function as expected in both the FlipbookViewer mode and SeparateFrame mode.
https://local.zooniverse.org:3000/projects/goplayoutside3/fem-flipbook-viewer/classify/workflow/22532?env=production

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected