### PR TITLE
Fixes for tests and SSR errors

### DIFF
--- a/packages/app-content-pages/pages/_app.js
+++ b/packages/app-content-pages/pages/_app.js
@@ -2,7 +2,7 @@ import zooTheme from '@zooniverse/grommet-theme'
 import { ZooFooter } from '@zooniverse/react-components'
 import { Grommet, base } from 'grommet'
 import makeInspectable from 'mobx-devtools-mst'
-import { Provider } from 'mobx-react'
+import { enableStaticRendering, Provider } from 'mobx-react'
 import { createGlobalStyle } from 'styled-components'
 import merge from 'lodash/merge'
 import Error from 'next/error'
@@ -19,6 +19,8 @@ const GlobalStyle = createGlobalStyle`
     margin: 0;
   }
 `
+
+enableStaticRendering(typeof window === 'undefined')
 
 function useStore(initialState) {
   const isServer = typeof window === 'undefined'

--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -1,6 +1,6 @@
 import { Box } from 'grommet'
 import makeInspectable from 'mobx-devtools-mst'
-import { Provider } from 'mobx-react'
+import { enableStaticRendering, Provider } from 'mobx-react'
 import Error from 'next/error'
 import { useEffect, useMemo } from 'react'
 import { createGlobalStyle } from 'styled-components'
@@ -20,6 +20,8 @@ const GlobalStyle = createGlobalStyle`
     margin: 0;
   }
 `
+
+enableStaticRendering(typeof window === 'undefined')
 
 /**
   useStore hook adapted from

--- a/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/QuickTalk/QuickTalk.spec.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { QuickTalk } from './QuickTalk'
@@ -84,7 +84,7 @@ describe('Component > QuickTalk', function () {
       await user.click(screen.queryByRole('button', quickTalkButton_target))
 
       expect(screen.queryByRole('button', quickTalkButton_target)).to.not.exist()
-      expect(screen.queryByRole('dialog', quickTalkPanel_target)).to.exist()
+      await waitFor(() => expect(screen.queryByRole('dialog', quickTalkPanel_target)).to.exist())
     })
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/PreviousMarks/PreviousMarks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/PreviousMarks/PreviousMarks.spec.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import zooTheme from '@zooniverse/grommet-theme'
 import { Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
@@ -110,7 +110,7 @@ describe('Component > PreviousMarks', function () {
   })
 
   describe('when there are drawing task annotations', function () {
-    it('should render disabled drawing marks per task by frame', function () {
+    it('should render disabled drawing marks per task by frame', async function () {
       render(
         <PreviousMarks />,
         {
@@ -124,11 +124,13 @@ describe('Component > PreviousMarks', function () {
         expect(mark.getAttribute('tabindex')).to.equal('-1')
       })
       store.subjectViewer.setFrame(1)
-      marks = document.querySelectorAll('g.drawingMark')
-      expect(marks).to.have.lengthOf(2)
-      marks.forEach(mark => {
-        expect(mark.getAttribute('aria-disabled')).to.equal('true')
-        expect(mark.getAttribute('tabindex')).to.equal('-1')
+      await waitFor(() => {
+        const marks = document.querySelectorAll('g.drawingMark')
+        expect(marks).to.have.lengthOf(2)
+        marks.forEach(mark => {
+          expect(mark.getAttribute('aria-disabled')).to.equal('true')
+          expect(mark.getAttribute('tabindex')).to.equal('-1')
+        })
       })
       store.subjectViewer.setFrame(0)
     })
@@ -165,7 +167,7 @@ describe('Component > PreviousMarks', function () {
   })
 
   describe('when shown marks is NONE', function () {
-    it('should not show any marks', function ()  {
+    it('should not show any marks', async function ()  {
       render(
         <PreviousMarks />,
         {
@@ -175,8 +177,10 @@ describe('Component > PreviousMarks', function () {
       expect(store.workflowSteps.interactionTask.shownMarks).to.equal(SHOWN_MARKS.ALL)
       store.workflowSteps.interactionTask.togglePreviousMarks(SHOWN_MARKS.NONE)
       expect(store.workflowSteps.interactionTask.shownMarks).to.equal(SHOWN_MARKS.NONE)
-      const marks = document.querySelectorAll('g.drawingMark')
-      expect(marks).to.have.lengthOf(0)
+      await waitFor(() => {
+        const marks = document.querySelectorAll('g.drawingMark')
+        expect(marks).to.have.lengthOf(0)
+      })
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.spec.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.spec.js
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { expect } from 'chai'
+import { when } from 'mobx'
 import sinon from 'sinon'
 import { EllipseTool, PointTool } from '@plugins/drawingTools/models/tools'
 import { Ellipse, Mark, Point } from '@plugins/drawingTools/components'
@@ -140,17 +141,18 @@ describe('Drawing tools > Mark', function () {
         point.setSubTaskVisibility(false)
         await user.tab()
         await user.keyboard('{Enter}')
+        await when(() => point.subTaskVisibility)
       })
 
       after(function () {
         onFinish.resetHistory()
       })
 
-      it('should open the subtasks popup', function () {
+      it('should open the subtasks popup', async function () {
         expect(point.subTaskVisibility).to.be.true()
       })
 
-      it('should call onFinish', function () {
+      it('should call onFinish', async function () {
         expect(onFinish).to.have.been.calledOnce()
       })
     })
@@ -179,17 +181,18 @@ describe('Drawing tools > Mark', function () {
         point.setSubTaskVisibility(false)
         await user.tab()
         await user.keyboard('{ }')
+        await when(() => point.subTaskVisibility)
       })
 
       after(function () {
         onFinish.resetHistory()
       })
 
-      it('should open the subtasks popup', function () {
+      it('should open the subtasks popup', async function () {
         expect(point.subTaskVisibility).to.be.true()
       })
 
-      it('should call onFinish', function () {
+      it('should call onFinish', async function () {
         expect(onFinish).to.have.been.calledOnce()
       })
     })
@@ -366,7 +369,7 @@ describe('Drawing tools > Mark', function () {
         window.scrollTo.resetHistory()
       })
 
-      it('should open the subtask popup', function () {
+      it('should open the subtask popup', async function () {
         expect(newMark.subTaskVisibility).to.be.true()
       })
     })


### PR DESCRIPTION
Fixes for tests to improve compatibility with React 18 and React Testing Library v14 (#3887.)

This PR also turns off `observer` during SSR (`enableStaticRendering(true)`). `observer` should only be run in the browser, and warns in the builds if you try to use it in Node. This is a warning with React 17, but will stop the NextJS apps from building with React 18.

## Package
app-content-pages
app-project
lib-classifier

## Linked PRs
- #3887.
- #3888.

## How to Review
Build and run the NextJS apps to test static rendering. Their behaviour shouldn't have changed.

Tests should all continue to pass. Builds should run without `useLayoutEffect` warnings.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
