### PR TITLE
ADR 57: library build scripts

### DIFF
--- a/docs/arch/README.md
+++ b/docs/arch/README.md
@@ -56,3 +56,4 @@
 - [ADR 54: app-root](adr-54.md)
 - [ADR 55: lib-user](adr-55.md)
 - [ADR 56: Use markdownz to parse markdown](adr-56.md)
+- [ADR 57: build @zooniverse/classifier and @zooniverse/react-components as ES modules](adr-57.md)

--- a/docs/arch/adr-57.md
+++ b/docs/arch/adr-57.md
@@ -1,0 +1,18 @@
+# ADR 57: build @zooniverse/classifier and @zooniverse/react-components as ES modules
+
+## Status
+Accepted
+
+## Context
+The classifier and React components libraries were originally built with Webpack. Each was built as a single large UMD `main.js` file.
+
+Since the monorepo was firsted started, ES modules have become the standard for JS packages. Recent versions of Webpack can [tree-shake ESM](https://webpack.js.org/guides/tree-shaking/) to remove unused code. CommonJS is used for legacy package support, and increasingly deprecated for newer packages. All modern browsers, and NodeJS, support `import/export`.
+
+## Decision
+Since [PR 3900](https://github.com/zooniverse/front-end-monorepo/pull/3900), each package is published as ESM, using Babel to transform the JSX source files to JS. A Babel CJS build, transforming `import/export` to `require`, is kept for legacy purposes.
+
+## Consequences
+- Each library has a `build:es6` script and a `build:cjs` script. Over time, the CJS build can be deprecated and removed.
+- Each library has two entrypoints: `dist/esm` for ESM, and `dist/cjs` for CommonJS.
+- Production builds and deploys only need the `build:es6` script.
+- Older libraries (`@zooniverse/async-states`, `@zooniverse/panoptes-js`, `@zooniverse/grommet-theme`) are still published as CommonJS.

--- a/docs/arch/adr-57.md
+++ b/docs/arch/adr-57.md
@@ -6,7 +6,7 @@ Accepted
 ## Context
 The classifier and React components libraries were originally built with Webpack. Each was built as a single large UMD `main.js` file.
 
-Since the monorepo was firsted started, ES modules have become the standard for JS packages. Recent versions of Webpack can [tree-shake ESM](https://webpack.js.org/guides/tree-shaking/) to remove unused code. CommonJS is used for legacy package support, and increasingly deprecated for newer packages. All modern browsers, and NodeJS, support `import/export`.
+Since the monorepo was first started, ES modules have become the standard for JS packages. Recent versions of Webpack can [tree-shake ESM](https://webpack.js.org/guides/tree-shaking/) to remove unused code. CommonJS is used for legacy package support, and increasingly deprecated for newer packages. All modern browsers, and NodeJS, support `import/export`.
 
 ## Decision
 Since [PR 3900](https://github.com/zooniverse/front-end-monorepo/pull/3900), each package is published as ESM, using Babel to transform the JSX source files to JS. A Babel CJS build, transforming `import/export` to `require`, is kept for legacy purposes.


### PR DESCRIPTION
A quick ADR to explain the switch from Webpack UMD builds to ESM builds with Babel in #3900.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier
- lib-react-components

## Linked Issue and/or Talk Post
- towards #4214.
