### PR TITLE
Bugfix: missing SWR package

### DIFF
--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.9.1] 2023-11-16
+
+### Fixed
+Added missing `swr` package (used by Panoptes data-fetching hooks.)
+
 ## [1.9.0] 2023-11-08
 
 ### Added

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -3,7 +3,7 @@
   "description": "Zooniverse React Components",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {
@@ -53,7 +53,8 @@
     "prop-types": "~15.8.1",
     "react-i18next": "~13.5.0",
     "react-resize-detector": "~9.1.0",
-    "react-rnd": "10.4.1"
+    "react-rnd": "10.4.1",
+    "swr": "~2.2.4"
   },
   "peerDependencies": {
     "@zooniverse/grommet-theme": "3.x.x",


### PR DESCRIPTION
Since #5574, `@zooniverse/react-components` uses the `swr` package in custom data-fetching hooks, but it isn't installed as a dependency.

- closes #5655.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-react-components

## Linked Issue and/or Talk Post
 - See the [build errors](https://github.com/zooniverse/community-catalog/actions/runs/6890778197/job/18744497530?pr=213) on https://github.com/zooniverse/community-catalog/pull/213


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser
