### PR TITLE
Turn off video controls for subject preview cards

### DIFF
--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/components/SubjectThumbnail/SubjectThumbnail.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/components/SubjectThumbnail/SubjectThumbnail.js
@@ -21,28 +21,29 @@ const StyledBox = styled(Box)`
   position: relative;
 `
 
+const Gradient = styled(Box)`
+  top: 0;
+  right: 0;
+  position: absolute;
+  background: linear-gradient(to top, rgba(0,0,0,0.8) -30%, rgba(0,0,0,0.2) 30%, transparent 100%);
+  z-index: 2; // Must be in front of Grommet Video component's z-index of 1
+`
+
 const StyledSpacedText = styled(SpacedText)`
   bottom: 1em;
   left: 1em;
   position: absolute;
-  text-shadow: 1px 1px 1px rgba(0,0,0,1), 1px 0 4px rgba(0,0,0,0.8);
-  z-index: 2; // Must be in front of Grommet Video component's z-index of 1
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  z-index: 3;
 `
 
-function SubjectThumbnail ({ height, href, width, subject }) {
+function SubjectThumbnail({ height, href, width, subject }) {
   const { t } = useTranslation('screens')
   const subjectURLs = subject.locations.map(location => Object.values(location)[0])
   const subjectURL = subjectURLs[0]
   return (
-    <StyledAnchor
-      href={`${href}/subjects/${subject.id}`}
-    >
-      <StyledBox
-        elevation='small'
-        fill
-        maxHeight={height}
-        maxWidth={width}
-      >
+    <StyledAnchor href={`${href}/subjects/${subject.id}`}>
+      <StyledBox elevation='small' fill maxHeight={height} maxWidth={width}>
         <Media
           alt={`subject ${subject.id}`}
           controls={false}
@@ -50,6 +51,7 @@ function SubjectThumbnail ({ height, href, width, subject }) {
           src={subjectURL}
           width={700}
         />
+        <Gradient fill />
         <StyledSpacedText color='white' weight='bold'>
           {t('Home.ZooniverseTalk.RecentSubjects.subjectLabel', { id: subject.id })}
         </StyledSpacedText>

--- a/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/components/SubjectThumbnail/SubjectThumbnail.js
+++ b/packages/app-project/src/screens/ProjectHomePage/components/ZooniverseTalk/components/RecentSubjects/components/SubjectThumbnail/SubjectThumbnail.js
@@ -25,7 +25,8 @@ const StyledSpacedText = styled(SpacedText)`
   bottom: 1em;
   left: 1em;
   position: absolute;
-  text-shadow: 0 2px 4px rgba(0,0,0,0.5);
+  text-shadow: 1px 1px 1px rgba(0,0,0,1), 1px 0 4px rgba(0,0,0,0.8);
+  z-index: 2; // Must be in front of Grommet Video component's z-index of 1
 `
 
 function SubjectThumbnail ({ height, href, width, subject }) {
@@ -40,12 +41,11 @@ function SubjectThumbnail ({ height, href, width, subject }) {
         elevation='small'
         fill
         maxHeight={height}
-        justify='start'
-        pad='none'
         maxWidth={width}
       >
         <Media
           alt={`subject ${subject.id}`}
+          controls={false}
           height={700}
           src={subjectURL}
           width={700}
@@ -65,9 +65,6 @@ SubjectThumbnail.propTypes = {
     id: PropTypes.string
   }).isRequired,
   width: PropTypes.number.isRequired
-}
-
-SubjectThumbnail.defaultProps = {
 }
 
 export default SubjectThumbnail

--- a/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.js
+++ b/packages/app-project/src/shared/components/SubjectPreview/SubjectPreview.js
@@ -31,7 +31,6 @@ function SubjectPreview ({
 }) {
   const subjectURLs = subject.locations.map(location => Object.values(location)[0])
   const subjectURL = subjectURLs[0]
-  const collectionsModal = createRef()
   const href = `/projects/${slug}/talk/subjects/${subject.id}`
 
   return (
@@ -53,6 +52,7 @@ function SubjectPreview ({
           <Media
             data-testid={`subject-image-${subject.id}`}
             alt={`subject ${subject.id}`}
+            controls={false}
             height={700}
             placeholder={placeholder}
             src={subjectURL}

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -12,6 +12,9 @@ Added an `onSignIn` function to AuthModal. A handler than can be called in the p
 ### Changed
 Standardized the variable name for when a user is using admin mode to `adminMode`.
 
+### Fixed
+Media's Video component was nesting an unused Anchor component. Removed it.
+
 ## [1.11.0] 2023-12-04
 
 ### Added

--- a/packages/lib-react-components/src/Media/components/Video/Video.js
+++ b/packages/lib-react-components/src/Media/components/Video/Video.js
@@ -28,9 +28,7 @@ export default function Video({
       maxHeight={height}
       width='100%'
     >
-      <GrommetVideo a11yTitle={alt} controls={controlsOption} fit={fit} preload='metadata' src={src}>
-        <Anchor href={src} label={alt} />
-      </GrommetVideo>
+      <GrommetVideo a11yTitle={alt} controls={controlsOption} fit={fit} preload='metadata' src={src} />
     </StyledBox>
   )
 }


### PR DESCRIPTION
## Package
app-project
lib-react-components

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/5840

## Describe your changes
- In app-project home pages and classify pages, turn off video controls for subject preview cards in RecentSubjects components.
- I also increased the contrast of the text-shadow behind the subject number displayed on project home pages. Although video subjects' controls are now hidden, there are data projects that use subjects with a white background

## How to Review

- Storybook for project home page's recent subjects: http://localhost:9001/?path=/story/project-app-screens-project-home-recent-subjects--plain
- Storybook for project classify page's recent subjects: http://localhost:9001/?path=/story/project-app-screens-classify-recent-subjects--plain
- An FEM project that has video subjects: https://local.zooniverse.org:3000/projects/elwest/woodpecker-cavity-cam?env=production
- An FEM project that has data subjects with white backgrounds: https://localhost.zooniverse.org:3000/projects/cobalt-lensing/black-hole-hunters?env=production

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed