### PR TITLE
Remove defaultProps from AdminCheckbox, CloseButton, and FavouritesButton

### DIFF
--- a/packages/lib-react-components/src/AdminCheckbox/AdminCheckbox.js
+++ b/packages/lib-react-components/src/AdminCheckbox/AdminCheckbox.js
@@ -5,34 +5,7 @@ import { useTranslation } from '../translations/i18n'
 
 import SpacedText from '../SpacedText'
 
-export default function AdminCheckbox ({ checked, colorTheme, label, onChange }) {
-  return (
-    <ThemeProvider theme={{ mode: colorTheme }}>
-      <CheckBox
-        checked={checked}
-        id='admin-checkbox'
-        name='admin-checkbox'
-        label={label}
-        onChange={onChange}
-        toggle
-      />
-    </ThemeProvider>
-  )
-}
-
-AdminCheckbox.defaultProps = {
-  checked: false,
-  colorTheme: 'light',
-  label: <Label />,
-  onChange: () => {}
-}
-
-AdminCheckbox.propTypes = {
-  checked: PropTypes.bool,
-  colorTheme: PropTypes.oneOf(['light', 'dark']),
-  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  onChange: PropTypes.func
-}
+const DEFAULT_HANDLER = () => {}
 
 function Label () {
   const { t } = useTranslation()
@@ -42,4 +15,25 @@ function Label () {
       {t('AdminCheckbox.label')}
     </SpacedText>
   )
+}
+
+export default function AdminCheckbox ({ checked = false, colorTheme = 'light', onChange = DEFAULT_HANDLER }) {
+  return (
+    <ThemeProvider theme={{ mode: colorTheme }}>
+      <CheckBox
+        checked={checked}
+        id='admin-checkbox'
+        name='admin-checkbox'
+        label={<Label />}
+        onChange={onChange}
+        toggle
+      />
+    </ThemeProvider>
+  )
+}
+
+AdminCheckbox.propTypes = {
+  checked: PropTypes.bool,
+  colorTheme: PropTypes.oneOf(['light', 'dark']),
+  onChange: PropTypes.func
 }

--- a/packages/lib-react-components/src/AdminCheckbox/AdminCheckbox.spec.js
+++ b/packages/lib-react-components/src/AdminCheckbox/AdminCheckbox.spec.js
@@ -1,21 +1,13 @@
-import { shallow } from 'enzyme'
-import sinon from 'sinon'
-import AdminCheckbox from './AdminCheckbox'
-import { CheckBox } from 'grommet'
+import * as stories from './AdminCheckbox.stories.js'
+import { render, screen } from '@testing-library/react'
+import { composeStories } from '@storybook/react'
 
 describe('<AdminCheckbox />', function () {
-  let wrapper
-  const onChangeSpy = sinon.spy()
-  before(function () {
-    wrapper = shallow(<AdminCheckbox onChange={onChangeSpy} />)
-  })
+  const { Default } = composeStories(stories)
 
-  it('should render without crashing', function () {
-    expect(wrapper).to.be.ok()
-  })
-
-  it('calls onChange prop when clicked', function () {
-    wrapper.find(CheckBox).simulate('change')
-    expect(onChangeSpy).to.have.been.calledOnce()
+  it('should render the label', function () {
+    render(<Default />)
+    const item = screen.getByText('Admin Mode')
+    expect(item).exists()
   })
 })

--- a/packages/lib-react-components/src/AdminCheckbox/AdminCheckbox.stories.js
+++ b/packages/lib-react-components/src/AdminCheckbox/AdminCheckbox.stories.js
@@ -1,18 +1,10 @@
 import { Box } from 'grommet'
 
 import AdminCheckbox from './AdminCheckbox'
-import readme from './README.md'
 
 export default {
   title: 'Components / AdminCheckbox',
   component: AdminCheckbox,
-  parameters: {
-    docs: {
-      description: {
-        component: readme
-      }
-    }
-  }
 }
 
 export const Default = () => {

--- a/packages/lib-react-components/src/CloseButton/CloseButton.js
+++ b/packages/lib-react-components/src/CloseButton/CloseButton.js
@@ -1,4 +1,4 @@
-import { func, string } from 'prop-types'
+import { bool, func, object, oneOfType, string } from 'prop-types'
 import styled from 'styled-components'
 import { Button } from 'grommet'
 import CloseIcon from './components/CloseIcon'
@@ -23,7 +23,9 @@ const StyledButton = styled(Button)`
   }
 `
 
-function CloseButton ({ as, closeFn, color, disabled, href, ...rest }) {
+const DEFAULT_HANDLER = () => {}
+
+function CloseButton ({ closeFn = DEFAULT_HANDLER, color = '', disabled = false, href = '', ...rest }) {
   // We've destructured href from the props to make sure it's NOT passed along
 
   const { t } = useTranslation()
@@ -41,11 +43,9 @@ function CloseButton ({ as, closeFn, color, disabled, href, ...rest }) {
 
 CloseButton.propTypes = {
   className: string,
-  closeFn: func.isRequired
-}
-
-CloseButton.defaultProps = {
-  className: ''
+  closeFn: func.isRequired,
+  color: oneOfType([string, object]),
+  disabled: bool
 }
 
 export default CloseButton

--- a/packages/lib-react-components/src/CloseButton/CloseButton.spec.js
+++ b/packages/lib-react-components/src/CloseButton/CloseButton.spec.js
@@ -1,17 +1,11 @@
 import { render, screen } from '@testing-library/react'
 import { composeStory } from '@storybook/react'
-import Meta, { Default, Light, Disabled } from './CloseButton.stories.js'
+import Meta, { Default, Disabled } from './CloseButton.stories.js'
 
 describe('Component > CloseButton', function () {
   it('renders the default button', function () {
     const DefaultStory = composeStory(Default, Meta)
     render(<DefaultStory />)
-    expect(screen.getByRole('button').hasAttribute('disabled')).to.be.false()
-  })
-
-  it('renders the light button', function () {
-    const LightStory = composeStory(Light, Meta)
-    render(<LightStory />)
     expect(screen.getByRole('button').hasAttribute('disabled')).to.be.false()
   })
 

--- a/packages/lib-react-components/src/CloseButton/CloseButton.stories.js
+++ b/packages/lib-react-components/src/CloseButton/CloseButton.stories.js
@@ -1,29 +1,18 @@
 import CloseButton from './CloseButton'
-// import readme from './README.md'
 
 export default {
   title: 'Components/CloseButton',
-  component: CloseButton,
-  args: {
-    closeFn: () => true
-  },
-  // parameters: {
-  //   docs: {
-  //     description: {
-  //       component: readme
-  //     }
-  //   }
-  // }
+  component: CloseButton
 }
 
-export const Default = ({ closeFn }) => (
-  <CloseButton closeFn={closeFn} />
+export const Default = () => (
+  <CloseButton />
 )
 
-export const Light = ({ closeFn }) => (
-  <CloseButton color='neutral-6' closeFn={closeFn} />
+export const CustomColor = () => (
+  <CloseButton color='neutral-6' />
 )
 
-export const Disabled = ({ closeFn }) => (
-  <CloseButton disabled closeFn={closeFn} />
+export const Disabled = () => (
+  <CloseButton disabled />
 )

--- a/packages/lib-react-components/src/FavouritesButton/FavouritesButton.js
+++ b/packages/lib-react-components/src/FavouritesButton/FavouritesButton.js
@@ -1,15 +1,17 @@
 import PropTypes from 'prop-types'
 import { useState } from 'react';
-import { withTheme } from 'styled-components'
+import { useTheme } from 'styled-components'
 import MetaToolsButton from '../MetaToolsButton'
 import HeartIcon from './HeartIcon'
 import { useTranslation } from '../translations/i18n'
 
-function FavouritesButton (props) {
-  const { checked, disabled, onClick } = props
+const DEFAULT_HANDLER = () => {}
+
+function FavouritesButton ({ checked = false, disabled = false, onClick = DEFAULT_HANDLER }) {
   const [isFavourite, setIsFavourite] = useState(checked)
+  const { global } = useTheme()
   const label = isFavourite ? 'FavouritesButton.remove' : 'FavouritesButton.add'
-  const fill = isFavourite ? props.theme.global.colors.statusColors.error : 'none'
+  const fill = isFavourite ? global.colors.statusColors.error : 'none'
 
   function toggleFavourite () {
     setIsFavourite(!isFavourite)
@@ -36,11 +38,4 @@ FavouritesButton.propTypes = {
   onClick: PropTypes.func
 }
 
-FavouritesButton.defaultProps = {
-  checked: false,
-  disabled: false,
-  onClick: () => false
-}
-
-export default withTheme(FavouritesButton)
-export { FavouritesButton }
+export default FavouritesButton

--- a/packages/lib-react-components/src/FavouritesButton/FavouritesButton.stories.js
+++ b/packages/lib-react-components/src/FavouritesButton/FavouritesButton.stories.js
@@ -1,17 +1,9 @@
 import FavouritesButton from './'
 import { FavouritesButtonSubjectMock } from './FavouritesButton.mock'
-// import readme from './README.md'
 
 export default {
   title: 'Components/Favourites Button',
-  component: FavouritesButton,
-  // parameters: {
-  //   docs: {
-  //     description: {
-  //       component: readme
-  //     }
-  //   }
-  // }
+  component: FavouritesButton
 }
 
 export const NotFavourited = () => (


### PR DESCRIPTION
## Package
lib-react-components

## Linked Issue and/or Talk Post

This work is toward app-root development to remove console warnings about `defaultProps` being deprecated in future versions of React.

## Describe your changes

- Remove `defaultProps` from AdminCheckbox, CloseButton, and FavouritesButton
- Use RTL for AdminCheckbox rather than enzyme
- `useTheme` hook in FavouritesButton rather than `withTheme` because it's a functional component
- Cleanup unused readme imports to Story files

## How to Review

- All three components have well documented Stories
- Run app-project locally to see AdminCheckbox in ZooFooter
- The CloseButton and FavouritesButton are used on the Classify page for any project

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected