### PR TITLE
Refactor Notifications store fetches when response is no unread notifications or conversations

### DIFF
--- a/packages/app-content-pages/src/shared/stores/User/UserPersonalization/Notifications/Notifications.js
+++ b/packages/app-content-pages/src/shared/stores/User/UserPersonalization/Notifications/Notifications.js
@@ -42,9 +42,7 @@ const Notifications = types
 
           const unreadConversationsIds = yield getUnreadConversationsIds(authorization)
 
-          if (unreadConversationsIds?.length) {
-            self.unreadConversationsIds = unreadConversationsIds
-          }
+          self.unreadConversationsIds = unreadConversationsIds
 
           self.conversationsLoadingState = asyncStates.success
         } catch (error) {
@@ -59,11 +57,10 @@ const Notifications = types
           const token = yield auth.checkBearerToken()
           const authorization = `Bearer ${token}`
 
-          const unreadNotificationsCount = yield getUnreadNotificationsCount(authorization)
+          let unreadNotificationsCount = 0
+          unreadNotificationsCount = yield getUnreadNotificationsCount(authorization)
 
-          if (unreadNotificationsCount) {
             self.unreadNotificationsCount = unreadNotificationsCount
-          }
 
           self.notificationsLoadingState = asyncStates.success
         } catch (error) {

--- a/packages/app-project/stores/User/UserPersonalization/Notifications/Notifications.js
+++ b/packages/app-project/stores/User/UserPersonalization/Notifications/Notifications.js
@@ -38,9 +38,7 @@ const Notifications = types
 
           const unreadConversationsIds = yield getUnreadConversationsIds(authorization)
 
-          if (unreadConversationsIds?.length) {
-            self.unreadConversationsIds = unreadConversationsIds
-          }
+          self.unreadConversationsIds = unreadConversationsIds
 
           self.setLoadingState(asyncStates.success)
         } catch (error) {
@@ -54,11 +52,9 @@ const Notifications = types
           const token = yield auth.checkBearerToken()
           const authorization = `Bearer ${token}`
 
-          const unreadNotificationsCount = yield getUnreadNotificationsCount(authorization)
-
-          if (unreadNotificationsCount) {
-            self.unreadNotificationsCount = unreadNotificationsCount
-          }
+          let unreadNotificationsCount = 0
+          unreadNotificationsCount = yield getUnreadNotificationsCount(authorization)
+          self.unreadNotificationsCount = unreadNotificationsCount
 
           self.setLoadingState(asyncStates.success)
         } catch (error) {


### PR DESCRIPTION
## Package
- app-content-pages
- app-project

## Linked Issue and/or Talk Post
Closes #5336 .
Currently on refresh, the previous store snapshot is applied (with a count of X) and when the Notification store receives the new/updated response of no unreads the store isn't updating because of unnecessary conditionals.

## Describe your changes
- add related failing tests
- refactor Notification store fetch functions for unread notifications and unread conversations to reflect responses for no unreads 

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - any FEM project, though I'd recommend one on production as there can be unexpected issues with Talk/sugar on staging
  - Here's a test project on production you're welcome to post in Talk, let me know if you want me to mention you in a post - https://local.zooniverse.org:3000/projects/markbouslog/digileap-testing-production?env=production&demo=true
- What user actions should my reviewer step through to review this PR?
  1. from a FEM page, confirm unread notifications
  2. in a different tab, mark notifications as read
  3. from the original FEM page, refresh, note unread notifications count zero (doesn't show a count)
- Which storybook stories should be reviewed? N/A
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated