### PR TITLE
Workflow Assignment Modal: URL fix

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.js
@@ -1,19 +1,12 @@
 import { useContext, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { MobXProviderContext, observer } from 'mobx-react'
-import { Button, Box, CheckBox, Text } from 'grommet'
+import { Button, Box, CheckBox } from 'grommet'
 import { Modal, PrimaryButton, SpacedText } from '@zooniverse/react-components'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
-import styled from 'styled-components'
-
-import NavLink from '@shared/components/NavLink'
-
-const StyledNavLink = styled(NavLink)`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`
+import Link from 'next/link'
+import addQueryParams from '@helpers/addQueryParams'
 
 function useStore() {
   const { store } = useContext(MobXProviderContext)
@@ -33,7 +26,7 @@ function WorkflowAssignmentModal({ currentWorkflowID = '' }) {
   const router = useRouter()
   const owner = router?.query?.owner
   const project = router?.query?.project
-  const url = `/projects/${owner}/${project}/classify/workflow/${assignedWorkflowID}`
+  const url = `/${owner}/${project}/classify/workflow/${assignedWorkflowID}`
 
   /** Check if user has dismissed the modal, but only in the browser */
   const isBrowser = typeof window !== 'undefined'
@@ -98,13 +91,10 @@ function WorkflowAssignmentModal({ currentWorkflowID = '' }) {
           label={t('Classify.WorkflowAssignmentModal.cancel')}
           onClick={() => closeFn()}
         />
-        <StyledNavLink
-          StyledAnchor={PrimaryButton}
-          StyledSpacedText={Text}
-          link={{
-            href: url,
-            text: t('Classify.WorkflowAssignmentModal.confirm'),
-          }}
+        <PrimaryButton
+          as={Link}
+          href={addQueryParams(url)}
+          label={t('Classify.WorkflowAssignmentModal.confirm')}
         />
       </Box>
     </Modal>

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.js
@@ -33,7 +33,7 @@ function WorkflowAssignmentModal({ currentWorkflowID = '' }) {
   const router = useRouter()
   const owner = router?.query?.owner
   const project = router?.query?.project
-  const url = `/${owner}/${project}/classify/workflow/${assignedWorkflowID}`
+  const url = `/projects/${owner}/${project}/classify/workflow/${assignedWorkflowID}`
 
   /** Check if user has dismissed the modal, but only in the browser */
   const isBrowser = typeof window !== 'undefined'

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.spec.js
@@ -17,7 +17,7 @@ describe('Component > WorkflowAssignmentModal', function () {
     })
 
     it('should render a confirmation link', function () {
-      const link = document.querySelector(`a[href='/zooniverse/snapshot-serengeti/classify/workflow/1234'`)
+      const link = document.querySelector(`a[href='/projects/zooniverse/snapshot-serengeti/classify/workflow/1234'`)
       expect(link).to.be.ok()
     })
 

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.spec.js
@@ -17,7 +17,7 @@ describe('Component > WorkflowAssignmentModal', function () {
     })
 
     it('should render a confirmation link', function () {
-      const link = document.querySelector(`a[href='/projects/zooniverse/snapshot-serengeti/classify/workflow/1234'`)
+      const link = document.querySelector(`a[href='/zooniverse/snapshot-serengeti/classify/workflow/1234'`)
       expect(link).to.be.ok()
     })
 


### PR DESCRIPTION
Fixes #5880 

May need iteration to fix tests / adopt alternate solution. Not sure whether this is an issue with the modal URL variable (as assumed by this original solution) or a larger router issue.

## Describe your changes
Adds `/projects` to link URL

## How to Review
Test with `zootester` prod user who has leveled up to second level on Gravity Spy:
1. Login as zootester (creds in Passbolt)
2. Navigate to Gravity Spy: https://www.zooniverse.org/projects/zooniverse/gravity-spy
3. Select Level 1 Workflow from homepage.
4. Because zootester is leveled up into Level 2, you should see the Workflow Assignment Modal pop-up -- note the incorrect URL for the "Take me to the next workflow" button.

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated