### PR TITLE
Subject Set Selection bug fixes

### DIFF
--- a/packages/app-project/pages/[panoptesEnv]/[owner]/[project]/classify/workflow/[workflowID]/subject-set/[subjectSetID]/subject/[subjectID]/index.js
+++ b/packages/app-project/pages/[panoptesEnv]/[owner]/[project]/classify/workflow/[workflowID]/subject-set/[subjectSetID]/subject/[subjectID]/index.js
@@ -6,7 +6,6 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 export async function getStaticProps({ locale, params }) {
   const { notFound, props: defaultProps } = await getDefaultPageProps({ locale, params })
   const { panoptesEnv, subjectID, subjectSetID, workflowID } = params
-  const props = { ...defaultProps, subjectID, subjectSetID, workflowID }
   const { workflows } = defaultProps
   const workflow = workflows?.find(workflow => workflow.id === params.workflowID)
   let pageTitle = workflow?.displayName || null

--- a/packages/app-project/src/components/ProjectHeader/components/ProjectTitle/ProjectTitle.js
+++ b/packages/app-project/src/components/ProjectHeader/components/ProjectTitle/ProjectTitle.js
@@ -25,10 +25,7 @@ const StyledAnchor = styled(Anchor)`
   }
 `
 
-function ProjectTitle({
-  textAlign = 'start',
-  title = ''
-}) {
+function ProjectTitle({ textAlign = 'start', title = '' }) {
   const router = useRouter()
   const { slug } = useStores()
   const linkProps = {
@@ -37,22 +34,18 @@ function ProjectTitle({
 
   const isCurrentPage = router?.isReady && router?.asPath === linkProps.href
 
-  const anchor = (
-    <StyledHeading color='white' margin='none' textAlign={textAlign}>
-      {title}
-    </StyledHeading>
-  )
-
   if (isCurrentPage) {
     return (
-      <StyledAnchor>
-        {anchor}
-      </StyledAnchor>
+      <StyledHeading level={1} color='white' margin='0' textAlign={textAlign}>
+        {title}
+      </StyledHeading>
     )
   } else {
     return (
       <StyledAnchor forwardedAs={Link} {...linkProps}>
-        {anchor}
+        <StyledHeading level={1} color='white' margin='0' textAlign={textAlign}>
+          {title}
+        </StyledHeading>
       </StyledAnchor>
     )
   }

--- a/packages/app-project/src/components/ProjectHeader/components/ProjectTitle/ProjectTitle.js
+++ b/packages/app-project/src/components/ProjectHeader/components/ProjectTitle/ProjectTitle.js
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { string } from 'prop-types'
 import styled from 'styled-components'
+import { useStores } from '../../hooks'
 
 import addQueryParams from '@helpers/addQueryParams'
 
@@ -29,13 +30,12 @@ function ProjectTitle({
   title = ''
 }) {
   const router = useRouter()
-  const owner = router?.query?.owner
-  const project = router?.query?.project
+  const { slug } = useStores()
   const linkProps = {
-    href: addQueryParams(`/${owner}/${project}`)
+    href: addQueryParams(`/${slug}`)
   }
 
-  const isCurrentPage = router?.pathname === linkProps.href
+  const isCurrentPage = router?.isReady && router?.asPath === linkProps.href
 
   const anchor = (
     <StyledHeading color='white' margin='none' textAlign={textAlign}>

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -25,7 +25,6 @@ function ClassifyPage({
   appLoadingState,
   onSubjectReset,
   screenSize,
-  setSelectedSubjectID,
   subjectID,
   subjectSetID,
   workflowFromUrl,
@@ -108,7 +107,6 @@ function ClassifyPage({
                 cachePanoptesData={cachePanoptesData}
                 onAddToCollection={onAddToCollection}
                 onSubjectReset={onSubjectReset}
-                setSelectedSubjectID={setSelectedSubjectID}
                 showTutorial={showTutorial}
                 {...classifierProps}
               />
@@ -143,10 +141,6 @@ ClassifyPage.propTypes = {
   onSubjectReset: func,
   /** withResponsiveContext */
   screenSize: string,
-  /** Sets subjectID state in ClassifiyPageContainer. Sometimes the current subject is
-   * selected via classifier UI and getDefaultPageProps is not called again.
-   * (For example Next and Prev buttons for prioritized subject selection) */
-  setSelectedSubjectID: func,
   /** This subjectID is a state variable in ClassifyPageContainer */
   subjectID: string,
   /** This subjectSetID is from getDefaultPageProps in page index.js */

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -75,6 +75,7 @@ function ClassifyPage({
     setShowTutorial(true)
   }
 
+  /** This subjectID is passed from the Classifier component's internal state */
   const onAddToCollection = useCallback((subjectID) => {
     setCollectionsSubjectID(subjectID)
     setCollectionsModalActive(true)

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -1,6 +1,6 @@
 import { Box, Grid } from 'grommet'
 import dynamic from 'next/dynamic'
-import { arrayOf, func, shape, string } from 'prop-types'
+import { arrayOf, func, object, shape, string } from 'prop-types'
 import { useCallback, useState } from 'react'
 import withResponsiveContext from '@zooniverse/react-components/helpers/withResponsiveContext'
 
@@ -27,17 +27,18 @@ function ClassifyPage({
   screenSize,
   subjectID,
   subjectSetID,
-  workflowID,
   workflowFromUrl,
+  workflowID,
   workflows = [],
 }) {
   /*
     Enable session caching in the classifier for projects with ordered subject selection.
   */
   const cachePanoptesData = workflows.some(workflow => workflow.prioritized)
-  const responsiveColumns = (screenSize === 'small')
-    ? ['auto']
-    : ['1em', 'auto', '1em']
+
+  /* Note that these columns will be removed when theme toggle is refactored to ZooHeader */
+  const responsiveColumns = (screenSize === 'small') ? ['auto'] : ['1em', 'auto', '1em']
+
   const [classifierProps, setClassifierProps] = useState({})
   const [showTutorial, setShowTutorial] = useState(false)
   const [collectionsModalActive, setCollectionsModalActive] = useState(false)
@@ -64,6 +65,7 @@ function ClassifyPage({
   const subjectSetChanged = classifierProps.subjectSetID !== subjectSetID
   const subjectChanged = classifierProps.subjectID !== subjectID
   const URLChanged = workflowChanged || subjectSetChanged || subjectChanged
+
   if (canClassify && URLChanged) {
     setClassifierProps({
       workflowID,
@@ -135,11 +137,21 @@ function ClassifyPage({
 }
 
 ClassifyPage.propTypes = {
-  addToCollection: func,
+  /** Sets subjectID state in ClassifyPageContainer to undefined */
+  onSubjectReset: func,
+  /** withResponsiveContext */
   screenSize: string,
+  /** This subjectID is a state variable in ClassifyPageContainer */
   subjectID: string,
+  /** This subjectSetID is from getDefaultPageProps in page index.js */
   subjectSetID: string,
+  /** In ClassifyPageContainer, we double check that a volunteer navigating to
+   * a url with workflowID is allowed to load that workflow.
+   * The workflowFromUrl object is the current workflow. */
+  workflowFromUrl: object,
+  /** The id of workflowFromUrl */
   workflowID: string,
+  /** workflows array is from getDefaultPageProps in page index.js */
   workflows: arrayOf(shape({
     id: string.isRequired
   }))

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPage.js
@@ -25,6 +25,7 @@ function ClassifyPage({
   appLoadingState,
   onSubjectReset,
   screenSize,
+  setSelectedSubjectID,
   subjectID,
   subjectSetID,
   workflowFromUrl,
@@ -107,6 +108,7 @@ function ClassifyPage({
                 cachePanoptesData={cachePanoptesData}
                 onAddToCollection={onAddToCollection}
                 onSubjectReset={onSubjectReset}
+                setSelectedSubjectID={setSelectedSubjectID}
                 showTutorial={showTutorial}
                 {...classifierProps}
               />
@@ -141,6 +143,10 @@ ClassifyPage.propTypes = {
   onSubjectReset: func,
   /** withResponsiveContext */
   screenSize: string,
+  /** Sets subjectID state in ClassifiyPageContainer. Sometimes the current subject is
+   * selected via classifier UI and getDefaultPageProps is not called again.
+   * (For example Next and Prev buttons for prioritized subject selection) */
+  setSelectedSubjectID: func,
   /** This subjectID is a state variable in ClassifyPageContainer */
   subjectID: string,
   /** This subjectSetID is from getDefaultPageProps in page index.js */

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { array, bool, string } from 'prop-types'
 
 import ClassifyPage from './ClassifyPage'
 
@@ -10,8 +11,12 @@ function ClassifyPageContainer ({
   workflows = [],
   ...props
 }) {
-  // selected subject state is derived from the page URL, but can be reset by the Classifier component.
+  /* Selected subjectID is initially derived from the page URL
+  via getDefaultPageProps, but subjectID can be reset by the Classifier
+  component via onSubjectReset(), or changed via prioritized subjects UI
+  (Next or Prev buttons) */
   const [selectedSubjectID, setSelectedSubjectID] = useState(subjectID)
+  console.log('SELECTED SUBJECT', selectedSubjectID)
 
   let assignedWorkflow
   let allowedWorkflows = workflows.slice()
@@ -20,6 +25,7 @@ function ClassifyPageContainer ({
     assignedWorkflow = workflows.find(workflow => workflow.id === assignedWorkflowID)
     assignedWorkflowLevel = parseInt(assignedWorkflow?.configuration.level, 10)
   }
+  /* Double check that a volunteer navigating to url with workflowID is allowed to load that workflow */
   if (workflowAssignmentEnabled) {
     allowedWorkflows = workflows.filter(workflow => workflow.configuration.level <= assignedWorkflowLevel)
   }
@@ -28,7 +34,6 @@ function ClassifyPageContainer ({
   useEffect(function onSubjectChange () {
     setSelectedSubjectID(subjectID)
   }, [subjectID])
-
 
   const onSubjectReset = useCallback(() => {
     setSelectedSubjectID(undefined)
@@ -49,3 +54,16 @@ function ClassifyPageContainer ({
 }
 
 export default ClassifyPageContainer
+
+ClassifyPageContainer.propTypes = {
+  /** assignedWorkflowID is in the Project Preferences Store */
+  assignedWorkflowID: string,
+  /** This subjectID is from getDefaultPageProps in page index.js */
+  subjectID: string,
+  /** workflowAssignmentEnabled is in the Project Store */
+  workflowAssignmentEnabled: bool,
+  /** This workflowID is from getDefaultPageProps in page index.js */
+  workflowID: string,
+  /** workflows array is from getDefaultPageProps in page index.js */
+  workflows: array
+}

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -13,10 +13,8 @@ function ClassifyPageContainer ({
 }) {
   /* Selected subjectID is initially derived from the page URL
   via getDefaultPageProps, but subjectID can be reset by the Classifier
-  component via onSubjectReset(), or changed via prioritized subjects UI
-  (Next or Prev buttons) */
+  component via onSubjectReset() */
   const [selectedSubjectID, setSelectedSubjectID] = useState(subjectID)
-  console.log('SELECTED SUBJECT', selectedSubjectID)
 
   let assignedWorkflow
   let allowedWorkflows = workflows.slice()

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -43,7 +43,6 @@ function ClassifyPageContainer ({
     <>
       <ClassifyPage
         onSubjectReset={onSubjectReset}
-        setSelectedSubjectID={setSelectedSubjectID}
         subjectID={selectedSubjectID}
         workflowFromUrl={workflowFromUrl}
         workflowID={workflowFromUrl?.id}

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -43,6 +43,7 @@ function ClassifyPageContainer ({
     <>
       <ClassifyPage
         onSubjectReset={onSubjectReset}
+        setSelectedSubjectID={setSelectedSubjectID}
         subjectID={selectedSubjectID}
         workflowFromUrl={workflowFromUrl}
         workflowID={workflowFromUrl?.id}

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -11,9 +11,9 @@ function ClassifyPageContainer ({
   workflows = [],
   ...props
 }) {
-  /* Selected subjectID is initially derived from the page URL
-  via getDefaultPageProps, but subjectID can be reset by the Classifier
-  component via onSubjectReset() */
+  /* SelectedSubjectID is initially derived from the page URL via getDefaultPageProps,
+  but can be reset by the Classifier component via onSubjectReset().
+  This state does not change via components of the prioritized subjects UI (Next/Prev buttons) */
   const [selectedSubjectID, setSelectedSubjectID] = useState(subjectID)
 
   let assignedWorkflow

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -37,7 +37,6 @@ export default function ClassifierWrapper({
   project = null,
   recents = null,
   router = null,
-  setSelectedSubjectID = DEFAULT_HANDLER,
   showTutorial = false,
   subjectID,
   subjectSetID,
@@ -180,10 +179,6 @@ ClassifierWrapper.propTypes = {
   router: shape({
     locale: string
   }),
-  /** Sets subjectID state in ClassifiyPageContainer. Sometimes the current subject is
-   * selected via classifier UI and getDefaultPageProps is not called again.
-   * (For example Next and Prev buttons for prioritized subject selection) */
-    setSelectedSubjectID: func,
   /** Allow the classifier to open a popup tutorial, if necessary. */
   showTutorial: bool,
   /** Stored as a state variable in ClassifierPageContainer */

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -85,7 +85,6 @@ export default function ClassifierWrapper({
   const onSubjectChange = useCallback(
     subject => {
       if (subjectInURL) {
-        setSelectedSubjectID(subject.id)
         const subjectPageURL = `${baseURL}/subject/${subject.id}`
         const href = addQueryParams(subjectPageURL)
         history.replaceState(null, "", href)

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -78,6 +78,7 @@ export default function ClassifierWrapper({
     baseURL = `${baseURL}/subject-set/${subjectSetID}`
   }
   const subjectInURL = router?.query.subjectID !== undefined
+  const replaceRoute = router?.replace
 
   /*
     Track the current classification subject, when it changes inside the classifier.
@@ -87,9 +88,9 @@ export default function ClassifierWrapper({
       if (subjectInURL) {
         const subjectPageURL = `${baseURL}/subject/${subject.id}`
         const href = addQueryParams(subjectPageURL)
-        history.replaceState(null, "", href)
+        replaceRoute(href)
     }
-  }, [baseURL, subjectInURL])
+  }, [baseURL, replaceRoute, subjectInURL])
 
   const addFavourites = collections?.addFavourites
   const removeFavourites = collections?.removeFavourites

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -2,7 +2,7 @@ import Classifier from '@zooniverse/classifier'
 import { useRouter } from 'next/router'
 import auth from 'panoptes-client/lib/auth'
 import { bool, func, string, shape } from 'prop-types'
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 import asyncStates from '@zooniverse/async-states'
 
 import { useAdminMode } from '@hooks'
@@ -23,8 +23,8 @@ const DEFAULT_HANDLER = () => true
   - classifier errors.
   - updates to project recents on classification complete.
   - updates to stored favourites, when the classification subject is favourited.
-  - updates to stored collections, when the classification subject is added to a collection.
   - Passing locale to classifier
+  - Modifies the url when using prioritized subjects in the classifier (Next or Prev btns)
 */
 export default function ClassifierWrapper({
   authClient = auth,
@@ -88,9 +88,10 @@ export default function ClassifierWrapper({
       if (subjectInURL) {
         const subjectPageURL = `${baseURL}/subject/${subject.id}`
         const href = addQueryParams(subjectPageURL)
-        replaceRoute(href, href, { scroll: false })
+        history.replaceState(null, "", href)
+        // replaceRoute(href, href, { shallow: true })
     }
-  }, [baseURL, replaceRoute, subjectInURL])
+  }, [baseURL, subjectInURL])
 
   const addFavourites = collections?.addFavourites
   const removeFavourites = collections?.removeFavourites
@@ -167,7 +168,8 @@ ClassifierWrapper.propTypes = {
   onAddToCollection: func,
   /** Panoptes Auth client */
   authClient: shape({}),
-  /** Callback that runs when the classifier subject queue is reset, so that we can pick a new subject. */
+  /** Callback that runs when the classifier subject queue is reset, so that we can pick a new subject.
+   * Sets subjectID state in ClassifyPageContainer to undefined */
   onSubjectReset: func,
   /** JSON snapshot of the active Panoptes project */
   project: shape({}),
@@ -180,9 +182,9 @@ ClassifierWrapper.propTypes = {
   }),
   /** Allow the classifier to open a popup tutorial, if necessary. */
   showTutorial: bool,
-  /** optional subjectID (from the classifierProps.) */
+  /** Stored as a state variable in ClassifierPageContainer */
   subjectID: string,
-  /** optional subject set ID (from the classifierProps.) */
+  /** optional subject set ID (from the classifierProps via getDefaultPageProps in page index.js) */
   subjectSetID: string,
   /** Current logged-in user */
   user: shape({
@@ -190,6 +192,6 @@ ClassifierWrapper.propTypes = {
   }),
   /** Logged-in user ID */
   userID: string,
-  /** required workflow ID (from the classifierProps.) */
+  /** required workflow ID (from the classifierProps via getDefaultPageProps in page index.js) */
   workflowID: string
 }

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -37,6 +37,7 @@ export default function ClassifierWrapper({
   project = null,
   recents = null,
   router = null,
+  setSelectedSubjectID = DEFAULT_HANDLER,
   showTutorial = false,
   subjectID,
   subjectSetID,
@@ -78,7 +79,6 @@ export default function ClassifierWrapper({
     baseURL = `${baseURL}/subject-set/${subjectSetID}`
   }
   const subjectInURL = router?.query.subjectID !== undefined
-  const replaceRoute = router?.replace
 
   /*
     Track the current classification subject, when it changes inside the classifier.
@@ -86,10 +86,10 @@ export default function ClassifierWrapper({
   const onSubjectChange = useCallback(
     subject => {
       if (subjectInURL) {
+        setSelectedSubjectID(subject.id)
         const subjectPageURL = `${baseURL}/subject/${subject.id}`
         const href = addQueryParams(subjectPageURL)
         history.replaceState(null, "", href)
-        // replaceRoute(href, href, { shallow: true })
     }
   }, [baseURL, subjectInURL])
 
@@ -180,6 +180,10 @@ ClassifierWrapper.propTypes = {
   router: shape({
     locale: string
   }),
+  /** Sets subjectID state in ClassifiyPageContainer. Sometimes the current subject is
+   * selected via classifier UI and getDefaultPageProps is not called again.
+   * (For example Next and Prev buttons for prioritized subject selection) */
+    setSelectedSubjectID: func,
   /** Allow the classifier to open a popup tutorial, if necessary. */
   showTutorial: bool,
   /** Stored as a state variable in ClassifierPageContainer */

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -81,16 +81,19 @@ export default function ClassifierWrapper({
   const replaceRoute = router?.replace
 
   /*
-    Track the current classification subject, when it changes inside the classifier.
+    When the prioritied subject selection feature was implemented, we used shallow routing
+    to change the [subjecID] subpath in the url in reaction to the subject changing in the
+    Classifier component. Shallow routing isn't supported in Next.js 13, so the url-changing
+    feature is turned off for now. See https://github.com/zooniverse/front-end-monorepo/issues/4977
   */
   const onSubjectChange = useCallback(
     subject => {
       if (subjectInURL) {
         const subjectPageURL = `${baseURL}/subject/${subject.id}`
         const href = addQueryParams(subjectPageURL)
-        replaceRoute(href)
+        // replaceRoute(href, href, { shallow: true })
     }
-  }, [baseURL, replaceRoute, subjectInURL])
+  }, [baseURL, subjectInURL])
 
   const addFavourites = collections?.addFavourites
   const removeFavourites = collections?.removeFavourites

--- a/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/ClassifierWrapper/ClassifierWrapper.js
@@ -11,7 +11,7 @@ import logToSentry from '@helpers/logger/logToSentry.js'
 import ErrorMessage from './components/ErrorMessage'
 import Loader from '@shared/components/Loader'
 
-function onError(error, errorInfo={}) {
+function onError(error, errorInfo = {}) {
   logToSentry(error, errorInfo)
   console.error('Classifier error', error)
 }
@@ -83,11 +83,12 @@ export default function ClassifierWrapper({
   /*
     Track the current classification subject, when it changes inside the classifier.
   */
-  const onSubjectChange = useCallback((subject) => {
-    if (subjectInURL) {
-      const subjectPageURL = `${baseURL}/subject/${subject.id}`
-      const href = addQueryParams(subjectPageURL)
-      replaceRoute(href, href, { shallow: true })
+  const onSubjectChange = useCallback(
+    subject => {
+      if (subjectInURL) {
+        const subjectPageURL = `${baseURL}/subject/${subject.id}`
+        const href = addQueryParams(subjectPageURL)
+        replaceRoute(href, href, { scroll: false })
     }
   }, [baseURL, replaceRoute, subjectInURL])
 
@@ -136,9 +137,7 @@ export default function ClassifierWrapper({
     }
   } catch (error) {
     onError(error)
-    return (
-      <ErrorMessage error={error} />
-    )
+    return <ErrorMessage error={error} />
   }
 
   return (


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/5770
Related to: https://github.com/zooniverse/front-end-monorepo/issues/4977

## Describe your changes

- Use the project `slug` from the store rather than rely on `router.query` to form href to project home page
- Don't render a link for the Project Title when already on the project's home page.
- Use `history.replaceState` rather than NextJS's `router.replace`. This line was causing the router object to be reset and the important `query` params were no longer available in ClassifierWrapper.
- Add more in-code documentation to props

## How to Review

- The bugs described in the Issues linked above can be tested on [PRINT](https://www.zooniverse.org/projects/printmigrationnetwork/print) and [Deciphering Secrets](https://www.zooniverse.org/projects/profdrrogerlouismartinez-davila/deciphering-secrets-unlocking-the-manuscripts-of-medieval-spain).
- There's a bonus fix in here because the Project Title component in the Project Header should not be clickable when a volunteer is already on the project home page.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated