### PR TITLE
Add drop shadow to transcribed lines

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
@@ -13,6 +13,7 @@ import ConsensusPopup from './components/ConsensusPopup'
 
 export const ConsensusLine = styled('g')`
   cursor: pointer;
+  filter: drop-shadow(1px 1px 4px #5c5c5c);
 
   &:focus {
     ${props => css`outline: solid 4px ${props.focusColor};`}
@@ -86,7 +87,7 @@ function TranscribedLines({
   const transcribedLines = lines.filter(line => !line.consensusReached)
   const fills = {
     transcribed: 'drawing-pink',
-    complete: 'light-5'
+    complete: 'light-4'
   }
 
   const focusColor = theme.global.colors[theme.global.colors.focus]


### PR DESCRIPTION
- add a drop shadow to all previously transcribed lines.
- darken the grey, completed lines to `light-4`.

<img width="300" alt="Screenshot of completed lines with a drop shadow in the storybook" src="https://github.com/zooniverse/front-end-monorepo/assets/59547/e9d62647-d9db-4e9e-8ca3-87f5aa13c1e1">
<img width="300" alt="Screenshot of completed lines with a drop shadow in the dev classifier." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/7b5efb89-d13f-413d-92eb-130896642c0e">

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- towards #5291.


## How to Review
You can use the Transcribed Lines story, in the Classifier storybook, to view the new styles.

You can also see them on Davy Notebooks:
https://localhost:8080/?project=humphrydavy/davy-notebooks-project&env=production&workflow=24822

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [x] Unit tests are included for the new feature
- [x] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
