### PR TITLE
Bump inline Sentry to 7.75.1

### DIFF
--- a/packages/app-project/pages/_document.js
+++ b/packages/app-project/pages/_document.js
@@ -81,9 +81,9 @@ export default class MyDocument extends Document {
           )}
           { /* https://docs.sentry.io/platforms/javascript/install/loader/#default-bundle */ }
           <script
-            src="https://browser.sentry-cdn.com/7.75.0/bundle.tracing.min.js"
-            integrity="sha384-qSD0df3NuJH4Xjg5NZdzKGjmUzaOVxnU9DKnWzt6uFajBD/3w0nFkCsqwc/83DGb"
-            crossorigin="anonymous"
+            src="https://browser.sentry-cdn.com/7.75.1/bundle.tracing.min.js"
+            integrity="sha384-rIgmxg/TFW1M9fLcLS+69P3ihyK3Cm63m8R1vXDbYLlbs+z6I6UO/ycue6O/u1f5"
+            crossOrigin="anonymous"
             defer
             id='sentryScript'
           ></script>


### PR DESCRIPTION
Bump the inline Sentry script, on project pages, to the latest version. It catches errors when page scripts fail to load.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project

## How to Review
I think this should be ok to merge once CI passes.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser
