### PR TITLE
Display Media images inline

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
@@ -50,9 +50,16 @@ export function NextLabel () {
 }
 
 // creating StyledMedia allows input state dependent styles as defined in StyledFrame
-export const StyledMedia = styled(Media)``
+export const StyledMedia = styled(Media)`
+  height: 40px;
+  width: 40px;
 
-export const StyledFrame = styled.label`
+  img {
+    aspect-ratio: 1 / 1;
+  }
+`
+
+export const StyledLabel = styled.label`
   ${props => props.theme && css`
     input:checked + ${StyledMedia} {
       border: solid ${props.theme.global.colors['neutral-2']};
@@ -67,21 +74,11 @@ export const StyledFrame = styled.label`
     }
   `}
 
-  height: 40px;
-  margin: 5px 0;
-  width: 40px;
-            
-  &:first-child {
-    margin-top: 14px;
-  }
-
-  &:last-child {
-    margin-bottom: 14px;
-  }
-
   input {
     opacity: 0.01;
     position: absolute;
+    height: 0;
+    width: 0;
   }
 
   :hover {
@@ -94,11 +91,26 @@ export const StyledFrameList = styled.ul`
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
+  list-style-type: none;
   margin: 0;
   overflow: auto;
   padding: 0;
   position: relative;
   scroll-behavior: smooth;
+
+  li {
+    height: 40px;
+    margin: 5px 0;
+    width: 40px;
+
+    &:first-child {
+      margin-top: 14px;
+    }
+
+    &:last-child {
+      margin-bottom: 14px;
+    }
+  }
 `
 
 class FrameCarousel extends Component {
@@ -158,30 +170,32 @@ class FrameCarousel extends Component {
       const activeFrame = frame === index
 
       return (
-        <StyledFrame
-          key={`${url}-${index}`}
-          ref={activeFrame ? this.activeLabel : null}
-        >
-          <input
-            checked={activeFrame}
-            name='frame'
-            onChange={() => this.handleFrameChange(index)}
-            type='radio'
-          />
-          <StyledMedia
-            alt={t('SubjectViewer.MultiFrameViewer.FrameCarousel.thumbnailAltText')}
-            background='accent-1'
-            fit='cover'
-            height={40}
-            placeholder={
-              <More
-                color='neutral-6'
-                size='medium'
-              />}
-            src={url}
-            width={40}
-          />
-        </StyledFrame>
+        <li>
+          <StyledLabel
+            key={`${url}-${index}`}
+            ref={activeFrame ? this.activeLabel : null}
+          >
+            <input
+              checked={activeFrame}
+              name='frame'
+              onChange={() => this.handleFrameChange(index)}
+              type='radio'
+            />
+            <StyledMedia
+              alt={t('SubjectViewer.MultiFrameViewer.FrameCarousel.thumbnailAltText')}
+              background='accent-1'
+              fit='cover'
+              height={40}
+              placeholder={
+                <More
+                  color='neutral-6'
+                  size='medium'
+                />}
+              src={url}
+              width={40}
+            />
+          </StyledLabel>
+        </li>
       )
     })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.spec.js
@@ -5,7 +5,7 @@ import {
   FrameCarousel,
   StyledControlButton,
   StyledMedia,
-  StyledFrame
+  StyledLabel
 } from './FrameCarousel'
 
 describe('Component > FrameCarousel', function () {
@@ -46,7 +46,7 @@ describe('Component > FrameCarousel', function () {
   })
 
   it('should render a label, input and an img for each location', function () {
-    const labels = wrapper.find(StyledFrame)
+    const labels = wrapper.find(StyledLabel)
     const inputs = wrapper.find('input')
     const images = wrapper.find(StyledMedia)
     expect(labels).to.have.lengthOf(numberOfFrames)

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.2] 2023-09-19
+
+### Fixed
+- display `Media` images inline.
+- `Markdownz`: convert line breaks to `<br>`.
+
 ## [1.6.1] 2023-09-18
 
 ### Fixed

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -3,7 +3,7 @@
   "description": "Zooniverse React Components",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "main": "dist/cjs/index.js",
   "exports": {
     ".": {
@@ -51,6 +51,7 @@
     "react-resize-detector": "~9.1.0",
     "react-rnd": "10.4.1",
     "remark": "~12.0.1",
+    "remark-breaks": "~2.0.2",
     "remark-emoji": "~2.0.2",
     "remark-external-links": "~3.1.1",
     "remark-footnotes": "2.0.0",

--- a/packages/lib-react-components/src/Markdownz/Markdownz.js
+++ b/packages/lib-react-components/src/Markdownz/Markdownz.js
@@ -20,6 +20,7 @@ import remarkSubSuper from 'remark-sub-super'
 import externalLinks from 'remark-external-links'
 import toc from 'remark-toc'
 import ping from './lib/ping'
+import breaks from 'remark-breaks'
 import footnotes from 'remark-footnotes'
 import Media from '../Media'
 import withThemeContext from '../helpers/withThemeContext'
@@ -127,6 +128,7 @@ function Markdownz({
       .use(emoji)
       .use(remarkSubSuper)
       .use(externalLinks)
+      .use(breaks)
       .use(footnotes, { inlineNotes: true })
       .use(ping, {
         ping: pingCallback,

--- a/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.js
+++ b/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.js
@@ -1,11 +1,17 @@
 import { Box, Image } from 'grommet'
+import styled from 'styled-components'
+
 import getThumbnailSrc from '../../helpers/getThumbnailSrc.js'
 import { propTypes, defaultProps } from '../../helpers/mediaPropTypes.js'
 import useProgressiveImage from '../../../hooks/useProgressiveImage.js'
 
+const InlineBox = styled.span`
+  display: inline-flex;
+`
+
 export function Placeholder({ children, flex, ...props}) {
   return (
-    <Box background='brand' flex={flex} justify='center' align='center' {...props}>
+    <Box as={InlineBox} background='brand' flex={flex} justify='center' align='center' {...props}>
       {children}
     </Box>
   )
@@ -30,6 +36,7 @@ export default function ThumbnailImage({
   const cssHeight = height > 0 ? `${height}px` : height
   const cssWidth = width > 0 ? `${width}px` : width
   const fallbackStyle = {
+    display: 'inline-block',
     maxHeight: cssHeight,
     maxWidth: cssWidth
   }
@@ -46,6 +53,7 @@ export default function ThumbnailImage({
         <Placeholder height={cssHeight} flex={flex} width={cssWidth} {...rest}>{placeholder}</Placeholder> :
         <Box
           animation={loading ? undefined : 'fadeIn'}
+          as={InlineBox}
           className='thumbnailImage'
           flex={flex}
           height={boxHeight}
@@ -60,9 +68,9 @@ export default function ThumbnailImage({
           />
         </Box>}
       <noscript>
-        <div style={fallbackStyle}>
+        <span style={fallbackStyle}>
           <img src={imageSrc} alt={alt} height='100%' width='100%' style={{ flex, objectFit: fit }} />
-        </div>
+        </span>
       </noscript>
     </>
   )

--- a/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.spec.js
+++ b/packages/lib-react-components/src/Media/components/ThumbnailImage/ThumbnailImage.spec.js
@@ -62,7 +62,7 @@ describe('ThumbnailImage', function () {
     it('should be set if specified', async function () {
       render(<ThumbnailImage alt='a test image' height={200} width={270} src={src} />)
       const image = await screen.findByRole('img', { name: 'a test image' })
-      const imageWrapper = document.querySelector('div.thumbnailImage')
+      const imageWrapper = document.querySelector('span.thumbnailImage')
       const { maxHeight, maxWidth } = window.getComputedStyle(imageWrapper)
       expect(maxHeight).to.equal('200px')
       expect(maxWidth).to.equal('270px')
@@ -71,7 +71,7 @@ describe('ThumbnailImage', function () {
     it('should fill the image container by default', async function () {
       render(<ThumbnailImage alt='a test image' src={src} />)
       const image = await screen.findByRole('img', { name: 'a test image' })
-      const imageWrapper = document.querySelector('div.thumbnailImage')
+      const imageWrapper = document.querySelector('span.thumbnailImage')
       const { maxHeight, maxWidth } = window.getComputedStyle(imageWrapper)
       expect(maxHeight).to.be.empty()
       expect(maxWidth).to.equal('100%')

--- a/yarn.lock
+++ b/yarn.lock
@@ -15177,6 +15177,13 @@ release-zalgo@^1.0.0:
   dependencies:
     es6-error "^4.0.1"
 
+remark-breaks@~2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/remark-breaks/-/remark-breaks-2.0.2.tgz#55fdec6c7da84f659aa7fdb1aa95b632870cee8d"
+  integrity sha512-LsQnPPQ7Fzp9RTjj4IwdEmjPOr9bxe9zYKWhs9ZQOg9hMg8rOfeeqQ410cvVdIK87Famqza1CKRxNkepp2EvUA==
+  dependencies:
+    unist-util-visit "^2.0.0"
+
 remark-emoji@~2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/remark-emoji/-/remark-emoji-2.0.2.tgz#49c134021132c192ee4cceed1988ec9b8ced7eb8"


### PR DESCRIPTION
- Display `Media` images with `inline-flex`, rather than `flex`, columns.
- Replace the container element with `span`, rather than `div`, so that media images can be displayed inside paragraphs.
- `Markdownz`: Convert line breaks to `<br>` with [`remark-breaks@2.02`](https://www.npmjs.com/package/remark-breaks/v/2.0.2).
- Bump `@zooniverse/react-components` to 1.6.2.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-react-components

## Linked Issue and/or Talk Post
- Closes #2462.

## How to Review
Images on the Galaxy Zoo Research page now display inline, as expected.
<img width="600" alt="Inline images of galaxies on the Galaxy Zoo Research page." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/d871cbc1-51b3-4f46-88e4-307526d37813">

However, there could be project teams that have relied on the incorrect, block display for images in their field guides etc., so that needs checking.

Here's the Galaxy Zoo field guide on this branch. Images are displayed inline, within paragraphs, and line breaks are converted to `<br>`*.

<img width="600" alt="The Galaxy Zoo field guide, demonstrating inline images and line breaks within paragraphs." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/72e77469-c681-4575-9f79-954bfe6fcbf4">

*this is non-standard markdown but matches how [`markdownz`](https://www.npmjs.com/package/markdownz) parses markdown to HTML. Standard markdown uses whitespace to represent line breaks, but this is controversial, quite hard to use in practice, and would mean converting all the non-standard markdown used by our projects.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
