### PR TITLE
Check if subject exists for recent subjects on homepage

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsContainer.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/RecentSubjectsContainer.js
@@ -1,4 +1,3 @@
-import asyncStates from '@zooniverse/async-states'
 import { MobXProviderContext, observer } from 'mobx-react'
 import { bool } from 'prop-types'
 import { useContext } from 'react'

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchRecentSubjects.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchRecentSubjects.js
@@ -7,7 +7,6 @@ async function fetchRecentSubjects({ projectId }) {
 
   if (talkData.length > 0) {
     const subjectIds = getSubjectIdsFromTalkData(talkData)
-    // const subjectIds = ['3815973', '1', '2']
     return await fetchSubjectData(subjectIds)
   }
 

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchRecentSubjects.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchRecentSubjects.js
@@ -2,11 +2,12 @@ import fetchSubjectData from './fetchSubjectData'
 import fetchTalkData from './fetchTalkData'
 import getSubjectIdsFromTalkData from './getSubjectIdsFromTalkData'
 
-async function fetchRecentSubjects ({ projectId }) {
+async function fetchRecentSubjects({ projectId }) {
   const talkData = await fetchTalkData(projectId)
 
   if (talkData.length > 0) {
     const subjectIds = getSubjectIdsFromTalkData(talkData)
+    // const subjectIds = ['3815973', '1', '2']
     return await fetchSubjectData(subjectIds)
   }
 

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchSubjectData.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchSubjectData.js
@@ -2,6 +2,7 @@ import { panoptes } from '@zooniverse/panoptes-js'
 import logToSentry from '@helpers/logger/logToSentry.js'
 
 async function fetchSubjectData(subjectIds) {
+  let recentlyDiscussedSubjects = []
   try {
     const response = await panoptes.get('/subjects', {
       id: subjectIds.join(',')
@@ -9,17 +10,17 @@ async function fetchSubjectData(subjectIds) {
     const { subjects } = response.body
     // response does not come back in the same order as subjectIds array
     // so we have to order them correctly here
-    const recentlyDiscussedSubjects = subjectIds.reduce((acc, id) => {
+    recentlyDiscussedSubjects = subjectIds.reduce((acc, id) => {
       // sometimes old subjects have been deleted, but their Talk thread still exists via their subject.id
       if (subjects.find(subject => subject.id === id)) {
         acc.push(subjects.find(subject => subject.id === id))
       }
       return acc
     }, [])
-    return recentlyDiscussedSubjects
   } catch (error) {
     logToSentry(error)
   }
+  return recentlyDiscussedSubjects
 }
 
 export default fetchSubjectData

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchSubjectData.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchSubjectData.js
@@ -12,8 +12,9 @@ async function fetchSubjectData(subjectIds) {
     // so we have to order them correctly here
     recentlyDiscussedSubjects = subjectIds.reduce((acc, id) => {
       // sometimes old subjects have been deleted, but their Talk thread still exists via their subject.id
-      if (subjects.find(subject => subject.id === id)) {
-        acc.push(subjects.find(subject => subject.id === id))
+      const subject = subjects.find(subject => subject.id === id);
+      if (subject) {
+        acc.push(subject);
       }
       return acc
     }, [])

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchSubjectData.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchSubjectData.js
@@ -12,7 +12,7 @@ async function fetchSubjectData(subjectIds) {
     // so we have to order them correctly here
     recentlyDiscussedSubjects = subjectIds.reduce((acc, id) => {
       // sometimes old subjects have been deleted, but their Talk thread still exists via their subject.id
-      const subject = subjects.find(subject => subject.id === id);
+      const subject = subjects.find(subject => subject.id === id)
       if (subject) {
         acc.push(subject);
       }

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchSubjectData.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/helpers/fetchRecentSubjects/fetchSubjectData.js
@@ -1,11 +1,25 @@
 import { panoptes } from '@zooniverse/panoptes-js'
+import logToSentry from '@helpers/logger/logToSentry.js'
 
-async function fetchSubjectData (subjectIds) {
-  const response = await panoptes.get('/subjects', {
-    id: subjectIds.join(',')
-  })
-  const { subjects } = response.body
-  return subjectIds.map(subjectID => subjects.find(subject => subject.id === subjectID))
+async function fetchSubjectData(subjectIds) {
+  try {
+    const response = await panoptes.get('/subjects', {
+      id: subjectIds.join(',')
+    })
+    const { subjects } = response.body
+    // response does not come back in the same order as subjectIds array
+    // so we have to order them correctly here
+    const recentlyDiscussedSubjects = subjectIds.reduce((acc, id) => {
+      // sometimes old subjects have been deleted, but their Talk thread still exists via their subject.id
+      if (subjects.find(subject => subject.id === id)) {
+        acc.push(subjects.find(subject => subject.id === id))
+      }
+      return acc
+    }, [])
+    return recentlyDiscussedSubjects
+  } catch (error) {
+    logToSentry(error)
+  }
 }
 
 export default fetchSubjectData


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/5765

## Describe your changes

- Check if a subject exists in `fetchSubjectData` helper before returning subjects array to RecentSubjects component
- Adjust error handling so that if a subject isn't found, the other recently commented-on subjects will still display

## How to Review

See in-code comment below about how to review by running locally.

Gravity Spy's home page was previously crashing due to the recently commented-on subjects, but enough comments have come through Talk that it's no longer crashing.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out

## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated