### PR TITLE
Make sure the array of points gets added for a closed path

### DIFF
--- a/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/FreehandLine/FreehandLine.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/experimental/models/marks/FreehandLine/FreehandLine.js
@@ -617,6 +617,15 @@ const FreehandLineModel = types
       }
     },
 
+    finalizePoints() {
+			self.pathX = []
+			self.pathY = []
+			self.points.forEach(point => {
+				self.pathX.push(point.x)
+				self.pathY.push(point.y)
+			})
+		},
+
     finish() {
       if (self.points.length < self.minimumPoints) {
         return self.tool.deleteMark(self)
@@ -628,13 +637,9 @@ const FreehandLineModel = types
       } else if (self.pathIsClosed) {
         // user closed the path on this initial drag
         self.finished = true
+				self.finalizePoints()
       } else {
-        self.pathX = []
-        self.pathY = []
-        self.points.forEach(point => {
-          self.pathX.push(point.x)
-          self.pathY.push(point.y)
-        })
+				self.finalizePoints()
       }
     },
   }))


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
https://github.com/zooniverse/front-end-monorepo/issues/6048

## Describe your changes
This bug was introduced by the freehand-line not recognizing the closing of a mark. In that fix, the follow up item of putting the [x,y] values in the annotations array.

## How to Review
Check out [this branch](https://fe-project-branch.preview.zooniverse.org/projects/kieftrav/freehand-line-multiframe/classify/workflow/3760?env=staging) and see that the Completed Classification in the `console.log()` has full `pathX` and `pathY` values for both closed and open marks.
 
## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
