### PR TITLE
Make the classifier's subject viewer sticky

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
@@ -61,15 +61,13 @@ export default function CenteredLayout({ separateFramesView = false }) {
             </Box>
           )}
         </Box>
-        <Box
+        <StickyTaskArea
           width={size === 'small' ? '100%' : '25rem'}
           fill={size === 'small' ? 'horizontal' : 'vertical'}
         >
-          <StickyTaskArea>
-            <TaskArea />
-            {separateFramesView && <FieldGuide />}
-          </StickyTaskArea>
-        </Box>
+          <TaskArea />
+          {separateFramesView && <FieldGuide />}
+        </StickyTaskArea>
       </Box>
       <FeedbackModal />
       <QuickTalk />

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/CenteredLayout/CenteredLayout.js
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { Box, ResponsiveContext } from 'grommet'
 
 import Banners from '@components/Classifier/components/Banners'
@@ -15,10 +15,23 @@ export const Relative = styled(Box)`
   position: relative; // Used for QuickTalk and FeedbackModal positioning
 `
 
+const StickySubjectViewer = styled(Box)`
+  ${props =>
+    props.size !== 'small' &&
+    css`
+      position: sticky;
+      top: 10px;
+    `}
+`
+
 const StickyTaskArea = styled(Box)`
   flex: initial; // Don't stretch vertically
-  position: sticky;
-  top: 10px;
+  ${props =>
+    props.size !== 'small' &&
+    css`
+      position: sticky;
+      top: 10px;
+    `}
 `
 
 const StickyImageToolbar = styled(ImageToolbar)`
@@ -50,11 +63,11 @@ export default function CenteredLayout({ separateFramesView = false }) {
           direction='row'
           margin={size === 'small' ? 'auto' : 'none'}
         >
-          <Box>
+          <StickySubjectViewer size={size}>
             <Banners />
             <SubjectViewer />
             <MetaTools />
-          </Box>
+          </StickySubjectViewer>
           {!separateFramesView && (
             <Box width='3rem' fill='vertical' style={{ minWidth: '3rem' }}>
               <StickyImageToolbar />
@@ -64,6 +77,7 @@ export default function CenteredLayout({ separateFramesView = false }) {
         <StickyTaskArea
           width={size === 'small' ? '100%' : '25rem'}
           fill={size === 'small' ? 'horizontal' : 'vertical'}
+          size={size}
         >
           <TaskArea />
           {separateFramesView && <FieldGuide />}

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
@@ -22,15 +22,17 @@ export const ContainerGrid = styled(Grid)`
 `
 
 export const ViewerGrid = styled(Grid)`
-  ${props => props.size !== 'small' && css`
-    position: sticky;
-    top: 10px;
-  `}
+  ${props =>
+    props.size !== 'small' &&
+    css`
+      position: sticky;
+      top: 10px;
+    `}
   height: fit-content;
   grid-area: viewer;
   grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
   grid-template-rows: auto;
-  grid-template-areas: "subject toolbar";
+  grid-template-areas: 'subject toolbar';
 `
 
 const StyledTaskAreaContainer = styled.div`
@@ -38,8 +40,12 @@ const StyledTaskAreaContainer = styled.div`
 `
 
 const StyledTaskArea = styled(Box)`
-  position: sticky;
-  top: 10px;
+  ${props =>
+    props.size !== 'small' &&
+    css`
+      position: sticky;
+      top: 10px;
+    `}
 `
 
 const StyledImageToolbarContainer = styled.div`
@@ -84,7 +90,7 @@ export default function MaxWidth({
           <MetaTools />
         </Box>
       ) : (
-        <ViewerGrid forwardedAs='section'>
+        <ViewerGrid forwardedAs='section' size={size}>
           <Box gridArea='subject'>
             <Banners />
             <SubjectViewer />
@@ -96,7 +102,7 @@ export default function MaxWidth({
         </ViewerGrid>
       )}
       <StyledTaskAreaContainer>
-        <StyledTaskArea>
+        <StyledTaskArea size={size}>
           <TaskArea />
           {separateFramesView && <FieldGuide />}
         </StyledTaskArea>

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/MaxWidth/MaxWidth.js
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { Box, Grid, ResponsiveContext } from 'grommet'
 
 import Banners from '@components/Classifier/components/Banners'
@@ -21,6 +21,18 @@ export const ContainerGrid = styled(Grid)`
   }
 `
 
+export const ViewerGrid = styled(Grid)`
+  ${props => props.size !== 'small' && css`
+    position: sticky;
+    top: 10px;
+  `}
+  height: fit-content;
+  grid-area: viewer;
+  grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
+  grid-template-rows: auto;
+  grid-template-areas: "subject toolbar";
+`
+
 const StyledTaskAreaContainer = styled.div`
   grid-area: task;
 `
@@ -38,21 +50,6 @@ const StyledImageToolbar = styled(ImageToolbar)`
   position: sticky;
   top: 10px;
 `
-
-export function ViewerGrid({ children }) {
-  return (
-    <Grid
-      as='section'
-      areas={[['subject', 'toolbar']]}
-      columns={['auto', 'clamp(3rem, 10%, 4.5rem)']}
-      gridArea='viewer'
-      height='fit-content'
-      rows={['auto']}
-    >
-      {children}
-    </Grid>
-  )
-}
 
 export const verticalLayout = {
   areas: [['viewer'], ['task']],
@@ -87,7 +84,7 @@ export default function MaxWidth({
           <MetaTools />
         </Box>
       ) : (
-        <ViewerGrid>
+        <ViewerGrid forwardedAs='section'>
           <Box gridArea='subject'>
             <Banners />
             <SubjectViewer />

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.js
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { Box, Grid, ResponsiveContext } from 'grommet'
 
 import Banners from '@components/Classifier/components/Banners'
@@ -21,6 +21,18 @@ const ContainerGrid = styled(Grid)`
   }
 `
 
+export const ViewerGrid = styled(Grid)`
+  ${props => props.size !== 'small' && css`
+    position: sticky;
+    top: 10px;
+  `}
+  height: fit-content;
+  grid-area: viewer;
+  grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
+  grid-template-rows: auto;
+  grid-template-areas: "subject toolbar";
+`
+
 const StyledTaskAreaContainer = styled.div`
   grid-area: task;
 `
@@ -39,19 +51,19 @@ const StyledImageToolbar = styled(ImageToolbar)`
   top: 10px;
 `
 
-export function ViewerGrid({ children }) {
-  return (
-    <Grid
-      as='section'
-      areas={[['subject', 'toolbar']]}
-      columns={['auto', 'clamp(3rem, 10%, 4.5rem)']}
-      gridArea='viewer'
-      height='fit-content'
-      rows={['auto']}
-    >
-      {children}
-    </Grid>
-  )
+const verticalLayout = {
+  areas: [['viewer'], ['task']],
+  columns: ['100%'],
+  gap: 'small',
+  margin: 'none',
+  rows: ['auto', 'auto']
+}
+
+const horizontalLayout = {
+  areas: [['viewer', 'task']],
+  columns: ['auto', '25rem'],
+  gap: 'medium',
+  rows: ['auto']
 }
 
 export default function NoMaxWidth({
@@ -59,19 +71,6 @@ export default function NoMaxWidth({
   separateFramesView = false
 }) {
   const size = useContext(ResponsiveContext)
-  const verticalLayout = {
-    areas: [['viewer'], ['task']],
-    columns: ['100%'],
-    gap: 'small',
-    margin: 'none',
-    rows: ['auto', 'auto']
-  }
-  const horizontalLayout = {
-    areas: [['viewer', 'task']],
-    columns: ['auto', '25rem'],
-    gap: 'medium',
-    rows: ['auto']
-  }
   const containerGridProps =
     size === 'small' ? verticalLayout : horizontalLayout
 
@@ -84,7 +83,7 @@ export default function NoMaxWidth({
           <MetaTools />
         </Box>
       ) : (
-        <ViewerGrid>
+        <ViewerGrid forwardedAs='section' size={size}>
           <Box gridArea='subject'>
             <Banners />
             <SubjectViewer />

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/components/NoMaxWidth/NoMaxWidth.js
@@ -22,15 +22,17 @@ const ContainerGrid = styled(Grid)`
 `
 
 export const ViewerGrid = styled(Grid)`
-  ${props => props.size !== 'small' && css`
-    position: sticky;
-    top: 10px;
-  `}
+  ${props =>
+    props.size !== 'small' &&
+    css`
+      position: sticky;
+      top: 10px;
+    `}
   height: fit-content;
   grid-area: viewer;
   grid-template-columns: auto clamp(3rem, 10%, 4.5rem);
   grid-template-rows: auto;
-  grid-template-areas: "subject toolbar";
+  grid-template-areas: 'subject toolbar';
 `
 
 const StyledTaskAreaContainer = styled.div`
@@ -38,8 +40,12 @@ const StyledTaskAreaContainer = styled.div`
 `
 
 const StyledTaskArea = styled(Box)`
-  position: sticky;
-  top: 10px;
+  ${props =>
+    props.size !== 'small' &&
+    css`
+      position: sticky;
+      top: 10px;
+    `}
 `
 
 const StyledImageToolbarContainer = styled.div`
@@ -95,7 +101,7 @@ export default function NoMaxWidth({
         </ViewerGrid>
       )}
       <StyledTaskAreaContainer>
-        <StyledTaskArea>
+        <StyledTaskArea size={size}>
           <TaskArea />
           {separateFramesView && <FieldGuide />}
         </StyledTaskArea>

--- a/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.js
+++ b/packages/lib-classifier/src/components/Classifier/components/Layout/helpers/getLayout/getLayout.js
@@ -4,7 +4,6 @@ export default function getLayout(layout) {
   if (layouts[layout]) {
     return layouts[layout]
   } else {
-    console.warn(`Couldn't find a layout for '${layout}', falling back to default`)
     return defaultLayout
   }
 }


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Toward: https://github.com/zooniverse/front-end-monorepo/issues/6063

## Describe your changes
- This change is intended to improve volunteer's classifying experience when a workflow has a "tall" task area and landscape oriented subject viewer. For example, when a volunteer clicks "Done" on a survey task, we want them to keep the subject in view rather than forced to scroll up and down the page to complete each classification.
- Added sticky css styling to the ViewerGrid component for NoMaxWidth and MaxWidth layout. MaxWidth layout is the default layout and NoMaxWidth layout is specific to transcription projects.
- The CenteredLayout's task area wasn't being sticky (e.g Daily Minor Planet) especially for separate frames view, so I fixed that. CenteredLayout only applies when a project team configures their workflow to "limit subject height".

## How to Review

A few types of projects to review are below. The full list of FEM projects is [here](https://docs.google.com/spreadsheets/d/1X9345vQ_xNX6BJf9_xwVCQCjxjbWWErGmV7Xe8WpHZo/edit#gid=0).
- [PH TESS](https://local.zooniverse.org:3000/projects/nora-dot-eisner/planet-hunters-tess?env=production&demo=true)
- [Daily Minor Planet](https://local.zooniverse.org:3000/projects/fulsdavid/the-daily-minor-planet/classify/workflow/22354?env=production&demo=true)
- [PRINT](https://local.zooniverse.org:3000/projects/printmigrationnetwork/print?env=production&demo=true)
- [Wildwatch Burrowing Owl](https://local.zooniverse.org:3000/projects/sandiegozooglobal/wildwatch-burrowing-owl?env=production&demo=true)
- [Squirrel Mapper](https://local.zooniverse.org:3000/projects/bcosentino/squirrelmapper?env=production&demo=true)

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## New Feature
- [x] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)