### PR TITLE
Clean up Sentry config

### DIFF
--- a/packages/app-content-pages/server/server.js
+++ b/packages/app-content-pages/server/server.js
@@ -2,7 +2,7 @@ if (process.env.NEWRELIC_LICENSE_KEY) {
   require('newrelic')
 }
 
-const Sentry = require('@sentry/node')
+const Sentry = require('@sentry/nextjs')
 const express = require('express')
 const next = require('next')
 

--- a/packages/app-project/server/server.js
+++ b/packages/app-project/server/server.js
@@ -2,7 +2,7 @@ if (process.env.NEWRELIC_LICENSE_KEY) {
   require('newrelic')
 }
 
-const Sentry = require('@sentry/node')
+const Sentry = require('@sentry/nextjs')
 const express = require('express')
 const next = require('next')
 

--- a/packages/app-project/webpack.config.test.js
+++ b/packages/app-project/webpack.config.test.js
@@ -1,7 +1,0 @@
-const webpackConfig = require('./webpack.config')
-
-const webpackTestConfig = Object.assign({}, webpackConfig)
-
-webpackTestConfig.resolve.alias['@sentry/node'] = '@sentry/browser'
-
-module.exports = webpackTestConfig


### PR DESCRIPTION
Remove outdated references to `@sentry/node` and `@sentry/browser`. Since #4764, we use `@sentry/nextjs`.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-content-pages
- app-project
## Linked Issue and/or Talk Post
- #4764.

## How to Review
The Next.js apps should still build and run without problems.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook
