### PR TITLE
fix(classifier): surveyTask.alwaysShowThumbnails must be a boolean

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/survey/models/SurveyTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/models/SurveyTask.js
@@ -44,6 +44,21 @@ const Survey = types.model('Survey', {
   thumbnails: types.maybe(types.string),
   type: types.literal('survey')
 })
+  .preProcessSnapshot(snapshot => {
+    if (snapshot.hasOwnProperty('alwaysShowThumbnails')) {
+      const newSnapshot = { ...snapshot }
+      // 'true' and 'false' are both true.
+      if (snapshot.alwaysShowThumbnails === 'false') {
+        newSnapshot.alwaysShowThumbnails = false
+      }
+      if (snapshot.alwaysShowThumbnails === 'true') {
+        newSnapshot.alwaysShowThumbnails = true
+      }
+      newSnapshot.alwaysShowThumbnails = !!newSnapshot.alwaysShowThumbnails
+      return newSnapshot
+    }
+    return snapshot
+  })
   .views(self => ({
     defaultAnnotation (id = cuid()) {
       return SurveyAnnotation.create({

--- a/packages/lib-classifier/src/plugins/tasks/survey/models/SurveyTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/models/SurveyTask.js
@@ -41,7 +41,9 @@ const Survey = types.model('Survey', {
   questions: types.frozen({}),
   questionsMap: types.frozen({}),
   questionsOrder: types.array(types.string),
-  thumbnails: types.maybe(types.string),
+  thumbnails: types.maybe(
+    types.enumeration('thumbnails', ['show', 'hide', 'default'])
+  ),
   type: types.literal('survey')
 })
   .preProcessSnapshot(snapshot => {
@@ -55,6 +57,13 @@ const Survey = types.model('Survey', {
         newSnapshot.alwaysShowThumbnails = true
       }
       newSnapshot.alwaysShowThumbnails = !!newSnapshot.alwaysShowThumbnails
+      /*
+      See the lab editor for the thumbnails/alwaysShowThumbnails logic:
+      https://github.com/zooniverse/Panoptes-Front-End/blob/9ca8f70f0d6e836ca931168915c9aed02edf8b1d/app/classifier/tasks/survey/editor.cjsx#L330
+      */
+      if (!newSnapshot.hasOwnProperty('thumbnails')) {
+        newSnapshot.thumbnails = newSnapshot.alwaysShowThumbnails ? 'show' : 'default'
+      }
       return newSnapshot
     }
     return snapshot

--- a/packages/lib-classifier/src/plugins/tasks/survey/models/SurveyTask.spec.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/models/SurveyTask.spec.js
@@ -370,6 +370,7 @@ const surveyTask = {
     'ARETHEREANYYOUNGPRESENT',
     'CLICKWOWIFTHISISANAWESOMEPHOTO'
   ],
+  alwaysShowThumbnails: '',
   required: '',
   taskKey: 'T0',
   type: 'survey'


### PR DESCRIPTION
Quick fix for a bug where the survey task won't display when `task.alwaysShowThumbnails` is a string. In that case, the snapshot preprocessor will coerce it to a boolean.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier/plugins/tasks/survey

## Linked Issue and/or Talk Post
- fixes #6084.

## How to Review
Task T0 for Offal Watching should be displayed in the classifier now.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
