### PR TITLE
fix(classifier): Fix wonky drag when image is rotated

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
+++ b/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/ImageToolbar.js
@@ -14,13 +14,16 @@ import ZoomOutButton from './components/ZoomOutButton'
 import { useKeyZoom } from '@hooks'
 
 function storeMapper(classifierStore) {
-  return { hasAnnotateTask: classifierStore.subjectViewer.hasAnnotateTask }
+  return {
+    hasAnnotateTask: classifierStore.subjectViewer.hasAnnotateTask,
+    rotation: classifierStore.subjectViewer.rotation
+  }
 }
 
 // Generalized ...props here are css rules from the page layout
 function ImageToolbar (props) {
-  const { hasAnnotateTask } = useStores(storeMapper)
-  const { onKeyZoom } = useKeyZoom()
+  const { hasAnnotateTask, rotation } = useStores(storeMapper)
+  const { onKeyZoom } = useKeyZoom(rotation)
   
   return (
     <Box

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/FlipbookViewer/FlipbookViewerContainer.js
@@ -64,7 +64,7 @@ function FlipbookViewerContainer({
     setOnZoom
   } = useStores(storeMapper)
 
-  const { onKeyZoom } = useKeyZoom()
+  const { onKeyZoom } = useKeyZoom(rotation)
 
   useEffect(
     function preloadImages() {

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
@@ -15,7 +15,7 @@ export const ConsensusLine = styled('g')`
   cursor: pointer;
   filter: drop-shadow(1px 1px 4px #5c5c5c);
 
-  &:focus {
+  &:focus-visible {
     ${props => css`outline: solid 4px ${props.focusColor};`}
   }
 
@@ -69,9 +69,7 @@ function TranscribedLines({
     /** Show/hide previously transcribed lines. */
     visible,
   } = useTranscriptionReductions()
-  const {
-    theme = defaultTheme
-  } = useTheme()
+  const theme = useTheme()
   const [ bounds, setBounds ] = useState({})
   const [ line, setLine ] = useState(defaultLine)
   const [ show, setShow ] = useState(false)

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
@@ -15,6 +15,10 @@ export const ConsensusLine = styled('g')`
   cursor: pointer;
   filter: drop-shadow(1px 1px 4px #5c5c5c);
 
+  &:focus {
+    outline: none;
+  }
+
   &:focus-visible {
     ${props => css`outline: solid 4px ${props.focusColor};`}
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/MultiFrameViewer/MultiFrameViewerContainer.js
@@ -72,7 +72,7 @@ function MultiFrameViewerContainer({
   setOnZoom = () => true,
   subject
 }) {
-  const { onKeyZoom } = useKeyZoom()
+  const { onKeyZoom } = useKeyZoom(rotation)
   const [dragMove, setDragMove] = useState()
   // TODO: replace this with a better function to parse the image location from a subject.
   const imageLocation = subject ? subject.locations[frame] : null

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -83,8 +83,8 @@ function SVGPanZoom({
   function onDrag(event, difference) {
     setViewBox((prevViewBox) => {
       const newViewBox = { ...prevViewBox }
-      newViewBox.x -= difference.x
-      newViewBox.y -= difference.y
+      newViewBox.x -= difference.x * .9
+      newViewBox.y -= difference.y * .9
       return newViewBox
     })
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.js
@@ -35,7 +35,7 @@ function SVGPanZoom({
     height: naturalHeight,
     width: naturalWidth
   }
-  const [zoom, setZoom] = useState(1)
+  const zoom = useRef(1)
   const [viewBox, setViewBox] = useState(defaultViewBox)
 
   function enableZoom() {
@@ -49,10 +49,6 @@ function SVGPanZoom({
     setOnPan(DEFAULT_HANDLER)
     setOnZoom(DEFAULT_HANDLER)
   }
-
-  useEffect(function onZoomChange() {
-    scaleViewBox(zoom)
-  }, [zoom])
 
   useEffect(() => {
     if (zooming) {
@@ -68,7 +64,7 @@ function SVGPanZoom({
       height: naturalHeight,
       width: naturalWidth
     })
-    setZoom(1)
+    zoom.current = 1
   }, [naturalWidth, naturalHeight])
 
   function scaleViewBox(scale) {
@@ -87,8 +83,8 @@ function SVGPanZoom({
   function onDrag(event, difference) {
     setViewBox((prevViewBox) => {
       const newViewBox = { ...prevViewBox }
-      newViewBox.x -= difference.x / 1.5
-      newViewBox.y -= difference.y / 1.5
+      newViewBox.x -= difference.x
+      newViewBox.y -= difference.y
       return newViewBox
     })
   }
@@ -105,11 +101,15 @@ function SVGPanZoom({
   function onZoom(type) {
     switch (type) {
       case 'zoomin': {
-        setZoom((prevZoom) => Math.min(prevZoom + 0.1, maxZoom))
+        const prevZoom = zoom.current
+        zoom.current = Math.min(prevZoom + 0.1, maxZoom)
+        scaleViewBox(zoom.current)
         return
       }
       case 'zoomout': {
-        setZoom((prevZoom) => Math.max(prevZoom - 0.1, minZoom))
+        const prevZoom = zoom.current
+        zoom.current = Math.max(prevZoom - 0.1, minZoom)
+        scaleViewBox(zoom.current)
         return
       }
       case 'zoomto': {
@@ -119,7 +119,7 @@ function SVGPanZoom({
           height: naturalHeight,
           width: naturalWidth
         })
-        setZoom(1)
+        zoom.current = 1
         return
       }
     }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
@@ -106,7 +106,7 @@ describe('Components > SVGPanZoom', function () {
     onDrag({}, { x: -15, y: 0 })
     await waitFor(() => {
       const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
-      expect(viewBox).to.equal('15 0 400 200')
+      expect(viewBox).to.equal('13.5 0 400 200')
     })
   })
 
@@ -114,7 +114,7 @@ describe('Components > SVGPanZoom', function () {
     onDrag({}, { x: 0, y: -15 })
     await waitFor(() => {
       const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
-      expect(viewBox).to.equal('0 15 400 200')
+      expect(viewBox).to.equal('0 13.5 400 200')
     })
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SVGComponents/SVGPanZoom/SVGPanZoom.spec.js
@@ -106,7 +106,7 @@ describe('Components > SVGPanZoom', function () {
     onDrag({}, { x: -15, y: 0 })
     await waitFor(() => {
       const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
-      expect(viewBox).to.equal('10 0 400 200')
+      expect(viewBox).to.equal('15 0 400 200')
     })
   })
 
@@ -114,7 +114,7 @@ describe('Components > SVGPanZoom', function () {
     onDrag({}, { x: 0, y: -15 })
     await waitFor(() => {
       const viewBox = document.querySelector('svg[viewBox]')?.getAttribute('viewBox')
-      expect(viewBox).to.equal('0 10 400 200')
+      expect(viewBox).to.equal('0 15 400 200')
     })
   })
 

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SeparateFramesViewer/components/SeparateFrame/SeparateFrame.js
@@ -95,9 +95,9 @@ const SeparateFrame = ({
 
   const onDrag = (event, difference) => {
     setViewBox(prevViewBox => {
-      const newViewBox = Object.assign({}, prevViewBox)
-      newViewBox.x -= difference.x / 1.5
-      newViewBox.y -= difference.y / 1.5
+      const newViewBox = { ...prevViewBox }
+      newViewBox.x -= difference.x
+      newViewBox.y -= difference.y
       return newViewBox
     })
   }

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -34,8 +34,8 @@ function SingleImageViewer({
   zoomControlFn = null,
   zooming = false
 }) {
-  const transformLayer = useRef()
-  const canvas = transformLayer.current
+  const canvasLayer = useRef()
+  const canvas = canvasLayer.current
   const transform = `rotate(${rotate} ${width / 2} ${height / 2})`
 
   return (
@@ -65,10 +65,10 @@ function SingleImageViewer({
             <title id={title.id}>{title.text}</title>
           )}
           <g
-            ref={transformLayer}
             transform={transform}
           >
             <SVGImageCanvas
+              ref={canvasLayer}
               viewBox={viewBox}
             >
               {children}

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -14,7 +14,9 @@ const PlaceholderSVG = styled.svg`
   max-width: ${props => props.maxWidth || '100%'};
   ${props => props.maxHeight && css`max-height: ${props.maxHeight};`}
 `
-
+const SVGImageCanvas = styled.svg`
+  overflow: visible;
+`
 function SingleImageViewer({
   children,
   enableInteractionLayer = false,
@@ -56,7 +58,7 @@ function SingleImageViewer({
           maxWidth={limitSubjectHeight ? `${width}px` : '100%'}
           onKeyDown={onKeyDown}
           tabIndex={0}
-          viewBox={viewBox}
+          viewBox={`0 0 ${width} ${height}`}
           xmlns='http://www.w3.org/2000/svg'
         >
           {title?.id && title?.text && (
@@ -66,16 +68,20 @@ function SingleImageViewer({
             ref={transformLayer}
             transform={transform}
           >
-            {children}
-            {enableInteractionLayer && (
-              <InteractionLayer
-                frame={frame}
-                height={height}
-                scale={scale}
-                subject={subject}
-                width={width}
-              />
-            )}
+            <SVGImageCanvas
+              viewBox={viewBox}
+            >
+              {children}
+              {enableInteractionLayer && (
+                <InteractionLayer
+                  frame={frame}
+                  height={height}
+                  scale={scale}
+                  subject={subject}
+                  width={width}
+                />
+              )}
+            </SVGImageCanvas>
           </g>
         </PlaceholderSVG>
       </Box>

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewerContainer.js
@@ -29,7 +29,7 @@ function SingleImageViewerContainer({
   zoomControlFn,
   zooming = true
 }) {
-  const { onKeyZoom } = useKeyZoom()
+  const { onKeyZoom } = useKeyZoom(rotation)
   const [dragMove, setDragMove] = useState()
   // TODO: replace this with a better function to parse the image location from a subject.
   const imageLocation = subject ? subject.locations[frame] : null

--- a/packages/lib-classifier/src/hooks/useKeyZoom.js
+++ b/packages/lib-classifier/src/hooks/useKeyZoom.js
@@ -24,7 +24,7 @@ function storeMapper(classifierStore) {
   }
 }
 
-export default function useKeyZoom() {
+export default function useKeyZoom(rotate=0) {
   const {
     panLeft,
     panRight,
@@ -33,49 +33,50 @@ export default function useKeyZoom() {
     zoomIn,
     zoomOut
   } = useStores(storeMapper)
+  const rotation = Math.abs(rotate) % 360
+  const keyMappings = {
+    '+': zoomIn,
+    '=': zoomIn,
+    '-': zoomOut,
+    '_': zoomOut
+  }
+  
+  if (rotation === 0) {
+    keyMappings['ArrowRight'] = panRight
+    keyMappings['ArrowLeft'] = panLeft
+    keyMappings['ArrowUp'] = panUp
+    keyMappings['ArrowDown'] = panDown
+  }
+  if (rotation === 90) {
+    keyMappings['ArrowRight'] = panDown
+    keyMappings['ArrowLeft'] = panUp
+    keyMappings['ArrowUp'] = panRight
+    keyMappings['ArrowDown'] = panLeft
+  }
+  if (rotation === 180) {
+    keyMappings['ArrowRight'] = panLeft
+    keyMappings['ArrowLeft'] = panRight
+    keyMappings['ArrowUp'] = panDown
+    keyMappings['ArrowDown'] = panUp
+  }
+  if (rotation === 270) {
+    keyMappings['ArrowRight'] = panUp
+    keyMappings['ArrowLeft'] = panDown
+    keyMappings['ArrowUp'] = panLeft
+    keyMappings['ArrowDown'] = panRight
+  }
 
   function onKeyZoom(event) {
-      const htmlTag = event.target?.tagName.toLowerCase()
-      if (ALLOWED_TAGS.includes(htmlTag)) {
-        switch (event.key) {
-          case '+':
-          case '=': {
-            zoomIn()
-            return true
-          }
-          case '-':
-          case '_': {
-            zoomOut()
-            return true
-          }
-          case 'ArrowRight': {
-            event.preventDefault()
-            panRight()
-            return false
-          }
-          case 'ArrowLeft': {
-            event.preventDefault()
-            panLeft()
-            return false
-          }
-          case 'ArrowUp': {
-            event.preventDefault()
-            panUp()
-            return false
-          }
-          case 'ArrowDown': {
-            event.preventDefault()
-            panDown()
-            return false
-          }
-          default: {
-            return true
-          }
-        }
-      }
-
-      return true
+    const htmlTag = event.target?.tagName.toLowerCase()
+    const handler = keyMappings[event.key]
+    if (ALLOWED_TAGS.includes(htmlTag) && handler) {
+      event.preventDefault()
+      handler()
+      return false
     }
+
+    return true
+  }
     
     return { onKeyZoom }
 }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
@@ -8,7 +8,7 @@ const STROKE_WIDTH = 2
 const SELECTED_STROKE_WIDTH = 4
 
 const StyledGroup = styled('g')`
-  &:focus {
+  &:focus-visible {
     ${(props) =>
     css`
         outline: solid 4px ${props.focusColor};

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
@@ -7,7 +7,11 @@ import draggable from '../draggable'
 const STROKE_WIDTH = 2
 const SELECTED_STROKE_WIDTH = 4
 
-const StyledGroup = styled('g')`
+const StyledGroup = styled.g`
+  &:focus {
+    outline: none;
+  }
+
   &:focus-visible {
     ${(props) =>
     css`

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -57,7 +57,6 @@ function draggable(WrappedComponent) {
     const [pointerId, setPointerId] = useState(-1)
 
     function onDragStart(event) {
-      console.log(canvas)
       event.stopPropagation()
       event.preventDefault()
       const { setPointerCapture } = wrappedComponent.current

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -53,15 +53,16 @@ function draggable(WrappedComponent) {
     const { canvas } = useContext(SVGContext)
     const wrappedComponent = ref || useRef()
     const [dragging, setDragging] = useState(false)
-    const [coords, setCoords] = useState(initialCoords)
+    const coords = useRef(initialCoords)
     const [pointerId, setPointerId] = useState(-1)
 
     function onDragStart(event) {
+      console.log(canvas)
       event.stopPropagation()
       event.preventDefault()
       const { setPointerCapture } = wrappedComponent.current
       const { x, y, pointerId } = convertEvent(event, canvas)
-      setCoords({ x, y })
+      coords.current = { x, y }
       setDragging(true)
       setPointerId(pointerId)
       dragStart({ x, y, pointerId })
@@ -74,11 +75,11 @@ function draggable(WrappedComponent) {
         const { x, y } = convertEvent(event, canvas)
         const { currentTarget } = event
         const difference = {
-          x: x - coords.x,
-          y: y - coords.y
+          x: x - coords.current.x,
+          y: y - coords.current.y
         }
         dragMove({ currentTarget, x, y, pointerId }, difference)
-        setCoords({ x, y })
+        coords.current = { x, y }
       }
     }
 
@@ -91,7 +92,7 @@ function draggable(WrappedComponent) {
         releasePointerCapture &&
           wrappedComponent.current.releasePointerCapture(pointerId)
       }
-      setCoords({ x: null, y: null })
+      coords.current = { x: null, y: null }
       setDragging(false)
       setPointerId(-1)
     }

--- a/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/draggable/draggable.js
@@ -15,7 +15,6 @@ function createPoint(event) {
 }
 
 function getEventOffset(event, canvas) {
-  const { clientX, clientY } = event
   const svgPoint = createPoint(event)
   const svgEventOffset = svgPoint.matrixTransform
     ? svgPoint.matrixTransform(canvas.getScreenCTM().inverse())
@@ -26,7 +25,6 @@ function getEventOffset(event, canvas) {
 function convertEvent(event, canvas) {
   const svgEventOffset = getEventOffset(event, canvas)
   const svgCoordinateEvent = {
-    pointerId: event.pointerId,
     type: event.type,
     x: svgEventOffset.x,
     y: svgEventOffset.y
@@ -54,46 +52,41 @@ function draggable(WrappedComponent) {
     const wrappedComponent = ref || useRef()
     const [dragging, setDragging] = useState(false)
     const coords = useRef(initialCoords)
-    const [pointerId, setPointerId] = useState(-1)
+    const pointerId = useRef(-1)
 
     function onDragStart(event) {
       event.stopPropagation()
       event.preventDefault()
-      const { setPointerCapture } = wrappedComponent.current
-      const { x, y, pointerId } = convertEvent(event, canvas)
+      const { x, y } = convertEvent(event, canvas)
       coords.current = { x, y }
       setDragging(true)
-      setPointerId(pointerId)
-      dragStart({ x, y, pointerId })
-      setPointerCapture &&
-        wrappedComponent.current.setPointerCapture(pointerId)
+      pointerId.current = event.pointerId
+      dragStart({ x, y, pointerId: event.pointerId })
+      wrappedComponent.current?.setPointerCapture(event.pointerId)
     }
 
     function onDragMove(event) {
-      if (dragging && event.pointerId === pointerId) {
+      if (dragging && event.pointerId === pointerId.current) {
         const { x, y } = convertEvent(event, canvas)
         const { currentTarget } = event
         const difference = {
           x: x - coords.current.x,
           y: y - coords.current.y
         }
-        dragMove({ currentTarget, x, y, pointerId }, difference)
+        dragMove({ currentTarget, x, y, pointerId: event.pointerId }, difference)
         coords.current = { x, y }
       }
     }
 
     function onDragEnd(event) {
-      const { releasePointerCapture } = wrappedComponent.current
-      const point = convertEvent(event, canvas)
+      const { x, y } = convertEvent(event, canvas)
       const { currentTarget } = event
-      if (point.pointerId === pointerId) {
-        dragEnd({ currentTarget, x: point.x, y: point.y, pointerId })
-        releasePointerCapture &&
-          wrappedComponent.current.releasePointerCapture(pointerId)
+      if (event.pointerId === pointerId.current) {
+        dragEnd({ currentTarget, x, y, pointerId: event.pointerId })
       }
       coords.current = { x: null, y: null }
       setDragging(false)
-      setPointerId(-1)
+      pointerId.current = -1
     }
 
     return (

--- a/packages/lib-classifier/src/plugins/drawingTools/models/marks/Ellipse/Ellipse.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/models/marks/Ellipse/Ellipse.js
@@ -29,8 +29,8 @@ const EllipseModel = types
 
     deleteButtonPosition(scale) {
       const theta = DELETE_BUTTON_ANGLE * (Math.PI / 180)
-      const dx = ((self.rx + BUFFER) / scale) * Math.cos(theta)
-      const dy = ((self.ry + BUFFER) / scale) * Math.sin(theta)
+      const dx = (self.rx + BUFFER) * Math.cos(theta)
+      const dy = (self.ry + BUFFER) * Math.sin(theta)
       return {
         x: dx,
         y: dy


### PR DESCRIPTION
- Refactor `SVGPanZoom` to use a ref for `zoom`, rather than component state. Hopefully, this will lead to fewer rerenders when dragging a zoomed image, and smoother performance.
- Use a ref to store pointer coordinates in the `draggable` decorator, to avoid unnecessary rerenders.
- Move the cropped SVG viewbox into a nested SVG, for better performance when dragging a zoomed image.
- Remove the `1.5` easing factor on dragged images, so that they 'stick' to the pointer when dragged.
- Use `focus-visible` so that focus rings are only shown for keyboard interactions.
- refactor the `useKeyZoom` hook to support rotated images. 

Screen recordings from Firefox 125 running on an M3 MacBook (Sonoma 14.4.1.)

Pan and zoom with a trackpad:

https://github.com/zooniverse/front-end-monorepo/assets/59547/43393ea6-3cd2-4b13-9e19-afef14865b58

Pan and zoom with a trackpad at a very high zoom level:

https://github.com/zooniverse/front-end-monorepo/assets/59547/bfe58619-dc91-4fe3-a611-07c2fc7bbaab



Keyboard focus with Tab and shift-Tab:

https://github.com/zooniverse/front-end-monorepo/assets/59547/bc92375e-c3e1-44a3-b70f-b9291e45081a




## Package
- lib-classifier

## Linked Issue and/or Talk Post
- fixes #2273.
- fixes #6067.

## How to Review
Zoom and pan an image in the dev classifier, using both the keyboard and a trackpad/mouse to pan the zoomed image. I've been testing this with Wildwatch Burrowing Owl in Chrome, Safari and Firefox.
https://localhost:8080/?project=sandiegozooglobal/wildwatch-burrowing-owl&env=production

You can test the focus styling by tabbing through the page, to check that drawn marks have focus styling when focused ([WCAG Success Criterion 2.4.7: focus visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html).) When a mark has keyboard focus, Enter will open any associated subtask popup, which should also be fully keyboard accessible. Backspace will delete the focused mark ([WCAG Success Criterion 2.1.1: Keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html).)

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
