### PR TITLE
Community section styling updates

### DIFF
--- a/packages/lib-content/src/components/Article/Article.js
+++ b/packages/lib-content/src/components/Article/Article.js
@@ -1,4 +1,4 @@
-import { Anchor, Box, Heading, Image, Paragraph, Text } from 'grommet'
+import { Anchor, Box, Heading, Paragraph } from 'grommet'
 import { string } from 'prop-types'
 import { useTranslation } from '../../translations/i18n.js'
 import styled from 'styled-components'
@@ -54,12 +54,18 @@ export default function Article({
           weight='bold'
           fill
         >
-          {title}
+          <Anchor href={url}>{title}</Anchor>
         </Heading>
         <StyledParagraph color={{ light: 'black', dark: 'white' }}>
           {excerpt}
         </StyledParagraph>
-        <Anchor href={url} size='1rem'>
+        <Anchor
+          href={url}
+          size='1rem'
+          alignSelf='end'
+          color={{ light: 'dark-5', dark: 'white' }}
+          weight='normal'
+        >
           {t('Article.url')}
         </Anchor>
       </Box>

--- a/packages/lib-content/src/screens/Home/Community/Community.js
+++ b/packages/lib-content/src/screens/Home/Community/Community.js
@@ -50,7 +50,12 @@ export default function Community({ dailyZooPosts = [], zooBlogPosts = [] }) {
         <Heading level={3} size='1rem'>
           {t('Home.Community.feedOne')}
         </Heading>
-        <Anchor href='https://daily.zooniverse.org' size='1rem'>
+        <Anchor
+          href='https://daily.zooniverse.org'
+          size='1rem'
+          weight='normal'
+          color={{ light: 'dark-5', dark: 'white' }}
+        >
           {t('Home.Community.seeAll')}
         </Anchor>
       </Box>
@@ -62,18 +67,25 @@ export default function Community({ dailyZooPosts = [], zooBlogPosts = [] }) {
 
       {/* The Zooniverse Blog */}
       <Box
+        border={{
+          side: 'bottom',
+          color: { light: 'light-4', dark: 'black' },
+          size: 'xsmall'
+        }}
         direction='row'
         justify='between'
         align='center'
-        border={{
-          position: 'bottom',
-          color: { light: 'light-1', dark: 'dark-1' }
-        }}
+        margin={{ vertical: 'small' }}
       >
         <Heading level={3} size='1rem'>
           {t('Home.Community.feedTwo')}
         </Heading>
-        <Anchor href='https://blog.zooniverse.org' size='1rem'>
+        <Anchor
+          href='https://blog.zooniverse.org'
+          size='1rem'
+          weight='normal'
+          color={{ light: 'dark-5', dark: 'white' }}
+        >
           {t('Home.Community.seeAll')}
         </Anchor>
       </Box>


### PR DESCRIPTION
## Package
lib-content

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/6152

## Describe your changes
- Blog post titles link out
- 'See all posts' and 'Read more' links  de-bolded and grey
- 'Read more' links right-aligned
- 'The Zooniverse Blog' header styling fixed

## How to Review

- Article and Community components are in lib-content's Storybook
- Run app-root locally and visit the homepage signed-out or signed-in

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser
