### PR TITLE
Quick fix for signed-in homepage mobile layout

### DIFF
--- a/packages/lib-user/src/components/UserHome/components/Dashboard/Dashboard.js
+++ b/packages/lib-user/src/components/UserHome/components/Dashboard/Dashboard.js
@@ -121,6 +121,11 @@ const StyledBadge = styled(Text)`
   padding: 3px 5px;
   background: ${props => props.theme.global.colors['neutral-1']};
   border-radius: 15px;
+
+  // For Grommet breakpoint small
+  @media (width < 769px) {
+    right: 60px;
+  }
 `
 
 // Same as ContentBox

--- a/packages/lib-user/src/components/UserHome/components/Dashboard/Dashboard.js
+++ b/packages/lib-user/src/components/UserHome/components/Dashboard/Dashboard.js
@@ -143,13 +143,7 @@ export default function Dashboard({ user, userLoading }) {
       : 'Learn more about your new homepage'
 
   return (
-    <Box
-      align='center'
-      // pad={{ bottom: '20px' }}
-      round={size === 'small' ? false : '16px 16px 8px 8px'}
-      // border={size === 'small' ? false : border}
-      // elevation={size === 'small' ? 'none' : 'xsmall'}
-    >
+    <Box align='center' round={size === 'small' ? false : '16px 16px 8px 8px'}>
       <Relative
         fill
         align='center'

--- a/packages/lib-user/src/components/UserHome/components/Dashboard/components/DashboardLink.js
+++ b/packages/lib-user/src/components/UserHome/components/Dashboard/components/DashboardLink.js
@@ -4,9 +4,9 @@ import { ResponsiveContext } from 'grommet'
 import { PlainButton } from '@zooniverse/react-components'
 import { Blank } from 'grommet-icons'
 
-function Icon({ icon, text = '' }) {
+function Icon({ icon, text = '', size = 'medium' }) {
   return (
-    <Blank role='img' aria-label={text} aria-hidden='false' size='1.5rem'>
+    <Blank role='img' aria-label={text} aria-hidden='false' size={size === 'small' ? '1.5rem' : '1rem'}>
       {icon}
     </Blank>
   )
@@ -19,7 +19,7 @@ export default function DashboardLink({ href = '', icon, text = '' }) {
       {size !== 'small' ? (
         <PlainButton href={href} text={text} icon={icon} />
       ) : (
-        <Icon text={text} icon={icon} />
+        <Icon text={text} icon={icon} size={size} />
       )}
     </>
   )

--- a/packages/lib-user/src/components/UserHome/components/UserHomeLayout/UserHomeLayout.js
+++ b/packages/lib-user/src/components/UserHome/components/UserHomeLayout/UserHomeLayout.js
@@ -25,8 +25,6 @@ const PageBody = styled(Box)`
   position: relative;
   min-height: 90vh;
   max-width: min(100%, calc(90rem - 160px));
-
-  margin-top: -70px; // half height of PageHeader
   border-radius: 8px 8px 0 0;
   padding-bottom: 50px;
 
@@ -119,7 +117,11 @@ function UserHomeLayout({
           width='min(100%, 90rem)'
           elevation='medium'
         >
-          <PageBody fill forwardedAs='main'>
+          <PageBody
+            fill
+            forwardedAs='main'
+            margin={size !== 'small' ? { top: '-70px' } : '0'}
+          >
             {children}
           </PageBody>
         </InnerPageContainer>


### PR DESCRIPTION
## Package
lib-user

## Linked Issue and/or Talk Post
Follow-up to https://github.com/zooniverse/front-end-monorepo/pull/6179 and https://github.com/zooniverse/front-end-monorepo/issues/6151

## Describe your changes

- Adjust the margin of PageBody for the UserHome-specific layout so that ZooHeader is not hidden on mobile widths.
- Icons in the Dashboard are 1.5rem on mobile, but should stay 1rem on desktop, so I fixed that here too.

## How to Review

I don't typically self-merge PRs, but this one affects only fe-root.preview, and the changes need to be deployed before ZTM sessions today for preview purposes.