### PR TITLE
Add Panoptes auth to app-root

### DIFF
--- a/packages/app-root/.eslintrc.json
+++ b/packages/app-root/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "extends": [
+    "next/core-web-vitals",
+    "plugin:jsx-a11y/recommended",
+    "plugin:@next/next/recommended"
+  ],
+  "rules": {
+    "consistent-return": "error"
+  },
+  "overrides": [
+      {
+        "files": [
+          "src/**/*.stories.js"
+        ],
+        "rules": {
+          "import/no-anonymous-default-export": "off"
+        }
+      }
+    ]
+}

--- a/packages/app-root/next.config.mjs
+++ b/packages/app-root/next.config.mjs
@@ -4,6 +4,10 @@ const bundleAnalyzer = withBundleAnalyzer({
 	enabled: process.env.ANALYZE === 'true',
 })
 
-const nextConfig = {}
+const nextConfig = {
+  experimental: {
+    optimizePackageImports: ['@zooniverse/react-components', 'grommet', 'grommet-icons'],
+  }
+}
 
 export default bundleAnalyzer(nextConfig)

--- a/packages/app-root/package.json
+++ b/packages/app-root/package.json
@@ -32,7 +32,9 @@
     "node": ">=20.5"
   },
   "devDependencies": {
-    "@next/bundle-analyzer": "~13.5.4",
+    "@next/bundle-analyzer": "~13.5.5",
+    "eslint-config-next": "~13.5.5",
+    "eslint-plugin-jsx-a11y": "~6.7.0",
     "selfsigned": "~2.1.1"
   }
 }

--- a/packages/app-root/package.json
+++ b/packages/app-root/package.json
@@ -6,9 +6,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "APP_ENV=${APP_ENV:-development} PANOPTES_ENV=${PANOPTES_ENV:-staging} node server/server.js",
     "build": "next build",
-    "start": "next start",
+    "start": "NODE_ENV=${NODE_ENV:-production} PANOPTES_ENV=${PANOPTES_ENV:-production} node server/server.js",
     "lint": "next lint"
   },
   "type": "module",
@@ -17,9 +17,12 @@
     "@zooniverse/grommet-theme": "~3.1.1",
     "@zooniverse/panoptes-js": "~0.4.1",
     "@zooniverse/react-components": "~1.6.1",
+    "express": "~4.18.2",
     "grommet": "~2.33.2",
     "grommet-icons": "~4.11.0",
+    "newrelic": "~11.2.0",
     "next": "~13.5.5",
+    "panoptes-client": "~5.5.6",
     "react": "~18.2.0",
     "react-dom": "~18.2.0",
     "styled-components": "~5.3.10"
@@ -28,6 +31,7 @@
     "node": ">=20.5"
   },
   "devDependencies": {
-    "@next/bundle-analyzer": "~13.5.4"
+    "@next/bundle-analyzer": "~13.5.4",
+    "selfsigned": "~2.1.1"
   }
 }

--- a/packages/app-root/package.json
+++ b/packages/app-root/package.json
@@ -25,7 +25,8 @@
     "panoptes-client": "~5.5.6",
     "react": "~18.2.0",
     "react-dom": "~18.2.0",
