### PR TITLE
Accessible project navigation: fix server-side page paths

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.js
@@ -44,12 +44,15 @@ function NavItem({ navLink }) {
   if (router?.asPath) {
     const routerPath = router.asPath.split('/')
     const hrefPath = navLink.href.split('/')
-    // server-side paths are prefixed with the API environment.
+    /*
+      Server-side routerPath will be ['', environment, owner, project, section, ...rest].
+      Client-side routerPath will be ['', owner, project, section, ...rest].
+    */
     const isSSR = ENVIRONMENTS.includes(routerPath[1])
     const section = isSSR ? routerPath[4] : routerPath[3]
     /*
-      The path arrays will be ['', owner, project, section, ...rest].
-      The section is always the fourth item in the hrefPath array.
+      The link hrefPath will be ['', owner, project, section, ...rest].
+      The section is always the fourth item in the array.
     */
     isCurrentPage = section === hrefPath[3]
   }

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.js
@@ -36,17 +36,22 @@ const StyledAnchor = styled(Anchor)`
   `}
 `
 
+const ENVIRONMENTS = ['production', 'staging']
+
 function NavItem({ navLink }) {
   const router = useRouter()
   let isCurrentPage
   if (router?.asPath) {
     const routerPath = router.asPath.split('/')
     const hrefPath = navLink.href.split('/')
+    // server-side paths are prefixed with the API environment.
+    const isSSR = ENVIRONMENTS.includes(routerPath[1])
+    const section = isSSR ? routerPath[4] : routerPath[3]
     /*
       The path arrays will be ['', owner, project, section, ...rest].
-      The section is always the fourth item.
+      The section is always the fourth item in the hrefPath array.
     */
-    isCurrentPage = routerPath[3] === hrefPath[3]
+    isCurrentPage = section === hrefPath[3]
   }
   return (
     <Box as='li' key={navLink.href} flex='grow' pad={{ left: 'small' }}>

--- a/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink/AboutNavLink.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink/AboutNavLink.js
@@ -16,8 +16,11 @@ const AboutNavLink = ({ link }) => {
   const { href } = link
   const router = useRouter()
   let isCurrentPage
-  if (router?.isReady) {
-    isCurrentPage = router.asPath === addQueryParams(href)
+  if (router?.asPath) {
+    const trimmedPath = router.asPath
+      .replace('/production', '')
+      .replace('/staging', '')
+    isCurrentPage = trimmedPath === addQueryParams(href)
   }
 
   return (

--- a/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink/AboutNavLink.js
+++ b/packages/app-project/src/screens/ProjectAboutPage/components/AboutNavLink/AboutNavLink.js
@@ -1,10 +1,10 @@
+import { Anchor, Box } from 'grommet'
+import { useRouter } from 'next/router'
 import { string, shape } from 'prop-types'
 import styled from 'styled-components'
-import { useRouter } from 'next/router'
 
-/** Components */
+import addQueryParams from '@helpers/addQueryParams'
 import NavLink from '@shared/components/NavLink'
-import { Anchor, Box } from 'grommet'
 
 const StyledAnchor = styled(Anchor)`
   &:hover {
@@ -16,14 +16,8 @@ const AboutNavLink = ({ link }) => {
   const { href } = link
   const router = useRouter()
   let isCurrentPage
-  if (router?.asPath) {
-    const routerPath = router.asPath.split('/')
-    const hrefPath = href.split('/')
-    /*
-      The path arrays will be ['', owner, project, section, ...rest].
-      The section is always the fourth item.
-    */
-    isCurrentPage = routerPath[3] === hrefPath[3]
+  if (router?.isReady) {
+    isCurrentPage = router.asPath === addQueryParams(href)
   }
 
   return (


### PR DESCRIPTION
- fix page navigation in the About section so that only one page is marked as the current page.
- add more robust checks for page paths during SSR, when a project page path will be prefixed with `/production` or `/staging` according to whether it is a production or staging project.