### PR TITLE
Fix missing padding in the logged-out user menu

### DIFF
--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.js
@@ -32,6 +32,7 @@ export const StyledLogoAnchor = styled(Anchor)`
 `
 
 const defaultHandler = () => true
+const signedOutUserNavPadding = { horizontal: 'medium', vertical: 'small' }
 
 export default function ZooHeader({
   breakpoint = 960,
@@ -72,6 +73,7 @@ export default function ZooHeader({
     t('ZooHeader.mainHeaderNavListLabels.build')
   ]
 
+  const userNavigationPadding = Object.keys(user).length === 0 ? signedOutUserNavPadding : undefined
   return (
     <StyledHeader
       ref={ref}
@@ -108,6 +110,7 @@ export default function ZooHeader({
         as='nav'
         align='center'
         direction='row'
+        pad={userNavigationPadding}
       >
         {Object.keys(user).length === 0 ?
           <SignedOutUserNavigation

--- a/packages/lib-react-components/src/ZooHeader/components/NarrowMenu/NarrowMenu.js
+++ b/packages/lib-react-components/src/ZooHeader/components/NarrowMenu/NarrowMenu.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import { Menu } from 'grommet'
 
 export default function NarrowMenu({
+  children,
   dropBackground = 'brand',
   icon,
   items,
@@ -23,7 +24,9 @@ export default function NarrowMenu({
       label={label}
       size={size}
       {...props}
-    />
+    >
+      {children}
+    </Menu>
   )
 }
 

--- a/packages/lib-react-components/src/ZooHeader/components/UserMenu/UserMenu.js
+++ b/packages/lib-react-components/src/ZooHeader/components/UserMenu/UserMenu.js
@@ -1,10 +1,12 @@
 import PropTypes from 'prop-types'
+import { Box } from 'grommet'
 import { FormDown } from 'grommet-icons'
 import styled from 'styled-components'
 import { useTranslation } from '../../../translations/i18n'
 
 import NarrowMenu from '../NarrowMenu'
 import NarrowMenuNavListItem from '../NarrowMenuNavListItem'
+import SpacedText from '../../../SpacedText'
 import { getHost } from '../../helpers'
 
 // The standard xsmall size in the theme isn't small enough
@@ -12,13 +14,14 @@ export const StyledFormDown = styled(FormDown)`
   width: 1em;
 `
 
+const textMargin = { right: 'small' }
+const menuButtonPadding = { horizontal: 'medium', vertical: 'small' }
+
 export default function UserMenu ({ signOut, user }) {
   const { t } = useTranslation()
 
   // Support staging urls...
   const host = getHost()
-
-  const userDisplayName = <NarrowMenuNavListItem color='#B2B2B2' text={user.display_name} lang='en' />
 
   const profileLabel = <NarrowMenuNavListItem text={t('ZooHeader.UserMenu.userNavListLabels.profile')} />
 
@@ -40,10 +43,27 @@ export default function UserMenu ({ signOut, user }) {
 
   return (
     <NarrowMenu
-      icon={<StyledFormDown color='#B2B2B2' />}
+      aria-label={user.display_name}
       items={userMenuNavListItems}
-      label={userDisplayName}
-    />
+    >
+      <Box
+        align="center"
+        as='span'
+        direction="row"
+        pad={menuButtonPadding}
+      >
+        <SpacedText
+          color='#b2b2b2'
+          lang='en'
+          margin={textMargin}
+          size='xsmall'
+          weight='bold'
+        >
+          {user.display_name}
+        </SpacedText>
+        <StyledFormDown color='#b2b2b2' />
+      </Box>
+    </NarrowMenu>
   )
 }
 


### PR DESCRIPTION
PR #5278 accidentally removed the padding from the signed-out user navigation menu in `ZooHeader`. This restores it.

This also fixes an invalid button label on the user account dropdown menu.

## Package
- lib-react-components

## How to Review
Compare the signed-out user navigation menu with the live web site.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated
