### PR TITLE
lib-user: fix RecentSubjects projectSlug variable

### DIFF
--- a/packages/lib-user/src/components/UserHome/components/RecentSubjects/RecentSubjects.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentSubjects/RecentSubjects.js
@@ -60,7 +60,7 @@ function RecentSubjects({
                     size={size}
                     subjectID={recent?.links.subject}
                     mediaSrc={subjectMedia?.[0]}
-                    projectSlug={recent?.project_slug}
+                    projectSlug={recent?.projectSlug}
                   />
                 </li>
               )


### PR DESCRIPTION
## Package
-lib-user

## Describe your changes
- rename `project_slug` to `projectSlug` to match the actual property of the object per [RecentSubjectContainer here](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-user/src/components/UserHome/components/RecentSubjects/RecentSubjectsContainer.js#L57)

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What user actions should my reviewer step through to review this PR?
  - go to logged-in homepage, note recent subjects now have expected/correct url
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated