### PR TITLE
Update breakpoints and brand documentation in lib-grommet-theme

### DIFF
--- a/packages/lib-grommet-theme/src/index.js
+++ b/packages/lib-grommet-theme/src/index.js
@@ -1,6 +1,7 @@
 const deepFreeze = require('deep-freeze')
+// Base Grommet Theme: https://github.com/grommet/grommet/blob/master/src/js/themes/base.js
 
-// Zooniverse brand: https://projects.invisionapp.com/dsm/zooniverse/primary-brand/folder/colors/5bbd0dbcd018e900118186e8
+// Zooniverse brand: https://www.figma.com/proto/HUWCyrjkwgPsGKLXhLGb21/Design-System
 const brand = '#00979d'
 
 // dark colors
@@ -81,7 +82,6 @@ const lightColors = [
   moreMiddleGrey // light-6
 ]
 
-// https://projects.invisionapp.com/dsm/zooniverse/primary-brand/folder/colors/5c68fab7fb26bb001855f29a
 const drawingTools = {
   red: '#FF3C25', // drawing-red
   orange: '#FF9300', // drawing-orange
@@ -149,6 +149,7 @@ Object.keys(statusColors).forEach((color) => {
 
 const theme = deepFreeze({
   global: {
+    // The default Grommet breakpoints are in use; see ResponsiveContext component
     breakpoints: {
       small: {
         edgeSize: {
@@ -161,8 +162,13 @@ const theme = deepFreeze({
           'medium-neg': `-20px`,
           'large-neg': `-25px`,
           'xlarge-neg': `-30px`
-        }
-      }
+        },
+        // value: 768, (viewports <= 768px)
+      },
+      // medium: {
+      //   value: 1536, (768px < viewports <= 1536px)
+      // },
+      // large: {} (viewports > 1536px)
     },
     colors,
     control: {


### PR DESCRIPTION
## Package
lib-grommet-theme

## Describe your changes
- Remove links to Invision (that app is deprecated)
- Add code comments outlining the default Grommet breakpoints that are in use for viewport width

# Checklist
## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected