### PR TITLE
Panoptes client: match project slugs more strictly

### DIFF
--- a/packages/lib-panoptes-js/docs/CHANGELOG.md
+++ b/packages/lib-panoptes-js/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.4.1] 2023-08-24
+- fix a check for the `/projects` path.
+
 ## [0.4.0] 2023-07-04
 - add `auth.decodeJWT(token)` to get a Panoptes user from a token.
 - allow `auth` methods to accept Authorization headers (which are used in the Classifier) as well as tokens.

--- a/packages/lib-panoptes-js/package.json
+++ b/packages/lib-panoptes-js/package.json
@@ -3,7 +3,7 @@
   "description": "A Javascript client for Panoptes API using Superagent",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "src/index.js",
   "repository": {
     "type": "git",

--- a/packages/lib-panoptes-js/src/resources/projects/commonRequests.js
+++ b/packages/lib-panoptes-js/src/resources/projects/commonRequests.js
@@ -7,7 +7,7 @@ function getBySlug (params) {
   const authorization = (params && params.authorization) ? params.authorization : ''
 
   if (queryParams.slug && typeof queryParams.slug !== 'string') return raiseError('Projects: Get request slug must be a string.', 'typeError')
-  if (queryParams.slug && queryParams.slug.includes('projects')) {
+  if (queryParams.slug?.startsWith('projects/') || queryParams.slug?.startsWith('/projects/')) {
     queryParams.slug = getProjectSlugFromURL(queryParams.slug)
   }
 

--- a/packages/lib-panoptes-js/src/resources/projects/commonRequests.spec.js
+++ b/packages/lib-panoptes-js/src/resources/projects/commonRequests.spec.js
@@ -51,7 +51,7 @@ describe('Projects resource common requests', function () {
     })
 
     it('should return the expected response if the slug is defined', async function () {
-      const slug = 'user/untitled-project-2'
+      const slug = 'user/untitled-projects-2'
       const response = await projects.getBySlug({ query: { slug } })
       expect(response.body).to.eql(expectedGetResponse)
     })


### PR DESCRIPTION
Catch any project slugs that begin with `/projects/` or `projects/`, rather than matching on `projects` anywhere in the slug. Add a test for the buggy behaviour and publish as v0.4.1.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-panoptes-js

## How to Review
Load a project that includes `projects` in either the username or the project name.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
