### PR TITLE
MetaToolsButton: Remove enzyme and convert to RTL

### DIFF
--- a/packages/lib-react-components/src/MetaToolsButton/MetaToolsButton.js
+++ b/packages/lib-react-components/src/MetaToolsButton/MetaToolsButton.js
@@ -17,16 +17,17 @@ export const StyledPlainButton = styled(PlainButton)`
 function MetaToolsButton (props) {
   const { disabled, icon, onClick, text } = props
 
-  return (
-    <StyledPlainButton
-      disabled={disabled}
-      icon={icon}
-      labelSize='small'
-      text={text}
-      onClick={onClick}
-      {...props}
-    />
-  )
+	return (
+		<StyledPlainButton
+			data-testid="test-meta-tools-button"
+			disabled={disabled}
+			icon={icon}
+			labelSize='small'
+			text={text}
+			onClick={onClick}
+			{...props}
+		/>
+	)
 }
 
 MetaToolsButton.propTypes = {

--- a/packages/lib-react-components/src/MetaToolsButton/MetaToolsButton.mock.js
+++ b/packages/lib-react-components/src/MetaToolsButton/MetaToolsButton.mock.js
@@ -1,0 +1,12 @@
+import { Add } from 'grommet-icons'
+
+export const MetaToolsButtonMock = {
+  disabled: false,
+  icon: (<Add size='small' />),
+  text: 'Add'
+}
+
+export const MetaToolsButtonLinkMock = {
+  ...MetaToolsButtonMock,
+  href: '/mypage',
+}

--- a/packages/lib-react-components/src/MetaToolsButton/MetaToolsButton.spec.js
+++ b/packages/lib-react-components/src/MetaToolsButton/MetaToolsButton.spec.js
@@ -1,15 +1,49 @@
-import { shallow } from 'enzyme'
-import { expect } from 'chai'
-import { MetaToolsButton, StyledPlainButton } from './MetaToolsButton'
+import { render, screen } from '@testing-library/react'
+import { composeStory } from '@storybook/react'
+import Meta, { Button, Link } from './MetaToolsButton.stories'
+import {
+  MetaToolsButtonMock,
+  MetaToolsButtonLinkMock
+} from './MetaToolsButton.mock'
 
 describe('MetaToolsButton', function () {
-  it('should render without crashing', function () {
-    const wrapper = shallow(<MetaToolsButton />)
-    expect(wrapper).to.be.ok()
+  describe('Plain Button', function () {
+    beforeEach(function () {
+      const MetaToolsButtonStory = composeStory(Button, Meta)
+      render(<MetaToolsButtonStory />)
+    })
+
+    it('should render the text', function () {
+      expect(screen.getByText(MetaToolsButtonMock.text)).to.exist()
+    })
+
+    it('should render the aria label', function () {
+      expect(screen.getByLabelText(MetaToolsButtonMock.text)).to.exist()
+    })
+
+    it('should not have a link', function () {
+      expect(screen.getByTestId('test-meta-tools-button').getAttribute('href'))
+        .to.equal('')
+    })
   })
 
-  it('should render a StyledPlainButton', function () {
-    const wrapper = shallow(<MetaToolsButton />)
-    expect(wrapper.find(StyledPlainButton)).to.have.lengthOf(1)
+  describe('Link Button', function () {
+    beforeEach(function () {
+      const MetaToolsButtonLinkStory = composeStory(Link, Meta)
+      render(<MetaToolsButtonLinkStory />)
+    })
+
+    it('should render the text', function () {
+      expect(screen.getByText(MetaToolsButtonMock.text)).to.exist()
+    })
+
+    it('should render the aria label', function () {
+      expect(screen.getByLabelText(MetaToolsButtonMock.text)).to.exist()
+    })
+
+    it('should have a link', function () {
+      expect(screen.getByTestId('test-meta-tools-button').getAttribute('href'))
+        .to.equal(MetaToolsButtonLinkMock.href)
+    })
   })
 })

--- a/packages/lib-react-components/src/MetaToolsButton/MetaToolsButton.stories.js
+++ b/packages/lib-react-components/src/MetaToolsButton/MetaToolsButton.stories.js
@@ -1,29 +1,27 @@
-import { Add } from 'grommet-icons'
-
 import MetaToolsButton from './'
-import readme from './README.md'
+import {
+  MetaToolsButtonMock,
+  MetaToolsButtonLinkMock
+} from './MetaToolsButton.mock'
+
+// import readme from './README.md'
 
 export default {
   title: 'Components / MetaToolsButton',
   component: MetaToolsButton,
-  parameters: {
-    docs: {
-      description: {
-        component: readme
-      }
-    }
-  }
+  // parameters: {
+  //   docs: {
+  //     description: {
+  //       component: readme
+  //     }
+  //   }
+  // }
 }
 
-export const Default = () => (
-  <MetaToolsButton disabled={false} icon={<Add size='small' />} text='Add' />
+export const Button = () => (
+  <MetaToolsButton {...MetaToolsButtonMock} />
 )
 
-export const AsLink = () => (
-  <MetaToolsButton
-    disabled={false}
-    href='/mypage'
-    icon={<Add size='small' />}
-    text='Add'
-  />
+export const Link = () => (
+  <MetaToolsButton {...MetaToolsButtonLinkMock} />
 )


### PR DESCRIPTION
## Package
lib-react-components

## Describe your changes
Converted tests for the MetaToolsButton from Enzyme to RTL. 

## How to Review
[MetaToolsButton Story](http://localhost:9001/?path=/story/components-metatoolsbutton--button)

## General
- [ ] Unit Tests are passing locally and on Github
- [ ] Storybook renders as expected
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected