### PR TITLE
Fix SVG subject scaling

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
@@ -78,7 +78,8 @@ const FlipbookViewer = ({
   return (
     <Box>
       <SVGPanZoom
-        img={subjectImage.current}
+        key={viewerLocation.url}
+        imgRef={subjectImage}
         limitSubjectHeight={limitSubjectHeight}
         maxZoom={5}
         minZoom={0.1}
@@ -97,8 +98,9 @@ const FlipbookViewer = ({
           rotate={rotation}
           width={img.naturalWidth}
         >
-          <g ref={subjectImage} role='tabpanel' id='flipbook-tab-panel'>
+          <g role='tabpanel' id='flipbook-tab-panel'>
             <SVGImage
+              ref={subjectImage}
               invert={invert}
               move={move}
               naturalHeight={img.naturalHeight}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
@@ -78,7 +78,7 @@ const FlipbookViewer = ({
   return (
     <Box>
       <SVGPanZoom
-        key={viewerLocation.url}
+        key={`${img.naturalWidth}-${img.naturalHeight}`}
         imgRef={subjectImage}
         limitSubjectHeight={limitSubjectHeight}
         maxZoom={5}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/FrameCarousel.js
@@ -170,9 +170,8 @@ class FrameCarousel extends Component {
       const activeFrame = frame === index
 
       return (
-        <li>
+        <li key={`${url}-${index}`}>
           <StyledLabel
-            key={`${url}-${index}`}
             ref={activeFrame ? this.activeLabel : null}
           >
             <input

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
@@ -120,7 +120,7 @@ function MultiFrameViewerContainer({
           locations={subject.locations}
         />
         <SVGPanZoom
-          key={img.src}
+          key={`${img.naturalWidth}-${img.naturalHeight}`}
           imgRef={subjectImage}
           limitSubjectHeight={limitSubjectHeight}
           maxZoom={5}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
@@ -120,7 +120,8 @@ function MultiFrameViewerContainer({
           locations={subject.locations}
         />
         <SVGPanZoom
-          img={subjectImage.current}
+          key={img.src}
+          imgRef={subjectImage}
           limitSubjectHeight={limitSubjectHeight}
           maxZoom={5}
           minZoom={0.1}
@@ -139,17 +140,16 @@ function MultiFrameViewerContainer({
             rotate={rotation}
             width={img.naturalWidth}
           >
-            <g ref={subjectImage}>
-              <SVGImage
-                invert={invert}
-                move={move}
-                naturalHeight={img.naturalHeight}
-                naturalWidth={img.naturalWidth}
-                onDrag={onDrag}
-                src={img.src}
-                subjectID={subjectID}
-              />
-            </g>
+            <SVGImage
+              ref={subjectImage}
+              invert={invert}
+              move={move}
+              naturalHeight={img.naturalHeight}
+              naturalWidth={img.naturalWidth}
+              onDrag={onDrag}
+              src={img.src}
+              subjectID={subjectID}
+            />
           </SingleImageViewer>
         </SVGPanZoom>
       </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGImage/SVGImage.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGImage/SVGImage.js
@@ -43,10 +43,13 @@ function SVGImageWithRef({
     width: naturalWidth,
   }
 
+  const ImageComponent = move ? DraggableImage : 'image'
+  if (move) {
+    props.dragMove = onDrag
+  }
   return (
-    <DraggableImage
+    <ImageComponent
       ref={ref}
-      dragMove={onDrag}
       {...props}
     />
   )

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGImage/SVGImage.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGImage/SVGImage.js
@@ -1,4 +1,5 @@
 import { PropTypes } from 'prop-types'
+import { forwardRef } from 'react'
 import styled from 'styled-components'
 
 import { draggable } from '@plugins/drawingTools/components'
@@ -20,7 +21,7 @@ const INVERT =
     </defs>
   </svg>`
 
-export default function SVGImage({
+function SVGImageWithRef({
   invert = false,
   move = false,
   naturalHeight,
@@ -28,7 +29,7 @@ export default function SVGImage({
   onDrag = () => true,
   src,
   subjectID
-}) {
+}, ref) {
   if (!document.getElementById('svg-invert-filter')) {
     document.body.insertAdjacentHTML('afterbegin', INVERT)
   }
@@ -43,17 +44,15 @@ export default function SVGImage({
   }
 
   return (
-    move ?
-      <DraggableImage
-        dragMove={onDrag}
-        {...props}
-      /> :
-      <image
-        {...props}
-      />
+    <DraggableImage
+      ref={ref}
+      dragMove={onDrag}
+      {...props}
+    />
   )
 }
 
+const SVGImage = forwardRef(SVGImageWithRef)
 SVGImage.propTypes = {
   invert: PropTypes.bool,
   move: PropTypes.bool,
@@ -63,3 +62,5 @@ SVGImage.propTypes = {
   src: PropTypes.string.isRequired,
   subjectID: PropTypes.string.isRequired
 }
+
+export default SVGImage

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -86,11 +86,9 @@ function SVGPanZoom({
 
   function onDrag(event, difference) {
     setViewBox((prevViewBox) => {
-      const newViewBox = {
-        ...prevViewBox,
-        x: prevViewBox.x - difference.x / 1.5,
-        y: prevViewBox.y - difference.y / 1.5
-      }
+      const newViewBox = { ...prevViewBox }
+      newViewBox.x -= difference.x / 1.5
+      newViewBox.y -= difference.y / 1.5
       return newViewBox
     })
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -1,10 +1,23 @@
 import PropTypes from 'prop-types'
-import { cloneElement, useEffect, useState } from 'react'
+import { cloneElement, useEffect, useRef, useState } from 'react'
+import styled from 'styled-components'
+
+const FullWidthDiv = styled.div`
+  width: 100%;
+`
+
+function imageScale(imgRef, naturalWidth) {
+  const { width: clientWidth, height: clientHeight } = imgRef?.current
+    ? imgRef.current.getBoundingClientRect()
+    : {}
+  const scale = clientWidth / naturalWidth
+  return !Number.isNaN(scale) ? scale : 1
+}
 
 const DEFAULT_HANDLER = () => true
 function SVGPanZoom({
+  imgRef = null,
   children,
-  img,
   limitSubjectHeight = false,
   maxZoom = 2,
   minZoom = 1,
@@ -38,8 +51,7 @@ function SVGPanZoom({
   }
 
   useEffect(function onZoomChange() {
-    const newViewBox = scaledViewBox(zoom)
-    setViewBox(newViewBox)
+    scaleViewBox(zoom)
   }, [zoom])
 
   useEffect(() => {
@@ -50,27 +62,26 @@ function SVGPanZoom({
   }, [zooming, src])
 
   useEffect(() => {
+    setViewBox({
+      x: 0,
+      y: 0,
+      height: naturalHeight,
+      width: naturalWidth
+    })
     setZoom(1)
-    setViewBox(defaultViewBox)
-  }, [src])
+  }, [naturalWidth, naturalHeight])
 
-  function imageScale(img) {
-    const { width: clientWidth, height: clientHeight } = img
-      ? img.getBoundingClientRect()
-      : {}
-    const scale = clientWidth / naturalWidth
-    return !Number.isNaN(scale) ? scale : 1
-  }
-
-  function scaledViewBox(scale) {
+  function scaleViewBox(scale) {
     const viewBoxScale = 1 / scale
-    const xCentre = viewBox.x + viewBox.width / 2
-    const yCentre = viewBox.y + viewBox.height / 2
     const width = parseInt(naturalWidth * viewBoxScale, 10)
     const height = parseInt(naturalHeight * viewBoxScale, 10)
-    const x = xCentre - width / 2
-    const y = yCentre - height / 2
-    return { x, y, width, height }
+    setViewBox((prevViewBox) => {
+      const xCentre = prevViewBox.x + prevViewBox.width / 2
+      const yCentre = prevViewBox.y + prevViewBox.height / 2
+      const x = xCentre - width / 2
+      const y = yCentre - height / 2
+      return { x, y, width, height }
+    })
   }
 
   function onDrag(event, difference) {
@@ -104,28 +115,29 @@ function SVGPanZoom({
         return
       }
       case 'zoomto': {
-        setZoom(1)
         setViewBox({
           x: 0,
           y: 0,
-          width: naturalWidth,
-          height: naturalHeight
+          height: naturalHeight,
+          width: naturalWidth
         })
+        setZoom(1)
+        return
       }
     }
   }
 
   const { x, y, width, height } = viewBox
-  const scale = imageScale(img)
+  const scale = imageScale(imgRef, naturalWidth)
 
   return (
-    <div style={{ width: '100%' }}>
+    <FullWidthDiv>
       {cloneElement(children, {
         scale,
         viewBox: `${x} ${y} ${width} ${height}`,
         svgMaxHeight: limitSubjectHeight ? `min(${naturalHeight}px, 90vh)` : null
       })}
-    </div>
+    </FullWidthDiv>
   )
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.js
@@ -206,17 +206,16 @@ const SeparateFrame = ({
         viewBox={`${x} ${y} ${width} ${height}`}
         width={naturalWidth}
       >
-        <g ref={subjectImage}>
-          <SVGImage
-            invert={invert}
-            move={separateFrameMove}
-            naturalHeight={naturalHeight}
-            naturalWidth={naturalWidth}
-            onDrag={onDrag}
-            src={frameSrc}
-            subjectID={frameUrl} // for aria-label
-          />
-        </g>
+        <SVGImage
+          ref={subjectImage}
+          invert={invert}
+          move={separateFrameMove}
+          naturalHeight={naturalHeight}
+          naturalWidth={naturalWidth}
+          onDrag={onDrag}
+          src={frameSrc}
+          subjectID={frameUrl} // for aria-label
+        />
       </SingleImageViewer>
       <Box
         background={{

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -63,7 +63,7 @@ function SingleImageViewerContainer({
 
     return (
       <SVGPanZoom
-        key={img.src}
+        key={`${img.naturalWidth}-${img.naturalHeight}`}
         imgRef={subjectImage}
         limitSubjectHeight={limitSubjectHeight}
         maxZoom={5}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -63,7 +63,8 @@ function SingleImageViewerContainer({
 
     return (
       <SVGPanZoom
-        img={subjectImage.current}
+        key={img.src}
+        imgRef={subjectImage}
         limitSubjectHeight={limitSubjectHeight}
         maxZoom={5}
         minZoom={0.1}
@@ -88,17 +89,16 @@ function SingleImageViewerContainer({
           zooming={zooming}
           subject={subject}
         >
-          <g ref={subjectImage}>
-            <SVGImage
-              invert={invert}
-              move={move}
-              naturalHeight={img.naturalHeight}
-              naturalWidth={img.naturalWidth}
-              onDrag={onDrag}
-              src={img.src}
-              subjectID={subjectID}
-            />
-          </g>
+          <SVGImage
+            ref={subjectImage}
+            invert={invert}
+            move={move}
+            naturalHeight={img.naturalHeight}
+            naturalWidth={img.naturalWidth}
+            onDrag={onDrag}
+            src={img.src}
+            subjectID={subjectID}
+          />
         </SingleImageViewer>
       </SVGPanZoom>
     )

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -1,4 +1,4 @@
-import { useContext, useRef, useState } from 'react';
+import { forwardRef, useContext, useRef, useState } from 'react';
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 
 function createPoint(event) {
@@ -42,16 +42,16 @@ const DEFAULT_COORDS = {
 const DEFAULT_HANDLER = event => true
 
 function draggable(WrappedComponent) {
-  function Draggable({
+  function DraggableWithRef({
     children,
     coords: initialCoords = DEFAULT_COORDS,
     dragStart = DEFAULT_HANDLER,
     dragMove = DEFAULT_HANDLER,
     dragEnd = DEFAULT_HANDLER,
     ...rest
-  }) {
+  }, ref) {
     const { canvas } = useContext(SVGContext)
-    const wrappedComponent = useRef()
+    const wrappedComponent = ref || useRef()
     const [dragging, setDragging] = useState(false)
     const [coords, setCoords] = useState(initialCoords)
     const [pointerId, setPointerId] = useState(-1)
@@ -113,6 +113,7 @@ function draggable(WrappedComponent) {
     )
   }
 
+  const Draggable = forwardRef(DraggableWithRef)
   const name =
     WrappedComponent.displayName ||
     WrappedComponent.name ||

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/helpers/constants.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/helpers/constants.js
@@ -1,5 +1,5 @@
 const HANDLE_RADIUS = 5
-const GRAB_STROKE_WIDTH = 6
+const GRAB_STROKE_WIDTH = 12
 
 export {
   HANDLE_RADIUS,


### PR DESCRIPTION
- [Reset the `SVGPanZoom` component state](https://react.dev/reference/react/useState#resetting-state-with-a-key) when its image size changes, so that the default viewbox always matches the current image height and width.
- allow `SVGImage` to be passed a ref. Use that ref to report subject image dimensions in classifications. 
- fix `TranscriptionLine` scaling.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- fixes #5384.
- closes #5291.


## How to Review
This bug was first reported on Davy Notebooks and Beyond Borders, because it's most obvious when previous transcription lines are shown on top of an image. However, it affects all the image subject viewers.

When a subject loads:
- the correct client dimensions should be recorded in the classification.
- previous transcription lines should be scaled correctly relative to the viewport, not shown too small (ie. not drawn at the same pixel scale as the full-size subject image.)

<img width="800" alt="Screenshot of a page from Davy Notebooks, in a reasonably wide browser window, showing the previously transcribed lines scaled to the correct size relative to the browser viewport." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/c8e1a7c4-b9ee-4b42-b757-30f1ab26301d">

With the line-width scaled to the subject size:
<img width="800" alt="Screenshot of a page from Davy Notebooks, in a reasonably wide browser window, showing the previously transcribed lines scaled to the correct size relative to the browser viewport and the subject image size." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/ead013e7-6a8c-470e-8993-697378cab3ca">


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
