### PR TITLE
lib-user: Add MemberCard

### DIFF
--- a/packages/lib-user/src/components/GroupStats/components/MemberCard/MemberCard.js
+++ b/packages/lib-user/src/components/GroupStats/components/MemberCard/MemberCard.js
@@ -10,25 +10,15 @@ function MemberCard({
   displayName = '',
   login = ''
 }) {
-  let displayValue = classifications
-  if (isNaN(classifications)) {
-    displayValue = 0
-  }
-
   return (
     <Box
       direction='row'
       gap='xsmall'
     >
-      {avatar ? (
-        <Avatar
-          alt={`${login} avatar`}
-          src={avatar}
-        />) : (
-        <Avatar
-          alt={`${login} avatar`}
-          src='https://www.zooniverse.org/assets/simple-avatar.png'
-        />)}
+      <Avatar
+        alt={`${login} avatar`}
+        src={avatar || 'https://www.zooniverse.org/assets/simple-avatar.png'}
+      />
       <Box
         justify='center'
       >
@@ -40,7 +30,7 @@ function MemberCard({
         <SpacedText
           uppercase={false}
         >
-          {`${Math.round(displayValue).toLocaleString()} Classifications`}
+          {`${Math.round(classifications).toLocaleString()} Classifications`}
         </SpacedText>
       </Box>
     </Box>

--- a/packages/lib-user/src/components/GroupStats/components/MemberCard/MemberCard.js
+++ b/packages/lib-user/src/components/GroupStats/components/MemberCard/MemberCard.js
@@ -1,0 +1,57 @@
+import { SpacedText } from '@zooniverse/react-components'
+import { Box } from 'grommet'
+import { number, string } from 'prop-types'
+
+import { Avatar } from '@components/shared'
+
+function MemberCard({
+  avatar = 'https://www.zooniverse.org/assets/simple-avatar.png',
+  classifications = 0,
+  displayName = '',
+  login = ''
+}) {
+  let displayValue = classifications
+  if (isNaN(classifications)) {
+    displayValue = 0
+  }
+
+  return (
+    <Box
+      direction='row'
+      gap='xsmall'
+    >
+      {avatar ? (
+        <Avatar
+          alt={`${login} avatar`}
+          src={avatar}
+        />) : (
+        <Avatar
+          alt={`${login} avatar`}
+          src='https://www.zooniverse.org/assets/simple-avatar.png'
+        />)}
+      <Box
+        justify='center'
+      >
+        <SpacedText
+          weight='bold'
+        >
+          {displayName}
+        </SpacedText>
+        <SpacedText
+          uppercase={false}
+        >
+          {`${Math.round(displayValue).toLocaleString()} Classifications`}
+        </SpacedText>
+      </Box>
+    </Box>
+  )
+}
+
+MemberCard.propTypes = {
+  avatar: string,
+  classifications: number,
+  displayName: string,
+  login: string
+}
+
+export default MemberCard

--- a/packages/lib-user/src/components/GroupStats/components/MemberCard/MemberCard.spec.js
+++ b/packages/lib-user/src/components/GroupStats/components/MemberCard/MemberCard.spec.js
@@ -1,0 +1,40 @@
+import { composeStory } from '@storybook/react'
+import { render, screen } from '@testing-library/react'
+
+import { USER } from '../../../../../test/mocks/panoptes'
+
+import Meta, { Default, NoAvatar } from './MemberCard.stories.js'
+
+describe('components > GroupStats > MemberCard', function () {
+  describe('with an avatar', function () {
+    const DefaultStory = composeStory(Default, Meta)
+
+    it('should show the user\'s avatar', function () {
+      render(<DefaultStory />)
+      const avatar = screen.getByAltText(`${USER.login} avatar`)
+      expect(avatar).to.be.ok()
+    })
+
+    it('should show the user\'s display name', function () {
+      render(<DefaultStory />)
+      const displayName = screen.getByText(USER.display_name)
+      expect(displayName).to.be.ok()
+    })
+
+    it('should show the user\'s classifications', function () {
+      render(<DefaultStory />)
+      const classifications = screen.getByText('1,234 Classifications')
+      expect(classifications).to.be.ok()
+    })
+  })
+
+  describe('without an avatar', function () {
+    const NoAvatarStory = composeStory(NoAvatar, Meta)
+
+    it('should show the default avatar', function () {
+      render(<NoAvatarStory />)
+      const avatar = screen.getByAltText(`${USER.login} avatar`)
+      expect(avatar).to.be.ok()
+    })
+  })
+})

--- a/packages/lib-user/src/components/GroupStats/components/MemberCard/MemberCard.stories.js
+++ b/packages/lib-user/src/components/GroupStats/components/MemberCard/MemberCard.stories.js
@@ -1,0 +1,43 @@
+import { Box } from 'grommet'
+
+import { USER } from '../../../../../test/mocks/panoptes'
+
+import MemberCard from './MemberCard'
+
+export default {
+  title: 'Components/GroupStats/MemberCard',
+  component: MemberCard,
+  decorators: [ComponentDecorator]
+}
+
+function ComponentDecorator(Story) {
+  return (
+    <Box
+      background={{
+        dark: 'dark-3',
+        light: 'neutral-6'
+      }}
+      pad='30px'
+    >
+      <Story />
+    </Box>
+  )
+}
+
+export const Default = {
+  args: {
+    avatar: USER.avatar_src,
+    classifications: 1234,
+    displayName: USER.display_name,
+    login: USER.login
+  }
+}
+
+export const NoAvatar = {
+  args: {
+    avatar: '',
+    classifications: 567,
+    displayName: USER.display_name,
+    login: USER.login
+  }
+}

--- a/packages/lib-user/src/components/GroupStats/components/MemberCard/index.js
+++ b/packages/lib-user/src/components/GroupStats/components/MemberCard/index.js
@@ -1,0 +1,1 @@
+export { default } from './MemberCard'

--- a/packages/lib-user/src/components/shared/Avatar/Avatar.js
+++ b/packages/lib-user/src/components/shared/Avatar/Avatar.js
@@ -1,0 +1,29 @@
+import { Image } from 'grommet'
+import { string } from 'prop-types'
+import styled from 'styled-components'
+
+const StyledAvatar = styled(Image)`
+  width: 50px;
+  height: 50px;
+  object-fit: cover;
+  border-radius: 50%;
+`
+
+function Avatar({
+  src,
+  alt
+}) {
+  return (
+    <StyledAvatar
+      src={src}
+      alt={alt}
+    />
+  )
+}
+
+Avatar.propTypes = {
+  src: string,
+  alt: string
+}
+
+export default Avatar

--- a/packages/lib-user/src/components/shared/Avatar/index.js
+++ b/packages/lib-user/src/components/shared/Avatar/index.js
@@ -1,0 +1,1 @@
+export { default } from './Avatar'

--- a/packages/lib-user/src/components/shared/ContentBox/ContentBox.stories.js
+++ b/packages/lib-user/src/components/shared/ContentBox/ContentBox.stories.js
@@ -130,7 +130,7 @@ export const TopContributors = {
       <Grid
         columns={[ 'auto', 'auto' ]}
         gap='small'
-        rows={['auto', 'auto', 'auto', 'auto', 'auto']}
+        rows={['repeat(5, auto)']}
         style={{ gridAutoFlow: 'column' }}
       >
         {USERS.map((user, index) => (

--- a/packages/lib-user/src/components/shared/ContentBox/ContentBox.stories.js
+++ b/packages/lib-user/src/components/shared/ContentBox/ContentBox.stories.js
@@ -1,7 +1,9 @@
 import { Box, Grid } from 'grommet'
 import ProjectCard from '@zooniverse/react-components/ProjectCard'
 
-import { PROJECTS } from '../../../../test/mocks/panoptes/projects.js'
+import { PROJECTS, USERS } from '../../../../test/mocks/panoptes'
+
+import MemberCard from '../../GroupStats/components/MemberCard'
 import ContentBox from './ContentBox'
 
 const NfnCaliFlowers = {
@@ -112,6 +114,34 @@ export const TopProjectsSplit = {
         <ProjectCard {...PlanetHuntersTess} size='small' />
         <ProjectCard {...CorrespondingWithQuakers} size='small' />
         <ProjectCard {...WildwatchKenya} size='small' />
+      </Grid>
+    </ContentBox>
+  )
+}
+
+export const TopContributors = {
+  render: () => (
+    <ContentBox
+      linkLabel='See all contributors and detailed stats'
+      linkProps={{ href: 'https://www.zooniverse.org/groups/12345/contributors' }}
+      title='Top Contributors'
+      width='625px'
+    >
+      <Grid
+        columns={[ 'auto', 'auto' ]}
+        gap='small'
+        rows={['auto', 'auto', 'auto', 'auto', 'auto']}
+        style={{ gridAutoFlow: 'column' }}
+      >
+        {USERS.map((user, index) => (
+          <MemberCard
+            key={`MemberCard-${index}`}
+            avatar={user.avatar_src}
+            classifications={Math.floor(Math.random() * 5000)}
+            displayName={user.display_name}
+            login={user.login}
+          />
+        ))}
       </Grid>
     </ContentBox>
   )

--- a/packages/lib-user/src/components/shared/ProfileHeader/ProfileHeader.js
+++ b/packages/lib-user/src/components/shared/ProfileHeader/ProfileHeader.js
@@ -1,16 +1,11 @@
-import { Box, Image } from 'grommet'
+import { Box } from 'grommet'
 import { number, string } from 'prop-types'
-import styled from 'styled-components'
 import { SpacedText, withResponsiveContext, ZooniverseLogo } from '@zooniverse/react-components'
 
-import TitledStat from '../TitledStat'
-
-const StyledAvatar = styled(Image)`
-  width: 50px;
-  height: 50px;
-  object-fit: cover;
-  border-radius: 50%;
-`
+import {
+  Avatar,
+  TitledStat
+} from '@components/shared'
 
 function ProfileHeader ({
   avatar = '',
@@ -34,7 +29,7 @@ function ProfileHeader ({
         gap='small'
       >
         {avatar ?
-          <StyledAvatar
+          <Avatar
             src={avatar}
             alt={`${login} avatar`}
           />

--- a/packages/lib-user/src/components/shared/ProfileHeader/ProfileHeader.spec.js
+++ b/packages/lib-user/src/components/shared/ProfileHeader/ProfileHeader.spec.js
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react'
 import { composeStory } from '@storybook/react'
+import { render, screen } from '@testing-library/react'
 
 import { USER, USER_GROUPS } from '../../../../test/mocks/panoptes'
 

--- a/packages/lib-user/src/components/shared/index.js
+++ b/packages/lib-user/src/components/shared/index.js
@@ -1,3 +1,4 @@
+export { default as Avatar } from './Avatar'
 export { default as BarChart } from './BarChart'
 export { default as ContentBox } from './ContentBox'
 export { default as Layout } from './Layout'

--- a/packages/lib-user/src/index.js
+++ b/packages/lib-user/src/index.js
@@ -4,12 +4,15 @@ export { default as MyGroups } from './components/MyGroups'
 export { default as GroupStats } from './components/GroupStats'
 
 // components/shared
+export { default as Avatar } from './components/shared/Avatar'
 export { default as BarChart } from './components/shared/BarChart'
 export { default as ContentBox } from './components/shared/ContentBox'
 export { default as Layout } from './components/shared/Layout'
+export { default as MainContent } from './components/shared/MainContent'
 export { default as ProfileHeader } from './components/shared/ProfileHeader'
 export { default as Select } from './components/shared/Select'
 export { default as Tabs } from './components/shared/Tabs'
+export { default as TitledStat } from './components/shared/TitledStat'
 
 // hooks
 export { usePanoptesAuth } from './hooks/usePanoptesAuth.js'

--- a/packages/lib-user/test/mocks/panoptes/index.js
+++ b/packages/lib-user/test/mocks/panoptes/index.js
@@ -1,4 +1,4 @@
 export { MEMBERSHIPS } from './memberships'
 export { PROJECTS } from './projects'
-export { USER, ADMIN_USER, GROUP_MEMBER_USER, GROUP_ADMIN_USER } from './users'
+export { USER, USERS, ADMIN_USER, GROUP_MEMBER_USER, GROUP_ADMIN_USER } from './users'
 export { USER_GROUPS } from './user_groups'

--- a/packages/lib-user/test/mocks/panoptes/users.js
+++ b/packages/lib-user/test/mocks/panoptes/users.js
@@ -29,3 +29,26 @@ export const GROUP_ADMIN_USER = {
   id: '09876',
   login: 'TeacherUser'
 }
+
+export const USERS = [
+  USER,
+  ADMIN_USER,
+  GROUP_MEMBER_USER,
+  GROUP_ADMIN_USER,
+  {
+    ...USER,
+    id: '23456',
+  },
+  {
+    ...GROUP_MEMBER_USER,
+    id: '34567',
+  },
+  {
+    ...ADMIN_USER,
+    id: '45678',
+  },
+  {
+    ...USER,
+    id: '56789',
+  }
+]


### PR DESCRIPTION
## Package
- lib-user

## Describe your changes
- refactor user avatar component from ProfileHeader to Avatar
- create MemberCard component
- add stories, tests
- refactor ContentBox stories with TopContributors story
- [related Figma design](https://www.figma.com/file/qbqbmR3t5XV6eKcpuRj7mG/Group-Stats?node-id=386-8409&mode=dev)

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a
- What user actions should my reviewer step through to review this PR? review noted stories
- Which storybook stories should be reviewed?
  - MemberCards: http://localhost:6008/?path=/story/components-groupstats-membercard--default
  - TopContributors: http://localhost:6008/?path=/story/components-shared-contentbox--top-contributors (note the order will be ranked from most to least classifications, but the story has random classification numbers)
- Are there plans for follow up PR’s to further fix this bug or develop this feature? yes, add to GroupStats

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected