### PR TITLE
Show transcribed lines in TranscribedLines story

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.stories.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.stories.js
@@ -80,7 +80,7 @@ function TranscribedLinesStory({ loadingState, stores, subject }) {
   return (
     <Provider classifierStore={stores}>
       <Box width='1000px'>
-        <MultiFrameViewer loadingState={loadingState} subject={subject} />
+        <MultiFrameViewer enableInteractionLayer loadingState={loadingState} subject={subject} />
       </Box>
     </Provider>
   )


### PR DESCRIPTION
`enableInteractionLayer` must be set now, in subject viewers, in order to display previously drawn marks on top of a subject.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## How to Review
The `TranscribedLines` story, in the classifier storybook, should now show previously transcribed lines from Caesar.

_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated
