### PR TITLE
Fix #5575, allow sticky sidebar in About page to overflow/scroll

### DIFF
--- a/packages/app-content-pages/src/screens/Publications/Publications.js
+++ b/packages/app-content-pages/src/screens/Publications/Publications.js
@@ -19,7 +19,9 @@ const Relative = styled.aside`
 `
 
 const StickySidebar = styled(Sidebar)`
-  position: sticky;
+  max-height: 100vh;
+  overflow: auto;
+  position: sticky;  
   top: 0;
 `
 

--- a/packages/app-content-pages/src/screens/Teams/Teams.js
+++ b/packages/app-content-pages/src/screens/Teams/Teams.js
@@ -16,7 +16,9 @@ const Relative = styled.aside`
 `
 
 const StickySidebar = styled(Sidebar)`
-  position: sticky;
+  max-height: 100vh;
+  overflow: auto;
+  position: sticky;  
   top: 0;
 `
 


### PR DESCRIPTION
## PR Overview

package: `app-content-pages`
Affects: About -> Team, About -> Publications
Fixes #5575
Follows #5552

This PR fixes a small UI issue where, on extremely vertically short viewports _(OR when the browser is zoomed in, OR the browser has increased font sizes),_ the nav list in the sticky sidebar isn't fully displayed and can't be scrolled

Solution is a very straightforward `max-height: 100vh` and `overflow: auto`

Design flaw/tradeoff:
- Curiously, with the existing sticky behaviour, if you scroll aaallll the way down to the end of the page, the sidebar will eventually show the final items in the nav list. (screenshot on left) With this PR, the sidebar needs to be manually scrolled. (screenshot on right) 

<img width="377" alt="image" src="https://github.com/zooniverse/front-end-monorepo/assets/13952701/1aeec426-30c4-49b1-8231-236365212df5">  <img width="389" alt="image" src="https://github.com/zooniverse/front-end-monorepo/assets/13952701/e49db521-f27c-4db7-b24b-5dc355a4634e"> 

### Testing

Tested with macOS + Chrome 119

- Open the About -> Publications page (since it has the longest nav list): https://local.zooniverse.org:3000/about/publications
- then choose one of the following scenarios to ensure the height of the sidebar exceeds the height of the browser viewport:
  - Narrow viewport: resize browser window to something like 740x360 (Samsung Galaxy S8+ sideways)
  - Page Zoom: Cmd + Plus(+) sign to zoom in
  - Font Size: modify your browser settings to display larger fonts (for Chrome, increase _minimum_ font size in advanced settings.) 
- scroll down the page (see screenshot below)
- observe that the sidebar exhibits "sticky" behaviour (i.e as you scroll down, the sidebar doesn't "scroll off beyond the top"
- 🆕 observe that you can scroll the sidebar (independently of the page content) to view the whole nav list. (Hint: first item in the 11-item list is "All", the final item is "Data")

<img width="367" alt="image" src="https://github.com/zooniverse/front-end-monorepo/assets/13952701/9368f60c-b962-407f-88cf-8789ff6c4601">

### Status

Ready for review. Low priority, but may have some impact on users who rely on zoomed-in views.

Discard if flaw/tradeoff isn't worth it.