### PR TITLE
Clean up the Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,10 +71,19 @@ ADD .yarnrc /usr/src/
 
 COPY --from=builder /usr/src/packages ./packages
 
-RUN --mount=type=cache,id=fem-runner-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn install --production --frozen-lockfile --ignore-scripts --prefer-offline
+RUN rm -rf /usr/src/packages/lib-react-components/node_modules
+RUN rm -rf /usr/src/packages/lib-classifier/node_modules
+RUN rm -rf /usr/src/packages/lib-user/node_modules
+RUN rm -rf /usr/src/packages/app-content-pages/node_modules
+RUN rm -rf /usr/src/packages/app-project/node_modules
+RUN rm -rf /usr/src/packages/app-root/node_modules
 
 RUN rm -rf /usr/src/packages/lib-react-components/src
 RUN rm -rf /usr/src/packages/lib-classifier/src
+RUN rm -rf /usr/src/packages/lib-user/src
 RUN rm -rf /usr/src/packages/app-content-pages/src
 RUN rm -rf /usr/src/packages/app-project/src
 RUN rm -rf /usr/src/packages/app-project/stores
+RUN rm -rf /usr/src/packages/app-root/src
+
+RUN --mount=type=cache,id=fem-runner-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn install --production --frozen-lockfile --ignore-scripts --prefer-offline


### PR DESCRIPTION
After building the libraries and apps, remove `node_modules` and `src` from each package before installing only the production dependencies.

This should cut the size of the image by removing unnecessary files like the storybook packages and so on.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
All of them

## How to Review
Run a Docker build and check the size of the final image.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook