### PR TITLE
withRequireUser: Remove enzyme and convert tests to RTL

### DIFF
--- a/packages/app-project/src/shared/components/withRequireUser/withRequireUser.mock.js
+++ b/packages/app-project/src/shared/components/withRequireUser/withRequireUser.mock.js
@@ -1,0 +1,24 @@
+const withRequireUserLoggedInStoreMock = {
+	user: {
+		isLoggedIn: true
+	}
+}
+
+const withRequireUserLoggedOutStoreMock = {
+	user: {
+		isLoggedIn: false
+	}
+}
+
+const withRequireUserText = 'With Require User'
+
+function withRequireUserStubComponent () {
+	return <p>{withRequireUserText}</p>
+}
+
+export {
+	withRequireUserLoggedOutStoreMock,
+	withRequireUserLoggedInStoreMock,
+	withRequireUserText,
+	withRequireUserStubComponent
+}

--- a/packages/app-project/src/shared/components/withRequireUser/withRequireUser.spec.js
+++ b/packages/app-project/src/shared/components/withRequireUser/withRequireUser.spec.js
@@ -1,52 +1,39 @@
-import { shallow } from 'enzyme'
-import { expect } from 'chai'
-
-import withRequireUser from './withRequireUser'
+import { render, screen } from '@testing-library/react'
+import { withRequireUserText } from './withRequireUser.mock'
+import { composeStory } from '@storybook/react'
+import Meta, { LoggedIn, LoggedOut } from './withRequireUser.stories'
 
 describe('withRequireUser', function () {
-  function StubComponent () {
-    return <p>Hello</p>
-  }
-  const WithRequireUser = withRequireUser(StubComponent)
-  let wrapper
-
-  const loggedOutStore = {
-    user: {
-      isLoggedIn: false
-    }
-  }
-
-  const loggedInStore = {
-    user: {
-      isLoggedIn: true
-    }
-  }
-
-  describe('behavior when not logged in', function () {
-    before(function () {
-      wrapper = shallow(<WithRequireUser mockStore={loggedOutStore} />)
-    })
-
-    it('should render the wrapped component', function () {
-      expect(wrapper.find(StubComponent)).to.have.lengthOf(1)
-    })
-
-    it('should include a message to login', function () {
-      expect(wrapper.html()).to.include('RequireUser.text')
-    })
-  })
-
   describe('behavior when logged in', function () {
-    before(function () {
-      wrapper = shallow(<WithRequireUser mockStore={loggedInStore} />)
+    beforeEach(function () {
+			const LoggedInStory = composeStory(LoggedIn, Meta)
+			render(<LoggedInStory />)
     })
 
     it('should render the wrapped component', function () {
-      expect(wrapper.find(StubComponent)).to.have.lengthOf(1)
+      expect(screen.getByText(withRequireUserText)).to.exist()
     })
 
-    it('shouldn\'t render anything else', function () {
-      expect(wrapper.children()).to.have.lengthOf(1)
+    it('shouldn\'t include a message to log in', function () {
+			// doesn't have translation so we use the key
+      expect(screen.queryByText('RequireUser.text')).to.be.null()
     })
   })
+
+	describe('behavior when not logged in', function () {
+    beforeEach(function () {
+			const LoggedOutStory = composeStory(LoggedOut, Meta)
+			render(<LoggedOutStory />)
+    })
+
+    it('should render the wrapped component', function () {
+      expect(screen.getByText(withRequireUserText)).to.exist()
+    })
+
+    it('should include a message to log in', function () {
+			// doesn't have translation so we use the key
+      expect(screen.queryByText('RequireUser.text')).to.exist()
+    })
+  })
+
 })

--- a/packages/app-project/src/shared/components/withRequireUser/withRequireUser.stories.js
+++ b/packages/app-project/src/shared/components/withRequireUser/withRequireUser.stories.js
@@ -1,0 +1,26 @@
+import { Provider } from 'mobx-react'
+import withRequireUser from './withRequireUser'
+import { 
+	withRequireUserLoggedInStoreMock,
+	withRequireUserLoggedOutStoreMock,
+	withRequireUserStubComponent
+} from './withRequireUser.mock'
+
+const WithRequireUser = withRequireUser(withRequireUserStubComponent)
+
+export default {
+	title: 'Project App / Shared / withRequireUser',
+	component: WithRequireUser
+}
+
+export const LoggedIn = () => (
+	<Provider store={withRequireUserLoggedInStoreMock}>
+		<WithRequireUser />
+	</Provider>
+)
+
+export const LoggedOut = () => (
+	<Provider store={withRequireUserLoggedOutStoreMock}>
+		<WithRequireUser />
+	</Provider>
+)


### PR DESCRIPTION
## Package
app-project

## Describe your changes
Converted tests for the withRequireUser from Enzyme to RTL. 

## How to Review
[withRequireUser Story](http://localhost:9001/?path=/story/project-app-shared-withrequireuser--default)

## General
- [x] Unit Tests are passing locally and on Github
- [x] Storybook renders as expected
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected