### PR TITLE
lib-user: Refactor group and membership changes with useSWRMutation

### DIFF
--- a/packages/lib-user/src/components/GroupStats/GroupStats.js
+++ b/packages/lib-user/src/components/GroupStats/GroupStats.js
@@ -128,7 +128,10 @@ function GroupStats({
         titleColor='black'
       >
         <GroupUpdateFormContainer
+          adminMode={adminMode}
+          authUserId={authUser?.id}
           group={group}
+          handleGroupModalActive={handleGroupModalActive}
           login={authUser?.login}
         >
           <MembersList

--- a/packages/lib-user/src/components/GroupStats/GroupStatsContainer.js
+++ b/packages/lib-user/src/components/GroupStats/GroupStatsContainer.js
@@ -26,7 +26,7 @@ function deleteJoinTokenParam() {
 }
 
 function GroupStatsContainer({
-  adminMode,
+  adminMode = false,
   authUser,
   groupId,
   joinToken

--- a/packages/lib-user/src/hooks/usePanoptesMemberships.js
+++ b/packages/lib-user/src/hooks/usePanoptesMemberships.js
@@ -3,8 +3,6 @@ import { panoptes } from '@zooniverse/panoptes-js'
 import auth from 'panoptes-client/lib/auth'
 import useSWR from 'swr'
 
-const endpoint = '/memberships'
-
 const isBrowser = typeof window !== 'undefined'
 
 const SWROptions = {
@@ -25,7 +23,7 @@ async function fetchMemberships({ query }) {
   if (!token) return null 
 
   try {
-    const { body } = await panoptes.get(endpoint, query, { authorization })
+    const { body } = await panoptes.get('/memberships', query, { authorization })
     return body
   } catch (error) {
     console.log(error)
@@ -36,6 +34,6 @@ async function fetchMemberships({ query }) {
 export function usePanoptesMemberships({ authUserId, joinStatus = null, query }) {
   const joinStatusSuccess = joinStatus === asyncStates.success
 
-  const key = (query.user_id || query.user_group_id) && authUserId ? { endpoint, query, joinStatusSuccess } : null
+  const key = (query.user_id || query.user_group_id) && authUserId ? { query, joinStatusSuccess } : null
   return useSWR(key, fetchMemberships, SWROptions)
 }

--- a/packages/lib-user/src/utils/deletePanoptesMembership.js
+++ b/packages/lib-user/src/utils/deletePanoptesMembership.js
@@ -1,8 +1,10 @@
 import { panoptes } from '@zooniverse/panoptes-js'
 import auth from 'panoptes-client/lib/auth'
 
-export async function deletePanoptesMembership({
-  membershipId
+export async function deletePanoptesMembership(key, {
+  arg: {
+    membershipId
+  }
 }) {
   const token = await auth.checkBearerToken()
   const authorization = `Bearer ${token}`

--- a/packages/lib-user/src/utils/updatePanoptesMembership.js
+++ b/packages/lib-user/src/utils/updatePanoptesMembership.js
@@ -1,9 +1,11 @@
 import { panoptes } from '@zooniverse/panoptes-js'
 import auth from 'panoptes-client/lib/auth'
 
-export async function updatePanoptesMembership({
-  membershipId,
-  data
+export async function updatePanoptesMembership(key, {
+  arg: {
+    membershipId,
+    data
+  }
 }) {
   const token = await auth.checkBearerToken()
   const authorization = `Bearer ${token}`
@@ -22,7 +24,9 @@ export async function updatePanoptesMembership({
         { memberships: data },
         headers
       )
-    return response
+    
+    const updatedMembership = response?.body?.memberships[0]
+    return updatedMembership
   } catch (error) {
     console.error(error)
     throw error

--- a/packages/lib-user/src/utils/updatePanoptesUserGroup.js
+++ b/packages/lib-user/src/utils/updatePanoptesUserGroup.js
@@ -1,9 +1,11 @@
 import { panoptes } from '@zooniverse/panoptes-js'
 import auth from 'panoptes-client/lib/auth'
 
-export async function updatePanoptesUserGroup({
-  groupId,
-  data
+export async function updatePanoptesUserGroup(key, {
+  arg: {
+    groupId,
+    data
+  }
 }) {
   const token = await auth.checkBearerToken()
   const authorization = `Bearer ${token}`
@@ -17,12 +19,14 @@ export async function updatePanoptesUserGroup({
   }
   
   try {
-    const response = await panoptes
+    const { body } = await panoptes
       .put(`/user_groups/${groupId}`,
         { user_groups: data },
         headers
       )
-    return response
+    const { user_groups } = body
+    const user_group = user_groups?.[0]
+    return user_group
   } catch (error) {
     console.error(error)
     throw error


### PR DESCRIPTION
## Package
- lib-user

## Linked Issue and/or Talk Post
- this PR comment - https://github.com/zooniverse/front-end-monorepo/pull/6100#discussion_r1624490539

## Describe your changes
- refactor group update with useSWRMutation
- refactor membership delete with useSWRMutation
- refactor membership update with useSWRMutation

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected