### PR TITLE
FreehandLine drawing not recognizing closed mark

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/FreehandLine/FreehandLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/FreehandLine/FreehandLine.js
@@ -196,7 +196,7 @@ const FreehandLineModel = types
       self.minimumPoints = isNaN(self.minimumPoints) ? 20 : self.minimumPoints
       self.undoActionPointThreshold = isNaN(self.undoActionPointThreshold) ? 20 : self.undoActionPointThreshold
       self.pathIsClosed = false
-    	self.points = [...points]
+      self.points = [...points]
 
       self.setClosePoint(self.points.at(0))
       self.setDragPoint(self.points.at(-1))
@@ -624,6 +624,9 @@ const FreehandLineModel = types
 
       if (self.isDragging) {
         self.appendPathEnd()
+        self.finished = true
+      } else if (self.pathIsClosed) {
+        // user closed the path on this initial drag
         self.finished = true
       } else {
         self.pathX = []


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post

[Issue #5922](https://github.com/zooniverse/front-end-monorepo/issues/5922)

## Describe your changes
Added a conditional check for when the mark is considered "finished" to check if its closed so that it updates the state properly to be a finished mark.

## How to Review
Load up the [FreehandLine Story](http://localhost:6006/?path=/story/drawing-tools-freehand-line--drawing) locally and test that you can draw two successive full, closed circle on first draw. Before this fix, you could not draw a 2nd mark without clicking the 'close' button in the LineControls.

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
