### PR TITLE
Refactor SVGPanZoom

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -124,7 +124,7 @@ function SVGPanZoom({
       {cloneElement(children, {
         scale,
         viewBox: `${x} ${y} ${width} ${height}`,
-        svgmaxheight: limitSubjectHeight ? `min(${naturalHeight}px, 90vh)` : null
+        svgMaxHeight: limitSubjectHeight ? `min(${naturalHeight}px, 90vh)` : null
       })}
     </div>
   )

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -36,18 +36,17 @@ function SVGPanZoom({
     setOnZoom(() => true)
   }
 
+  useEffect(function onZoomChange() {
+    const newViewBox = scaledViewBox(zoom)
+    setViewBox(newViewBox)
+  }, [zoom])
+
   useEffect(() => {
     if (zooming) {
       enableZoom()
       return disableZoom
     }
   }, [zooming, src])
-
-  useEffect(
-    function onZoomChange() {
-      const newViewBox = scaledViewBox(zoom)
-      setViewBox(newViewBox)
-    }, [zoom])
 
   useEffect(() => {
     setZoom(1)
@@ -75,16 +74,18 @@ function SVGPanZoom({
 
   function onDrag(event, difference) {
     setViewBox((prevViewBox) => {
-      const newViewBox = Object.assign({}, prevViewBox)
-      newViewBox.x -= difference.x / 1.5
-      newViewBox.y -= difference.y / 1.5
+      const newViewBox = {
+        ...prevViewBox,
+        x: prevViewBox.x - difference.x,
+        y: prevViewBox.y - difference.y
+      }
       return newViewBox
     })
   }
 
   function onPan(dx, dy) {
     setViewBox((prevViewBox) => {
-      const newViewBox = Object.assign({}, prevViewBox)
+      const newViewBox = { ...prevViewBox }
       newViewBox.x += dx * 10
       newViewBox.y += dy * 10
       return newViewBox
@@ -113,7 +114,7 @@ function SVGPanZoom({
     }
   }
 
-  const { x, y, width, height } = scaledViewBox(zoom)
+  const { x, y, width, height } = viewBox
   const scale = imageScale(img)
 
   return (
@@ -121,7 +122,7 @@ function SVGPanZoom({
       {cloneElement(children, {
         scale,
         viewBox: `${x} ${y} ${width} ${height}`,
-        svgMaxHeight: limitSubjectHeight ? `min(${naturalHeight}px, 90vh)` : null
+        svgmaxheight: limitSubjectHeight ? `min(${naturalHeight}px, 90vh)` : null
       })}
     </div>
   )

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -1,3 +1,4 @@
+import debounce from 'lodash/debounce'
 import PropTypes from 'prop-types'
 import { cloneElement, useEffect, useState } from 'react'
 
@@ -25,7 +26,7 @@ function SVGPanZoom({
   const [viewBox, setViewBox] = useState(defaultViewBox)
 
   function enableZoom() {
-    setOnDrag(onDrag)
+    setOnDrag(debounce(onDrag, 10))
     setOnPan(onPan)
     setOnZoom(onZoom)
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -2,6 +2,7 @@ import debounce from 'lodash/debounce'
 import PropTypes from 'prop-types'
 import { cloneElement, useEffect, useState } from 'react'
 
+const DEFAULT_HANDLER = () => true
 function SVGPanZoom({
   children,
   img,
@@ -10,9 +11,9 @@ function SVGPanZoom({
   minZoom = 1,
   naturalHeight,
   naturalWidth,
-  setOnDrag = () => true,
-  setOnPan = () => true,
-  setOnZoom = () => true,
+  setOnDrag = DEFAULT_HANDLER,
+  setOnPan = DEFAULT_HANDLER,
+  setOnZoom = DEFAULT_HANDLER,
   src,
   zooming = true
 }) {
@@ -32,9 +33,9 @@ function SVGPanZoom({
   }
 
   function disableZoom() {
-    setOnDrag(() => true)
-    setOnPan(() => true)
-    setOnZoom(() => true)
+    setOnDrag(DEFAULT_HANDLER)
+    setOnPan(DEFAULT_HANDLER)
+    setOnZoom(DEFAULT_HANDLER)
   }
 
   useEffect(function onZoomChange() {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme'
+import { render, waitFor } from '@testing-library/react'
 import sinon from 'sinon'
 import SVGPanZoom from './SVGPanZoom'
 
@@ -18,7 +18,7 @@ describe('Components > SVGPanZoom', function () {
   const src = 'https://example.com/image.png'
 
   beforeEach(function () {
-    wrapper = mount(
+    wrapper = render(
       <SVGPanZoom
         img={img}
         naturalHeight={200}
@@ -33,104 +33,131 @@ describe('Components > SVGPanZoom', function () {
     )
   })
   
-  it('should enable zoom in', function () {
+  it('should enable zoom in', async function () {
     onZoom('zoomin', 1)
-    wrapper.update()
-    const viewBox = wrapper.find('svg').prop('viewBox')
-    expect(viewBox).to.equal('18.5 9.5 363 181')
+    await waitFor(() => {
+      const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+      expect(viewBox).to.equal('18.5 9.5 363 181')
+    })
   })
 
-  it('should enable zoom out', function () {
+  it('should enable zoom out', async function () {
     onZoom('zoomin', 1)
-    wrapper.update()
-    let viewBox = wrapper.find('svg').prop('viewBox')
-    expect(viewBox).to.equal('18.5 9.5 363 181')
+    await waitFor(() => {
+      const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+      expect(viewBox).to.equal('18.5 9.5 363 181')
+    })
     onZoom('zoomout', -1)
-    wrapper.update()
-    viewBox = wrapper.find('svg').prop('viewBox')
-    expect(viewBox).to.equal('0 0 400 200')
+    await waitFor(() => {
+      const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+      expect(viewBox).to.equal('0 0 400 200')
+    })
   })
 
   describe('panning', function () {
     describe('left', function () {
-      it('should move the viewbox left', function () {
-        let viewBox = wrapper.find('svg').prop('viewBox')
+      it('should move the viewbox left', async function () {
+        let viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
         expect(viewBox).to.equal('0 0 400 200')
         onPan(-1, 0)
-        wrapper.update()
-        viewBox = wrapper.find('svg').prop('viewBox')
-        expect(viewBox).to.equal('-10 0 400 200')
+        await waitFor(() => {
+          const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+          expect(viewBox).to.equal('-10 0 400 200')
+        })
       })
     })
 
     describe('right', function () {
-      it('should move the viewbox right', function () {
-        let viewBox = wrapper.find('svg').prop('viewBox')
+      it('should move the viewbox right', async function () {
+        let viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
         expect(viewBox).to.equal('0 0 400 200')
         onPan(1, 0)
-        wrapper.update()
-        viewBox = wrapper.find('svg').prop('viewBox')
-        expect(viewBox).to.equal('10 0 400 200')
+        await waitFor(() => {
+          const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+          expect(viewBox).to.equal('10 0 400 200')
+        })
       })
     })
     describe('up', function () {
-      it('should move the viewbox up', function () {
-        let viewBox = wrapper.find('svg').prop('viewBox')
+      it('should move the viewbox up', async function () {
+        let viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
         expect(viewBox).to.equal('0 0 400 200')
         onPan(0, -1)
-        wrapper.update()
-        viewBox = wrapper.find('svg').prop('viewBox')
-        expect(viewBox).to.equal('0 -10 400 200')
+        await waitFor(() => {
+          const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+          expect(viewBox).to.equal('0 -10 400 200')
+        })
       })
     })
     describe('down', function () {
-      it('should move the viewbox down', function () {
-        let viewBox = wrapper.find('svg').prop('viewBox')
+      it('should move the viewbox down', async function () {
+        let viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
         expect(viewBox).to.equal('0 0 400 200')
         onPan(0, 1)
-        wrapper.update()
-        viewBox = wrapper.find('svg').prop('viewBox')
-        expect(viewBox).to.equal('0 10 400 200')
+        await waitFor(() => {
+          const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+          expect(viewBox).to.equal('0 10 400 200')
+        })
       })
     })
   })
 
-  it('should should pan horizontally on drag', function () {
+  it('should should pan horizontally on drag', async function () {
     onDrag({}, { x: -15, y: 0 })
-    wrapper.update()
-    const viewBox = wrapper.find('svg').prop('viewBox')
-    expect(viewBox).to.equal('10 0 400 200')
+    const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+    await waitFor(() => expect(viewBox).to.equal('15 0 400 200'))
   })
 
-  it('should should pan vertically on drag', function () {
+  it('should should pan vertically on drag', async function () {
     onDrag({}, { x: 0, y: -15 })
-    wrapper.update()
-    const viewBox = wrapper.find('svg').prop('viewBox')
-    expect(viewBox).to.equal('0 10 400 200')
+    const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+    await waitFor(() => expect(viewBox).to.equal('0 15 400 200'))
   })
 
-  it('should reset pan with new src', function () {
+  it('should reset pan with new src', async function () {
     onPan(-1, 0)
-    wrapper.update()
-    let viewBox = wrapper.find('svg').prop('viewBox')
-    expect(viewBox).to.equal('-10 0 400 200')
+    let viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+    await waitFor(() => expect(viewBox).to.equal('-10 0 400 200'))
 
-    wrapper.setProps({ naturalHeight: 400, naturalWidth: 200, src: 'http://placekitten.com/200/400' })
-    wrapper.update()
-    viewBox = wrapper.find('svg').prop('viewBox')
-    expect(viewBox).to.equal('0 0 200 400')
+    wrapper.rerender(
+      <SVGPanZoom
+        img={img}
+        naturalHeight={400}
+        naturalWidth={200}
+        setOnDrag={callback => { onDrag = callback }}
+        setOnPan={callback => { onPan = callback }}
+        setOnZoom={callback => { onZoom = callback }}
+        src={'http://placekitten.com/200/400'}
+      >
+        <svg />
+      </SVGPanZoom>
+    )
+    viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+    await waitFor(() => expect(viewBox).to.equal('0 0 200 400'))
   })
 
-  it('should reset zoom with new src', function () {
+  it('should reset zoom with new src', async function () {
     onZoom('zoomin', 1)
-    wrapper.update()
-    let viewBox = wrapper.find('svg').prop('viewBox')
-    expect(viewBox).to.equal('18.5 9.5 363 181')
+    await waitFor(() => {
+      const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+      expect(viewBox).to.equal('18.5 9.5 363 181')
+    })
 
-    wrapper.setProps({ naturalHeight: 400, naturalWidth: 200, src: 'http://placekitten.com/200/400' })
-    wrapper.update()
-    viewBox = wrapper.find('svg').prop('viewBox')
-    expect(viewBox).to.equal('0 0 200 400')
+    wrapper.rerender(
+      <SVGPanZoom
+        img={img}
+        naturalHeight={400}
+        naturalWidth={200}
+        setOnDrag={callback => { onDrag = callback }}
+        setOnPan={callback => { onPan = callback }}
+        setOnZoom={callback => { onZoom = callback }}
+        src={'http://placekitten.com/200/400'}
+      >
+        <svg />
+      </SVGPanZoom>
+    )
+    const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+    await waitFor(() => expect(viewBox).to.equal('0 0 200 400'))
   })
 
   describe('when zooming function is controlled by prop', function () {
@@ -139,7 +166,7 @@ describe('Components > SVGPanZoom', function () {
       setOnDragSpy = sinon.spy()
       setOnPanSpy = sinon.spy()
       setOnZoomSpy = sinon.spy()
-      wrapper = mount(
+      wrapper = render(
         <SVGPanZoom
           img={img}
           naturalHeight={200}
@@ -162,14 +189,40 @@ describe('Components > SVGPanZoom', function () {
     })
 
     it('should register the handlers when zooming is set to true', function () {
-      wrapper.setProps({ zooming: true })
+      wrapper.rerender(
+        <SVGPanZoom
+          img={img}
+          naturalHeight={200}
+          naturalWidth={400}
+          setOnDrag={setOnDragSpy}
+          setOnPan={setOnPanSpy}
+          setOnZoom={setOnZoomSpy}
+          src={src}
+          zooming={true}
+        >
+          <svg />
+        </SVGPanZoom>
+      )
       expect(setOnDragSpy).to.have.been.called()
       expect(setOnPanSpy).to.have.been.called()
       expect(setOnZoomSpy).to.have.been.called()
     })
 
     it('should unregister the handler when zooming is set to false', function () {
-      wrapper.setProps({ zooming: false })
+      wrapper.rerender(
+        <SVGPanZoom
+          img={img}
+          naturalHeight={200}
+          naturalWidth={400}
+          setOnDrag={setOnDragSpy}
+          setOnPan={setOnPanSpy}
+          setOnZoom={setOnZoomSpy}
+          src={src}
+          zooming={false}
+        >
+          <svg />
+        </SVGPanZoom>
+      )
       expect(setOnDragSpy).to.have.been.calledTwice()
       expect(setOnPanSpy).to.have.been.calledTwice()
       expect(setOnZoomSpy).to.have.been.calledTwice()

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
@@ -104,14 +104,18 @@ describe('Components > SVGPanZoom', function () {
 
   it('should should pan horizontally on drag', async function () {
     onDrag({}, { x: -15, y: 0 })
-    const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
-    await waitFor(() => expect(viewBox).to.equal('15 0 400 200'))
+    await waitFor(() => {
+      const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+      expect(viewBox).to.equal('15 0 400 200')
+    })
   })
 
   it('should should pan vertically on drag', async function () {
     onDrag({}, { x: 0, y: -15 })
-    const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
-    await waitFor(() => expect(viewBox).to.equal('0 15 400 200'))
+    await waitFor(() => {
+      const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
+      expect(viewBox).to.equal('0 15 400 200')
+    })
   })
 
   it('should reset pan with new src', async function () {


### PR DESCRIPTION
- Remove `Object.assign()`.
- Use local component state to pass the SVG viewbox down to child components.
- debounce the drag handler for smoother dragging (#5110.)
- Remove Enzyme tests.

## Package
lib-classifier

## How to Review
Image zooming should continue to work as before on a project like I Fancy Cats.

_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
