### PR TITLE
ZooFooter: Adjust spacing

### DIFF
--- a/packages/lib-react-components/src/ZooFooter/ZooFooter.js
+++ b/packages/lib-react-components/src/ZooFooter/ZooFooter.js
@@ -140,7 +140,13 @@ export default function ZooFooter({
           margin={{ horizontal: 'medium' }}
         >
           <LogoAndTagline tagLine={t('ZooFooter.tagLine')} />
-          <Box align='end' direction='row' gap='small' responsive={false}>
+          <Box
+            align='end'
+            direction='row'
+            gap='small'
+            justify='end'
+            responsive={false}
+          >
             <SocialAnchor service='facebook' />
             <SocialAnchor service='twitter' />
             <SocialAnchor service='instagram' />
@@ -154,7 +160,7 @@ export default function ZooFooter({
             count: 'fit',
             size: '120px'
           }}
-          pad='medium'
+          pad={{ horizontal: 'large', top: 'medium', bottom: 'large' }}
         >
           <LinkList labels={projectNavListLabels} urls={projectNavListURLs} />
           <LinkList labels={aboutNavListLabels} urls={aboutNavListURLs} />

--- a/packages/lib-react-components/src/ZooFooter/ZooFooter.js
+++ b/packages/lib-react-components/src/ZooFooter/ZooFooter.js
@@ -1,7 +1,6 @@
-import { Box, Grid, Image } from 'grommet'
+import { Box, Grid } from 'grommet'
 import { arrayOf, node, string } from 'prop-types'
-import { useEffect } from 'react';
-import styled from 'styled-components'
+import { useEffect } from 'react'
 import i18n, { useTranslation } from '../translations/i18n'
 import { useHasMounted } from '../hooks'
 
@@ -12,23 +11,6 @@ import {
   SocialAnchor
 } from './components'
 
-export const StyledEasterEgg = styled(Image)`
-  bottom: 100%;
-  display: inline-block;
-  height: 74px;
-  margin: 0;
-  opacity: 0;
-  position: absolute;
-  right: 0;
-  transition: opacity 0.5s ease;
-  transition-delay: 0.25s;
-  width: 62px;
-  z-index: 1;
-
-  &:hover {
-    opacity: 1;
-  }
-`
 const defaultProps = {
   aboutNavListURLs: [
     'https://www.zooniverse.org/about',
@@ -63,15 +45,11 @@ const defaultProps = {
     'https://status.zooniverse.org/',
     'https://www.zooniverse.org/security'
   ],
-  projectNavListURLs: [
-    'https://www.zooniverse.org/projects'
-  ],
-  talkNavListURLs: [
-    'https://www.zooniverse.org/talk'
-  ]
+  projectNavListURLs: ['https://www.zooniverse.org/projects'],
+  talkNavListURLs: ['https://www.zooniverse.org/talk']
 }
 
-export default function ZooFooter ({
+export default function ZooFooter({
   aboutNavListURLs = defaultProps.aboutNavListURLs,
   adminContainer,
   buildNavListURLs = defaultProps.buildNavListURLs,
@@ -129,18 +107,13 @@ export default function ZooFooter ({
     t('ZooFooter.policyLabels.security')
   ]
 
-  const projectNavListLabels = [
-    t('ZooFooter.projectLabels.projects')
-  ]
+  const projectNavListLabels = [t('ZooFooter.projectLabels.projects')]
 
-  const talkNavListLabels = [
-    t('ZooFooter.talkLabels.talk')
-  ]
+  const talkNavListLabels = [t('ZooFooter.talkLabels.talk')]
 
   return (
     <Box
       as='footer'
-      align='center'
       background={{
         dark: 'dark-1',
         light: 'white'
@@ -152,15 +125,9 @@ export default function ZooFooter ({
       }}
       className={className}
       direction='column'
-      pad={{
-        top: 'large'
-      }}
       responsive
     >
-      <Box
-        pad={{ horizontal: 'large', bottom: 'medium' }}
-        fill='horizontal'
-      >
+      <Box>
         <Box
           border={{
             color: 'light-6',
@@ -169,17 +136,11 @@ export default function ZooFooter ({
           }}
           direction='row-responsive'
           justify='between'
-          margin={{ bottom: 'medium' }}
-          pad={{ bottom: 'medium' }}
+          pad={{ vertical: 'medium' }}
+          margin={{ horizontal: 'medium' }}
         >
           <LogoAndTagline tagLine={t('ZooFooter.tagLine')} />
-          <Box
-            align='end'
-            direction='row'
-            gap='small'
-            justify='end'
-            responsive={false}
-          >
+          <Box align='end' direction='row' gap='small' responsive={false}>
             <SocialAnchor service='facebook' />
             <SocialAnchor service='twitter' />
             <SocialAnchor service='instagram' />
@@ -188,51 +149,33 @@ export default function ZooFooter ({
 
         <Grid
           as='section'
-          fill
           gap='small'
           columns={{
-            'count': 'fit',
-            'size': '120px'
+            count: 'fit',
+            size: '120px'
           }}
-          margin={{ bottom: 'large' }}
+          pad='medium'
         >
-          <LinkList
-            labels={projectNavListLabels}
-            urls={projectNavListURLs}
-          />
-          <LinkList
-            labels={aboutNavListLabels}
-            urls={aboutNavListURLs}
-          />
+          <LinkList labels={projectNavListLabels} urls={projectNavListURLs} />
+          <LinkList labels={aboutNavListLabels} urls={aboutNavListURLs} />
           <LinkList
             labels={getInvolvedNavListLabels}
             urls={getInvolvedNavListURLs}
           />
-          <LinkList
-            labels={talkNavListLabels}
-            urls={talkNavListURLs}
-          />
-          <LinkList
-            labels={buildNavListLabels}
-            urls={buildNavListURLs}
-          />
-          <LinkList
-            labels={newsNavListLabels}
-            urls={newsNavListURLs}
-          />
+          <LinkList labels={talkNavListLabels} urls={talkNavListURLs} />
+          <LinkList labels={buildNavListLabels} urls={buildNavListURLs} />
+          <LinkList labels={newsNavListLabels} urls={newsNavListURLs} />
         </Grid>
       </Box>
       <Box
-        align='center'
         background={{
           dark: 'dark-3',
           light: 'light-1'
         }}
         direction='row'
-        fill='horizontal'
         justify='between'
         pad={{
-          horizontal: 'large',
+          horizontal: 'medium',
           vertical: 'small'
         }}
       >
@@ -240,9 +183,7 @@ export default function ZooFooter ({
           labels={policyNavListLabels}
           urls={policyNavListURLs}
         />
-        <Box>
-          {hasMounted && adminContainer}
-        </Box>
+        <Box>{hasMounted && adminContainer}</Box>
       </Box>
     </Box>
   )

--- a/packages/lib-react-components/src/ZooFooter/components/LinkList/LinkList.js
+++ b/packages/lib-react-components/src/ZooFooter/components/LinkList/LinkList.js
@@ -8,6 +8,9 @@ import SpacedText from '../../../SpacedText'
 const StyledBox = styled(Box)`
   height: fit-content;
   list-style-type: none;
+  padding-inline-start: 0;
+  margin-block-start: 0;
+  margin-block-end: 0;
 `
 
 export default function LinkList ({ className, labels, urls }) {
@@ -19,7 +22,6 @@ export default function LinkList ({ className, labels, urls }) {
       as='ul'
       className={className}
       direction='column'
-      pad='none'
     >
 
       <li>

--- a/packages/lib-react-components/src/ZooFooter/components/PolicyLinkSection/PolicyLinkSection.js
+++ b/packages/lib-react-components/src/ZooFooter/components/PolicyLinkSection/PolicyLinkSection.js
@@ -19,13 +19,13 @@ function PolicyLinkSection ({
       aria-label={t('ZooFooter.zooniversePolicies')}
       as='nav'
       direction={direction}
-      gap='medium'
     >
     {links.length > 0 && links.map(link => (
       <Anchor
         href={link.url}
         key={link.url}
         size='small'
+        margin={screenSize !== 'small' ? { right: 'medium' } : { bottom: 'xsmall' }}
       >
         <SpacedText weight='bold'>
           {link.label}


### PR DESCRIPTION
## Package
lib-react-components

## Linked Issue and/or Talk Post
Follows decision to make all page sections' horizontal padding Grommet's `medium`: https://github.com/zooniverse/front-end-monorepo/discussions/5598
Closes: https://github.com/zooniverse/front-end-monorepo/issues/5630

## Describe your changes

Adjusted various padding and margin in ZooFooter to match 30px on desktop and 20px on mobile screens.

I removed `gap` from PolicyLInkSection because Grommet `gap` inserts divs into a nav list.

## How to Review

Run lib-react-components storybook to view ZooFooter on various viewport widths.

## Screenshots

Desktop:
<img width="1352" alt="desktop" src="https://github.com/zooniverse/front-end-monorepo/assets/23665803/0c12b9b6-b145-44ef-9551-082fb408d36d">

Mobile:
<img width="400" alt="mobile" src="https://github.com/zooniverse/front-end-monorepo/assets/23665803/ccb95370-8cdd-4316-801b-e0622fa5a914">


# Checklist

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook