### PR TITLE
Add ADR template

### DIFF
--- a/docs/ADR_TEMPLATE.md
+++ b/docs/ADR_TEMPLATE.md
@@ -1,0 +1,17 @@
+(From https://github.com/joelparkerhenderson/architecture-decision-record#adr-example-templates)
+
+Please add new ADRs to the Table of Contents [README.md](./arch/README.md).
+
+# Title
+
+## Status
+What is the status, such as proposed, accepted, rejected, deprecated, superseded, etc.?
+
+## Context
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+What is the change that we're proposing and/or doing?
+
+## Consequences
+What becomes easier or more difficult to do because of this change?


### PR DESCRIPTION
## Linked Issue and/or Talk Post

This is a follow up to the FEM Documentation discussion at ZTM.

## Describe your changes

I added a basic ADR template for our reference. It's based on the examples here: https://github.com/joelparkerhenderson/architecture-decision-record#adr-example-templates

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected