### PR TITLE
feat: Accessible project headings for Publications

### DIFF
--- a/packages/app-content-pages/src/screens/Publications/components/Category/Category.js
+++ b/packages/app-content-pages/src/screens/Publications/components/Category/Category.js
@@ -21,7 +21,12 @@ function Category({
         slug={slug}
       />
       {projects.map(project => (
-        <Project {...project} key={project.title} />
+        <Project
+          {...project}
+          key={project.title}
+          sectionIndex={sectionIndex}
+          setActiveSection={setActiveSection}
+        />
       ))}
     </Box>
   )

--- a/packages/app-content-pages/src/screens/Publications/components/Project/Project.js
+++ b/packages/app-content-pages/src/screens/Publications/components/Project/Project.js
@@ -1,5 +1,5 @@
 import { Box, Heading } from 'grommet'
-import { arrayOf, shape, string } from 'prop-types'
+import { arrayOf, func, number, shape, string } from 'prop-types'
 import { useEffect, useRef } from 'react'
 import { Media, ZooniverseLogo } from '@zooniverse/react-components'
 import styled from 'styled-components'
@@ -118,7 +118,6 @@ function Project({
 Project.propTypes = {
   avatarSrc: string,
   projectId: string,
-  title: string,
   publications: arrayOf(
     shape({
       authors: string,
@@ -126,7 +125,10 @@ Project.propTypes = {
       url: string,
       year: string
     })
-  )
+  ),
+  sectionIndex: number,
+  setActiveSection: func,
+  title: string,
 }
 
 export default Project

--- a/packages/app-content-pages/src/screens/Publications/components/Project/Project.js
+++ b/packages/app-content-pages/src/screens/Publications/components/Project/Project.js
@@ -1,5 +1,6 @@
 import { Box, Heading } from 'grommet'
 import { arrayOf, shape, string } from 'prop-types'
+import { useEffect, useRef } from 'react'
 import { Media, ZooniverseLogo } from '@zooniverse/react-components'
 import styled from 'styled-components'
 
@@ -24,10 +25,57 @@ const Placeholder = ({ title }) => {
   )
 }
 
-function Project(props) {
-  const { avatarSrc, id, title, publications } = props
+const DEFAULT_HANDLER = () => true
+const DEFAULT_PUBLICATIONS = []
+
+function slugify(string) {
+  return string
+    // convert letters to lowercase
+    .toLowerCase()
+    // replace any spaces with Z
+    .replace(/\s/g, 'Z')
+    // remove all punctuation and whitespace
+    .replace(/\W/g, '')
+    // replace any Zs with a single dash
+    .replace(/Z+/g, '-')
+}
+
+const intersectionOptions = {
+  rootMargin: '0px 0px -70% 0px', // observe visibility in the top 30% of the viewport
+}
+
+function Project({
+  avatarSrc = null,
+  id = null,
+  title = '',
+  publications = DEFAULT_PUBLICATIONS,
+  sectionIndex = 0,
+  setActiveSection = DEFAULT_HANDLER
+}) {
+  const slug = slugify(title)
+  const sectionRef = useRef()
+
+  useEffect(() => {
+    const intersectionObserver = new window.IntersectionObserver(entries => {
+      if (entries[0].intersectionRatio > 0) {
+        setActiveSection(sectionIndex)
+      }
+    }, intersectionOptions)
+
+    intersectionObserver.observe(sectionRef.current)
+
+    return () => {
+      intersectionObserver.disconnect()
+    }
+  }, [sectionRef.current])
+
   return (
-    <Box as='section' key={id}>
+    <Box
+      as='section'
+      key={id}
+      ref={sectionRef}
+      aria-labelledby={slug}
+    >
       <Box
         direction='row'
         align='center'
@@ -39,6 +87,7 @@ function Project(props) {
           {!avatarSrc && <Placeholder title={title} />}
           {avatarSrc && (
             <Media
+              width={50}
               height={50}
               src={avatarSrc}
               placeholder={<Placeholder title={title} />}
@@ -46,6 +95,8 @@ function Project(props) {
           )}
         </StyledBox>
         <Heading
+          id={slug}
+          tabIndex={-1}
           color={{ light: 'black', dark: 'white' }}
           level='3'
           size='small'


### PR DESCRIPTION
- give each project a slug eg. `galaxy-zoo` or `backyard-worlds-planet-9`.
- give each project heading an `id` and `tabindex` to make it linkable and accessible.
- add an intersection observer, which sets the active navigation section for each project section (eg. Planet Hunters will set the active section to Space), when that project section is near the top of the viewport. 
- make sure that project sections are labelled.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-content-pages

## Linked Issue and/or Talk Post
- [Slack post asking for a link direct to the list of Galaxy Zoo publications](https://zooniverse.slack.com/archives/C06LHUC6R/p1713511420283709).

## How to Review
Project headings have human-readable IDs, which should work as links. The intersection observer should make sure that the appropriate section is set in the sidebar, when you link directly to a project.

Screenshots are from Firefox but this should work in any standards-compliant browser. Labelled sections should show up as region landmarks in software that supports landmark navigation (eg. VoiceOver, JAWS, NVDA.) Alternatively, you can right-click on a section to inspect its accessible name and role in browser dev tools. 

The rule for generating a project's URL slug is: convert to lowercase, remove all punctuation and replace spaces with a single `-`.

https://localhost:3000/about/publications#when-do-mountain-goats-shed-winter-coats
<img width="800" alt="The publications page, with When Do Mountain Goats Shed Winter Coats focussed and 'medicine' highlighted in the page navigation menu." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/23487275-a2e4-48bd-8038-927041855a68">

https://localhost:3000/about/publications#galaxy-zoo
<img width="800" alt="The publications page, with Galaxy Zoo at the top of the viewport and 'space' highlighted in the navigation." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/7f8609e8-a0e8-4aaf-86a0-f3e68575d5b8">

https://localhost:3000/about/publications#backyard-worlds-planet-9
<img width="800" alt="The publications page, linking directly to Backyard Worlds, as an example of a project with punctuation in its full title." src="https://github.com/zooniverse/front-end-monorepo/assets/59547/530c5ded-cca6-4fa4-88aa-05e4144e4a96">



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
