### PR TITLE
[Security] Ignore post-install scripts

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -19,7 +19,7 @@ jobs:
          node-version: 'lts/hydrogen'
          cache: 'yarn'
 
-      - run: yarn install --production=false --frozen-lockfile
+      - run: yarn install --production=false --frozen-lockfile --ignore-scripts
       - run: yarn workspace @zooniverse/react-components build:es6
       - run: yarn workspace @zooniverse/classifier build:es6
       - run: yarn workspace @zooniverse/fe-project build
@@ -41,7 +41,7 @@ jobs:
          node-version: 'lts/hydrogen'
          cache: 'yarn'
 
-      - run: yarn install --production=false --frozen-lockfile
+      - run: yarn install --production=false --frozen-lockfile --ignore-scripts
       - run: yarn workspace @zooniverse/react-components build:es6
       - run: yarn workspace @zooniverse/classifier build:es6
       - run: yarn workspace @zooniverse/fe-content-pages build
@@ -57,7 +57,7 @@ jobs:
          node-version: 'lts/hydrogen'
          cache: 'yarn'
 
-      - run: yarn install --production=false --frozen-lockfile
+      - run: yarn install --production=false --frozen-lockfile --ignore-scripts
       - run: yarn workspace @zooniverse/react-components build:es6
       - run: yarn workspace @zooniverse/classifier build:es6
       - run: yarn deploy-storybook --dry-run

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 'lts/hydrogen'
           cache: 'yarn'
 
-      - run: yarn install --production=false --frozen-lockfile
+      - run: yarn install --production=false --frozen-lockfile --ignore-scripts
       - run: yarn workspace @zooniverse/react-components build:cjs
       - run: yarn workspace @zooniverse/classifier build:cjs
       - run: yarn test:ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN chown -R node:node .
 
 USER node
 
-RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn install --production=false --frozen-lockfile
+RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn install --production=false --frozen-lockfile --ignore-scripts
 RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn workspace @zooniverse/react-components build:es6
 RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn workspace @zooniverse/classifier build:es6
 RUN echo $COMMIT_ID > /usr/src/packages/app-content-pages/public/commit_id.txt


### PR DESCRIPTION
Don't run post-install scripts during Docker builds. This is a vector for supply chain attacks, and there have been a few cases where they have been exploited to distribute malware via NPM.
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## How to Review
A Docker build should still run without errors, even though post-install scripts don't run during the build stage. 

Unfortunately, we don't run a Docker build during CI, so that won't be tested by our test builds. 

CI tests and CI builds in Node should still run successfully without post-install scripts. 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected