### PR TITLE
Revert: build(deps-dev): bump sinon from 16.1.0 to 16.1.1 (#5490)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15817,9 +15817,9 @@ sinon-chai@~3.7.0:
   integrity sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==
 
 sinon@~16.1.0:
-  version "16.1.1"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-16.1.1.tgz#2aee7c0b2ebcf2523b66599e79922e367a907dab"
-  integrity sha512-tu0DS1g4Rm2xHT9mWK5g5aTogTXWwGGz3fQK/L5fnECPkcAQ3YcbAbJ4XxOkpDDnV4EV5n+lee5neq5QyVxoSg==
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-16.1.0.tgz#645b836563c9bedb21defdbe48831cb2afb687f2"
+  integrity sha512-ZSgzF0vwmoa8pq0GEynqfdnpEDyP1PkYmEChnkjW0Vyh8IDlyFEJ+fkMhCP0il6d5cJjPl2PUsnUSAuP5sttOQ==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
     "@sinonjs/fake-timers" "^10.3.0"


### PR DESCRIPTION
This reverts commit 550176f616668c1d17e9c5b44e3dc9e64b4e367d.

The FEM staging [deploy](https://zooniverse.slack.com/archives/C01M8PJGLR5/p1697668103030929) is failing this afternoon with the message `ERROR: failed to solve: process "/bin/sh -c YARN_CACHE_FOLDER=/home/node/.yarn yarn install --production=false --frozen-lockfile" did not complete successfully: exit code: 127`

