### PR TITLE
SubjectPreview: Remove enzyme and convert tests to RTL

### DIFF
--- a/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.js
@@ -10,7 +10,7 @@ const defaultSubject = {
   toggleFavorite: () => false,
   locations: []
 }
-function SubjectPreview ({
+function SubjectPreview({
   height = '250px',
   isLoggedIn = false,
   placeholder,
@@ -28,6 +28,7 @@ function SubjectPreview ({
       fill
     >
       <Anchor
+        data-testid={`subject-preview-link-${subject.id}`}
         href={href}
       >
         <Box
@@ -37,6 +38,7 @@ function SubjectPreview ({
           width={width}
         >
           <Media
+            data-testid={`subject-image-${subject.id}`}
             alt={`subject ${subject.id}`}
             height={700}
             placeholder={placeholder}

--- a/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.mock.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.mock.js
@@ -1,0 +1,57 @@
+import Store from '@stores/Store'
+
+export const SubjectPreviewState = {
+  isLoggedIn: true,
+  slug: 'zooniverse/snapshot-serengeti',
+  subjectId: '123'
+}
+
+export const PlainSubjectMock = {
+  favorite: false,
+  id: SubjectPreviewState.subjectId,
+  locations: [
+    {
+      'image/jpeg':
+        'https://panoptes-uploads.zooniverse.org/production/subject_location/48972f7b-8a4d-4f98-a85b-ed3578db75f0.jpeg'
+    }
+  ]
+}
+
+export const TranscriptionSubjectMock = {
+  favorite: false,
+  id: SubjectPreviewState.subjectId,
+  locations: [
+    {
+      'image/jpeg':
+        'https://panoptes-uploads.zooniverse.org/production/subject_location/fb2c57e2-96f7-49b1-9bd4-9bdc73d847f8.jpeg'
+    }
+  ]
+}
+
+export const VideoSubjectMock = {
+  favorite: false,
+  id: SubjectPreviewState.subjectId,
+  locations: [
+    {
+      'video/mp4':
+        'https://panoptes-uploads.zooniverse.org/production/subject_location/279b23de-b1e8-4a1c-90c4-2d25bbee787d.mp4'
+    }
+  ]
+}
+
+const snapshot = {
+  project: {
+    strings: {
+      display_name: 'Snapshot Serengeti',
+    }
+  },
+  user: {
+    collections: {
+      collections: [],
+    }
+  }
+}
+
+export const StoreMock = Store.create(snapshot)
+
+

--- a/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.spec.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.spec.js
@@ -1,108 +1,88 @@
-import { shallow } from 'enzyme'
-import { Anchor } from 'grommet'
-import { FavouritesButton, Media } from '@zooniverse/react-components'
-
-import SubjectPreview from './SubjectPreview'
-import { CollectionsButton, TalkLink } from './components'
+import { render, screen } from '@testing-library/react'
+import { composeStory } from '@storybook/react'
+import Meta, { Plain, Transcription, Video } from './SubjectPreview.stories.js'
+import { SubjectPreviewState } from './SubjectPreview.mock.js'
 
 describe('Component > SubjectPreview', function () {
-  let wrapper
-  const subject = {
-    favorite: false,
-    id: '12345',
-    locations: [
-      { 'image/jpeg': 'https://somedomain/photo.jpg' }
-    ],
-    toggleFavourite: () => false
-  }
-  const slug = 'owner/projectName'
+  [Plain, Transcription, Video].forEach(Component => {
+    describe(`${Component.name} logged in story`, function () {
+      beforeEach(function () {
+        const Story = composeStory(Component, Meta)
+        render(<Story />)
+      })
 
-  before(function () {
-    wrapper = shallow(
-      <SubjectPreview
-        isLoggedIn
-        subject={subject}
-        slug={slug}
-      />
-    )
-  })
+      it('should link to the subject Talk page from the preview media', function () {
+        expect(screen.getByTestId(`subject-preview-link-${SubjectPreviewState.subjectId}`)).to.have.property('href')
+          .to.equal(`https://localhost/projects/${SubjectPreviewState.slug}/talk/subjects/${SubjectPreviewState.subjectId}`)
+      })
 
-  it('should render without crashing', function () {
-    expect(wrapper).to.be.ok()
-  })
+      it('should display the subject image preview media', function () {
+        expect(screen.getByTestId(`subject-image-${SubjectPreviewState.subjectId}`)).to.exist()
+      })
 
-  describe('the preview media', function () {
-    let link
-    let media
+      it('should have a talk link', function () {
+        expect(screen.getByText('SubjectPreview.TalkLink.label')).to.exist()
+      })
 
-    before(function () {
-      link = wrapper.find(Anchor)
-      media = link.find(Media)
+      it('should have a favorites button', function () {
+        expect(screen.getByText('Add to favorites')).to.exist()
+      })
+
+      it('should be able to add to favorites', function () {
+        expect(screen.getByRole('checkbox', { checked: false })).to.exist()
+      })
+
+      it('should not have favorites disabled', function () {
+        expect(screen.getByRole('checkbox', { checked: false })).to.have.property('disabled').to.equal(false)
+      })
+
+      it('should have a collections button', function () {
+        expect(screen.getByText('SubjectPreview.CollectionsButton.add')).to.exist()
+      })
+
+      it('should have collections enabled', function () {
+        expect(screen.getByTestId('subject-collections-button')).to.have.property('disabled').to.equal(false)
+      })
     })
 
-    it('should link to the subject Talk page', function () {
-      expect(link.prop('href')).to.equal(`/projects/${slug}/talk/subjects/${subject.id}`)
-    })
+    describe(`${Component.name} logged out story`, function () {
+      beforeEach(function () {
+        const Story = composeStory(Component, Meta)
+        render(<Story isLoggedIn={false} />)
+      })
 
-    it('should display the first subject location', function () {
-      expect(media.prop('src')).to.equal('https://somedomain/photo.jpg')
-    })
+      it('should link to the subject Talk page from the preview media', function () {
+        expect(screen.getByTestId(`subject-preview-link-${SubjectPreviewState.subjectId}`)).to.have.property('href')
+          .to.equal(`https://localhost/projects/${SubjectPreviewState.slug}/talk/subjects/${SubjectPreviewState.subjectId}`)
+      })
 
-    it('should have alt text', function () {
-      expect(media.prop('alt')).to.equal('subject 12345')
-    })
-  })
+      it('should display the subject image preview media', function () {
+        expect(screen.getByTestId(`subject-image-${SubjectPreviewState.subjectId}`)).to.exist()
+      })
 
-  it('should have a talk link', function () {
-    expect(wrapper.find(TalkLink).length).to.equal(1)
-  })
+      it('should have a talk link', function () {
+        expect(screen.getByText('SubjectPreview.TalkLink.label')).to.exist()
+      })
 
-  describe('the favourites button', function () {
-    let favouritesButton
+      it('should have a favorites button', function () {
+        expect(screen.getByText('Add to favorites')).to.exist()
+      })
 
-    beforeEach(function () {
-      favouritesButton = wrapper.find(FavouritesButton)
-    })
+      it('should be able to add to favorites', function () {
+        expect(screen.getByRole('checkbox', { checked: false })).to.exist()
+      })
 
-    it('should exist', function () {
-      expect(favouritesButton.length).to.equal(1)
-    })
+      it('should have favorites disabled', function () {
+        expect(screen.getByRole('checkbox', { checked: false })).to.have.property('disabled').to.equal(true)
+      })
 
-    it('should be enabled', function () {
-      expect(favouritesButton.prop('disabled')).to.be.false()
-    })
+      it('should have a collections button', function () {
+        expect(screen.getByText('SubjectPreview.CollectionsButton.add')).to.exist()
+      })
 
-    it('should not be checked', function () {
-      expect(favouritesButton.prop('checked')).to.be.false()
-    })
-  })
-
-  describe('the collections button', function () {
-    it('should exist', function () {
-      expect(wrapper.find(CollectionsButton).length).to.equal(1)
-    })
-
-    it('should be enabled', function () {
-      expect(wrapper.find(CollectionsButton).prop('disabled')).to.be.false()
-    })
-  })
-
-  describe('without a logged-in user', function () {
-    before(function () {
-      wrapper = shallow(
-        <SubjectPreview
-          subject={subject}
-          slug={slug}
-        />
-      )
-    })
-
-    it('should disable favourites', function () {
-      expect(wrapper.find(FavouritesButton).prop('disabled')).to.be.true()
-    })
-
-    it('should disable collections', function () {
-      expect(wrapper.find(CollectionsButton).prop('disabled')).to.be.true()
+      it('should have collections disabled', function () {
+        expect(screen.getByTestId('subject-collections-button')).to.have.property('disabled').to.equal(true)
+      })
     })
   })
 })

--- a/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.stories.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.stories.js
@@ -1,132 +1,63 @@
 import { Box } from 'grommet'
 import { Provider } from 'mobx-react'
-import Store from '@stores/Store'
-
 import SubjectPreview from './'
-
-const GIRAFFE = {
-  favorite: false,
-  id: '123',
-  locations: [
-    {
-      'image/jpeg':
-        'https://panoptes-uploads.zooniverse.org/production/subject_location/48972f7b-8a4d-4f98-a85b-ed3578db75f0.jpeg'
-    }
-  ]
-}
-
-const PORTRAIT_PAGE = {
-  favorite: false,
-  id: '123',
-  locations: [
-    {
-      'image/jpeg':
-        'https://panoptes-uploads.zooniverse.org/production/subject_location/fb2c57e2-96f7-49b1-9bd4-9bdc73d847f8.jpeg'
-    }
-  ]
-}
-
-const VIDEO = {
-  favorite: false,
-  id: '123',
-  locations: [
-    {
-      'video/mp4':
-        'https://panoptes-uploads.zooniverse.org/production/subject_location/279b23de-b1e8-4a1c-90c4-2d25bbee787d.mp4'
-    }
-  ]
-}
-
-function toggle() {
-  this.favorite = !this.favorite
-}
-
-;[GIRAFFE, PORTRAIT_PAGE, VIDEO].forEach(subject => {
-  subject.toggleFavourite = toggle.bind(subject)
-})
-
-const snapshot = {
-  project: {
-    strings: {
-      display_name: 'Snapshot Serengeti',
-    }
-  },
-  user: {
-    collections: {
-      collections: [],
-    }
-  }
-}
-
-const store = Store.create(snapshot)
+import {
+  PlainSubjectMock,
+  TranscriptionSubjectMock,
+  VideoSubjectMock,
+  SubjectPreviewState,
+  StoreMock
+} from './SubjectPreview.mock'
 
 export default {
   title: 'Project App / Shared / Subject Preview',
   component: SubjectPreview
 }
 
-export function Plain({ isLoggedIn, subject, slug }) {
-  return (
-    <Provider store={store}>
-      <Box height='medium' pad='medium' width='medium'>
-        <SubjectPreview
-          height='200px'
-          isLoggedIn={isLoggedIn}
-          subject={subject}
-          slug={slug}
-          width='270px'
-        />
-      </Box>
-    </Provider>
-  )
-}
+export const Plain = ({ isLoggedIn, subject, slug }) => (
+  <Provider store={StoreMock}>
+    <Box height='medium' pad='medium' width='medium'>
+      <SubjectPreview
+        height='200px'
+        isLoggedIn={isLoggedIn}
+        subject={subject}
+        slug={slug}
+        width='270px'
+      />
+    </Box>
+  </Provider>
+)
 
-Plain.args = {
-  isLoggedIn: true,
-  subject: GIRAFFE,
-  slug: 'zooniverse/snapshot-serengeti'
-}
+Plain.args = { ...SubjectPreviewState, subject: PlainSubjectMock }
 
-export function Transcription({ isLoggedIn, subject, slug }) {
-  return (
-    <Provider store={store}>
-      <Box height='medium' pad='medium' width='medium'>
-        <SubjectPreview
-          height='200px'
-          isLoggedIn={isLoggedIn}
-          subject={subject}
-          slug={slug}
-          width='270px'
-        />
-      </Box>
-    </Provider>
-  )
-}
+export const Transcription = ({ isLoggedIn, subject, slug }) => (
+  <Provider store={StoreMock}>
+    <Box height='medium' pad='medium' width='medium'>
+      <SubjectPreview
+        height='200px'
+        isLoggedIn={isLoggedIn}
+        subject={subject}
+        slug={slug}
+        width='270px'
+      />
+    </Box>
+  </Provider>
+)
 
-Transcription.args = {
-  isLoggedIn: true,
-  subject: PORTRAIT_PAGE,
-  slug: 'zooniverse/snapshot-serengeti'
-}
+Transcription.args = { ...SubjectPreviewState, subject: TranscriptionSubjectMock }
 
-export function Video({ isLoggedIn, subject, slug }) {
-  return (
-    <Provider store={store}>
-      <Box height='medium' pad='medium' width='medium'>
-        <SubjectPreview
-          height='200px'
-          isLoggedIn={isLoggedIn}
-          subject={subject}
-          slug={slug}
-          width='270px'
-        />
-      </Box>
-    </Provider>
-  )
-}
+export const Video = ({ isLoggedIn, subject, slug }) => (
+  <Provider store={StoreMock}>
+    <Box height='medium' pad='medium' width='medium'>
+      <SubjectPreview
+        height='200px'
+        isLoggedIn={isLoggedIn}
+        subject={subject}
+        slug={slug}
+        width='270px'
+      />
+    </Box>
+  </Provider>
+)
 
-Video.args = {
-  isLoggedIn: true,
-  subject: VIDEO,
-  slug: 'zooniverse/snapshot-serengeti'
-}
+Video.args = { ...SubjectPreviewState, subject: VideoSubjectMock }

--- a/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.js
@@ -23,6 +23,7 @@ export default function CollectionsButton({ disabled, onClick, subject }) {
         subjectID={subject.id}
       />
       <MetaToolsButton
+        data-testid="subject-collections-button"
         disabled={disabled}
         icon={<CollectionsIcon color='dark-5' size='15px' />}
         text={t('SubjectPreview.CollectionsButton.add')}

--- a/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.spec.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.spec.js
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { composeStory } from '@storybook/react'
+import Meta, { CollectionsButton } from './CollectionsButton.stories.js'
+
+describe('Component > CollectionsButton', function () {
+  beforeEach(function () {
+    const CollectionsButtonStory = composeStory(CollectionsButton, Meta)
+    render(<CollectionsButtonStory />)
+  })
+
+  it('should render the CollectionsButton', function () {
+    expect(screen.getByText('SubjectPreview.CollectionsButton.add')).to.exist()
+  })
+
+  // NOTE: We do not test the CollectionsModal functionality here.
+  // It is tested in the CollectionsModal component.
+  it('should open the CollectionsModal and dismiss correctly', function () {
+    fireEvent.click(screen.getByText('SubjectPreview.CollectionsButton.add'))
+    waitFor(function() {
+      expect(screen.getByText('CollectionsModal.title')).to.exist()
+      fireEvent.click(screen.getByLabelText('Close'))
+      waitFor(function() {
+        expect(screen.getByText('SubjectPreview.CollectionsButton.add')).to.exist()
+      })
+    })
+  })
+})

--- a/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.stories.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/components/CollectionsButton/CollectionsButton.stories.js
@@ -2,7 +2,9 @@
 import { Provider } from 'mobx-react'
 
 import Store from '@stores/Store'
-import CollectionsButton from './'
+import CollectionsButtonComponent from './'
+import { Grommet } from 'grommet'
+import zooTheme from '@zooniverse/grommet-theme'
 
 const CAT = {
   favorite: false,
@@ -27,7 +29,7 @@ const store = Store.create(snapshot)
 
 export default {
   title: 'Project App / Shared / Collections Button',
-  component: CollectionsButton,
+  component: CollectionsButtonComponent,
   parameters: {
     // docs: {
     //   description: {
@@ -37,8 +39,10 @@ export default {
   }
 }
 
-export const Plain = () => (
+export const CollectionsButton = () => (
   <Provider store={store}>
-    <CollectionsButton disabled={false} subject={CAT} />
+    <Grommet theme={zooTheme}>
+      <CollectionsButtonComponent disabled={false} subject={CAT} />
+    </Grommet>
   </Provider>
 )

--- a/packages/app-project/src/shared/components/SubjectPreview/components/TalkLink/TalkIcon.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/components/TalkLink/TalkIcon.js
@@ -1,9 +1,10 @@
 import { Blank } from 'grommet-icons'
 
-export default function TalkIcon (props) {
+export default function TalkIcon(props) {
   return (
     <Blank
       viewBox='0 0 24 24'
+      data-testid="talk-icon"
       {...props}
     >
       <path

--- a/packages/app-project/src/shared/components/SubjectPreview/components/TalkLink/TalkLink.spec.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/components/TalkLink/TalkLink.spec.js
@@ -1,29 +1,18 @@
-import { shallow } from 'enzyme'
-import { MetaToolsButton } from '@zooniverse/react-components'
-
-import TalkLink from './TalkLink'
-import TalkIcon from './TalkIcon'
-
-let wrapper
+import { render, screen } from '@testing-library/react'
+import { composeStory } from '@storybook/react'
+import Meta, { TalkLink } from './TalkLink.stories.js'
 
 describe('Component > TalkLink', function () {
-  before(function () {
-    wrapper = shallow(<TalkLink href='/project/slug/talk/1234' />)
-  })
-
-  it('should render without crashing', function () {
-    expect(wrapper).to.be.ok()
+  beforeEach(function () {
+    const TalkLinkStory = composeStory(TalkLink, Meta)
+    render(<TalkLinkStory />)
   })
 
   it('should display a Talk icon', function () {
-    const button = wrapper.find(MetaToolsButton)
-    const { icon } = button.props()
-    expect(icon).to.deep.equal(<TalkIcon color='dark-5' size='15px' />)
+    expect(screen.getByTestId('talk-icon', { hidden: true })).to.exist()
   })
 
   it('should link to the subject Talk page', function () {
-    const button = wrapper.find(MetaToolsButton)
-    const { href } = button.props()
-    expect(href).to.equal('/project/slug/talk/1234')
+    expect(screen.getByText('SubjectPreview.TalkLink.label')).to.exist()
   })
 })

--- a/packages/app-project/src/shared/components/SubjectPreview/components/TalkLink/TalkLink.stories.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/components/TalkLink/TalkLink.stories.js
@@ -1,0 +1,14 @@
+import TalkLinkComponent from './'
+import { Grommet } from 'grommet'
+import zooTheme from '@zooniverse/grommet-theme'
+
+export default {
+  title: 'Project App / Shared / Talk Link',
+  component: TalkLinkComponent,
+}
+
+export const TalkLink = () => (
+  <Grommet theme={zooTheme}>
+    <TalkLinkComponent href='/project/slug/talk/1234' />
+  </Grommet>
+)


### PR DESCRIPTION
## Package
app-project

## Describe your changes
Converted tests for the SubjectPreview from Enzyme to RTL. Includes changes for CollectionsButton and TalkLink.

## How to Review
[SubjectPreview Story](http://localhost:9001/?path=/story/project-app-shared-subject-preview--plain)
[CollectionsButton Story](http://localhost:9001/?path=/story/project-app-shared-collections-button--collections-button)
[TalkLink Story](http://localhost:9001/?path=/story/project-app-shared-talk-link--talk-link)

## General
- [ ] Unit Tests are passing locally and on Github
- [ ] Storybook renders as expected
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected