### PR TITLE
Use InteractionLayerContainer as frame source for drawn marks

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
@@ -97,6 +97,7 @@ const FlipbookViewer = ({
       >
         <SingleImageViewer
           enableInteractionLayer={enableInteractionLayer}
+          frame={currentFrame}
           height={naturalHeight}
           limitSubjectHeight={limitSubjectHeight}
           onKeyDown={handleSpaceBar}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -90,7 +90,6 @@ function InteractionLayer({
   }
 
   function createMark(event) {
-    // TODO: add case for played = undefined
     const timeStamp = getFixedNumber(played, 5)
     const mark = activeTool.createMark({
       id: cuid(),
@@ -181,6 +180,7 @@ function InteractionLayer({
       />
       <DrawingToolMarks
         activeMark={activeMark}
+        frame={frame}
         marks={marks}
         onDelete={inactivateMark}
         onDeselectMark={inactivateMark}
@@ -205,6 +205,10 @@ InteractionLayer.propTypes = {
     value: PropTypes.array
   }).isRequired,
   disabled: PropTypes.bool,
+  /**
+   * Passed from parent subject viewer such as Flipbook, MultiFrame, or SeparateFrame
+   * Coerced to 0 if "clone marks in all frames" is true.
+  */
   frame: PropTypes.number,
   height: PropTypes.number.isRequired,
   marks: PropTypes.array,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.js
@@ -10,6 +10,7 @@ function DrawingToolMarks({
     setSubTaskVisibility: () => { }
   },
   disabled = false,
+  frame = 0,
   marks = [],
   onDelete = () => true,
   onDeselectMark = () => true,
@@ -21,6 +22,8 @@ function DrawingToolMarks({
   played,
 }) {
   const { canvas } = useContext(SVGContext)
+
+  // Filter marks array here to display only marks with mark.frame === frame prop.
 
   return marks.map((mark, index) => {
     /*
@@ -124,6 +127,8 @@ DrawingToolMarks.propTypes = {
     id: PropTypes.string,
     setSubTaskVisibility: PropTypes.func
   }),
+  /** Passed from parent subject viewer such as Flipbook, MultiFrame, or SeparateFrame */
+  frame: PropTypes.number,
   marks: PropTypes.array.isRequired,
   onDelete: PropTypes.func,
   onDeselectMark: PropTypes.func,

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarks.spec.js
@@ -5,6 +5,8 @@ import { Mark } from '@plugins/drawingTools/components'
 import SVGContext from '@plugins/drawingTools/shared/SVGContext'
 import DrawingToolMarks from './DrawingToolMarks'
 
+// recommend converting this from enzyme to RTL and testing filtering for current frame
+
 describe('Components > DrawingToolMarks', function () {
   let mockContext
   let canvas

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarksConnector.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/DrawingToolMarks/DrawingToolMarksConnector.js
@@ -5,7 +5,8 @@ import DrawingToolMarks from './DrawingToolMarks'
 
 function withFreehandLineReductions(Component) {
   function WithFreehandLineReductions(props, ref) {
-    const freehandLineProps = useFreehandLineReductions()
+    const { frame } = props
+    const freehandLineProps = useFreehandLineReductions(frame)
     return <Component ref={ref} {...props} {...freehandLineProps} />
   }
   return observer(forwardRef(WithFreehandLineReductions))

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/PreviousMarks/PreviousMarks.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/PreviousMarks/PreviousMarks.js
@@ -10,9 +10,6 @@ function storeMapper(classifierStore) {
     classifications: {
       active: classification
     },
-    subjectViewer: {
-      frame
-    },
     workflowSteps: {
       activeInteractionTask,
       interactionTask: {
@@ -22,16 +19,15 @@ function storeMapper(classifierStore) {
   } = classifierStore
 
   const previousAnnotations = classification?.previousInteractionTaskAnnotations(activeInteractionTask.taskKey) || []
-  return { frame, previousAnnotations, shownMarks }
+  return { previousAnnotations, shownMarks }
 }
 
 function PreviousMarks ({
+  frame = 0,
   /** SVG image scale (client size / natural size.)*/
   scale = 1
 }) {
   const {
-    /** The current active frame in the subject viewer. */
-    frame = 0,
     /** Annotations from previous marking tasks. Each annotation is an array of marks. */
     previousAnnotations,
     /** The show/hide previous marks setting. */
@@ -41,8 +37,8 @@ function PreviousMarks ({
   const marksToShow = shownMarks === SHOWN_MARKS.ALL || shownMarks === SHOWN_MARKS.USER
 
   if (previousAnnotations?.length > 0 && marksToShow) {
-    // Wrapping the array in an react fragment because enzyme errors otherwise 
-    // React v16 allows this, though. 
+    // Wrapping the array in an react fragment because enzyme errors otherwise
+    // React v16 allows this, though.
     return (
       <>
         {previousAnnotations.map((annotation) => {
@@ -69,6 +65,8 @@ function PreviousMarks ({
 }
 
 PreviousMarks.propTypes = {
+  /** Passed from parent subject viewer. Different source of truth depedendent on Flipbook, MultiFrame, or SeparateFrame */
+  frame: PropTypes.number,
   scale: PropTypes.number
 }
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/SeparateFramesViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/SeparateFramesViewer.js
@@ -81,9 +81,10 @@ function SeparateFramesViewer({
         columns={forceColLayout ? 'auto' : [`repeat(${numFramesHorizontally}, 1fr)`]}
         rows='auto'
       >
-        {subject.locations?.map(location => (
+        {subject.locations?.map((location, index) => (
           <SeparateFrame
             enableInteractionLayer={enableInteractionLayer}
+            frame={index}
             frameUrl={location.url}
             key={location.url}
             limitSubjectHeight={limitSubjectHeight}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.js
@@ -20,6 +20,7 @@ const DEFAULT_HANDLER = () => true
 const SeparateFrame = ({
   enableInteractionLayer = false,
   enableRotation = DEFAULT_HANDLER,
+  frame = 0,
   frameUrl = '',
   limitSubjectHeight = false,
   onError = DEFAULT_HANDLER,
@@ -200,6 +201,7 @@ const SeparateFrame = ({
       <SingleImageViewer
         enableInteractionLayer={enableInteractionLayer}
         height={naturalHeight}
+        frame={frame}
         limitSubjectHeight={limitSubjectHeight}
         onKeyDown={onKeyDown}
         rotate={rotation}
@@ -260,6 +262,8 @@ SeparateFrame.propTypes = {
   enableInteractionLayer: PropTypes.bool,
   /** Function passed from Subject Viewer Store */
   enableRotation: PropTypes.func,
+  /** Index in multi-image subject's locations array */
+  frame: PropTypes.number,
   /** String of Object.values(subject.locations[this frame index][0]) */
   frameUrl: PropTypes.string,
   /** Function passed from Workflow Configuration */

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -18,13 +18,14 @@ const PlaceholderSVG = styled.svg`
 function SingleImageViewer({
   children,
   enableInteractionLayer = false,
+  frame = 0,
   height,
   limitSubjectHeight = false,
   onKeyDown = () => true,
   rotate = 0,
   scale = 1,
   svgMaxHeight = null,
-subject,
+  subject,
   title = {},
   viewBox,
   width,
@@ -69,6 +70,7 @@ subject,
             {enableInteractionLayer && (
               <InteractionLayer
                 scale={scale}
+                frame={frame}
                 height={height}
                 width={width}
                 subject={subject}

--- a/packages/lib-classifier/src/hooks/useFreehandLineReductions.js
+++ b/packages/lib-classifier/src/hooks/useFreehandLineReductions.js
@@ -2,11 +2,8 @@ import { getType } from 'mobx-state-tree'
 import { useStores } from '@hooks'
 import { useCaesarReductions } from './'
 
-export default function useFreehandLineReductions() {
+export default function useFreehandLineReductions(frame = 0) {
   const {
-    subjectViewer: {
-      frame
-    },
     workflows: {
       active: workflow
     },

--- a/packages/lib-classifier/src/store/WorkflowStore/Workflow/Workflow.spec.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/Workflow/Workflow.spec.js
@@ -54,6 +54,8 @@ describe('Model > Workflow', function () {
     it('should have limit_subject_height default to false', function () {
       expect(workflow.configuration.limit_subject_height).to.be.false()
     })
+
+    // need a unit test for multi_image_clone_markers here
   })
 
   describe('with custom configuration', function () {

--- a/packages/lib-classifier/src/store/WorkflowStore/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
+++ b/packages/lib-classifier/src/store/WorkflowStore/Workflow/WorkflowConfiguration/WorkflowConfiguration.js
@@ -7,6 +7,7 @@ const WorkflowConfiguration = types.snapshotProcessor(
     flipbook_autoplay: types.optional(types.boolean, false),
     invert_subject: types.optional(types.boolean, false),
     limit_subject_height: types.optional(types.boolean, false),
+    multi_image_clone_markers: types.optional(types.boolean, false),
     multi_image_mode: types.optional(types.enumeration('multiImageMode', ['flipbook', 'separate']), 'flipbook'),
     multi_image_layout: types.optional(types.enumeration('multiImageLayout', ['col', 'grid2', 'grid3', 'row']), 'col'),
     playIterations: types.optional(types.number, 3),


### PR DESCRIPTION
## Package
lib-classifer

## Linked Issue and/or Talk Post

This draft PR corresponds with review in https://github.com/zooniverse/front-end-monorepo/pull/5754. The changes here either need to be used in PR #5754, or dev toward https://github.com/zooniverse/front-end-monorepo/issues/5493 can continue on this branch.

## Describe your changes

- Use InteractionLayerContainer as source of `frame` for drawing workflows
- Pass `frame` from Flipbook Viewer local state or SeparateFrame (via `locations` array index)
- When task type is transcription, use `frame` from the SubjectViewerStore
- Cloning marks: FlipbookViewer and SeparateFrame has its own local state for “currently viewed frame”, yet when we want to clone marks, I’m telling InteractionLayer that `frame` is always 0, even if the "currently viewed frame" is not 0 in FlipbookViewer or SeparateFrame.
- Handle frame in DrawingToolMarks
- Handle frame in PreviousMarks
- Pass `frame` to useFreehandLineReductions rather than get it from SubjectViewerStore

## How to Review

Follow-up steps are listed in this [comment](https://github.com/zooniverse/front-end-monorepo/pull/5754#pullrequestreview-1822355926) too (@kieftrav), but the main follow-up steps are the addition of unit tests, and confirming that this PR's strategy can work with freehand line reductions in all cases. I did not test many live projects iyet, and left in-code comments to be filled in.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)