### PR TITLE
ZRC: restore the package main entry point

### DIFF
--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
   "version": "1.6.0",
+  "main": "dist/cjs/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",


### PR DESCRIPTION
Since #5325 replaced `main` with `exports`, `@zooniverse/react-components` is empty when published. This fixes that by restoring the main entry point.

- Fixes #5338.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-react-components

## How to Review
`npm publish --dry-run` or `npx npm-packlist` to preview the files that will be included in the published package.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed