### PR TITLE
Handle partial translated project-specific translation strings

### DIFF
--- a/packages/lib-classifier/src/hooks/usePanoptesTranslations.js
+++ b/packages/lib-classifier/src/hooks/usePanoptesTranslations.js
@@ -1,5 +1,6 @@
 import useSWR from 'swr'
 import { panoptes } from '@zooniverse/panoptes-js'
+import { mergeWith } from 'lodash'
 
 const SWRoptions = {
   revalidateIfStale: true,
@@ -9,7 +10,12 @@ const SWRoptions = {
   refreshInterval: 0
 }
 
-async function fetchTranslations({ translated_id, translated_type, language, fallback = 'en' }) {
+async function fetchTranslations({
+  translated_id,
+  translated_type,
+  language,
+  fallback = 'en'
+}) {
   const lowerCaseLang = language?.toLowerCase() // zh-CN and zh-TW are stored as lowercase in panoptes
   const languages = language === fallback ? fallback : `${lowerCaseLang},${fallback}`
   const response = await panoptes.get('/translations', {
@@ -17,13 +23,29 @@ async function fetchTranslations({ translated_id, translated_type, language, fal
     translated_id,
     translated_type
   })
+
   const translation = response.body.translations.find(t => t.language === lowerCaseLang)
   const original = response.body.translations.find(t => t.language === fallback)
-  return translation || original
+
+  if (!translation || !Object.keys(translation.strings).length) {
+    return original
+  }
+
+  /* If a project team leaves part of a language untranslated, backfill it with the strings from the fallback language */
+  const customizer = (objValue, srcValue) => objValue === "" ? srcValue : objValue
+
+  const mergedStrings = mergeWith(translation.strings, original.strings, customizer)
+  return Object.assign(translation, {strings: mergedStrings})
 }
 
-export default function usePanoptesTranslations({ translated_id, translated_type, language }) {
-  const key = translated_id ? { translated_id, translated_type, language } : null
+export default function usePanoptesTranslations({
+  translated_id,
+  translated_type,
+  language
+}) {
+  const key = translated_id
+    ? { translated_id, translated_type, language }
+    : null
   const { data } = useSWR(key, fetchTranslations, SWRoptions)
   return data
 }


### PR DESCRIPTION
## Package
app-project
lib-classifier

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/6015

## Describe your changes

I edited `fetchTranslations()` and `usePanoptesTranslations()` in app-project and lib-classifier respectively. When a project team enables project-specific translations for a language in the project builder, but does not complete all necessary translation strings for a workflow resource, project page, etc, those translation keys end up as empty strings. Rather than display an empty string, we want the frontend to fallback to English.

## How to Review

Bug is described with screenshots in the Issue linked above, but generally you should be able to visit any project and change the selected locale via the dropdown or coerced in the URL. For example, in [Daily Minor Planet](https://local.zooniverse.org:3000/projects/de/fulsdavid/the-daily-minor-planet?env=production) you can select German which is not fully translated by the project team, or the Test Language which does not have _any_ project-specific translation strings. Also [this workflow](https://localhost.zooniverse.org:3000/projects/fr/zooniverse/snapshot-serengeti/classify/workflow/4655?env=production) in French for Snapshot Serengeti should fallback to English in the task area where translation strings are missing for project-specific task labels.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated