### PR TITLE
ZRC: Refactor ZooHeader to avoid hydration errors

### DIFF
--- a/packages/app-project/pages/_app.js
+++ b/packages/app-project/pages/_app.js
@@ -84,7 +84,7 @@ function MyApp({ Component, pageProps }) {
       <>
         <GlobalStyle />
         <Provider store={store}>
-          <MediaContextProvider>
+          <MediaContextProvider disableDynamicMediaQueries>
             <GrommetWrapper>
               <Head host={pageProps.host} pageTitle={pageProps.pageTitle} />
               <Box>

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.5.6] 2023-09-04
+
+### Changed
+- refactor `SignedInUserNavigation` to avoid hydration errors during SSR.
+
 ## [1.5.5] 2023-08-15
 
 ### Changed

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -3,7 +3,7 @@
   "description": "Zooniverse React Components",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.js
@@ -103,29 +103,38 @@ export default function ZooHeader({
           mainHeaderNavListURLs={mainHeaderNavListURLs}
         />
       </Box>
-      <SignedOutUserNavigation
-        adminNavLinkLabel={adminNavLinkLabel}
-        adminNavLinkURL={adminNavLinkURL}
-        isAdmin={isAdmin}
-        isNarrow={isNarrow}
-        mainHeaderNavListLabels={mainHeaderNavListLabels}
-        mainHeaderNavListURLs={mainHeaderNavListURLs}
-        register={register}
-        signIn={signIn}
-        user={user}
-      />
-      <SignedInUserNavigation
-        adminNavLinkLabel={adminNavLinkLabel}
-        adminNavLinkURL={adminNavLinkURL}
-        isAdmin={isAdmin}
-        isNarrow={isNarrow}
-        mainHeaderNavListLabels={mainHeaderNavListLabels}
-        mainHeaderNavListURLs={mainHeaderNavListURLs}
-        unreadMessages={unreadMessages}
-        unreadNotifications={unreadNotifications}
-        signOut={signOut}
-        user={user}
-      />
+      <Box
+        aria-label={t('ZooHeader.SignedInUserNavigation.ariaLabel')}
+        as='nav'
+        align='center'
+        direction='row'
+      >
+        {Object.keys(user).length === 0 ?
+          <SignedOutUserNavigation
+            adminNavLinkLabel={adminNavLinkLabel}
+            adminNavLinkURL={adminNavLinkURL}
+            isAdmin={isAdmin}
+            isNarrow={isNarrow}
+            mainHeaderNavListLabels={mainHeaderNavListLabels}
+            mainHeaderNavListURLs={mainHeaderNavListURLs}
+            register={register}
+            signIn={signIn}
+            user={user}
+          /> :
+          <SignedInUserNavigation
+            adminNavLinkLabel={adminNavLinkLabel}
+            adminNavLinkURL={adminNavLinkURL}
+            isAdmin={isAdmin}
+            isNarrow={isNarrow}
+            mainHeaderNavListLabels={mainHeaderNavListLabels}
+            mainHeaderNavListURLs={mainHeaderNavListURLs}
+            unreadMessages={unreadMessages}
+            unreadNotifications={unreadNotifications}
+            signOut={signOut}
+            user={user}
+          />
+        }
+      </Box>
     </StyledHeader>
   )
 }

--- a/packages/lib-react-components/src/ZooHeader/components/NavListItem/NavListItem.js
+++ b/packages/lib-react-components/src/ZooHeader/components/NavListItem/NavListItem.js
@@ -20,7 +20,6 @@ export const StyledNavListItem = styled(Anchor)`
   }
 `
 
-// TODO: This component is causing a styled-components error and needs a fix
 function NavListItem ({ className, color, label, margin, theme, url }) {
   return (
     <StyledNavListItem className={className} color={color} href={url} margin={margin} theme={theme} >

--- a/packages/lib-react-components/src/ZooHeader/components/NavListItem/NavListItem.js
+++ b/packages/lib-react-components/src/ZooHeader/components/NavListItem/NavListItem.js
@@ -21,9 +21,9 @@ export const StyledNavListItem = styled(Anchor)`
 `
 
 // TODO: This component is causing a styled-components error and needs a fix
-function NavListItem ({ className, color, label, theme, url }) {
+function NavListItem ({ className, color, label, margin, theme, url }) {
   return (
-    <StyledNavListItem className={className} color={color} href={url} theme={theme} >
+    <StyledNavListItem className={className} color={color} href={url} margin={margin} theme={theme} >
       <SpacedText
         size='xsmall'
         weight='bold'
@@ -46,6 +46,7 @@ NavListItem.defaultProps = {
 NavListItem.propTypes = {
   color: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
+  margin: PropTypes.object,
   theme: PropTypes.object,
   url: PropTypes.string.isRequired
 }

--- a/packages/lib-react-components/src/ZooHeader/components/SignedInUserNavigation/SignedInUserNavigation.js
+++ b/packages/lib-react-components/src/ZooHeader/components/SignedInUserNavigation/SignedInUserNavigation.js
@@ -70,22 +70,18 @@ export default function SignedInUserNavigation({
 
   if (Object.keys(user).length > 0 && signOut) {
     return (
-      <Box
-        aria-label={t('ZooHeader.SignedInUserNavigation.ariaLabel')}
-        as='nav'
-        align='center'
-        direction='row'
-        gap='small'
-      >
+      <>
         <NavListItem
           color={unreadNotifications ? 'accent-1' : '#B2B2B2'}
           label={notificationLabel}
+          margin={{ right: 'small' }}
           unread={unreadNotifications}
           url={`${host}/notifications`}
         />
         <NavListItem
           color={unreadMessages ? 'accent-1' : '#B2B2B2'}
           label={messagesLabel}
+          margin={{ right: 'small' }}
           unread={unreadMessages}
           url={`${host}/inbox`}
         />
@@ -101,7 +97,7 @@ export default function SignedInUserNavigation({
             mainHeaderNavListLabels={mainHeaderNavListLabels}
             mainHeaderNavListURLs={mainHeaderNavListURLs}
           />}
-      </Box>
+      </>
     )
   }
 

--- a/packages/lib-react-components/src/ZooHeader/components/SignedOutUserNavigation/SignedOutUserNavigation.js
+++ b/packages/lib-react-components/src/ZooHeader/components/SignedOutUserNavigation/SignedOutUserNavigation.js
@@ -20,14 +20,8 @@ export default function SignedOutUserNavigation({
   if (Object.keys(user).length === 0 && signIn) {
     return (
       <>
-        <Box
-          direction='row'
-          justify='center'
-          pad={{ horizontal: 'medium', vertical: 'small' }}
-        >
-          <NavButton label={t('ZooHeader.SignedOutUserNavigation.signIn')} onClick={signIn} />
-          <NavButton label={t('ZooHeader.SignedOutUserNavigation.register')} onClick={register} />
-        </Box>
+        <NavButton label={t('ZooHeader.SignedOutUserNavigation.signIn')} onClick={signIn} />
+        <NavButton label={t('ZooHeader.SignedOutUserNavigation.register')} onClick={register} />
         {isNarrow &&
           <NarrowMainNavMenu
             adminNavLinkLabel={adminNavLinkLabel}


### PR DESCRIPTION
- **lib-react-components:** wrap both `SignedInUserNavigation` and `SignedOutUserNavigation` in a labelled `nav` element, to avoid this hydration error in the header: `Expected server HTML to contain a matching <nav> in <div>.` (#5273)
- bump `@zooniverse/react-components` to 1.5.6.
- update the changelog.
- **app-project:** add `disableDynamicMediaQueries` (see https://github.com/artsy/fresnel/blob/main/README.md#%EF%B8%8F-react-18-notice.)

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
 - app-project
 - lib-react-components
 
## Linked Issue and/or Talk Post
- towards #5273.

## How to Review
Run the project app with `yarn dev`. Some page components will still throw mismatch errors, but they should be fixed in `ZooHeader`. Sign in and out should continue to work as before. 

Accessibility fix: The signed-out user menu should now be labelled as a navigation landmark, called 'User Account'.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated

