### PR TITLE
ZRC: restore the ES module entry point

### DIFF
--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -3,8 +3,9 @@
   "description": "Zooniverse React Components",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",


### PR DESCRIPTION
- Restore the `module` entry point to `@zooniverse/react-components`. It was removed in #5325.
- Bump the version to 1.6.3.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-react-components
