### PR TITLE
Background refresh project Talk recent subjects

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsContainer.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsContainer.spec.js
@@ -22,9 +22,9 @@ describe('Component > RecentSubjectsContainer', function () {
   ]
 
   const MOCK_SUBJECTS = [
-    { id: '1' },
-    { id: '2' },
-    { id: '3' }
+    { id: '1', locations: [] },
+    { id: '2', locations: [] },
+    { id: '3', locations: [] }
   ]
 
   before(function () {

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchRecentSubjects.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchRecentSubjects.js
@@ -2,7 +2,7 @@ import fetchSubjectData from './fetchSubjectData'
 import fetchTalkData from './fetchTalkData'
 import getSubjectIdsFromTalkData from './getSubjectIdsFromTalkData'
 
-async function fetchRecentSubjects (projectId) {
+async function fetchRecentSubjects ({ projectId }) {
   const talkData = await fetchTalkData(projectId)
 
   if (talkData.length > 0) {

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchRecentSubjects.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchRecentSubjects.js
@@ -7,9 +7,7 @@ async function fetchRecentSubjects ({ projectId }) {
 
   if (talkData.length > 0) {
     const subjectIds = getSubjectIdsFromTalkData(talkData)
-    const subjects = await fetchSubjectData(subjectIds)
-      .then(response => response.body.subjects)
-    return subjects
+    return await fetchSubjectData(subjectIds)
   }
 
   return []

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchRecentSubjects.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchRecentSubjects.spec.js
@@ -7,8 +7,8 @@ const PANOPTES_URL = 'https://panoptes-staging.zooniverse.org/api'
 
 const MOCK_COMMENTS = [
   { focus_id: '1' },
-  { focus_id: '2' },
-  { focus_id: '3' }
+  { focus_id: '3' },
+  { focus_id: '2' }
 ]
 
 const MOCK_SUBJECTS = [
@@ -56,7 +56,11 @@ describe('Helpers > fetchRecentSubjects', function () {
 
     it('should return an array of subjects', async function () {
       const result = await fetchRecentSubjects({ projectId: '2' })
-      expect(result).to.deep.equal(MOCK_SUBJECTS)
+      expect(result).to.deep.equal([
+        { id: '1', locations: [] },
+        { id: '3', locations: [] },
+        { id: '2', locations: [] }
+      ])
     })
   })
 })

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchRecentSubjects.spec.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchRecentSubjects.spec.js
@@ -12,9 +12,9 @@ const MOCK_COMMENTS = [
 ]
 
 const MOCK_SUBJECTS = [
-  { id: '1' },
-  { id: '2' },
-  { id: '3' }
+  { id: '1', locations: [] },
+  { id: '2', locations: [] },
+  { id: '3', locations: [] }
 ]
 
 describe('Helpers > fetchRecentSubjects', function () {
@@ -34,7 +34,7 @@ describe('Helpers > fetchRecentSubjects', function () {
     })
 
     it('should return an empty array', async function () {
-      const result = await fetchRecentSubjects('1')
+      const result = await fetchRecentSubjects({ projectId: '1' })
       expect(result).to.deep.equal([])
     })
   })
@@ -55,7 +55,7 @@ describe('Helpers > fetchRecentSubjects', function () {
     })
 
     it('should return an array of subjects', async function () {
-      const result = await fetchRecentSubjects('2')
+      const result = await fetchRecentSubjects({ projectId: '2' })
       expect(result).to.deep.equal(MOCK_SUBJECTS)
     })
   })

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchSubjectData.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchSubjectData.js
@@ -1,9 +1,11 @@
 import { panoptes } from '@zooniverse/panoptes-js'
 
 async function fetchSubjectData (subjectIds) {
-  return panoptes.get('/subjects', {
+  const response = await panoptes.get('/subjects', {
     id: subjectIds.join(',')
   })
+  const { subjects } = response.body
+  return subjectIds.map(subjectID => subjects.find(subject => subject.id === subjectID))
 }
 
 export default fetchSubjectData


### PR DESCRIPTION
Refactor home page `RecentSubjects` to use `useSWR`. The `RecentSubjects` component, on the project home page, will now refresh in the background when the fetched API data is stale.

Preserve the subject comment order when fetching subjects from Panoptes.

- Closes #5589.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project

## How to Review
With a project home page open in a tab, the list of recent Talk subjects should now refresh in the background when recent subject comments change in Panoptes. Previously, you would have to reload the page to see new comments.

Here, I open the project home page in one tab, leave a new subject comment in another tab, then see the recent subjects update in the original tab.

https://github.com/zooniverse/front-end-monorepo/assets/59547/87194006-9ba0-44f3-8fc8-6b28352a7047



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
