### PR TITLE
Fix issue with pressing Undo on the LineControls until the mark is deleted

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/components/LineControls/LineControls.js
@@ -61,6 +61,12 @@ const LineControls = forwardRef(function LineControls({
     return onDelete(event)
   }
 
+  function undo(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    return mark.undo()
+  }
+
   const deleteButtons = [
     {
       label: t('LineControls.deleteCancel'),
@@ -96,7 +102,7 @@ const LineControls = forwardRef(function LineControls({
   const defaultButtons = [
     {
       label: t('LineControls.undo'),
-      action: mark.undo,
+      action: undo,
       icon: {
         type: Undo,
         size: (10 / scale),


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
https://github.com/zooniverse/front-end-monorepo/issues/3667

## Describe your changes
Prevent event bubbling when the user clicks the Undo button on the LineControls

## How to Review
Load up the Classifier Storybook and check out the Freehand Line story. Start creating a mark and then click the undo button until the mark disappears. If it doesn't throw an error visually or in the console, we're done.

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated