### PR TITLE
Remove useWindowMoveEvents from VisX Brush for Scatterplot Viewer

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/Selections/Selections.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer/components/ScatterPlot/components/Selections/Selections.js
@@ -233,7 +233,6 @@ function Selections({
           onBrushStart={onStartSelection}
           onBrushEnd={onEndSelection}
           selectedBoxStyle={brushStyle}
-          useWindowMoveEvents
           width={width}
           xScale={xScale}
           yScale={yScale}


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
This reverts https://github.com/zooniverse/front-end-monorepo/pull/5306
Closes: https://github.com/zooniverse/front-end-monorepo/issues/5826
Re-opens: https://github.com/zooniverse/front-end-monorepo/issues/5304

## Describe your changes

Remove `useWindowMoveEvents` from VisX Brush component in Scatterplot's Selections component

## How to Review

- View the Scatterplot's X-range selection [storybook](http://localhost:6006/?path=/story/subject-viewers-scatterplotviewer--x-range-selection). Test that you can draw a selection via mouse click and with touch emulation in browser tools. You can also run the storybook locally on your mobile device via [IP address strategy](https://github.com/zooniverse/how-to-zooniverse/blob/master/Frontend-Handbook/general-dev-resources.md#how-to-test-local-code-on-a-mobile-device).
- Note that you'll encounter https://github.com/zooniverse/front-end-monorepo/issues/5272 when run locally
- This Black Hole Hunters [workflow](https://local.zooniverse.org:3000/projects/cobalt-lensing/black-hole-hunters/classify/workflow/25070?env=production) can also be run locally, but admin mode must be on

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated