### PR TITLE
Classifier: use Text for field guide anchors

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItemAnchor/FieldGuideItemAnchor.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItemAnchor/FieldGuideItemAnchor.js
@@ -1,9 +1,8 @@
-import { Anchor, Box, Paragraph } from 'grommet'
+import { Anchor, Box, Text } from 'grommet'
 import { observable } from 'mobx'
-import PropTypes from 'prop-types'
+import { object, string} from 'prop-types'
 import { PropTypes as MobXPropTypes } from 'mobx-react'
 import { useCallback } from 'react'
-import { withTheme } from 'styled-components'
 import FieldGuideItemIcon from '../FieldGuideItemIcon'
 
 const defaultIcons = observable.map()
@@ -23,12 +22,10 @@ export function AnchorLabel({
         icon={icon}
         width={100}
       />
-      <Paragraph>{title}</Paragraph>
+      <Text margin={{ vertical: '15px' }}>{title}</Text>
     </Box>
   )
 }
-
-const defaultTheme = { dark: false }
 
 function FieldGuideItemAnchor({
   className = '',
@@ -36,7 +33,6 @@ function FieldGuideItemAnchor({
   item,
   itemIndex,
   onClick,
-  theme = defaultTheme,
   title
 }) {
   const selectItem = useCallback(function (event) {
@@ -45,11 +41,10 @@ function FieldGuideItemAnchor({
   }, [itemIndex, onClick])
 
   const label = <AnchorLabel icons={icons} item={item} title={title} />
-  const anchorColor = theme.dark ? 'light-3' : 'dark-5'
   return (
     <Anchor
       className={className}
-      color={anchorColor}
+      color={{ light: 'dark-5', dark: 'light-3' }}
       href={`#field-guide-item-${itemIndex}`}
       label={label}
       onClick={selectItem}
@@ -58,14 +53,10 @@ function FieldGuideItemAnchor({
 }
 
 FieldGuideItemAnchor.propTypes = {
-  className: PropTypes.string,
+  className: string,
   icons: MobXPropTypes.observableMap,
-  item: PropTypes.object.isRequired,
-  label: PropTypes.string,
-  theme: PropTypes.shape({
-    dark: PropTypes.bool
-  })
+  item: object.isRequired,
+  label: string,
 }
 
-export default withTheme(FieldGuideItemAnchor)
-export { FieldGuideItemAnchor }
+export default FieldGuideItemAnchor

--- a/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItemAnchor/FieldGuideItemAnchor.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/components/FieldGuide/components/FieldGuide/components/FieldGuideItemAnchor/FieldGuideItemAnchor.spec.js
@@ -1,8 +1,8 @@
 import { mount, shallow } from 'enzyme'
 import sinon from 'sinon'
 import { observable, toJS } from 'mobx'
-import { Anchor, Grommet, Paragraph } from 'grommet'
-import { FieldGuideItemAnchor, AnchorLabel } from './FieldGuideItemAnchor'
+import { Anchor, Grommet, Text } from 'grommet'
+import FieldGuideItemAnchor, { AnchorLabel } from './FieldGuideItemAnchor'
 import FieldGuideItemIcon from '../FieldGuideItemIcon'
 import { FieldGuideMediumFactory } from '@test/factories'
 import zooTheme from '@zooniverse/grommet-theme'
@@ -83,7 +83,7 @@ describe('Component > FieldGuideItemAnchor', function () {
           item={item}
           title='Cat'
         />)
-      expect(wrapper.find(Paragraph).contains(item.title)).to.be.true()
+      expect(wrapper.find(Text).contains(item.title)).to.be.true()
     })
 
     it('should render an FieldGuideItemIcon component', function () {


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Follow-up from https://github.com/zooniverse/front-end-monorepo/pull/6007

## Describe your changes
- Use a Text component for field guide anchor labels to reduce the line height and font size. The labels do not need to be paragraphs and their line height is too large at the moment.

## How to Review

- Review the local lib-classifier Field Guide [story](http://localhost:6006/?path=/story/help-resources-field-guide--general) compared to the production [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/story/help-resources-field-guide--general)
- Field guide anchor labels are used in every FEM project - [spreadsheet](https://docs.google.com/spreadsheets/d/1X9345vQ_xNX6BJf9_xwVCQCjxjbWWErGmV7Xe8WpHZo/edit#gid=0)
- I got design approval from Sean in-office 👍 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [x] The PR creator has described the reason for refactoring
- [x] The refactored component(s) continue to work as expected