### PR TITLE
Increase transcription line width

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/components/TranscriptionLineMark/TranscriptionLineMark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/components/TranscriptionLineMark/TranscriptionLineMark.js
@@ -38,7 +38,7 @@ const TranscriptionLineMark = forwardRef((props, ref) => {
       fill={color}
       ref={ref}
       stroke={color}
-      strokeWidth={2}
+      strokeWidth={4 / scale}
     >
       <line x1={x1 + offsetX} y1={y1 + offsetY} x2={x2} y2={y2} />
       <line x1={x1} y1={y1} x2={x2} y2={y2} strokeWidth={GRAB_STROKE_WIDTH / scale} strokeOpacity='0' />

--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/helpers/constants.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/TranscriptionLine/helpers/constants.js
@@ -1,5 +1,5 @@
 const HANDLE_RADIUS = 5
-const GRAB_STROKE_WIDTH = 6
+const GRAB_STROKE_WIDTH = 12
 
 export {
   HANDLE_RADIUS,


### PR DESCRIPTION
Increase transcription line width to 4px, scaled to account for the subject image size.

Increase the transparent, clickable line width to 12px, also scaled to the subject size. 

<img width="800" alt="Screenshot of a page from the Davy Notebooks Project, with much thicker lines overlaid on the page." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/4fae4099-8fc7-4320-b4d1-78c180186150">


_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## Linked Issue and/or Talk Post
- towards #5291. 

## How to Review
On a project like Davy Notebooks, or in the Transcribed Lines story, transcription lines should be thicker and easier to click. The line thickness should also scale to the subject size, so lines won’t get thinner as the subject gets bigger. 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
