### PR TITLE
ContentBox: Remove enzyme and convert tests to RTL

### DIFF
--- a/packages/app-project/src/shared/components/ContentBox/ContentBox.mock.js
+++ b/packages/app-project/src/shared/components/ContentBox/ContentBox.mock.js
@@ -1,0 +1,10 @@
+export const ContentBoxMock = {
+  title: 'Test Title',
+  linkLabel: 'Test Label',
+  linkProps: {
+    href: 'https://www.zooniverse.org/projects/zooniverse/serengeti'
+  },
+  contentText: `Test content text...`
+}
+
+ContentBoxMock.content = (<div>{ContentBoxMock.contentText}</div>)

--- a/packages/app-project/src/shared/components/ContentBox/ContentBox.spec.js
+++ b/packages/app-project/src/shared/components/ContentBox/ContentBox.spec.js
@@ -1,58 +1,69 @@
-import { shallow } from 'enzyme'
-import NavLink from '@shared/components/NavLink'
-
-import { ContentBox } from './ContentBox'
-
-const Foobar = () => (<div>Foobar</div>)
+import { render, screen } from '@testing-library/react'
+import { Grommet } from 'grommet'
+import { zooTheme } from '@zooniverse/grommet-theme'
+import { composeStory } from '@storybook/react'
+import Meta, { Plain, ContentWithTitle, ContentWithTitleAndALink } from './ContentBox.stories.js'
+import { ContentBoxMock } from './ContentBox.mock'
 
 describe('Component > ContentBox', function () {
-  let wrapper
-  before(function () {
-    wrapper = shallow(
-      <ContentBox theme={{ dark: false }}>
-        <Foobar />
-      </ContentBox>
-    )
-  })
-
-  it('should render without crashing', function () {
-    expect(wrapper).to.be.ok()
-  })
-
-  it('should render its children', function () {
-    expect(wrapper.find(Foobar)).to.have.lengthOf(1)
-  })
-
-  describe('with link props', function () {
-    let wrapper
-
-    before(function () {
-      let linkProps = {
-        href: '/projects/test/project/stats'
-      }
-      wrapper = shallow(
-        <ContentBox
-          theme={{ dark: false }}
-          linkLabel='View more stats'
-          linkProps={linkProps}
-          >
-          <Foobar />
-        </ContentBox>
-      )
+  describe('content only', function () {
+    beforeEach(function () {
+      const PlainStory = composeStory(Plain, Meta)
+      render(<Grommet theme={zooTheme}><PlainStory /></Grommet>)
     })
 
-    it('should render a navigation link', function () {
-      expect(wrapper.find(NavLink)).to.have.lengthOf(1)
+    it('should render the content', async function () {
+      expect(screen.getByText(ContentBoxMock.contentText)).to.exist()
     })
 
-    it('should link to the specified href', function () {
-      const link = wrapper.find(NavLink).prop('link')
-      expect(link.href).to.equal('/projects/test/project/stats')
+    it('should not render the title', async function () {
+      expect(screen.queryByText(ContentBoxMock.title)).to.be.null()
     })
     
-    it('should use the specified link text', function () {
-      const link = wrapper.find(NavLink).prop('link')
-      expect(link.text).to.equal('View more stats')
+    it('should not render the link', function () {
+      expect(screen.queryByRole('link')).to.be.null()
+    })
+  })
+
+  describe('content with title', function () {
+    beforeEach(function () {
+      const ContentWithTitleStory = composeStory(ContentWithTitle, Meta)
+      render(<Grommet theme={zooTheme}><ContentWithTitleStory /></Grommet>)
+    })
+
+    it('should render the content', async function () {
+      expect(screen.getByText(ContentBoxMock.contentText)).to.exist()
+    })
+
+    it('should render the title', async function () {
+      expect(screen.getByText(ContentBoxMock.title)).to.exist()
+    })
+    
+    it('should not render the link', function () {
+      expect(screen.queryByRole('link')).to.be.null()
+    })
+  })
+
+  describe('content with title and link', function () {
+    beforeEach(function () {
+      const ContentWithTitleAndALinkStory = composeStory(ContentWithTitleAndALink, Meta)
+      render(<Grommet theme={zooTheme}><ContentWithTitleAndALinkStory /></Grommet>)
+    })
+
+    it('should render the content', async function () {
+      expect(screen.getByText(ContentBoxMock.contentText)).to.exist()
+    })
+
+    it('should render the title', async function () {
+      expect(screen.getByText(ContentBoxMock.title)).to.exist()
+    })
+    
+    it('should render the link', function () {
+      expect(screen.getByRole('link')).to.have.property('href')
+        .to.equal(ContentBoxMock.linkProps.href)
+
+      expect(screen.getByRole('link')).to.have.property('text')
+        .to.equal(ContentBoxMock.linkLabel)
     })
   })
 })

--- a/packages/app-project/src/shared/components/ContentBox/ContentBox.stories.js
+++ b/packages/app-project/src/shared/components/ContentBox/ContentBox.stories.js
@@ -1,32 +1,26 @@
 import ContentBox from './ContentBox'
-
-const CONTENT = (
-  <div>
-    A natoque elementum venenatis tempus nec vel placerat vehicula vestibulum
-    platea, posuere eget quam donec magna sodales euismod parturient fermentum.
-    Gravida suspendisse dictum consectetur nec convallis ridiculus nisi, integer
-    proin condimentum urna in vestibulum adipiscing, lectus eros tempus metus
-    primis fermentum. Maecenas torquent posuere sit lorem vehicula conubia
-    habitant, vel est placerat semper hendrerit neque porta, parturient mi massa
-    metus integer quam.
-  </div>
-)
-const LINK_LABEL = 'A link'
-const LINK_URL = '#'
-const TITLE = 'Here is a title'
+import { ContentBoxMock } from './ContentBox.mock'
 
 export default {
   title: 'Project App / Shared / ContentBox'
 }
 
-export const Plain = () => <ContentBox>{CONTENT}</ContentBox>
+export const Plain = () => (
+  <ContentBox>{ContentBoxMock.content}</ContentBox>
+)
 
 export const ContentWithTitle = () => (
-  <ContentBox title={TITLE}>{CONTENT}</ContentBox>
+  <ContentBox title={ContentBoxMock.title}>
+    {ContentBoxMock.content}
+  </ContentBox>
 )
 
 export const ContentWithTitleAndALink = () => (
-  <ContentBox linkLabel={LINK_LABEL} linkUrl={LINK_URL} title={TITLE}>
-    {CONTENT}
+  <ContentBox
+    linkLabel={ContentBoxMock.linkLabel}
+    linkProps={ContentBoxMock.linkProps}
+    title={ContentBoxMock.title}
+  >
+    {ContentBoxMock.content}
   </ContentBox>
 )


### PR DESCRIPTION
## Package
app-project

## Describe your changes
Converted tests for the ContentBox from Enzyme to RTL. 

## How to Review
[ContentBox Story](http://localhost:9001/?path=/story/project-app-shared-contentbox--plain)

## General
- [ ] Unit Tests are passing locally and on Github
- [ ] Storybook renders as expected
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected