### PR TITLE
Use explicit labels for TaskInput components

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/components/TaskInput/TaskInput.js
+++ b/packages/lib-classifier/src/plugins/tasks/components/TaskInput/TaskInput.js
@@ -36,7 +36,7 @@ function getHoverStyles (props, active = false) {
   }
 }
 
-export const StyledTaskLabel = styled(Text)`
+const StyledText = styled(Text)`
   align-items: baseline;
   ${props => props.theme.dark ?
     css`background: transparent;` :
@@ -50,7 +50,7 @@ export const StyledTaskLabel = styled(Text)`
   margin-bottom: .5em;
 `
 
-export const StyledTaskInput = styled.label`
+const StyledLabel = styled.label`
   position: relative;
 
   input {
@@ -58,19 +58,19 @@ export const StyledTaskInput = styled.label`
     position: absolute;
   }
 
-  input:enabled + ${StyledTaskLabel}:hover {
+  input:enabled + ${StyledText}:hover {
     ${props => getHoverStyles(props)}
   }
 
-  input:focus + ${StyledTaskLabel} {
+  input:focus + ${StyledText} {
     ${props => getHoverStyles(props)}
   }
 
-  input:enabled:active + ${StyledTaskLabel} {
+  input:enabled:active + ${StyledText} {
     ${props => getHoverStyles(props, true)}
   }
 
-  input:checked + ${StyledTaskLabel} {
+  input:checked + ${StyledText} {
     ${props => css`background: ${props.theme.global.colors.brand};`}
     ${props => props.theme.dark ?
       css`border: 2px solid ${props.theme.global.colors['light-1']};` :
@@ -79,8 +79,8 @@ export const StyledTaskInput = styled.label`
     ${props => props.theme.dark ? css`color: ${props.theme.global.colors.text.dark};` : css`color: white;`}
   }
 
-  input:focus:checked + ${StyledTaskLabel},
-  input:checked + ${StyledTaskLabel}:hover {
+  input:focus:checked + ${StyledText},
+  input:checked + ${StyledText}:hover {
     ${props => props.theme.dark ?
       css`border: 2px solid ${props.theme.global.colors['light-1']};` :
       css`border: 2px solid ${props.theme.global.colors['neutral-1']};`
@@ -91,7 +91,7 @@ export const StyledTaskInput = styled.label`
     }
   }
 
-  input:checked + ${StyledTaskLabel}:hover {
+  input:checked + ${StyledText}:hover {
     > div > span > p {
       ${props => props.theme.dark ?
         css`color: ${props.theme.global.colors.text.dark};` :
@@ -103,7 +103,7 @@ export const StyledTaskInput = styled.label`
 
 const DEFAULT_HANDLER = () => true
 
-export function TaskInput ({
+export function TaskInput({
   autoFocus = false,
   checked = false,
   className = '',
@@ -112,28 +112,30 @@ export function TaskInput ({
   label = '',
   labelIcon = null,
   labelStatus = null,
-  name = '',
+  name,
   onChange = DEFAULT_HANDLER,
   type
 }) {
-
+  const id = `${type}-${name}-${index}`
   return (
-    <StyledTaskInput
+    <StyledLabel
       className={className}
+      htmlFor={id}
     >
       <input
         autoFocus={autoFocus}
         checked={checked}
         disabled={disabled}
+        id={id}
         name={name}
         onChange={onChange}
         type={type}
         value={index}
       />
-      <StyledTaskLabel margin={{ vertical: 'small', horizontal: 'none' }}>
+      <StyledText margin={{ vertical: 'small', horizontal: 'none' }}>
         <TaskInputLabel label={label} labelIcon={labelIcon} labelStatus={labelStatus} />
-      </StyledTaskLabel>
-    </StyledTaskInput>
+      </StyledText>
+    </StyledLabel>
   )
 }
 
@@ -146,7 +148,7 @@ TaskInput.propTypes = {
   label: PropTypes.string,
   labelIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.object]),
   labelStatus: PropTypes.oneOfType([PropTypes.node, PropTypes.object]),
-  name: PropTypes.string,
+  name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   type: PropTypes.string.isRequired
 }

--- a/packages/lib-classifier/src/plugins/tasks/components/TaskInput/components/TaskInputLabel/TaskInputLabel.js
+++ b/packages/lib-classifier/src/plugins/tasks/components/TaskInput/components/TaskInputLabel/TaskInputLabel.js
@@ -15,6 +15,8 @@ const StyledTaskInputLabelWrapper = styled.span`
 `
 
 const StyledText = styled(Text)`
+  display: block;
+  margin: 1em 0;
   padding-left: 15px;
   padding-right: 15px;
 
@@ -23,15 +25,6 @@ const StyledText = styled(Text)`
     vertical-align: middle;
   }
 `
-
-const StyledSpan = styled.span`
-  display: block;
-  margin: 1em 0;
-`
-
-const inlineComponents = {
-  p: StyledSpan
-}
 
 export default function TaskInputLabel({
   label = '',
@@ -52,7 +45,7 @@ export default function TaskInputLabel({
       {labelIcon &&
         labelIcon}
       <StyledText>
-        <Markdownz components={inlineComponents}>{label}</Markdownz>
+        <Markdownz inline >{label}</Markdownz>
       </StyledText>
       {labelStatus &&
         labelStatus}

--- a/packages/lib-classifier/src/plugins/tasks/components/TaskInput/components/TaskInputLabel/TaskInputLabel.js
+++ b/packages/lib-classifier/src/plugins/tasks/components/TaskInput/components/TaskInputLabel/TaskInputLabel.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { Markdownz } from '@zooniverse/react-components'
 import { doesTheLabelHaveAnImage } from '../../helpers'
 
-export const StyledTaskInputLabelWrapper = styled.span`
+const StyledTaskInputLabelWrapper = styled.span`
   &:first-child {
     margin-top: 0;
   }
@@ -14,7 +14,7 @@ export const StyledTaskInputLabelWrapper = styled.span`
   }
 `
 
-export const StyledLabel = styled(Text)`
+const StyledText = styled(Text)`
   padding-left: 15px;
   padding-right: 15px;
 
@@ -33,7 +33,11 @@ const inlineComponents = {
   p: StyledSpan
 }
 
-export default function TaskInputLabel ({ label, labelIcon, labelStatus }) {
+export default function TaskInputLabel({
+  label = '',
+  labelIcon = null,
+  labelStatus = null
+}) {
   const howShouldTheLabelBeAligned = ((label && doesTheLabelHaveAnImage(label)) || (label && labelIcon))
     ? 'start'
     : 'center'
@@ -47,19 +51,13 @@ export default function TaskInputLabel ({ label, labelIcon, labelStatus }) {
     >
       {labelIcon &&
         labelIcon}
-      <StyledLabel>
+      <StyledText>
         <Markdownz components={inlineComponents}>{label}</Markdownz>
-      </StyledLabel>
+      </StyledText>
       {labelStatus &&
         labelStatus}
     </Box>
   )
-}
-
-TaskInputLabel.defaultProps = {
-  label: '',
-  labelIcon: null,
-  labelStatus: null
 }
 
 TaskInputLabel.propTypes = {

--- a/packages/lib-classifier/src/plugins/tasks/components/TaskInput/index.js
+++ b/packages/lib-classifier/src/plugins/tasks/components/TaskInput/index.js
@@ -1,1 +1,1 @@
-export { default, StyledTaskInput } from './TaskInput'
+export { default } from './TaskInput'


### PR DESCRIPTION
- Clarify the naming of the task label and text for `TaskInput` components.
- Give each input a unique ID, based on the input type, task key and index.
- Explicitly label each input with the HTML `for` attribute.
- Clarify the naming of the label text in `TaskInputLabel`.
- Render labels with the inline markdown parser.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier/plugins/tasks

## Linked Issue and/or Talk Post
- towards #5737.

## How to Review
This can be reviewed in the storybook, using the stories for question tasks (single and multiple choice), drawing tasks and data annotation tasks. The behaviour of the radio button and checkbox inputs should not have changed, but they should all now be labelled with the HTML `for` attribute. Explicit labelling is needed by assistive technology such as Dragon Naturally Speaking and some screen readers (see #5737.)

In the code itself, the input label should be easier to find now.

In the dev classifier, you can use Galaxy Zoo to test question tasks with markdown labels:
https://localhost:8080?project=zookeeper/galaxy-zoo&env=production

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

