### PR TITLE
lib-user: Add getDateRangeSelectOptions tests before and after UTC

### DIFF
--- a/packages/lib-user/src/components/shared/MainContent/helpers/getDateRangeSelectOptions.js
+++ b/packages/lib-user/src/components/shared/MainContent/helpers/getDateRangeSelectOptions.js
@@ -16,7 +16,7 @@ export function getDateRangeSelectOptions(created_at = '2015-07-01') {
     },
     {
       label: 'THIS MONTH',
-      value: new Date(endDate.getUTCFullYear(), endDate.getUTCMonth(), 1).toISOString().substring(0, 10)
+      value: new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), 1)).toISOString().substring(0, 10)
     },
     {
       label: 'LAST 3 MONTHS',
@@ -24,11 +24,11 @@ export function getDateRangeSelectOptions(created_at = '2015-07-01') {
     },
     {
       label: 'THIS YEAR',
-      value: new Date(endDate.getUTCFullYear(), 0, 1).toISOString().substring(0, 10)
+      value: new Date(Date.UTC(endDate.getUTCFullYear(), 0, 1)).toISOString().substring(0, 10)
     },
     {
       label: 'LAST 12 MONTHS',
-      value: new Date((endDate.getUTCFullYear() - 1), getNextMonth(endDate.getUTCMonth()), 1).toISOString().substring(0, 10)
+      value: new Date(Date.UTC((endDate.getUTCFullYear() - 1), getNextMonth(endDate.getUTCMonth()), 1)).toISOString().substring(0, 10)
     },
     {
       label: 'ALL TIME',

--- a/packages/lib-user/src/components/shared/MainContent/helpers/getDateRangeSelectOptions.spec.js
+++ b/packages/lib-user/src/components/shared/MainContent/helpers/getDateRangeSelectOptions.spec.js
@@ -8,7 +8,7 @@ describe.only('utils > getDateRangeSelectOptions', function () {
   describe('when the current date is after UTC', function () {
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(new Date('2023-04-15T12:00:00+02:00'))
+      clock = sinon.useFakeTimers(new Date('2023-04-15T00:00:00+02:00'))
     })
 
     afterEach(function () {
@@ -53,7 +53,7 @@ describe.only('utils > getDateRangeSelectOptions', function () {
   describe('when the current date is before UTC', function () {
       
     beforeEach(function () {
-      clock = sinon.useFakeTimers(new Date('2023-04-15T12:00:00-02:00'))
+      clock = sinon.useFakeTimers(new Date('2023-04-15T00:00:00-02:00'))
     })
 
     afterEach(function () {

--- a/packages/lib-user/src/components/shared/MainContent/helpers/getDateRangeSelectOptions.spec.js
+++ b/packages/lib-user/src/components/shared/MainContent/helpers/getDateRangeSelectOptions.spec.js
@@ -2,48 +2,96 @@ import sinon from 'sinon'
 
 import { getDateRangeSelectOptions } from './getDateRangeSelectOptions'
 
-describe('utils > getDateRangeSelectOptions', function () {
+describe.only('utils > getDateRangeSelectOptions', function () {
   let clock
 
-  beforeEach(function () {
-    clock = sinon.useFakeTimers(new Date(2023, 3, 15))
+  describe('when the current date is after UTC', function () {
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers(new Date('2023-04-15T12:00:00+02:00'))
+    })
+
+    afterEach(function () {
+      clock.restore()
+    })
+
+    it('should return the expected date range select options', function () {
+      const dateRangeSelectOptions = getDateRangeSelectOptions('2015-07-01')
+      expect(dateRangeSelectOptions).to.deep.equal([
+        {
+          label: 'LAST 7 DAYS',
+          value: '2023-04-09'
+        },
+        {
+          label: 'LAST 30 DAYS',
+          value: '2023-03-17'
+        },
+        {
+          label: 'THIS MONTH',
+          value: '2023-04-01'
+        },
+        {
+          label: 'LAST 3 MONTHS',
+          value: '2023-01-15'
+        },
+        {
+          label: 'THIS YEAR',
+          value: '2023-01-01'
+        },
+        {
+          label: 'LAST 12 MONTHS',
+          value: '2022-05-01'
+        },
+        {
+          label: 'ALL TIME',
+          value: '2015-07-01'
+        }
+      ])
+    })
   })
 
-  afterEach(function () {
-    clock.restore()
-  })
+  describe('when the current date is before UTC', function () {
+      
+    beforeEach(function () {
+      clock = sinon.useFakeTimers(new Date('2023-04-15T12:00:00-02:00'))
+    })
 
-  it('should return the expected date range select options', function () {
-    const dateRangeSelectOptions = getDateRangeSelectOptions('2015-07-01')
-    expect(dateRangeSelectOptions).to.deep.equal([
-      {
-        label: 'LAST 7 DAYS',
-        value: '2023-04-09'
-      },
-      {
-        label: 'LAST 30 DAYS',
-        value: '2023-03-17'
-      },
-      {
-        label: 'THIS MONTH',
-        value: '2023-04-01'
-      },
-      {
-        label: 'LAST 3 MONTHS',
-        value: '2023-01-15'
-      },
-      {
-        label: 'THIS YEAR',
-        value: '2023-01-01'
-      },
-      {
-        label: 'LAST 12 MONTHS',
-        value: '2022-05-01'
-      },
-      {
-        label: 'ALL TIME',
-        value: '2015-07-01'
-      }
-    ])
+    afterEach(function () {
+      clock.restore()
+    })
+
+    it('should return the expected date range select options', function () {
+      const dateRangeSelectOptions = getDateRangeSelectOptions('2015-07-01')
+      expect(dateRangeSelectOptions).to.deep.equal([
+        {
+          label: 'LAST 7 DAYS',
+          value: '2023-04-09'
+        },
+        {
+          label: 'LAST 30 DAYS',
+          value: '2023-03-17'
+        },
+        {
+          label: 'THIS MONTH',
+          value: '2023-04-01'
+        },
+        {
+          label: 'LAST 3 MONTHS',
+          value: '2023-01-15'
+        },
+        {
+          label: 'THIS YEAR',
+          value: '2023-01-01'
+        },
+        {
+          label: 'LAST 12 MONTHS',
+          value: '2022-05-01'
+        },
+        {
+          label: 'ALL TIME',
+          value: '2015-07-01'
+        }
+      ])
+    })
   })
 })

--- a/packages/lib-user/src/components/shared/MainContent/helpers/getDateRangeSelectOptions.spec.js
+++ b/packages/lib-user/src/components/shared/MainContent/helpers/getDateRangeSelectOptions.spec.js
@@ -2,21 +2,25 @@ import sinon from 'sinon'
 
 import { getDateRangeSelectOptions } from './getDateRangeSelectOptions'
 
-describe.only('utils > getDateRangeSelectOptions', function () {
+describe('utils > getDateRangeSelectOptions', function () {
   let clock
 
-  describe('when the current date is after UTC', function () {
+  describe('when the user\'s date is the day after UTC', function () {
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(new Date('2023-04-15T00:00:00+02:00'))
+      // Set the user's clock April 16, 1AM, in a timezone 2 hours ahead of UTC,
+      // so that the UTC date is April 15, 11PM
+      clock = sinon.useFakeTimers(new Date('2023-04-16T01:00:00+02:00'))
     })
 
     afterEach(function () {
       clock.restore()
     })
 
-    it('should return the expected date range select options', function () {
+    it('should return the expected date range select options in UTC', function () {
       const dateRangeSelectOptions = getDateRangeSelectOptions('2015-07-01')
+
+      // the following expected values are based on the UTC date April 15, 11PM, **NOT** the user's date of April 16, 1AM
       expect(dateRangeSelectOptions).to.deep.equal([
         {
           label: 'LAST 7 DAYS',
@@ -50,18 +54,22 @@ describe.only('utils > getDateRangeSelectOptions', function () {
     })
   })
 
-  describe('when the current date is before UTC', function () {
+  describe('when the user\'s date is the day before UTC', function () {
       
     beforeEach(function () {
-      clock = sinon.useFakeTimers(new Date('2023-04-15T00:00:00-02:00'))
+      // Set the user's clock April 14, 11PM, in a timezone 2 hours behind UTC,
+      // so that the UTC date is April 15, 1AM
+      clock = sinon.useFakeTimers(new Date('2023-04-14T23:00:00-02:00'))
     })
 
     afterEach(function () {
       clock.restore()
     })
 
-    it('should return the expected date range select options', function () {
+    it('should return the expected date range select options in UTC', function () {
       const dateRangeSelectOptions = getDateRangeSelectOptions('2015-07-01')
+
+      // the following expected values are based on the UTC date April 15, 1AM, **NOT** the user's date of April 14, 11PM
       expect(dateRangeSelectOptions).to.deep.equal([
         {
           label: 'LAST 7 DAYS',


### PR DESCRIPTION
## Package
- lib-user

## Linked Issue and/or Talk Post
- getDateRangeSelectOptions tests failed when running FEM locally in Oxford, but passed when running in CI (presumably in a US timezone), [related Slack thread](https://zooniverse.slack.com/archives/C010QAPB67J/p1721631284997649)

## Context
- stats are recorded (ERAS) and displayed (user/group stats pages) in UTC

## Describe your changes
- refactor tests to reflect when there might be conflicts between a user's date and UTC, i.e. someone 2 hours ahead of UTC at 1AM (the user is on the 16th of the month, but UTC is still the 15th) or someone 2 hours behind UTC at 11pm (the user on the 14th of the month, but UTC is on the 15th)
- refactor getDateRangeSelectOptions to properly reflect UTC date (not user's local date)

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a
- What user actions should my reviewer step through to review this PR?
  - review refactored tests
  - review refactored helper function
  - confirm user stats or group stats date range select operates as expected (i.e. app-root https://local.zooniverse.org:3000/users/markb-panoptes/stats)
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
