### PR TITLE
WidgetHeading: Remove enzyme and convert tests to RTL

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.spec.js
@@ -24,6 +24,7 @@ describe('Component > ClassifyPageContainer', function () {
     }
   }
 
+	this.timeout(10000)
   let wrapper
   let componentWrapper
 

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.spec.js
@@ -24,7 +24,6 @@ describe('Component > ClassifyPageContainer', function () {
     }
   }
 
-	this.timeout(10000)
   let wrapper
   let componentWrapper
 

--- a/packages/app-project/src/shared/components/WidgetHeading/WidgetHeading.js
+++ b/packages/app-project/src/shared/components/WidgetHeading/WidgetHeading.js
@@ -1,6 +1,6 @@
 import { SpacedText } from '@zooniverse/react-components'
 import { Heading } from 'grommet'
-import { string } from 'prop-types'
+import { string, node } from 'prop-types'
 import styled from 'styled-components'
 
 const StyledHeading = styled(Heading)`
@@ -29,7 +29,7 @@ function WidgetHeading ({
 
 WidgetHeading.propTypes = {
   level: string,
-  text: string
+  children: node
 }
 
 export default WidgetHeading

--- a/packages/app-project/src/shared/components/WidgetHeading/WidgetHeading.mock.js
+++ b/packages/app-project/src/shared/components/WidgetHeading/WidgetHeading.mock.js
@@ -1,0 +1,6 @@
+export const WidgetHeadingMock = {
+  level: '2',
+  text: `Test content text...`
+}
+
+WidgetHeadingMock.children = (<div>{WidgetHeadingMock.text}</div>)

--- a/packages/app-project/src/shared/components/WidgetHeading/WidgetHeading.spec.js
+++ b/packages/app-project/src/shared/components/WidgetHeading/WidgetHeading.spec.js
@@ -1,25 +1,13 @@
-import { shallow } from 'enzyme'
-
-import WidgetHeading from './WidgetHeading'
-
-let wrapper
-const LEVEL = '2'
-const TEXT = 'Foobar'
+import { render, screen } from '@testing-library/react'
+import { composeStory } from '@storybook/react'
+import Meta, { WidgetHeading } from './WidgetHeading.stories.js'
+import { WidgetHeadingMock } from './WidgetHeading.mock'
 
 describe('Component > WidgetHeading', function () {
-  before(function () {
-    wrapper = shallow(<WidgetHeading level={LEVEL}>{TEXT}</WidgetHeading>)
-  })
-
-  it('should render without crashing', function () {
-    expect(wrapper).to.be.ok()
-  })
-
-  it('should include the text from the `text` prop', function () {
-    expect(wrapper.render().html()).to.include(TEXT)
-  })
-
-  it('should pass down the `level` prop to the `Heading` component', function () {
-    expect(wrapper.prop('level')).to.equal(LEVEL)
+  it('should render the element correctly', async function () {
+    const WidgetHeadingStory = composeStory(WidgetHeading, Meta)
+    render(<WidgetHeadingStory />)
+    expect(screen.getByRole('heading', {level: parseInt(WidgetHeadingMock.level, 10)})).to.exist()
+    expect(screen.getByText(WidgetHeadingMock.text)).to.exist()
   })
 })

--- a/packages/app-project/src/shared/components/WidgetHeading/WidgetHeading.stories.js
+++ b/packages/app-project/src/shared/components/WidgetHeading/WidgetHeading.stories.js
@@ -1,0 +1,13 @@
+import WidgetHeadingComponent from './index'
+import { WidgetHeadingMock } from './WidgetHeading.mock'
+
+export default {
+  title: 'Project App / Shared / Widget Heading',
+  component: WidgetHeadingComponent
+}
+
+export const WidgetHeading = () => (
+  <WidgetHeadingComponent level={WidgetHeadingMock.level}>
+    {WidgetHeadingMock.children}
+  </WidgetHeadingComponent>
+)


### PR DESCRIPTION
## Package
app-project

## Describe your changes
Converted tests for the WidgetHeading from Enzyme to RTL. 

## How to Review
[WidgetHeading Story](http://localhost:9001/?path=/story/project-app-shared-widget-heading--widget-heading)

## General
- [ ] Unit Tests are passing locally and on Github
- [ ] Storybook renders as expected
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected