### PR TITLE
Create wrapper function for running Stories in Specs

### DIFF
--- a/packages/app-content-pages/.storybook/lib/i18n.js
+++ b/packages/app-content-pages/.storybook/lib/i18n.js
@@ -15,11 +15,11 @@ i18n.use(initReactI18next).init({
 })
 
 supportedLngs.forEach(lang => {
-  namespaces.forEach(n => {
+  namespaces.forEach(async function(n) {
     i18n.addResourceBundle(
       lang,
       n,
-      require(`../../public/locales/${lang}/${n}.json`)
+      await import(`../../public/locales/${lang}/${n}.json`)
     )
   })
 })

--- a/packages/app-content-pages/.storybook/specConfig.js
+++ b/packages/app-content-pages/.storybook/specConfig.js
@@ -1,0 +1,3 @@
+import * as globalStorybookConfig from './preview.js'
+import { setProjectAnnotations } from '@storybook/react'
+setProjectAnnotations(globalStorybookConfig)

--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -10,8 +10,8 @@
     "dev": "APP_ENV=${APP_ENV:-development} PANOPTES_ENV=${PANOPTES_ENV:-production} node server/server.js",
     "lint": "next lint",
     "start": "NODE_ENV=${NODE_ENV:-production} PANOPTES_ENV=${PANOPTES_ENV:-production} node server/server.js",
-    "test": "BABEL_ENV=test mocha --config ./test/.mocharc.json \"./{src,server,test}/**/*.spec.js\"",
-    "test:ci": "BABEL_ENV=test mocha --config ./test/.mocharc.json --reporter=min \"./{src,server,test}/**/*.spec.js\"",
+    "test": "BABEL_ENV=test mocha --config ./test/.mocharc.json ./.storybook/specConfig.js \"./{src,server,test}/**/*.spec.js\"",
+    "test:ci": "BABEL_ENV=test mocha --config ./test/.mocharc.json ./.storybook/specConfig.js --reporter=min \"./{src,server,test}/**/*.spec.js\"",
     "storybook": "storybook dev -p 9002",
     "build-storybook": "storybook build"
   },

--- a/packages/app-content-pages/src/screens/Publications/PublicationsContainer.spec.js
+++ b/packages/app-content-pages/src/screens/Publications/PublicationsContainer.spec.js
@@ -5,7 +5,6 @@ import Router from 'next/router'
 import { composeStory } from '@storybook/react'
 
 import Meta, { Default } from './Publications.stories.js'
-import projectAnnotations from '../../../.storybook/preview.js'
 
 function RouterMock({ children }) {
   const mockRouter = {
@@ -28,7 +27,7 @@ function RouterMock({ children }) {
 }
 
 describe('Component > PublicationsContainer', function () {
-  const DefaultStory = composeStory(Default, Meta, projectAnnotations)
+  const DefaultStory = composeStory(Default, Meta)
 
   beforeEach(function () {
     render(

--- a/packages/app-content-pages/src/screens/Publications/PublicationsContainer.spec.js
+++ b/packages/app-content-pages/src/screens/Publications/PublicationsContainer.spec.js
@@ -48,7 +48,7 @@ describe('Component > PublicationsContainer', function () {
   })
 
   it('should have sidebar nav with accessible label', function () {
-    const sideBar = screen.getByLabelText('Filter by category')
+    const sideBar = screen.getByLabelText('Publications.sideBarLabel')
     expect(sideBar).to.be.ok()
   })
 

--- a/packages/app-content-pages/src/screens/Teams/TeamsContainer.spec.js
+++ b/packages/app-content-pages/src/screens/Teams/TeamsContainer.spec.js
@@ -43,7 +43,7 @@ describe('Component > TeamsContainer', function () {
   })
 
   it('should have a sidebar nav with accessible label', function () {
-    const sideBar = screen.getByLabelText('Filter by team location')
+    const sideBar = screen.getByLabelText('Team.sideBarLabel')
     expect(sideBar).to.be.ok()
   })
 

--- a/packages/app-content-pages/src/screens/Teams/TeamsContainer.spec.js
+++ b/packages/app-content-pages/src/screens/Teams/TeamsContainer.spec.js
@@ -3,8 +3,6 @@ import { RouterContext } from 'next/dist/shared/lib/router-context'
 import Router from 'next/router'
 import { composeStory } from '@storybook/react'
 import { within } from '@testing-library/dom'
-
-import projectAnnotations from '../../../.storybook/preview.js'
 import mockData from './TeamsContainer.mock.json'
 import Meta, { Default } from './Teams.stories.js'
 
@@ -26,7 +24,7 @@ function RouterMock({ children }) {
 }
 
 describe('Component > TeamsContainer', function () {
-  const DefaultStory = composeStory(Default, Meta, projectAnnotations)
+  const DefaultStory = composeStory(Default, Meta)
 
   beforeEach(function () {
     render(

--- a/packages/app-content-pages/src/shared/components/AboutHeader/AboutHeader.spec.js
+++ b/packages/app-content-pages/src/shared/components/AboutHeader/AboutHeader.spec.js
@@ -2,9 +2,7 @@ import { render } from '@testing-library/react'
 import { composeStory } from '@storybook/react'
 import { RouterContext } from 'next/dist/shared/lib/router-context'
 import Router from 'next/router'
-
 import Meta, { Default } from './AboutHeader.stories.js'
-import projectAnnotations from '../../../../.storybook/preview.js'
 
 function RouterMock({ children }) {
   const mockRouter = {
@@ -24,7 +22,7 @@ function RouterMock({ children }) {
 }
 
 describe('Component > AboutHeader', function () {
-  const DefaultStory = composeStory(Default, Meta, projectAnnotations)
+  const DefaultStory = composeStory(Default, Meta)
 
   before(function () {
     render(

--- a/packages/app-content-pages/src/shared/components/AuthModal/components/RegisterForm/components/Form/Form.spec.js
+++ b/packages/app-content-pages/src/shared/components/AuthModal/components/RegisterForm/components/Form/Form.spec.js
@@ -217,10 +217,10 @@ describe('RegisterForm > Component > Form', function () {
         <Form />,
         shallowOptions
       )
-      expect(wrapper.find({ htmlFor: userNameFieldId }).props().help).equal('This will be shown publicly on message boards, etc.')
-      expect(wrapper.find({ id: privacyAgreementFieldId }).props().label.props.children[0]).equal('You agree to our privacy policy (required)')
-      expect(wrapper.find({ id: emailListSignUpFieldId }).props().label.props.children).equal(`It's ok to send me an email every once in a while (optional)`)
-      expect(wrapper.find({ htmlFor: emailFieldId }).props().label.props.children).equal('Email Address (Required)')
+      expect(wrapper.find({ htmlFor: userNameFieldId }).props().help).equal('RegisterForm.usernameHelp')
+      expect(wrapper.find({ id: privacyAgreementFieldId }).props().label.props.children[0]).equal('RegisterForm.privacyAgreement')
+      expect(wrapper.find({ id: emailListSignUpFieldId }).props().label.props.children).equal(`RegisterForm.emailListSignUp`)
+      expect(wrapper.find({ htmlFor: emailFieldId }).props().label.props.children).equal('RegisterForm.email')
     })
 
     it('should show field labels for under 16 registrants when the checkbox is checked', function () {
@@ -230,10 +230,10 @@ describe('RegisterForm > Component > Form', function () {
       )
       wrapper.setProps({ values: { underageWithParent: true } })
 
-      expect(wrapper.find({ htmlFor: userNameFieldId }).props().help).equal('You’ll use this name to log in. It will be shown publicly. Don’t use your real name.')
-      expect(wrapper.find({ id: privacyAgreementFieldId }).props().label.props.children[0]).equal('I confirm I am the parent/guardian and give permission for my child to register by providing my email address as the main contact address. Both I and my child understand and agree to the privacy policy (required)')
-      expect(wrapper.find({ id: emailListSignUpFieldId }).props().label.props.children).equal('If you agree, we will periodically send email promoting new research-related projects or other information relating to our research. We will not use your contact information for commercial purposes. (optional)')
-      expect(wrapper.find({ htmlFor: emailFieldId }).props().label.props.children).equal('Parent/Guardian’s email address (Required)')
+      expect(wrapper.find({ htmlFor: userNameFieldId }).props().help).equal('RegisterForm.underageNotRealName')
+      expect(wrapper.find({ id: privacyAgreementFieldId }).props().label.props.children[0]).equal('RegisterForm.underageConsent')
+      expect(wrapper.find({ id: emailListSignUpFieldId }).props().label.props.children).equal('RegisterForm.underageEmailSignUp')
+      expect(wrapper.find({ htmlFor: emailFieldId }).props().label.props.children).equal('RegisterForm.underageEmail')
     })
   })
 

--- a/packages/app-project/.storybook/lib/i18n.js
+++ b/packages/app-project/.storybook/lib/i18n.js
@@ -15,11 +15,11 @@ i18n.use(initReactI18next).init({
 })
 
 supportedLngs.forEach(lang => {
-  namespaces.forEach(n => {
+  namespaces.forEach(async function (n) {
     i18n.addResourceBundle(
       lang,
       n,
-      require(`/public/locales/${lang}/${n}.json`)
+      await import(`/public/locales/${lang}/${n}.json`)
     )
   })
 })

--- a/packages/app-project/.storybook/specConfig.js
+++ b/packages/app-project/.storybook/specConfig.js
@@ -1,0 +1,3 @@
+import * as globalStorybookConfig from './preview.js'
+import { setProjectAnnotations } from '@storybook/react'
+setProjectAnnotations(globalStorybookConfig)

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -11,8 +11,8 @@
     "dev:inspect": "APP_ENV=${APP_ENV:-development} PANOPTES_ENV=${PANOPTES_ENV:-staging} NODE_OPTIONS='--inspect' node server/server.js",
     "lint": "next lint",
     "start": "NODE_ENV=${NODE_ENV:-production} PANOPTES_ENV=${PANOPTES_ENV:-production} node server/server.js",
-    "test": "BABEL_ENV=test mocha --config test/.mocharc.json \"./{src,pages,stores}/**/*.spec.js\"",
-    "test:ci": "BABEL_ENV=test mocha --config test/.mocharc.json --reporter=min \"./{src,pages,stores}/**/*.spec.js\"",
+    "test": "BABEL_ENV=test mocha --config test/.mocharc.json ./.storybook/specConfig.js \"./{src,pages,stores}/**/*.spec.js\"",
+    "test:ci": "BABEL_ENV=test mocha --config test/.mocharc.json ./.storybook/specConfig.js --reporter=min \"./{src,pages,stores}/**/*.spec.js\"",
     "storybook": "storybook dev -p 9001",
     "build-storybook": "storybook build"
   },

--- a/packages/app-project/src/components/ProjectName/ProjectName.mock.js
+++ b/packages/app-project/src/components/ProjectName/ProjectName.mock.js
@@ -1,5 +1,3 @@
 export const ProjectNameMock = {
-  project: {
-    display_name: 'Test Project Name'
-  }
+  projectName: 'Test Project Name'
 }

--- a/packages/app-project/src/components/ProjectName/ProjectName.spec.js
+++ b/packages/app-project/src/components/ProjectName/ProjectName.spec.js
@@ -10,6 +10,6 @@ describe('Component > ProjectName', function () {
   })
 
   it('should render the project name', function () {
-    expect(screen.getByText(ProjectNameMock.project.display_name)).to.exist()
+    expect(screen.getByText(ProjectNameMock.projectName)).to.exist()
   })
 })

--- a/packages/app-project/src/components/ProjectName/ProjectName.stories.js
+++ b/packages/app-project/src/components/ProjectName/ProjectName.stories.js
@@ -1,5 +1,5 @@
 import { Provider } from 'mobx-react'
-import ProjectNameComponent from './index'
+import { ProjectName as ProjectNameComponent } from './ProjectName'
 import { ProjectNameMock } from './ProjectName.mock'
 
 export default {
@@ -8,7 +8,5 @@ export default {
 }
 
 export const ProjectName = () => (
-  <Provider store={ProjectNameMock}>
-    <ProjectNameComponent />
-  </Provider>
+  <ProjectNameComponent {...ProjectNameMock} />
 )

--- a/packages/lib-classifier/.storybook/specConfig.js
+++ b/packages/lib-classifier/.storybook/specConfig.js
@@ -1,0 +1,3 @@
+import * as globalStorybookConfig from './preview.js'
+import { setProjectAnnotations } from '@storybook/react'
+setProjectAnnotations(globalStorybookConfig)

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -19,8 +19,8 @@
     "lint": "zoo-standard --fix | snazzy",
     "eslint": "eslint ./src --fix | snazzy",
     "start": "PANOPTES_ENV=production npm run dev",
-    "test": "NODE_PATH=. NODE_ENV=test mocha --exit --config ./test/.mocharc.json \"./{src,test}/**/*.spec.js\"",
-    "test:ci": "NODE_PATH=. NODE_ENV=test mocha --exit --config ./test/.mocharc.json --reporter=min \"./{src,test}/**/*.spec.js\"",
+    "test": "NODE_PATH=. NODE_ENV=test mocha --exit --config ./test/.mocharc.json ./.storybook/specConfig.js  \"./{src,test}/**/*.spec.js\"",
+    "test:ci": "NODE_PATH=. NODE_ENV=test mocha --exit --config ./test/.mocharc.json ./.storybook/specConfig.js  --reporter=min \"./{src,test}/**/*.spec.js\"",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.spec.js
@@ -1,13 +1,10 @@
 import { render, screen } from '@testing-library/react'
 import { composeStory } from '@storybook/react'
-
-import projectAnnotations from '../../../../../../../.storybook/preview'
-
 import Meta, { Default, mockTask } from './CenteredLayout.stories.js'
 
 describe('Component > Layouts > Centered', function () {
   it('should render a subject and a task', function () {
-    const DefaultStory = composeStory(Default, Meta, projectAnnotations)
+    const DefaultStory = composeStory(Default, Meta)
     render(<DefaultStory />)
     expect(screen.getByLabelText('Subject 1')).exists() // img aria-label from SVGImage
     expect(screen.getByText(mockTask.init.strings.question)).exists() // task question paragraph

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.spec.js
@@ -1,14 +1,11 @@
 import { render, screen } from '@testing-library/react'
 import { composeStory } from '@storybook/react'
-
-import projectAnnotations from '../../../../../../../.storybook/preview'
-
 import Meta, { Default, mockTask } from './MaxWidth.stories.js'
 
 describe('Component > Layouts > MaxWidth', function () {
 
   it('should render a subject and a task', function () {
-    const DefaultStory = composeStory(Default, Meta, projectAnnotations)
+    const DefaultStory = composeStory(Default, Meta)
     render(<DefaultStory />)
     expect(screen.getByLabelText('Subject 1')).exists() // img aria-label from SVGImage
     expect(screen.getByText(mockTask.init.strings.question)).exists() // task question paragraph

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.spec.js
@@ -1,13 +1,10 @@
 import { render, screen } from '@testing-library/react'
 import { composeStory } from '@storybook/react'
-
-import projectAnnotations from '../../../../../../../.storybook/preview'
-
 import Meta, { Default, mockTask } from './NoMaxWidth.stories.js'
 
 describe('Component > Layouts > NoMaxWidth', function () {
   it('should render a subject and a task', function () {
-    const DefaultStory = composeStory(Default, Meta, projectAnnotations)
+    const DefaultStory = composeStory(Default, Meta)
     render(<DefaultStory />)
     expect(screen.getByLabelText('Subject 1')).exists() // img aria-label from SVGImage
     expect(screen.getByText(mockTask.init.strings.question)).exists() // task question paragraph

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.spec.js
@@ -3,10 +3,9 @@ import { expect } from 'chai'
 import Meta, { Default, NoSubject } from './FlipbookViewer.stories'
 import { composeStory } from '@storybook/react'
 import userEvent from '@testing-library/user-event'
-import projectAnnotations from '../../../../../../../.storybook/preview'
 
 describe('Component > FlipbookViewer', function () {
-  const DefaultStory = composeStory(Default, Meta, projectAnnotations)
+  const DefaultStory = composeStory(Default, Meta)
 
   describe('with a valid subject', function () {
     it('should render the correct number of thumbnnails', function () {
@@ -63,7 +62,7 @@ describe('Component > FlipbookViewer', function () {
   })
 
   describe('without a subject', function () {
-    const NoSubjectStory = composeStory(NoSubject, Meta, projectAnnotations)
+    const NoSubjectStory = composeStory(NoSubject, Meta)
 
     it('should display an error message and no image element ', function () {
       const { container } = render(<NoSubjectStory />)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ImageAndTextViewer/ImageAndTextViewer.spec.js
@@ -3,13 +3,11 @@ import { composeStory } from '@storybook/react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import asyncStates from '@zooniverse/async-states'
-import projectAnnotations from '../../../../../../../.storybook/preview'
-
 import Meta, { Default, TextLocationFirst } from './ImageAndTextViewer.stories'
 
 describe('ImageAndTextViewer', function () {
-  const DefaultStory = composeStory(Default, Meta, projectAnnotations)
-  const TextLocationFirstStory = composeStory(TextLocationFirst, Meta, projectAnnotations)
+  const DefaultStory = composeStory(Default, Meta)
+  const TextLocationFirstStory = composeStory(TextLocationFirst, Meta)
   
   describe('with loading state of error', function () {
     it('should render "Something went wrong."', function () {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/JSONDataViewer/JSONDataViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/JSONDataViewer/JSONDataViewer.spec.js
@@ -1,14 +1,12 @@
 import { expect } from 'chai'
 import { render, screen, waitFor } from '@testing-library/react'
 import { composeStory } from '@storybook/react'
-
 import Meta, { DataSeries, TESSLightCurve, VariableStar } from './JSONDataViewer.stories'
-import projectAnnotations from '../../../../../../../.storybook/preview'
 
 describe('Component > JSONDataViewer', function () {
   describe('with a data series plot', function () {
     it('should render a scatter plot viewer', async function () {
-      const DataSeriesStory = composeStory(DataSeries, Meta, projectAnnotations)
+      const DataSeriesStory = composeStory(DataSeries, Meta)
       render(<DataSeriesStory />)
       await waitFor(() => expect(document.querySelector('.DataSeriesPlot')).to.exist())
     })
@@ -16,7 +14,7 @@ describe('Component > JSONDataViewer', function () {
 
   describe('with a TESS light curve', function () {
     it('should render a light curve viewer', async function () {
-      const TESSLightCurveStory = composeStory(TESSLightCurve, Meta, projectAnnotations)
+      const TESSLightCurveStory = composeStory(TESSLightCurve, Meta)
       render(<TESSLightCurveStory />)
       await waitFor(() => expect(document.querySelector('.TESSLightCurve')).to.exist())
     })
@@ -24,7 +22,7 @@ describe('Component > JSONDataViewer', function () {
 
   describe('with variable star data', function () {
     it('should render a variable star viewer', async function () {
-      const VariableStarStory = composeStory(VariableStar, Meta, projectAnnotations)
+      const VariableStarStory = composeStory(VariableStar, Meta)
       render(<VariableStarStory />)
       await waitFor(() => expect(document.querySelector('.VariableStarPlots')).to.exist())
     })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/ScatterPlotViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/ScatterPlotViewer.spec.js
@@ -1,15 +1,13 @@
 import { composeStory } from '@storybook/react'
 import { render } from '@testing-library/react'
-
 import Meta, { Default, ErrorBars, KeplerLightCurve } from './ScatterPlotViewer.stories.js'
-import projectAnnotations from '../../../../../../../.storybook/preview'
 
 describe('Component > ScatterPlotViewer', function () {
   describe('default plot', function () {
     let chart
 
     beforeEach(function () {
-      const MockScatterPlotViewer = composeStory(Default, Meta, projectAnnotations)
+      const MockScatterPlotViewer = composeStory(Default, Meta)
       render(<MockScatterPlotViewer initialHeight={500} initialWidth={500} />)
       chart = document.querySelector('svg.scatterPlot')
     })
@@ -36,7 +34,7 @@ describe('Component > ScatterPlotViewer', function () {
     let chart
 
     beforeEach(function () {
-      const MockScatterPlotViewer = composeStory(ErrorBars, Meta, projectAnnotations)
+      const MockScatterPlotViewer = composeStory(ErrorBars, Meta)
       render(<MockScatterPlotViewer initialHeight={500} initialWidth={500} />)
       chart = document.querySelector('svg.scatterPlot')
     })
@@ -63,7 +61,7 @@ describe('Component > ScatterPlotViewer', function () {
     let chart
 
     beforeEach(function () {
-      const MockScatterPlotViewer = composeStory(KeplerLightCurve, Meta, projectAnnotations)
+      const MockScatterPlotViewer = composeStory(KeplerLightCurve, Meta)
       render(<MockScatterPlotViewer initialHeight={500} initialWidth={500} />)
       chart = document.querySelector('svg.scatterPlot')
     })

--- a/packages/lib-classifier/src/plugins/tasks/experimental/highlighter/components/HighlighterTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/highlighter/components/HighlighterTask.spec.js
@@ -1,11 +1,9 @@
 import { composeStory } from '@storybook/react'
 import { render, screen } from '@testing-library/react'
-import projectAnnotations from '../../../../../../.storybook/preview'
-
 import Meta, { Default } from './HighlighterTask.stories'
 
 describe('HighlighterTask', function () {
-  const DefaultStory = composeStory(Default, Meta, projectAnnotations)
+  const DefaultStory = composeStory(Default, Meta)
 
   describe('when it renders', function () {
     it('should show the instruction', function () {

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.spec.js
@@ -1,15 +1,13 @@
 import { expect } from 'chai'
 import { composeStory } from '@storybook/react'
 import { render, screen } from '@testing-library/react'
-import projectAnnotations from '../../../../../.storybook/preview'
-
 import Meta, { Default, NoFiltersNoInstruction } from './SurveyTask.stories'
 
 describe('SurveyTask', function () {
   describe('when choices are showing / without a selected choice', function () {
     describe('with task instruction', function () {
       it('should show the instruction', function () {
-        const DefaultStory = composeStory(Default, Meta, projectAnnotations)
+        const DefaultStory = composeStory(Default, Meta)
         render(<DefaultStory />)
 
         const instruction = screen.findByText('Select the animals you see in the image.')
@@ -22,7 +20,7 @@ describe('SurveyTask', function () {
       let filterButton, choiceButtons, choicesShowingCount, clearFiltersButton
 
       before(function () {
-        const DefaultStory = composeStory(Default, Meta, projectAnnotations)
+        const DefaultStory = composeStory(Default, Meta)
         render(<DefaultStory />)
         // filterButton is the Filter button above the choices
         filterButton = screen.queryByLabelText('SurveyTask.CharacteristicsFilter.filter')
@@ -65,7 +63,7 @@ describe('SurveyTask', function () {
       let filterButton, choiceButtons, choicesShowingCount, clearFiltersButton
 
       before(function () {
-        const NoFiltersNoInstructionStory = composeStory(NoFiltersNoInstruction, Meta, projectAnnotations)
+        const NoFiltersNoInstructionStory = composeStory(NoFiltersNoInstruction, Meta)
         render(<NoFiltersNoInstructionStory />)
         // filterButton is the Filter button above the choices
         filterButton = screen.queryByLabelText('SurveyTask.CharacteristicsFilter.filter')

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.userClicks.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.userClicks.spec.js
@@ -2,14 +2,12 @@ import { expect } from 'chai'
 import { composeStory } from '@storybook/react'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import projectAnnotations from '../../../../../.storybook/preview'
-
 import Meta, { Default } from './SurveyTask.stories'
 
 describe('SurveyTask with user clicks', function () {
   // this turns off Mocha's time limit for slow tests
   this.timeout(0)
-  const DefaultStory = composeStory(Default, Meta, projectAnnotations)
+  const DefaultStory = composeStory(Default, Meta)
 
   describe('when the Filter button is clicked', function () {
     let user, filterButton

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.userKeystrokes.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/SurveyTask.userKeystrokes.spec.js
@@ -2,16 +2,14 @@ import { expect } from 'chai'
 import { composeStory } from '@storybook/react'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import projectAnnotations from '../../../../../.storybook/preview'
-
 import Meta, { Default, NoFiltersNoInstruction } from './SurveyTask.stories'
 
 describe('SurveyTask with user keystrokes', function () {
   // this turns off Mocha's time limit for slow tests
   this.timeout(0)
 
-  const DefaultStory = composeStory(Default, Meta, projectAnnotations)
-  const NoFiltersNoInstructionStory = composeStory(NoFiltersNoInstruction, Meta, projectAnnotations)
+  const DefaultStory = composeStory(Default, Meta)
+  const NoFiltersNoInstructionStory = composeStory(NoFiltersNoInstruction, Meta)
 
   describe('without filters', function() {
     let user, choiceButton, choiceButtons

--- a/packages/lib-react-components/.storybook/specConfig.js
+++ b/packages/lib-react-components/.storybook/specConfig.js
@@ -1,0 +1,3 @@
+import * as globalStorybookConfig from './preview.js'
+import { setProjectAnnotations } from '@storybook/react'
+setProjectAnnotations(globalStorybookConfig)

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -19,8 +19,8 @@
     "lint": "zoo-standard --fix | snazzy",
     "prepare": "yarn build",
     "start": "start-storybook -p 6007",
-    "test": "mocha --config ./test/.mocharc.json \"./src/**/*.spec.js\"",
-    "test:ci": "mocha --config ./test/.mocharc.json --reporter=min \"./src/**/*.spec.js\"",
+    "test": "mocha --config ./test/.mocharc.json ./.storybook/specConfig.js \"./src/**/*.spec.js\"",
+    "test:ci": "mocha --config ./test/.mocharc.json ./.storybook/specConfig.js --reporter=min \"./src/**/*.spec.js\"",
     "storybook": "storybook dev -p 6007",
     "build-storybook": "storybook build"
   },


### PR DESCRIPTION
## Package
app-project, lib-classifier, and lib-react-components

## Linked Issue and/or Talk Post
Incorporates the alternative config implementation from [PR#5310](https://github.com/zooniverse/front-end-monorepo/pull/5310) based on https://storybook.js.org/docs/react/writing-tests/stories-in-unit-tests#configure. 

## Describe your changes
- Create a specConfig.js file in `lib-classifier`, `app-project`, and `lib-react-components` that sets the global config for Storybook's projectAnnotations (needed for Grommet in stories that are included in spec files).
- Remove manually added projectAnnotations from spec files
- Add specConfig.js file to test command in package.json
- Fix import of i18n files from `require()` to an `async import`

## How to Review
Pull code and run tests locally. 

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected