### PR TITLE
fix: image dragging for rotated images

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -32,8 +32,8 @@ function SingleImageViewer({
   zoomControlFn = null,
   zooming = false
 }) {
-  const transformLayer = useRef()
-  const canvas = transformLayer.current
+  const canvasLayer = useRef()
+  const canvas = canvasLayer.current
   const transform = `rotate(${rotate} ${width / 2} ${height / 2})`
 
   return (
@@ -62,20 +62,19 @@ function SingleImageViewer({
           {title?.id && title?.text && (
             <title id={title.id}>{title.text}</title>
           )}
-          <g
-            ref={transformLayer}
-            transform={transform}
-          >
-            {children}
-            {enableInteractionLayer && (
-              <InteractionLayer
-                frame={frame}
-                height={height}
-                scale={scale}
-                subject={subject}
-                width={width}
-              />
-            )}
+          <g ref={canvasLayer}>
+            <g transform={transform}>
+              {children}
+              {enableInteractionLayer && (
+                <InteractionLayer
+                  frame={frame}
+                  height={height}
+                  scale={scale}
+                  subject={subject}
+                  width={width}
+                />
+              )}
+            </g>
           </g>
         </PlaceholderSVG>
       </Box>


### PR DESCRIPTION
Move the SVG rotation transform into a separate element, for SVG subject images, so that rotation doesn't affect the calculation of the mouse coordinates when dragging the image.

https://github.com/zooniverse/front-end-monorepo/assets/59547/1f788067-3053-4af8-9812-eee970a44a02





## Package
- lib-classifier

## Linked Issue and/or Talk Post
- fixes #6067.

## How to Review
Dragging a rotated subject image should work now. The image should follow the direction that the pointer is moving in.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
