### PR TITLE
app-root: Fix group join issue

### DIFF
--- a/packages/app-root/src/app/groups/[groupId]/GroupStatsContainer.js
+++ b/packages/app-root/src/app/groups/[groupId]/GroupStatsContainer.js
@@ -6,7 +6,8 @@ import { useContext } from 'react'
 import { PanoptesAuthContext } from '../../../contexts'
 
 function GroupStatsContainer({
-  groupId
+  groupId,
+  joinToken
 }) {
   const { adminMode, user } = useContext(PanoptesAuthContext)
   
@@ -15,6 +16,7 @@ function GroupStatsContainer({
       adminMode={adminMode}
       authUser={user}
       groupId={groupId}
+      joinToken={joinToken}
     />
   )
 }

--- a/packages/lib-user/src/components/GroupStats/GroupStatsContainer.js
+++ b/packages/lib-user/src/components/GroupStats/GroupStatsContainer.js
@@ -61,7 +61,10 @@ function GroupStatsContainer({
       user_id: authUser?.id
     }
   })
-  const role = membershipsData?.memberships?.[0]?.roles?.[0]
+  let role = null
+  if (membershipsData) {
+    role = membershipsData?.memberships?.[0]?.roles?.[0]
+  }
   
   useEffect(function handleJoinGroup() {
     async function createGroupMembership() {
@@ -82,7 +85,7 @@ function GroupStatsContainer({
       }
     }
 
-    if (authUser && !role && joinToken && joinStatus === null) {
+    if (authUser && role === undefined && joinToken && joinStatus === null) {
       setJoinStatus(asyncStates.posting)
       createGroupMembership()
     }


### PR DESCRIPTION
## Package
- app-root

## Describe your changes
- when I rebased recent PRs I neglected to update the app-root GroupStats component with the `joinToken` passed from the group stats `page.js` file
- refactors role and joinGroup useEffect for if already a member but have join_token in url

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What user actions should my reviewer step through to review this PR?
  - production group, should show group not found: https://local.zooniverse.org:3000/groups/2620016?env=production
  - production group, join should fail: https://local.zooniverse.org:3000/groups/2620016?env=production&join_token=1234567
  - production group, join should work: https://local.zooniverse.org:3000/groups/2620016?env=production&join_token=a05cc85a3b11b6d8
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [ ] Unit tests are added or updated