### PR TITLE
Use local state for Flipbook Viewer's frame to avoid MST re-renders

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.js
@@ -13,8 +13,8 @@ import FlipbookControls from './components'
 const DEFAULT_HANDLER = () => true
 
 const FlipbookViewer = ({
+  defaultFrame = 0,
   enableInteractionLayer = false,
-  frame = 0,
   enableRotation = DEFAULT_HANDLER,
   flipbookAutoplay = false,
   invert = false,
@@ -25,17 +25,17 @@ const FlipbookViewer = ({
   onReady = DEFAULT_HANDLER,
   playIterations,
   rotation,
-  setFrame = DEFAULT_HANDLER,
   setOnPan = DEFAULT_HANDLER,
   setOnZoom = DEFAULT_HANDLER,
   subject
 }) => {
+  const [currentFrame, setCurrentFrame] = useState(defaultFrame)
   const [playing, setPlaying] = useState(false)
   const [dragMove, setDragMove] = useState()
   /** This initializes an image element from the subject's defaultFrame src url.
    * We do this so the SVGPanZoom has dimensions of the subject image.
    * We're assuming all frames in one subject have the same dimensions. */
-  const defaultFrameLocation = subject ? subject.locations[frame] : null
+  const defaultFrameLocation = subject ? subject.locations[defaultFrame] : null
   const { img, error, loading, subjectImage } = useSubjectImage({
     src: defaultFrameLocation.url,
     onReady,
@@ -46,7 +46,7 @@ const FlipbookViewer = ({
     naturalWidth = 800
   } = img
 
-  const viewerLocation = subject?.locations ? subject.locations[frame] : ''
+  const viewerLocation = subject?.locations ? subject.locations[currentFrame] : ''
 
   useEffect(() => {
     enableRotation()
@@ -97,7 +97,7 @@ const FlipbookViewer = ({
       >
         <SingleImageViewer
           enableInteractionLayer={enableInteractionLayer}
-          frame={frame}
+          frame={currentFrame}
           height={naturalHeight}
           limitSubjectHeight={limitSubjectHeight}
           onKeyDown={handleSpaceBar}
@@ -119,9 +119,9 @@ const FlipbookViewer = ({
         </SingleImageViewer>
       </SVGPanZoom>
       <FlipbookControls
-        currentFrame={frame}
+        currentFrame={currentFrame}
         locations={subject.locations}
-        onFrameChange={setFrame}
+        onFrameChange={setCurrentFrame}
         onPlayPause={onPlayPause}
         playing={playing}
         playIterations={playIterations}
@@ -131,12 +131,12 @@ const FlipbookViewer = ({
 }
 
 FlipbookViewer.propTypes = {
+  /** Fetched from metadata.default_frame or initialized to zero */
+  defaultFrame: PropTypes.number,
   /** Passed from Subject Viewer Store */
   enableInteractionLayer: PropTypes.bool,
   /** Function passed from Subject Viewer Store */
   enableRotation: PropTypes.func,
-  /** Index of currently viewed Frame or initialized to zero */
-  frame: PropTypes.number,
   /** Fetched from workflow configuration. Determines whether to autoplay the loop on viewer load */
   flipbookAutoplay: PropTypes.bool,
   /** Passed from Subject Viewer Store */

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewer.spec.js
@@ -46,19 +46,18 @@ describe('Component > FlipbookViewer', function () {
       expect(newButtonStyle.border).to.equal('2px solid #f0b200')
     })
 
-    // NOTE: these tests are run sequentially and the frame state of the below test is inherited from the above test
     it('should handle using arrow keys on the tablist', async function () {
       const user = userEvent.setup({ delay: null })
 
       const { getAllByRole } = render(<DefaultStory />)
       const thumbnailButtons = getAllByRole('tab')
-      expect(thumbnailButtons[1].tabIndex).to.equal(0)
+      expect(thumbnailButtons[0].tabIndex).to.equal(0)
 
-      thumbnailButtons[1].focus()
+      thumbnailButtons[0].focus()
       await user.keyboard('{ArrowRight}')
 
-      expect(thumbnailButtons[1].tabIndex).to.equal(-1)
-      expect(thumbnailButtons[2].tabIndex).to.equal(0)
+      expect(thumbnailButtons[0].tabIndex).to.equal(-1)
+      expect(thumbnailButtons[1].tabIndex).to.equal(0)
     })
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.js
@@ -60,7 +60,6 @@ function FlipbookViewerContainer({
     playIterations,
     rotation,
     separateFramesView,
-    setFrame,
     setOnPan,
     setOnZoom
   } = useStores(storeMapper)
@@ -107,7 +106,6 @@ function FlipbookViewerContainer({
           onReady={onReady}
           playIterations={playIterations}
           rotation={rotation}
-          setFrame={setFrame}
           setOnPan={setOnPan}
           setOnZoom={setOnZoom}
           subject={subject}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.js
@@ -11,16 +11,15 @@ import SeparateFramesViewer from '../SeparateFramesViewer/SeparateFramesViewer'
 function storeMapper(store) {
   const {
     enableRotation,
-    frame,
+    frame: defaultFrame,
     invert,
     move,
     rotation,
     separateFramesView,
-    setFrame,
     setOnPan,
     setOnZoom
   } = store.subjectViewer
-  
+
   const {
     flipbook_autoplay: flipbookAutoplay,
     limit_subject_height: limitSubjectHeight,
@@ -28,7 +27,7 @@ function storeMapper(store) {
   } = store.workflows?.active?.configuration
 
   return {
-    frame,
+    defaultFrame,
     enableRotation,
     flipbookAutoplay,
     invert,
@@ -37,7 +36,6 @@ function storeMapper(store) {
     playIterations,
     rotation,
     separateFramesView,
-    setFrame,
     setOnPan,
     setOnZoom
   }
@@ -53,7 +51,7 @@ function FlipbookViewerContainer({
   subject
 }) {
   const {
-    frame,
+    defaultFrame,
     enableRotation,
     flipbookAutoplay,
     invert,
@@ -97,8 +95,8 @@ function FlipbookViewerContainer({
         />
       ) : (
         <FlipbookViewer
+          defaultFrame={defaultFrame}
           enableInteractionLayer={enableInteractionLayer}
-          frame={frame}
           enableRotation={enableRotation}
           flipbookAutoplay={flipbookAutoplay}
           invert={invert}


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Partial fix of https://github.com/zooniverse/front-end-monorepo/issues/5951

❗ This bug is not specific to the flipbook viewer, however it was reported via Daily Minor Planet because that project has an autoplay flipbook, hence exacerbating the Issue linked above. This PR is not a full fix, but of high priority to get Daily Minor Planet data exports back online while I investigate a full fix for all subject viewers.

## Describe your changes
- Use local state for `frame` in FlipbookViewer rather than `setFrame` and `frame` from the SubjectViewerStore.
- This is how flipbook worked prior to #5754, so this is a partial reversion of that PR for now.

## How to Review

Steps to reproduce the bug are outlined in the linked Issue. Here is a flipbook projects for testing (Daily Minor Planet's workflow might be deactivated):
- https://localhost.zooniverse.org:3000/projects/goplayoutside3/fem-flipbook-viewer/classify/workflow/24066?env=production
- You should be able to play/pause the viewer, select frames via the thumbnail controls, and use the drawing tool for each step.
- `metadata.subject_dimensions` should have only one record of dimensions upon classification.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
