### PR TITLE
Classifier README updates

### DIFF
--- a/packages/lib-classifier/README.md
+++ b/packages/lib-classifier/README.md
@@ -1,6 +1,41 @@
 # Zooniverse Classifier
 
-A standalone library for the Zooniverse project classifier, including state management and UI component views.
+A standalone library for the Zooniverse Project Classifier. The `Classifier` is comprised of three major pieces - the [SubjectViewer](/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/README.md), the [Tasks](/packages/lib-classifier/src/plugins/tasks/README.md), and the [Store](/packages/lib-classifier/src/store/README.md).
+
+```mermaid
+flowchart TD
+    Classifier-->SubjectViewer
+    Classifier-->TaskArea
+    Classifier-->RootStore
+```
+
+- `SubjectViewer` is responsible for subject interaction and display
+- `Tasks` are responsible for describing the type of data that the research team collects for a given `subject`.
+- `Store` is responsible for managing the application state throughout the classification process.
+
+## Classifier Render Process
+
+The render process starts with a [Layout](/packages/lib-classifier/src/components/Classifier/components/Layout/README.md) that determines which components get loaded. The components that are loaded within the `Layout` but aren't related directly to the `SubjectViewer`, `Tasks`, or `Store` are as follows:
+
+- [Banners](/packages/lib-classifier/src/components/Classifier/components/Banners/README.md)
+- Feedback
+- [ImageToolbar](/packages/lib-classifier/src/components/Classifier/components/ImageToolbar/README.md)
+- MetaTools
+- [QuickTalk](/packages/lib-classifier/src/components/Classifier/components/QuickTalk/README.md)
+
+```mermaid
+flowchart TB
+	Layout-->SubjectViewer
+	Layout-->TaskArea
+	Layout-->ImageToolbar
+	Layout-->Banners
+	Layout-->Feedback
+	Layout-->MetaTools
+	Layout-->QuickTalk
+```
+
+## Classifier Hooks
+[Hooks](/packages/lib-classifier/src/hooks/README.md) are a collection of utility functions for the `Classifier`.
 
 ## Contributing
 

--- a/packages/lib-classifier/README.md
+++ b/packages/lib-classifier/README.md
@@ -5,13 +5,13 @@ A standalone library for the Zooniverse Project Classifier. The `Classifier` is 
 ```mermaid
 flowchart TD
     Classifier-->SubjectViewer
-    Classifier-->TaskArea
-    Classifier-->RootStore
+    Classifier-->Tasks
+    Classifier-->Store
 ```
 
 - `SubjectViewer` is responsible for subject interaction and display
-- `Tasks` are responsible for describing the type of data that the research team collects for a given `subject`.
-- `Store` is responsible for managing the application state throughout the classification process.
+- `Tasks` are responsible for describing the type of data that the research team collects for a given `subject`. These get rendered in the `TaskArea` component.
+- `Store` is responsible for managing the application state throughout the classification process. The store is initiated and setup within the `RootStore` file.
 
 ## Classifier Render Process
 
@@ -26,7 +26,7 @@ The render process starts with a [Layout](/packages/lib-classifier/src/component
 ```mermaid
 flowchart TB
 	Layout-->SubjectViewer
-	Layout-->TaskArea
+	Layout-->Tasks
 	Layout-->ImageToolbar
 	Layout-->Banners
 	Layout-->Feedback

--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/README.md
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/README.md
@@ -27,6 +27,8 @@ A subject viewer is a component designed to render the media of a subject and an
 
 - [`VariableStarViewer`](components/VariableStarViewer/README.md) - renders JSON and an image media file for a composite of two scatter plots, two bar charts, and an image. Supports pan and zoom for each scatter plot independently as well as project specific interactive tools for the scatter plots.
 - [`DataImageViewer`](components/DataImageViewer/README.md) - renders JSON as a scatter plot and an image media file side by side. Supports pan and zoom for the scatter plot and image independently.
+- [`FlipbookViewer`](components/FlipbookViewer/README.md) - renders subjects with multiple images one image at a time using the `SingleImageViewer`. 
+- [`SeparateFramesViewer`](components/SeparateFramesViewer/README.md) - renders subjects with multiple images all at the same time using the `SingleImageViewer` for each image. Must use the `FlipbookViewer` first to enable separate frames.
 - [`SubjectGroupViewer`](components/SubjectGroupViewer/README.md) - renders a group of subjects each with their own single image media file. This is meant to only work with the subject group comparison task. Supports pan and zoom for all subjects simultaneously as well as some configurations for rendering.
 - [`ImageAndTextViewer`](components/ImageAndTextViewer/README.md) - renders a single image or a single text media file, with a toggle to switch between which media file is displayed.
 

--- a/packages/lib-classifier/src/plugins/tasks/readme.md
+++ b/packages/lib-classifier/src/plugins/tasks/readme.md
@@ -1,5 +1,51 @@
-# Classifier tasks
-## Importing tasks
+# Classifier Tasks
+
+Tasks are the individual steps in a workflow that are used to collect data for an individual subject. The currently supported tasks are listed below:
+
+- [Highlighter](/packages/lib-classifier/src/plugins/tasks/experimental/highlighter/README.md)
+- [Simple Dropdown](/packages/lib-classifier/src/plugins/tasks/dropdown-simple/README.md)
+- [Subject Group Comparison](/packages/lib-classifier/src/plugins/tasks/subjectGroupComparison/README.md)
+- [Text from Subject](/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/README.md)
+- [Transcription](/packages/lib-classifier/src/plugins/tasks/experimental/transcription/README.md)
+- [Drawing](/packages/lib-classifier/src/plugins/drawingTools/README.md)
+
+** Note: Drawing tasks can be subdivided into Drawing Tools with corresponding `model`, `component`, and `annotation` models. There are some special cases called out with their own documentation.
+- [Circle](/packages/lib-classifier/src/plugins/drawingTools/components/Circle/README.md)
+- [Polygon](/packages/lib-classifier/src/plugins/drawingTools/components/Polygon/README.md)
+- [FreehandLine](/packages/lib-classifier/src/plugins/drawingTools/experimental/components/FreehandLine/README.md)
+
+## Task Structure
+
+Every task has the same general structure:
+
+```mermaid
+flowchart TB
+	Task
+	Task---TaskComponent
+	Task---TaskModel
+	Task---AnnotationModel
+```
+
+## Adding a New Task
+- create a new directory under `tasks` for your task.
+- export a view component and task and annotation models.
+```js
+import { default as TaskComponent } from './components/MyNewTask'
+import { default as TaskModel } from './models/MyNewTask'
+import { default as AnnotationModel } from './models/MyNewAnnotation'
+
+export default {
+	TaskComponent,
+	TaskModel,
+	AnnotationModel
+}
+```
+- export your task from `tasks/index.js`, using the task type as the named export.
+```js
+	export { default as myNewTask } from './myNewTask'
+```
+
+## Importing Tasks
 
 ```js
 import * as tasks from '@plugins/tasks'
@@ -16,25 +62,6 @@ The default tasks export is a simple map of unique task types (`single`, `multip
   - `taskRegistry.get(type (string))`: return the `Task` for `type`, or an empty object.
   - `taskRegistry.values(property ('TaskComponent|TaskModel|AnnotationModel'))`: return all registered Tasks. Specify an optional property to return an array of only those properties eg. `const annotationModels = taskRegistry.values('AnnotationModel')`.
   
-## Adding a new task
-  - create a new directory under `tasks` for your task.
-  - export a view component and task and annotation models.
-  ```js
-  import { default as TaskComponent } from './components/MyNewTask'
-  import { default as TaskModel } from './models/MyNewTask'
-  import { default as AnnotationModel } from './models/MyNewAnnotation'
-  
-  export default {
-    TaskComponent,
-    TaskModel,
-    AnnotationModel
-  }
-  ```
-  - export your task from `tasks/index.js`, using the task type as the named export.
-  ```js
-    export { default as myNewTask } from './myNewTask'
-  ```
-
 ## React Components
 
 A React component for a task takes a Task model and renders it as HTML. The basic shape is:
@@ -48,7 +75,7 @@ const SingleChoiceTask = tasks.single.TaskComponent
  - _task_ is the task model to render.
  - _disabled_ should be set if the task is disabled eg. while waiting for a subject to load.
 
-## Task models
+## Task Models
 
 ```js
 import * as tasks from '@plugins/tasks'
@@ -75,7 +102,7 @@ Tasks may implement the following actions to hook into the workflow classificati
 - _complete(annotation)_ Runs when exiting a step task by pressing Next or Done.
 - _validate_ Runs when exiting a step task by pressing Next or Done. Intended for annotation validation, but could be used for any kind of validation if it must run on step Next or Done. Drawing task deletes invalid tool marks when this is called.
 
-## Annotation models
+## Annotation Models
 
 ```js
 import * as tasks from '@plugins/tasks'

--- a/packages/lib-classifier/src/plugins/tasks/readme.md
+++ b/packages/lib-classifier/src/plugins/tasks/readme.md
@@ -2,12 +2,16 @@
 
 Tasks are the individual steps in a workflow that are used to collect data for an individual subject. The currently supported tasks are listed below:
 
+- Data Vis
+- [Drawing](/packages/lib-classifier/src/plugins/drawingTools/README.md)
 - [Highlighter](/packages/lib-classifier/src/plugins/tasks/experimental/highlighter/README.md)
-- [Simple Dropdown](/packages/lib-classifier/src/plugins/tasks/dropdown-simple/README.md)
+- Multiple Answer Question
+- Single Answer Question
 - [Subject Group Comparison](/packages/lib-classifier/src/plugins/tasks/subjectGroupComparison/README.md)
+- [Simple Dropdown](/packages/lib-classifier/src/plugins/tasks/dropdown-simple/README.md)
+- Survey
 - [Text from Subject](/packages/lib-classifier/src/plugins/tasks/experimental/textFromSubject/README.md)
 - [Transcription](/packages/lib-classifier/src/plugins/tasks/experimental/transcription/README.md)
-- [Drawing](/packages/lib-classifier/src/plugins/drawingTools/README.md)
 
 ** Note: Drawing tasks can be subdivided into Drawing Tools with corresponding `model`, `component`, and `annotation` models. There are some special cases called out with their own documentation.
 - [Circle](/packages/lib-classifier/src/plugins/drawingTools/components/Circle/README.md)

--- a/packages/lib-classifier/src/store/README.md
+++ b/packages/lib-classifier/src/store/README.md
@@ -7,6 +7,52 @@ The classifier store is built upon [mobx-state-tree](https://mobx-state-tree.js.
 - snapshotting for caching, time travelling, logging, etc
 - observability and reactivity
 
+## Store Architecture
+The `RootStore` is the base model for the classifier, and is a hierarchically flat key-value mapping of `{ [typeStore]: [typeStore]() }` to make referencing between related stores easier. The `RootStore` is composed of the following stores:
+
+- ClassificationStore
+- FeedbackStore
+- FieldGuideStore
+- ProjectStore
+- SubjectStore
+- SubjectSetStore
+- SubjectViewerStore
+- TutorialStore
+- UserProjectPreferences
+- WorkflowStore
+- WorkflowStepStore
+
+Although the `RootStore` state is managed in a flat hierarchy, the data model of a `Project` in relation to a user's `Classification` is hierarchical with its dependency graph as follows:
+
+```mermaid
+flowchart LR
+	Project
+	Project-->Feedback
+	Project-->FieldGuide
+	Project-->SubjectSet
+	Project-->Workflow
+	Project-->Tutorial
+
+	SubjectSet-->Subject
+	SubjectSet-->Workflow
+	Tutorial-->Workflow
+
+	Subject-->Annotation
+	Workflow-->WorkflowStep
+	WorkflowStep-->Annotation
+	Annotation-->Classification
+```
+
+## Stores with Documentation
+- [Feedback](/packages/lib-classifier/src/store/feedback/README.md)
+- [SubjectGroup](/packages/lib-classifier/src/store/subjects/SubjectGroup/README.md)
+- [SubjectViewerStore](/packages/lib-classifier/src/store/SubjectViewerStore/README.md)
+
+## Utilities
+- [Utilities](/packages/lib-classifier/src/store/utils/README.md)
+- [Translations](/packages/lib-classifier/src/translations/README.md)
+- [Workers](/packages/lib-classifier/src/workers/README.md)
+
 ## Panoptes resources
 
 We mostly work with Panoptes resources, so we have a standardized model to work with them. The `Resource` model defines the baseline model for Panoptes resources defining the resource id as the unique identifier to use in the tree. The `ResourceStore` model defines set of actions that can be used to asynchronously HTTP request and store the result of the request. Every Panoptes resource we request for should be a composition with the `ResourceStore`.

--- a/packages/lib-classifier/src/store/feedback/README.md
+++ b/packages/lib-classifier/src/store/feedback/README.md
@@ -40,10 +40,11 @@ Note: lab components are currently part of [Panoptes-Front-End](https://github.c
 
 ## Strategies
 
-A strategy is the method for reconciling a user's annotations and the known data defined on the subject. The following strategies are available:
+A [strategy](strategies/README.md) is the method for reconciling a user's annotations and the known data defined on the subject. The following strategies are available:
 
 ### Drawing Task
 
+- [Column](strategies/drawing/column/README.md)
 - [Radial](strategies/drawing/radial/README.md)
 
 ### Question Task


### PR DESCRIPTION
## Packages

lib-classifier

## Describe your changes

The purpose of this Classifier Documentation PR is to link together all of the existing README’s in the Classifier and to provide some visual/overarching sense of the code architecture and underlying data models that tie together the Classifier. Because this has no effect on the underlying code, this can be merged in without testing / other deployment-oriented concerns.

### Main README
- Updated to give more of an overview of what the Classifier is and the underlying concepts that create the classifier
- Add some Mermaid diagrams to visualize the relationship between the SubjectViewer, TaskArea, and RootStore
- Describe the Render process with links to other Classifier documentation
- Add link to the Hooks Readme so they are not orphaned

### SubjectViewer README
- Add links to the FlipbookViewer and SeparateFramesViewer

### Tasks README
- Created a more robust explanation of Tasks with links to those Tasks that have documentation
- Added Mermaid diagram to explain the conceptual structure of a Task

### Store README
- Updated main README with a stronger conceptual explanation of the data models used
- Added dependency graph on the Models to explain how we translate the underlying Panoptes data structure into what’s usable by the Classifier
- Add links to other Stores and Utilities

### Store Feedback README
- Added link to the Strategies README and the Column Drawing Task README
