### PR TITLE
refactor: sync annotate visibility when workflow changes

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -14,12 +14,12 @@ import ZoomOutButton from './components/ZoomOutButton'
 import { useKeyZoom } from '@hooks'
 
 function storeMapper(classifierStore) {
-  return { showAnnotateButton: classifierStore.subjectViewer.showAnnotate }
+  return { hasAnnotateTask: classifierStore.subjectViewer.hasAnnotateTask }
 }
 
 // Generalized ...props here are css rules from the page layout
 function ImageToolbar (props) {
-  const { showAnnotateButton } = useStores(storeMapper)
+  const { hasAnnotateTask } = useStores(storeMapper)
   const { onKeyZoom } = useKeyZoom()
   
   return (
@@ -44,7 +44,7 @@ function ImageToolbar (props) {
         fill
         pad='clamp(8px, 15%, 10px)'
       >
-        {showAnnotateButton && <AnnotateButton />}
+        {hasAnnotateTask && <AnnotateButton />}
         <MoveButton />
         <ZoomInButton />
         <ZoomOutButton />

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Box } from 'grommet'
 import PropTypes from 'prop-types'
+import { useStores } from '@hooks'
 
 import useSubjectImage from '@hooks/useSubjectImage.js'
 import SingleImageViewer from '../../../SingleImageViewer/SingleImageViewer.js'
@@ -16,6 +17,10 @@ import {
 } from '../../../../../ImageToolbar/components'
 
 const DEFAULT_HANDLER = () => true
+
+function storeMapper(classifierStore) {
+  return { hasAnnotateTask: classifierStore.subjectViewer.hasAnnotateTask }
+}
 
 const SeparateFrame = ({
   enableInteractionLayer = false,
@@ -98,7 +103,6 @@ const SeparateFrame = ({
   }
 
   /** Image Toolbar functions */
-
   const separateFrameEnableAnnotate = () => {
     setSeparateFrameAnnotate(true)
     setSeparateFrameMove(false)
@@ -107,6 +111,12 @@ const SeparateFrame = ({
   const separateFrameEnableMove = () => {
     setSeparateFrameMove(true)
     setSeparateFrameAnnotate(false)
+  }
+
+  /** NOTE: This is to disable the annotate button if there are no annotate tasks */
+  const { hasAnnotateTask } = useStores(storeMapper)
+  if (!hasAnnotateTask && separateFrameAnnotate) {
+    separateFrameEnableMove();
   }
 
   const separateFrameZoomIn = () => {
@@ -239,10 +249,12 @@ const SeparateFrame = ({
         pad='8px'
         style={{ width: '3rem' }}
       >
-        <AnnotateButton
-          separateFrameAnnotate={separateFrameAnnotate}
-          separateFrameEnableAnnotate={separateFrameEnableAnnotate}
-        />
+        { hasAnnotateTask &&
+          <AnnotateButton
+            separateFrameAnnotate={separateFrameAnnotate}
+            separateFrameEnableAnnotate={separateFrameEnableAnnotate}
+          />
+        }
         <MoveButton
           separateFrameMove={separateFrameMove}
           separateFrameEnableMove={separateFrameEnableMove}

--- a/packages/lib-classifier/src/store/RootStore.js
+++ b/packages/lib-classifier/src/store/RootStore.js
@@ -83,28 +83,12 @@ const RootStore = types
       self.subjects.reset()
     }
 
-    function _afterInitialize() {
-      // Because the root store is initialized all the sub-stores are as well
-      // We enable listening between this root store's stores by calling an afterRootInitialize() method on all these sub-stores
-      const allKeys = keys(self)
-      allKeys.forEach(key => {
-        // Filter the current model to only the observable properties of the root store since that's all our models
-        const isFunction = typeof self[key] === 'function'
-        const isVolatile = !isObservableProp(self, key)
-        if (isFunction || isVolatile) return
-
-        // If the sub-store has the afterRootInitialize() method, run it
-        self[key].afterRootInitialize?.()
-      })
-    }
-
     // Public actions
     function afterCreate () {
       addMiddleware(self, _addMiddleware)
       onAction(self, _onAction)
       onPatch(self, _onPatch)
       self.authClient?.listen('change', _onUserChange)
-      _afterInitialize()
     }
 
     function setLocale (newLocale) {


### PR DESCRIPTION
Add `workflowSteps.hasAnnotateTask` to the `SubjectViewerStore` model as
a view. Add an `autorun` reaction which syncs `subjectViewer.annotateVisibility`
when `subjectViewer.hasAnnotateTask` changes.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
lib-classifier

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