-    "styled-components": "~5.3.10"
+    "styled-components": "~5.3.10",
+    "swr": "~2.2.4"
   },
   "engines": {
     "node": ">=20.5"

--- a/packages/app-root/server/server.js
+++ b/packages/app-root/server/server.js
@@ -1,0 +1,53 @@
+if (process.env.NEWRELIC_LICENSE_KEY) {
+  await import('newrelic')
+}
+
+import express from 'express'
+import next from 'next'
+
+const port = parseInt(process.env.PORT, 10) || 3000
+const dev = process.env.NODE_ENV !== 'production'
+
+const APP_ENV = process.env.APP_ENV || 'development'
+
+const hostnames = {
+  development: 'local.zooniverse.org',
+  branch: 'fe-project-branch.preview.zooniverse.org',
+  staging: 'frontend.preview.zooniverse.org',
+  production : 'www.zooniverse.org'
+}
+const hostname = hostnames[APP_ENV]
+
+const app = next({ dev, hostname, port })
+const handle = app.getRequestHandler()
+
+app.prepare().then(async () => {
+  const server = express()
+
+  server.get('*', (req, res) => {
+    return handle(req, res)
+  })
+
+  let selfsigned
+  try {
+    selfsigned = await import('selfsigned')
+  } catch (error) {
+    console.error(error)
+  }
+  if (APP_ENV === 'development' && selfsigned) {
+    const https = await import('https')
+
+    const attrs = [{ name: 'commonName', value: hostname }];
+    const { cert, private: key } = selfsigned.generate(attrs, { days: 365 })
+    return https.createServer({ cert, key }, server)
+      .listen(port, err => {
+        if (err) throw err
+        console.log(`> Ready on https://${hostname}:${port}`)
+      })
+  } else {
+    return server.listen(port, err => {
+      if (err) throw err
+      console.log(`> Ready on http://${hostname}:${port}`)
+    })
+  }
+})

--- a/packages/app-root/src/app/about/page.js
+++ b/packages/app-root/src/app/about/page.js
@@ -1,5 +1,8 @@
 export default function AboutPage() {
   return (
+    <header aria-label='About the Zooniverse'>
+      <p>This is the section header.</p>
+    </header>
     <div>
       <p>This is lib-content-pages</p>
     </div>

--- a/packages/app-root/src/app/projects/page.js
+++ b/packages/app-root/src/app/projects/page.js
@@ -1,5 +1,8 @@
 export default function ProjectPage() {
   return (
+    <header aria-label='Project header'>
+      <p>This is the project header.</p>
+    </header>
     <div>
       <p>This is lib-project</p>
     </div>

--- a/packages/app-root/src/components/PageContextProviders.js
+++ b/packages/app-root/src/components/PageContextProviders.js
@@ -1,0 +1,42 @@
+'use client'
+
+import zooTheme from '@zooniverse/grommet-theme'
+import { Grommet } from 'grommet'
+import { createGlobalStyle } from 'styled-components'
+
+import { PanoptesAuthContext } from '../contexts'
+import { useAdminMode, usePanoptesUser } from '../hooks'
+
+const GlobalStyle = createGlobalStyle`
+  body {
+    margin: 0;
+  }
+`
+
+/**
+  Context for every page:
+  - global page styles.
+  - Zooniverse Grommet theme.
+  - Panoptes auth (user account and admin mode.)
+*/
+export default function PageContextProviders({ children }) {
+  const { data: user, error, isLoading } = usePanoptesUser()
+  const { adminMode, toggleAdmin } = useAdminMode(user)
+  const authContext = { adminMode, error, isLoading, toggleAdmin, user }
+
+  return (
+    <PanoptesAuthContext.Provider value={authContext}>
+      <GlobalStyle />
+      <Grommet
+        background={{
+          dark: 'dark-1',
+          light: 'light-1'
+        }}
+        theme={zooTheme}
+      >
+        {children}
+      </Grommet>
+    </PanoptesAuthContext.Provider>
+  )
+
+}

--- a/packages/app-root/src/components/PageFooter.js
+++ b/packages/app-root/src/components/PageFooter.js
@@ -1,0 +1,13 @@
+'use client'
+import ZooFooter from '@zooniverse/react-components/ZooFooter'
+
+import { usePanoptesUser } from '../hooks'
+
+export default function PageFooter() {
+  // we'll need the user in order to detect admin mode.
+  const { data: user } = usePanoptesUser()
+
+  return (
+    <ZooFooter />
+  )
+}

--- a/packages/app-root/src/components/PageFooter.js
+++ b/packages/app-root/src/components/PageFooter.js
@@ -1,16 +1,16 @@
 'use client'
 import AdminCheckbox from '@zooniverse/react-components/AdminCheckbox'
 import ZooFooter from '@zooniverse/react-components/ZooFooter'
+import { useContext } from 'react'
 
-import { useAdminMode, usePanoptesUser } from '../hooks'
+import { PanoptesAuthContext } from '../contexts'
 
 export default function PageFooter() {
-  const { data: user, isLoading } = usePanoptesUser()
-  const { adminMode, toggleAdmin } = useAdminMode(user)
+  const { adminMode, toggleAdmin, user } = useContext(PanoptesAuthContext)
 
   return (
     <ZooFooter
-      adminContainer={(!isLoading && user?.admin) ? <AdminCheckbox onChange={toggleAdmin} checked={adminMode} /> : null}
+      adminContainer={user?.admin ? <AdminCheckbox onChange={toggleAdmin} checked={adminMode} /> : null}
     />
   )
 }

--- a/packages/app-root/src/components/PageFooter.js
+++ b/packages/app-root/src/components/PageFooter.js
@@ -1,13 +1,16 @@
 'use client'
+import AdminCheckbox from '@zooniverse/react-components/AdminCheckbox'
 import ZooFooter from '@zooniverse/react-components/ZooFooter'
 
-import { usePanoptesUser } from '../hooks'
+import { useAdminMode, usePanoptesUser } from '../hooks'
 
 export default function PageFooter() {
-  // we'll need the user in order to detect admin mode.
-  const { data: user } = usePanoptesUser()
+  const { data: user, isLoading } = usePanoptesUser()
+  const { adminMode, toggleAdmin } = useAdminMode(user)
 
   return (
-    <ZooFooter />
+    <ZooFooter
+      adminContainer={(!isLoading && user?.admin) ? <AdminCheckbox onChange={toggleAdmin} checked={adminMode} /> : null}
+    />
   )
 }

--- a/packages/app-root/src/components/PageFooter.js
+++ b/packages/app-root/src/components/PageFooter.js
@@ -1,6 +1,5 @@
 'use client'
-import AdminCheckbox from '@zooniverse/react-components/AdminCheckbox'
-import ZooFooter from '@zooniverse/react-components/ZooFooter'
+import { AdminCheckbox, ZooFooter } from '@zooniverse/react-components'
 import { useContext } from 'react'
 
 import { PanoptesAuthContext } from '../contexts'

--- a/packages/app-root/src/components/PageHeader.js
+++ b/packages/app-root/src/components/PageHeader.js
@@ -1,0 +1,14 @@
+'use client'
+import ZooHeader from '@zooniverse/react-components/ZooHeader'
+
+import { usePanoptesUser } from '../hooks'
+
+export default function PageHeader() {
+  const { data: user } = usePanoptesUser()
+
+  return (
+    <ZooHeader
+      user={user}
+    />
+  )
+}

--- a/packages/app-root/src/components/PageHeader.js
+++ b/packages/app-root/src/components/PageHeader.js
@@ -15,11 +15,13 @@ export default function PageHeader() {
   const { data: unreadNotifications }= useUnreadNotifications(user)
 
   return (
-    <ZooHeader
-      isAdmin={adminMode}
-      unreadMessages={unreadMessages}
-      unreadNotifications={unreadNotifications}
-      user={user}
-    />
+    <header aria-label='Zooniverse site header'>
+      <ZooHeader
+        isAdmin={adminMode}
+        unreadMessages={unreadMessages}
+        unreadNotifications={unreadNotifications}
+        user={user}
+      />
+    </header>
   )
 }

--- a/packages/app-root/src/components/PageHeader.js
+++ b/packages/app-root/src/components/PageHeader.js
@@ -1,13 +1,21 @@
 'use client'
 import ZooHeader from '@zooniverse/react-components/ZooHeader'
 
-import { usePanoptesUser } from '../hooks'
+import {
+  usePanoptesUser,
+  useUnreadMessages,
+  useUnreadNotifications
+} from '../hooks'
 
 export default function PageHeader() {
   const { data: user } = usePanoptesUser()
+  const { data: unreadMessages }= useUnreadMessages(user)
+  const { data: unreadNotifications }= useUnreadNotifications(user)
 
   return (
     <ZooHeader
+      unreadMessages={unreadMessages}
+      unreadNotifications={unreadNotifications}
       user={user}
     />
   )

--- a/packages/app-root/src/components/PageHeader.js
+++ b/packages/app-root/src/components/PageHeader.js
@@ -1,5 +1,5 @@
 'use client'
-import ZooHeader from '@zooniverse/react-components/ZooHeader'
+import { ZooHeader } from '@zooniverse/react-components'
 import { useContext } from 'react'
 
 import {

--- a/packages/app-root/src/components/PageHeader.js
+++ b/packages/app-root/src/components/PageHeader.js
@@ -1,18 +1,18 @@
 'use client'
 import ZooHeader from '@zooniverse/react-components/ZooHeader'
+import { useContext } from 'react'
 
 import {
-  useAdminMode,
-  usePanoptesUser,
   useUnreadMessages,
   useUnreadNotifications
 } from '../hooks'
 
+import { PanoptesAuthContext } from '../contexts'
+
 export default function PageHeader() {
-  const { data: user } = usePanoptesUser()
+  const { adminMode, user } = useContext(PanoptesAuthContext)
   const { data: unreadMessages }= useUnreadMessages(user)
   const { data: unreadNotifications }= useUnreadNotifications(user)
-  const { adminMode, toggleAdmin } = useAdminMode(user)
 
   return (
     <ZooHeader

--- a/packages/app-root/src/components/PageHeader.js
+++ b/packages/app-root/src/components/PageHeader.js
@@ -2,6 +2,7 @@
 import ZooHeader from '@zooniverse/react-components/ZooHeader'
 
 import {
+  useAdminMode,
   usePanoptesUser,
   useUnreadMessages,
   useUnreadNotifications
@@ -11,9 +12,11 @@ export default function PageHeader() {
   const { data: user } = usePanoptesUser()
   const { data: unreadMessages }= useUnreadMessages(user)
   const { data: unreadNotifications }= useUnreadNotifications(user)
+  const { adminMode, toggleAdmin } = useAdminMode(user)
 
   return (
     <ZooHeader
+      isAdmin={adminMode}
       unreadMessages={unreadMessages}
       unreadNotifications={unreadNotifications}
       user={user}

--- a/packages/app-root/src/components/RootLayout.js
+++ b/packages/app-root/src/components/RootLayout.js
@@ -8,8 +8,9 @@
 import { createGlobalStyle } from 'styled-components'
 import { Grommet } from 'grommet'
 import zooTheme from '@zooniverse/grommet-theme'
-import ZooHeader from '@zooniverse/react-components/ZooHeader'
-import ZooFooter from '@zooniverse/react-components/ZooFooter'
+
+import PageHeader from './PageHeader.js'
+import PageFooter from './PageFooter.js'
 
 const GlobalStyle = createGlobalStyle`
   body {
@@ -28,9 +29,9 @@ export default function RootLayout({ children }) {
         }}
         theme={zooTheme}
       >
-        <ZooHeader />
+        <PageHeader />
         {children}
-        <ZooFooter />
+        <PageFooter />
       </Grommet>
     </body>
   )

--- a/packages/app-root/src/components/RootLayout.js
+++ b/packages/app-root/src/components/RootLayout.js
@@ -1,38 +1,15 @@
-'use client'
-/**
- * Note that all child components are now client components.
- * If we want children of RootLayout to be server components
- * a ZooHeaderContainer and ZooFooterContainer could be created instead.
- */
-
-import { createGlobalStyle } from 'styled-components'
-import { Grommet } from 'grommet'
-import zooTheme from '@zooniverse/grommet-theme'
-
+import PageContextProviders from './PageContextProviders.js'
 import PageHeader from './PageHeader.js'
 import PageFooter from './PageFooter.js'
-
-const GlobalStyle = createGlobalStyle`
-  body {
-    margin: 0;
-  }
-`
 
 export default function RootLayout({ children }) {
   return (
     <body>
-      <GlobalStyle />
-      <Grommet
-        background={{
-          dark: 'dark-1',
-          light: 'light-1'
-        }}
-        theme={zooTheme}
-      >
+      <PageContextProviders>
         <PageHeader />
         {children}
         <PageFooter />
-      </Grommet>
+      </PageContextProviders>
     </body>
   )
 }

--- a/packages/app-root/src/contexts/PanoptesAuthContext.js
+++ b/packages/app-root/src/contexts/PanoptesAuthContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react'
+
+const PanoptesAuthContext = createContext({})
+
+export default PanoptesAuthContext

--- a/packages/app-root/src/contexts/index.js
+++ b/packages/app-root/src/contexts/index.js
@@ -1,0 +1,1 @@
+export { default as PanoptesAuthContext } from './PanoptesAuthContext.js'

--- a/packages/app-root/src/helpers/fetchPanoptesUser.js
+++ b/packages/app-root/src/helpers/fetchPanoptesUser.js
@@ -5,7 +5,7 @@ import { auth as authHelpers } from '@zooniverse/panoptes-js'
   Get a Panoptes user from a Panoptes JSON Web Token (JWT), if we have one, or from
   the Panoptes API otherwise.
 */
-export default async function fetchPanoptesUser(storedUser) {
+export default async function fetchPanoptesUser({ user: storedUser }) {
   try {
     const jwt = await auth.checkBearerToken()
     /*

--- a/packages/app-root/src/helpers/fetchPanoptesUser.js
+++ b/packages/app-root/src/helpers/fetchPanoptesUser.js
@@ -1,0 +1,38 @@
+import auth from 'panoptes-client/lib/auth'
+import { auth as authHelpers } from '@zooniverse/panoptes-js'
+
+/**
+  Get a Panoptes user from a Panoptes JSON Web Token (JWT), if we have one, or from
+  the Panoptes API otherwise.
+*/
+export default async function fetchPanoptesUser(storedUser) {
+  try {
+    const jwt = await auth.checkBearerToken()
+    /*
+      `crypto.subtle` is needed to decrypt the Panoptes JWT.
+      It will only exist for https:// URLs.
+    */
+    const isSecure = crypto?.subtle
+    if (jwt && isSecure) {
+      /*
+        avatar_src isn't encoded in the Panoptes JWT, so we need to add it.
+        https://github.com/zooniverse/panoptes/issues/4217
+      */
+      const { user, error } = await authHelpers.decodeJWT(jwt)
+      if (user) {
+        const { admin, display_name, id, login } = user
+        return {
+          avatar_src: storedUser.avatar_src,
+          ...user
+        }
+      }
+      if (error) {
+        throw error
+      }
+    }
+  } catch (error) {
+    console.log(error)
+  }
+  const { admin, avatar_src, display_name, id, login } = await auth.checkCurrent()
+  return { admin, avatar_src, display_name, id, login }
+}

--- a/packages/app-root/src/helpers/index.js
+++ b/packages/app-root/src/helpers/index.js
@@ -1,0 +1,1 @@
+export { default as fetchPanoptesUser } from './fetchPanoptesUser.js'

--- a/packages/app-root/src/hooks/index.js
+++ b/packages/app-root/src/hooks/index.js
@@ -1,3 +1,4 @@
+export { default as useAdminMode } from './useAdminMode.js'
 export { default as usePanoptesUser } from './usePanoptesUser.js'
 export { default as useUnreadMessages } from './useUnreadMessages.js'
 export { default as useUnreadNotifications } from './useUnreadNotifications.js'

--- a/packages/app-root/src/hooks/index.js
+++ b/packages/app-root/src/hooks/index.js
@@ -1,1 +1,3 @@
 export { default as usePanoptesUser } from './usePanoptesUser.js'
+export { default as useUnreadMessages } from './useUnreadMessages.js'
+export { default as useUnreadNotifications } from './useUnreadNotifications.js'

--- a/packages/app-root/src/hooks/index.js
+++ b/packages/app-root/src/hooks/index.js
@@ -1,0 +1,1 @@
+export { default as usePanoptesUser } from './usePanoptesUser.js'

--- a/packages/app-root/src/hooks/useAdminMode.js
+++ b/packages/app-root/src/hooks/useAdminMode.js
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+
+const isBrowser = typeof window !== 'undefined'
+const localStorage = isBrowser ? window.localStorage : null
+const storedAdminFlag = !!localStorage?.getItem('adminFlag')
+const adminBorderImage = 'repeating-linear-gradient(45deg,#000,#000 25px,#ff0 25px,#ff0 50px) 5'
+
+export default function useAdminMode(user) {
+  const [adminState, setAdminState] = useState(storedAdminFlag)
+  const adminMode = user?.admin && adminState
+
+  useEffect(function onUserChange() {
+    const isAdmin = user?.admin
+    if (isAdmin) {
+      const adminFlag = !!localStorage?.getItem('adminFlag')
+      setAdminState(adminFlag)
+    } else {
+      localStorage?.removeItem('adminFlag')
+    }
+  }, [user?.admin])
+
+  useEffect(function onAdminChange() {
+    if (adminMode) {
+      document.body.style.border = '5px solid'
+      document.body.style.borderImage = adminBorderImage
+    }
+    return () => {
+      document.body.style.border = ''
+      document.body.style.borderImage = ''
+    }
+  }, [adminMode])
+
+  function toggleAdmin() {
+    let newAdminState = !adminState
+    setAdminState(newAdminState)
+    if (newAdminState) {
+      localStorage?.setItem('adminFlag', true)
+    } else {
+      localStorage?.removeItem('adminFlag')
+    }
+  }
+  
+  return { adminMode, toggleAdmin }
+}

--- a/packages/app-root/src/hooks/usePanoptesUser.js
+++ b/packages/app-root/src/hooks/usePanoptesUser.js
@@ -1,0 +1,60 @@
+import auth from 'panoptes-client/lib/auth'
+import { auth as authHelpers } from '@zooniverse/panoptes-js'
+import { useEffect, useState } from 'react'
+
+if (typeof window !== 'undefined') {
+  auth.checkCurrent()
+}
+
+async function fetchPanoptesUser() {
+  try {
+    const authorization = await auth.checkBearerToken()
+    /* 
+      Use crypto.subtle as a proxy for checking for SSL.
+      It will only exist for https:// URLs.
+    */
+    const isSecure = crypto?.subtle
+    if (authorization && isSecure) {
+      const { user, error } = await authHelpers.decodeJWT(authorization)
+      if (user) {
+        return user
+      }
+      if (error) {
+        throw error
+      }
+    }
+  } catch (error) {
+    console.log(error)
+  }
+  return await auth.checkCurrent()
+}
+
+export default function usePanoptesUser() {
+  const [error, setError] = useState(null)
+  const [user, setUser] = useState({})
+  const [loading, setLoading] = useState(true)
+
+  useEffect(function () {
+    async function checkUserSession() {
+      setLoading(true)
+      try {
+        const panoptesUser = await fetchPanoptesUser()
+        setUser(panoptesUser)
+      } catch (error) {
+        setError(error)
+      }
+      setLoading(false)
+    }
+
+    if (typeof window !== 'undefined') {
+      checkUserSession()
+    }
+    auth.listen('change', checkUserSession)
+
+    return function () {
+      auth.stopListening('change', checkUserSession)
+    }
+  }, [])
+
+  return { data: user, error, isLoading: loading }
+}

--- a/packages/app-root/src/hooks/usePanoptesUser.js
+++ b/packages/app-root/src/hooks/usePanoptesUser.js
@@ -1,38 +1,21 @@
 import auth from 'panoptes-client/lib/auth'
-import { auth as authHelpers } from '@zooniverse/panoptes-js'
 import { useEffect, useState } from 'react'
 
-if (typeof window !== 'undefined') {
+import { fetchPanoptesUser } from '../helpers'
+
+const isBrowser = typeof window !== 'undefined'
+
+if (isBrowser) {
   auth.checkCurrent()
 }
 
-async function fetchPanoptesUser() {
-  try {
-    const authorization = await auth.checkBearerToken()
-    /* 
-      Use crypto.subtle as a proxy for checking for SSL.
-      It will only exist for https:// URLs.
-    */
-    const isSecure = crypto?.subtle
-    if (authorization && isSecure) {
-      const { user, error } = await authHelpers.decodeJWT(authorization)
-      if (user) {
-        return user
-      }
-      if (error) {
-        throw error
-      }
-    }
-  } catch (error) {
-    console.log(error)
-  }
-  return await auth.checkCurrent()
-}
-
-const isBrowser = typeof window !== 'undefined'
 const localStorage = isBrowser ? window.localStorage : null
 const storedUserJSON = localStorage?.getItem('panoptes-user')
 let user = storedUserJSON && JSON.parse(storedUserJSON)
+/*
+  Null users crash the ZooHeader component.
+  Set them to undefined for now.
+*/
 if (user === null) {
   user = undefined
 }
@@ -45,11 +28,10 @@ export default function usePanoptesUser() {
     async function checkUserSession() {
       setLoading(true)
       try {
-        const panoptesUser = await fetchPanoptesUser()
+        const panoptesUser = await fetchPanoptesUser(user)
         if (panoptesUser) {
-          const { admin, avatar_src, display_name, id, login } = panoptesUser
-          user = { admin, avatar_src, display_name, id, login }
-          localStorage?.setItem('panoptes-user', JSON.stringify(user))
+          localStorage?.setItem('panoptes-user', JSON.stringify(panoptesUser))
+          user = panoptesUser
         } else {
           user = undefined
           localStorage?.removeItem('panoptes-user')
@@ -60,7 +42,7 @@ export default function usePanoptesUser() {
       setLoading(false)
     }
 
-    if (typeof window !== 'undefined') {
+    if (isBrowser) {
       checkUserSession()
     }
     auth.listen('change', checkUserSession)

--- a/packages/app-root/src/hooks/usePanoptesUser.js
+++ b/packages/app-root/src/hooks/usePanoptesUser.js
@@ -29,17 +29,30 @@ async function fetchPanoptesUser() {
   return await auth.checkCurrent()
 }
 
+let user
+
 export default function usePanoptesUser() {
   const [error, setError] = useState(null)
-  const [user, setUser] = useState({})
   const [loading, setLoading] = useState(true)
 
   useEffect(function () {
     async function checkUserSession() {
       setLoading(true)
       try {
-        const panoptesUser = await fetchPanoptesUser()
-        setUser(panoptesUser)
+        const {
+          admin,
+          avatar_src,
+          display_name,
+          id,
+          login,
+        } = await fetchPanoptesUser()
+        user = {
+          admin,
+          avatar_src,
+          display_name,
+          id,
+          login,
+        }
       } catch (error) {
         setError(error)
       }

--- a/packages/app-root/src/hooks/usePanoptesUser.js
+++ b/packages/app-root/src/hooks/usePanoptesUser.js
@@ -29,7 +29,13 @@ async function fetchPanoptesUser() {
   return await auth.checkCurrent()
 }
 
-let user
+const isBrowser = typeof window !== 'undefined'
+const localStorage = isBrowser ? window.localStorage : null
+const storedUserJSON = localStorage?.getItem('panoptes-user')
+let user = storedUserJSON && JSON.parse(storedUserJSON)
+if (user === null) {
+  user = undefined
+}
 
 export default function usePanoptesUser() {
   const [error, setError] = useState(null)
@@ -39,19 +45,14 @@ export default function usePanoptesUser() {
     async function checkUserSession() {
       setLoading(true)
       try {
-        const {
-          admin,
-          avatar_src,
-          display_name,
-          id,
-          login,
-        } = await fetchPanoptesUser()
-        user = {
-          admin,
-          avatar_src,
-          display_name,
-          id,
-          login,
+        const panoptesUser = await fetchPanoptesUser()
+        if (panoptesUser) {
+          const { admin, avatar_src, display_name, id, login } = panoptesUser
+          user = { admin, avatar_src, display_name, id, login }
+          localStorage?.setItem('panoptes-user', JSON.stringify(user))
+        } else {
+          user = undefined
+          localStorage?.removeItem('panoptes-user')
         }
       } catch (error) {
         setError(error)

--- a/packages/app-root/src/hooks/useUnreadMessages.js
+++ b/packages/app-root/src/hooks/useUnreadMessages.js
@@ -1,0 +1,55 @@
+import { talkAPI } from '@zooniverse/panoptes-js'
+import auth from 'panoptes-client/lib/auth'
+import useSWR from 'swr'
+
+const SWROptions = {
+  revalidateIfStale: true,
+  revalidateOnMount: true,
+  revalidateOnFocus: true,
+  revalidateOnReconnect: true,
+  refreshInterval: 0
+}
+
+async function fetchUnreadMessageCount({ endpoint = '/conversations' }) {
+  const token = await auth.checkBearerToken()
+  const authorization = `Bearer ${token}`
+  if (!authorization) return undefined
+
+  let unreadConversationsIds = []
+
+  async function getConversations (page = 1) {
+    const query = {
+      unread: true,
+      page: page
+    }
+
+    const response = await talkAPI.get(endpoint, query, { authorization })
+    const { meta, conversations } = response?.body || {}
+
+    if (conversations && conversations.length) {
+      unreadConversationsIds = unreadConversationsIds.concat(
+        conversations.map(conversation => conversation.id)
+      )
+    }
+
+    if (meta?.next_page) {
+      return getConversations(meta.next_page)
+    }
+
+    return unreadConversationsIds
+  }
+
+  await getConversations(1)
+  return unreadConversationsIds.length
+}
+
+export default function useUnreadMessages(user) {
+  let key = null
+  if (user) {
+    key = {
+      user,
+      endpoint: '/conversations'
+    }
+  }
+  return useSWR(key, fetchUnreadMessageCount, SWROptions)
+}

--- a/packages/app-root/src/hooks/useUnreadNotifications.js
+++ b/packages/app-root/src/hooks/useUnreadNotifications.js
@@ -1,0 +1,36 @@
+import { talkAPI } from '@zooniverse/panoptes-js'
+import auth from 'panoptes-client/lib/auth'
+import useSWR from 'swr'
+
+const SWROptions = {
+  revalidateIfStale: true,
+  revalidateOnMount: true,
+  revalidateOnFocus: true,
+  revalidateOnReconnect: true,
+  refreshInterval: 0
+}
+
+async function fetchUnreadNotificationsCount({ endpoint = '/notifications' }) {
+  const token = await auth.checkBearerToken()
+  const authorization = `Bearer ${token}`
+  if (!authorization) return undefined
+
+  const query = {
+    delivered: false,
+    page_size: 1
+  }
+
+  const response = await talkAPI.get(endpoint, query, { authorization })
+  return response?.body?.meta?.notifications?.count
+}
+
+export default function useUnreadNotifications(user) {
+  let key = null
+  if (user) {
+    key = {
+      user,
+      endpoint: '/notifications'
+    }
+  }
+  return useSWR(key, fetchUnreadNotificationsCount, SWROptions)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2317,7 +2317,7 @@
   resolved "https://registry.yarnpkg.com/@newrelic/superagent/-/superagent-7.0.1.tgz#8d5bb92579cf0b291e1298f480c4939a3d70ec09"
   integrity sha512-QZlW0VxHSVOXcMAtlkg+Mth0Nz3vFku8rfzTEmoI/pXcckHXGEYuiVUhhboCTD3xTKVgnZRUp9BWF6SOggGUSw==
 
-"@next/bundle-analyzer@~13.5.4":
+"@next/bundle-analyzer@~13.5.5":
   version "13.5.5"
   resolved "https://registry.yarnpkg.com/@next/bundle-analyzer/-/bundle-analyzer-13.5.5.tgz#301edbfe05ff910ce3c9ba691ea2a6257e0032cb"
   integrity sha512-v69BJm8ONM/e6l39Ao0ar8TwZyFnhI5s6id8LGayNq/3JaqkbzW97bIcBkTI0H9RiX3zZNIiaIyMgdKcbJqvsw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1983,7 +1983,7 @@
   resolved "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@grpc/grpc-js@^1.9.4":
+"@grpc/grpc-js@^1.8.10", "@grpc/grpc-js@^1.9.4":
   version "1.9.7"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.7.tgz#7d0e29bc162287bee2523901c9bc9320d8402397"
   integrity sha512-yMaA/cIsRhGzW3ymCNpdlPcInXcovztlgu/rirThj2b87u3RzWUszliOqZ/pldy7yhmJPS8uwog+kZSTa4A0PQ==
@@ -2260,12 +2260,12 @@
     pump "^3.0.0"
     tar-fs "^2.1.1"
 
-"@newrelic/aws-sdk@^7.0.2":
+"@newrelic/aws-sdk@^7.0.0", "@newrelic/aws-sdk@^7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@newrelic/aws-sdk/-/aws-sdk-7.0.2.tgz#e93f1796c89be8323a75f3d7ec45b1bdd5a29292"
   integrity sha512-nT19hzId0MbjR3v1ks5YetvNfrwIEgMfeai+T2pQkuWkjCsYm3z+OybLOYMCN66gueqOOqGTq60qhM4dFu5s5w==
 
-"@newrelic/koa@^8.0.1":
+"@newrelic/koa@^8.0.0", "@newrelic/koa@^8.0.1":
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/@newrelic/koa/-/koa-8.0.1.tgz#26c1c6a69b15ad4b64a148b6be537ec2ca734206"
   integrity sha512-GyeZGKPllpUu6gWXRwVP/FlvE9+tU2lOprRiTdoXNM8jdVGL02IfHnvAzrIANoZoUdf3+Vev8NNeCup2Eojcvg==
@@ -2306,6 +2306,11 @@
     unescape-js "^1.1.4"
     uuid "^9.0.0"
     ws "^7.5.9"
+
+"@newrelic/superagent@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@newrelic/superagent/-/superagent-7.0.0.tgz"
+  integrity sha512-fNB4NC+pJYYrFZRLcXaTb4Z7XFEfHi7fVQ3O9Qh10m/9CBM2W+Qc/6yyK9M1liRfgUGo5NOILRdjA23SS7720A==
 
 "@newrelic/superagent@^7.0.1":
   version "7.0.1"
@@ -9254,7 +9259,7 @@ execa@^5.0.0, execa@^5.1.1:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
-express@^4.17.1, express@^4.17.3:
+express@^4.17.1, express@^4.17.3, express@~4.18.2:
   version "4.18.2"
   resolved "https://registry.npmjs.org/express/-/express-4.18.2.tgz"
   integrity sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==
@@ -12972,6 +12977,33 @@ newrelic@^11.0.0, newrelic@~11.4.0:
     "@newrelic/native-metrics" "^10.0.0"
     "@prisma/prisma-fmt-wasm" "^4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085"
 
+newrelic@~11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/newrelic/-/newrelic-11.2.0.tgz#eded32c7b7d97cae36e45396e8926a201e441793"
+  integrity sha512-gkt6c5nphsKTRBmKd0H12xELwnhdV9Xph5CL8IXT7nj0C1gL/xxfuTrwj6g+JqDvVz983iNNfdfXBEhIUJC4nQ==
+  dependencies:
+    "@grpc/grpc-js" "^1.8.10"
+    "@grpc/proto-loader" "^0.7.5"
+    "@newrelic/aws-sdk" "^7.0.0"
+    "@newrelic/koa" "^8.0.0"
+    "@newrelic/security-agent" "0.3.0"
+    "@newrelic/superagent" "^7.0.0"
+    "@tyriar/fibonacci-heap" "^2.0.7"
+    concat-stream "^2.0.0"
+    https-proxy-agent "^7.0.1"
+    import-in-the-middle "^1.4.2"
+    json-bigint "^1.0.0"
+    json-stringify-safe "^5.0.0"
+    module-details-from-path "^1.0.3"
+    readable-stream "^3.6.1"
+    require-in-the-middle "^7.2.0"
+    semver "^7.5.2"
+    winston-transport "^4.5.0"
+  optionalDependencies:
+    "@contrast/fn-inspect" "^3.3.0"
+    "@newrelic/native-metrics" "^10.0.0"
+    "@prisma/prisma-fmt-wasm" "^4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085"
+
 next-absolute-url@~1.2.2:
   version "1.2.2"
   resolved "https://registry.npmjs.org/next-absolute-url/-/next-absolute-url-1.2.2.tgz"
@@ -13814,7 +13846,7 @@ pako@~1.0.5:
   resolved "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
-panoptes-client@~5.5.1:
+panoptes-client@~5.5.1, panoptes-client@~5.5.6:
   version "5.5.6"
   resolved "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.5.6.tgz"
   integrity sha512-TvcKIS7ggrfuh8dA+9ORgHw53lWCoRjyIZWtSjOGOlIIBB2QF+3dPEgyDUltQ6Kpo49TV7PRAYNczJI3GGn07w==
@@ -15588,6 +15620,13 @@ selfsigned@^2.1.1, selfsigned@~2.4.1:
   integrity sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==
   dependencies:
     "@types/node-forge" "^1.3.0"
+    node-forge "^1"
+
+selfsigned@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.1.2.tgz#9f9a4b0d472a5f29f892eb52358056c61a7387e3"
+  integrity sha512-xc6ZKMc9owNuU3uEPuW45RnSPylOlRK5Brj8oWf/2+BQV2gD1c+/eJaHFCcTG8w8kRkEfb5mzn/yIpie6gJ1tA==
+  dependencies:
     node-forge "^1"
 
 "semver@2 || 3 || 4 || 5", semver@^5.6.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -16440,7 +16440,7 @@ swc-loader@^0.2.3:
   resolved "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.3.tgz"
   integrity sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==
 
-swr@~2.2.0:
+swr@~2.2.0, swr@~2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/swr/-/swr-2.2.4.tgz#03ec4c56019902fbdc904d78544bd7a9a6fa3f07"
   integrity sha512-njiZ/4RiIhoOlAaLYDqwz5qH/KZXVilRLvomrx83HjzCWTfa+InyfAjv05PSFxnmLzZkNO9ZfvgoqzAaEI4sGQ==


### PR DESCRIPTION
- configure ESLint.
- add the [Panoptes auth client](https://zooniverse.github.io/panoptes-javascript-client/#panoptes-javascript-client-auth), from `panoptes-client`.
- add the [`useSWR` hook](https://swr.vercel.app/), from 'swr'.
- add `usePanoptesUser` for SWR-style user fetching.
- add an express server to handle HTTPS in local development.
- add a page context component to provide global styling, the Grommet theme, and Panoptes auth context.
- add the panoptes user to both page header and footer.
- fetch your unread message count (`useUnreadMessages`) and unread notifications count (`useUnreadNotifications`), once you've signed in.
- add an admin toggle to the page footer, and an admin border to the page body.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-root

## How to Review
Either `yarn dev` or `yarn start` should run a local HTTPS server on https://local.zooniverse.org:3000.

If you have a Panoptes session cookie for `local.zooniverse.org:3000`, you should be logged in when the page loads, and see your username top right.

<img width="800" alt="Screenshot of the app home page, with a logged-in user top right." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/51b44271-5ba7-4f15-9e17-332570c6eca5">

There's no sign-in form yet. If you aren't logged in, you'll need to log in to `local.zooniverse.org:3000` in another tab (eg. with the content pages app), in order to set the session cookie.

Admin mode should toggle the top-level admin menu and page border, and persist across page loads.

Once you are logged in, the user object is persisted in local storage for faster sign-in across tabs. 

https://github.com/zooniverse/front-end-monorepo/assets/59547/e0910b29-a474-409d-8b64-3c156a89aaf8



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
