### PR TITLE
Fix keyboard autofocus for question tasks

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/components/TaskInput/TaskInput.js
+++ b/packages/lib-classifier/src/plugins/tasks/components/TaskInput/TaskInput.js
@@ -102,7 +102,7 @@ export const StyledTaskInput = styled.label`
 `
 
 const DEFAULT_HANDLER = () => true
-  
+
 export function TaskInput ({
   autoFocus = false,
   checked = false,

--- a/packages/lib-classifier/src/plugins/tasks/components/TaskInput/TaskInput.js
+++ b/packages/lib-classifier/src/plugins/tasks/components/TaskInput/TaskInput.js
@@ -1,7 +1,6 @@
-import { memo } from 'react';
 import PropTypes from 'prop-types'
 
-import styled, { css, withTheme } from 'styled-components'
+import styled, { css } from 'styled-components'
 import { darken, lighten } from 'polished'
 import { Text } from 'grommet'
 
@@ -102,26 +101,25 @@ export const StyledTaskInput = styled.label`
   }
 `
 
-export function TaskInput (props) {
-  const {
-    autoFocus,
-    checked,
-    className,
-    disabled,
-    index,
-    label,
-    labelIcon,
-    labelStatus,
-    name,
-    onChange,
-    theme,
-    type
-  } = props
+const DEFAULT_HANDLER = () => true
+  
+export function TaskInput ({
+  autoFocus = false,
+  checked = false,
+  className = '',
+  disabled = false,
+  index,
+  label = '',
+  labelIcon = null,
+  labelStatus = null,
+  name = '',
+  onChange = DEFAULT_HANDLER,
+  type
+}) {
 
   return (
     <StyledTaskInput
       className={className}
-      theme={theme}
     >
       <input
         autoFocus={autoFocus}
@@ -132,26 +130,11 @@ export function TaskInput (props) {
         type={type}
         value={index}
       />
-      <StyledTaskLabel margin={{ vertical: 'small', horizontal: 'none' }} theme={theme}>
+      <StyledTaskLabel margin={{ vertical: 'small', horizontal: 'none' }}>
         <TaskInputLabel label={label} labelIcon={labelIcon} labelStatus={labelStatus} />
       </StyledTaskLabel>
     </StyledTaskInput>
   )
-}
-
-TaskInput.defaultProps = {
-  autoFocus: false,
-  checked: false,
-  disabled: false,
-  className: '',
-  label: '',
-  labelIcon: null,
-  labelStatus: null,
-  name: '',
-  onChange: () => {},
-  theme: {
-    dark: false
-  }
 }
 
 TaskInput.propTypes = {
@@ -165,10 +148,7 @@ TaskInput.propTypes = {
   labelStatus: PropTypes.oneOfType([PropTypes.node, PropTypes.object]),
   name: PropTypes.string,
   onChange: PropTypes.func,
-  theme: PropTypes.shape({
-    dark: PropTypes.bool
-  }),
   type: PropTypes.string.isRequired
 }
 
-export default memo(withTheme(TaskInput))
+export default TaskInput

--- a/packages/lib-classifier/src/plugins/tasks/components/TaskInput/TaskInput.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/components/TaskInput/TaskInput.spec.js
@@ -1,8 +1,11 @@
-import { shallow } from 'enzyme'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import zooTheme from '@zooniverse/grommet-theme'
 import { expect } from 'chai'
+import { Grommet } from 'grommet'
 import sinon from 'sinon'
-import { TaskInput, StyledTaskInput, StyledTaskLabel } from './TaskInput'
-import TaskInputLabel from './components/TaskInputLabel'
+
+import TaskInput from './TaskInput'
 
 const radioTypeAnnotation = {
   _key: 1,
@@ -11,54 +14,69 @@ const radioTypeAnnotation = {
 }
 
 describe('TaskInput', function () {
+  function withGrommet() {
+    return function Wrapper({ children }) {
+      return (
+        <Grommet theme={zooTheme}>
+          {children}
+        </Grommet>
+      )
+    }
+  }
+
   describe('render', function () {
-    let wrapper
-    before(function () {
-      wrapper = shallow(<TaskInput annotation={radioTypeAnnotation} index={0} type='radio' />)
+    it('should render a radio button', function () {
+      render(
+        <TaskInput annotation={radioTypeAnnotation} index={0} type='radio' />,
+        { wrapper: withGrommet()}
+      )
+      expect(document.querySelectorAll('input[type="radio"]')).to.have.lengthOf(1)
     })
 
-    it('should render without crashing', function () {
-      expect(wrapper).to.be.ok()
+    it('should render a label', function () {
+      render(
+        <TaskInput annotation={radioTypeAnnotation} index={0} type='radio' />,
+        { wrapper: withGrommet()}
+      )
+      expect(document.querySelectorAll('label')).to.have.lengthOf(1)
     })
 
-    it('should render a StyledTaskInput', function () {
-      expect(wrapper.find(StyledTaskInput)).to.have.lengthOf(1)
-    })
-
-    it('should render a StyledTaskLabel', function () {
-      expect(wrapper.find(StyledTaskLabel)).to.have.lengthOf(1)
-    })
-
-    it('should render a TaskInputLabel', function () {
-      expect(wrapper.find(TaskInputLabel)).to.have.lengthOf(1)
-    })
-
-    it('should use props.className in its classlist', function () {
-      wrapper.setProps({ className: 'active' })
-      expect(wrapper.find(StyledTaskInput).props().className).to.include('active')
+    it('should pass props.className to the label', function () {
+      render(
+        <TaskInput className='active' annotation={radioTypeAnnotation} index={0} type='radio' />,
+        { wrapper: withGrommet()}
+      )
+      expect(document.querySelector('label').className).to.include('active')
     })
 
     it('should disable the form input when disabled', function () {
-      expect(wrapper.find('input').prop('disabled')).to.be.false()
-      wrapper.setProps({ disabled: true })
-      expect(wrapper.find('input').prop('disabled')).to.be.true()
+      render(
+        <TaskInput disabled annotation={radioTypeAnnotation} index={0} type='radio' />,
+        { wrapper: withGrommet()}
+      )
+      const radioButton = document.querySelector('input[type="radio"]')
+      expect(radioButton.disabled).to.be.true()
     })
   })
 
   describe('onChange method', function () {
-    let onChangeSpy
-    let wrapper
-    before(function () {
-      onChangeSpy = sinon.spy()
-      wrapper = shallow(<TaskInput annotation={radioTypeAnnotation} onChange={onChangeSpy} index={0} type='radio' />)
+    const onChangeSpy = sinon.spy()
+
+    beforeEach(function () {
+      render(
+        <TaskInput annotation={radioTypeAnnotation} onChange={onChangeSpy} index={0} type='radio' />,
+        { wrapper: withGrommet()}
+      )
     })
 
     afterEach(function () {
       onChangeSpy.resetHistory()
     })
 
-    it('should call onChange when the on change event is fired', function () {
-      wrapper.find('input').simulate('change')
+    it('should call onChange when the on change event is fired', async function () {
+      const user = userEvent.setup()
+      const radioButton = document.querySelector('input[type="radio"]')
+      await user.click(radioButton)
       expect(onChangeSpy).to.have.been.calledOnce()
     })
   })

--- a/packages/lib-classifier/src/plugins/tasks/components/TaskInput/TaskInput.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/components/TaskInput/TaskInput.spec.js
@@ -7,12 +7,6 @@ import sinon from 'sinon'
 
 import TaskInput from './TaskInput'
 
-const radioTypeAnnotation = {
-  _key: 1,
-  task: 'T0',
-  value: null
-}
-
 describe('TaskInput', function () {
   function withGrommet() {
     return function Wrapper({ children }) {
@@ -27,7 +21,7 @@ describe('TaskInput', function () {
   describe('render', function () {
     it('should render a radio button', function () {
       render(
-        <TaskInput annotation={radioTypeAnnotation} index={0} type='radio' />,
+        <TaskInput index={0} type='radio' />,
         { wrapper: withGrommet()}
       )
       expect(document.querySelectorAll('input[type="radio"]')).to.have.lengthOf(1)
@@ -35,7 +29,7 @@ describe('TaskInput', function () {
 
     it('should render a label', function () {
       render(
-        <TaskInput annotation={radioTypeAnnotation} index={0} type='radio' />,
+        <TaskInput index={0} type='radio' />,
         { wrapper: withGrommet()}
       )
       expect(document.querySelectorAll('label')).to.have.lengthOf(1)
@@ -43,7 +37,7 @@ describe('TaskInput', function () {
 
     it('should pass props.className to the label', function () {
       render(
-        <TaskInput className='active' annotation={radioTypeAnnotation} index={0} type='radio' />,
+        <TaskInput className='active' index={0} type='radio' />,
         { wrapper: withGrommet()}
       )
       expect(document.querySelector('label').className).to.include('active')
@@ -51,7 +45,7 @@ describe('TaskInput', function () {
 
     it('should disable the form input when disabled', function () {
       render(
-        <TaskInput disabled annotation={radioTypeAnnotation} index={0} type='radio' />,
+        <TaskInput disabled index={0} type='radio' />,
         { wrapper: withGrommet()}
       )
       const radioButton = document.querySelector('input[type="radio"]')
@@ -64,7 +58,7 @@ describe('TaskInput', function () {
 
     beforeEach(function () {
       render(
-        <TaskInput annotation={radioTypeAnnotation} onChange={onChangeSpy} index={0} type='radio' />,
+        <TaskInput onChange={onChangeSpy} index={0} type='radio' />,
         { wrapper: withGrommet()}
       )
     })

--- a/packages/lib-classifier/src/plugins/tasks/components/TaskInput/components/TaskInputLabel/TaskInputLabel.js
+++ b/packages/lib-classifier/src/plugins/tasks/components/TaskInput/components/TaskInputLabel/TaskInputLabel.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { Markdownz } from '@zooniverse/react-components'
 import { doesTheLabelHaveAnImage } from '../../helpers'
 
-export const StyledTaskInputLabelWrapper = styled(Box)`
+export const StyledTaskInputLabelWrapper = styled.span`
   &:first-child {
     margin-top: 0;
   }
@@ -24,13 +24,23 @@ export const StyledLabel = styled(Text)`
   }
 `
 
+const StyledSpan = styled.span`
+  display: block;
+  margin: 1em 0;
+`
+
+const inlineComponents = {
+  p: StyledSpan
+}
+
 export default function TaskInputLabel ({ label, labelIcon, labelStatus }) {
   const howShouldTheLabelBeAligned = ((label && doesTheLabelHaveAnImage(label)) || (label && labelIcon))
     ? 'start'
     : 'center'
 
   return (
-    <StyledTaskInputLabelWrapper
+    <Box
+      as={StyledTaskInputLabelWrapper}
       direction='row'
       fill='horizontal'
       justify={howShouldTheLabelBeAligned}
@@ -38,11 +48,11 @@ export default function TaskInputLabel ({ label, labelIcon, labelStatus }) {
       {labelIcon &&
         labelIcon}
       <StyledLabel>
-        <Markdownz>{label}</Markdownz>
+        <Markdownz components={inlineComponents}>{label}</Markdownz>
       </StyledLabel>
       {labelStatus &&
         labelStatus}
-    </StyledTaskInputLabelWrapper>
+    </Box>
   )
 }
 

--- a/packages/lib-classifier/src/plugins/tasks/components/TaskInput/components/TaskInputLabel/TaskInputLabel.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/components/TaskInput/components/TaskInputLabel/TaskInputLabel.spec.js
@@ -5,7 +5,7 @@
   "react/jsx-boolean-value": ["error", "always"]
 */
 
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react'
 import { expect } from 'chai'
 import TaskInputLabel from './TaskInputLabel'
 import { Markdownz } from '@zooniverse/react-components'
@@ -14,37 +14,31 @@ const label = 'test label'
 
 describe('TaskInputLabel', function () {
   it('should render without crashing', function () {
-    const wrapper = shallow(<TaskInputLabel />)
-    expect(wrapper).to.be.ok()
-  })
-
-  it('should render Markdownz', function () {
-    const wrapper = shallow(<TaskInputLabel />)
-    expect(wrapper.find(Markdownz)).to.have.lengthOf(1)
+    render(<TaskInputLabel />)
   })
 
   it('should use props.label as the innerHTML text', function () {
-    const wrapper = shallow(<TaskInputLabel label={label} />)
-    expect(wrapper.contains(label)).to.be.true()
+    render(<TaskInputLabel label={label} />)
+    expect(screen.getByText(label)).to.exist()
   })
 
   it('should not render props.labelIcon if not defined', function () {
-    const wrapper = shallow(<TaskInputLabel label={label} />)
-    expect(wrapper.find('span#icon')).to.have.lengthOf(0)
+    render(<TaskInputLabel label={label} />)
+    expect(document.querySelector('span#icon')).to.be.null()
   })
 
   it('should not render props.labelStatus if not defined', function () {
-    const wrapper = shallow(<TaskInputLabel label={label} />)
-    expect(wrapper.find('div#status')).to.have.lengthOf(0)
+    render(<TaskInputLabel label={label} />)
+    expect(document.querySelector('span#status')).to.be.null()
   })
 
   it('should render props.labelIcon if defined', function () {
-    const wrapper = shallow(<TaskInputLabel label={label} labelIcon={<span id='icon' />} />)
-    expect(wrapper.find('span#icon')).to.have.lengthOf(1)
+    render(<TaskInputLabel label={label} labelIcon={<span id='icon' />} />)
+    expect(document.querySelectorAll('span#icon')).to.have.lengthOf(1)
   })
 
   it('should render props.labelStatus if defined', function () {
-    const wrapper = shallow(<TaskInputLabel label={label} labelStatus={<div id='status' />} />)
-    expect(wrapper.find('div#status')).to.have.lengthOf(1)
+    render(<TaskInputLabel label={label} labelStatus={<span id='status' />} />)
+    expect(document.querySelectorAll('span#status')).to.have.lengthOf(1)
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.js
@@ -3,13 +3,20 @@ import pxToRem from '@zooniverse/react-components/helpers/pxToRem'
 import { Box, Text } from 'grommet'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
-import styled, { css } from 'styled-components'
+import { useEffect, useRef } from 'react'
+import styled, { css, useTheme } from 'styled-components'
 
 import TaskInput from '../../components/TaskInput'
 
 const maxWidth = pxToRem(60)
 const StyledFieldset = styled.fieldset`
   border: none;
+
+  &:focus-visible {
+    outline: none;
+    ${props => props.focusColor && css`box-shadow: 0 0 2px 2px ${props.focusColor};`}
+  }
+
   img:only-child, svg:only-child {
     ${props => props.theme && css`background: ${props.theme.global.colors.brand};`}
     max-width: ${maxWidth};
@@ -37,7 +44,17 @@ function MultipleChoiceTask ({
   disabled = false,
   task
 }) {
+  const fieldset = useRef()
+  const theme = useTheme()
+  const focusColor = theme?.global.colors[theme?.global.colors.focus]
   const { value } = annotation
+  const questionHasFocus = autoFocus && value.length === 0
+
+  useEffect(function autofocusFieldset() {
+    if (questionHasFocus && document.activeElement !== fieldset.current) {
+      fieldset.current?.focus()
+    }
+  }, [questionHasFocus])
 
   function onChange (index, event) {
     const newValue = value ? value.slice(0) : []
@@ -53,9 +70,12 @@ function MultipleChoiceTask ({
   return (
     <Box
       as={StyledFieldset}
+      ref={fieldset}
       className={className}
       disabled={disabled}
-      tabIndex={0}
+      focusColor={focusColor}
+      tabIndex={-1}
+      theme={theme}
     >
       <StyledText as='legend' size='small'>
         <Markdownz components={inlineComponents}>

--- a/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.js
@@ -1,5 +1,4 @@
 import { Markdownz } from '@zooniverse/react-components'
-import pxToRem from '@zooniverse/react-components/helpers/pxToRem'
 import { Box, Text } from 'grommet'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
@@ -8,7 +7,6 @@ import styled, { css, useTheme } from 'styled-components'
 
 import TaskInput from '../../components/TaskInput'
 
-const maxWidth = pxToRem(60)
 const StyledFieldset = styled.fieldset`
   border: none;
 
@@ -19,7 +17,7 @@ const StyledFieldset = styled.fieldset`
 
   img:only-child, svg:only-child {
     ${props => props.theme && css`background: ${props.theme.global.colors.brand};`}
-    max-width: ${maxWidth};
+    max-width: 2.5rem;
   }
 `
 

--- a/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.js
@@ -8,7 +8,8 @@ import styled, { css } from 'styled-components'
 import TaskInput from '../../components/TaskInput'
 
 const maxWidth = pxToRem(60)
-const StyledBox = styled(Box)`
+const StyledFieldset = styled.fieldset`
+  border: none;
   img:only-child, svg:only-child {
     ${props => props.theme && css`background: ${props.theme.global.colors.brand};`}
     max-width: ${maxWidth};
@@ -25,14 +26,17 @@ const StyledText = styled(Text)`
   }
 `
 
-function MultipleChoiceTask (props) {
-  const {
-    annotation,
-    className,
-    disabled,
-    task,
-    theme
-  } = props
+const inlineComponents = {
+  p: StyledText
+}
+
+function MultipleChoiceTask ({
+  annotation,
+  autoFocus = false,
+  className = '',
+  disabled = false,
+  task
+}) {
   const { value } = annotation
 
   function onChange (index, event) {
@@ -47,14 +51,14 @@ function MultipleChoiceTask (props) {
   }
 
   return (
-    <StyledBox
-      autoFocus={(value && value.length === 0)}
+    <Box
+      as={StyledFieldset}
       className={className}
       disabled={disabled}
-      theme={theme}
+      tabIndex={0}
     >
       <StyledText as='legend' size='small'>
-        <Markdownz>
+        <Markdownz components={inlineComponents}>
           {task.question}
         </Markdownz>
       </StyledText>
@@ -75,18 +79,8 @@ function MultipleChoiceTask (props) {
           />
         )
       })}
-    </StyledBox>
+    </Box>
   )
-}
-
-MultipleChoiceTask.defaultProps = {
-  className: '',
-  disabled: false,
-  theme: {
-    global: {
-      colors: {}
-    }
-  }
 }
 
 MultipleChoiceTask.propTypes = {
@@ -94,6 +88,7 @@ MultipleChoiceTask.propTypes = {
     update: PropTypes.func,
     value: PropTypes.array
   }).isRequired,
+  autoFocus: PropTypes.bool,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   task: PropTypes.shape({
@@ -102,13 +97,8 @@ MultipleChoiceTask.propTypes = {
     })),
     help: PropTypes.string,
     question: PropTypes.string,
-    required: PropTypes.string
-  }).isRequired,
-  theme: PropTypes.shape({
-    global: PropTypes.shape({
-      colors: PropTypes.object
-   })
- })
+    required: PropTypes.bool
+  }).isRequired
 }
 
 export default observer(MultipleChoiceTask)

--- a/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.spec.js
@@ -1,5 +1,9 @@
-import { shallow } from 'enzyme'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import zooTheme from '@zooniverse/grommet-theme'
 import { expect } from 'chai'
+import { Grommet } from 'grommet'
+
 import { MultipleChoiceTask } from './MultipleChoiceTask'
 import Task from '@plugins/tasks/multiple'
 
@@ -19,84 +23,100 @@ describe('MultipleChoiceTask', function () {
 
   const annotation = task.defaultAnnotation()
 
-  describe('when it renders', function () {
-    let wrapper
-    before(function () {
-      wrapper = shallow(<MultipleChoiceTask annotation={annotation} task={task} />)
-    })
+  function withGrommet() {
+    return function Wrapper({ children }) {
+      return (
+        <Grommet theme={zooTheme}>
+          {children}
+        </Grommet>
+      )
+    }
+  }
 
-    it('should render without crashing', function () {
-      expect(wrapper).to.be.ok()
+  describe('when it renders', function () {
+    beforeEach(function () {
+      render(
+        <MultipleChoiceTask annotation={annotation} task={task} />,
+        {wrapper: withGrommet()}
+      )
     })
 
     it('should have a question', function () {
-      expect(wrapper.contains(task.question)).to.be.true()
+      const question = screen.getByText(task.question)
+      expect(question).to.exist()
     })
 
     it('should render the correct number of answer choices', function () {
-      task.answers.forEach((answer) => {
-        expect(wrapper.find({ label: answer.label })).to.have.lengthOf(1)
+      task.answers.forEach((answer, index) => {
+        const label = task.strings.get(`answers.${index}.label`)
+        const checkbox = screen.getByRole('checkbox', { name: label })
+        expect(checkbox).to.exist()
       })
     })
   })
 
   describe('with an annotation', function () {
-    let wrapper
-
-    before(function () {
+    beforeEach(function () {
       annotation.update([0])
-      wrapper = shallow(
+      render(
         <MultipleChoiceTask
           annotation={annotation}
           task={task}
-        />
+        />,
+        {wrapper: withGrommet()}
       )
     })
 
     it('should check the selected answer', function () {
-      const answer = task.answers[0]
-      const input = wrapper.find({ label: answer.label })
-      expect(input.prop('checked')).to.be.true()
+      const label = task.strings.get('answers.0.label')
+      const checkbox = screen.getByRole('checkbox', { name: label })
+      expect(checkbox.checked).to.be.true()
     })
   })
 
   describe('onChange', function () {
-    let wrapper
     beforeEach(function () {
       annotation.update([])
-      wrapper = shallow(
+      render(
         <MultipleChoiceTask
           annotation={annotation}
           task={task}
-        />
+        />,
+        {wrapper: withGrommet()}
       )
     })
 
-    it('should update the annotation', function () {
+    it('should update the annotation', async function () {
+      const user = userEvent.setup()
       const expectedValue = []
-      task.answers.forEach((answer, index) => {
-        const node = wrapper.find({ label: answer.label })
-        node.simulate('change', { target: { checked: true } })
+      const answerTests = task.answers.map(async (answer, index) => {
+        const label = task.strings.get(`answers.${index}.label`)
+        const checkbox = screen.getByRole('checkbox', { name: label })
         expectedValue.push(index)
-        expect(annotation.value).to.deep.equal(expectedValue)
+        expect(annotation.value).to.not.equal(expectedValue)
+        await user.click(checkbox)
+        waitFor(() => expect(annotation.value).to.equal(expectedValue))
       })
+      await Promise.all(answerTests)
     })
 
-    it('should add checked answers to the annotation value', function () {
-      const firstNode = wrapper.find({ label: task.answers[0].label })
-      firstNode.simulate('change', { target: { checked: true } })
-      expect(annotation.value).to.deep.equal([0])
-      const lastNode = wrapper.find({ label: task.answers[2].label })
-      lastNode.simulate('change', { target: { checked: true } })
-      expect(annotation.value).to.deep.equal([0, 2])
-    })
-
-    it('should remove unchecked answers from the annotation value', function () {
-      const firstNode = wrapper.find({ label: task.answers[0].label })
-      firstNode.simulate('change', { target: { checked: true } })
-      expect(annotation.value).to.deep.equal([0])
-      firstNode.simulate('change', { target: { checked: false } })
-      expect(annotation.value).to.deep.equal([])
+    it('should add and remove checked and unchecked answers from the annotation value', async function () {
+      const user = userEvent.setup()
+      let label = task.strings.get('answers.0.label')
+      let checkbox = screen.getByRole('checkbox', { name: label })
+      await user.click(checkbox)
+      waitFor(() => expect(annotation.value).to.deep.equal([0]))
+      label = task.strings.get('answers.2.label')
+      checkbox = screen.getByRole('checkbox', { name: label })
+      await user.click(checkbox)
+      waitFor(() => expect(annotation.value).to.deep.equal([0, 2]))
+      checkbox = screen.getByRole('checkbox', { name: label })
+      await user.click(checkbox)
+      waitFor(() => expect(annotation.value).to.deep.equal([0]))
+      label = task.strings.get('answers.0.label')
+      checkbox = screen.getByRole('checkbox', { name: label })
+      await user.click(checkbox)
+      waitFor(() => expect(annotation.value).to.deep.equal([]))
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.spec.js
@@ -1,44 +1,19 @@
+import { composeStory } from '@storybook/react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import zooTheme from '@zooniverse/grommet-theme'
 import { expect } from 'chai'
-import { Grommet } from 'grommet'
 
-import { MultipleChoiceTask } from './MultipleChoiceTask'
 import Task from '@plugins/tasks/multiple'
+import Meta, { Default, WithAnnotation } from './MultipleChoiceTask.stories'
+import mockTask from './mockTask'
 
 describe('MultipleChoiceTask', function () {
-  const task = Task.TaskModel.create({
-    answers: [{ label: 'napping' }, { label: 'standing' }, { label: 'playing' }],
-    required: false,
-    strings: {
-      'answers.0.label': 'napping',
-      'answers.1.label': 'standing',
-      'answers.2.label': 'playing',
-      question: 'What is/are the cat(s) doing?'
-    },
-    taskKey: 'T1',
-    type: 'multiple'
-  })
-
-  const annotation = task.defaultAnnotation()
-
-  function withGrommet() {
-    return function Wrapper({ children }) {
-      return (
-        <Grommet theme={zooTheme}>
-          {children}
-        </Grommet>
-      )
-    }
-  }
+  const task = Task.TaskModel.create(mockTask)
 
   describe('when it renders', function () {
     beforeEach(function () {
-      render(
-        <MultipleChoiceTask annotation={annotation} task={task} />,
-        {wrapper: withGrommet()}
-      )
+      const DefaultStory = composeStory(Default, Meta)
+      render(<DefaultStory />)
     })
 
     it('should have a question', function () {
@@ -55,16 +30,10 @@ describe('MultipleChoiceTask', function () {
     })
   })
 
-  describe('with an annotation', function () {
+  describe('with an existing annotation', function () {
     beforeEach(function () {
-      annotation.update([0])
-      render(
-        <MultipleChoiceTask
-          annotation={annotation}
-          task={task}
-        />,
-        {wrapper: withGrommet()}
-      )
+      const WithAnnotationStory = composeStory(WithAnnotation, Meta)
+      render(<WithAnnotationStory />)
     })
 
     it('should check the selected answer', function () {
@@ -75,15 +44,12 @@ describe('MultipleChoiceTask', function () {
   })
 
   describe('onChange', function () {
+    let annotation
+
     beforeEach(function () {
-      annotation.update([])
-      render(
-        <MultipleChoiceTask
-          annotation={annotation}
-          task={task}
-        />,
-        {wrapper: withGrommet()}
-      )
+      const DefaultStory = composeStory(Default, Meta)
+      render(<DefaultStory />)
+      annotation = task.defaultAnnotation()
     })
 
     it('should update the annotation', async function () {

--- a/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/multiple/components/MultipleChoiceTask.stories.js
@@ -1,6 +1,9 @@
 import asyncStates from '@zooniverse/async-states'
+import { useEffect } from 'react'
+
 import { MockTask } from '@stories/components'
 import MultipleChoiceTask from './MultipleChoiceTask'
+import mockTask from './mockTask'
 
 export default {
   title: 'Tasks / Multiple Choice Question',
@@ -23,19 +26,15 @@ export default {
 export function Default({ isThereTaskHelp, required, subjectReadyState }) {
   const tasks = {
     T1: {
-      answers: [{ label: 'sleeping' }, { label: 'playing' }, { label: 'looking indifferent' }],
+      ...mockTask,
       required,
       strings: {
+        ...mockTask.strings,
         help: isThereTaskHelp ? 'Pick as many answers as apply, then press Done.' : '',
-        question: 'What is it doing?',
-        'answers.0.label': 'sleeping',
-        'answers.1.label': 'playing',
-        'answers.2.label': 'looking indifferent'
-      },
-      taskKey: 'T1',
-      type: 'multiple'
+      }
     }
   }
+
   return (
     <MockTask
       isThereTaskHelp={isThereTaskHelp}
@@ -44,3 +43,29 @@ export function Default({ isThereTaskHelp, required, subjectReadyState }) {
     />
   )
 }
+
+export function WithAnnotation({ isThereTaskHelp, required, subjectReadyState }) {
+  const tasks = {
+    T1: {
+      ...mockTask,
+      required,
+      strings: {
+        ...mockTask.strings,
+        help: isThereTaskHelp ? 'Pick as many answers as apply, then press Done.' : '',
+      }
+    }
+  }
+
+  useEffect(() => {
+    MockTask.store.classifications.addAnnotation(tasks.T1, [0,2])
+  }, [])
+
+  return (
+    <MockTask
+      isThereTaskHelp={isThereTaskHelp}
+      subjectReadyState={subjectReadyState}
+      tasks={tasks}
+    />
+  )
+}
+

--- a/packages/lib-classifier/src/plugins/tasks/multiple/components/mockTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/multiple/components/mockTask.js
@@ -1,0 +1,15 @@
+const mockTask = {
+  answers: [{ label: 'sleeping' }, { label: 'playing' }, { label: 'looking indifferent' }],
+  required: false,
+  strings: {
+    help: 'Pick as many answers as apply, then press Done.',
+    question: 'What is it doing?',
+    'answers.0.label': 'sleeping',
+    'answers.1.label': 'playing',
+    'answers.2.label': 'looking indifferent'
+  },
+  taskKey: 'T1',
+  type: 'multiple'
+}
+
+export default mockTask

--- a/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.js
@@ -3,11 +3,12 @@ import pxToRem from '@zooniverse/react-components/helpers/pxToRem'
 import { Box, Text } from 'grommet'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
-import styled, { css } from 'styled-components'
+import styled, { css, useTheme } from 'styled-components'
 import TaskInput from '../../components/TaskInput'
 
 const maxWidth = pxToRem(60)
-const StyledBox = styled(Box)`
+const StyledFieldset = styled.fieldset`
+  border: none;
   img:only-child, svg:only-child {
     ${props => props.theme && css`background: ${props.theme.global.colors.brand};`}
     max-width: ${maxWidth};
@@ -24,27 +25,32 @@ const StyledText = styled(Text)`
   }
 `
 
-function SingleChoiceTask (props) {
-  const {
-    annotation,
-    className,
-    disabled,
-    task,
-    theme
-  } = props
+const inlineComponents = {
+  p: StyledText
+}
+
+function SingleChoiceTask ({
+  annotation,
+  autoFocus = false,
+  className = '',
+  disabled = false,
+  task
+}) {
+  const theme = useTheme()
   const { value } = annotation
   function onChange (index, event) {
     if (event.target.checked) annotation.update(index)
   }
 
   return (
-    <StyledBox
+    <Box
+      as={StyledFieldset}
       className={className}
       disabled={disabled}
-      theme={theme}
+      tabIndex={0}
     >
       <StyledText as='legend' size='small'>
-        <Markdownz>
+        <Markdownz components={inlineComponents}>
           {task.question}
         </Markdownz>
       </StyledText>
@@ -66,18 +72,8 @@ function SingleChoiceTask (props) {
           />
         )
       })}
-    </StyledBox>
+    </Box>
   )
-}
-
-SingleChoiceTask.defaultProps = {
-  className: '',
-  disabled: false,
-  theme: {
-    global: {
-      colors: {}
-    }
-  }
 }
 
 SingleChoiceTask.propTypes = {
@@ -85,6 +81,7 @@ SingleChoiceTask.propTypes = {
     update: PropTypes.func,
     value: PropTypes.number
   }).isRequired,
+  autoFocus: PropTypes.bool,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   task: PropTypes.shape({
@@ -93,9 +90,8 @@ SingleChoiceTask.propTypes = {
     })),
     help: PropTypes.string,
     question: PropTypes.string,
-    required: PropTypes.oneOfType([ PropTypes.string, PropTypes.bool ])
-  }).isRequired,
-  theme: PropTypes.object
+    required: PropTypes.bool
+  }).isRequired
 }
 
 export default observer(SingleChoiceTask)

--- a/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.js
@@ -1,5 +1,4 @@
 import { Markdownz } from '@zooniverse/react-components'
-import pxToRem from '@zooniverse/react-components/helpers/pxToRem'
 import { Box, Text } from 'grommet'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
@@ -7,7 +6,6 @@ import { useEffect, useRef } from 'react'
 import styled, { css, useTheme } from 'styled-components'
 import TaskInput from '../../components/TaskInput'
 
-const maxWidth = pxToRem(60)
 const StyledFieldset = styled.fieldset`
   border: none;
 
@@ -18,7 +16,7 @@ const StyledFieldset = styled.fieldset`
 
   img:only-child, svg:only-child {
     ${props => props.theme && css`background: ${props.theme.global.colors.brand};`}
-    max-width: ${maxWidth};
+    max-width: 2.5rem;
   }
 `
 

--- a/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.js
@@ -3,12 +3,19 @@ import pxToRem from '@zooniverse/react-components/helpers/pxToRem'
 import { Box, Text } from 'grommet'
 import { observer } from 'mobx-react'
 import PropTypes from 'prop-types'
+import { useEffect, useRef } from 'react'
 import styled, { css, useTheme } from 'styled-components'
 import TaskInput from '../../components/TaskInput'
 
 const maxWidth = pxToRem(60)
 const StyledFieldset = styled.fieldset`
   border: none;
+
+  &:focus-visible {
+    outline: none;
+    ${props => props.focusColor && css`box-shadow: 0 0 2px 2px ${props.focusColor};`}
+  }
+
   img:only-child, svg:only-child {
     ${props => props.theme && css`background: ${props.theme.global.colors.brand};`}
     max-width: ${maxWidth};
@@ -36,8 +43,18 @@ function SingleChoiceTask ({
   disabled = false,
   task
 }) {
+  const fieldset = useRef()
   const theme = useTheme()
+  const focusColor = theme?.global.colors[theme?.global.colors.focus]
   const { value } = annotation
+  const questionHasFocus = autoFocus && value === null
+  
+  useEffect(function autofocusFieldset() {
+    if (questionHasFocus && document.activeElement !== fieldset.current) {
+      fieldset.current?.focus()
+    }
+  }, [questionHasFocus])
+
   function onChange (index, event) {
     if (event.target.checked) annotation.update(index)
   }
@@ -45,9 +62,12 @@ function SingleChoiceTask ({
   return (
     <Box
       as={StyledFieldset}
+      ref={fieldset}
       className={className}
       disabled={disabled}
-      tabIndex={0}
+      focusColor={focusColor}
+      tabIndex={-1}
+      theme={theme}
     >
       <StyledText as='legend' size='small'>
         <Markdownz components={inlineComponents}>

--- a/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.spec.js
@@ -1,42 +1,19 @@
+import { composeStory } from '@storybook/react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import zooTheme from '@zooniverse/grommet-theme'
 import { expect } from 'chai'
-import { Grommet } from 'grommet'
 
-import SingleChoiceTask from './SingleChoiceTask'
 import Task from '@plugins/tasks/single'
+import Meta, { Default, WithAnnotation } from './SingleChoiceTask.stories'
+import mockTask from './mockTask'
 
 describe('SingleChoiceTask', function () {
-  const task = Task.TaskModel.create({
-    answers: [{ label: 'yes' }, { label: 'no' }],
-    required: true,
-    strings: {
-      'answers.0.label': 'yes',
-      'answers.1.label': 'no',
-      question: 'Is there a cat?'
-    },
-    taskKey: 'init',
-    type: 'single'
-  })
-  const annotation = task.defaultAnnotation()
-
-  function withGrommet() {
-    return function Wrapper({ children }) {
-      return (
-        <Grommet theme={zooTheme}>
-          {children}
-        </Grommet>
-      )
-    }
-  }
+  const task = Task.TaskModel.create(mockTask)
 
   describe('when it renders', function () {
     beforeEach(function () {
-      render(
-        <SingleChoiceTask annotation={annotation} task={task} />,
-        { wrapper: withGrommet()}
-      )
+      const DefaultStory = composeStory(Default, Meta)
+      render(<DefaultStory />)
     })
 
     it('should have a question', function () {
@@ -53,17 +30,11 @@ describe('SingleChoiceTask', function () {
     })
   })
 
-  describe('with an annotation', function () {
+  describe('with an existing annotation', function () {
 
     beforeEach(function () {
-      annotation.update(0)
-      render(
-        <SingleChoiceTask
-          annotation={annotation}
-          task={task}
-        />,
-        { wrapper: withGrommet()}
-      )
+      const WithAnnotationStory = composeStory(WithAnnotation, Meta)
+      render(<WithAnnotationStory />)
     })
 
     it('should check the selected answer', function () {
@@ -74,15 +45,11 @@ describe('SingleChoiceTask', function () {
   })
 
   describe('onChange event handler', function () {
+    let annotation
     beforeEach(function () {
-      annotation.update(null)
-      render(
-        <SingleChoiceTask
-          annotation={annotation}
-          task={task}
-        />,
-        { wrapper: withGrommet()}
-      )
+      const DefaultStory = composeStory(Default, Meta)
+      render(<DefaultStory />)
+      annotation = task.defaultAnnotation()
     })
 
     it('should update the annotation', async function () {

--- a/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.spec.js
@@ -1,5 +1,9 @@
-import { shallow } from 'enzyme'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import zooTheme from '@zooniverse/grommet-theme'
 import { expect } from 'chai'
+import { Grommet } from 'grommet'
+
 import SingleChoiceTask from './SingleChoiceTask'
 import Task from '@plugins/tasks/single'
 
@@ -17,66 +21,90 @@ describe('SingleChoiceTask', function () {
   })
   const annotation = task.defaultAnnotation()
 
-  describe('when it renders', function () {
-    let wrapper
-    before(function () {
-      wrapper = shallow(<SingleChoiceTask annotation={annotation} task={task} />)
-    })
+  function withGrommet() {
+    return function Wrapper({ children }) {
+      return (
+        <Grommet theme={zooTheme}>
+          {children}
+        </Grommet>
+      )
+    }
+  }
 
-    it('should render without crashing', function () {
-      expect(wrapper).to.be.ok()
+  describe('when it renders', function () {
+    beforeEach(function () {
+      render(
+        <SingleChoiceTask annotation={annotation} task={task} />,
+        { wrapper: withGrommet()}
+      )
     })
 
     it('should have a question', function () {
-      expect(wrapper.contains(task.question)).to.be.true()
+      const question = screen.getByText(task.question)
+      expect(question).to.exist()
     })
 
     it('should render the correct number of answer choices', function () {
-      task.answers.forEach((answer) => {
-        expect(wrapper.find({ label: answer.label })).to.have.lengthOf(1)
+      task.answers.forEach((answer, index) => {
+        const label = task.strings.get(`answers.${index}.label`)
+        const radioButton = screen.getByRole('radio', { name: label })
+        expect(radioButton).to.exist()
       })
     })
   })
 
   describe('with an annotation', function () {
-    let wrapper
 
-    before(function () {
+    beforeEach(function () {
       annotation.update(0)
-      wrapper = shallow(
+      render(
         <SingleChoiceTask
           annotation={annotation}
           task={task}
-        />
+        />,
+        { wrapper: withGrommet()}
       )
     })
 
     it('should check the selected answer', function () {
-      const answer = task.answers[0]
-      const input = wrapper.find({ label: answer.label })
-      expect(input.prop('checked')).to.be.true()
+      const label = task.strings.get('answers.0.label')
+      const radioButton = screen.getByRole('radio', { name: label })
+      expect(radioButton.checked).to.be.true()
     })
   })
 
   describe('onChange event handler', function () {
-    let wrapper
     beforeEach(function () {
       annotation.update(null)
-      wrapper = shallow(<SingleChoiceTask annotation={annotation} task={task} />)
+      render(
+        <SingleChoiceTask
+          annotation={annotation}
+          task={task}
+        />,
+        { wrapper: withGrommet()}
+      )
     })
 
-    it('should update the annotation', function () {
-      task.answers.forEach((answer, index) => {
-        const node = wrapper.find({ label: answer.label })
-        node.simulate('change', { target: { checked: true } })
-        expect(annotation.value).to.equal(index)
+    it('should update the annotation', async function () {
+      const user = userEvent.setup()
+      const answerTests = task.answers.map(async (answer, index) => {
+        const label = task.strings.get(`answers.${index}.label`)
+        const radioButton = screen.getByRole('radio', { name: label })
+        expect(annotation.value).to.not.equal(index)
+        await user.click(radioButton)
+        waitFor(() => expect(annotation.value).to.equal(index))
       })
+      await Promise.all(answerTests)
     })
 
-    it('should not update the annotation if the answer is not checked', function () {
-      const node = wrapper.find({ label: task.answers[1].label })
-      node.simulate('change', { target: { checked: false } })
-      expect(annotation.value).to.be.null()
+    it('should not update the annotation if the answer is already checked', async function () {
+      const user = userEvent.setup()
+      const label = task.strings.get('answers.1.label')
+      const radioButton = screen.getByRole('radio', { name: label })
+      await user.click(radioButton)
+      waitFor(() => expect(annotation.value).to.equal(1))
+      await user.click(radioButton)
+      waitFor(() => expect(annotation.value).to.equal(1))
     })
   })
 })

--- a/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.stories.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/components/SingleChoiceTask.stories.js
@@ -1,6 +1,9 @@
 import asyncStates from '@zooniverse/async-states'
+import { useEffect } from 'react'
+
 import { MockTask } from '@stories/components'
 import SingleChoiceTask from './SingleChoiceTask'
+import mockTask from './mockTask'
 
 export default {
   title: 'Tasks / Single Choice Question',
@@ -21,20 +24,43 @@ export default {
 }
 
 export function Default({ isThereTaskHelp, required, subjectReadyState }) {
-  const tasks = {
-    init: {
-      answers: [{ label: 'yes' }, { label: 'no' }],
-      required,
-      strings: {
-        help: isThereTaskHelp ? 'Choose an answer from the choices given, then press Done.' : '',
-        question: 'Is there a cat?',
-        'answers.0.label': 'yes',
-        'answers.1.label': 'no'
-      },
-      taskKey: 'init',
-      type: 'single'
+  const taskSnapshot = {
+    ...mockTask,
+    required,
+    strings: {
+      ...mockTask.strings,
+      help: isThereTaskHelp ? 'Choose an answer from the choices given, then press Done.' : ''
     }
   }
+  const tasks = {
+    init: taskSnapshot
+  }
+  return (
+    <MockTask
+      isThereTaskHelp={isThereTaskHelp}
+      subjectReadyState={subjectReadyState}
+      tasks={tasks}
+    />
+  )
+}
+
+export function WithAnnotation({ isThereTaskHelp, required, subjectReadyState }) {
+  const taskSnapshot = {
+    ...mockTask,
+    required,
+    strings: {
+      ...mockTask.strings,
+      help: isThereTaskHelp ? 'Choose an answer from the choices given, then press Done.' : ''
+    }
+  }
+  const tasks = {
+    init: taskSnapshot
+  }
+  
+  useEffect(() => {
+    MockTask.store.classifications.addAnnotation(tasks.init, 0)
+  },[])
+
   return (
     <MockTask
       isThereTaskHelp={isThereTaskHelp}

--- a/packages/lib-classifier/src/plugins/tasks/single/components/mockTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/single/components/mockTask.js
@@ -1,0 +1,14 @@
+const mockTask = {
+  answers: [{ label: 'yes' }, { label: 'no' }],
+  required: true,
+  strings: {
+    help: 'Choose an answer from the choices given, then press Done.',
+    question: 'Is there a cat?',
+    'answers.0.label': 'yes',
+    'answers.1.label': 'no'
+  },
+  taskKey: 'init',
+  type: 'single'
+}
+
+export default mockTask


### PR DESCRIPTION
- refactor `MultipleChoiceTask` and `SingleChoiceTask` to use `fieldset` and `span`, so that they produce valid HTML.
- refactor `TaskInputLabel` to use `span` inside `label`, rather than `p`.
- Add new task stories to show `MultipleChoiceTask` and `SingleChoiceTask` with an existing annotation.
- convert the `MultipleChoiceTask` and `SingleChoiceTask` tests from Enzyme to React Testing Library.
- convert `TaskInput` and `TaskInputLabel` tests to RTL.
- add experimental support for `autoFocus` on question fieldsets. Autofocus the fieldset itself when there is no selected answer.

TODO: 
- [x] make sure the task has focus when working through a workflow.
- [x] fix themed styling for question tasks.

In the process of fixing focus for question tasks (#5417), I've updated the question tasks to use valid fieldsets, labels, legends, and RTL tests.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #5417 by adding very experimental support for `autoFocus` on question tasks.

## How to Review
You can test this in the storybook. Since `TaskInput` is used by more than one task, you should check single choice questions, multiple choice questions and drawing tasks.

Changes to task focus can be tested on the knitting pattern project, where you should be able to work through the workflow from the keyboard.
https://localhost:8080/?project=elliereed185/knitting-leaflet-project&workflow=24462&env=production

See [Basic workflow: Initial focus and tab order ](https://frontend.preview.zooniverse.org/projects/elliereed185/knitting-leaflet-project/talk/4675/3112391?comment=5095306&page=1)on Talk for the expected behaviour.

Galaxy Zoo  has a workflow based on question tasks:
https://localhost:8080/?project=zookeeper/galaxy-zoo&workflow=24122&env=production

The Daily Minor Planet also has a question workflow that can be used to test keyboard focus:
https://local.zooniverse.org:3000/projects/fulsdavid/the-daily-minor-planet/classify/workflow/22354

You can also test autofocus for questions with the Multiple Tasks story in the classifier storybook:
http://localhost:6006/?path=/story/tasks-general--multiple-tasks

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
