### PR TITLE
fix: Store all drawn marks in the classification

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/InteractionLayer.js
@@ -104,7 +104,7 @@ function InteractionLayer({
     mark.setSubTaskVisibility(false)
     // Add a time value for tools that care about time. For most tools, this value is ignored.
     mark.setVideoTime(timeStamp, duration)
-    const markIDs = marks.map((mark) => mark.id)
+    const markIDs = annotation.value?.map((mark) => mark.id)
     annotation.update([...markIDs, mark.id])
   }
 


### PR DESCRIPTION
After creating a new mark, add the new mark to the previous annotation value and store this as a new annotation. Should fix a bug raised in this comment: https://github.com/zooniverse/front-end-monorepo/pull/5913#issuecomment-1945219415

You can try this out on How Did We Get Here, in the dev classifier. Draw on both frames of a subject, then check whether the drawn marks persist, in the classification, on the second step of the workflow.
https://local.zooniverse.org:8080/?project=communitiesandcrowds/how-did-we-get-here&env=production

## Expected behaviour

When I create a new mark, `classification.annotations` should be updated to include all the marks that I've drawn for the current task.

## Actual behaviour

When I draw a mark, the new drawing task annotation only contains mark IDs from the active frame. Mark IDs from other frames are silently dropped from the classification.

The marks themselves are still stored on their respective drawing tools, but the references to them are removed from the task annotation.