### PR TITLE
Fix for allowing multiple marks when using the FreehandLine tool conn…

### DIFF
--- a/packages/lib-classifier/src/hooks/useFreehandLineReductions.js
+++ b/packages/lib-classifier/src/hooks/useFreehandLineReductions.js
@@ -19,20 +19,28 @@ export default function useFreehandLineReductions() {
   const { loaded, caesarReductions } = useCaesarReductions(workflow.caesarReducer)
 
   if (loaded && getType(caesarReductions).name === 'FreehandLineReductions') {
-    const caesarMark = caesarReductions.findCurrentTaskMark({
+    const caesarMarks = caesarReductions.findCurrentTaskMarks({
       stepKey: step.stepKey,
       tasks: step.tasks,
       frame,
     })
 
-    if (caesarMark) {
-      const { frame, markId: id, taskIndex, toolIndex, pathX, pathY } = caesarMark
-      const task = step?.tasks[taskIndex]
-      const tool = task?.tools[toolIndex]
+    if (caesarMarks) {
+      let marksUsed = false;
 
-      if (tool && !tool.marks.has(id) && caesarReductions.isUsed === false) {
+      caesarMarks.forEach(caesarMark => {
+        const { frame, markId: id, taskIndex, toolIndex, pathX, pathY } = caesarMark
+        const task = step?.tasks[taskIndex]
+        const tool = task?.tools[toolIndex]
+
+        if (tool && !tool.marks.has(id) && caesarReductions.isUsed === false) {
+          marksUsed = true;
+          tool.createMark({ frame, id, toolIndex, pathX, pathY })
+        }
+      })
+
+      if (marksUsed) {
         caesarReductions.setIsUsed()
-        tool.createMark({ frame, id, toolIndex, pathX, pathY })
       }
     }
   }

--- a/packages/lib-classifier/src/store/subjects/Subject/FreehandLineReductions/FreehandLineReductions.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/FreehandLineReductions/FreehandLineReductions.js
@@ -15,29 +15,31 @@ const FreehandLineReductions = types
   }))
   .views(self => {
     return {
-      findCurrentTaskMark({ stepKey, tasks, frame }) {
+      findCurrentTaskMarks({ stepKey, tasks, frame }) {
         if (stepKey === undefined || tasks === undefined || frame === undefined) {
           return
         }
 
-        let caesarMark;
+        let caesarMarks = [];
 
         self.reductions.forEach(reduction => {
-          let { data } = reduction
-          let task = tasks[data.taskIndex]
-          let tool = task.tools[data.toolIndex]
+          let { data } = reduction.data   // Caesar expects data attribute to be an object
+          data.forEach(datum => {
+            let task = tasks[datum.taskIndex]
+            let tool = task.tools[datum.toolIndex]
 
-          if (data.frame === frame
-            && data.stepKey === stepKey
-            && data.taskKey === task.taskKey
-            && data.taskType === task.type
-            && data.toolType === tool.type
-          ) {
-            caesarMark = data
-          }
+            if (datum.frame === frame
+              && datum.stepKey === stepKey
+              && datum.taskKey === task.taskKey
+              && datum.taskType === task.type
+              && datum.toolType === tool.type
+            ) {
+              caesarMarks.push(datum)
+            }
+          })
         })
 
-        return caesarMark
+        return caesarMarks
       }
     }
   })

--- a/packages/lib-classifier/src/store/subjects/Subject/FreehandLineReductions/FreehandLineReductions.spec.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/FreehandLineReductions/FreehandLineReductions.spec.js
@@ -35,15 +35,18 @@ describe('Models > FreehandLineReductions', () => {
   })
 
   it('should find a current mark', () => {
-    reductionsModel.reductions.forEach(reduction => expect(reduction.data.markId).to.equal('clhhuqm9'))
-    expect(reductionsModel.findCurrentTaskMark(reductionsTaskStub)).not.to.be.empty()
+    reductionsModel.reductions.forEach(reduction => {
+      expect(reduction.data.data[0].markId).to.equal('clhhuqm9')
+    })
+    expect(reductionsModel.findCurrentTaskMarks(reductionsTaskStub)).not.to.be.empty()
   })
 
   it('should have array of x and y values', () => {
-    let caesarMark = reductionsModel.findCurrentTaskMark(reductionsTaskStub)
-    expect(caesarMark.pathX).to.be.a('array')
-    expect(caesarMark.pathY).to.be.a('array')
-    expect(caesarMark.pathX).not.to.be.empty()
-    expect(caesarMark.pathY).not.to.be.empty()
+    let caesarMarks = reductionsModel.findCurrentTaskMarks(reductionsTaskStub)
+    expect(caesarMarks).to.be.a('array')
+    expect(caesarMarks[0].pathX).to.be.a('array')
+    expect(caesarMarks[0].pathY).to.be.a('array')
+    expect(caesarMarks[0].pathX).not.to.be.empty()
+    expect(caesarMarks[0].pathY).not.to.be.empty()
   })
 })

--- a/packages/lib-classifier/src/store/subjects/Subject/FreehandLineReductions/mocks/reducedSubject.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/FreehandLineReductions/mocks/reducedSubject.js
@@ -1,12 +1,16 @@
 export default {
-  'stepKey': 'S0',				    // which step in the workflow, usually S0
-  'taskIndex': 0,             // which task in the workflow, usually 0
-  'taskKey': 'T0',					  // correlates with taskIndex, usually T0
-  'taskType': 'drawing',			// focused on correct-a-cell
-  'toolIndex': 0,					    // which tool in the task, usually 0
-  'toolType': 'freehandLine',	// focused on correct-a-cell
-  'frame': 0,					        // usually 0 unless in multi-frame view
-  'markId': 'clhhuqm9',			  // alphanumeric string that ensures the machine-generated mark is rendered
-  'pathX': [200, 175, 150], 	// array of x values
-  'pathY': [100, 75, 75],		  // array of y values
+  data: [
+    {
+      'stepKey': 'S0',				    // which step in the workflow, usually S0
+      'taskIndex': 0,             // which task in the workflow, usually 0
+      'taskKey': 'T0',					  // correlates with taskIndex, usually T0
+      'taskType': 'drawing',			// focused on correct-a-cell
+      'toolIndex': 0,					    // which tool in the task, usually 0
+      'toolType': 'freehandLine',	// focused on correct-a-cell
+      'frame': 0,					        // usually 0 unless in multi-frame view
+      'markId': 'clhhuqm9',			  // alphanumeric string that ensures the machine-generated mark is rendered
+      'pathX': [200, 175, 150], 	// array of x values
+      'pathY': [100, 75, 75],		  // array of y values
+    }
+  ]
 }


### PR DESCRIPTION
## Describe your changes
The FreehandLine tool needs to be able to display multiple marks from Caesar. The changes are minimal and are a refactor to allow multiple marks to be processed. 

## How to Review
- Run the branch locally and ensure that the [Staging Freehand Line Project](https://localhost:8080/?project=kieftrav/freehand-line-test&env=staging) loads two marks.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated