### PR TITLE
Build new ThemeModeToggle in ZooHeader

### DIFF
--- a/packages/app-root/src/components/PageContextProviders.js
+++ b/packages/app-root/src/components/PageContextProviders.js
@@ -5,8 +5,8 @@ import { usePanoptesUser } from '@zooniverse/react-components/hooks'
 import { Grommet } from 'grommet'
 import { createGlobalStyle } from 'styled-components'
 
-import { PanoptesAuthContext } from '../contexts'
-import { useAdminMode } from '../hooks'
+import { PanoptesAuthContext, ThemeModeContext } from '../contexts'
+import { useAdminMode, useDarkMode } from '../hooks'
 
 const GlobalStyle = createGlobalStyle`
   body {
@@ -17,7 +17,7 @@ const GlobalStyle = createGlobalStyle`
 /**
   Context for every page:
   - global page styles.
-  - Zooniverse Grommet theme.
+  - Zooniverse Grommet theme and mode.
   - Panoptes auth (user account and admin mode.)
 */
 export default function PageContextProviders({ children }) {
@@ -25,19 +25,24 @@ export default function PageContextProviders({ children }) {
   const { adminMode, toggleAdmin } = useAdminMode(user)
   const authContext = { adminMode, error, isLoading, toggleAdmin, user }
 
+  const { darkMode, toggleTheme } = useDarkMode()
+  const themeContext = { darkMode, toggleTheme }
+
   return (
     <PanoptesAuthContext.Provider value={authContext}>
-      <GlobalStyle />
-      <Grommet
-        background={{
-          dark: 'dark-1',
-          light: 'light-1'
-        }}
-        theme={zooTheme}
-      >
-        {children}
-      </Grommet>
+      <ThemeModeContext.Provider value={themeContext}>
+        <GlobalStyle />
+        <Grommet
+          background={{
+            dark: 'dark-1',
+            light: 'light-1'
+          }}
+          theme={zooTheme}
+          themeMode={darkMode ? 'dark' : 'light'}
+        >
+          {children}
+        </Grommet>
+      </ThemeModeContext.Provider>
     </PanoptesAuthContext.Provider>
   )
-
 }

--- a/packages/app-root/src/components/PageHeader.js
+++ b/packages/app-root/src/components/PageHeader.js
@@ -4,13 +4,15 @@ import { useUnreadMessages, useUnreadNotifications } from '@zooniverse/react-com
 import auth from 'panoptes-client/lib/auth'
 import { useContext, useState } from 'react'
 
-import { PanoptesAuthContext } from '../contexts'
+import { PanoptesAuthContext, ThemeModeContext } from '../contexts'
 
 export default function PageHeader() {
   const { adminMode, user } = useContext(PanoptesAuthContext)
   const { data: unreadMessages }= useUnreadMessages(user)
   const { data: unreadNotifications }= useUnreadNotifications(user)
   const [activeIndex, setActiveIndex] = useState(-1)
+
+  const { darkMode, toggleTheme } = useContext(ThemeModeContext)
 
   function openRegisterModal() {
     setActiveIndex(1)
@@ -36,8 +38,11 @@ export default function PageHeader() {
         onActive={setActiveIndex}
       />
       <ZooHeader
+        darkMode={darkMode}
         isAdmin={adminMode}
+        onThemeChange={toggleTheme}
         register={openRegisterModal}
+        showThemeToggle
         signIn={openSignInModal}
         signOut={onSignOut}
         unreadMessages={unreadMessages}

--- a/packages/app-root/src/contexts/ThemeModeContext.js
+++ b/packages/app-root/src/contexts/ThemeModeContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react'
+
+const ThemeModeContext = createContext({})
+
+export default ThemeModeContext

--- a/packages/app-root/src/contexts/index.js
+++ b/packages/app-root/src/contexts/index.js
@@ -1,1 +1,2 @@
 export { default as PanoptesAuthContext } from './PanoptesAuthContext.js'
+export { default as ThemeModeContext } from './ThemeModeContext.js'

--- a/packages/app-root/src/hooks/index.js
+++ b/packages/app-root/src/hooks/index.js
@@ -1,1 +1,2 @@
 export { default as useAdminMode } from './useAdminMode.js'
+export { default as useDarkMode } from './useDarkMode.js'

--- a/packages/app-root/src/hooks/useDarkMode.js
+++ b/packages/app-root/src/hooks/useDarkMode.js
@@ -1,0 +1,21 @@
+import { useState } from 'react'
+
+const isBrowser = typeof window !== 'undefined'
+const localStorage = isBrowser ? window.localStorage : null
+const storedDarkMode = !!localStorage?.getItem('darkMode')
+
+export default function useDarkMode() {
+  const [darkMode, setDarkMode] = useState(storedDarkMode)
+
+  function toggleTheme() {
+    let newTheme = !darkMode
+    setDarkMode(newTheme)
+    if (newTheme) {
+      localStorage?.setItem('darkMode', true)
+    } else {
+      localStorage?.removeItem('darkMode')
+    }
+  }
+
+  return { darkMode, toggleTheme }
+}

--- a/packages/lib-react-components/src/ZooHeader/README.md
+++ b/packages/lib-react-components/src/ZooHeader/README.md
@@ -4,6 +4,8 @@ The standard Zooniverse header to be used on Zooniverse sites. Built using:
 - [Grommet v2](https://v2.grommet.io/components)
 - [styled-components](https://www.styled-components.com/)
 
-The header does not have light and dark theme variants. It remains black for both. 
+The header does not have light and dark theme variants. It remains black for both.
 
 The `signIn` (function), `signOut` (function), and `user` (object) props are required. These props can be defined using the API from @zooniverse/auth. See the development mini-app in the lib-auth folder for an example of using its API.
+
+If you wish to display a theme toggle for `light` and `dark` Grommet `themeMode`, pass `showThemeToggle` as a prop to ZooHeader. Handling of the Grommet Provider should be in ZooHeader's parent app.

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.js
@@ -10,18 +10,20 @@ import MainNavList from './components/MainNavList'
 import SignedInUserNavigation from './components/SignedInUserNavigation'
 import SignedOutUserNavigation from './components/SignedOutUserNavigation'
 import ZooniverseLogo from '../ZooniverseLogo'
+import ThemeModeToggle from './components/ThemeModeToggle/ThemeModeToggle'
 
 export const StyledHeader = styled(Box)`
-  color: #B2B2B2;
+  color: #b2b2b2;
   font-size: 1em;
 `
 
 export const StyledLogoAnchor = styled(Anchor)`
   border-bottom: 2px solid transparent;
-  color: #B2B2B2;
+  color: #b2b2b2;
   margin-right: 2em;
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     border-bottom-color: ${zooTheme.global.colors.brand};
   }
 
@@ -36,8 +38,11 @@ const signedOutUserNavPadding = { horizontal: 'medium', vertical: 'small' }
 
 export default function ZooHeader({
   breakpoint = 960,
+  darkMode = false,
+  showThemeToggle = false,
   isAdmin = false,
   isNarrow = false,
+  onThemeChange = defaultHandler,
   register = defaultHandler,
   signIn = defaultHandler,
   signOut = defaultHandler,
@@ -73,7 +78,8 @@ export default function ZooHeader({
     t('ZooHeader.mainHeaderNavListLabels.build')
   ]
 
-  const userNavigationPadding = Object.keys(user).length === 0 ? signedOutUserNavPadding : undefined
+  const userNavigationPadding =
+    Object.keys(user).length === 0 ? signedOutUserNavPadding : undefined
   return (
     <StyledHeader
       ref={ref}
@@ -105,47 +111,56 @@ export default function ZooHeader({
           mainHeaderNavListURLs={mainHeaderNavListURLs}
         />
       </Box>
-      <Box
-        aria-label={t('ZooHeader.SignedInUserNavigation.ariaLabel')}
-        as='nav'
-        align='center'
-        direction='row'
-        pad={userNavigationPadding}
-      >
-        {Object.keys(user).length === 0 ?
-          <SignedOutUserNavigation
-            adminNavLinkLabel={adminNavLinkLabel}
-            adminNavLinkURL={adminNavLinkURL}
-            isAdmin={isAdmin}
-            isNarrow={isNarrow}
-            mainHeaderNavListLabels={mainHeaderNavListLabels}
-            mainHeaderNavListURLs={mainHeaderNavListURLs}
-            register={register}
-            signIn={signIn}
-            user={user}
-          /> :
-          <SignedInUserNavigation
-            adminNavLinkLabel={adminNavLinkLabel}
-            adminNavLinkURL={adminNavLinkURL}
-            isAdmin={isAdmin}
-            isNarrow={isNarrow}
-            mainHeaderNavListLabels={mainHeaderNavListLabels}
-            mainHeaderNavListURLs={mainHeaderNavListURLs}
-            unreadMessages={unreadMessages}
-            unreadNotifications={unreadNotifications}
-            signOut={signOut}
-            user={user}
-          />
-        }
+      <Box direction='row'>
+        {showThemeToggle && (
+          <ThemeModeToggle darkMode={darkMode} onThemeChange={onThemeChange} />
+        )}
+        <Box
+          aria-label={t('ZooHeader.SignedInUserNavigation.ariaLabel')}
+          as='nav'
+          align='center'
+          direction='row'
+          pad={userNavigationPadding}
+        >
+          {Object.keys(user).length === 0 ? (
+            <SignedOutUserNavigation
+              adminNavLinkLabel={adminNavLinkLabel}
+              adminNavLinkURL={adminNavLinkURL}
+              isAdmin={isAdmin}
+              isNarrow={isNarrow}
+              mainHeaderNavListLabels={mainHeaderNavListLabels}
+              mainHeaderNavListURLs={mainHeaderNavListURLs}
+              register={register}
+              signIn={signIn}
+              user={user}
+            />
+          ) : (
+            <SignedInUserNavigation
+              adminNavLinkLabel={adminNavLinkLabel}
+              adminNavLinkURL={adminNavLinkURL}
+              isAdmin={isAdmin}
+              isNarrow={isNarrow}
+              mainHeaderNavListLabels={mainHeaderNavListLabels}
+              mainHeaderNavListURLs={mainHeaderNavListURLs}
+              unreadMessages={unreadMessages}
+              unreadNotifications={unreadNotifications}
+              signOut={signOut}
+              user={user}
+            />
+          )}
+        </Box>
       </Box>
     </StyledHeader>
   )
 }
 
 ZooHeader.propTypes = {
+  darkMode: PropTypes.bool,
   isAdmin: PropTypes.bool,
   isNarrow: PropTypes.bool,
+  onThemeChange: PropTypes.bool,
   register: PropTypes.func,
+  showThemeToggle: PropTypes.bool,
   signIn: PropTypes.func.isRequired,
   signOut: PropTypes.func.isRequired,
   unreadMessages: PropTypes.number,

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.spec.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.spec.js
@@ -1,13 +1,9 @@
 import { within } from '@testing-library/dom'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import MainNavList from './components/MainNavList'
-import SignedOutUserNavigation from './components/SignedOutUserNavigation'
-import SignedInUserNavigation from './components/SignedInUserNavigation'
-import ZooniverseLogo from '../ZooniverseLogo'
 import ZooHeader from './ZooHeader'
 
-describe('ZooHeader', function () {
+describe.only('ZooHeader', function () {
   this.timeout(5000)
   let mainNavList, zooLogo
 
@@ -211,6 +207,17 @@ describe('ZooHeader', function () {
 
       it('should have an admin link', function () {
         expect(adminLink.href).to.equal('https://www.zooniverse.org/admin')
+      })
+    })
+
+    describe('showing a theme toggle', function () {
+      before(function () {
+        render(<ZooHeader showThemeToggle signIn={() => {}} signOut={() => {}} />)
+      })
+
+      it('shows theme toggle', function () {
+        const toggle = screen.getByLabelText('Switch to dark theme')
+        expect(toggle).to.exist()
       })
     })
   })

--- a/packages/lib-react-components/src/ZooHeader/ZooHeader.stories.js
+++ b/packages/lib-react-components/src/ZooHeader/ZooHeader.stories.js
@@ -1,4 +1,5 @@
 import { Box } from 'grommet'
+import { useState } from 'react'
 
 import ZooHeader from './ZooHeader'
 import readme from './README.md'
@@ -21,6 +22,24 @@ export default {
       }
     }
   }
+}
+
+export function showThemeToggle({ signIn, signOut }) {
+  const [darkMode, setDarkMode] = useState(false)
+  function onThemeChange() {
+    setDarkMode(!darkMode)
+  }
+
+  return (
+    <ZooHeader
+      darkMode={darkMode}
+      onThemeChange={onThemeChange}
+      showThemeToggle
+      signIn={signIn}
+      signOut={signOut}
+      user={{}}
+    />
+  )
 }
 
 export function SignedOut({ signIn, signOut }) {

--- a/packages/lib-react-components/src/ZooHeader/components/ThemeModeToggle/ThemeModeToggle.js
+++ b/packages/lib-react-components/src/ZooHeader/components/ThemeModeToggle/ThemeModeToggle.js
@@ -1,0 +1,37 @@
+import { Button } from 'grommet'
+import { useTranslation } from '../../../translations/i18n'
+import PropTypes from 'prop-types'
+import { Sun, Moon } from 'grommet-icons'
+import styled from 'styled-components'
+
+const StyledButton = styled(Button)`
+  padding-right: 15px;
+
+  &:hover {
+    > svg {
+      stroke: white;
+    }
+  }
+`
+
+export default function ThemeModeToggle({ darkMode, onThemeChange }) {
+  const { t } = useTranslation()
+
+  const label = darkMode
+    ? t('ZooHeader.ThemeModeToggle.switchToLight')
+    : t('ZooHeader.ThemeModeToggle.switchToDark')
+
+  return (
+    <StyledButton
+      aria-label={label}
+      icon={darkMode ? <Moon /> : <Sun />}
+      onClick={onThemeChange}
+      plain
+    />
+  )
+}
+
+ThemeModeToggle.propTypes = {
+  darkMode: PropTypes.string,
+  onThemeChange: PropTypes.func
+}

--- a/packages/lib-react-components/src/translations/ar.json
+++ b/packages/lib-react-components/src/translations/ar.json
@@ -13,6 +13,10 @@
   "ZooHeader": {
     "mainHeaderNavListLabels": {
       "talk": "محادثة"
+    },
+    "ThemeModeToggle": {
+      "switchToDark": "استبدل الخلفيّة غامق",
+      "switchToLight": "استبدل الخلفيّة فاتح"
     }
   }
 }

--- a/packages/lib-react-components/src/translations/cs.json
+++ b/packages/lib-react-components/src/translations/cs.json
@@ -37,6 +37,10 @@
       "register": "Zaregistrovat se",
       "signIn": "Přihlásit se"
     },
+    "ThemeModeToggle": {
+      "switchToDark": "Přepnout do tmavého prostředí",
+      "switchToLight": "Přepnout do světlého prostředí"
+    },
     "UserMenu": {
       "userNavListLabels": {
         "collections": "Alba",

--- a/packages/lib-react-components/src/translations/de.json
+++ b/packages/lib-react-components/src/translations/de.json
@@ -37,6 +37,10 @@
       "register": "Registrierung",
       "signIn": "Anmeldung"
     },
+    "ThemeModeToggle": {
+      "switchToDark": "Klicken für dunklen Hintergrund",
+      "switchToLight": "Klicken für hellen Hintergrund"
+    },
     "UserMenu": {
       "userNavListLabels": {
         "collections": "Sammlungen",

--- a/packages/lib-react-components/src/translations/en.json
+++ b/packages/lib-react-components/src/translations/en.json
@@ -122,6 +122,10 @@
       "register": "Register",
       "signIn": "Sign In"
     },
+    "ThemeModeToggle": {
+      "switchToDark": "Switch to dark theme",
+      "switchToLight": "Switch to light theme"
+    },
     "UserMenu": {
       "userNavListLabels": {
         "profile": "Profile",

--- a/packages/lib-react-components/src/translations/es.json
+++ b/packages/lib-react-components/src/translations/es.json
@@ -66,6 +66,10 @@
       "register": "Registrarse",
       "signIn": "Iniciar sesión"
     },
+    "ThemeModeToggle": {
+      "switchToDark": "Cambiar a diseño oscuro",
+      "switchToLight": "Cambiar a diseño claro"
+    },
     "UserMenu": {
       "userNavListLabels": {
         "collections": "Colecciones",

--- a/packages/lib-react-components/src/translations/fr.json
+++ b/packages/lib-react-components/src/translations/fr.json
@@ -37,6 +37,10 @@
       "register": "S'inscrire",
       "signIn": "Se connecter"
     },
+    "ThemeModeToggle": {
+      "switchToDark": "Passer au thème foncé",
+      "switchToLight": "Passer au thème clair"
+    },
     "UserMenu": {
       "userNavListLabels": {
         "collections": "Collections d'images",

--- a/packages/lib-react-components/src/translations/he.json
+++ b/packages/lib-react-components/src/translations/he.json
@@ -13,6 +13,10 @@
   "ZooHeader": {
     "mainHeaderNavListLabels": {
       "talk": "שיחה"
+    },
+    "ThemeModeToggle": {
+      "switchToDark": "החלף לרקע כהה",
+      "switchToLight": "החלף לרקע בהיר"
     }
   }
 }

--- a/packages/lib-react-components/src/translations/hi.json
+++ b/packages/lib-react-components/src/translations/hi.json
@@ -21,6 +21,10 @@
     "SignedOutUserNavigation": {
       "register": "रजिस्टर",
       "signIn": "साइन इन"
+    },
+    "ThemeModeToggle": {
+      "switchToDark": "थीम से बदलें गहरा",
+      "switchToLight": "थीम से बदलें हल्का"
     }
   }
 }

--- a/packages/lib-react-components/src/translations/hr.json
+++ b/packages/lib-react-components/src/translations/hr.json
@@ -37,6 +37,10 @@
       "register": "Registrirajte se",
       "signIn": "Prijavite se"
     },
+    "ThemeModeToggle": {
+      "switchToDark": "Prebaci na tamno temu",
+      "switchToLight": "Prebaci na svijetlo temu"
+    },
     "UserMenu": {
       "userNavListLabels": {
         "collections": "Zbirke",

--- a/packages/lib-react-components/src/translations/it.json
+++ b/packages/lib-react-components/src/translations/it.json
@@ -37,6 +37,10 @@
       "register": "Registrazione",
       "signIn": "Login"
     },
+    "ThemeModeToggle": {
+      "switchToDark": "Passa al tema scuro",
+      "switchToLight": "Passa al tema chiaro"
+    },
     "UserMenu": {
       "userNavListLabels": {
         "collections": "Collezioni",

--- a/packages/lib-react-components/src/translations/ja.json
+++ b/packages/lib-react-components/src/translations/ja.json
@@ -21,6 +21,10 @@
     "SignedOutUserNavigation": {
       "register": "新規登録",
       "signIn": "サインイン"
+    },
+    "ThemeModeToggle": {
+      "switchToDark": "ダーク へ切り替える",
+      "switchToLight": "ライト へ切り替える"
     }
   }
 }

--- a/packages/lib-react-components/src/translations/nl.json
+++ b/packages/lib-react-components/src/translations/nl.json
@@ -17,6 +17,10 @@
     "SignedOutUserNavigation": {
       "register": "Registreren",
       "signIn": "Inloggen"
+    },
+    "ThemeModeToggle": {
+      "switchToDark": "Wissel naar donker thema",
+      "switchToLight": "Wissel naar licht thema"
     }
   }
 }

--- a/packages/lib-react-components/src/translations/pl.json
+++ b/packages/lib-react-components/src/translations/pl.json
@@ -11,6 +11,10 @@
     "mainHeaderNavListLabels": {
       "talk": "Dyskutowanie"
     },
+    "ThemeModeToggle": {
+      "switchToDark": "Przełącz do ciemnego trybu",
+      "switchToLight": "Przełącz do jasnego trybu"
+    },
     "UserMenu": {
       "userNavListLabels": {
         "collections": "Kolekcje"

--- a/packages/lib-react-components/src/translations/pt.json
+++ b/packages/lib-react-components/src/translations/pt.json
@@ -37,6 +37,10 @@
       "register": "Registar-se",
       "signIn": "Entrar"
     },
+    "ThemeModeToggle": {
+      "switchToDark": "Mudar para o tema escuro",
+      "switchToLight": "Mudar para o tema claro"
+    },
     "UserMenu": {
       "userNavListLabels": {
         "collections": "Colecções",

--- a/packages/lib-react-components/src/translations/ru.json
+++ b/packages/lib-react-components/src/translations/ru.json
@@ -37,6 +37,10 @@
       "register": "Зарегистрироваться",
       "signIn": "Войти"
     },
+    "ThemeModeToggle": {
+      "switchToDark": "Переключиться на Темный тему",
+      "switchToLight": "Переключиться на Светный тему"
+    },
     "UserMenu": {
       "userNavListLabels": {
         "collections": "Коллекции",

--- a/packages/lib-react-components/src/translations/sv.json
+++ b/packages/lib-react-components/src/translations/sv.json
@@ -30,6 +30,10 @@
     "SignedOutUserNavigation": {
       "register": "Registrera dig",
       "signIn": "Logga in"
+    },
+    "ThemeModeToggle": {
+      "switchToDark": "Byt till mörkt tema",
+      "switchToLight": "Byt till ljust tema"
     }
   }
 }

--- a/packages/lib-react-components/src/translations/test.json
+++ b/packages/lib-react-components/src/translations/test.json
@@ -121,6 +121,10 @@
       "register": "Translated",
       "signIn": "Translated"
     },
+    "ThemeModeToggle": {
+      "switchToDark": "Translated",
+      "switchToLight": "Translated"
+    },
     "UserMenu": {
       "userNavListLabels": {
         "profile": "Translated",

--- a/packages/lib-react-components/src/translations/tr.json
+++ b/packages/lib-react-components/src/translations/tr.json
@@ -66,6 +66,10 @@
       "register": "Kayıt ol",
       "signIn": "Giriş yap"
     },
+    "ThemeModeToggle": {
+      "switchToDark": "Koyu temaya geç",
+      "switchToLight": "Açık temaya geç"
+    },
     "UserMenu": {
       "userNavListLabels": {
         "collections": "Koleksiyonlar",

--- a/packages/lib-react-components/src/translations/ur.json
+++ b/packages/lib-react-components/src/translations/ur.json
@@ -37,6 +37,10 @@
       "register": "اندراج ",
       "signIn": "سائن ان"
     },
+    "ThemeModeToggle": {
+      "switchToDark": "موضوع تبدیل کریں",
+      "switchToLight": "موضوع تبدیل کریں"
+    },
     "UserMenu": {
       "userNavListLabels": {
         "collections": "مجموعہ",

--- a/packages/lib-react-components/src/translations/zh-CN.json
+++ b/packages/lib-react-components/src/translations/zh-CN.json
@@ -21,6 +21,10 @@
     "SignedOutUserNavigation": {
       "register": "注册",
       "signIn": "登录"
+    },
+    "ThemeModeToggle": {
+      "switchToDark": "切换至 深色 主题",
+      "switchToLight": "切换至 浅色 主题"
     }
   }
 }


### PR DESCRIPTION
## Package
lib-react-components
app-root

## Linked Issue and/or Talk Post
Toward: https://github.com/zooniverse/front-end-monorepo/issues/5571

## Describe your changes

lib-react-components
- Build a new ThemeModeToggle in ZooHeader
- Move corresponding translation keys into lib-react-components
- Add a story and spec for the toggle
- The new toggle component includes a prop `showThemeToggle` because applications that use lib-react-components might not all want to have a theme toggle in their header

app-root
- Create a theme context based on the same pattern as AdminToggle
- Store selected theme mode as `darkMode` (true or false) in localStorage


## How to Review

- Run lib-react-components storybook and view the new story.
- Run app-root locally and try out the toggle in ZooHeader. You should be able to close your browser tab and re-open a new tab and app-root will remember your theme preference in localStorage.
- The toggle should not appear in app-project or app-content-pages. There will be a follow-up PR to implement the new toggle in those apps.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).