### PR TITLE
Replace subject placeholder with background image

### DIFF
--- a/packages/app-project/src/components/Head/Head.js
+++ b/packages/app-project/src/components/Head/Head.js
@@ -33,6 +33,8 @@ function Head (props) {
       <link rel='apple-touch-icon' href='/touch-icon.png' />
       <link rel='mask-icon' href='/favicon-mask.svg' color='#49B882' />
       <link rel='icon' href='/favicon.ico' />
+      // preload the classifier's subject placeholder
+      <link rel='preload' as='image' href='https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png' fetchpriority='high' />
 
       <meta property='og:url' content={url} />
       <meta property='og:title' content={fullTitle} />

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.spec.js
@@ -134,7 +134,7 @@ describe('components > ClassifierContainer', function () {
     it('should be able to view active workflows', async function () {
       await waitFor(() => {
         const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
-        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+        expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
       })
       expect(workflowRequest.isDone()).to.be.true()
       expect(firstSubjectsRequest.isDone()).to.be.true()
@@ -142,7 +142,7 @@ describe('components > ClassifierContainer', function () {
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
-        expect(radioButton.disabled).to.be.true()
+        expect(radioButton.disabled).to.be.false()
       })
     })
   })
@@ -229,7 +229,7 @@ describe('components > ClassifierContainer', function () {
     it('should be able to view active workflows', async function () {
       await waitFor(() => {
         const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
-        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+        expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
       })
       expect(workflowRequest.isDone()).to.be.true()
       expect(firstSubjectsRequest.isDone()).to.be.true()
@@ -237,7 +237,7 @@ describe('components > ClassifierContainer', function () {
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
-        expect(radioButton.disabled).to.be.true()
+        expect(radioButton.disabled).to.be.false()
       })
     })
   })
@@ -325,7 +325,7 @@ describe('components > ClassifierContainer', function () {
     it('should be able to view active workflows', async function () {
       await waitFor(() => {
         const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
-        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+        expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
       })
       expect(workflowRequest.isDone()).to.be.true()
       expect(firstSubjectsRequest.isDone()).to.be.true()
@@ -333,7 +333,7 @@ describe('components > ClassifierContainer', function () {
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
-        expect(radioButton.disabled).to.be.true()
+        expect(radioButton.disabled).to.be.false()
       })
     })
   })
@@ -421,7 +421,7 @@ describe('components > ClassifierContainer', function () {
     it('should be able to view inactive workflows', async function () {
       await waitFor(() => {
         const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
-        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+        expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
       })
       expect(workflowRequest.isDone()).to.be.true()
       expect(firstSubjectsRequest.isDone()).to.be.true()
@@ -429,7 +429,7 @@ describe('components > ClassifierContainer', function () {
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
-        expect(radioButton.disabled).to.be.true()
+        expect(radioButton.disabled).to.be.false()
       })
     })
   })
@@ -517,7 +517,7 @@ describe('components > ClassifierContainer', function () {
     it('should be able to view inactive workflows', async function () {
       await waitFor(() => {
         const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
-        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+        expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
       })
       expect(workflowRequest.isDone()).to.be.true()
       expect(firstSubjectsRequest.isDone()).to.be.true()
@@ -525,7 +525,7 @@ describe('components > ClassifierContainer', function () {
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
-        expect(radioButton.disabled).to.be.true()
+        expect(radioButton.disabled).to.be.false()
       })
     })
   })
@@ -613,7 +613,7 @@ describe('components > ClassifierContainer', function () {
     it('should be able to view inactive workflows', async function () {
       await waitFor(() => {
         const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
-        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+        expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
       })
       expect(workflowRequest.isDone()).to.be.true()
       expect(firstSubjectsRequest.isDone()).to.be.true()
@@ -621,7 +621,7 @@ describe('components > ClassifierContainer', function () {
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
-        expect(radioButton.disabled).to.be.true()
+        expect(radioButton.disabled).to.be.false()
       })
     })
   })
@@ -710,7 +710,7 @@ describe('components > ClassifierContainer', function () {
     it('should be able to view inactive workflows', async function () {
       await waitFor(() => {
         const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
-        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+        expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
       })
       expect(workflowRequest.isDone()).to.be.true()
       expect(firstSubjectsRequest.isDone()).to.be.true()
@@ -718,7 +718,7 @@ describe('components > ClassifierContainer', function () {
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
-        expect(radioButton.disabled).to.be.true()
+        expect(radioButton.disabled).to.be.false()
       })
     })
   })
@@ -897,7 +897,7 @@ describe('components > ClassifierContainer', function () {
       )
       await waitFor(() => {
         const subjectImage = screen.getByRole('img', {name: `Subject ${subjectSnapshot.id}` })
-        expect(subjectImage.getAttribute('href')).to.equal('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png')
+        expect(subjectImage.getAttribute('href')).to.equal('https://foo.bar/example.png')
       })
 
       // locale changes when the language menu changes.
@@ -927,7 +927,7 @@ describe('components > ClassifierContainer', function () {
       expect(taskAnswers).to.have.lengthOf(workflowSnapshot.tasks.T0.answers.length)
       taskAnswers.forEach(radioButton => {
         expect(radioButton.name).to.equal('T0')
-        expect(radioButton.disabled).to.be.true()
+        expect(radioButton.disabled).to.be.false()
       })
       expect(translationRequests.isDone()).to.be.true()
     })

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
@@ -40,6 +40,10 @@ const FlipbookViewer = ({
     onReady,
     onError
   })
+  const {
+    naturalHeight = 600,
+    naturalWidth = 800
+  } = img
 
   const viewerLocation = subject?.locations ? subject.locations[currentFrame] : ''
 
@@ -78,13 +82,13 @@ const FlipbookViewer = ({
   return (
     <Box>
       <SVGPanZoom
-        key={`${img.naturalWidth}-${img.naturalHeight}`}
+        key={`${naturalWidth}-${naturalHeight}`}
         imgRef={subjectImage}
         limitSubjectHeight={limitSubjectHeight}
         maxZoom={5}
         minZoom={0.1}
-        naturalHeight={img.naturalHeight}
-        naturalWidth={img.naturalWidth}
+        naturalHeight={naturalHeight}
+        naturalWidth={naturalWidth}
         setOnDrag={setOnDrag}
         setOnPan={setOnPan}
         setOnZoom={setOnZoom}
@@ -92,19 +96,19 @@ const FlipbookViewer = ({
       >
         <SingleImageViewer
           enableInteractionLayer={false}
-          height={img.naturalHeight}
+          height={naturalHeight}
           limitSubjectHeight={limitSubjectHeight}
           onKeyDown={handleSpaceBar}
           rotate={rotation}
-          width={img.naturalWidth}
+          width={naturalWidth}
         >
           <g role='tabpanel' id='flipbook-tab-panel'>
             <SVGImage
               ref={subjectImage}
               invert={invert}
               move={move}
-              naturalHeight={img.naturalHeight}
-              naturalWidth={img.naturalWidth}
+              naturalHeight={naturalHeight}
+              naturalWidth={naturalWidth}
               onDrag={onDrag}
               src={viewerLocation.url}
               subjectID={subject.id}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
@@ -81,6 +81,10 @@ function MultiFrameViewerContainer({
     onReady,
     onError
   })
+  const {
+    naturalHeight = 600,
+    naturalWidth = 800
+  } = img
 
   useEffect(function onMount() {
     enableRotation()
@@ -120,13 +124,13 @@ function MultiFrameViewerContainer({
           locations={subject.locations}
         />
         <SVGPanZoom
-          key={`${img.naturalWidth}-${img.naturalHeight}`}
+          key={`${naturalWidth}-${naturalHeight}`}
           imgRef={subjectImage}
           limitSubjectHeight={limitSubjectHeight}
           maxZoom={5}
           minZoom={0.1}
-          naturalHeight={img.naturalHeight}
-          naturalWidth={img.naturalWidth}
+          naturalHeight={naturalHeight}
+          naturalWidth={naturalWidth}
           setOnDrag={setOnDrag}
           setOnPan={setOnPan}
           setOnZoom={setOnZoom}
@@ -134,18 +138,18 @@ function MultiFrameViewerContainer({
         >
           <SingleImageViewer
             enableInteractionLayer={enableDrawing}
-            height={img.naturalHeight}
+            height={naturalHeight}
             limitSubjectHeight={limitSubjectHeight}
             onKeyDown={onKeyZoom}
             rotate={rotation}
-            width={img.naturalWidth}
+            width={naturalWidth}
           >
             <SVGImage
               ref={subjectImage}
               invert={invert}
               move={move}
-              naturalHeight={img.naturalHeight}
-              naturalWidth={img.naturalWidth}
+              naturalHeight={naturalHeight}
+              naturalWidth={naturalWidth}
               onDrag={onDrag}
               src={img.src}
               subjectID={subjectID}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGImage/SVGImage.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGImage/SVGImage.js
@@ -7,7 +7,6 @@ import { draggable } from '@plugins/drawingTools/components'
 export const DraggableImage = styled(draggable('image'))`
   cursor: move;
 `
-
 const INVERT =
   `<svg style="position: fixed; right: 100%; top: 100%; visibility: hidden;">
     <defs>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.js
@@ -30,7 +30,7 @@ const SeparateFrame = ({
     onError
   })
 
-  const { naturalHeight, naturalWidth, src: frameSrc } = img
+  const { naturalHeight = 600, naturalWidth = 800, src: frameSrc } = img
 
   const maxZoom = 5
   const minZoom = 0.1

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -1,7 +1,7 @@
 import { Box } from 'grommet'
 import PropTypes from 'prop-types'
 import { useRef } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import InteractionLayer from '../InteractionLayer'
@@ -10,6 +10,9 @@ import locationValidator from '../../helpers/locationValidator'
 
 const PlaceholderSVG = styled.svg`
   background: no-repeat center / contain url('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png');
+  touch-action: pinch-zoom;
+  max-width: ${props => props.maxWidth || '100%'};
+  ${props => props.maxHeight && css`max-height: ${props.maxHeight};`}
 `
 
 function SingleImageViewer({
@@ -48,12 +51,9 @@ subject,
       >
         <PlaceholderSVG
           focusable
+          maxHeight={svgMaxHeight}
+          maxWidth={limitSubjectHeight ? `${width}px` : '100%'}
           onKeyDown={onKeyDown}
-          style={{
-            touchAction: 'pinch-zoom',
-            maxHeight: svgMaxHeight,
-            maxWidth: limitSubjectHeight ? `${width}px` : '100%'
-          }}
           tabIndex={0}
           viewBox={viewBox}
           xmlns='http://www.w3.org/2000/svg'

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -1,29 +1,33 @@
 import { Box } from 'grommet'
 import PropTypes from 'prop-types'
 import { useRef } from 'react'
+import styled from 'styled-components'
 
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import InteractionLayer from '../InteractionLayer'
 import ZoomControlButton from '../ZoomControlButton'
 import locationValidator from '../../helpers/locationValidator'
 
-function SingleImageViewer(props) {
-  const {
-    children,
-    enableInteractionLayer = true,
-    height,
-    limitSubjectHeight = false,
-    onKeyDown = () => true,
-    rotate = 0,
-    scale = 1,
-    svgMaxHeight = null,
-	subject,
-    title = {},
-    viewBox,
-    width,
-    zoomControlFn = null,
-    zooming = false
-  } = props
+const PlaceholderSVG = styled.svg`
+  background: no-repeat center / contain url('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png');
+`
+
+function SingleImageViewer({
+  children,
+  enableInteractionLayer = true,
+  height,
+  limitSubjectHeight = false,
+  onKeyDown = () => true,
+  rotate = 0,
+  scale = 1,
+  svgMaxHeight = null,
+subject,
+  title = {},
+  viewBox,
+  width,
+  zoomControlFn = null,
+  zooming = false
+}) {
   const transformLayer = useRef()
   const canvas = transformLayer.current
   const transform = `rotate(${rotate} ${width / 2} ${height / 2})`
@@ -42,7 +46,7 @@ function SingleImageViewer(props) {
         width='100%'
         align='flex-end'
       >
-        <svg
+        <PlaceholderSVG
           focusable
           onKeyDown={onKeyDown}
           style={{
@@ -71,7 +75,7 @@ function SingleImageViewer(props) {
               />
             )}
           </g>
-        </svg>
+        </PlaceholderSVG>
       </Box>
     </SVGContext.Provider>
   )

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -38,6 +38,10 @@ function SingleImageViewerContainer({
     onReady,
     onError
   })
+  const {
+    naturalHeight = 600,
+    naturalWidth = 800
+  } = img
 
   useEffect(function onMount() {
     enableRotation()
@@ -63,13 +67,13 @@ function SingleImageViewerContainer({
 
     return (
       <SVGPanZoom
-        key={`${img.naturalWidth}-${img.naturalHeight}`}
+        key={`${naturalWidth}-${naturalHeight}`}
         imgRef={subjectImage}
         limitSubjectHeight={limitSubjectHeight}
         maxZoom={5}
         minZoom={0.1}
-        naturalHeight={img.naturalHeight}
-        naturalWidth={img.naturalWidth}
+        naturalHeight={naturalHeight}
+        naturalWidth={naturalWidth}
         setOnDrag={setOnDrag}
         setOnPan={setOnPan}
         setOnZoom={setOnZoom}
@@ -78,13 +82,13 @@ function SingleImageViewerContainer({
       >
         <SingleImageViewer
           enableInteractionLayer={enableDrawing}
-          height={img.naturalHeight}
+          height={naturalHeight}
           invert={invert}
           limitSubjectHeight={limitSubjectHeight}
           onKeyDown={onKeyZoom}
           rotate={rotation}
           title={title}
-          width={img.naturalWidth}
+          width={naturalWidth}
           zoomControlFn={zoomControlFn}
           zooming={zooming}
           subject={subject}
@@ -93,8 +97,8 @@ function SingleImageViewerContainer({
             ref={subjectImage}
             invert={invert}
             move={move}
-            naturalHeight={img.naturalHeight}
-            naturalWidth={img.naturalWidth}
+            naturalHeight={naturalHeight}
+            naturalWidth={naturalWidth}
             onDrag={onDrag}
             src={img.src}
             subjectID={subjectID}

--- a/packages/lib-classifier/src/hooks/useSubjectImage.js
+++ b/packages/lib-classifier/src/hooks/useSubjectImage.js
@@ -1,21 +1,18 @@
 import { useEffect, useRef } from 'react'
 import { useProgressiveImage } from '@zooniverse/react-components/hooks'
 
-// Use this instead of https://www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png to save on network calls
-export const PLACEHOLDER_URL = 'https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png'
-
 export default function useSubjectImage({ src, onReady, onError }) {
   const subjectImage = useRef()
 
   const { img, error, loading } = useProgressiveImage({
-    placeholderSrc: PLACEHOLDER_URL,
+    placeholderSrc: '',
     src
   })
   
 
   useEffect(function onImageLoad() {
     const { naturalHeight, naturalWidth, src } = img
-    if (src !== PLACEHOLDER_URL ) {
+    if (src !== '' ) {
       const svgImage = subjectImage.current
       const { width: clientWidth, height: clientHeight } = svgImage
         ? svgImage.getBoundingClientRect()


### PR DESCRIPTION
- Style `SingleImageViewer` with a placeholder background image.
- Set default placeholder dimensions for each styled image viewer.
- Remove the placeholder image from `useSubjectImage`.
- Preload the placeholder image when a project first loads in the browser.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project
- lib-classifier

## Linked Issue and/or Talk Post
Inspired by this idea from Harry Roberts: https://csswizardry.com/2023/09/the-ultimate-lqip-lcp-technique/

## How to Review
Try out a few different subject image viewers. They shouldn't have changed, except that the subject image now starts to download immediately, rather than waiting for the placeholder image to load.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
