### PR TITLE
Fix missing dependency in lib-react-components

### DIFF
--- a/packages/app-content-pages/package.json
+++ b/packages/app-content-pages/package.json
@@ -20,7 +20,7 @@
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/grommet-theme": "~3.2.0",
     "@zooniverse/panoptes-js": "~0.5.0",
-    "@zooniverse/react-components": "~1.9.0",
+    "@zooniverse/react-components": "~1.10.0",
     "contentful": "~10.6.0",
     "dotenv": "~16.3.0",
     "dotenv-webpack": "~8.0.0",

--- a/packages/app-project/package.json
+++ b/packages/app-project/package.json
@@ -29,7 +29,7 @@
     "@zooniverse/classifier": "^0.0.1",
     "@zooniverse/grommet-theme": "~3.2.0",
     "@zooniverse/panoptes-js": "~0.5.0",
-    "@zooniverse/react-components": "~1.9.0",
+    "@zooniverse/react-components": "~1.10.0",
     "cookie": "~0.6.0",
     "d3": "~6.7.0",
     "engine.io-client": "~6.5.0",

--- a/packages/app-root/package.json
+++ b/packages/app-root/package.json
@@ -16,7 +16,7 @@
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/grommet-theme": "~3.2.0",
     "@zooniverse/panoptes-js": "~0.5.0",
-    "@zooniverse/react-components": "~1.9.0",
+    "@zooniverse/react-components": "~1.10.0",
     "express": "~4.18.2",
     "grommet": "~2.34.0",
     "grommet-icons": "~4.11.0",

--- a/packages/lib-classifier/package.json
+++ b/packages/lib-classifier/package.json
@@ -80,7 +80,7 @@
     "@wojtekmaj/enzyme-adapter-react-17": "~0.8.0",
     "@zooniverse/grommet-theme": "~3.2.0",
     "@zooniverse/panoptes-js": "~0.5.0",
-    "@zooniverse/react-components": "~1.9.0",
+    "@zooniverse/react-components": "~1.10.0",
     "@zooniverse/standard": "~2.0.0",
     "babel-loader": "~9.1.0",
     "babel-plugin-module-resolver": "~5.0.0",

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.10.0] 2023-11-22
+
+### Fixed
+Added missing `@zooniverse/panoptes-js` package (used by Panoptes data-fetching hooks.)
+
+### Added
+- `Media` can now display text subjects.
+
 ## [1.9.1] 2023-11-16
 
 ### Fixed

--- a/packages/lib-react-components/package.json
+++ b/packages/lib-react-components/package.json
@@ -3,7 +3,7 @@
   "description": "Zooniverse React Components",
   "license": "Apache-2.0",
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {
@@ -38,6 +38,7 @@
   "dependencies": {
     "@fortawesome/free-regular-svg-icons": "~6.4.0",
     "@fortawesome/free-solid-svg-icons": "~6.4.0",
+    "@zooniverse/panoptes-js": "~0.5.0",
     "@tippyjs/react": "~4.2.6",
     "@visx/glyph": "~3.3.0",
     "@visx/group": "~3.3.0",


### PR DESCRIPTION
Add `@zooniverse/panoptes-js`, which is used by the `fetchPanoptesUser` helper.

Bump the version to 1.10, to include the new text subject feature.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- @zooniverse/react-components

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser
