### PR TITLE
Add lib-content to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ USER node
 
 RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn install --production=false --frozen-lockfile --ignore-scripts
 RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn workspace @zooniverse/react-components build:es6
+RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn workspace @zooniverse/content build:es6
 RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn workspace @zooniverse/classifier build:es6
 RUN --mount=type=cache,id=fem-builder-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn workspace @zooniverse/user build:es6
 RUN echo $COMMIT_ID > /usr/src/packages/app-content-pages/public/commit_id.txt
@@ -77,6 +78,7 @@ COPY --from=builder /usr/src/packages ./packages
 RUN --mount=type=cache,id=fem-runner-yarn,uid=1000,gid=1000,target=/home/node/.yarn YARN_CACHE_FOLDER=/home/node/.yarn yarn install --production --frozen-lockfile --ignore-scripts --prefer-offline
 
 RUN rm -rf /usr/src/packages/lib-react-components/src
+RUN rm -rf /usr/src/packages/lib-content/src
 RUN rm -rf /usr/src/packages/lib-classifier/src
 RUN rm -rf /usr/src/packages/lib-user/src
 RUN rm -rf /usr/src/packages/app-content-pages/src


### PR DESCRIPTION
## Package
To include the new lib-content package in FEM's staging deploy

## Linked Issue and/or Talk Post
Follows https://github.com/zooniverse/front-end-monorepo/pull/6034

## Describe your changes

- Add lib-content to the Dockerfile in a similar config to the other react component libraries.

## How to Review

I don't think this can be reviewed locally, but will need to be tested via Github Action such as the failed one: https://github.com/zooniverse/front-end-monorepo/actions/runs/8805448704