### PR TITLE
app-root: Refactor users pages per user and adminMode

### DIFF
--- a/packages/app-root/src/app/users/[login]/components/AuthenticatedUsersPageContainer.js
+++ b/packages/app-root/src/app/users/[login]/components/AuthenticatedUsersPageContainer.js
@@ -1,0 +1,33 @@
+'use client'
+
+function AuthenticatedUsersPageContainer({
+  adminMode,
+  children,
+  isLoading,
+  login,
+  user
+}) {
+  if (typeof window === 'undefined' || isLoading) {
+    return (
+      <p>Loading...</p>
+    )
+  }
+
+  if (!user) {
+    return (
+      <p>Please log in.</p>
+    )
+  }
+
+  if (user && login !== user?.login && !adminMode) {
+    return (
+      <p>Not authorized.</p>
+    )
+  }
+
+  return (
+    <>{children}</>
+  )
+}
+
+export default AuthenticatedUsersPageContainer

--- a/packages/app-root/src/app/users/[login]/groups/MyGroupsContainer.js
+++ b/packages/app-root/src/app/users/[login]/groups/MyGroupsContainer.js
@@ -8,11 +8,28 @@ import { PanoptesAuthContext } from '../../../../contexts'
 function MyGroupsContainer({
   login
 }) {
-  const { adminMode, user } = useContext(PanoptesAuthContext)
+  const { adminMode, isLoading, user } = useContext(PanoptesAuthContext)
+
+  if (typeof window === 'undefined' || isLoading) {
+    return (
+      <p>Loading...</p>
+    )
+  }
+
+  if (!user) {
+    return (
+      <p>Please log in.</p>
+    )
+  }
+
+  if (user && login !== user?.login && !adminMode) {
+    return (
+      <p>Not authorized.</p>
+    )
+  }
 
   return (
     <MyGroups
-      adminMode={adminMode}  
       authUser={user}
       login={login}
     />

--- a/packages/app-root/src/app/users/[login]/groups/MyGroupsContainer.js
+++ b/packages/app-root/src/app/users/[login]/groups/MyGroupsContainer.js
@@ -4,35 +4,25 @@ import { MyGroups } from '@zooniverse/user'
 import { useContext } from 'react'
 
 import { PanoptesAuthContext } from '../../../../contexts'
+import AuthenticatedUsersPageContainer from '../components/AuthenticatedUsersPageContainer'
 
 function MyGroupsContainer({
   login
 }) {
   const { adminMode, isLoading, user } = useContext(PanoptesAuthContext)
 
-  if (typeof window === 'undefined' || isLoading) {
-    return (
-      <p>Loading...</p>
-    )
-  }
-
-  if (!user) {
-    return (
-      <p>Please log in.</p>
-    )
-  }
-
-  if (user && login !== user?.login && !adminMode) {
-    return (
-      <p>Not authorized.</p>
-    )
-  }
-
   return (
-    <MyGroups
-      authUser={user}
+    <AuthenticatedUsersPageContainer
+      adminMode={adminMode}
+      isLoading={isLoading}
       login={login}
-    />
+      user={user}
+    >
+      <MyGroups
+        authUser={user}
+        login={login}
+      />
+    </AuthenticatedUsersPageContainer>
   )
 }
 

--- a/packages/app-root/src/app/users/[login]/stats/UserStatsContainer.js
+++ b/packages/app-root/src/app/users/[login]/stats/UserStatsContainer.js
@@ -4,35 +4,25 @@ import { UserStats } from '@zooniverse/user'
 import { useContext } from 'react'
 
 import { PanoptesAuthContext } from '../../../../contexts'
+import AuthenticatedUsersPageContainer from '../components/AuthenticatedUsersPageContainer'
 
 function UserStatsContainer({
   login
 }) {
   const { adminMode, isLoading, user } = useContext(PanoptesAuthContext)
 
-  if (typeof window === 'undefined' || isLoading) {
-    return (
-      <p>Loading...</p>
-    )
-  }
-
-  if (!user) {
-    return (
-      <p>Please log in.</p>
-    )
-  }
-
-  if (user && login !== user?.login && !adminMode) {
-    return (
-      <p>Not authorized.</p>
-    )
-  }
-
   return (
-    <UserStats
-      authUser={user}
+    <AuthenticatedUsersPageContainer
+      adminMode={adminMode}
+      isLoading={isLoading}
       login={login}
-    />
+      user={user}
+    >
+      <UserStats
+        authUser={user}
+        login={login}
+      />
+    </AuthenticatedUsersPageContainer>
   )
 }
 

--- a/packages/app-root/src/app/users/[login]/stats/UserStatsContainer.js
+++ b/packages/app-root/src/app/users/[login]/stats/UserStatsContainer.js
@@ -8,11 +8,28 @@ import { PanoptesAuthContext } from '../../../../contexts'
 function UserStatsContainer({
   login
 }) {
-  const { adminMode, user } = useContext(PanoptesAuthContext)
+  const { adminMode, isLoading, user } = useContext(PanoptesAuthContext)
+
+  if (typeof window === 'undefined' || isLoading) {
+    return (
+      <p>Loading...</p>
+    )
+  }
+
+  if (!user) {
+    return (
+      <p>Please log in.</p>
+    )
+  }
+
+  if (user && login !== user?.login && !adminMode) {
+    return (
+      <p>Not authorized.</p>
+    )
+  }
 
   return (
     <UserStats
-      adminMode={adminMode}  
       authUser={user}
       login={login}
     />

--- a/packages/lib-user/dev/components/App/App.js
+++ b/packages/lib-user/dev/components/App/App.js
@@ -1,5 +1,5 @@
 import zooTheme from '@zooniverse/grommet-theme'
-import { AdminCheckbox, AuthModal, ZooHeader, ZooFooter } from '@zooniverse/react-components'
+import { AuthModal } from '@zooniverse/react-components'
 import { Grommet } from 'grommet'
 import auth from 'panoptes-client/lib/auth.js'
 import { string } from 'prop-types'
@@ -19,7 +19,6 @@ function App({
   users = null
 }) {
   const [activeIndex, setActiveIndex] = useState(-1)
-  const [adminMode, setAdminMode] = useState(false)
   const [dark, setDarkTheme] = useState(false)
   const [loading, setLoading] = useState(false)
   const [user, setUser] = useState(null)
@@ -44,10 +43,6 @@ function App({
       auth.stopListening('change', checkUserSession)
     }
   }, [])
-
-  function openRegisterModal() {
-    setActiveIndex(1)
-  }
 
   function openSignInModal() {
     setActiveIndex(0)
@@ -111,7 +106,6 @@ function App({
 
       content = (
         <GroupStats
-          adminMode={adminMode}
           authUser={user}
           groupId={groupId}
           joinToken={joinToken}
@@ -129,7 +123,6 @@ function App({
     } else if (subpaths[1] === 'stats') {
       content = (
         <UserStats
-          adminMode={adminMode}
           authUser={user}
           login={login}
         />
@@ -137,7 +130,6 @@ function App({
     } else if (subpaths[1] === 'groups') {
       content = (
         <MyGroups
-          adminMode={adminMode}
           authUser={user}
           login={login}
         />
@@ -156,44 +148,39 @@ function App({
       theme={zooTheme}
       themeMode={dark ? 'dark' : 'light'}
     >
-      <main className={adminMode ? 'admin-mode' : ''}>
-        <header aria-label='Zooniverse site header'>
-          <AuthModal
-            activeIndex={activeIndex}
-            closeModal={closeAuthModal}
-            onActive={setActiveIndex}
-          />
-          <ZooHeader
-            adminMode={adminMode}
-            onThemeChange={() => setDarkTheme(!dark)}
-            register={openRegisterModal}
-            showThemeToggle
-            signIn={openSignInModal}
-            signOut={onSignOut}
-            themeMode={dark ? 'dark' : 'light'}
-            user={user || {}}
-          />
+      <main>
+        <AuthModal
+          activeIndex={activeIndex}
+          closeModal={closeAuthModal}
+          onActive={setActiveIndex}
+        />
+        <header>
+          <p>
+            <a href='/'>lib-user - dev app</a>
+          </p>
+          {user ? (
+            <button onClick={onSignOut}>Sign Out</button>
+          ) : (
+            <>
+              <button onClick={openSignInModal}>Sign In</button>
+            </>
+          )}
+          <div>
+            <label htmlFor='dark-theme-toggle'>Dark Theme</label>
+            <input
+              id='dark-theme-toggle'
+              type='checkbox'
+              checked={dark}
+              onChange={() => setDarkTheme(!dark)}
+            />
+          </div>
         </header>
-        <div>
-          <p>⚠️ WARNING ⚠️ : this is a dev app for lib-user, links in the header, footer, and components may not work as expected</p>
-          <p><a href='/'>lib-user root</a></p>
-        </div>
         {loading ? 
           <p>Loading...</p> : (
           <div>
             {content}
           </div>
         )}
-        <footer>
-          <ZooFooter
-            adminContainer={user?.admin ? (
-              <AdminCheckbox
-                onChange={() => setAdminMode(!adminMode)}
-                checked={adminMode}
-              />
-            ) : null}
-          />
-        </footer>
       </main>
     </Grommet>
   )

--- a/packages/lib-user/dev/index.html
+++ b/packages/lib-user/dev/index.html
@@ -9,10 +9,6 @@
         padding: 0;
         box-sizing: border-box;
       }
-      .admin-mode {
-        border: .3em solid;
-        border-image: repeating-linear-gradient(45deg, #000, #000 1%, #ff00ff 1%, #ff00ff 2%) 5;
-      }
     </style>
   </head>
   <body>

--- a/packages/lib-user/src/components/MyGroups/MyGroupsContainer.js
+++ b/packages/lib-user/src/components/MyGroups/MyGroupsContainer.js
@@ -1,6 +1,6 @@
 'use client'
 
-import { bool, shape, string } from 'prop-types'
+import { shape, string } from 'prop-types'
 import { useState } from 'react'
 
 import {
@@ -19,7 +19,6 @@ import GroupForm from './components/GroupForm'
 import GroupModal from './components/GroupModal'
 
 function MyGroupsContainer({
-  adminMode,
   authUser,
   login
 }) {
@@ -30,7 +29,6 @@ function MyGroupsContainer({
     error: userError,
     isLoading: userLoading
   } = usePanoptesUser({
-    adminMode,
     authUser,
     login
   })
@@ -81,7 +79,6 @@ function MyGroupsContainer({
 }
 
 MyGroupsContainer.propTypes = {
-  adminMode: bool,
   authUser: shape({
     id: string
   }),

--- a/packages/lib-user/src/components/UserStats/UserStatsContainer.js
+++ b/packages/lib-user/src/components/UserStats/UserStatsContainer.js
@@ -1,6 +1,6 @@
 'use client'
 
-import { bool, shape, string } from 'prop-types'
+import { shape, string } from 'prop-types'
 import { useState } from 'react'
 
 import {
@@ -18,7 +18,6 @@ import UserStats from './UserStats'
 const STATS_ENDPOINT = '/classifications/users'
 
 function UserStatsContainer({
-  adminMode,
   authUser,
   login,
 }) {
@@ -31,7 +30,6 @@ function UserStatsContainer({
     error: userError,
     isLoading: userLoading
   } = usePanoptesUser({
-    adminMode,
     authUser,
     login
   })
@@ -98,7 +96,6 @@ function UserStatsContainer({
 }
 
 UserStatsContainer.propTypes = {
-  adminMode: bool,
   authUser: shape({
     id: string
   }),

--- a/packages/lib-user/src/hooks/usePanoptesUser.js
+++ b/packages/lib-user/src/hooks/usePanoptesUser.js
@@ -41,12 +41,8 @@ async function fetchPanoptesUser({ authUser, login }) {
   return panoptesUser
 }
 
-export function usePanoptesUser({ adminMode, authUser, login }) {
-  const key = (
-      (login === authUser?.login) // user viewing their own stats page
-      || (login && adminMode) // admin viewing a user's stats page
-    ) 
-    ? { authUser, login }
-    : null
+export function usePanoptesUser({ authUser, login }) {
+  const key = authUser && login ? { authUser, login } : null
+
   return useSWR(key, fetchPanoptesUser, SWRoptions)
 }


### PR DESCRIPTION
## Package
-app-root
-lib-user

## Describe your changes
- remove ZooHeader and ZooFooter from lib-user - I thought about [this comment](https://github.com/zooniverse/front-end-monorepo/pull/6071#discussion_r1595749686) and think they're too much, feel out of place for a _library_ dev app
- remove adminMode from lib-user UserStats and MyGroups components
- add user and adminMode state handling to app-root UserStats and MyGroups
- create AuthenticatedUsersPageContainer for related shared state handling, will also be used for certificate page

## Other Notes
- unrelated to these changes, in app-root if you refresh with admin mode on there are hydration errors, can see at https://local.zooniverse.org:3000/users
- GroupStats will need adminMode passed from app-root to lib-user, so no related changes

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a
- What user actions should my reviewer step through to review this PR?
  - access your user stats page
  - attempt to access someone else's user stats page or my groups page with admin mode off
    - staging: https://local.zooniverse.org:3000/users/markb-volunteer11/stats
    - production: https://local.zooniverse.org:3000/users/markbouslog/stats
  - access someone else's user stats page or my groups page with admin mode on
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected