### PR TITLE
404 page: fix invalid HTML

### DIFF
--- a/packages/app-project/pages/404.js
+++ b/packages/app-project/pages/404.js
@@ -22,6 +22,7 @@ const Overlay = styled(Box)`
 `
 
 const PageContent = styled(Box)`
+  line-height: 2em;
   z-index: 3;
 `
 
@@ -65,20 +66,22 @@ export default function Error404({
         />
 
         <PageContent
-          height="44px"
           alignContent="center"
           justify="center"
           textAlign="center"
         >
-          <Paragraph textAlign="center" style={{ lineHeight: '2em' }}>
+          <Paragraph textAlign="center">
             <Image
               id="404-logo"
               fit="contain"
-              height="44px"
+              height="44"
+              width="132"
               alt="404"
               src={`/projects/assets/logoWhite404.png`}
             />
-            <Heading level="2" textAlign="center" style={{ maxWidth: '100%' }}>{t('404.heading')}</Heading>
+          </Paragraph>
+          <Heading level="2" textAlign="center" style={{ maxWidth: '100%' }}>{t('404.heading')}</Heading>
+          <Paragraph textAlign="center">
             {t('404.message')}
             <br />
             <Anchor

--- a/packages/app-project/src/hooks/useSugarProject.js
+++ b/packages/app-project/src/hooks/useSugarProject.js
@@ -7,13 +7,14 @@ export default function useSugarProject(project) {
   const projectID = project?.id
 
   useEffect(function onProjectChange() {
+    let cleanup
     if (isBrowser && projectID) {
       const channel = `project-${projectID}`
       sugarClient.subscribeTo(channel)
-      return () => {
+      cleanup = () => {
         sugarClient.unsubscribeFrom(channel)
       }
     }
-    return null
+    return cleanup
   }, [projectID])
 }


### PR DESCRIPTION
Headings can't be nested inside paragraphs, so this fixes the 404 page by moving the heading and 404 image into the `PageContent` div.

`useEffect` must return a function or undefined, so this also fixes the broken `useSugarProject` hook, which crashes the 404 page in development.

- Fixes #5277.
- Fixes #5276.

## Package
app-project

## How to Review
Build the project app, then start it and browse to a project URL that doesn't exist.
eg. https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats123

The 404 page should also render in development mode, `yarn dev`, without crashing.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
