### PR TITLE
FavouritesButton: Remove enzyme and convert to RTL

### DIFF
--- a/packages/lib-react-components/src/FavouritesButton/FavouritesButton.mock.js
+++ b/packages/lib-react-components/src/FavouritesButton/FavouritesButton.mock.js
@@ -1,0 +1,10 @@
+export const FavouritesButtonSubjectMock = {
+  favorite: false,
+  id: '123',
+  locations: [
+    {
+      'image/jpeg':
+        'https://panoptes-uploads.zooniverse.org/335/0/2d63944e-f0bc-4fc5-8531-f603886513a1.jpeg'
+    }
+  ]
+}

--- a/packages/lib-react-components/src/FavouritesButton/FavouritesButton.spec.js
+++ b/packages/lib-react-components/src/FavouritesButton/FavouritesButton.spec.js
@@ -1,100 +1,76 @@
-import { shallow } from 'enzyme'
-import sinon from 'sinon'
-import MetaToolsButton from '../MetaToolsButton'
-
-import { FavouritesButton } from './FavouritesButton'
-import HeartIcon from './HeartIcon'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { composeStory } from '@storybook/react'
+import Meta, { NotFavourited, Favourited, Disabled } from './FavouritesButton.stories.js'
 
 describe('Component > FavouritesButton', function () {
-  let wrapper
-  const mockTheme = {
-    global: {
-      colors: {
-        statusColors: {
-          error: 'status-error'
-        }
-      }
-    }
-  }
-  before(function () {
-    wrapper = shallow(<FavouritesButton theme={mockTheme} />)
-  })
+  const user = userEvent.setup()
 
-  it('should render without crashing', function () {
-    expect(wrapper).to.be.ok()
-  })
-
-  it('should display an empty icon', function () {
-    const button = wrapper.find(MetaToolsButton)
-    const { icon } = button.props()
-    expect(icon).to.deep.equal(<HeartIcon color='dark-5' fill='none' size='15px' />)
-  })
-
-  it('should not be checked', function () {
-    const checked = wrapper.prop('aria-checked')
-    expect(checked).to.be.false()
-  })
-
-  describe('on click', function () {
-    let onClickStub
-
-    before(function () {
-      onClickStub = sinon.stub()
-      wrapper = shallow(<FavouritesButton theme={mockTheme} checked={false} onClick={onClickStub} />)
+  describe('when not favourited', function () {
+    const NotFavouritedStory = composeStory(NotFavourited, Meta)
+      
+    beforeEach(function () {
+      render(<NotFavouritedStory />)
     })
 
-    afterEach(function () {
-      onClickStub.resetHistory()
+    it('should not show a favourited icon', function () {
+      expect(screen.getByRole('checkbox', { checked: false })).to.exist()
+      expect(screen.getByText('Add to favorites')).to.exist()
     })
 
-    it('should toggle favourites on', function () {
-      wrapper.simulate('click')
-      const icon = wrapper.prop('icon')
-      expect(icon.props.fill).to.equal(mockTheme.global.colors.statusColors.error)
+    it('should toggle favourites on', async function () {
+      await user.click(screen.getByRole('checkbox', { checked: false }))
+      expect(screen.getByRole('checkbox', { checked: true })).to.exist()
+      expect(screen.getByText('Added to favorites')).to.exist()
     })
 
-    it('should toggle favourites off', function () {
-      wrapper.simulate('click')
-      const icon = wrapper.prop('icon')
-      expect(icon.props.fill).to.equal('none')
-    })
-
-    it('should call props.onClick', function () {
-      wrapper.simulate('click')
-      expect(onClickStub).to.have.been.calledOnce()
+    it('should toggle favourites on then off', async function () {
+      await user.click(screen.getByRole('checkbox', { checked: false}))
+      await user.click(screen.getByRole('checkbox', { checked: true }))
+      expect(screen.getByRole('checkbox', { checked: false })).to.exist()
+      expect(screen.getByText('Add to favorites')).to.exist()
     })
   })
 
-  describe('when checked', function () {
-    before(function () {
-      wrapper = shallow(<FavouritesButton theme={mockTheme} checked />)
+  describe('when favourited', function () {
+    const FavouritedStory = composeStory(Favourited, Meta)
+
+    beforeEach(function () {
+      render(<FavouritedStory />)
     })
 
-    it('should display a filled icon', function () {
-      const button = wrapper.find(MetaToolsButton)
-      const { icon } = button.props()
-      const fill = mockTheme.global.colors.statusColors.error
-      expect(icon).to.deep.equal(<HeartIcon color='dark-5' fill={fill} size='15px' />)
+    it('should show a favourited icon', function () {
+      expect(screen.getByRole('checkbox', { checked: true })).to.exist()
+      expect(screen.getByText('Added to favorites')).to.exist()
     })
 
-    it('should be checked', function () {
-      const checked = wrapper.find(MetaToolsButton).prop('aria-checked')
-      expect(checked).to.be.true()
+    it('should toggle favourites off', async function () {
+      await user.click(screen.getByRole('checkbox', { checked: true}))
+      expect(screen.getByRole('checkbox', { checked: false })).to.exist()
+      expect(screen.getByText('Add to favorites')).to.exist()
+    })
+
+    it('should toggle favourites off then on', async function () {
+      await user.click(screen.getByRole('checkbox', { checked: true}))
+      await user.click(screen.getByRole('checkbox', { checked: false }))
+      expect(screen.getByRole('checkbox', { checked: true })).to.exist()
+      expect(screen.getByText('Added to favorites')).to.exist()
     })
   })
 
   describe('when disabled', function () {
-    const onClick = sinon.stub()
-    wrapper = shallow(
-      <FavouritesButton
-        disabled
-        onClick={onClick}
-      />
-    )
+    const DisabledStory = composeStory(Disabled, Meta)
 
-    it('should not be clickable', function () {
-      wrapper.find(MetaToolsButton).simulate('click')
-      expect(onClick).to.not.have.been.called()
+    beforeEach(function () {
+      render(<DisabledStory />)
+    })
+
+    it('should not be clickable', async function () {
+      expect(screen.getByRole('checkbox', { checked: false })).to.exist()
+      expect(screen.getByText('Add to favorites')).to.exist()
+      await user.click(screen.getByRole('checkbox', { checked: false}))
+      expect(screen.getByRole('checkbox', { checked: false })).to.exist()
+      expect(screen.getByText('Add to favorites')).to.exist()
     })
   })
 })

--- a/packages/lib-react-components/src/FavouritesButton/FavouritesButton.stories.js
+++ b/packages/lib-react-components/src/FavouritesButton/FavouritesButton.stories.js
@@ -1,37 +1,27 @@
 import FavouritesButton from './'
-import readme from './README.md'
-
-const CAT = {
-  favorite: false,
-  id: '123',
-  locations: [
-    {
-      'image/jpeg':
-        'https://panoptes-uploads.zooniverse.org/335/0/2d63944e-f0bc-4fc5-8531-f603886513a1.jpeg'
-    }
-  ]
-}
+import { FavouritesButtonSubjectMock } from './FavouritesButton.mock'
+// import readme from './README.md'
 
 export default {
   title: 'Components/Favourites Button',
   component: FavouritesButton,
-  parameters: {
-    docs: {
-      description: {
-        component: readme
-      }
-    }
-  }
+  // parameters: {
+  //   docs: {
+  //     description: {
+  //       component: readme
+  //     }
+  //   }
+  // }
 }
 
-export const Default = () => (
-  <FavouritesButton disabled={false} subject={CAT} />
+export const NotFavourited = () => (
+  <FavouritesButton disabled={false} subject={FavouritesButtonSubjectMock} />
 )
 
-export const Checked = () => (
-  <FavouritesButton checked disabled={false} subject={CAT} />
+export const Favourited = () => (
+  <FavouritesButton checked disabled={false} subject={FavouritesButtonSubjectMock} />
 )
 
 export const Disabled = () => (
-  <FavouritesButton checked={false} disabled subject={CAT} />
+  <FavouritesButton checked={false} disabled subject={FavouritesButtonSubjectMock} />
 )


### PR DESCRIPTION
## Package
lib-react-components

## Describe your changes
Converted tests for the FavouritesButton from Enzyme to RTL. 

## How to Review
[FavouritesButton Story](http://localhost:9001/?path=/story/components-favourites-button--disabled)

## General
- [ ] Unit Tests are passing locally and on Github
- [ ] Storybook renders as expected
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected