### PR TITLE
NavLink: Remove enzyme and convert tests to RTL

### DIFF
--- a/packages/app-project/src/shared/components/NavLink/NavLink.mock.js
+++ b/packages/app-project/src/shared/components/NavLink/NavLink.mock.js
@@ -1,0 +1,22 @@
+export const NavLinkCurrentPageMock = {
+  asPath: '/projects/foo/bar/baz',
+  pathname: '/projects/[project]/[owner]/baz',
+  query: {
+    owner: 'foo',
+    project: 'bar'
+  }
+}
+
+export const NavLinkOtherPageMock = {
+  asPath: '/projects/foo/bar/bing',
+  pathname: '/projects/[project]/[owner]/bing',
+  query: {
+    owner: 'foo',
+    project: 'bar'
+  }
+}
+
+export const NavLinkMock = {
+  href: '/projects/foo/bar/baz',
+  text: 'Foobar'
+}

--- a/packages/app-project/src/shared/components/NavLink/NavLink.spec.js
+++ b/packages/app-project/src/shared/components/NavLink/NavLink.spec.js
@@ -1,101 +1,51 @@
-import { expect } from 'chai'
-import { shallow } from 'enzyme'
-import { Anchor } from 'grommet'
-import Link from 'next/link'
-
-import { NavLink } from './NavLink'
+import { render, screen } from '@testing-library/react'
+import { composeStory } from '@storybook/react'
+import Meta, { OnCurrentPage, NotOnCurrentPage, Disabled } from './NavLink.stories.js'
+import { NavLinkMock } from './NavLink.mock'
 
 describe('Component > NavLink', function () {
-  const ROUTER_ON_CURRENT_PAGE = {
-    asPath: '/projects/foo/bar/baz',
-    pathname: '/projects/[project]/[owner]/baz',
-    query: {
-      owner: 'foo',
-      project: 'bar'
-    }
-  }
-
-  const ROUTER_ON_OTHER_PAGE = {
-    asPath: '/projects/foo/bar/bing',
-    pathname: '/projects/[project]/[owner]/bing',
-    query: {
-      owner: 'foo',
-      project: 'bar'
-    }
-  }
-
-  const LINK = {
-    href: '/projects/foo/bar/baz',
-    text: 'Foobar'
-  }
-
-  describe('default behaviour', function () {
-    let wrapper
-
-    before(function () {
-      wrapper = shallow(<NavLink router={ROUTER_ON_OTHER_PAGE} link={LINK} />)
-    })
-
-    it('should render without crashing', function () {
-      expect(wrapper).to.be.ok()
-    })
-
-    it('should have the correct text', function () {
-      const link = wrapper.find(Anchor)
-      const { label } = link.props()
-      expect(label.props.children).to.equal(LINK.text)
-    })
-  })
-
-  describe('when not on the current page', function () {
-    let wrapper
-
-    before(function () {
-      wrapper = shallow(<NavLink router={ROUTER_ON_OTHER_PAGE} link={LINK} />)
-    })
-
-    it('should have a link', function () {
-      const link = wrapper.find(Link)
-      expect(link).to.have.lengthOf(1)
-    })
-
-    it(`should have an href`, function () {
-      const link = wrapper.find(Link)
-      expect(link.prop('href')).to.equal(LINK.href)
-    })
-  })
-
-  describe('when on the current page', function () {
-    let wrapper
-
-    before(function () {
-      wrapper = shallow(<NavLink router={ROUTER_ON_CURRENT_PAGE} link={LINK} />)
-    })
-
-    it('should not have a href', function () {
-      const link = wrapper.find(Anchor)
-      expect(link.prop('href')).to.be.undefined()
+  describe('when on current page', function () {
+    beforeEach(function () {
+      const OnCurrentPageStory = composeStory(OnCurrentPage, Meta)
+      render(<OnCurrentPageStory />)
     })
 
     it('should not have a link', function () {
-      const link = wrapper.find(Link)
-      expect(link).to.be.empty()
+      expect(screen.queryByRole('link')).to.be.null()
+    })
+
+    it('should have the correct text', function () {
+      expect(screen.getByText(NavLinkMock.text)).to.be.ok()
     })
   })
 
-  describe('when the link is "disabled"', function () {
-    let wrapper
-    before(function () {
-      wrapper = shallow(<NavLink disabled router={ROUTER_ON_OTHER_PAGE} link={LINK} />)
+  describe('when not on current page', function () {
+    beforeEach(function () {
+      const NotOnCurrentPageStory = composeStory(NotOnCurrentPage, Meta)
+      render(<NotOnCurrentPageStory />)
     })
 
-    it('should render as a span', function () {
-      expect(wrapper.find(Anchor).props().as).to.equal('span')
+    it('should have the correct link', function () {
+      expect(screen.getByRole('link').getAttribute('href')).to.equal(NavLinkMock.href)
     })
 
-    it('should not use client side links', function () {
-      const nextLink = wrapper.find(Link)
-      expect(nextLink).to.be.empty()
+    it('should have the correct text', function () {
+      expect(screen.getByText(NavLinkMock.text)).to.be.ok()
+    })
+  })
+
+  describe('when link is disabled', function () {
+    beforeEach(function () {
+      const DisabledStory = composeStory(Disabled, Meta)
+      render(<DisabledStory />)
+    })
+
+    it('should have the correct link', function () {
+      expect(screen.queryByRole('link')).to.be.null()
+    })
+
+    it('should have the correct text', function () {
+      expect(screen.getByText(NavLinkMock.text)).to.be.ok()
     })
   })
 })

--- a/packages/app-project/src/shared/components/NavLink/NavLink.stories.js
+++ b/packages/app-project/src/shared/components/NavLink/NavLink.stories.js
@@ -1,0 +1,19 @@
+import NavLink from './NavLink'
+import { NavLinkCurrentPageMock, NavLinkOtherPageMock, NavLinkMock } from './NavLink.mock'
+
+export default {
+  title: 'Project App / Shared / NavLink',
+  component: NavLink
+}
+
+export const OnCurrentPage = () => (
+  <NavLink router={NavLinkCurrentPageMock} link={NavLinkMock} />
+)
+
+export const NotOnCurrentPage = () => (
+  <NavLink router={NavLinkOtherPageMock} link={NavLinkMock} />
+)
+
+export const Disabled = () => (
+  <NavLink disabled router={NavLinkOtherPageMock} link={NavLinkMock} />
+)


### PR DESCRIPTION
## Package
app-project

## Describe your changes
Converted tests for the NavLink from Enzyme to RTL. 

## How to Review
[NavLink Story](http://localhost:9001/?path=/story/project-app-shared-navlink--on-current-page)

## General
- [ ] Unit Tests are passing locally and on Github
- [ ] Storybook renders as expected
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected