### PR TITLE
fix: ensure upp.settings.workflow_id is a string

### DIFF
--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
@@ -5,16 +5,26 @@ import asyncStates from '@zooniverse/async-states'
 import logToSentry from '@helpers/logger/logToSentry.js'
 import numberString from '@stores/types/numberString'
 
-const Preferences = types
+export const Preferences = types
   .model('Preferences', {
     minicourses: types.maybe(types.frozen()),
     selected_workflow: types.maybe(types.string),
     tutorials_completed_at: types.maybe(types.frozen())
   })
 
-const Settings = types
+export const Settings = types
   .model('Settings', {
-    workflow_id: types.maybe(types.string)
+    workflow_id: types.maybe(numberString)
+  })
+  .preProcessSnapshot(snapshot => {
+    if (!snapshot) {
+      return snapshot
+    }
+    const normalisedSnapshot = {
+      ...snapshot,
+      workflow_id: snapshot?.workflow_id?.toString()
+    }
+    return normalisedSnapshot
   })
 
 const UserProjectPreferences = types

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
@@ -8,7 +8,7 @@ import numberString from '@stores/types/numberString'
 export const Preferences = types
   .model('Preferences', {
     minicourses: types.maybe(types.frozen()),
-    selected_workflow: types.maybe(types.string),
+    selected_workflow: types.maybe(numberString),
     tutorials_completed_at: types.maybe(types.frozen())
   })
 

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
@@ -8,6 +8,7 @@ import { talkAPI } from '@zooniverse/panoptes-js'
 import initStore from '@stores/initStore'
 import { statsClient } from '../YourStats'
 import UserProjectPreferences, { Settings } from './UserProjectPreferences'
+import { expect } from 'chai'
 
 describe('Stores > UserProjectPreferences', function () {
   const project = {
@@ -433,6 +434,13 @@ describe('Stores > UserProjectPreferences', function () {
         expect(settings.workflow_id).to.equal('123')
         settings = Settings.create({ workflow_id: 123 })
         expect(settings.workflow_id).to.equal('123')
+      })
+      specify('should be a Panoptes ID', function () {
+        expect(() => Settings.create({ workflow_id: '123456' })).not.to.throw()
+        expect(() => Settings.create({ workflow_id: 123456 })).not.to.throw()
+        expect(() => Settings.create({ workflow_id: '123.456' })).to.throw()
+        expect(() => Settings.create({ workflow_id: 123.456 })).to.throw()
+        expect(() => Settings.create({ workflow_id: 'not an ID' })).to.throw()
       })
       specify('should be optional', function () {
         const settings = Settings.create({})

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
@@ -7,7 +7,7 @@ import { talkAPI } from '@zooniverse/panoptes-js'
 
 import initStore from '@stores/initStore'
 import { statsClient } from '../YourStats'
-import UserProjectPreferences from './UserProjectPreferences'
+import UserProjectPreferences, { Settings } from './UserProjectPreferences'
 
 describe('Stores > UserProjectPreferences', function () {
   const project = {
@@ -422,6 +422,21 @@ describe('Stores > UserProjectPreferences', function () {
         expect(projectPreferences.promptAssignment('123')).to.be.true()
         expect(rootStore.project.workflowIsActive('123')).to.be.true()
         expect(rootStore.project.workflowIsActive('555')).to.be.true()
+      })
+    })
+  })
+
+  describe('Settings', function () {
+    describe('workflow_id', function () {
+      specify('should always be a string', function () {
+        let settings = Settings.create({ workflow_id: '123' })
+        expect(settings.workflow_id).to.equal('123')
+        settings = Settings.create({ workflow_id: 123 })
+        expect(settings.workflow_id).to.equal('123')
+      })
+      specify('should be optional', function () {
+        const settings = Settings.create({})
+        expect(settings.workflow_id).to.be.undefined()
       })
     })
   })


### PR DESCRIPTION
Handle the case where `upp.settings.workflow_id` is a number
by converting it to a string before storing it.
- add tests to specify the behaviour of UPP settings.
- use the `numberString` type for Panoptes workflow IDs.
- fix the bug where `workflow_id` errors if it is a number.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project
## Linked Issue and/or Talk Post
- fixes #5972

## How to Review
See #5972 for a test case, I think.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
