### PR TITLE
Refactor URLs in subject metadata

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.js
@@ -1,5 +1,5 @@
 import { Markdownz, Modal, SpacedText } from '@zooniverse/react-components'
-import { Box, DataTable, Text } from 'grommet'
+import { Anchor, Box, DataTable, Text } from 'grommet'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import filterByLabel, { filters as defaultFilters } from './filterByLabel'
@@ -26,14 +26,19 @@ const DatumWrapper = styled(Text)`
   }
 `
 
-export function formatValue (value) {
-  if (value) {
-    const stringValue = value.toString()
-    stringValue.trim()
-    return stringValue
+export function formatValue(value) {
+  const stringValue = value?.toString()
+  stringValue?.trim()
+  if (stringValue?.startsWith('http')) {
+    return <Anchor target='_blank' rel='nofollow noopener noreferrer' href={value}>{value}</Anchor>
+  }
+  if (stringValue) {
+    return <Markdownz options={{ forceInline: true }}>{stringValue}</Markdownz>
   }
 
-  if (value === null) return 'null'
+  if (value === null) {
+    return 'null'
+  }
 
   return ''
 }
@@ -64,7 +69,7 @@ export default function MetadataModal ({
     const value = formatValue(metadata[label])
     return {
       label: label.replace(RegExp(`^(${prefixes.join('|')})`), ''),
-      value: <Markdownz options={{ forceInline: true }}>{value}</Markdownz>
+      value
     }
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.spec.js
@@ -11,21 +11,21 @@ describe('MetadataModal', function () {
     render(<DefaultStory />)
     const tableBody = document.querySelector('tbody')
     const rows = within(tableBody).getAllByRole('row')
+    // the DefaultStory mock subject metadata includes 5 items, 2 of which should be filtered/hidden per default filters, leaving 3 rows rendered
     expect(rows).to.have.lengthOf(3)
   })
 
-  describe('with undefined filters', function () {
+  describe('with no filters on metadata keys', function () {
     it('should render the correct number of table rows', function () {
       render(
         <DefaultStory
-          filters={undefined}
+          filters={[]}
         />
       )
       const tableBody = document.querySelector('tbody')
       const rows = within(tableBody).getAllByRole('row')
 
-      // the DefaultStory mock subject metadata includes 5 items, 2 of which should be filtered/hidden per default filters, leaving 3 rows rendered
-      expect(rows).to.have.lengthOf(3)
+      expect(rows).to.have.lengthOf(5)
     })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/MetaTools/components/Metadata/components/MetadataModal/MetadataModal.stories.js
@@ -4,9 +4,9 @@ import { filters } from './filterByLabel'
 
 const args = {
   active: true,
-  filters: filters,
+  filters,
   metadata: {
-    id: '1',
+    id: 1,
     href: 'https://zooniverse.org',
     '#hidden': true,
     '!onlyTalk': false,


### PR DESCRIPTION
- Test subject metadata with and without filtered labels.
- Test mock subject metadata with a mixture of numbers and strings.
- Render URLs in subject metadata as HTML links with `target=_blank` and `rel="nofollow noopener noreferrer"`.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- #5352.

## How to Review
Open up the subject metadata modal in I Fancy Cats. The Flickr link should open in a new tab. `window.opener` should be empty in the new tab.

In the storybook, the link in the `MetadataModal` story should continue to open in a new tab (again, without `window.opener` set.)

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected
