### PR TITLE
Restore image viewer drag performance

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -1,4 +1,3 @@
-import debounce from 'lodash/debounce'
 import PropTypes from 'prop-types'
 import { cloneElement, useEffect, useState } from 'react'
 
@@ -27,7 +26,7 @@ function SVGPanZoom({
   const [viewBox, setViewBox] = useState(defaultViewBox)
 
   function enableZoom() {
-    setOnDrag(debounce(onDrag, 10))
+    setOnDrag(onDrag)
     setOnPan(onPan)
     setOnZoom(onZoom)
   }
@@ -78,8 +77,8 @@ function SVGPanZoom({
     setViewBox((prevViewBox) => {
       const newViewBox = {
         ...prevViewBox,
-        x: prevViewBox.x - difference.x,
-        y: prevViewBox.y - difference.y
+        x: prevViewBox.x - difference.x / 1.5,
+        y: prevViewBox.y - difference.y / 1.5
       }
       return newViewBox
     })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
@@ -32,7 +32,7 @@ describe('Components > SVGPanZoom', function () {
       </SVGPanZoom>
     )
   })
-  
+
   it('should enable zoom in', async function () {
     onZoom('zoomin', 1)
     await waitFor(() => {
@@ -106,7 +106,7 @@ describe('Components > SVGPanZoom', function () {
     onDrag({}, { x: -15, y: 0 })
     await waitFor(() => {
       const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
-      expect(viewBox).to.equal('15 0 400 200')
+      expect(viewBox).to.equal('10 0 400 200')
     })
   })
 
@@ -114,7 +114,7 @@ describe('Components > SVGPanZoom', function () {
     onDrag({}, { x: 0, y: -15 })
     await waitFor(() => {
       const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
-      expect(viewBox).to.equal('0 15 400 200')
+      expect(viewBox).to.equal('0 10 400 200')
     })
   })
 


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post

This is a follow-up to https://github.com/zooniverse/front-end-monorepo/pull/5165. 

Note that this PR does _not_ solve https://github.com/zooniverse/front-end-monorepo/issues/5110. However, my latest comment in https://github.com/zooniverse/front-end-monorepo/issues/5110 shows a video of the degraded drag/pan feature for subject viewers specifically using a cursor in desktop browsers. This PR intends to revert that degraded UX, but a bit of lag will remain (as initially described when that Issue was first opened).

## Describe your changes

1. I found that lodash's `debounce` was the cause of unresponsive dragging in the image subject viewers, and the responsiveness increased when I removed it from `setOnDrag`. I think debouncing was causing a build up of `onDrag` calls, and when the 10ms delay was up, it resulted in a very lagging drag UX. 

    I attempted to used lodash's `throttle` instead, but found that number 2 below was still required to prevent jumpy dragging, so I restored `setOnDrag` to simply `setOnDrag(onDrag)`.

2. A calculation of `/ 1.5` in the `onDrag` function was removed in https://github.com/zooniverse/front-end-monorepo/pull/5165:
https://github.com/zooniverse/front-end-monorepo/blob/faa9dc51029644279d74cc41070468e1008db51a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js#L81-L82
I think the `/ 1.5` originally was in the function to prevent jumpy dragging behavior. I added it back in for now, but recognize that it could be a contributor to the original reason https://github.com/zooniverse/front-end-monorepo/issues/5110 was documented.

## How to Review

Run this branch locally, and try out the drag/pan feature in subject viewers either in the lib-classifier Storybook, or in a MultiFrameViewer, SingleImageViewer, or FlipbookViewer projects:
- [i-fancy-cats](https://localhost.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [PRINT](https://local.zooniverse.org:3000/projects/printmigrationnetwork/print/classify?env=production)
- [Daily Minor Planet](https://local.zooniverse.org:3000/projects/fulsdavid/the-daily-minor-planet?env=production)

Please specifically check that desktop Chrome, Safari, and Firefox can be used to drag a subject image in addition to mobile and your fav browser.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated