### PR TITLE
SingleChoiceTask: Remove enzyme and convert to RTL

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/components/TaskInput/TaskInput.js
+++ b/packages/lib-classifier/src/plugins/tasks/components/TaskInput/TaskInput.js
@@ -124,6 +124,7 @@ export function TaskInput (props) {
       theme={theme}
     >
       <input
+        data-testid={`test-task-input-${index}`}
         autoFocus={autoFocus}
         checked={checked}
         disabled={disabled}

--- a/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.mock.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.mock.js
@@ -1,0 +1,16 @@
+export const SingleChoiceTaskDataMock = ({ isThereTaskHelp = false, required = false }) => {
+  return {
+    init: {
+      answers: [{ label: 'yes' }, { label: 'no' }],
+      required,
+      strings: {
+        help: (isThereTaskHelp) ? 'Choose an answer from the choices given, then press Done.' : '',
+        question: 'Is there a cat?',
+        'answers.0.label': 'yes',
+        'answers.1.label': 'no'
+      },
+      taskKey: 'init',
+      type: 'single'
+    }
+  }
+}

--- a/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.spec.js
@@ -1,82 +1,34 @@
-import { shallow } from 'enzyme'
-import { expect } from 'chai'
-import SingleChoiceTask from './SingleChoiceTask'
-import Task from '@plugins/tasks/single'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { composeStory } from '@storybook/react'
+import Meta, { SingleChoiceQuestion } from './SingleChoiceTask.stories.js'
+import preview from '@storybook_config/preview.js'
+import { SingleChoiceTaskDataMock } from './SingleChoiceTask.mock'
 
 describe('SingleChoiceTask', function () {
-  const task = Task.TaskModel.create({
-    answers: [{ label: 'yes' }, { label: 'no' }],
-    required: true,
-    strings: {
-      'answers.0.label': 'yes',
-      'answers.1.label': 'no',
-      question: 'Is there a cat?'
-    },
-    taskKey: 'init',
-    type: 'single'
+  const taskData = { isThereTaskHelp: false, required: false }
+  const taskMock = SingleChoiceTaskDataMock(taskData)
+
+  beforeEach(function () {
+    const SingleChoiceQuestionStory = composeStory(SingleChoiceQuestion, Meta, preview)
+    render(<SingleChoiceQuestionStory {...taskData} />)
   })
-  const annotation = task.defaultAnnotation()
 
-  describe('when it renders', function () {
-    let wrapper
-    before(function () {
-      wrapper = shallow(<SingleChoiceTask annotation={annotation} task={task} />)
-    })
+  it('should render the question', function () {
+    expect(screen.getByText(taskMock.init.strings.question)).to.exist()
+  })
 
-    it('should render without crashing', function () {
-      expect(wrapper).to.be.ok()
-    })
-
-    it('should have a question', function () {
-      expect(wrapper.contains(task.question)).to.be.true()
-    })
-
-    it('should render the correct number of answer choices', function () {
-      task.answers.forEach((answer) => {
-        expect(wrapper.find({ label: answer.label })).to.have.lengthOf(1)
-      })
+  it('should render the correct number of answer choices', function () {
+    taskMock.init.answers.forEach(answer => {
+      expect(screen.getByText(answer.label)).to.exist()
     })
   })
 
-  describe('with an annotation', function () {
-    let wrapper
-
-    before(function () {
-      annotation.update(0)
-      wrapper = shallow(
-        <SingleChoiceTask
-          annotation={annotation}
-          task={task}
-        />
-      )
-    })
-
-    it('should check the selected answer', function () {
-      const answer = task.answers[0]
-      const input = wrapper.find({ label: answer.label })
-      expect(input.prop('checked')).to.be.true()
-    })
-  })
-
-  describe('onChange event handler', function () {
-    let wrapper
-    beforeEach(function () {
-      annotation.update(null)
-      wrapper = shallow(<SingleChoiceTask annotation={annotation} task={task} />)
-    })
-
-    it('should update the annotation', function () {
-      task.answers.forEach((answer, index) => {
-        const node = wrapper.find({ label: answer.label })
-        node.simulate('change', { target: { checked: true } })
-        expect(annotation.value).to.equal(index)
-      })
-    })
-
-    it('should not update the annotation if the answer is not checked', function () {
-      const node = wrapper.find({ label: task.answers[1].label })
-      node.simulate('change', { target: { checked: false } })
-      expect(annotation.value).to.be.null()
-    })
+  it('should be able to select an answer', async function () {
+    let el = screen.getByTestId('test-task-input-0');
+    
+    fireEvent.click(el)
+    
+    await expect(el.getAttribute('autofocus')).to.exist()
+    expect(screen.getByTestId('test-task-input-1').getAttribute('autofocus')).to.be.null()
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.stories.js
@@ -1,10 +1,11 @@
 import asyncStates from '@zooniverse/async-states'
 import { MockTask } from '@stories/components'
-import SingleChoiceTask from './SingleChoiceTask'
+import { SingleChoiceTaskDataMock } from './SingleChoiceTask.mock'
+import SingleChoiceTaskComponent from './SingleChoiceTask'
 
 export default {
   title: 'Tasks / Single Choice Question',
-  component: SingleChoiceTask,
+  component: SingleChoiceTaskComponent,
   args: {
     isThereTaskHelp: true,
     required: false,
@@ -20,26 +21,12 @@ export default {
   }
 }
 
-export function Default({ isThereTaskHelp, required, subjectReadyState }) {
-  const tasks = {
-    init: {
-      answers: [{ label: 'yes' }, { label: 'no' }],
-      required,
-      strings: {
-        help: isThereTaskHelp ? 'Choose an answer from the choices given, then press Done.' : '',
-        question: 'Is there a cat?',
-        'answers.0.label': 'yes',
-        'answers.1.label': 'no'
-      },
-      taskKey: 'init',
-      type: 'single'
-    }
-  }
+export function SingleChoiceQuestion({ isThereTaskHelp = false, required = false, subjectReadyState }) {
   return (
     <MockTask
       isThereTaskHelp={isThereTaskHelp}
       subjectReadyState={subjectReadyState}
-      tasks={tasks}
+      tasks={SingleChoiceTaskDataMock({ isThereTaskHelp, required })}
     />
   )
 }


### PR DESCRIPTION
## Package
lib-classifier

## Describe your changes
Converted tests for the SingleChoiceTask from Enzyme to RTL. 

## How to Review
Load the SingleChoiceTask Story and run the tests locally

## General
- [ ] Unit Tests are passing locally and on Github
- [ ] Storybook renders as expected
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected