### PR TITLE
app-project: Refactor YourStats fetch request for tests

### DIFF
--- a/packages/app-project/stores/User/Recents/Recents.spec.js
+++ b/packages/app-project/stores/User/Recents/Recents.spec.js
@@ -4,6 +4,7 @@ import { getSnapshot } from 'mobx-state-tree'
 import auth from 'panoptes-client/lib/auth'
 
 import initStore from '@stores/initStore'
+import { statsClient } from '../UserPersonalization/YourStats'
 
 describe('Stores > Recents', function () {
   let rootStore
@@ -38,11 +39,13 @@ describe('Stores > Recents', function () {
         collections: []
       }
     }))
+    sinon.stub(statsClient, 'fetchDailyStats').callsFake(() => Promise.resolve(null))
   })
 
   after(function () {
     console.error.restore()
     rootStore.client.panoptes.get.restore()
+    statsClient.fetchDailyStats.restore()
   })
 
   it('should exist', function () {

--- a/packages/app-project/stores/User/User.spec.js
+++ b/packages/app-project/stores/User/User.spec.js
@@ -3,6 +3,9 @@ import * as client from '@zooniverse/panoptes-js'
 import { expect } from 'chai'
 import { when } from 'mobx'
 import nock from 'nock'
+import sinon from 'sinon'
+
+import { statsClient } from './UserPersonalization/YourStats'
 
 import Store from '@stores/Store'
 
@@ -16,6 +19,8 @@ describe('stores > User', function () {
   let userStore
 
   beforeEach(function () {
+    sinon.stub(statsClient, 'fetchDailyStats')
+
     nock('https://panoptes-staging.zooniverse.org/api')
     .persist()
     .get('/users/1/recents')
@@ -57,11 +62,6 @@ describe('stores > User', function () {
     .query(true)
     .reply(200, { notifications: [] })
 
-    nock('https://graphql-stats.zooniverse.org')
-    .persist()
-    .post('/graphql')
-    .reply(200, { data: { statsCount: [] }})
-
     rootStore = Store.create({ project: {
       id: '1',
       loadingState: asyncStates.success
@@ -70,6 +70,7 @@ describe('stores > User', function () {
   })
 
   afterEach(function () {
+    statsClient.fetchDailyStats.restore()
     nock.cleanAll()
   })
 

--- a/packages/app-project/stores/User/UserPersonalization/Notifications/Notifications.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/Notifications/Notifications.spec.js
@@ -6,6 +6,7 @@ import asyncStates from '@zooniverse/async-states'
 import { talkAPI } from '@zooniverse/panoptes-js'
 
 import initStore from '@stores/initStore'
+import { statsClient } from '../YourStats'
 import Notifications from './Notifications'
 
 describe('Stores > Notifications', function () {
@@ -18,12 +19,14 @@ describe('Stores > Notifications', function () {
   }
 
   before(function () {
+    sinon.stub(statsClient, 'fetchDailyStats')
     sinon.stub(sugarClient, 'subscribeTo')
     sinon.stub(sugarClient, 'on')
     sinon.stub(sugarClient, 'unsubscribeFrom')
   })
 
   after(function () {
+    statsClient.fetchDailyStats.restore()
     sugarClient.subscribeTo.restore()
     sugarClient.on.restore()
     sugarClient.unsubscribeFrom.restore()

--- a/packages/app-project/stores/User/UserPersonalization/UserPersonalization.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserPersonalization.spec.js
@@ -7,6 +7,7 @@ import { talkAPI } from '@zooniverse/panoptes-js'
 
 import initStore from '@stores/initStore'
 import UserPersonalization from './UserPersonalization'
+import { statsClient } from './YourStats'
 
 describe('Stores > UserPersonalization', function () {
   let rootStore, nockScope
@@ -22,6 +23,16 @@ describe('Stores > UserPersonalization', function () {
 
   before(function () {
     sinon.stub(console, 'error')
+    const MOCK_DAILY_COUNTS = [
+      { count: 12, period: '2019-09-29' },
+      { count: 12, period: '2019-09-30' },
+      { count: 13, period: '2019-10-01' },
+      { count: 14, period: '2019-10-02' },
+      { count: 10, period: '2019-10-03' },
+      { count: 11, period: '2019-10-04' },
+      { count: 8, period: '2019-10-05' },
+      { count: 15, period: '2019-10-06' }
+    ]
     nockScope = nock('https://panoptes-staging.zooniverse.org/api')
       .persist()
       .get('/project_preferences')
@@ -45,12 +56,14 @@ describe('Stores > UserPersonalization', function () {
 
     rootStore = initStore(true, { project })
     sinon.spy(rootStore.client.panoptes, 'get')
+    sinon.stub(statsClient, 'fetchDailyStats').callsFake(() => Promise.resolve({ data: MOCK_DAILY_COUNTS }))
     sinon.stub(talkAPI, 'get').callsFake(() => Promise.resolve(undefined))
   })
 
   after(function () {
     console.error.restore()
     rootStore.client.panoptes.get.restore()
+    statsClient.fetchDailyStats.restore()
     talkAPI.get.restore()
     nock.cleanAll()
   })
@@ -60,12 +73,10 @@ describe('Stores > UserPersonalization', function () {
   })
 
   describe('with a project and user', function () {
-    let clock, fetchDailyCountsSpy
+    let clock
 
     before(function () {
       clock = sinon.useFakeTimers({ now: new Date(2019, 9, 1, 12), toFake: ['Date'] })
-      fetchDailyCountsSpy = sinon.spy()
-      rootStore.user.personalization.stats.fetchDailyCounts = fetchDailyCountsSpy
       rootStore.user.set(user)
     })
 
@@ -86,7 +97,7 @@ describe('Stores > UserPersonalization', function () {
     })
 
     it('should trigger the child YourStats node to request user statistics', function () {
-      expect(fetchDailyCountsSpy).to.have.been.calledOnce()
+      expect(statsClient.fetchDailyStats).to.have.been.calledOnceWith({ projectId: '2', userId: '123' })
     })
 
     it('should trigger the child Notifications store to request unread notifications', function () {

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
@@ -6,6 +6,7 @@ import asyncStates from '@zooniverse/async-states'
 import { talkAPI } from '@zooniverse/panoptes-js'
 
 import initStore from '@stores/initStore'
+import { statsClient } from '../YourStats'
 import UserProjectPreferences, { Settings } from './UserProjectPreferences'
 import { expect } from 'chai'
 
@@ -71,10 +72,12 @@ describe('Stores > UserProjectPreferences', function () {
   }
 
   before(function () {
+    sinon.stub(statsClient, 'fetchDailyStats')
     sinon.stub(talkAPI, 'get').resolves([])
   })
 
   after(function () {
+    statsClient.fetchDailyStats.restore()
     talkAPI.get.restore()
   })
 

--- a/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
+++ b/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
@@ -12,6 +12,22 @@ function statsHost(env) {
   }
 }
 
+export const statsClient = {
+  fetchDailyStats: async function fetchDailyStats({ projectId, userId }) {
+    const token = await auth.checkBearerToken()
+    const Authorization = `Bearer ${token}`
+    const stats  = statsHost(env)
+    const queryParams = new URLSearchParams({
+      period: 'day',
+      project_id: projectId
+    }).toString()
+
+    const response = await fetch(`${stats}/classifications/users/${userId}?${queryParams}`, { headers: { Authorization } })
+    const jsonResponse = await response.json()
+    return jsonResponse
+  }
+}
+
 // https://stackoverflow.com/a/51918448/10951669
 function firstDayOfWeek (dateObject, firstDayOfWeekIndex) {
   const dayOfWeek = dateObject.getUTCDay()
@@ -74,16 +90,7 @@ const YourStats = types
         self.setLoadingState(asyncStates.loading)
         let dailyCounts
         try {
-          const token = yield auth.checkBearerToken()
-          const Authorization = `Bearer ${token}`
-          const stats  = statsHost(env)
-          const queryParams = new URLSearchParams({
-            period: 'day',
-            project_id: project.id
-          }).toString()
-
-          const statsResponse = yield fetch(`${stats}/classifications/users/${user.id}?${queryParams}`, { headers: { Authorization } })
-          const statsData = yield statsResponse.json()
+          const statsData = yield statsClient.fetchDailyStats({ projectId: project.id, userId: user.id })
           dailyCounts = statsData.data
           self.setLoadingState(asyncStates.success)
         } catch (error) {

--- a/packages/app-project/stores/User/UserPersonalization/YourStats/index.js
+++ b/packages/app-project/stores/User/UserPersonalization/YourStats/index.js
@@ -1,1 +1,1 @@
-export { default } from './YourStats'
+export { default, statsClient } from './YourStats'


### PR DESCRIPTION
## Package
- app-project

## Linked Issue and/or Talk Post
- iteration on #5963 

## Describe your changes
- move ERAS fetch request to small single purpose (user's daily project classification stats) `statsClient`
- ^ allows stubbing for tests
- to large degree refactors to existing (`main`'s) testing setup 
- I think @yuenmichelle1 suggested something along these lines when we initially were working on, apologies for the back and forth, but @yuenmichelle1 and @eatyourgreens let me know what you think

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - any, or
  - I used https://local.zooniverse.org:3000/projects/markb-panoptes/pizza-please/classify/workflow/3779?env=staging
- What user actions should my reviewer step through to review this PR?
  - login, make some classifications, note YourStats classification count and bar chart
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? see linked PR

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected