### PR TITLE
lib-user: Add Tabs component

### DIFF
--- a/packages/lib-user/src/components/shared/Select/Select.spec.js
+++ b/packages/lib-user/src/components/shared/Select/Select.spec.js
@@ -1,6 +1,6 @@
+import { composeStory } from '@storybook/react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { composeStory } from '@storybook/react'
 
 import dateRanges from '../BarChart/helpers/dateRanges'
 import Meta, { DateRanges } from './Select.stories'

--- a/packages/lib-user/src/components/shared/Tabs/Tabs.js
+++ b/packages/lib-user/src/components/shared/Tabs/Tabs.js
@@ -1,0 +1,13 @@
+import { Tabs as GrommetTabs, ThemeContext } from 'grommet'
+
+import tabTheme from './theme'
+
+function Tabs (props) {
+  return (
+    <ThemeContext.Extend value={tabTheme}>
+      <GrommetTabs {...props} />
+    </ThemeContext.Extend>
+  )
+}
+
+export default Tabs

--- a/packages/lib-user/src/components/shared/Tabs/Tabs.spec.js
+++ b/packages/lib-user/src/components/shared/Tabs/Tabs.spec.js
@@ -1,0 +1,38 @@
+import { composeStory } from '@storybook/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import Meta, { Default } from './Tabs.stories'
+
+describe('components > shared > Tabs', function () {
+  const user = userEvent.setup()
+  const DefaultStory = composeStory(Default, Meta)
+  let arrayOfTabs
+  let tabPanel
+
+  before(function () {
+    render(<DefaultStory />)
+    arrayOfTabs = screen.getAllByRole('tab')
+    tabPanel = screen.getAllByRole('tabpanel')
+  })
+
+  it('should render the correct number of tabs', function () {
+    expect(arrayOfTabs).to.have.lengthOf(2)
+  })
+
+  it('should have exactly one active panel', function () {
+    expect(tabPanel).to.have.lengthOf(1)
+  })
+
+  it('should change the active tab panel when a tab button is clicked', async function () {
+    render(<DefaultStory />)
+
+    const tabPanel = screen.getByRole('tabpanel')
+    const tabButtonHours = screen.getByRole('tab', { name: 'hours' })
+
+    expect(within(tabPanel).getByText('Classification bar chart goes here.')).to.be.ok()
+
+    user.click(tabButtonHours)
+    await waitFor(() => expect(within(tabPanel).getByText('Hours bar chart goes here.')).to.be.ok())
+  })
+})

--- a/packages/lib-user/src/components/shared/Tabs/Tabs.stories.js
+++ b/packages/lib-user/src/components/shared/Tabs/Tabs.stories.js
@@ -1,0 +1,35 @@
+import { SpacedText } from '@zooniverse/react-components'
+import { Box, Tab } from 'grommet'
+
+import Tabs from './Tabs.js'
+
+export default {
+  title: 'Components/shared/Tabs',
+  component: Tabs,
+  decorators: [ComponentDecorator]
+}
+
+function ComponentDecorator (Story) {
+  return (
+    <Box
+      background={{
+        dark: 'dark-3',
+        light: 'neutral-6'
+      }}
+      fill
+      pad='30px'
+    >
+      <Story />
+    </Box>
+  )
+}
+
+export const Default = {
+  args: {
+    children: [
+      <Tab key='classifications' title={<SpacedText>classifications</SpacedText>}><Box>Classification bar chart goes here.</Box></Tab>,
+      <Tab key='hours' title={<SpacedText>hours</SpacedText>}><Box>Hours bar chart goes here.</Box></Tab>
+    ],
+    justify: 'start'
+  }
+}

--- a/packages/lib-user/src/components/shared/Tabs/index.js
+++ b/packages/lib-user/src/components/shared/Tabs/index.js
@@ -1,0 +1,1 @@
+export { default as Tabs } from './Tabs.js'

--- a/packages/lib-user/src/components/shared/Tabs/theme.js
+++ b/packages/lib-user/src/components/shared/Tabs/theme.js
@@ -1,0 +1,43 @@
+import { css } from 'styled-components'
+
+const tabTheme = {
+  tab: {
+    active: {
+      color: {
+        dark: 'brand',
+        light: 'brand'
+      },
+    },
+    border: {
+      active: {
+        color: 'brand',
+      },
+      color: {
+        dark: 'dark-3',
+        light: 'neutral-6'
+      },
+      side: 'bottom',
+      size: 'medium'
+    }
+  },
+  tabs: {
+    extend: props => {
+      return css`
+        button[role="tab"] {
+          > div > span {
+            font-size: 1em;
+          }
+
+          &[aria-selected="true"] {
+            > div > span {
+              color: ${props.theme.dark ? '#ffffff' : '#000000'};
+              font-weight: 700;
+            }
+          }
+        }
+      `
+    },
+  }
+}
+
+export default tabTheme


### PR DESCRIPTION
## Package
- lib-user

## Describe your changes
- adds Tabs component, mainly for related custom styling, per [related design](https://www.figma.com/file/qbqbmR3t5XV6eKcpuRj7mG/Group-Stats?node-id=96%3A831&mode=dev)
- adds related story and tests

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a
- What user actions should my reviewer step through to review this PR?
  - review related story
- Which storybook stories should be reviewed?
  - http://localhost:6008/?path=/story/components-shared-tabs--default
- Are there plans for follow up PR’s to further fix this bug or develop this feature? info/tip is not included intentionally, will be included in subsequent PR

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)