### PR TITLE
Refactor daily classification counts

### DIFF
--- a/packages/app-project/stores/User/UserPersonalization/UserPersonalization.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserPersonalization.js
@@ -46,8 +46,7 @@ const UserPersonalization = types
     },
 
     get totalClassificationCount() {
-      const activityCount = self.projectPreferences?.activity_count || 0
-      return  activityCount + self.sessionCount
+      return self.projectPreferences?.activity_count || 0
     }
   }))
   .actions(self => {
@@ -66,6 +65,7 @@ const UserPersonalization = types
       increment() {
         self.sessionCount = self.sessionCount + 1
         self.todaysStats?.increment()
+        self.projectPreferences?.incrementActivityCount()
         const { user } = getRoot(self)
         if (user?.id && self.sessionCountIsDivisibleByFive) {
           self.projectPreferences.refreshSettings()

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
@@ -19,7 +19,7 @@ const Settings = types
 
 const UserProjectPreferences = types
   .model('UserProjectPreferences', {
-    activity_count: types.maybe(types.number),
+    activity_count: types.optional(types.number, 0),
     activity_count_by_workflow: types.maybe(types.frozen()),
     error: types.maybeNull(types.frozen({})),
     id: types.maybe(numberString),
@@ -71,7 +71,7 @@ const UserProjectPreferences = types
     return {
       reset() {
         const resetSnapshot = {
-          activity_count: undefined,
+          activity_count: 0,
           activity_count_by_workflow: undefined,
           error: undefined,
           id: undefined,
@@ -119,7 +119,11 @@ const UserProjectPreferences = types
         } catch (error) {
           console.error(error)
         }
-      })
+      }),
+
+      incrementActivityCount() {
+        self.activity_count = self.activity_count + 1
+      }
     }
   })
 

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
@@ -97,7 +97,7 @@ const UserProjectPreferences = types
             self.setLoadingState(asyncStates.loading)
             const preferences = yield _fetch()
             if (preferences) {
-              self.setResource(preferences)
+              applySnapshot(self, preferences)
             }
             self.setLoadingState(asyncStates.success)
           }
@@ -112,7 +112,7 @@ const UserProjectPreferences = types
       refreshSettings: flow(function * refreshSettings() {
         try {
           const preferences = yield _fetch()
-          if (preferences) {
+          if (preferences?.settings) {
             self.settings = preferences.settings
           }
           self.setLoadingState(asyncStates.success)

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
@@ -28,7 +28,7 @@ describe('Stores > UserProjectPreferences', function () {
     }
   }
   const initialState = {
-    activity_count: undefined,
+    activity_count: 0,
     activity_count_by_workflow: undefined,
     error: undefined,
     id: undefined,

--- a/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
+++ b/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
@@ -24,6 +24,11 @@ const Count = types
     dayNumber: types.number,
     period: types.string
   })
+  .actions(self => ({
+    increment() {
+      self.count = self.count + 1
+    }
+  }))
 
 const YourStats = types
   .model('YourStats', {


### PR DESCRIPTION
- store `user.personalization.sessionCount` in user snapshots, so that it can persist across page visits (closes #5081.)
- only run the graphQL query for daily stats when we're fetching a new user from Panoptes. Existing users (including users stored in browser session storage) will already have their stats stored in the personalisation models.
- increment daily counts separately from session counts, since open tabs can persist across calendar days.
- increment project activity count separately from session counts, to avoid double counting of classifications.
- add `user.personalization.todaysStats` and `user.personalization.todaysCount` for convenience.
- add `stats.increment()` as a convenience method to increment daily counts.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
app-project

## Linked Issue and/or Talk Post
- #5081.
- [bug concerning vanishing classifications statistics / resetting total classifications counter](https://www.zooniverse.org/talk/17/3011540) (Zooniverse Talk.)

## How to Review
On a workflow like Gravity Spy Level 1, you should be able to make a few quick classifications, while logged in, leave the page and come back to see your work still recorded.

Logged out, your counts should be recorded while you're on the page, but won't be persisted if you leave the page.

<img width="300" alt="Daily classification statistics for a Gravity Spy volunteer." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/19dd03d6-90d0-4ad5-b364-92a1d588c270">

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
