### PR TITLE
SubjectPicker: slugify data property names

### DIFF
--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/columns.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/columns.js
@@ -1,5 +1,7 @@
 import NavLink from '@shared/components/NavLink'
 
+import slugify from './slugify.js'
+
 function subjectLink({ subject_id }, baseUrl) {
   const href = `${baseUrl}/subject/${subject_id}`
   const link = {
@@ -20,7 +22,7 @@ export default function columns(customHeaders, baseUrl) {
       align: 'start',
       header,
       primary: (header === 'subject_id'),
-      property: header,
+      property: slugify(header),
       render,
       search: customHeaders.includes(header),
       size: (header === 'status') ? 'xsmall' : 'small',

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchStatuses.spec.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchStatuses.spec.js
@@ -5,16 +5,16 @@ import { fetchStatuses, fetchSubjects } from './'
 describe('Components > Subject Picker > helpers > fetchStatuses', function () {
   let subjects
   const expectedData = [
-    { subject_id: 1, Page: '43', Date: '23 January 1916', status: 'SubjectPicker.unclassified' },
-    { subject_id: 2, Page: '44', Date: '24 January 1916', status: 'SubjectPicker.alreadySeen' },
-    { subject_id: 3, Page: '45', Date: '25 January 1916', status: 'SubjectPicker.retired' },
+    { subject_id: 1, page: '43', date_with_space: '23 January 1916', status: 'SubjectPicker.unclassified' },
+    { subject_id: 2, page: '44', date_with_space: '24 January 1916', status: 'SubjectPicker.alreadySeen' },
+    { subject_id: 3, page: '45', date_with_space: '25 January 1916', status: 'SubjectPicker.retired' },
   ]
 
   before(async function () {
     const columns = [
       'subject_id',
       'Page',
-      'Date'
+      'Date. With space'
     ]
     const rows = [
       [1, '43', '23 January 1916'],

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchSubjects.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/fetchSubjects.js
@@ -1,3 +1,5 @@
+import slugify from './slugify.js'
+
 const API_HOST = 'https://subject-set-search-api.zooniverse.org/subjects'
 const ASCENDING_SORT = '_sort'
 const DESCENDING_SORT = '_sort_desc'
@@ -16,7 +18,7 @@ export default async function fetchSubjects(
   const subjects = rows.map(row => {
     const subject = {}
     columns.forEach((column, index) => {
-      subject[column] = row[index]
+      subject[slugify(column)] = row[index]
     })
     subject.status = 'loading'
     return subject

--- a/packages/app-project/src/shared/components/SubjectPicker/helpers/slugify.js
+++ b/packages/app-project/src/shared/components/SubjectPicker/helpers/slugify.js
@@ -1,0 +1,8 @@
+export default function slugify(string) {
+  return string
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s_]/g, '')
+    .replace(/[\s_-]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}


### PR DESCRIPTION
Slugify data property names in subject metadata so that, for example, 'verm. Lemma' becomes `verm_lemma`.

Fixes a bug where the data table used by `SubjectPicker` won't display a data column with names that contain punctuation or whitespace.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project

## How to Review
The subject data table here should now show some values in the 'verm. Lemma' and 'verm. Ort' columns.
https://local.zooniverse.org:3000/projects/dschopper/the-abcs-of-dialect/classify/workflow/25015/subject-set/116692

<img width="600" alt="Subject metadata for a single subject set from 'The ABCS of Dialect'. Columns contain data, even where the column name contains punctuation and whitespace." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/2bc4112a-c24c-4480-980a-aba3f9f5d07b">


Compare with staging, where those columns are empty.
https://frontend.preview.zooniverse.org/projects/dschopper/the-abcs-of-dialect/classify/workflow/25015/subject-set/116692

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
