### PR TITLE
@zooniverse/react-components: remove require

### DIFF
--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased 2023-09-22
+
+### Fixed
+- replace `require` with `import`.
+- remove the `React` global from tests.
+
 ## [1.6.2] 2023-09-19
 
 ### Fixed

--- a/packages/lib-react-components/src/PrimaryButton/helpers/getGradientShade.js
+++ b/packages/lib-react-components/src/PrimaryButton/helpers/getGradientShade.js
@@ -1,4 +1,4 @@
-const { parseToRgb, rgb } = require('polished')
+import { parseToRgb, rgb } from 'polished'
 
 function getGradientShade (hex) {
   const color = parseToRgb(hex)

--- a/packages/lib-react-components/src/translations/i18n.js
+++ b/packages/lib-react-components/src/translations/i18n.js
@@ -37,8 +37,9 @@ zrcI18n.use(initReactI18next).init({
   }
 })
 
-supportedLngs.forEach(lang => {
-  zrcI18n.addResourceBundle(lang, 'translation', require(`./${lang}.json`))
+supportedLngs.forEach( async lang => {
+  const dictionary = await import(`./${lang}.json`)
+  zrcI18n.addResourceBundle(lang, 'translation', dictionary)
 })
 
 export function useTranslation(ns) {

--- a/packages/lib-react-components/test/setup.js
+++ b/packages/lib-react-components/test/setup.js
@@ -1,6 +1,5 @@
 /* eslint-env browser, mocha */
 /* eslint import/no-extraneous-dependencies: ["error", { "devDependencies": true  }] */
-import React from 'react'
 import chai from 'chai'
 import dirtyChai from 'dirty-chai'
 import sinonChai from 'sinon-chai'
@@ -10,7 +9,6 @@ import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 
 chai.use(dirtyChai)
 chai.use(sinonChai)
-global.React = React
 global.expect = chai.expect
 
 const jsdom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://localhost'})


### PR DESCRIPTION
- Replace `require` with `import` in a couple of places.
- Remove the `React` global from the tests.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-react-components

## How to Review

```sh
# clean installed packages and builds
yarn panic
# install and build from scratch
yarn bootstrap
# test the project app on eg. https://local.zooniverse.org:3000/projects/zooniverse/gravity-spy
cd packages/app-project
yarn start
# test the content pages app on eg. https://local.zooniverse.org:3000/about/publications
cd ../app-content-pages
yarn start
```

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
