### PR TITLE
app-project: Track AuthModal's active index in the UI store

### DIFF
--- a/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitation.stories.js
+++ b/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitation.stories.js
@@ -19,6 +19,9 @@ const stores = {
   project: {
     isComplete: false
   },
+  ui: {
+    setAuthModalActiveIndex: () => {}
+  },
   user: {
     isLoggedIn: false,
     personalization: {

--- a/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationConnector.js
+++ b/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationConnector.js
@@ -11,21 +11,27 @@ function useStores(mockStore) {
   const stores = useContext(MobXProviderContext)
   const store = mockStore || stores.store
 
+  const { setAuthModalActiveIndex } = store.ui
+
   const { isLoggedIn } = store.user
   const { sessionCount } = store.user.personalization
   const { isComplete } = store.project
   const afterFive = sessionCount >= 5
   const isVisible = !isLoggedIn && !isComplete && afterFive
   return {
-    isVisible
+    isVisible,
+    setAuthModalActiveIndex
   }
 }
 
-function AuthenticationInvitationConnector ({ mockStore }) {
-  const { isVisible = false } = useStores(mockStore)
+function AuthenticationInvitationConnector({ mockStore }) {
+  const { isVisible = false, setAuthModalActiveIndex } = useStores(mockStore)
 
   return (
-    <DynamicallyImportedAuthenticationInvitationContainer isVisible={isVisible} />
+    <DynamicallyImportedAuthenticationInvitationContainer
+      isVisible={isVisible}
+      setAuthModalActiveIndex={setAuthModalActiveIndex}
+    />
   )
 }
 

--- a/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationConnector.spec.js
+++ b/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationConnector.spec.js
@@ -11,6 +11,9 @@ describe('Component > AuthenticationInvitationConnector', function () {
       project: {
         isComplete: false
       },
+      ui: {
+        setAuthModalActiveIndex: () => {}
+      },
       user: {
         isLoggedIn: false,
         personalization: {

--- a/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationContainer.js
+++ b/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationContainer.js
@@ -1,34 +1,27 @@
 import { useState } from 'react'
-import styled from 'styled-components'
 import { useTranslation } from 'next-i18next'
+import PlainButton from '@zooniverse/react-components/PlainButton'
+import { bool, func } from 'prop-types'
 
-import { Anchor } from 'grommet'
-import NavLink from '@shared/components/NavLink'
 import GenericAnnouncement from '../GenericAnnouncement'
 
-const StyledAnchor = styled(Anchor)`
-  line-height: 19px;
-`
+const DEFAULT_HANDLER = () => {}
 
-export default function AuthenticationInvitationContainer({ isVisible }) {
+export default function AuthenticationInvitationContainer({
+  isVisible = false,
+  setAuthModalActiveIndex = DEFAULT_HANDLER
+}) {
   const { t } = useTranslation('components')
   const [dismissed, setDismissed] = useState(false)
-  const { pathname } = window.location
-  const signInLink = {
-    href: `${pathname}?login=true`,
-    text: t('Announcements.AuthenticationInvitation.signIn')
-  }
-  const registerLink = {
-    href: `${pathname}?register=true`,
-    text: t('Announcements.AuthenticationInvitation.register')
-  }
 
-  // TODO: maybe show project specific message here. Then fallback on generic.
   const announcement = t('Announcements.AuthenticationInvitation.announcement')
 
   function dismissBanner() {
     setDismissed(true)
   }
+
+  const signInLabel = t('Announcements.AuthenticationInvitation.signIn')
+  const registerLabel = t('Announcements.AuthenticationInvitation.register')
 
   if (isVisible && !dismissed) {
     return (
@@ -38,11 +31,26 @@ export default function AuthenticationInvitationContainer({ isVisible }) {
         color='neutral-5'
         dismissable
       >
-        <NavLink color='#000000' link={signInLink} weight='normal' StyledAnchor={StyledAnchor} />
-        <NavLink color='#000000' link={registerLink} weight='normal' StyledAnchor={StyledAnchor} />
+        <PlainButton
+          color='black'
+          text={signInLabel}
+          onClick={() => setAuthModalActiveIndex(0)}
+        />
+        <PlainButton
+          color='black'
+          text={registerLabel}
+          onClick={() => setAuthModalActiveIndex(1)}
+        />
       </GenericAnnouncement>
     )
   }
 
   return null
+}
+
+AuthenticationInvitationContainer.propTypes = {
+  /** Announcement component is visible when not logged in and after 5 classifications */
+  isVisible: bool,
+  /** Handles AuthModal in PageHeader */
+  setAuthModalActiveIndex: func
 }

--- a/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationContainer.spec.js
+++ b/packages/app-project/src/components/Announcements/components/AuthenticationInvitation/AuthenticationInvitationContainer.spec.js
@@ -1,9 +1,8 @@
 import { mount, shallow } from 'enzyme'
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime'
-import { CloseButton } from '@zooniverse/react-components'
+import { CloseButton, PlainButton } from '@zooniverse/react-components'
 import AuthenticationInvitationContainer from './AuthenticationInvitationContainer'
 import GenericAnnouncement from '../GenericAnnouncement'
-import NavLink from '@shared/components/NavLink'
 
 describe('Component > AuthenticationInvitationContainer', function () {
   const mockRouter = {
@@ -27,16 +26,6 @@ describe('Component > AuthenticationInvitationContainer', function () {
 
   it('should render the `GenericAnnouncement` component if visible', function () {
     expect(componentWrapper).to.have.lengthOf(1)
-  })
-
-  it('should have a link to the login form', function () {
-    const signInLink = wrapper.find(NavLink).first()
-    expect(signInLink.props().link.href).to.equal(`${window.location.pathname}?login=true`)
-  })
-
-  it('should have a link to the register form', function () {
-    const registerLink = wrapper.find(NavLink).last()
-    expect(registerLink.props().link.href).to.equal(`${window.location.pathname}?register=true`)
   })
 
   describe('when not visible', function () {

--- a/packages/app-project/src/components/PageHeader/PageHeader.js
+++ b/packages/app-project/src/components/PageHeader/PageHeader.js
@@ -1,20 +1,19 @@
 import { AuthModal, ZooHeader } from '@zooniverse/react-components'
 import auth from 'panoptes-client/lib/auth'
 import { MobXProviderContext, observer } from 'mobx-react'
-import { useContext, useState } from 'react'
+import { useContext } from 'react'
 import { bool } from 'prop-types'
 import ThemeModeContext from '@shared/contexts/ThemeModeContext.js'
 
 function useStore() {
   const { store } = useContext(MobXProviderContext)
-  const { user: userStore } = store
-  return { userStore }
+  const { user: userStore, ui: uiStore } = store
+  return { uiStore, userStore }
 }
 
 function PageHeader({ adminMode }) {
-  const [activeIndex, setActiveIndex] = useState(-1)
-
-  const { userStore } = useStore()
+  const { uiStore, userStore } = useStore()
+  const { authModalActiveIndex, setAuthModalActiveIndex } = uiStore
   const { admin, display_name, login } = userStore
 
   const userProp = userStore.isLoggedIn ? { admin, display_name, login } : {}
@@ -37,23 +36,23 @@ function PageHeader({ adminMode }) {
   }
 
   function openRegisterModal() {
-    setActiveIndex(1)
+    setAuthModalActiveIndex(1)
   }
 
   function openSignInModal() {
-    setActiveIndex(0)
+    setAuthModalActiveIndex(0)
   }
 
   function closeAuthModal() {
-    setActiveIndex(-1)
+    setAuthModalActiveIndex(-1)
   }
 
   return (
     <>
       <AuthModal
-        activeIndex={activeIndex}
+        activeIndex={authModalActiveIndex}
         closeModal={closeAuthModal}
-        onActive={setActiveIndex}
+        onActive={setAuthModalActiveIndex}
         onSignIn={onSignIn}
       />
       <ZooHeader

--- a/packages/app-project/stores/UI.js
+++ b/packages/app-project/stores/UI.js
@@ -9,6 +9,7 @@ const canSetCookie = process.browser || process.env.BABEL_ENV === 'test'
 
 const UI = types
   .model('UI', {
+    authModalActiveIndex: types.optional(types.number, -1),
     dismissedProjectAnnouncementBanner: types.maybeNull(types.number),
   })
 
@@ -66,6 +67,10 @@ const UI = types
       if (canSetCookie) {
         self.dismissedProjectAnnouncementBanner = parseInt(getCookie('dismissedProjectAnnouncementBanner'), 10) || null
       }
+    },
+
+    setAuthModalActiveIndex(index) {
+      self.authModalActiveIndex = index
     },
 
     setProjectAnnouncementBannerCookie() {


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/5869

## Describe your changes

- Create `authModalActiveIndex` on the UI store for the project pages. PageHeader was previously the only component setup to open or close the sign-in/register modal, but we want to be able to do so from other components too.
- Use `setAuthModalActiveIndex` in AuthenticationInvitation component rather than rely on changing the url to open the auth modal (that was legacy behavior).
- Ideally in the future all of the Announcements components will get a refactor in favor of RTL tests and more responsive styling, but for now I've only put a bandaid fix on the affected spec files.

## How to Review

- AuthenticationInvitation has a story that can be run for a visual check
- To try out sign-in or register buttons, run app-project locally and visit https://local.zooniverse.org:3000/projects/cobalt-lensing/black-hole-hunters?env=production. Make 5 classifications on the Training Workflow while logged out.
- The AuthenticationInvitation banner should appear in the above case, but should not appear if 5 classifications are completed while signed in to your account.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated