### PR TITLE
FreehandLine LineControls: Add confirm or cancel to delete.

### DIFF
--- a/packages/lib-classifier/src/translations/en/plugins.json
+++ b/packages/lib-classifier/src/translations/en/plugins.json
@@ -55,6 +55,8 @@
     "lineControls": "Line Controls",
     "close": "Close",
     "delete": "Delete",
+    "deleteCancel": "Cancel Delete",
+    "deleteConfirm": "Confirm Delete",
     "move": "Move",
     "redo": "Redo",
     "undo": "Undo"


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- [x] classifier

## Linked Issue and/or Talk Post
https://github.com/zooniverse/front-end-monorepo/issues/5604

## Describe your changes
Added a confirm / cancel when clicking the delete icon on the LineControl for the FreehandLine tool.

## How to Review
[FreehandLine Storybook](http://localhost:6006/?path=/story/drawing-tools-freehand-line--drawing)

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).