### PR TITLE
Adjust size of placeholder behind subject image

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -9,7 +9,7 @@ import ZoomControlButton from '../ZoomControlButton'
 import locationValidator from '../../helpers/locationValidator'
 
 const PlaceholderSVG = styled.svg`
-  background: no-repeat center / contain url('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png');
+  background: no-repeat center / cover url('https://static.zooniverse.org/www.zooniverse.org/assets/fe-project-subject-placeholder-800x600.png');
   touch-action: pinch-zoom;
   max-width: ${props => props.maxWidth || '100%'};
   ${props => props.maxHeight && css`max-height: ${props.maxHeight};`}


### PR DESCRIPTION
_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/5750

## Describe your changes
- Use `cover` instead of `contain` so the placeholder image behind a subject image stretches to the dimensions of the viewer rather than remain a landscape rectangle

## How to Review

- Any project that incorporates the SingleImageViewer can be reviewed locally (i-fancy-cats, Daily Minor Planet, etc). Here's the current FEM project's [spreadsheet](https://docs.google.com/spreadsheets/d/1X9345vQ_xNX6BJf9_xwVCQCjxjbWWErGmV7Xe8WpHZo/edit#gid=0) and use the Zoom Out button in the image toolbar 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out

## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed