### PR TITLE
Add sign-in/register to root app

### DIFF
--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -20,7 +20,7 @@
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/grommet-theme": "~3.2.0",
     "@zooniverse/panoptes-js": "~0.5.0",
-    "@zooniverse/react-components": "~1.8.1",
+    "@zooniverse/react-components": "~1.9.0",
     "contentful": "~10.6.0",
     "dotenv": "~16.3.0",
     "dotenv-webpack": "~8.0.0",

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -29,7 +29,7 @@
     "@zooniverse/classifier": "^0.0.1",
     "@zooniverse/grommet-theme": "~3.2.0",
     "@zooniverse/panoptes-js": "~0.5.0",
-    "@zooniverse/react-components": "~1.8.1",
+    "@zooniverse/react-components": "~1.9.0",
     "cookie": "~0.6.0",
     "d3": "~6.7.0",
     "engine.io-client": "~6.5.0",

--- a/packages/app-root/next.config.mjs
+++ b/packages/app-root/next.config.mjs
@@ -7,6 +7,16 @@ const bundleAnalyzer = withBundleAnalyzer({
 const nextConfig = {
   experimental: {
     optimizePackageImports: ['@zooniverse/react-components', 'grommet', 'grommet-icons'],
+  },
+  webpack: (config, options) => {
+    config.resolve = {
+      ...config.resolve,
+      fallback: {
+        ...config.resolve.fallback,
+        fs: false
+      }
+    }
+    return config
   }
 }
 

--- a/packages/app-root/package.json
+++ b/packages/app-root/package.json
@@ -16,7 +16,7 @@
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/grommet-theme": "~3.2.0",
     "@zooniverse/panoptes-js": "~0.5.0",
-    "@zooniverse/react-components": "~1.8.1",
+    "@zooniverse/react-components": "~1.9.0",
     "express": "~4.18.2",
     "grommet": "~2.34.0",
     "grommet-icons": "~4.11.0",

--- a/packages/app-root/src/components/PageContextProviders.js
+++ b/packages/app-root/src/components/PageContextProviders.js
@@ -1,11 +1,12 @@
 'use client'
 
 import zooTheme from '@zooniverse/grommet-theme'
+import { usePanoptesUser } from '@zooniverse/react-components/hooks'
 import { Grommet } from 'grommet'
 import { createGlobalStyle } from 'styled-components'
 
 import { PanoptesAuthContext } from '../contexts'
-import { useAdminMode, usePanoptesUser } from '../hooks'
+import { useAdminMode } from '../hooks'
 
 const GlobalStyle = createGlobalStyle`
   body {

--- a/packages/app-root/src/components/PageHeader.js
+++ b/packages/app-root/src/components/PageHeader.js
@@ -1,11 +1,8 @@
 'use client'
-import { ZooHeader } from '@zooniverse/react-components'
-import { useContext } from 'react'
-
-import {
-  useUnreadMessages,
-  useUnreadNotifications
-} from '../hooks'
+import { AuthModal, ZooHeader } from '@zooniverse/react-components'
+import { useUnreadMessages, useUnreadNotifications } from '@zooniverse/react-components/hooks'
+import auth from 'panoptes-client/lib/auth'
+import { useContext, useState } from 'react'
 
 import { PanoptesAuthContext } from '../contexts'
 
@@ -13,11 +10,36 @@ export default function PageHeader() {
   const { adminMode, user } = useContext(PanoptesAuthContext)
   const { data: unreadMessages }= useUnreadMessages(user)
   const { data: unreadNotifications }= useUnreadNotifications(user)
+  const [activeIndex, setActiveIndex] = useState(-1)
+
+  function openRegisterModal() {
+    setActiveIndex(1)
+  }
+
+  function openSignInModal() {
+    setActiveIndex(0)
+  }
+
+  function onSignOut() {
+    auth.signOut()
+  }
+
+  function closeAuthModal() {
+    setActiveIndex(-1)
+  }
 
   return (
     <header aria-label='Zooniverse site header'>
+      <AuthModal
+        activeIndex={activeIndex}
+        closeModal={closeAuthModal}
+        onActive={setActiveIndex}
+      />
       <ZooHeader
         isAdmin={adminMode}
+        register={openRegisterModal}
+        signIn={openSignInModal}
+        signOut={onSignOut}
         unreadMessages={unreadMessages}
         unreadNotifications={unreadNotifications}
         user={user}

--- a/packages/app-root/src/helpers/index.js
+++ b/packages/app-root/src/helpers/index.js
@@ -1,1 +1,0 @@
-export { default as fetchPanoptesUser } from './fetchPanoptesUser.js'

--- a/packages/app-root/src/hooks/index.js
+++ b/packages/app-root/src/hooks/index.js
@@ -1,4 +1,1 @@
 export { default as useAdminMode } from './useAdminMode.js'
-export { default as usePanoptesUser } from './usePanoptesUser.js'
-export { default as useUnreadMessages } from './useUnreadMessages.js'
-export { default as useUnreadNotifications } from './useUnreadNotifications.js'

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -80,7 +80,7 @@
     "@wojtekmaj/enzyme-adapter-react-17": "~0.8.0",
     "@zooniverse/grommet-theme": "~3.2.0",
     "@zooniverse/panoptes-js": "~0.5.0",
-    "@zooniverse/react-components": "~1.8.1",
+    "@zooniverse/react-components": "~1.9.0",
     "@zooniverse/standard": "~2.0.0",
     "babel-loader": "~9.1.0",
     "babel-plugin-module-resolver": "~5.0.0",

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.9.0] 2023-11-08
+
+### Added
+- `AuthModal` component for Zooniverse username/password sign-in, and Zooniverse user registration.
+- New hooks for working with authenticated Panoptes users:
+  - `usePanoptesUser`: exchange a Panoptes session cookie for an authenticated user session.
+  - `useUnreadMessages`: check unread private messages.
+  - `useUnreadNotifications`: check unread Talk notifications.
+
 ## [1.8.1] 2023-11-02
 
 ### Fixed

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -3,7 +3,7 @@
   "description": "Zooniverse React Components",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {
@@ -48,6 +48,7 @@
     "i18next": "~23.7.1",
     "markdownz": "~9.1.3",
     "mime": "~3.0.0",
+    "panoptes-client": "~5.5.6",
     "polished": "~4.2.2",
     "prop-types": "~15.8.1",
     "react-i18next": "~13.4.1",

--- a/packages/lib-react-components/src/AuthModal/AuthModal.js
+++ b/packages/lib-react-components/src/AuthModal/AuthModal.js
@@ -1,0 +1,79 @@
+import { func, number, shape, string } from 'prop-types'
+import styled, { css } from 'styled-components'
+
+import Modal from '../Modal'
+import Tabs from '../Tabs'
+import Tab from '../Tab'
+import withThemeContext from '../helpers/withThemeContext'
+import { useTranslation } from '../translations/i18n'
+import authModalTheme from './theme'
+import LoginForm from './components/LoginForm'
+import RegisterForm from './components/RegisterForm'
+
+const StyledTabs = styled(Tabs)`
+  div[role="tabpanel"] {
+    ${css`background: ${props => props.theme.dark
+    ? props.theme.global.colors['dark-5']
+    : props.theme.global.colors['white']
+};`}
+    overflow: auto;
+  }
+  button[role="tab"][aria-selected="true"] > div {
+    ${css`background: ${props => props.theme.dark
+    ? props.theme.global.colors['dark-5']
+    : props.theme.global.colors['white']
+};`}
+  }
+`
+
+/**
+  A modal dialog that provides a choice to either sign-in to your Zooniverse account, or create a new account.
+  Password reset is handled by a link to the reset page. Sign-in is handled by the [Panoptes JS
+  Client](https://zooniverse.github.io/panoptes-javascript-client/#panoptes-javascript-client-auth), using the
+  [OAuth password flow](https://oauth.net/2/grant-types/password/).
+*/
+function AuthModal({
+  activeIndex = -1,
+  className = '',
+  closeModal,
+  project,
+  onActive
+}) {
+  const { t } = useTranslation()
+  return (
+    <Modal
+      active={activeIndex > -1}
+      aria-label={t("AuthModal.title")}
+      aria-modal='true'
+      className={className}
+      closeFn={closeModal}
+      role='dialog'
+    >
+      <StyledTabs activeIndex={activeIndex} onActive={onActive}>
+        <Tab title='Sign In'>
+          <LoginForm closeModal={closeModal} />
+        </Tab>
+        <Tab title='Register'>
+          <RegisterForm closeModal={closeModal} project={project} />
+        </Tab>
+      </StyledTabs>
+    </Modal>
+  )
+}
+
+AuthModal.propTypes = {
+  /** Active tab index: -1 (no selection), 0 (sign in), or 1 (register.) */
+  activeIndex: number,
+  /** Optional CSS class(es.) */
+  className: string,
+  /** Callback function to reset the active tab index */
+  closeModal: func.isRequired,
+  /** Optional Zooniverse project. */
+  project: shape({
+    id: string
+  }),
+  /** Callback to switch the active tab. */
+  onActive: func
+}
+
+export default withThemeContext(AuthModal, authModalTheme)

--- a/packages/lib-react-components/src/AuthModal/AuthModal.js
+++ b/packages/lib-react-components/src/AuthModal/AuthModal.js
@@ -50,10 +50,10 @@ function AuthModal({
       role='dialog'
     >
       <StyledTabs activeIndex={activeIndex} onActive={onActive}>
-        <Tab title='Sign In'>
+        <Tab title={t("AuthModal.LoginForm.signIn")}>
           <LoginForm closeModal={closeModal} />
         </Tab>
-        <Tab title='Register'>
+        <Tab title={t("AuthModal.RegisterForm.register")}>
           <RegisterForm closeModal={closeModal} project={project} />
         </Tab>
       </StyledTabs>

--- a/packages/lib-react-components/src/AuthModal/AuthModal.spec.js
+++ b/packages/lib-react-components/src/AuthModal/AuthModal.spec.js
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react'
+import { composeStory } from '@storybook/react'
+
+import Meta, * as Stories from './AuthModal.stories.js'
+
+describe('AuthModal', function () {
+  describe('Sign in', function () {
+    it('should render a modal dialog', function () {
+      const Story = composeStory(Stories.SignIn, Meta)
+      render(<Story />)
+      const dialog = screen.getByRole('dialog', { name: 'Sign in or create a new account.' })
+      expect(dialog).to.exist()
+    })
+
+    it('should show username and password fields', function () {
+      const Story = composeStory(Stories.SignIn, Meta)
+      render(<Story />)
+      const username = screen.getByRole('textbox', { name: 'Username or email address' })
+      const password = document.querySelector('input[type=password]')
+      expect(username).to.exist()
+      expect(password).to.exist()
+    })
+  })
+
+  describe('Register', function () {
+    it('should render a modal dialog', function () {
+      const Story = composeStory(Stories.Register, Meta)
+      render(<Story />)
+      const dialog = screen.getByRole('dialog', { name: 'Sign in or create a new account.' })
+      expect(dialog).to.exist()
+    })
+
+    it('should collect username, password, email, and real name', function () {
+      const Story = composeStory(Stories.Register, Meta)
+      render(<Story />)
+      const username = screen.getByRole('textbox', { name: 'Username (Required)' })
+      const email = screen.getByRole('textbox', { name: 'Email Address (Required)' })
+      const emailConfirm = screen.getByRole('textbox', { name: 'Confirm Email Address (Required)' })
+      const realName = screen.getByRole('textbox', { name: 'Real Name (Optional)' })
+      const password = document.querySelector('input[type=password][name=password]')
+      const passwordConfirm = document.querySelector('input[type=password][name=passwordConfirm]')
+      expect(username).to.exist()
+      expect(email).to.exist()
+      expect(emailConfirm).to.exist()
+      expect(realName).to.exist()
+      expect(password).to.exist()
+      expect(passwordConfirm).to.exist()
+    })
+
+    it('should show checkboxes for privacy, email preferences and age.', function () {
+      const Story = composeStory(Stories.Register, Meta)
+      render(<Story />)
+      const privacy = screen.getByRole('checkbox', { name: 'You agree to our privacy policy (required)' })
+      const emailPrefs = screen.getByRole('checkbox', { name: 'It\'s ok to send me an email every once in a while (optional)' })
+      const betaPrefs = screen.getByRole('checkbox', { name: 'I\'d like to help test new projects and be emailed when they\'re available (optional)' })
+      const underAge = screen.getByRole('checkbox', { name: 'If you are under 16 years old, tick this box to confirm that you\'ve completed the form with your parent or guardian' })
+      expect(privacy).to.exist()
+      expect(emailPrefs).to.exist()
+      expect(betaPrefs).to.exist()
+      expect(underAge).to.exist()
+    })
+  })
+})

--- a/packages/lib-react-components/src/AuthModal/AuthModal.stories.js
+++ b/packages/lib-react-components/src/AuthModal/AuthModal.stories.js
@@ -1,0 +1,37 @@
+import { useState } from 'react'
+import AuthModal from './'
+
+export default {
+  title: 'Components / AuthModal',
+  component: AuthModal
+}
+
+export function SignIn() {
+  const [activeIndex, setActiveIndex] = useState(0)
+  function closeModal() {
+    setActiveIndex(-1)
+  }
+  function signIn() {
+    setActiveIndex(0);
+  }
+
+  return [
+    <button onClick={signIn}>Sign In</button>,
+    <AuthModal activeIndex={activeIndex} closeModal={closeModal} onActive={setActiveIndex} />
+  ]
+}
+
+export function Register() {
+  const [activeIndex, setActiveIndex] = useState(1)
+  function closeModal() {
+    setActiveIndex(-1)
+  }
+  function register() {
+    setActiveIndex(1);
+  }
+
+  return [
+    <button onClick={register}>Register</button>,
+    <AuthModal activeIndex={activeIndex} closeModal={closeModal} onActive={setActiveIndex} />
+  ]
+}

--- a/packages/lib-react-components/src/AuthModal/Readme.md
+++ b/packages/lib-react-components/src/AuthModal/Readme.md
@@ -1,0 +1,33 @@
+# AuthModal
+
+A modal dialog that provides a choice to either sign-in to your Zooniverse account, or create a new account. Password reset is handled by a link to the reset page. Sign-in is handled by the [Panoptes JS Client](https://zooniverse.github.io/panoptes-javascript-client/#panoptes-javascript-client-auth), using the [OAuth password flow](https://oauth.net/2/grant-types/password/).
+
+```js
+import { AuthModal } from '@zooniverse/react-components';
+import { useState } from 'react';
+
+function MyAuthComponent() {
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  // Sign in by activating the Sign In tab.
+  function signIn() {
+    setActiveIndex(0);
+  }
+
+  // Register by activating the Register tab.
+  function register() {
+    setActiveIndex(1);
+  }
+
+  // Close the modal by deselecting the active tab.
+  function closeModal() {
+    setActiveIndex(-1);
+  }
+
+  return (
+    <button onClick={signIn}>Sign In</button>
+    <button onClick={register}>Register</button>
+    <AuthModal activeIndex={activeIndex} onActive={setActiveIndex} closeModal={closeModal} />
+  );
+}
+```

--- a/packages/lib-react-components/src/AuthModal/Readme.md
+++ b/packages/lib-react-components/src/AuthModal/Readme.md
@@ -1,6 +1,6 @@
 # AuthModal
 
-A modal dialog that provides a choice to either sign-in to your Zooniverse account, or create a new account. Password reset is handled by a link to the reset page. Sign-in is handled by the [Panoptes JS Client](https://zooniverse.github.io/panoptes-javascript-client/#panoptes-javascript-client-auth), using the [OAuth password flow](https://oauth.net/2/grant-types/password/).
+A modal dialog that provides a tabbed interface to either sign-in to your Zooniverse account, or create a new account. Password reset is handled by a link to the reset page. Sign-in is handled by the [Panoptes JS Client](https://zooniverse.github.io/panoptes-javascript-client/#panoptes-javascript-client-auth), using the [OAuth password flow](https://oauth.net/2/grant-types/password/). The selected tab state is controlled via component props.
 
 ```js
 import { AuthModal } from '@zooniverse/react-components';

--- a/packages/lib-react-components/src/AuthModal/components/LoginForm/LoginForm.js
+++ b/packages/lib-react-components/src/AuthModal/components/LoginForm/LoginForm.js
@@ -4,9 +4,17 @@ import { func, string } from 'prop-types'
 import Form from './components/Form'
 import { useTranslation } from '../../../translations/i18n'
 
-function LoginForm (props) {
+const DEFAULT_VALUES = {
+  login: '',
+  password: ''
+}
+const DEFAULT_HANDLER = () => true
+
+function LoginForm ({
+  generalError = '',
+  onSubmit = DEFAULT_HANDLER
+}) {
   const { t } = useTranslation()
-  const { generalError, onSubmit, validate } = props
   return (
     <Box width='medium'>
       <Heading size='small' margin={{ bottom: 'xsmall', top: 'none' }}>
@@ -20,15 +28,11 @@ function LoginForm (props) {
         <Text color={{ light: 'status-critical', dark: 'status-error' }} role='alert'>{generalError}</Text>}
 
       <Form
-        initialValues={{ login: '', password: '' }}
+        initialValues={DEFAULT_VALUES}
         onSubmit={onSubmit}
       />
     </Box>
   )
-}
-
-LoginForm.defaultProps = {
-  generalError: ''
 }
 
 LoginForm.propTypes = {

--- a/packages/lib-react-components/src/AuthModal/components/LoginForm/LoginForm.js
+++ b/packages/lib-react-components/src/AuthModal/components/LoginForm/LoginForm.js
@@ -1,0 +1,39 @@
+import { Box, Heading, Text } from 'grommet'
+import { func, string } from 'prop-types'
+
+import Form from './components/Form'
+import { useTranslation } from '../../../translations/i18n'
+
+function LoginForm (props) {
+  const { t } = useTranslation()
+  const { generalError, onSubmit, validate } = props
+  return (
+    <Box width='medium'>
+      <Heading size='small' margin={{ bottom: 'xsmall', top: 'none' }}>
+        {t('AuthModal.LoginForm.heading')}
+      </Heading>
+      <Text>
+        {t('AuthModal.LoginForm.instruction')}
+      </Text>
+
+      {generalError &&
+        <Text color={{ light: 'status-critical', dark: 'status-error' }} role='alert'>{generalError}</Text>}
+
+      <Form
+        initialValues={{ login: '', password: '' }}
+        onSubmit={onSubmit}
+      />
+    </Box>
+  )
+}
+
+LoginForm.defaultProps = {
+  generalError: ''
+}
+
+LoginForm.propTypes = {
+  generalError: string,
+  onSubmit: func.isRequired
+}
+
+export default LoginForm

--- a/packages/lib-react-components/src/AuthModal/components/LoginForm/LoginFormContainer.js
+++ b/packages/lib-react-components/src/AuthModal/components/LoginForm/LoginFormContainer.js
@@ -1,5 +1,5 @@
 import auth from 'panoptes-client/lib/auth'
-import { func, shape } from 'prop-types'
+import { func } from 'prop-types'
 import { useState } from 'react'
 
 import { useTranslation } from '../../../translations/i18n'
@@ -35,4 +35,8 @@ export default function LoginFormContainer({
   return (
     <LoginForm generalError={error} onSubmit={onSubmit} />
   )
+}
+
+LoginFormContainer.propTypes = {
+  closeModal: func
 }

--- a/packages/lib-react-components/src/AuthModal/components/LoginForm/LoginFormContainer.js
+++ b/packages/lib-react-components/src/AuthModal/components/LoginForm/LoginFormContainer.js
@@ -1,0 +1,38 @@
+import auth from 'panoptes-client/lib/auth'
+import { func, shape } from 'prop-types'
+import { useState } from 'react'
+
+import { useTranslation } from '../../../translations/i18n'
+import LoginForm from './LoginForm'
+
+const DEFAULT_HANDLER = () => true
+
+export default function LoginFormContainer({
+  closeModal = DEFAULT_HANDLER
+}) {
+  const { t } = useTranslation()
+  const [error, setError] = useState('')
+
+  async function onSubmit(values, { setFieldError, setSubmitting }) {
+    if (error) setError('')
+    try {
+      const user = await auth.signIn(values)
+      setSubmitting(false)
+      closeModal()
+    } catch (error) {
+      console.error(error)
+      if (error && error.message === 'Invalid email or password.') {
+        const errorMessage = t('AuthModal.LoginForm.error')
+        setFieldError('login', errorMessage)
+        setFieldError('password', errorMessage)
+      } else {
+        setError(error.message)
+      }
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <LoginForm generalError={error} onSubmit={onSubmit} />
+  )
+}

--- a/packages/lib-react-components/src/AuthModal/components/LoginForm/components/Form/Form.js
+++ b/packages/lib-react-components/src/AuthModal/components/LoginForm/components/Form/Form.js
@@ -21,6 +21,7 @@ function Form({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, to
         label={<FieldLabel>{t('AuthModal.LoginForm.login')}</FieldLabel>}
       >
         <TextInput
+          autoComplete='username'
           autoFocus
           disabled={isSubmitting}
           focusIndicator
@@ -41,6 +42,7 @@ function Form({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, to
         label={<FieldLabel>{t('AuthModal.LoginForm.password')}</FieldLabel>}
       >
         <TextInput
+          autocomplete='password'
           disabled={isSubmitting}
           focusIndicator
           id={passwordFieldId}

--- a/packages/lib-react-components/src/AuthModal/components/LoginForm/components/Form/Form.js
+++ b/packages/lib-react-components/src/AuthModal/components/LoginForm/components/Form/Form.js
@@ -10,7 +10,22 @@ import FieldLabel from '../../../../shared/components/FieldLabel'
 export const userNameFieldId = 'LoginForm_login'
 export const passwordFieldId = 'LoginForm_password'
 
-function Form({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, touched, values }) {
+const DEFAULT_VALUES = {
+  login: '',
+  password: ''
+}
+const DEFAULT_HANDLER = () => true
+const DEFAULT_OBJECT = {}
+
+function Form({
+  errors = DEFAULT_OBJECT,
+  handleBlur = DEFAULT_HANDLER,
+  handleChange = DEFAULT_HANDLER,
+  handleSubmit = DEFAULT_HANDLER,
+  isSubmitting = false,
+  touched = DEFAULT_OBJECT,
+  values = DEFAULT_VALUES
+}) {
   const { t } = useTranslation()
   return (
     <Box as='form' onSubmit={handleSubmit} margin={{ top: 'small' }}>
@@ -73,19 +88,6 @@ function Form({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, to
   )
 }
 
-Form.defaultProps = {
-  errors: {},
-  handleBlur: () => { },
-  handleChange: () => { },
-  handleSubmit: () => { },
-  isSubmitting: false,
-  touched: {},
-  values: {
-    login: '',
-    password: ''
-  }
-}
-
 Form.propTypes = {
   errors: PropTypes.object,
   handleBlur: PropTypes.func,
@@ -97,4 +99,3 @@ Form.propTypes = {
 }
 
 export default withCustomFormik(Form)
-export { Form }

--- a/packages/lib-react-components/src/AuthModal/components/LoginForm/components/Form/Form.js
+++ b/packages/lib-react-components/src/AuthModal/components/LoginForm/components/Form/Form.js
@@ -1,0 +1,98 @@
+/* eslint-disable jsx-a11y/no-autofocus */
+import { Anchor, Box, Button, FormField, TextInput } from 'grommet'
+import PropTypes from 'prop-types'
+
+import { SpacedText } from '../../../../../'
+import withCustomFormik from '../../../../../helpers/withCustomFormik'
+import { useTranslation } from '../../../../../translations/i18n'
+import FieldLabel from '../../../../shared/components/FieldLabel'
+
+export const userNameFieldId = 'LoginForm_login'
+export const passwordFieldId = 'LoginForm_password'
+
+function Form({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, touched, values }) {
+  const { t } = useTranslation()
+  return (
+    <Box as='form' onSubmit={handleSubmit} margin={{ top: 'small' }}>
+
+      <FormField
+        error={errors.login && touched.login && errors.login}
+        htmlFor={userNameFieldId}
+        label={<FieldLabel>{t('AuthModal.LoginForm.login')}</FieldLabel>}
+      >
+        <TextInput
+          autoFocus
+          disabled={isSubmitting}
+          focusIndicator
+          id={userNameFieldId}
+          name='login'
+          onBlur={handleBlur}
+          onChange={handleChange}
+          placeholder={t('AuthModal.LoginForm.placeholder')}
+          required
+          type='text'
+          value={values.login}
+        />
+      </FormField>
+
+      <FormField
+        error={errors.password && touched.password && errors.password}
+        htmlFor={passwordFieldId}
+        label={<FieldLabel>{t('AuthModal.LoginForm.password')}</FieldLabel>}
+      >
+        <TextInput
+          disabled={isSubmitting}
+          focusIndicator
+          id={passwordFieldId}
+          name='password'
+          onChange={handleChange}
+          onBlur={handleBlur}
+          required
+          type='password'
+          value={values.password}
+        />
+      </FormField>
+
+      <Box align='center' margin={{ bottom: 'small' }}>
+        <Anchor href='/reset-password' size='small'>
+          <SpacedText>
+            {t('AuthModal.LoginForm.forgot')}
+          </SpacedText>
+        </Anchor>
+      </Box>
+
+      <Button
+        disabled={isSubmitting}
+        label={t('AuthModal.LoginForm.signIn')}
+        primary
+        type='submit'
+      />
+    </Box>
+  )
+}
+
+Form.defaultProps = {
+  errors: {},
+  handleBlur: () => { },
+  handleChange: () => { },
+  handleSubmit: () => { },
+  isSubmitting: false,
+  touched: {},
+  values: {
+    login: '',
+    password: ''
+  }
+}
+
+Form.propTypes = {
+  errors: PropTypes.object,
+  handleBlur: PropTypes.func,
+  handleChange: PropTypes.func,
+  handleSubmit: PropTypes.func,
+  isSubmitting: PropTypes.bool,
+  touched: PropTypes.object,
+  values: PropTypes.object
+}
+
+export default withCustomFormik(Form)
+export { Form }

--- a/packages/lib-react-components/src/AuthModal/components/LoginForm/components/Form/index.js
+++ b/packages/lib-react-components/src/AuthModal/components/LoginForm/components/Form/index.js
@@ -1,0 +1,1 @@
+export { default } from './Form'

--- a/packages/lib-react-components/src/AuthModal/components/LoginForm/index.js
+++ b/packages/lib-react-components/src/AuthModal/components/LoginForm/index.js
@@ -1,0 +1,1 @@
+export { default } from './LoginFormContainer'

--- a/packages/lib-react-components/src/AuthModal/components/RegisterForm/RegisterForm.js
+++ b/packages/lib-react-components/src/AuthModal/components/RegisterForm/RegisterForm.js
@@ -1,0 +1,51 @@
+import PropTypes from 'prop-types'
+import { Box, Heading, Text } from 'grommet'
+
+import Form from './components/Form'
+import { useTranslation } from '../../../translations/i18n'
+
+function RegisterForm ({ generalError, validate, onSubmit }) {
+  const initialValues = {
+    betaListSignUp: false,
+    email: '',
+    emailConfirm: '',
+    emailListSignUp: false,
+    password: '',
+    passwordConfirm: '',
+    privacyAgreement: false,
+    realName: '',
+    username: '',
+    underageWithParent: false
+  }
+
+  const { t } = useTranslation()
+
+  return (
+    <Box width='large'>
+      <Heading size='small' margin={{ bottom: 'xsmall', top: 'none' }}>
+        {t('AuthModal.RegisterForm.heading')}
+      </Heading>
+      <Text>
+        {t('AuthModal.RegisterForm.instruction')}
+      </Text>
+
+      {generalError &&
+        <Text color={{ light: 'status-critical', dark: 'status-error' }} role='alert'>{generalError}</Text>}
+
+      <Form initialValues={initialValues} onSubmit={onSubmit} validate={validate} />
+    </Box>
+  )
+}
+
+RegisterForm.propTypes = {
+  generalError: PropTypes.string,
+  onSubmit: PropTypes.func.isRequired,
+  validate: PropTypes.func
+}
+
+RegisterForm.defaultProps = {
+  generalError: '',
+  validate: () => {}
+}
+
+export default RegisterForm

--- a/packages/lib-react-components/src/AuthModal/components/RegisterForm/RegisterForm.js
+++ b/packages/lib-react-components/src/AuthModal/components/RegisterForm/RegisterForm.js
@@ -4,20 +4,25 @@ import { Box, Heading, Text } from 'grommet'
 import Form from './components/Form'
 import { useTranslation } from '../../../translations/i18n'
 
-function RegisterForm ({ generalError, validate, onSubmit }) {
-  const initialValues = {
-    betaListSignUp: false,
-    email: '',
-    emailConfirm: '',
-    emailListSignUp: false,
-    password: '',
-    passwordConfirm: '',
-    privacyAgreement: false,
-    realName: '',
-    username: '',
-    underageWithParent: false
-  }
+const DEFAULT_VALUES = {
+  betaListSignUp: false,
+  email: '',
+  emailConfirm: '',
+  emailListSignUp: false,
+  password: '',
+  passwordConfirm: '',
+  privacyAgreement: false,
+  realName: '',
+  username: '',
+  underageWithParent: false
+}
+const DEFAULT_HANDLER = () => true
 
+function RegisterForm ({
+  generalError = '',
+  validate = DEFAULT_HANDLER,
+  onSubmit = DEFAULT_HANDLER
+}) {
   const { t } = useTranslation()
 
   return (
@@ -32,7 +37,7 @@ function RegisterForm ({ generalError, validate, onSubmit }) {
       {generalError &&
         <Text color={{ light: 'status-critical', dark: 'status-error' }} role='alert'>{generalError}</Text>}
 
-      <Form initialValues={initialValues} onSubmit={onSubmit} validate={validate} />
+      <Form initialValues={DEFAULT_VALUES} onSubmit={onSubmit} validate={validate} />
     </Box>
   )
 }

--- a/packages/lib-react-components/src/AuthModal/components/RegisterForm/RegisterFormContainer.js
+++ b/packages/lib-react-components/src/AuthModal/components/RegisterForm/RegisterFormContainer.js
@@ -1,0 +1,94 @@
+import auth from 'panoptes-client/lib/auth'
+import { func, shape, string } from 'prop-types'
+import { useState } from 'react'
+
+import { useTranslation } from '../../../translations/i18n'
+import RegisterForm from './RegisterForm'
+
+const DEFAULT_HANDLER = () => true
+
+// The error handler in the panoptes-javascript-client still doesn't return the vanilla error message
+// It swallows an error message array into a string, so now we have to do things like this :(
+function errorTest(errorMessage, regex) {
+  return regex.test(errorMessage)
+}
+
+function validationErrors({ email, emailConfirm, password, passwordConfirm, privacyAgreement }) {
+  let errors = {}
+  if (email !== emailConfirm) {
+    errors.emailConfirm = 'AuthModal.RegisterForm.emailConfirmError'
+  }
+  if (password !== passwordConfirm) {
+    errors.passwordConfirm = 'AuthModal.RegisterForm.passwordConfirmError'
+  }
+  if (!privacyAgreement) {
+    errors.privacyAgreement = 'AuthModal.RegisterForm.privacyAgreementError'
+  }
+  return Object.entries(errors)
+}
+
+export default function RegisterFormContainer({
+  closeModal = DEFAULT_HANDLER,
+  project = null
+}) {
+  const { t } = useTranslation()
+  const [error, setError] = useState('')
+
+  function validate(values) {
+    const errorKeys = validationErrors(values)
+    const errorMessages = errorKeys.map(([field, translationKey]) => [field, t(translationKey)])
+    return Object.fromEntries(errorMessages)
+  }
+
+  async function onSubmit(values, { setFieldError, setSubmitting }) {
+    console.log('submitting...')
+    const { betaListSignUp, email, emailListSignUp, password, realName, username } = values
+    const emailErrorRegex = /email(.+)taken/mi
+    const usernameErrorRegex = /login(.+)taken/mi
+    const valuesToSubmit = {
+      beta_email_communication: betaListSignUp,
+      credited_name: realName,
+      email,
+      global_email_communication: emailListSignUp,
+      login: username,
+      password,
+      project_email_communication: emailListSignUp,
+      project_id: project?.id
+    }
+
+    try {
+      await auth.register(valuesToSubmit)
+      setSubmitting(false)
+      closeModal()
+    } catch (error) {
+      console.error(error)
+      const usernameConflict = errorTest(error.message, emailErrorRegex)
+      const emailConflict = errorTest(error.message, usernameErrorRegex)
+      if (usernameConflict) {
+        setFieldError('email', t('AuthModal.RegisterForm.emailConflict'))
+      }
+      if (emailConflict) {
+        setFieldError('username', t('AuthModal.RegisterForm.usernameConflict'))
+      }
+      if (error.message && !usernameConflict && !emailConflict) {
+        setError(error.message)
+      }
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <RegisterForm
+      generalError={error}
+      onSubmit={onSubmit}
+      validate={validate}
+    />
+  )
+}
+
+RegisterFormContainer.propTypes = {
+  closeModal: func,
+  project: shape({
+    id: string
+  })
+}

--- a/packages/lib-react-components/src/AuthModal/components/RegisterForm/components/Form/Form.js
+++ b/packages/lib-react-components/src/AuthModal/components/RegisterForm/components/Form/Form.js
@@ -30,7 +30,29 @@ const contentProps = {
   gap: 'xsmall'
 }
 
-function Form ({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, values }) {
+const DEFAULT_VALUES = {
+  betaListSignUp: false,
+  email: '',
+  emailConfirm: '',
+  emailListSignUp: false,
+  password: '',
+  passwordConfirm: '',
+  privacyAgreement: false,
+  realName: '',
+  username: '',
+  underageWithParent: false
+}
+const DEFAULT_HANDLER = () => true
+const DEFAULT_OBJECT = {}
+
+function Form ({
+  errors = DEFAULT_OBJECT,
+  handleBlur = DEFAULT_HANDLER,
+  handleChange = DEFAULT_HANDLER,
+  handleSubmit = DEFAULT_HANDLER,
+  isSubmitting = false,
+  values = DEFAULT_VALUES
+}) {
   const { t } = useTranslation()
   const userNameFieldHelp = (values.underageWithParent)
     ? t('AuthModal.RegisterForm.underageNotRealName')
@@ -262,26 +284,6 @@ function Form ({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, v
   )
 }
 
-Form.defaultProps = {
-  errors: {},
-  handleBlur: () => {},
-  handleChange: () => {},
-  handleSubmit: () => {},
-  isSubmitting: false,
-  values: {
-    betaListSignUp: false,
-    email: '',
-    emailConfirm: '',
-    emailListSignUp: false,
-    password: '',
-    passwordConfirm: '',
-    privacyAgreement: false,
-    realName: '',
-    username: '',
-    underageWithParent: false
-  }
-}
-
 Form.propTypes = {
   errors: PropTypes.object,
   handleBlur: PropTypes.func,
@@ -292,4 +294,3 @@ Form.propTypes = {
 }
 
 export default withCustomFormik(Form)
-export { Form }

--- a/packages/lib-react-components/src/AuthModal/components/RegisterForm/components/Form/Form.js
+++ b/packages/lib-react-components/src/AuthModal/components/RegisterForm/components/Form/Form.js
@@ -1,0 +1,289 @@
+import PropTypes from 'prop-types'
+import { Anchor, Box, Button, CheckBox, Grid, Text, FormField, TextInput } from 'grommet'
+import styled from 'styled-components'
+
+import FieldLabel from '../../../../shared/components/FieldLabel'
+import withCustomFormik from '../../../../../helpers/withCustomFormik'
+import { useTranslation } from '../../../../../translations/i18n'
+
+export const userNameFieldId = 'RegisterForm_username'
+export const passwordFieldId = 'RegisterForm_password'
+export const passwordConfirmFieldId = 'RegisterForm_password_confirm'
+export const emailFieldId = 'RegisterForm_email'
+export const emailConfirmFieldId = 'RegisterForm_email_confirm'
+export const realNameFieldId = 'RegisterForm_real_name'
+export const privacyAgreementFieldId = 'RegisterForm_privacy_agreement'
+export const emailListSignUpFieldId = 'RegisterForm_email_list_sign_up'
+export const betaListSignUpFieldId = 'RegisterForm_beta_list_sign_up'
+export const underageWithParentFieldId = 'RegisterForm_underage_with_parent'
+
+const PrivacyPolicyLink = () => {
+  const { t } = useTranslation()
+  return (
+    <Anchor href='/privacy' size='small'>{t('AuthModal.RegisterForm.privacyLink')}</Anchor>
+  )
+}
+
+// default form field box layout.
+const contentProps = {
+  direction: 'row',
+  gap: 'xsmall'
+}
+
+function Form ({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, values }) {
+  const { t } = useTranslation()
+  const userNameFieldHelp = (values.underageWithParent)
+    ? t('AuthModal.RegisterForm.underageNotRealName')
+    : t('AuthModal.RegisterForm.usernameHelp')
+  const privacyAgreementLabel = (values.underageWithParent)
+    ? <Text>{t('AuthModal.RegisterForm.underageConsent')}</Text>
+    : <Text>{t('AuthModal.RegisterForm.privacyAgreement')}</Text>
+  const emailListSignUpLabel = (values.underageWithParent)
+    ? <Text>{t('AuthModal.RegisterForm.underageEmailSignUp')}</Text>
+    : <Text>{t('AuthModal.RegisterForm.emailListSignUp')}</Text>
+  const emailInputLabel = (values.underageWithParent)
+    ? <FieldLabel>{t('AuthModal.RegisterForm.underageEmail')}</FieldLabel>
+    : <FieldLabel>{t('AuthModal.RegisterForm.email')}</FieldLabel>
+
+  return (
+    <Box as='form' onSubmit={handleSubmit} margin={{ top: 'small' }}>
+      <Box>
+        <FormField
+          htmlFor={underageWithParentFieldId}
+        >
+          <CheckBox
+            autoFocus
+            checked={values.underageWithParent}
+            disabled={isSubmitting}
+            focusIndicator
+            id={underageWithParentFieldId}
+            label={<Text>{t('AuthModal.RegisterForm.underageWithParent')}</Text>}
+            name='underageWithParent'
+            onChange={handleChange}
+            onBlur={handleBlur}
+          />
+        </FormField>
+      </Box>
+      <Grid columns={['1fr', '1fr']} gap='medium'>
+        <Box>
+          <FormField
+            error={errors.username}
+            help={userNameFieldHelp}
+            htmlFor={userNameFieldId}
+            label={<FieldLabel>{t('AuthModal.RegisterForm.username')}</FieldLabel>}
+            required
+          >
+            <TextInput
+              disabled={isSubmitting}
+              focusIndicator
+              id={userNameFieldId}
+              name='username'
+              onBlur={handleBlur}
+              onChange={handleChange}
+              pattern='[a-zA-Z0-9_\-.]+'
+              placeholder={t('AuthModal.RegisterForm.usernamePlaceholder')}
+              required
+              title={t('AuthModal.RegisterForm.usernamePatternHelp')}
+              type='text'
+              value={values.username}
+            />
+          </FormField>
+
+          <FormField
+            htmlFor={passwordFieldId}
+            label={<FieldLabel>{t('AuthModal.RegisterForm.password')}</FieldLabel>}
+            required
+          >
+            <TextInput
+              disabled={isSubmitting}
+              focusIndicator
+              id={passwordFieldId}
+              minLength={8}
+              name='password'
+              onChange={handleChange}
+              onBlur={handleBlur}
+              required
+              type='password'
+              value={values.password}
+            />
+          </FormField>
+
+          <FormField
+            error={errors.passwordConfirm}
+            htmlFor={passwordConfirmFieldId}
+            label={<FieldLabel>{t('AuthModal.RegisterForm.passwordConfirm')}</FieldLabel>}
+            required
+          >
+            <TextInput
+              disabled={isSubmitting}
+              focusIndicator
+              id={passwordConfirmFieldId}
+              minLength={8}
+              name='passwordConfirm'
+              onChange={handleChange}
+              onBlur={handleBlur}
+              required
+              type='password'
+              value={values.passwordConfirm}
+            />
+          </FormField>
+        </Box>
+
+        <Box>
+          <FormField
+            error={errors.email}
+            htmlFor={emailFieldId}
+            label={emailInputLabel}
+            required
+          >
+            <TextInput
+              disabled={isSubmitting}
+              focusIndicator
+              id={emailFieldId}
+              name='email'
+              onChange={handleChange}
+              onBlur={handleBlur}
+              placeholder={t('AuthModal.RegisterForm.emailPlaceholder')}
+              required
+              type='email'
+              value={values.email}
+            />
+          </FormField>
+
+          <FormField
+            error={errors.emailConfirm}
+            htmlFor={emailConfirmFieldId}
+            label={<FieldLabel>{t('AuthModal.RegisterForm.emailConfirm')}</FieldLabel>}
+            required
+          >
+            <TextInput
+              disabled={isSubmitting}
+              focusIndicator
+              id={emailConfirmFieldId}
+              name='emailConfirm'
+              onChange={handleChange}
+              onBlur={handleBlur}
+              placeholder={t('AuthModal.RegisterForm.emailPlaceholder')}
+              required
+              type='email'
+              value={values.emailConfirm}
+            />
+          </FormField>
+
+          <FormField
+            help={t('AuthModal.RegisterForm.realNameHelp')}
+            htmlFor={realNameFieldId}
+            label={<FieldLabel>{t('AuthModal.RegisterForm.realName')}</FieldLabel>}
+          >
+            <TextInput
+              disabled={isSubmitting}
+              focusIndicator
+              id={realNameFieldId}
+              name='realName'
+              onChange={handleChange}
+              onBlur={handleBlur}
+              pattern='[^@]+'
+              placeholder={t('AuthModal.RegisterForm.realNamePlaceholder')}
+              title={t('AuthModal.RegisterForm.realNamePatternHelp')}
+              type='text'
+              value={values.realName}
+            />
+          </FormField>
+        </Box>
+      </Grid>
+
+      <Box margin={{ top: 'xsmall' }}>
+        <FormField
+          contentProps={contentProps}
+          error={errors.privacyAgreement}
+          htmlFor={privacyAgreementFieldId}
+          required
+        >
+          <CheckBox
+            checked={values.privacyAgreement}
+            disabled={isSubmitting}
+            focusIndicator
+            id={privacyAgreementFieldId}
+            label={privacyAgreementLabel}
+            name='privacyAgreement'
+            onChange={handleChange}
+            onBlur={handleBlur}
+            required
+          />
+          <Text>
+            (<PrivacyPolicyLink />)
+          </Text>
+        </FormField>
+
+        <FormField
+          htmlFor={emailListSignUpFieldId}
+        >
+          <CheckBox
+            checked={values.emailListSignUp}
+            disabled={isSubmitting}
+            focusIndicator
+            id={emailListSignUpFieldId}
+            label={emailListSignUpLabel}
+            name='emailListSignUp'
+            onChange={handleChange}
+            onBlur={handleBlur}
+          />
+        </FormField>
+
+        <FormField
+          htmlFor={betaListSignUpFieldId}
+        >
+          <CheckBox
+            checked={values.betaListSignUp}
+            disabled={isSubmitting}
+            focusIndicator
+            id={betaListSignUpFieldId}
+            label={<Text>{t('AuthModal.RegisterForm.betaListSignUp')}</Text>}
+            name='betaListSignUp'
+            onChange={handleChange}
+            onBlur={handleBlur}
+          />
+        </FormField>
+      </Box>
+
+      <Button
+        disabled={isSubmitting}
+        label={(isSubmitting) ? t('AuthModal.RegisterForm.registering') : t('AuthModal.RegisterForm.register')}
+        primary
+        type='submit'
+      />
+    </Box>
+  )
+}
+
+Form.defaultProps = {
+  errors: {},
+  handleBlur: () => {},
+  handleChange: () => {},
+  handleSubmit: () => {},
+  isSubmitting: false,
+  values: {
+    betaListSignUp: false,
+    email: '',
+    emailConfirm: '',
+    emailListSignUp: false,
+    password: '',
+    passwordConfirm: '',
+    privacyAgreement: false,
+    realName: '',
+    username: '',
+    underageWithParent: false
+  }
+}
+
+Form.propTypes = {
+  errors: PropTypes.object,
+  handleBlur: PropTypes.func,
+  handleChange: PropTypes.func,
+  handleSubmit: PropTypes.func,
+  isSubmitting: PropTypes.bool,
+  values: PropTypes.object
+}
+
+export default withCustomFormik(Form)
+export { Form }

--- a/packages/lib-react-components/src/AuthModal/components/RegisterForm/components/Form/Form.js
+++ b/packages/lib-react-components/src/AuthModal/components/RegisterForm/components/Form/Form.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types'
 import { Anchor, Box, Button, CheckBox, Grid, Text, FormField, TextInput } from 'grommet'
-import styled from 'styled-components'
 
 import FieldLabel from '../../../../shared/components/FieldLabel'
 import withCustomFormik from '../../../../../helpers/withCustomFormik'

--- a/packages/lib-react-components/src/AuthModal/components/RegisterForm/components/Form/Form.js
+++ b/packages/lib-react-components/src/AuthModal/components/RegisterForm/components/Form/Form.js
@@ -74,6 +74,7 @@ function Form ({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, v
             required
           >
             <TextInput
+              autoComplete='username'
               disabled={isSubmitting}
               focusIndicator
               id={userNameFieldId}
@@ -95,6 +96,7 @@ function Form ({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, v
             required
           >
             <TextInput
+              autoComplete='new-password'
               disabled={isSubmitting}
               focusIndicator
               id={passwordFieldId}
@@ -115,6 +117,7 @@ function Form ({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, v
             required
           >
             <TextInput
+              autoComplete='password'
               disabled={isSubmitting}
               focusIndicator
               id={passwordConfirmFieldId}
@@ -137,6 +140,7 @@ function Form ({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, v
             required
           >
             <TextInput
+              autoComplete='email'
               disabled={isSubmitting}
               focusIndicator
               id={emailFieldId}
@@ -157,6 +161,7 @@ function Form ({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, v
             required
           >
             <TextInput
+              autoComplete='email'
               disabled={isSubmitting}
               focusIndicator
               id={emailConfirmFieldId}
@@ -176,6 +181,7 @@ function Form ({ errors, handleBlur, handleChange, handleSubmit, isSubmitting, v
             label={<FieldLabel>{t('AuthModal.RegisterForm.realName')}</FieldLabel>}
           >
             <TextInput
+              autoComplete='name'
               disabled={isSubmitting}
               focusIndicator
               id={realNameFieldId}

--- a/packages/lib-react-components/src/AuthModal/components/RegisterForm/components/Form/index.js
+++ b/packages/lib-react-components/src/AuthModal/components/RegisterForm/components/Form/index.js
@@ -1,0 +1,1 @@
+export { default } from './Form'

--- a/packages/lib-react-components/src/AuthModal/components/RegisterForm/index.js
+++ b/packages/lib-react-components/src/AuthModal/components/RegisterForm/index.js
@@ -1,0 +1,1 @@
+export { default } from './RegisterFormContainer'

--- a/packages/lib-react-components/src/AuthModal/index.js
+++ b/packages/lib-react-components/src/AuthModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './AuthModal'

--- a/packages/lib-react-components/src/AuthModal/shared/components/FieldLabel/FieldLabel.js
+++ b/packages/lib-react-components/src/AuthModal/shared/components/FieldLabel/FieldLabel.js
@@ -1,0 +1,9 @@
+import SpacedText from '../../../../SpacedText'
+
+function FieldLabel (props) {
+  return (
+    <SpacedText weight='bold' {...props} />
+  )
+}
+
+export default FieldLabel

--- a/packages/lib-react-components/src/AuthModal/shared/components/FieldLabel/index.js
+++ b/packages/lib-react-components/src/AuthModal/shared/components/FieldLabel/index.js
@@ -1,0 +1,1 @@
+export { default } from './FieldLabel'

--- a/packages/lib-react-components/src/AuthModal/theme.js
+++ b/packages/lib-react-components/src/AuthModal/theme.js
@@ -1,0 +1,68 @@
+import { css } from 'styled-components'
+
+const theme = {
+  checkBox: {
+    border: {
+      width: '1px'
+    },
+    check: {
+      radius: '0px'
+    },
+    gap: 'xsmall',
+    size: '16px'
+  },
+  formField: {
+    border: {
+      side: 'all',
+      error: {
+        color: {
+          dark: 'status-error',
+          light: 'status-critical'
+        }
+      }
+    },
+    error: {
+      color: {
+        dark: 'status-error',
+        light: 'status-critical'
+      },
+      margin: { top: 'xsmall', bottom: 'none', horizontal: 'none' }
+    },
+    extend: css`
+      & > span {
+        font-style: italic;
+        margin-top: 5px;
+        order: 1;
+      }
+    `,
+    help: {
+      color: {
+        light: 'dark-5',
+        dark: 'light-1'
+      },
+      margin: {
+        left: 'none'
+      }
+    },
+    label: {
+      margin: {
+        horizontal: 'none',
+        vertical: 'xsmall'
+      }
+    },
+    margin: {
+      bottom: 'xsmall'
+    }
+  },
+  textInput: {
+    extend: props => css`
+      color: ${props.theme.dark
+    ? props.theme.global.colors['white']
+    : props.theme.global.colors['dark-1']
+};
+      font-weight: 400;
+    `
+  }
+}
+
+export default theme

--- a/packages/lib-react-components/src/helpers/fetchPanoptesUser/fetchPanoptesUser.js
+++ b/packages/lib-react-components/src/helpers/fetchPanoptesUser/fetchPanoptesUser.js
@@ -22,7 +22,7 @@ export default async function fetchPanoptesUser({ user: storedUser }) {
       if (user) {
         const { admin, display_name, id, login } = user
         return {
-          avatar_src: storedUser.avatar_src,
+          avatar_src: storedUser?.avatar_src,
           ...user
         }
       }
@@ -33,6 +33,11 @@ export default async function fetchPanoptesUser({ user: storedUser }) {
   } catch (error) {
     console.log(error)
   }
-  const { admin, avatar_src, display_name, id, login } = await auth.checkCurrent()
-  return { admin, avatar_src, display_name, id, login }
+  const panoptesUser = await auth.checkCurrent()
+  if (panoptesUser) {
+    const { admin, avatar_src, display_name, id, login } = panoptesUser
+    return { admin, avatar_src, display_name, id, login }
+  }
+
+  return {}
 }

--- a/packages/lib-react-components/src/helpers/fetchPanoptesUser/index.js
+++ b/packages/lib-react-components/src/helpers/fetchPanoptesUser/index.js
@@ -1,0 +1,1 @@
+export { default } from './fetchPanoptesUser'

--- a/packages/lib-react-components/src/helpers/withCustomFormik/withCustomFormik.js
+++ b/packages/lib-react-components/src/helpers/withCustomFormik/withCustomFormik.js
@@ -1,41 +1,36 @@
-import { Component, forwardRef } from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types'
 import { Formik } from 'formik'
 
+const DEFAULT_HANDLER = () => true
+
 function withCustomFormik (WrappedComponent) {
-  class FormikHOC extends Component {
-    constructor () {
-      super()
+  function FormikHOC({
+    forwardedRef = null,
+    initialValues,
+    onBlur = DEFAULT_HANDLER,
+    onChange = DEFAULT_HANDLER,
+    onSubmit = DEFAULT_HANDLER,
+    ...optionalProps
+  }) {
 
-      this.handleBlurWithCallback = this.handleBlurWithCallback.bind(this)
-      this.handleChangeWithCallback = this.handleChangeWithCallback.bind(this)
-    }
-
-    handleBlurWithCallback(event, formikProps) {
+    function handleBlurWithCallback(event, formikProps) {
       formikProps.handleBlur(event)
-      this.props.onBlur(event, formikProps)
+      onBlur(event, formikProps)
     }
 
-    handleChangeWithCallback (event, formikProps) {
+    function handleChangeWithCallback(event, formikProps) {
       formikProps.handleChange(event)
-      this.props.onChange(event, formikProps)
+      onChange(event, formikProps)
     }
 
-    renderForm (props, ref) {
-      // render the wrapped form but override handleChange with a custom callback
-      const {
-        handleBlur,
-        handleChange,
-        ...rest
-      } = props
-      const { handleBlurWithCallback, handleChangeWithCallback } = this
-
-      function handleCustomBlur (event) {
-        handleBlurWithCallback(event, props)
+    function renderForm({ handleBlur, handleChange, ...rest } , ref) {
+      function handleCustomBlur(event) {
+        handleBlurWithCallback(event, { handleBlur, handleChange, ...rest })
       }
 
-      function handleCustomChange (event) {
-        handleChangeWithCallback(event, props)
+      function handleCustomChange(event) {
+        handleChangeWithCallback(event, { handleBlur, handleChange, ...rest })
       }
 
       return (
@@ -48,24 +43,15 @@ function withCustomFormik (WrappedComponent) {
       )
     }
 
-    render () {
-      const { forwardedRef, initialValues, onSubmit, ...optionalProps } = this.props
-      return (
-        <Formik
-          initialValues={initialValues}
-          onSubmit={onSubmit}
-          {...optionalProps}
-        >
-          {(innerProps) => this.renderForm(innerProps, forwardedRef)}
-        </Formik>
-      )
-    }
-  }
-
-  FormikHOC.defaultProps = {
-    forwardedRef: null,
-    onBlur: () => {},
-    onChange: () => {}
+    return (
+      <Formik
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+        {...optionalProps}
+      >
+        {(innerProps) => renderForm(innerProps, forwardedRef)}
+      </Formik>
+    )
   }
 
   FormikHOC.propTypes = {

--- a/packages/lib-react-components/src/hooks/Readme.md
+++ b/packages/lib-react-components/src/hooks/Readme.md
@@ -1,0 +1,61 @@
+# Zooniverse React hooks
+
+## useJSONData
+
+Fetch the raw JSON data and MobX State Tree data type for a Panoptes JSON subject.
+
+```js
+const url = 'https://panoptes-uploads.zooniverse.org/subject_location/74fddc9b-790d-47c6-9eac-110c64022ea8.json'
+const { loading, data, type, error } = useJSONData(url)
+
+if (loading) {
+  return null
+}
+
+if (error) {
+  return `There was an error. ${error.message}.`
+}
+
+if (data) {
+  console.log('Subject type', type)
+  console.log('Raw data', data)
+}
+```
+## usePanoptesUser
+
+Exchange a Panoptes session cookie for the logged-in user, using [`useSWR`](https://swr.vercel.app/docs/api).
+
+```js
+const { data: user, error, isLoading } = usePanoptesUser()
+```
+## useProgressiveImage
+
+Use a placeholder while an image downloads.
+
+```jsx
+const src = 'https://panoptes-uploads.zooniverse.org/production/subject_location/66094a64-8823-4314-8ef4-1ee228e49470.jpeg'
+const { img, error, loading } = useProgressiveImage({ delay: 0, src })
+
+return <img src={img.src} alt='This is an example of an image with a placeholder.'/>
+```
+## useUnreadMessages
+
+Fetch unread messages for a Zooniverse account, using [`useSWR`](https://swr.vercel.app/docs/api).
+
+```js
+const { data: user } = usePanoptesUser()
+const { data, error, isLoading }= useUnreadMessages(user)
+
+return `You have ${data} unread messages.`
+````
+
+## useUnreadNotifications
+
+Fetch the notification count for a Zooniverse account, using [`useSWR`](https://swr.vercel.app/docs/api).
+
+```js
+const { data: user } = usePanoptesUser()
+const { data, error, isLoading }= useUnreadNotifications(user)
+
+return `You have ${data} notifications.`
+```

--- a/packages/lib-react-components/src/hooks/index.js
+++ b/packages/lib-react-components/src/hooks/index.js
@@ -1,2 +1,5 @@
 export { default as useJSONData } from './useJSONData'
+export { default as usePanoptesUser } from './usePanoptesUser.js'
+export { default as useUnreadMessages } from './useUnreadMessages.js'
+export { default as useUnreadNotifications } from './useUnreadNotifications.js'
 export { default as useProgressiveImage } from './useProgressiveImage'

--- a/packages/lib-react-components/src/hooks/useUnreadMessages.js
+++ b/packages/lib-react-components/src/hooks/useUnreadMessages.js
@@ -2,12 +2,18 @@ import { talkAPI } from '@zooniverse/panoptes-js'
 import auth from 'panoptes-client/lib/auth'
 import useSWR from 'swr'
 
+const isBrowser = typeof window !== 'undefined'
+
 const SWROptions = {
   revalidateIfStale: true,
   revalidateOnMount: true,
   revalidateOnFocus: true,
   revalidateOnReconnect: true,
   refreshInterval: 0
+}
+
+if (isBrowser) {
+  auth.checkCurrent()
 }
 
 async function fetchUnreadMessageCount({ endpoint = '/conversations' }) {

--- a/packages/lib-react-components/src/hooks/useUnreadNotifications.js
+++ b/packages/lib-react-components/src/hooks/useUnreadNotifications.js
@@ -2,12 +2,18 @@ import { talkAPI } from '@zooniverse/panoptes-js'
 import auth from 'panoptes-client/lib/auth'
 import useSWR from 'swr'
 
+const isBrowser = typeof window !== 'undefined'
+
 const SWROptions = {
   revalidateIfStale: true,
   revalidateOnMount: true,
   revalidateOnFocus: true,
   revalidateOnReconnect: true,
   refreshInterval: 0
+}
+
+if (isBrowser) {
+  auth.checkCurrent()
 }
 
 async function fetchUnreadNotificationsCount({ endpoint = '/notifications' }) {

--- a/packages/lib-react-components/src/index.js
+++ b/packages/lib-react-components/src/index.js
@@ -1,4 +1,5 @@
 export { default as AdminCheckbox } from './AdminCheckbox/index.js'
+export { default as AuthModal } from './AuthModal/index.js'
 export { default as CloseButton } from './CloseButton/index.js'
 export { default as FavouritesButton } from './FavouritesButton/index.js'
 export { default as Markdownz } from './Markdownz/index.js'

--- a/packages/lib-react-components/src/translations/en.json
+++ b/packages/lib-react-components/src/translations/en.json
@@ -2,6 +2,53 @@
   "AdminCheckbox": {
     "label": "Admin Mode"
   },
+  "AuthModal": {
+    "title": "Sign in or create a new account.",
+    "LoginForm": {
+      "error": "Username or password is incorrect",
+      "forgot": "Forgot your password?",
+      "heading": "Welcome back!",
+      "instruction": "We're glad you're back! Sign in to pick up where you left off.",
+      "login": "Username or email address",
+      "password": "Password",
+      "placeholder": "e.g. ZooniverseFan123",
+      "signIn": "Sign in"
+    },
+    "RegisterForm": {
+      "betaListSignUp": "I'd like to help test new projects and be emailed when they're available (optional)",
+      "email": "Email Address (Required)",
+      "emailConfirm": "Confirm Email Address (Required)",
+      "emailConfirmError": "The email addresses do not match, please try again.",
+      "emailConflict": "An account with this address already exists",
+      "emailPlaceholder": "e.g. zoofan31@gmail.com",
+      "emailListSignUp": "It's ok to send me an email every once in a while (optional)",
+      "forgot": "Forgot your password?",
+      "heading": "Welcome back!",
+      "instruction": "Please create an account to start doing real research.",
+      "password": "Password (Required)",
+      "passwordConfirm": "Confirm Password (Required)",
+      "passwordConfirmError": "The passwords do not match, please try again.",
+      "privacyAgreement": "You agree to our privacy policy (required)",
+      "privacyAgreementError": "Agreeing to the privacy policy is required.",
+      "privacyLink": "Read our privacy policy",
+      "realName": "Real Name (Optional)",
+      "realNameHelp": "We'll use this to give you credit in scientific papers, posters, etc.",
+      "realNamePatternHelp": "Enter a name, not an email address",
+      "realNamePlaceholder": "e.g. Maggie Smith",
+      "register": "Register",
+      "registering": "Registering...",
+      "underageConsent": "I confirm I am the parent/guardian and give permission for my child to register by providing my email address as the main contact address. Both I and my child understand and agree to the privacy policy (required)",
+      "underageEmail": "Parent/Guardian’s email address (Required)",
+      "underageEmailSignUp": "If you agree, we will periodically send email promoting new research-related projects or other information relating to our research. We will not use your contact information for commercial purposes. (optional)",
+      "underageNotRealName": "You’ll use this name to log in. It will be shown publicly. Don’t use your real name.",
+      "underageWithParent": "If you are under 16 years old, tick this box to confirm that you've completed the form with your parent or guardian",
+      "username": "Username (Required)",
+      "usernameConflict": "That username is taken",
+      "usernameHelp": "This will be shown publicly on message boards, etc.",
+      "usernamePatternHelp": "Usernames can only contain letters, numbers, '.','-', and '_'",
+      "usernamePlaceholder": "e.g. ZooniverseFan123"
+    }
+  },
   "CloseButton": {
     "close": "Close"
   },

--- a/packages/lib-react-components/src/translations/test.json
+++ b/packages/lib-react-components/src/translations/test.json
@@ -2,6 +2,53 @@
   "AdminCheckbox": {
     "label": "Translated"
   },
+  "AuthModal": {
+    "title": "Translated",
+    "LoginForm": {
+      "error": "Translated",
+      "forgot": "Translated",
+      "heading": "Translated",
+      "instruction": "Translated",
+      "login": "Translated",
+      "password": "Translated",
+      "placeholder": "Translated",
+      "signIn": "Translated"
+    },
+    "RegisterForm": {
+      "betaListSignUp": "Translated",
+      "email": "Translated",
+      "emailConfirm": "Translated",
+      "emailConfirmError": "Translated",
+      "emailConflict": "Translated",
+      "emailListSignUp": "Translated",
+      "emailPlaceholder": "Translated",
+      "forgot": "Translated",
+      "heading": "Translated",
+      "instruction": "Translated",
+      "password": "Translated",
+      "passwordConfirm": "Translated",
+      "passwordConfirmError": "Translated",
+      "privacyAgreement": "Translated",
+      "privacyAgreementError": "Translated",
+      "privacyLink": "Translated",
+      "realName": "Translated",
+      "realNameHelp": "Translated",
+      "realNamePatternHelp": "Translated",
+      "realNamePlaceholder": "Translated",
+      "register": "Translated",
+      "registering": "Translated",
+      "underageConsent": "Translated",
+      "underageEmail": "Translated",
+      "underageEmailSignUp": "Translated",
+      "underageNotRealName": "Translated",
+      "underageWithParent": "Translated",
+      "username": "Translated",
+      "usernameConflict": "Translated",
+      "usernameHelp": "Translated",
+      "usernamePatternHelp": "Translated",
+      "usernamePlaceholder": "Translated"
+    }
+  },
   "CloseButton": {
     "close": "Translated"
   },


### PR DESCRIPTION
- [x] Add `AuthModal` to `@zooniverse/react-components`.
- [x] Add `AuthModal` to the global page header, and wire it up to the Sign In and Register buttons in the header.
- [x] Wire up the tabs to switch between the two forms.
- [x] Add an optional `project_id` to the registration form. 
- [x] Test the login form fields.
- [x] Test the registration form fields. 
- [x] Add visible focus indicators.
- [x] Move shared hooks to `@zooniverse/react-components`.
- [ ] Test user interaction with the forms.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-root
- lib-react-components

## How to Review
Sign in and sign out should work now.


https://github.com/zooniverse/front-end-monorepo/assets/59547/341a0e92-c102-4e57-a4cc-d6123b123555

The modal should show up as a labelled dialog in the accessibility tree. I'm not sure why the labels for the tabs aren't showing up.

<img width="600" alt="Screenshot of the auth modal's properties in the Firefox accessibility tree." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/b9f76d2f-0d3e-4c87-9374-e585764fe312">

There are also a couple of stories in the React Components storybook, which show the static forms.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).