### PR TITLE
Restore newrelic monitoring for app-content-pages

### DIFF
--- a/packages/app-content-pages/next.config.js
+++ b/packages/app-content-pages/next.config.js
@@ -1,3 +1,7 @@
+if (process.env.NEWRELIC_LICENSE_KEY) {
+  require('newrelic')
+}
+
 require('dotenv').config()
 
 const { execSync } = require('child_process')

--- a/packages/app-project/next.config.js
+++ b/packages/app-project/next.config.js
@@ -9,9 +9,17 @@ const { i18n } = require('./next-i18next.config')
 
 const assetPrefixes = {}
 
-function commitID () {
+function commitID() {
   try {
     return execSync('git rev-parse HEAD').toString('utf8').trim()
+  } catch (error) {
+    return error.message
+  }
+}
+
+function branchName() {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD').toString('utf8').trim()
   } catch (error) {
     return error.message
   }
@@ -24,7 +32,7 @@ const SENTRY_PROJECT_DSN = isDevelopment ? '' : 'https://2a50683835694829b4bc3cc
 const APP_ENV = process.env.APP_ENV || 'development'
 const COMMIT_ID = process.env.COMMIT_ID || commitID()
 const assetPrefix = assetPrefixes[APP_ENV]
-const GITHUB_REF_NAME = process.env.GITHUB_REF_NAME
+const GITHUB_REF_NAME = process.env.GITHUB_REF_NAME || branchName()
 
 console.info({ GITHUB_REF_NAME, APP_ENV, PANOPTES_ENV, assetPrefix })
 


### PR DESCRIPTION
- restore `newrelic` to the content pages app. It was accidentally removed in #5427.
- fix a missing default for `GITHUB_REF_NAME` in the project app.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-content-pages
- app-project

## How to Review
`GITHUB_REF_NAME` should now be set when you build the project app locally (and shouldn't trigger build warnings about a missing string.)

The content pages app should start sending telemetry data to newrelic again, once this is deployed to staging. The content pages config should now match the project app config.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
