### PR TITLE
Fix Not Found responses for project About pages

### DIFF
--- a/packages/app-project/src/helpers/fetchProjectPage/fetchProjectPage.js
+++ b/packages/app-project/src/helpers/fetchProjectPage/fetchProjectPage.js
@@ -4,8 +4,9 @@ import logToSentry from '@helpers/logger/logToSentry.js'
 
 export default async function fetchProjectPage(project, locale, key, env) {
   const { headers, host } = getServerSideAPIHost(env)
-  const page = project.about_pages.find(page => page.url_key === key)
+  let page = null
   try {
+    page = project.about_pages.find(page => page.url_key === key)
     const translations = await fetchTranslations({
       translated_id: page?.id,
       translated_type: 'project_page',

--- a/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.js
+++ b/packages/app-project/src/helpers/getStaticPageProps/getStaticPageProps.js
@@ -21,12 +21,12 @@ export default async function getStaticPageProps({ locale, params }) {
   if (params.owner && params.project) {
     const projectSlug = `${params.owner}/${params.project}`
     const project = await fetchProjectData(projectSlug, { env })
+    if (!project.id) {
+      return notFoundError(`Project ${params.owner}/${params.project} was not found`)
+    }
     project.about_pages = await fetchProjectPageTitles(project, params.panoptesEnv)
 
     applySnapshot(store.project, project)
-    if (!store.project.id) {
-      return notFoundError(`Project ${params.owner}/${params.project} was not found`)
-    }
   }
 
   /*


### PR DESCRIPTION
Return '404 Not Found' for project About pages, when the project doesn't exist.

- Fixes #5533.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project

## How to Review
Build the project app, then run it with `yarn start` or `npm start` and check the following URLs:
- https://local.zooniverse.org:3000/projects/zoniverse/gravity-spy/about/research should show a 404 page.
- https://local.zooniverse.org:3000/projects/zooniverse/gravity-spy/about/research should show the Gravity Spy Research page.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated
