### PR TITLE
Enable/disable annotate button if the workflow has a drawing task

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -1,5 +1,6 @@
 import { Box } from 'grommet'
 import { observer } from 'mobx-react'
+import { useStores } from '@hooks'
 
 import FieldGuide from '../FieldGuide'
 import AnnotateButton from './components/AnnotateButton'
@@ -12,9 +13,15 @@ import ZoomInButton from './components/ZoomInButton'
 import ZoomOutButton from './components/ZoomOutButton'
 import { useKeyZoom } from '@hooks'
 
+function storeMapper(classifierStore) {
+  return { showAnnotateButton: classifierStore.subjectViewer.showAnnotate }
+}
+
 // Generalized ...props here are css rules from the page layout
 function ImageToolbar (props) {
+  const { showAnnotateButton } = useStores(storeMapper)
   const { onKeyZoom } = useKeyZoom()
+  
   return (
     <Box
       height='min-content'
@@ -37,7 +44,7 @@ function ImageToolbar (props) {
         fill
         pad='clamp(8px, 15%, 10px)'
       >
-        <AnnotateButton />
+        {showAnnotateButton && <AnnotateButton />}
         <MoveButton />
         <ZoomInButton />
         <ZoomOutButton />

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.spec.js
@@ -1,34 +1,71 @@
-import { render } from '@testing-library/react'
-import zooTheme from '@zooniverse/grommet-theme'
-import { Grommet } from 'grommet'
+import { render, screen } from '@testing-library/react'
 import { Provider } from 'mobx-react'
-
 import mockStore from '@test/mockStore/mockStore.js'
-
 import ImageToolbar from './ImageToolbar'
 
-describe('Component > ImageToolbar', function () {
-  function withStore() {
-    return function Wrapper({
-      children = null,
-      store = mockStore()
-    }) {
-      return (
-        <Grommet theme={zooTheme}>
-          <Provider classifierStore={store}>
-            {children}
-          </Provider>
-        </Grommet>
-      )
-    }
-  }
+import {
+  DrawingTaskFactory,
+  SingleChoiceTaskFactory,
+  MultipleChoiceTaskFactory,
+  TextTaskFactory,
+  TranscriptionTaskFactory,
+  WorkflowFactory,
+} from '@test/factories'
 
-  it('should render without crashing', function () {
-    render(
-      <ImageToolbar />,
-      {
-        wrapper: withStore()
+const taskTypes = [
+  {
+    type: 'drawing',
+    annotateShow: true,
+    task: DrawingTaskFactory.build(),
+  },
+  {
+    type:'singleChoice',
+    annotateShow: false,
+    task: SingleChoiceTaskFactory.build()
+  },
+  {
+    type:'multipleChoice',
+    annotateShow: false,
+    task: MultipleChoiceTaskFactory.build()
+  },
+  {
+    type:'text',
+    annotateShow: false,
+    task: TextTaskFactory.build()
+  },
+  {
+    type:'transcription',
+    annotateShow: true,
+    task: TranscriptionTaskFactory.build()
+  },
+]
+
+describe('Component > ImageToolbar', function () {
+  taskTypes.forEach(task => {
+    const withOrWithout = task.annotateShow ? 'with' : 'without'
+
+    it(`should render ${withOrWithout} the annotate button`, function () {
+      // Create minimal store with the current task
+      const store = mockStore({
+        workflow: WorkflowFactory.build({
+          tasks: {
+            T1: task.task,
+          }
+        })
+      })
+      
+      render(
+        <Provider classifierStore={store}>
+          <ImageToolbar />
+        </Provider>
+      )
+  
+      // Button should exist if annotateShow is true
+      if (task.annotateShow) {
+        expect(screen.queryByLabelText('ImageToolbar.AnnotateButton.ariaLabel')).to.exist()
+      } else {
+        expect(screen.queryByLabelText('ImageToolbar.AnnotateButton.ariaLabel')).to.be.null()
       }
-    )
+    })
   })
 })

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButtonContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/AnnotateButton/AnnotateButtonContainer.js
@@ -19,7 +19,11 @@ function AnnotateButtonContainer({
   separateFrameAnnotate = false,
   separateFrameEnableAnnotate = () => true
 }) {
-  const { annotate, enableAnnotate, separateFramesView } = useStores(storeMapper)
+  const {
+    annotate,
+    enableAnnotate,
+    separateFramesView
+  } = useStores(storeMapper)
 
   return (
     <AnnotateButton

--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/MoveButton/MoveButton.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/components/MoveButton/MoveButton.spec.js
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event'
 import zooTheme from '@zooniverse/grommet-theme'
 
 import mockStore from '@test/mockStore'
-
+import { DrawingTaskFactory, WorkflowFactory } from '@test/factories'
 import MoveButtonContainer from './MoveButtonContainer'
 
 describe('Component > MoveButton', function () {
@@ -36,7 +36,13 @@ describe('Component > MoveButton', function () {
 
   it('should change the subject viewer annotate and move state when clicked', async function () {
     const user = userEvent.setup({ delay: null })
-    const store = mockStore()
+    const store = mockStore({
+      workflow: WorkflowFactory.build({
+        tasks: {
+          T1: DrawingTaskFactory.build(),
+        }
+      })
+    })
 
     expect(store.subjectViewer.move).to.be.false()
     expect(store.subjectViewer.annotate).to.be.true()

--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -1,4 +1,4 @@
-import { configure } from 'mobx'
+import { configure, keys, isObservableProp } from 'mobx'
 import {
   addMiddleware,
   getEnv,
@@ -83,12 +83,28 @@ const RootStore = types
       self.subjects.reset()
     }
 
+    function _afterInitialize() {
+      // Because the root store is initialized all the sub-stores are as well
+      // We enable listening between this root store's stores by calling an afterRootInitialize() method on all these sub-stores
+      const allKeys = keys(self)
+      allKeys.forEach(key => {
+        // Filter the current model to only the observable properties of the root store since that's all our models
+        const isFunction = typeof self[key] === 'function'
+        const isVolatile = !isObservableProp(self, key)
+        if (isFunction || isVolatile) return
+
+        // If the sub-store has the afterRootInitialize() method, run it
+        self[key].afterRootInitialize?.()
+      })
+    }
+
     // Public actions
     function afterCreate () {
       addMiddleware(self, _addMiddleware)
       onAction(self, _onAction)
       onPatch(self, _onPatch)
       self.authClient?.listen('change', _onUserChange)
+      _afterInitialize()
     }
 
     function setLocale (newLocale) {

--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -75,6 +75,17 @@ const WorkflowStepStore = types
       return activeInteractionTask || {}
     },
 
+    // Needs to check all steps, not just the active one
+    get hasAnnotateTask () {
+      for (const key in self.workflow?.tasks) {
+        const task = self.workflow.tasks[key]
+        if (task.type === 'drawing' || task.type === 'transcription' || task.type === 'dataVisAnnotation') {
+          return true
+        }
+      }
+      return false
+    },
+
     get locale() {
       return getRoot(self).locale
     },


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Issue #4454 

## Describe your changes
Updated the `SubjectViewerStore` to have a property that's used by the `ImageToolbar` component to enable/disable the visibility of the annotate button depending upon whether or not the currently active workflow has a drawing task. 

## How to Review
Load the "[kieftrav/annotate-or-not](https://localhost:8080/?project=kieftrav%2Fannotate-or-not&workflow=3785)" project in the classifier locally. Workflow [3782](https://localhost:8080/?project=kieftrav%2Fannotate-or-not&workflow=3782) and [3785](https://localhost:8080/?project=kieftrav%2Fannotate-or-not&workflow=3785) have a drawing task and non-drawing task respectively. The "Drawing" workflow should have the annotate button loaded. The "No Drawing" workflow should have the annotate button hidden and the Move icon active.

When deployed on the FE Project Branch, here are two different examples:
- No Drawing: [Daily Minor Plant](https://fe-project-branch.preview.zooniverse.org/projects/fulsdavid/the-daily-minor-planet/classify/workflow/22354?demo=true)
- Drawing: [Etch-a-cell](https://fe-project-branch.preview.zooniverse.org/projects/willcharlie/etch-a-cell-correct-a-cell/classify/workflow/24998?demo=true)

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature