### PR TITLE
Remove legacy next/link components

### DIFF
--- a/packages/app-content-pages/src/screens/Publications/Publications.js
+++ b/packages/app-content-pages/src/screens/Publications/Publications.js
@@ -14,6 +14,8 @@ const StyledLi = styled.li`
 `
 
 const StyledButton = styled(Button)`
+  text-decoration: none;
+  color: black;
   ${props =>
     props.active &&
     css`
@@ -59,15 +61,15 @@ function Publications({ className = '', data = [], filters = [] }) {
       <Box as='ul'>
         {filters.map(filter => (
           <StyledLi key={filter.name}>
-            <Link legacyBehavior href={filter.slug ? `#${filter.slug}` : ''} passHref>
-              <StyledButton
-                active={filter.active}
-                ariaChecked={filter.active}
-                label={filter.name}
-                onClick={filter.setActive}
-                plain
-              />
-            </Link>
+            <StyledButton
+              as={Link}
+              active={filter.active}
+              href={filter.slug ? `#${filter.slug}` : ''}
+              onClick={filter.setActive}
+              plain
+            >
+              {filter.name}
+            </StyledButton>
           </StyledLi>
         ))}
       </Box>

--- a/packages/app-content-pages/src/screens/Teams/Teams.js
+++ b/packages/app-content-pages/src/screens/Teams/Teams.js
@@ -14,6 +14,8 @@ const StyledLi = styled.li`
 `
 
 const StyledButton = styled(Button)`
+  text-decoration: none;
+  color: black;
   ${props => props.active && css`
     background: none;
     font-weight: bold;
@@ -51,14 +53,16 @@ function TeamComponent ({
       <Box as='ul'>
         {filters.map(filter => (
           <StyledLi key={filter.name}>
-            <Link legacyBehavior href={filter.slug ? `#${filter.slug}` : ''} passHref>
-              <StyledButton
-                active={filter.active}
-                label={filter.name}
-                onClick={filter.setActive}
-                plain
-              />
-            </Link>
+            <StyledButton
+              as={Link}
+              active={filter.active}
+              href={filter.slug ? `#${filter.slug}` : ''}
+              label={filter.name}
+              onClick={filter.setActive}
+              plain
+            >
+              {filter.name}
+            </StyledButton>
           </StyledLi>
         ))}
       </Box>

--- a/packages/app-content-pages/src/shared/components/AboutHeader/components/NavLink/NavLink.js
+++ b/packages/app-content-pages/src/shared/components/AboutHeader/components/NavLink/NavLink.js
@@ -10,18 +10,18 @@ function NavLink ({
   const { asPath } = useRouter()
   const isActive = asPath === href
   return (
-    <Link legacyBehavior href={href} passHref>
-      <Anchor
-        aria-current={isActive ? 'page' : undefined}
-        size='medium'
-        weight='normal'
-        active={isActive}
-      >
-        <Box pad={{ horizontal: 'small', vertical: 'xsmall' }}>
-          {label}
-        </Box>
-      </Anchor>
-    </Link>
+    <Anchor
+      as={Link}
+      aria-current={isActive ? 'page' : undefined}
+      href={href}
+      size='medium'
+      weight='normal'
+      active={isActive}
+    >
+      <Box pad={{ horizontal: 'small', vertical: 'xsmall' }}>
+        {label}
+      </Box>
+    </Anchor>
   )
 }
 


### PR DESCRIPTION
Replace `next/link` links with `as={Link}` on styled Grommet anchors and button links.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-content-pages

## Linked Issue and/or Talk Post
- closes #5467.

## How to Review
Navigation links and sidebar links should continue to work, without being wrapped in an extra `<a>` element. `next/link` no longer [requires a link as a child](https://nextjs.org/docs/pages/api-reference/components/link#legacybehavior).

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
