### PR TITLE
lib-user: Refactor BarChart and getCompleteData to show x-axis labels as intended

### DIFF
--- a/packages/lib-user/src/components/shared/BarChart/BarChart.js
+++ b/packages/lib-user/src/components/shared/BarChart/BarChart.js
@@ -105,10 +105,10 @@ function BarChart({
         {
           property: 'period',
           label: dateRangeLabel.countLabel,
-          render: ((period, datam, dataIndex) => {
+          render: ((period, datum, datumIndex) => {
             const date = new Date(period)
 
-            if (xAxisFrequency === X_AXIS_FREQUENCY.everyOther && datam?.index % 2 !== 0) {
+            if (xAxisFrequency === X_AXIS_FREQUENCY.everyOther && datum?.index % 2 !== 0) {
               return (
                 <Text
                   className='hidden-period-label'
@@ -118,7 +118,7 @@ function BarChart({
                   {date.toLocaleDateString('en-US', dateRangeLabel.tLDS)}
                 </Text>
               )
-            } else if (xAxisFrequency === X_AXIS_FREQUENCY.everyFourth && datam?.index % 4 !== 0) {
+            } else if (xAxisFrequency === X_AXIS_FREQUENCY.everyFourth && datum?.index % 4 !== 0) {
               return (
                 <Text
                   className='hidden-period-label'

--- a/packages/lib-user/src/components/shared/BarChart/BarChart.js
+++ b/packages/lib-user/src/components/shared/BarChart/BarChart.js
@@ -1,6 +1,7 @@
 import { DataChart, ResponsiveContext, Text } from 'grommet'
 import { arrayOf, func, number, shape, string } from 'prop-types'
 import { useContext } from 'react'
+import styled from 'styled-components'
 
 import {
   getDateInterval as defaultGetDateInterval
@@ -8,6 +9,22 @@ import {
 
 import { getCompleteData as defaultGetCompleteData } from './helpers/getCompleteData'
 import getDateRangeLabel from './helpers/getDateRangeLabel'
+
+const TYPE_LABEL = {
+  count: 'Classifications',
+  session_time: 'Time'
+}
+
+const X_AXIS_FREQUENCY = {
+  everyOther: 'everyOther',
+  everyFourth: 'everyFourth'
+}
+
+const StyledDataChart = styled(DataChart)`
+  .hidden-period-label {
+    display: none;
+  }
+`
 
 function BarChart({
   data = [],
@@ -26,7 +43,7 @@ function BarChart({
   const completeData = getCompleteData({ data, dateInterval })
   
   const dateRangeLabel = getDateRangeLabel(dateInterval)
-  const typeLabel = type === 'count' ? 'Classifications' : 'Time'
+  const typeLabel = TYPE_LABEL[type]
   
   // with no data set gradient as 'brand'
   let gradient = 'brand'
@@ -47,10 +64,19 @@ function BarChart({
     type: 'bar'
   }
 
+  let xAxisFrequency
+  if (completeData.length > 12 && completeData.length < 25) {
+    xAxisFrequency = X_AXIS_FREQUENCY.everyOther
+  } else if (completeData.length > 24) {
+    xAxisFrequency = X_AXIS_FREQUENCY.everyFourth
+  }
+
   if (size !== 'small' && completeData.length < 9) {
     chartOptions.thickness = 'xlarge'
   }
   if (size === 'small') {
+    xAxisFrequency = xAxisFrequency || X_AXIS_FREQUENCY.everyOther
+
     if (completeData.length < 12) {
       chartOptions.thickness = 'small'
     } else if (completeData.length > 11 && completeData.length < 19) {
@@ -60,17 +86,11 @@ function BarChart({
     }
   }
 
-  // set x axis granularity based on data length
-  let xAxisGranularity = 'fine'
-  if (completeData.length > 12) {
-    xAxisGranularity = 'medium'
-  }
-
   return (
-    <DataChart
+    <StyledDataChart
       a11yTitle={`Bar chart of ${typeLabel} by ${dateRangeLabel.countLabel} from ${dateRange.startDate} to ${dateRange.endDate}`}
       axis={{
-        x: { granularity: xAxisGranularity, property: 'period' },
+        x: { granularity: 'fine', property: 'period' },
         y: { granularity: 'fine', property: type },
       }}
       chart={chartOptions}
@@ -85,14 +105,40 @@ function BarChart({
         {
           property: 'period',
           label: dateRangeLabel.countLabel,
-          render: (period) => {
+          render: ((period, datam, dataIndex) => {
             const date = new Date(period)
-            return (
-              <Text data-testid='periodLabel' textAlign='center'>
-                {date.toLocaleDateString('en-US', dateRangeLabel.tLDS)}
-              </Text>
-            )
-          },
+
+            if (xAxisFrequency === X_AXIS_FREQUENCY.everyOther && datam?.index % 2 !== 0) {
+              return (
+                <Text
+                  className='hidden-period-label'
+                  data-testid='periodLabel'
+                  textAlign='center'
+                >
+                  {date.toLocaleDateString('en-US', dateRangeLabel.tLDS)}
+                </Text>
+              )
+            } else if (xAxisFrequency === X_AXIS_FREQUENCY.everyFourth && datam?.index % 4 !== 0) {
+              return (
+                <Text
+                  className='hidden-period-label'
+                  data-testid='periodLabel'
+                  textAlign='center'
+                >
+                  {date.toLocaleDateString('en-US', dateRangeLabel.tLDS)}
+                </Text>
+              )
+            } else {
+              return (
+                <Text
+                  data-testid='periodLabel'
+                  textAlign='center'
+                >
+                  {date.toLocaleDateString('en-US', dateRangeLabel.tLDS)}
+                </Text>
+              )
+            }
+          }),
         },
         {
           property: type,

--- a/packages/lib-user/src/components/shared/BarChart/BarChart.spec.js
+++ b/packages/lib-user/src/components/shared/BarChart/BarChart.spec.js
@@ -38,7 +38,14 @@ describe('components > shared > BarChart', function () {
     it('should show the expected number of period labels', function () {
       render(<Last30DaysHoursStory />)
       
-      expect(screen.getAllByTestId('periodLabel')).to.have.lengthOf(2)
+      const periodLabels = screen.getAllByTestId('periodLabel')
+      const visiblePeriodLabels = periodLabels.filter(periodLabel => {
+        const className = periodLabel.className
+        return !className.includes('hidden-period-label')
+      })
+
+      // every fourth day within 30 days would be 8 days
+      expect(visiblePeriodLabels).to.have.lengthOf(8)
     })
   })
   

--- a/packages/lib-user/src/components/shared/BarChart/BarChart.stories.js
+++ b/packages/lib-user/src/components/shared/BarChart/BarChart.stories.js
@@ -42,7 +42,10 @@ export const Last7Days = {
       startDate: last7days[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return last7days
+      return last7days.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: last7days[last7days.length - 1]?.period.substring(0, 10),
@@ -60,7 +63,10 @@ export const Last7DaysHours = {
       startDate: last7days[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return last7days
+      return last7days.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: last7days[last7days.length - 1]?.period.substring(0, 10),
@@ -79,7 +85,10 @@ export const Last30Days = {
       startDate: last30days[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return last30days
+      return last30days.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: last30days[last30days.length - 1]?.period.substring(0, 10),
@@ -97,7 +106,10 @@ export const Last30DaysHours = {
       startDate: last30days[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return last30days
+      return last30days.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: last30days[last30days.length - 1]?.period.substring(0, 10),
@@ -116,7 +128,10 @@ export const ThisMonth = {
       startDate: thisMonth[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return thisMonth
+      return thisMonth.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: thisMonth[thisMonth.length - 1]?.period.substring(0, 10),
@@ -134,7 +149,10 @@ export const ThisMonthHours = {
       startDate: thisMonth[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return thisMonth
+      return thisMonth.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: thisMonth[thisMonth.length - 1]?.period.substring(0, 10),
@@ -153,7 +171,10 @@ export const Last3Months = {
       startDate: last3months[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return last3months
+      return last3months.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: last3months[last3months.length - 1]?.period.substring(0, 10),
@@ -171,7 +192,10 @@ export const Last3MonthsHours = {
       startDate: last3months[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return last3months
+      return last3months.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: last3months[last3months.length - 1]?.period.substring(0, 10),
@@ -190,7 +214,10 @@ export const ThisYearLessThan6Months = {
       startDate: thisYearLessThan6Months[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return thisYearLessThan6Months
+      return thisYearLessThan6Months.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: thisYearLessThan6Months[thisYearLessThan6Months.length - 1]?.period.substring(0, 10),
@@ -208,7 +235,10 @@ export const ThisYearLessThan6MonthsHours = {
       startDate: thisYearLessThan6Months[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return thisYearLessThan6Months
+      return thisYearLessThan6Months.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: thisYearLessThan6Months[thisYearLessThan6Months.length - 1]?.period.substring(0, 10),
@@ -227,7 +257,10 @@ export const ThisYearMoreThan6Months = {
       startDate: thisYearMoreThan6Months[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return thisYearMoreThan6Months
+      return thisYearMoreThan6Months.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: thisYearMoreThan6Months[thisYearMoreThan6Months.length - 1]?.period.substring(0, 10),
@@ -245,7 +278,10 @@ export const ThisYearMoreThan6MonthsHours = {
       startDate: thisYearMoreThan6Months[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return thisYearMoreThan6Months
+      return thisYearMoreThan6Months.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: thisYearMoreThan6Months[thisYearMoreThan6Months.length - 1]?.period.substring(0, 10),
@@ -264,7 +300,10 @@ export const Last12Months = {
       startDate: last12months[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return last12months
+      return last12months.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: last12months[last12months.length - 1]?.period.substring(0, 10),
@@ -282,7 +321,10 @@ export const Last12MonthsHours = {
       startDate: last12months[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return last12months
+      return last12months.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: last12months[last12months.length - 1]?.period.substring(0, 10),
@@ -301,7 +343,10 @@ export const AllTime = {
       startDate: allTime[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return allTime
+      return allTime.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: allTime[allTime.length - 1]?.period.substring(0, 10),
@@ -319,7 +364,10 @@ export const AllTimeHours = {
       startDate: allTime[0]?.period.substring(0, 10)
     },
     getCompleteData: () => {
-      return allTime
+      return allTime.map((data, index) => ({
+        index,
+        ...data,
+      }))
     },
     getDateInterval: () => ({
       end_date: allTime[allTime.length - 1]?.period.substring(0, 10),

--- a/packages/lib-user/src/components/shared/BarChart/helpers/getCompleteData.js
+++ b/packages/lib-user/src/components/shared/BarChart/helpers/getCompleteData.js
@@ -6,6 +6,7 @@ export function getCompleteData({ data, dateInterval }) {
     const startDate = start_date ? new Date(start_date) : new Date(data[0]?.period)
     const endDate = end_date ? new Date(end_date) : new Date()
     let currentDate = startDate
+    let index = 0
     if (period === 'week') {
       // determine the Monday on or before the start date
       const day = startDate.getUTCDay()
@@ -34,9 +35,13 @@ export function getCompleteData({ data, dateInterval }) {
       })
       
       if (matchingData) {
-        completeData.push(matchingData)
+        completeData.push({
+          index,
+          ...matchingData
+        })
       } else {
         completeData.push({
+          index,
           period: currentDate.toISOString(),
           count: 0,
           session_time: 0
@@ -52,6 +57,7 @@ export function getCompleteData({ data, dateInterval }) {
       } else if (period === 'year') {
         currentDate.setUTCFullYear(currentDate.getUTCFullYear() + 1)
       }
+      index += 1
     }
   }
   return completeData

--- a/packages/lib-user/src/components/shared/BarChart/helpers/getCompleteData.spec.js
+++ b/packages/lib-user/src/components/shared/BarChart/helpers/getCompleteData.spec.js
@@ -13,9 +13,9 @@ describe('components > shared > BarChart > getCompleteData', function () {
     }
     const completeData = getCompleteData({ data, dateInterval })
     expect(completeData).to.deep.equal([
-      { period: '2021-01-01T00:00:00.000Z', count: 3, session_time: 180 },
-      { period: '2021-01-02T00:00:00.000Z', count: 0, session_time: 0 },
-      { period: '2021-01-03T00:00:00.000Z', count: 1, session_time: 60 }
+      { period: '2021-01-01T00:00:00.000Z', count: 3, session_time: 180, index: 0 },
+      { period: '2021-01-02T00:00:00.000Z', count: 0, session_time: 0, index: 1 },
+      { period: '2021-01-03T00:00:00.000Z', count: 1, session_time: 60, index: 2 }
     ])
   })
 
@@ -31,9 +31,9 @@ describe('components > shared > BarChart > getCompleteData', function () {
     }
     const completeData = getCompleteData({ data, dateInterval })
     expect(completeData).to.deep.equal([
-      { period: '2024-01-01T00:00:00.000Z', count: 3, session_time: 180 },
-      { period: '2024-01-08T00:00:00.000Z', count: 0, session_time: 0 },
-      { period: '2024-01-15T00:00:00.000Z', count: 1, session_time: 60 }
+      { period: '2024-01-01T00:00:00.000Z', count: 3, session_time: 180, index: 0 },
+      { period: '2024-01-08T00:00:00.000Z', count: 0, session_time: 0, index: 1 },
+      { period: '2024-01-15T00:00:00.000Z', count: 1, session_time: 60, index: 2 }
     ])
   })
 
@@ -49,10 +49,10 @@ describe('components > shared > BarChart > getCompleteData', function () {
     }
     const completeData = getCompleteData({ data, dateInterval })
     expect(completeData).to.deep.equal([
-      { period: '2022-09-01T00:00:00.000Z', count: 3, session_time: 180 },
-      { period: '2022-10-01T00:00:00.000Z', count: 0, session_time: 0 },
-      { period: '2022-11-01T00:00:00.000Z', count: 0, session_time: 0 },
-      { period: '2022-12-01T00:00:00.000Z', count: 1, session_time: 60 }
+      { period: '2022-09-01T00:00:00.000Z', count: 3, session_time: 180, index: 0 },
+      { period: '2022-10-01T00:00:00.000Z', count: 0, session_time: 0, index: 1 },
+      { period: '2022-11-01T00:00:00.000Z', count: 0, session_time: 0, index: 2 },
+      { period: '2022-12-01T00:00:00.000Z', count: 1, session_time: 60, index: 3 }
     ])
   })
 
@@ -68,11 +68,11 @@ describe('components > shared > BarChart > getCompleteData', function () {
     }
     const completeData = getCompleteData({ data, dateInterval })
     expect(completeData).to.deep.equal([
-      { period: '2020-01-01T00:00:00.000Z', count: 3, session_time: 180 },
-      { period: '2021-01-01T00:00:00.000Z', count: 0, session_time: 0 },
-      { period: '2022-01-01T00:00:00.000Z', count: 0, session_time: 0 },
-      { period: '2023-01-01T00:00:00.000Z', count: 0, session_time: 0 },
-      { period: '2024-01-01T00:00:00.000Z', count: 1, session_time: 60 }
+      { period: '2020-01-01T00:00:00.000Z', count: 3, session_time: 180, index: 0 },
+      { period: '2021-01-01T00:00:00.000Z', count: 0, session_time: 0, index: 1 },
+      { period: '2022-01-01T00:00:00.000Z', count: 0, session_time: 0, index: 2 },
+      { period: '2023-01-01T00:00:00.000Z', count: 0, session_time: 0, index: 3 },
+      { period: '2024-01-01T00:00:00.000Z', count: 1, session_time: 60, index: 4 }
     ])
   })
 })


### PR DESCRIPTION
## Package
- lib-user

## Linked Issue and/or Talk Post
- closes #5841 

## Describe your changes
- add index to complete (includes empty periods) stats data array
- based on data length, show appropriate number of x-axis labels (less data -> show all x-axis labels, a lot of data -> show every fourth item's label)
- update stories and tests

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a
- What user actions should my reviewer step through to review this PR?
  - review your user stats bar chart, noting x-axis label frequency with different date ranges
  - review a group stats bar chart, noting x-axis label frequency with different date ranges
- Which storybook stories should be reviewed?
  - BarChart stories, most notably http://localhost:6008/?path=/story/components-shared-barchart--last-30-days-hours
- Are there plans for follow up PR’s to further fix this bug or develop this feature? yes, see linked GitHub project

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated