### PR TITLE
Build and deploy with Node 20 (lts/iron)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,10 +13,10 @@ jobs:
       PANOPTES_ENV: production
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-         node-version: 'lts/hydrogen'
+         node-version: 'lts/iron'
          cache: 'yarn'
 
       - run: yarn install --production=false --frozen-lockfile --ignore-scripts
@@ -35,10 +35,10 @@ jobs:
       CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-         node-version: 'lts/hydrogen'
+         node-version: 'lts/iron'
          cache: 'yarn'
 
       - run: yarn install --production=false --frozen-lockfile --ignore-scripts
@@ -51,10 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-         node-version: 'lts/hydrogen'
+         node-version: 'lts/iron'
          cache: 'yarn'
 
       - run: yarn install --production=false --frozen-lockfile --ignore-scripts

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,10 +15,10 @@ jobs:
       PANOPTES_ENV: test
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/hydrogen'
+          node-version: 'lts/iron'
           cache: 'yarn'
 
       - run: yarn install --production=false --frozen-lockfile --ignore-scripts

--- a/.github/workflows/deploy_storybook.yml
+++ b/.github/workflows/deploy_storybook.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-         node-version: 'lts/hydrogen'
+         node-version: 'lts/iron'
          cache: 'yarn'
 
       - run: yarn install --production=false --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine as builder
+FROM node:20-alpine as builder
 
 ARG COMMIT_ID
 ENV COMMIT_ID=$COMMIT_ID
@@ -52,7 +52,7 @@ RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.
 RUN echo $COMMIT_ID > /usr/src/packages/app-project/public/commit_id.txt
 RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn workspace @zooniverse/fe-project build
 
-FROM node:18-alpine as runner
+FROM node:20-alpine as runner
 
 ARG NODE_ENV=production
 ENV NODE_ENV=$NODE_ENV

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ## Requirements
 
 - [Browser support](docs/arch/adr-3.md)
-- Node 16
+- Node 20
 - Git
 - Yarn
 

--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -18,9 +18,9 @@
   "dependencies": {
     "@sentry/nextjs": "~7.76.0",
     "@zooniverse/async-states": "~0.0.1",
-    "@zooniverse/grommet-theme": "~3.1.0",
-    "@zooniverse/panoptes-js": "~0.4.0",
-    "@zooniverse/react-components": "~1.6.0",
+    "@zooniverse/grommet-theme": "~3.2.0",
+    "@zooniverse/panoptes-js": "~0.5.0",
+    "@zooniverse/react-components": "~1.7.0",
     "contentful": "~10.6.0",
     "dotenv": "~16.3.0",
     "dotenv-webpack": "~8.0.0",
@@ -74,6 +74,6 @@
     "storybook-react-i18next": "~2.0.1"
   },
   "engines": {
-    "node": ">=18.13"
+    "node": ">=20.5"
   }
 }

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -27,9 +27,9 @@
     "@visx/text": "~3.3.0",
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/classifier": "^0.0.1",
-    "@zooniverse/grommet-theme": "~3.1.0",
-    "@zooniverse/panoptes-js": "~0.4.0",
-    "@zooniverse/react-components": "~1.6.0",
+    "@zooniverse/grommet-theme": "~3.2.0",
+    "@zooniverse/panoptes-js": "~0.5.0",
+    "@zooniverse/react-components": "~1.7.0",
     "cookie": "~0.5.0",
     "d3": "~6.7.0",
     "engine.io-client": "~6.5.0",
@@ -89,6 +89,6 @@
     "storybook-react-i18next": "~2.0.1"
   },
   "engines": {
-    "node": ">=18.13"
+    "node": ">=20.5"
   }
 }

--- a/packages/app-root/package.json
+++ b/packages/app-root/package.json
@@ -25,7 +25,7 @@
     "styled-components": "~5.3.10"
   },
   "engines": {
-    "node": ">=18.13"
+    "node": ">=20.5"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "~13.5.4"

--- a/packages/lib-async-states/package.json
+++ b/packages/lib-async-states/package.json
@@ -22,7 +22,7 @@
     "snazzy": "~9.0.0"
   },
   "engines": {
-    "node": ">=18.13"
+    "node": ">=20.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "@zooniverse/grommet-theme": "3.x.x",
-    "@zooniverse/panoptes-js": "~0.4.0",
+    "@zooniverse/panoptes-js": "~0.5.0",
     "@zooniverse/react-components": "~1.x.x",
     "grommet": "~2.x.x",
     "grommet-icons": "~4.x.x",
@@ -78,9 +78,9 @@
     "@testing-library/user-event": "~14.5.0",
     "@visx/mock-data": "~3.3.0",
     "@wojtekmaj/enzyme-adapter-react-17": "~0.8.0",
-    "@zooniverse/grommet-theme": "~3.1.0",
-    "@zooniverse/panoptes-js": "~0.4.0",
-    "@zooniverse/react-components": "~1.6.0",
+    "@zooniverse/grommet-theme": "~3.2.0",
+    "@zooniverse/panoptes-js": "~0.5.0",
+    "@zooniverse/react-components": "~1.7.0",
     "@zooniverse/standard": "~2.0.0",
     "babel-loader": "~9.1.0",
     "babel-plugin-module-resolver": "~5.0.0",
@@ -124,6 +124,6 @@
     "webpack-dev-server": "~4.15.0"
   },
   "engines": {
-    "node": ">=18.13"
+    "node": ">=20.5"
   }
 }

--- a/packages/lib-grommet-theme/CHANGELOG.md
+++ b/packages/lib-grommet-theme/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.2.0]
+### Changed
+- build with Node 20.
+
 ## [3.1.1]
 ### Changed
 - updated package repo description.

--- a/packages/lib-grommet-theme/package.json
+++ b/packages/lib-grommet-theme/package.json
@@ -3,7 +3,7 @@
   "description": "A Zooniverse theme for the Grommet React library",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "main": "src/index.js",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "grommet": ">=2"
   },
   "engines": {
-    "node": ">=18.13"
+    "node": ">=20.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lib-panoptes-js/docs/CHANGELOG.md
+++ b/packages/lib-panoptes-js/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.0] 2023-10-26
+- build with Node 20.
+
 ## [0.4.1] 2023-08-24
 - fix a check for the `/projects` path.
 

--- a/packages/lib-panoptes-js/package.json
+++ b/packages/lib-panoptes-js/package.json
@@ -3,7 +3,7 @@
   "description": "A Javascript client for Panoptes API using Superagent",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "main": "src/index.js",
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
     "snazzy": "~9.0.0"
   },
   "engines": {
-    "node": ">=18.13"
+    "node": ">=20.5"
   },
   "standard": {
     "env": {

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.7.0] 2023-10-26
+### Changed
+- build with Node 20.
+
+### Fixed
+- export `package.json` for build tools.
+
 ## [1.6.4] 2023-10-05
 
 ### Fixed

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -3,7 +3,7 @@
   "description": "Zooniverse React Components",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {
@@ -85,7 +85,7 @@
     "@testing-library/react": "~14.0.0",
     "@testing-library/user-event": "~14.5.0",
     "@wojtekmaj/enzyme-adapter-react-17": "~0.8.0",
-    "@zooniverse/grommet-theme": "~3.1.0",
+    "@zooniverse/grommet-theme": "~3.2.0",
     "@zooniverse/standard": "~2.0.0",
     "babel-plugin-transform-imports": "~2.0.0",
     "chai": "~4.3.4",
@@ -111,7 +111,7 @@
     "styled-components": "~5.3.3"
   },
   "engines": {
-    "node": ">=18.13"
+    "node": ">=20.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lib-user/package.json
+++ b/packages/lib-user/package.json
@@ -54,6 +54,6 @@
     "webpack-dev-server": "~4.15.0"
   },
   "engines": {
-    "node": ">=18.13"
+    "node": ">=20.5"
   }
 }


### PR DESCRIPTION
Upgrade all the build scripts, and the Dockerfile, from Node 18 to Node 20. 20 is now the Active LTS release of Node.

Bump the libraries with new minor versions.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
All of them (I think.)

## How to Review
Install and build the monorepo with Node 20. You should be able to run the Next.js apps without any changes in their behaviour.

Docker builds should build and run the Next.js apps on Node 20 on Alpine Linux. There shouldn't be any changes in behaviour.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Maintenance
- [x] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
