### PR TITLE
Content pages: run with next start

### DIFF
--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -9,7 +9,7 @@
     "build": "APP_ENV=${APP_ENV:-development} NODE_ENV=${NODE_ENV:-production} PANOPTES_ENV=${PANOPTES_ENV:-production} next build",
     "dev": "APP_ENV=${APP_ENV:-development} PANOPTES_ENV=${PANOPTES_ENV:-production} node server/server.js",
     "lint": "next lint",
-    "start": "NODE_ENV=${NODE_ENV:-production} PANOPTES_ENV=${PANOPTES_ENV:-production} node server/server.js",
+    "start": "NODE_ENV=${NODE_ENV:-production} PANOPTES_ENV=${PANOPTES_ENV:-production} next start",
     "test": "BABEL_ENV=test mocha --config ./test/.mocharc.json ./.storybook/specConfig.js \"./{src,server,test}/**/*.spec.js\"",
     "test:ci": "BABEL_ENV=test mocha --config ./test/.mocharc.json ./.storybook/specConfig.js --reporter=min \"./{src,server,test}/**/*.spec.js\"",
     "storybook": "storybook dev -p 9002",


### PR DESCRIPTION
Replace the custom Express server with `next start`.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-content-pages

## How to Review
The app should start without problems on kubernetes?

