### PR TITLE
Fix Subject Set Selection: Choose a new workflow bug

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -2,7 +2,7 @@ import Classifier from '@zooniverse/classifier'
 import { useRouter } from 'next/router'
 import auth from 'panoptes-client/lib/auth'
 import { bool, func, string, shape } from 'prop-types'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import asyncStates from '@zooniverse/async-states'
 
 import { useAdminMode } from '@hooks'
@@ -45,7 +45,10 @@ export default function ClassifierWrapper({
   workflowID,
   yourStats
 }) {
+  /* setClassifierSubjectID() is called when the subject changes inside the classifier component
+     subjectID comes from classifierProps in ClassifyPage */
   const [classifierSubjectID, setClassifierSubjectID] = useState(subjectID)
+
   const { adminMode } = useAdminMode()
   const nextRouter = useRouter()
   router = router || nextRouter
@@ -53,6 +56,7 @@ export default function ClassifierWrapper({
   const ownerSlug = router?.query.owner
   const projectSlug = router?.query.project
 
+  /* Only increment stats on the classify page if the subject is not retired or not already seen by current user */
   const incrementStats = yourStats?.increment
   const addRecents = recents?.add
   const onCompleteClassification = useCallback((classification, subject) => {
@@ -71,26 +75,21 @@ export default function ClassifierWrapper({
     If the page URL contains a subject ID, update that ID when the classification subject changes.
     Subject page URLs can be either `/classify/workflow/{workflowID}/subject/{subjectID}`
     or `/classify/workflow/{workflowID}/subject-set/{subjectSetID}/subject/{subjectID}`.
+    Example: Subject Set Progress Banner arrow buttons
   */
-  const replaceRoute = router.replace
   let baseURL = `/${ownerSlug}/${projectSlug}/classify/workflow/${workflowID}`
   if (subjectSetID) {
     baseURL = `${baseURL}/subject-set/${subjectSetID}`
   }
-  let subjectPageURL = null
-  let subjectRouteChanged = false
-  if (subjectID) {
-    subjectPageURL = `${baseURL}/subject/${classifierSubjectID}`
-    subjectRouteChanged = router?.query.subjectID !== classifierSubjectID
-  }
 
-  useEffect(function updatePageURL() {
-    if (subjectPageURL && subjectRouteChanged) {
+  if (router.query.subjectID && classifierSubjectID) {
+    const subjectPageURL = `${baseURL}/subject/${classifierSubjectID}`
+    /* True when the classifier subject changed, but new id is not yet reflected in the url */
+    if (router?.query.subjectID !== classifierSubjectID) {
       const href = addQueryParams(subjectPageURL)
-      const as = href
-      replaceRoute(href, as, { shallow: true })
+      router.push(href, href, { shallow: true })
     }
-  }, [replaceRoute, subjectPageURL, subjectRouteChanged])
+  }
 
   /*
     Track the current classification subject, when it changes inside the classifier.
@@ -110,7 +109,7 @@ export default function ClassifierWrapper({
   if (somethingWentWrong) {
     const { error: projectError } = project
     const { error: userError } = user
-    
+
     const errorToMessage = projectError || userError || new Error('Something went wrong')
     return (
       <ErrorMessage error={errorToMessage} />
@@ -180,7 +179,7 @@ ClassifierWrapper.propTypes = {
   onSubjectReset: func,
   /** JSON snapshot of the active Panoptes project */
   project: shape({}),
-  /** 
+  /**
     Optional custom router. Overrides the default NextJS.
     Useful for mocking the router in stories and shallow tests.
   */
@@ -189,9 +188,9 @@ ClassifierWrapper.propTypes = {
   }),
   /** Allow the classifier to open a popup tutorial, if necessary. */
   showTutorial: bool,
-  /** optional subjectID (from the page URL.) */
+  /** optional subjectID (from the classifierProps.) */
   subjectID: string,
-  /** optional subject set ID (from the page URL.) */
+  /** optional subject set ID (from the classifierProps.) */
   subjectSetID: string,
   /** Current logged-in user */
   user: shape({
@@ -199,6 +198,6 @@ ClassifierWrapper.propTypes = {
   }),
   /** Logged-in user ID */
   userID: string,
-  /** required workflow ID (from the page URL.) */
+  /** required workflow ID (from the classifierProps.) */
   workflowID: string
 }


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Closes https://github.com/zooniverse/front-end-monorepo/issues/5385

## Describe your changes

The `subjectID` prop passed to ClassifierWrapper component is derived from the `classifierProps`. Code in ClassifierWrapper was assuming `subjectID` derived from the url, and therefore incorrectly comparing it to `classifierSubjectID`. This resulted in an infinite loop when viewing a project with subject selection enabled, and opening the Workflow Menu Modal by clicking Classify in the project header.

I refactored parts of ClassifierWrapper to correctly compare the classifier's subject id to the subject id in the url.

## How to Review

[Deciphering Secrets](https://local.zooniverse.org:3000/projects/profdrrogerlouismartinez-davila/deciphering-secrets-unlocking-the-manuscripts-of-medieval-spain?env=production&demo=true) is a good project to test with subject selection. You should be able to:
- Use the Next and Previous arrows in the Subject Set Progress Banner. The subject id in the classifier and url should always match
- If viewing a retired subject, you should be able to click "Next Available" to view a new subject, including the correct subject id in the url
- When viewing a subject in Deciphering Secrets, you should be able to click Classify in the Project Header to choose a new workflow, subject set, or new subject.

The changes in this PR should not affect any other projects. You should be able to easily select new workflows in projects without subject selection such as [Davy Notebooks](https://local.zooniverse.org:3000/projects/humphrydavy/davy-notebooks-project?env=production&demo=true).

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated