### PR TITLE
lib-classifier: Fix highlighter task label text alignment

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/experimental/highlighter/components/HighlighterTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/highlighter/components/HighlighterTask.js
@@ -91,7 +91,10 @@ function StyledButtonLabel ({ color, count = 0, label }) {
         justify='between'
         margin={{ left: 'small' }}
       >
-        <Text size='16px'>
+        <Text
+          size='16px'
+          textAlign='start'
+        >
           {label}
         </Text>
         <Text

--- a/packages/lib-classifier/src/plugins/tasks/experimental/highlighter/components/HighlighterTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/experimental/highlighter/components/HighlighterTask.stories.js
@@ -45,7 +45,7 @@ export function Default ({
         },
         {
           'color': '#fced54',
-          'label': 'Collector Name'
+          'label': 'Collector Name with Extra Text'
         },
         {
           'color': '#ee7bcf',
@@ -58,7 +58,7 @@ export function Default ({
         instruction: 'Highlight the text',
         'highlighterLabels.0.label': 'Species Name',
         'highlighterLabels.1.label': 'Location',
-        'highlighterLabels.2.label': 'Collector Name',
+        'highlighterLabels.2.label': 'Collector Name with Extra Text',
         'highlighterLabels.3.label': 'Habitat'
       },
       taskKey: 'T0',


### PR DESCRIPTION
## Package
- lib-classifier

## Describe your changes
- fix highlighter task label text alignment so labels that wrap align at start to match labels that don't wrap

Before changes:
![screenshot of highlighter task story showing labels with inconsistent alignment](https://github.com/zooniverse/front-end-monorepo/assets/12118751/9ad75262-4f3f-4d9f-894f-58fbf5836ef4)

With changes:
![screenshot of highlighter task story showing labels with consist alignment at start](https://github.com/zooniverse/front-end-monorepo/assets/12118751/b554495a-132f-4e8e-8b7f-2d93d9b47135)

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - https://local.zooniverse.org:8080/?project=1952&workflow=3538
- What user actions should my reviewer step through to review this PR?
  - note label with wrapped text alignment
- Which storybook stories should be reviewed?
  - http://localhost:6006/?path=/story/tasks-highlighter--default
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected