### PR TITLE
Change Flipbook and SeparateFrames viewers behavior to not clone drawing marks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
@@ -13,8 +13,8 @@ import FlipbookControls from './components'
 const DEFAULT_HANDLER = () => true
 
 const FlipbookViewer = ({
-  defaultFrame = 0,
-	enableInteractionLayer = false,
+  enableInteractionLayer = false,
+  frame = 0,
   enableRotation = DEFAULT_HANDLER,
   flipbookAutoplay = false,
   invert = false,
@@ -25,17 +25,17 @@ const FlipbookViewer = ({
   onReady = DEFAULT_HANDLER,
   playIterations,
   rotation,
+  setFrame = DEFAULT_HANDLER,
   setOnPan = DEFAULT_HANDLER,
   setOnZoom = DEFAULT_HANDLER,
   subject
 }) => {
-  const [currentFrame, setCurrentFrame] = useState(defaultFrame)
   const [playing, setPlaying] = useState(false)
   const [dragMove, setDragMove] = useState()
   /** This initializes an image element from the subject's defaultFrame src url.
    * We do this so the SVGPanZoom has dimensions of the subject image.
    * We're assuming all frames in one subject have the same dimensions. */
-  const defaultFrameLocation = subject ? subject.locations[defaultFrame] : null
+  const defaultFrameLocation = subject ? subject.locations[frame] : null
   const { img, error, loading, subjectImage } = useSubjectImage({
     src: defaultFrameLocation.url,
     onReady,
@@ -46,7 +46,7 @@ const FlipbookViewer = ({
     naturalWidth = 800
   } = img
 
-  const viewerLocation = subject?.locations ? subject.locations[currentFrame] : ''
+  const viewerLocation = subject?.locations ? subject.locations[frame] : ''
 
   useEffect(() => {
     enableRotation()
@@ -97,6 +97,7 @@ const FlipbookViewer = ({
       >
         <SingleImageViewer
           enableInteractionLayer={enableInteractionLayer}
+          frame={frame}
           height={naturalHeight}
           limitSubjectHeight={limitSubjectHeight}
           onKeyDown={handleSpaceBar}
@@ -118,9 +119,9 @@ const FlipbookViewer = ({
         </SingleImageViewer>
       </SVGPanZoom>
       <FlipbookControls
-        currentFrame={currentFrame}
+        currentFrame={frame}
         locations={subject.locations}
-        onFrameChange={setCurrentFrame}
+        onFrameChange={setFrame}
         onPlayPause={onPlayPause}
         playing={playing}
         playIterations={playIterations}
@@ -130,12 +131,12 @@ const FlipbookViewer = ({
 }
 
 FlipbookViewer.propTypes = {
-  /** Fetched from metadata.default_frame or initialized to zero */
-  defaultFrame: PropTypes.number,
   /** Passed from Subject Viewer Store */
   enableInteractionLayer: PropTypes.bool,
   /** Function passed from Subject Viewer Store */
   enableRotation: PropTypes.func,
+  /** Index of currently viewed Frame or initialized to zero */
+  frame: PropTypes.number,
   /** Fetched from workflow configuration. Determines whether to autoplay the loop on viewer load */
   flipbookAutoplay: PropTypes.bool,
   /** Passed from Subject Viewer Store */

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.spec.js
@@ -46,18 +46,19 @@ describe('Component > FlipbookViewer', function () {
       expect(newButtonStyle.border).to.equal('2px solid #f0b200')
     })
 
+    // NOTE: these tests are run sequentially and the frame state of the below test is inherited from the above test
     it('should handle using arrow keys on the tablist', async function () {
       const user = userEvent.setup({ delay: null })
 
       const { getAllByRole } = render(<DefaultStory />)
       const thumbnailButtons = getAllByRole('tab')
-      expect(thumbnailButtons[0].tabIndex).to.equal(0)
+      expect(thumbnailButtons[1].tabIndex).to.equal(0)
 
-      thumbnailButtons[0].focus()
+      thumbnailButtons[1].focus()
       await user.keyboard('{ArrowRight}')
 
-      expect(thumbnailButtons[0].tabIndex).to.equal(-1)
-      expect(thumbnailButtons[1].tabIndex).to.equal(0)
+      expect(thumbnailButtons[1].tabIndex).to.equal(-1)
+      expect(thumbnailButtons[2].tabIndex).to.equal(0)
     })
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.js
@@ -11,14 +11,16 @@ import SeparateFramesViewer from '../SeparateFramesViewer/SeparateFramesViewer'
 function storeMapper(store) {
   const {
     enableRotation,
-    frame: defaultFrame,
+    frame,
     invert,
     move,
     rotation,
     separateFramesView,
+    setFrame,
     setOnPan,
     setOnZoom
   } = store.subjectViewer
+  
   const {
     flipbook_autoplay: flipbookAutoplay,
     limit_subject_height: limitSubjectHeight,
@@ -26,7 +28,7 @@ function storeMapper(store) {
   } = store.workflows?.active?.configuration
 
   return {
-    defaultFrame,
+    frame,
     enableRotation,
     flipbookAutoplay,
     invert,
@@ -35,6 +37,7 @@ function storeMapper(store) {
     playIterations,
     rotation,
     separateFramesView,
+    setFrame,
     setOnPan,
     setOnZoom
   }
@@ -50,7 +53,7 @@ function FlipbookViewerContainer({
   subject
 }) {
   const {
-    defaultFrame,
+    frame,
     enableRotation,
     flipbookAutoplay,
     invert,
@@ -59,6 +62,7 @@ function FlipbookViewerContainer({
     playIterations,
     rotation,
     separateFramesView,
+    setFrame,
     setOnPan,
     setOnZoom
   } = useStores(storeMapper)
@@ -93,8 +97,8 @@ function FlipbookViewerContainer({
         />
       ) : (
         <FlipbookViewer
-          defaultFrame={defaultFrame}
           enableInteractionLayer={enableInteractionLayer}
+          frame={frame}
           enableRotation={enableRotation}
           flipbookAutoplay={flipbookAutoplay}
           invert={invert}
@@ -105,6 +109,7 @@ function FlipbookViewerContainer({
           onReady={onReady}
           playIterations={playIterations}
           rotation={rotation}
+          setFrame={setFrame}
           setOnPan={setOnPan}
           setOnZoom={setOnZoom}
           subject={subject}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -1,6 +1,6 @@
 import cuid from 'cuid'
 import PropTypes from 'prop-types'
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import styled, { css } from 'styled-components'
 import DrawingToolMarks from './components/DrawingToolMarks'
 import TranscribedLines from './components/TranscribedLines'
@@ -34,6 +34,7 @@ function InteractionLayer({
   height,
   marks = [],
   move,
+  multiImageCloneMarkers = false,
   setActiveMark = () => { },
   scale = 1,
   subject,
@@ -90,11 +91,11 @@ function InteractionLayer({
   }
 
   function createMark(event) {
-    // TODO: add case for played = undefined
     const timeStamp = getFixedNumber(played, 5)
     const mark = activeTool.createMark({
       id: cuid(),
-      frame,
+      // GH Issue 5493 decided multiImageCloneMarkers force new mark frames to 0
+      frame: (multiImageCloneMarkers) ? 0 : frame,
       toolIndex: activeToolIndex
     })
 
@@ -104,7 +105,7 @@ function InteractionLayer({
     mark.setSubTaskVisibility(false)
     // Add a time value for tools that care about time. For most tools, this value is ignored.
     mark.setVideoTime(timeStamp, duration)
-    const markIDs = marks.map((mark) => mark.id)
+    const markIDs = annotation.value?.map((mark) => mark.id)
     annotation.update([...markIDs, mark.id])
   }
 
@@ -205,9 +206,11 @@ InteractionLayer.propTypes = {
     value: PropTypes.array
   }).isRequired,
   disabled: PropTypes.bool,
+  /** Index of the Frame. Initially inherits from parent Viewer or overwritten in Viewer with SubjectViewerStore */
   frame: PropTypes.number,
   height: PropTypes.number.isRequired,
   marks: PropTypes.array,
+  multiImageCloneMarkers: PropTypes.bool,
   scale: PropTypes.number,
   setActiveMark: PropTypes.func,
   subject: PropTypes.shape({

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayerContainer.js
@@ -10,7 +10,10 @@ import locationValidator from '../../helpers/locationValidator'
 function storeMapper(classifierStore) {
   const activeStepAnnotations = classifierStore.subjects.active?.stepHistory?.latest?.annotations
   const { activeStepTasks } = classifierStore.workflowSteps
-  const { frame, move } = classifierStore.subjectViewer
+  const { move } = classifierStore.subjectViewer
+  const {
+    multi_image_clone_markers: multiImageCloneMarkers
+  } = classifierStore.workflows?.active?.configuration
 
   const [activeInteractionTask] = activeStepTasks.filter(
     (task) => task.type === 'drawing' || task.type === 'transcription'
@@ -38,10 +41,10 @@ function storeMapper(classifierStore) {
     activeToolIndex,
     annotation,
     disabled,
-    frame,
     hidingIndex,
     marks,
     move,
+    multiImageCloneMarkers,
     setActiveMark,
     shownMarks,
     taskKey
@@ -59,6 +62,7 @@ export function InteractionLayerContainer({
   hidingIndex,
   marks = [],
   move = false,
+  multiImageCloneMarkers = false,
   scale = 1,
   setActiveMark = () => { },
   shownMarks = SHOWN_MARKS.ALL,
@@ -69,13 +73,12 @@ export function InteractionLayerContainer({
   played,
   duration
 }) {
-
   const newMarks =
     shownMarks === SHOWN_MARKS.NONE ? marks.slice(hidingIndex) : marks
-  const visibleMarksPerFrame = newMarks?.filter(
-    (mark) => mark.frame === frame
-  )
-
+  const visibleMarksPerFrame = (multiImageCloneMarkers)
+    ? newMarks
+    : newMarks?.filter((mark) => mark.frame === frame)
+    
   return (
     <>
       {activeTool && (
@@ -91,6 +94,7 @@ export function InteractionLayerContainer({
           key={taskKey}
           marks={visibleMarksPerFrame}
           move={move}
+          multiImageCloneMarkers={multiImageCloneMarkers}
           played={played}
           setActiveMark={setActiveMark}
           scale={scale}
@@ -99,7 +103,10 @@ export function InteractionLayerContainer({
           width={width}
         />
       )}
-      <PreviousMarks scale={scale} />
+      <PreviousMarks
+        scale={scale}
+        frame={frame}
+      />
     </>
   )
 }
@@ -109,6 +116,7 @@ InteractionLayerContainer.propTypes = {
   activeTool: PropTypes.object,
   disabled: PropTypes.bool,
   duration: PropTypes.number,
+  /** Index of the Frame. Always inherits from SingleImageViewer, which inherits from the Viewer */
   frame: PropTypes.number,
   height: PropTypes.number.isRequired,
   interactionTaskAnnotations: PropTypes.array,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/PreviousMarks/PreviousMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/PreviousMarks/PreviousMarks.js
@@ -10,9 +10,6 @@ function storeMapper(classifierStore) {
     classifications: {
       active: classification
     },
-    subjectViewer: {
-      frame
-    },
     workflowSteps: {
       activeInteractionTask,
       interactionTask: {
@@ -21,17 +18,28 @@ function storeMapper(classifierStore) {
     }
   } = classifierStore
 
+  const {
+    multi_image_clone_markers: multiImageCloneMarkers
+  } = classifierStore.workflows?.active?.configuration
+
   const previousAnnotations = classification?.previousInteractionTaskAnnotations(activeInteractionTask.taskKey) || []
-  return { frame, previousAnnotations, shownMarks }
+
+  return {
+    multiImageCloneMarkers,
+    previousAnnotations,
+    shownMarks
+  }
 }
 
 function PreviousMarks ({
+  /** The current active frame in the subject viewer. */
+  frame = 0,
   /** SVG image scale (client size / natural size.)*/
   scale = 1
 }) {
   const {
-    /** The current active frame in the subject viewer. */
-    frame = 0,
+    /** Clone all previous marks across all frames */
+    multiImageCloneMarkers,
     /** Annotations from previous marking tasks. Each annotation is an array of marks. */
     previousAnnotations,
     /** The show/hide previous marks setting. */
@@ -46,7 +54,10 @@ function PreviousMarks ({
     return (
       <>
         {previousAnnotations.map((annotation) => {
-          const annotationValuesPerFrame = annotation.value.filter(value => value.frame === frame)
+          const annotationValuesPerFrame = (multiImageCloneMarkers)
+            ? annotation.value
+            : annotation.value.filter(value => value.frame === frame)
+          
           return (
             <g
               className='markGroup'
@@ -69,6 +80,7 @@ function PreviousMarks ({
 }
 
 PreviousMarks.propTypes = {
+  frame: PropTypes.number,
   scale: PropTypes.number
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/PreviousMarks/PreviousMarks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/PreviousMarks/PreviousMarks.spec.js
@@ -1,6 +1,4 @@
 import { render, waitFor } from '@testing-library/react'
-import zooTheme from '@zooniverse/grommet-theme'
-import { Grommet } from 'grommet'
 import { Provider } from 'mobx-react'
 
 import SHOWN_MARKS from '@helpers/shownMarks'
@@ -8,7 +6,6 @@ import { WorkflowFactory } from '@test/factories'
 import mockStore from '@test/mockStore'
 
 import PreviousMarks from './PreviousMarks'
-import DrawingToolMarks from '../DrawingToolMarks'
 
 describe('Component > PreviousMarks', function () {
   const workflow = WorkflowFactory.build({
@@ -63,13 +60,11 @@ describe('Component > PreviousMarks', function () {
   function withStore(store) {
     return function Wrapper({ children }) {
       return (
-        <Grommet theme={zooTheme}>
-          <Provider classifierStore={store}>
-            <svg>
-              {children}
-            </svg>
-          </Provider>
-        </Grommet>
+        <Provider classifierStore={store}>
+          <svg>
+            {children}
+          </svg>
+        </Provider>
       )
     }
   }
@@ -110,9 +105,9 @@ describe('Component > PreviousMarks', function () {
   })
 
   describe('when there are drawing task annotations', function () {
-    it('should render disabled drawing marks per task by frame', async function () {
+    it('should render disabled drawing marks per task for frame 0', async function () {
       render(
-        <PreviousMarks />,
+        <PreviousMarks frame={0} />,
         {
           wrapper: withStore(store)
         }
@@ -123,16 +118,22 @@ describe('Component > PreviousMarks', function () {
         expect(mark.getAttribute('aria-disabled')).to.equal('true')
         expect(mark.getAttribute('tabindex')).to.equal('-1')
       })
-      store.subjectViewer.setFrame(1)
-      await waitFor(() => {
-        const marks = document.querySelectorAll('g.drawingMark')
-        expect(marks).to.have.lengthOf(2)
-        marks.forEach(mark => {
-          expect(mark.getAttribute('aria-disabled')).to.equal('true')
-          expect(mark.getAttribute('tabindex')).to.equal('-1')
-        })
+    })
+
+    it('should render disabled drawing marks per task for frame 1', async function () {
+      render(
+        <PreviousMarks frame={1} />,
+        {
+          wrapper: withStore(store)
+        }
+      )
+
+      const marks = document.querySelectorAll('g.drawingMark')
+      expect(marks).to.have.lengthOf(2)
+      marks.forEach(mark => {
+        expect(mark.getAttribute('aria-disabled')).to.equal('true')
+        expect(mark.getAttribute('tabindex')).to.equal('-1')
       })
-      store.subjectViewer.setFrame(0)
     })
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
@@ -135,6 +135,7 @@ function MultiFrameViewerContainer({
         >
           <SingleImageViewer
             enableInteractionLayer={loadingState === asyncStates.success && enableInteractionLayer}
+            frame={frame}
             height={naturalHeight}
             limitSubjectHeight={limitSubjectHeight}
             onKeyDown={onKeyZoom}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/SeparateFramesViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/SeparateFramesViewer.js
@@ -31,7 +31,10 @@ function SeparateFramesViewer({
   onReady = DEFAULT_HANDLER,
   subject
 }) {
-  const { limitSubjectHeight, multiImageLayout } = useStores(storeMapper)
+  const {
+    limitSubjectHeight,
+    multiImageLayout
+  } = useStores(storeMapper)
 
   const [forceColLayout, setForceColLayout] = useState(false)
   const [numFramesHorizontally, setNumFramesHorizontally] = useState(1)
@@ -81,9 +84,10 @@ function SeparateFramesViewer({
         columns={forceColLayout ? 'auto' : [`repeat(${numFramesHorizontally}, 1fr)`]}
         rows='auto'
       >
-        {subject.locations?.map(location => (
+        {subject.locations?.map((location, index) => (
           <SeparateFrame
             enableInteractionLayer={enableInteractionLayer}
+            frame={index}
             frameUrl={location.url}
             key={location.url}
             limitSubjectHeight={limitSubjectHeight}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.js
@@ -20,6 +20,7 @@ const DEFAULT_HANDLER = () => true
 const SeparateFrame = ({
   enableInteractionLayer = false,
   enableRotation = DEFAULT_HANDLER,
+  frame = 0,
   frameUrl = '',
   limitSubjectHeight = false,
   onError = DEFAULT_HANDLER,
@@ -199,6 +200,7 @@ const SeparateFrame = ({
     <Box direction='row'>
       <SingleImageViewer
         enableInteractionLayer={enableInteractionLayer}
+        frame={frame}
         height={naturalHeight}
         limitSubjectHeight={limitSubjectHeight}
         onKeyDown={onKeyDown}
@@ -260,6 +262,8 @@ SeparateFrame.propTypes = {
   enableInteractionLayer: PropTypes.bool,
   /** Function passed from Subject Viewer Store */
   enableRotation: PropTypes.func,
+  /** Index of the Frame */
+  frame: PropTypes.number,
   /** String of Object.values(subject.locations[this frame index][0]) */
   frameUrl: PropTypes.string,
   /** Function passed from Workflow Configuration */

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -18,13 +18,14 @@ const PlaceholderSVG = styled.svg`
 function SingleImageViewer({
   children,
   enableInteractionLayer = false,
+  frame = 0,
   height,
   limitSubjectHeight = false,
   onKeyDown = () => true,
   rotate = 0,
   scale = 1,
   svgMaxHeight = null,
-subject,
+  subject,
   title = {},
   viewBox,
   width,
@@ -68,10 +69,11 @@ subject,
             {children}
             {enableInteractionLayer && (
               <InteractionLayer
-                scale={scale}
+                frame={frame}
                 height={height}
-                width={width}
+                scale={scale}
                 subject={subject}
+                width={width}
               />
             )}
           </g>
@@ -82,6 +84,8 @@ subject,
 }
 
 SingleImageViewer.propTypes = {
+  /** Index of the Frame. Initially inherits from parent Viewer or overwritten in Viewer with SubjectViewerStore */
+  frame: PropTypes.number,
   /** Passed from container */
   enableInteractionLayer: PropTypes.bool,
   /** Calculated by useSubjectImage() */

--- a/packages/lib-classifier/src/hooks/useFreehandLineReductions.js
+++ b/packages/lib-classifier/src/hooks/useFreehandLineReductions.js
@@ -4,45 +4,49 @@ import { useCaesarReductions } from './'
 
 export default function useFreehandLineReductions() {
   const {
-    subjectViewer: {
-      frame
-    },
     workflows: {
       active: workflow
     },
     workflowSteps: {
       active: step,
       findTasksByType
+    },
+    subjects: {
+      active: activeSubject,
     }
   } = useStores()
 
   const { loaded, caesarReductions } = useCaesarReductions(workflow.caesarReducer)
+  const stepIndex = parseInt(step.stepKey.replace('S',''), 10)
 
-  if (loaded && getType(caesarReductions).name === 'FreehandLineReductions') {
+  if (loaded
+    && getType(caesarReductions).name === 'FreehandLineReductions'
+    && activeSubject.caesarReductionsLoadedForStep[stepIndex] !== true) {
+    
+    // step.tasks is only the CURRENT TASK
+    // Test project with 3 steps means we need to run this 3 times to check for reductions on each step
+    // This is likely due to the potentially recursive nature of step navigation
+
     const caesarMarks = caesarReductions.findCurrentTaskMarks({
-      stepKey: step.stepKey,
-      tasks: step.tasks,
-      frame,
+      stepKey: step.stepKey
     })
-
+    
     if (caesarMarks) {
-      let marksUsed = false;
-
       caesarMarks.forEach(caesarMark => {
-        const { frame, markId: id, taskIndex, toolIndex, pathX, pathY } = caesarMark
-        const task = step?.tasks[taskIndex]
-        const tool = task?.tools[toolIndex]
+        const { frame, markId: id, toolIndex, pathX, pathY } = caesarMark
+        const task = step?.tasks[0]	// we only get access to one task at a time in a step
 
-        if (tool && !tool.marks.has(id) && caesarReductions.isUsed === false) {
-          marksUsed = true;
-          tool.createMark({ frame, id, toolIndex, pathX, pathY })
-        }
+        task.activeTool.createMark({
+          id,
+          frame,
+          pathX,
+          pathY,
+          toolIndex
+        })
       })
-
-      if (marksUsed) {
-        caesarReductions.setIsUsed()
-      }
     }
+
+    activeSubject.setCaesarReductionsLoadedForStep(stepIndex)
   }
 
   const [drawingTask] = findTasksByType('drawing')

--- a/packages/lib-classifier/src/store/WorkflowStore/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
@@ -7,6 +7,7 @@ const WorkflowConfiguration = types.snapshotProcessor(
     flipbook_autoplay: types.optional(types.boolean, false),
     invert_subject: types.optional(types.boolean, false),
     limit_subject_height: types.optional(types.boolean, false),
+    multi_image_clone_markers: types.optional(types.boolean, false),
     multi_image_mode: types.optional(types.enumeration('multiImageMode', ['flipbook', 'separate']), 'flipbook'),
     multi_image_layout: types.optional(types.enumeration('multiImageLayout', ['col', 'grid2', 'grid3', 'row']), 'col'),
     playIterations: types.optional(types.number, 3),

--- a/packages/lib-classifier/src/store/subjects/Subject/FreehandLineReductions/FreehandLineReductions.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/FreehandLineReductions/FreehandLineReductions.js
@@ -10,13 +10,10 @@ const FreehandLineReductions = types
     subjectId: types.string,
     workflowId: types.string
   })
-  .volatile(self => ({
-    isUsed: types.boolean,
-  }))
   .views(self => {
     return {
-      findCurrentTaskMarks({ stepKey, tasks, frame }) {
-        if (stepKey === undefined || tasks === undefined || frame === undefined) {
+      findCurrentTaskMarks({ stepKey }) {
+        if (stepKey === undefined) {
           return
         }
 
@@ -24,34 +21,15 @@ const FreehandLineReductions = types
 
         self.reductions.forEach(reduction => {
           let { data } = reduction.data   // Caesar expects data attribute to be an object
-          data.forEach(datum => {
-            let task = tasks[datum.taskIndex]
-            let tool = task.tools[datum.toolIndex]
 
-            if (datum.frame === frame
-              && datum.stepKey === stepKey
-              && datum.taskKey === task.taskKey
-              && datum.taskType === task.type
-              && datum.toolType === tool.type
-            ) {
+          data.forEach(datum => {
+            if (datum.stepKey === stepKey) {
               caesarMarks.push(datum)
             }
           })
         })
 
         return caesarMarks
-      }
-    }
-  })
-
-  .actions(self => {
-    return {
-      afterCreate: () => {
-        self.isUsed = false
-      },
-
-      setIsUsed() {
-        self.isUsed = true;
       }
     }
   })

--- a/packages/lib-classifier/src/store/subjects/Subject/FreehandLineReductions/FreehandLineReductions.spec.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/FreehandLineReductions/FreehandLineReductions.spec.js
@@ -4,17 +4,15 @@ import FreehandLineReductions from './FreehandLineReductions'
 
 let reductionsTaskStub = {
   stepKey: 'S0',
-  tasks: [
-    {
-      taskKey: 'T0',
-      type: 'drawing',
-      tools: [
-        {
-          type: 'freehandLine'
-        }
-      ]
-    }
-  ],
+  task: {
+    taskKey: 'T0',
+    type: 'drawing',
+    tools: [
+      {
+        type: 'freehandLine'
+      }
+    ]
+  },
   frame: 0,
 }
 

--- a/packages/lib-classifier/src/store/subjects/Subject/Subject.js
+++ b/packages/lib-classifier/src/store/subjects/Subject/Subject.js
@@ -22,8 +22,12 @@ const Subject = types
     shouldDiscuss: types.maybe(types.frozen()),
     stepHistory: types.maybe(StepHistory),
     user_has_finished_workflow: types.optional(types.boolean, false),
-    caesarReductions: types.maybeNull(CaesarReductions)
+    caesarReductions: types.maybeNull(CaesarReductions),
   })
+
+  .volatile(self => ({
+    caesarReductionsLoadedForStep: types.array(types.boolean)
+  }))
 
   .postProcessSnapshot(snapshot => {
     const newSnapshot = Object.assign({}, snapshot)
@@ -153,13 +157,18 @@ const Subject = types
       rootStore.onToggleFavourite(self.id, self.favorite)
     }
 
+    function setCaesarReductionsLoadedForStep(stepIndex) {
+      self.caesarReductionsLoadedForStep[stepIndex] = true
+    }
+
     return {
       addToCollection,
       markAsSeen,
       openInTalk,
       setCaesarReductions,
       startClassification,
-      toggleFavorite
+      toggleFavorite,
+      setCaesarReductionsLoadedForStep
     }
   })
 


### PR DESCRIPTION
## Package
- lib-classifier
 
## Linked Issue and/or Talk Post
[Issue #5493](https://github.com/zooniverse/front-end-monorepo/issues/5493) 
[Issue #5833](https://github.com/zooniverse/front-end-monorepo/issues/5833) (unresolved in this PR)

## Describe your changes
- Pull the frame into and through the `FlipbookViewer`, `SeparateFrameViewer`, and `SingleImageViewer` components. 
- Enable Interaction Layer in `FlipbookViewer`
- Use the 'setCurrentFrame` hook from the `SubjectViewerStore` for all frame changes
- Update `FlipbookViewer` spec given serial vs async test running
- Moved mark process storage into the individual Subject store instead of SubjectStore
- Frame selection happens at the Viewer level
- All new marks get the actual frame value from where they were created (editing on a different frame won’t change the mark frame value)
- Because SeparateFrameViewer displays multiple frames, we isolate the subjectViewerStore.frame to only those that display 1 frame at a time (FlipbookViewer, MultiFrameViewer)
- PreviousMarks now gets passed the Frame reference because of SeparateFramesViewer

## How to Review
- Pull down the branch and visit the classifier for the "[Freehand Line Multiframe](https://localhost:8080/?project=kieftrav/freehand-line-multiframe)" project. There are two workflows, one for cloning marks and one for not.
- Each drawing task is now 3 Steps: Drawing Task 1, Yes/No question, Drawing Task 2
- Caesar now has 1 mark for 1 image in each drawing task. This means there will be 1 green mark pre-loaded for the first drawing task, and 1 blue mark loaded for the second drawing task.
- Each mark on a Subject from Caesar is unique to that Subject (before different subjects would have the same mark so it wasn’t easy to disambiguate between subjects and ensure clean state as we change subjects)

When deployed to [project branch](https://fe-project-branch.preview.zooniverse.org/projects/kieftrav/freehand-line-multiframe/classify/workflow/3760?env=staging).

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser