### PR TITLE
lib-user: Refactor usePanoptesProjects hook with auth, update usage accordingly

### DIFF
--- a/packages/lib-user/src/components/Certificate/CertificateContainer.js
+++ b/packages/lib-user/src/components/Certificate/CertificateContainer.js
@@ -44,12 +44,15 @@ function CertificateContainer({
   })
 
   // fetch projects, if selectedProject is not 'AllProjects'
-  const projectIds = selectedProject !== 'AllProjects' ? [selectedProject] : null
+  const projectId = selectedProject !== 'AllProjects' ? selectedProject : null
   const {
     data: projects,
     error: projectsError,
     isLoading: projectsLoading
-  } = usePanoptesProjects(projectIds)
+  } = usePanoptesProjects({
+    cards: true,
+    id: projectId
+  })
   
   const hours = convertStatsSecondsToHours(stats?.time_spent)
   const projectsCount = stats?.project_contributions?.length || 0

--- a/packages/lib-user/src/components/Contributors/Contributors.js
+++ b/packages/lib-user/src/components/Contributors/Contributors.js
@@ -70,7 +70,11 @@ function Contributors({
     data: projects,
     error: projectsError,
     isLoading: projectsLoading
-  } = usePanoptesProjects(projectIds)
+  } = usePanoptesProjects({
+    cards: true,
+    id: projectIds?.join(','),
+    page_size: 100
+  })
 
   // combine member stats with user data
   let contributors = []

--- a/packages/lib-user/src/components/GroupStats/GroupStats.js
+++ b/packages/lib-user/src/components/GroupStats/GroupStats.js
@@ -90,13 +90,17 @@ function GroupStats({
   })
   
   // fetch projects
-  const projectIDs = allProjectsStats?.project_contributions?.map(project => project.project_id)
+  const projectIds = allProjectsStats?.project_contributions?.map(project => project.project_id)
 
   const {
     data: projects,
     error: projectsError,
     isLoading: projectsLoading
-  } = usePanoptesProjects(projectIDs)
+  } = usePanoptesProjects({
+    cards: true,
+    id: projectIds?.join(','),
+    page_size: 100
+  })
 
   function handleGroupModalActive () {
     setGroupModalActive(!groupModalActive)

--- a/packages/lib-user/src/components/UserStats/UserStatsContainer.js
+++ b/packages/lib-user/src/components/UserStats/UserStatsContainer.js
@@ -66,13 +66,17 @@ function UserStatsContainer({
   })
   
   // fetch projects
-  const projectIDs = allProjectsStats?.project_contributions?.map(project => project.project_id)
+  const projectIds = allProjectsStats?.project_contributions?.map(project => project.project_id)
   
   const {
     data: projects,
     error: projectsError,
     isLoading: projectsLoading
-  } = usePanoptesProjects(projectIDs)
+  } = usePanoptesProjects({
+    cards: true,
+    id: projectIds?.join(','),
+    page_size: 100
+  })
 
   function handleDateRangeSelect (dateRange) {
     setSelectedDateRange(dateRange.value)

--- a/packages/lib-user/src/hooks/usePanoptesProjects.js
+++ b/packages/lib-user/src/hooks/usePanoptesProjects.js
@@ -1,5 +1,8 @@
 import { projects as panoptesProjects } from '@zooniverse/panoptes-js'
+import auth from 'panoptes-client/lib/auth'
 import useSWR from 'swr'
+
+const isBrowser = typeof window !== 'undefined'
 
 const SWROptions = {
   revalidateIfStale: true,
@@ -9,17 +12,28 @@ const SWROptions = {
   refreshInterval: 0
 }
 
-async function fetchProjects(id) {
+if (isBrowser) {
+  auth.checkCurrent()
+}
+
+async function fetchProjects(query) {
+  let token = await auth.checkBearerToken()
+  if (!token) {
+    await auth.checkCurrent()
+    token = await auth.checkBearerToken()
+  }
+  const authorization = `Bearer ${token}`
+
   let projectsAccumulator = []
   
   async function getProjects (page = 1) {
-    const query = {
-      cards: true,
-      id,
-      page,
-      page_size: 100
-    }
-    const response = await panoptesProjects.get({ query })
+    const response = await panoptesProjects.get({
+      query: {
+        page,
+        ...query
+      },
+      authorization
+    })
     const { meta, projects } = response?.body || {}
 
     if (meta?.projects?.page_count > 5) {
@@ -42,11 +56,10 @@ async function fetchProjects(id) {
   return projectsAccumulator
 }
 
-export function usePanoptesProjects(projectIds) {
+export function usePanoptesProjects(query) {
   let key = null
-  if (projectIds) {
-    const id = projectIds.join(',')
-    key = id
+  if (query?.id) {
+    key = query
   }
   return useSWR(key, fetchProjects, SWROptions)
 }

--- a/packages/lib-user/src/hooks/usePanoptesProjects.js
+++ b/packages/lib-user/src/hooks/usePanoptesProjects.js
@@ -22,7 +22,7 @@ async function fetchProjects(query) {
     await auth.checkCurrent()
     token = await auth.checkBearerToken()
   }
-  const authorization = `Bearer ${token}`
+  const authorization = token ? `Bearer ${token}` : undefined
 
   let projectsAccumulator = []
   


### PR DESCRIPTION
## Package
- lib-user

## Linked Issue and/or Talk Post
- if a user made a classification on a private or development project then the related recent or project_preference would cause an error on the logged-in homepage when the previous `usePanotpesProjects` hook would return a list of projects that would not include the private or development project 

## Describe your changes
- adds auth to `usePanoptesProjects` so private or development projects will be returned
- adds filters and slices to prevent RecentProjects and RecentSubjects errors
- refactors UserStats, Certificate, GroupStats, and Contributors components use of `usePanoptesProjects`

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a
- What user actions should my reviewer step through to review this PR?
  - reproduce bug: if your logged-in homepage (https://fe-root.preview.zooniverse.org/) loads, then classify on the following projects (might have to enable admin) to reproduce the crash:
    - https://www.zooniverse.org/projects/markbouslog/orgstatstest3/classify
    - https://www.zooniverse.org/projects/markbouslog/project-2024/classify
  - confirm bug fixed: from app-root, run `yarn build` and `yarn start`
    - check https://local.zooniverse.org:3000/ - confirm no crash, page loads 🤞 
    - note user stats, certificate, groups stats, and contributors pages load as expected, signed-in
    - note a public group still loads projects as expected, signed-out - https://local.zooniverse.org:3000/groups/2620016
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? see linked GitHub project

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated