### PR TITLE
Mark ZRC as free of side effects

### DIFF
--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.5.5] 2023-08-15
+
+### Changed
+- add `sideEffects: false` to enable pruning of unused exports during tree-shaking.
+
 ## [1.5.4] 2023-06-01
 
 ### Fixed

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -3,9 +3,10 @@
   "description": "Zooniverse React Components",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/zooniverse/front-end-monorepo.git",


### PR DESCRIPTION
`@zooniverse/react-components` version 1.5.5
- add `sideEffects: false` to `package.json`, so that [bundlers prune unused exports](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free).

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-react-components

## How to Review
Build and run the NextJS apps. You should see that the output from `next build` reports somewhat smaller sizes for the first load JS. Webpack bundler analyzer (#5155) should report smaller bundled sizes for `@zooniverse/react-components`.

You can also look in the CI build logs to check the build sizes for each app.
- [content pages](https://github.com/zooniverse/front-end-monorepo/actions/runs/5872109608/job/15923026217?pr=5186#step:7:54).
- [project pages](https://github.com/zooniverse/front-end-monorepo/actions/runs/5872109608/job/15923026067?pr=5186#step:7:65).

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out

## Maintenance
- [x] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
