### PR TITLE
fix(lib-react-components): AnimatedNumber displays async values as 0

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStats.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStats.js
@@ -15,7 +15,12 @@ function YourStats(props) {
       <Paragraph margin={{ top: 'none' }}>
         {t('Classify.YourStats.text')}
       </Paragraph>
-      <Box border={{ color: 'light-5', side: 'bottom' }} pad={{ bottom: 'small' }}>
+      <Box
+        role='status'
+        aria-live='polite'
+        border={{ color: 'light-5', side: 'bottom' }}
+        pad={{ bottom: 'small' }}
+      >
         <Grid columns={['1fr', '1fr']} gap='small'>
           <Stat
             className="test-classify-your-stats-today-count"
@@ -33,7 +38,7 @@ function YourStats(props) {
         <DailyClassificationsChart />
       </Box>
     </ContentBox>
-  )
+  );
 }
 
 YourStats.propTypes = {

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - ZooFooter and ZooHeader styling to include `display: none;` when printing (`@media print`)
 - PlainButton has text-decoration underline on hover even for links.
-- refactor `AnimatedNumber` to fix missing `useEffect` dependencies.
+
+### Fixed
+
+- refactor `AnimatedNumber` to fix a bug where deferred values are displayed as 0.
 
 ## [1.13.0] 2024-05-17
 

--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - ZooFooter and ZooHeader styling to include `display: none;` when printing (`@media print`)
 - PlainButton has text-decoration underline on hover even for links.
+- refactor `AnimatedNumber` to fix missing `useEffect` dependencies.
 
 ## [1.13.0] 2024-05-17
 

--- a/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.js
+++ b/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.js
@@ -89,11 +89,9 @@ function AnimatedNumber({ duration = 1000, value }) {
       if (entries[0].intersectionRatio <= 0) return
 
       // Once target element is in viewport, animate it then unobserve
-      if (!prefersReducedMotion() && !animated) {
-        await animateValue(numElement, initialValue, value, duration)
-      } else {
-        await lessAnimation(numElement, initialValue, value)
-      }
+      const animationFunction =
+        !prefersReducedMotion() && !animated ? animateValue : lessAnimation
+      await animationFunction(numElement, initialValue, value, duration)
       setAnimated(true)
       initialValueRef.current = value
       intersectionObserver.unobserve(numElement)

--- a/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.js
+++ b/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.js
@@ -9,8 +9,9 @@ const initialValue = 0
 let prefersReducedMotion
 const isBrowser = typeof window !== 'undefined'
 if (isBrowser) {
-  prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  prefersReducedMotion = () => window.matchMedia('(prefers-reduced-motion: reduce)').matches
 }
+export { prefersReducedMotion }
 
 function AnimatedNumber({ duration = 1000, value }) {
   const numRef = useRef(null)
@@ -61,7 +62,7 @@ function AnimatedNumber({ duration = 1000, value }) {
       if (entries[0].intersectionRatio <= 0) return
 
       // Once target element is in viewport, animate it then unobserve
-      if (!prefersReducedMotion && !animated) {
+      if (!prefersReducedMotion() && !animated) {
         animateValue()
         intersectionObserver.unobserve(numElement)
       } else {

--- a/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.js
+++ b/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.js
@@ -50,6 +50,8 @@ function AnimatedNumber({ duration = 1000, value = 0 }) {
      * so use node.textContent to check if we've already rendered the value.
      */
     const numElement = numRef.current
+    const animationInProgress = numElement.textContent !== formatValue(initialValue)
+    if (animationInProgress) return // there's an animation already running.
     if (animated) return // only run the intersection observer once.
     if (formatValue(value) === numElement.textContent) return // nothing to animate yet.
 

--- a/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.spec.js
+++ b/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.spec.js
@@ -1,0 +1,187 @@
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { composeStory } from '@storybook/react'
+import sinon from 'sinon'
+
+import Meta, * as Stories from './AnimatedNumber.stories'
+import { prefersReducedMotion } from './AnimatedNumber'
+
+describe('AnimatedNumber', function () {
+  let oldIntersectionObserver
+  /*
+  * The tests run in Node, so we need to mock the IntersectionObserver
+  * and manually set mock entries.
+  */
+  const mockEntries = [{
+    isIntersecting: true,
+    intersectionRatio: 1
+  }]
+
+  class MockIntersectionObserver {
+    constructor(fn) {
+      this.fn = fn
+    }
+    observe() {
+      this.fn(mockEntries)
+    }
+    unobserve() { }
+    disconnect() { }
+  }
+
+  beforeEach(function () {
+    oldIntersectionObserver = window.IntersectionObserver
+    window.IntersectionObserver = MockIntersectionObserver
+  })
+
+  afterEach(function () {
+    window.IntersectionObserver = oldIntersectionObserver
+  })
+
+  describe('without any animation', function () {
+    describe('default behaviour', function () {
+      it('should animate the number', async function () {
+        const Story = composeStory(Stories.Default, Meta)
+        render(<Story />)
+        expect(prefersReducedMotion()).to.be.true()
+        const number = document.querySelector('span')
+        expect(number.textContent).to.equal('0')
+        await waitFor(() => {
+          expect(number.textContent).to.equal('123,456')
+        })
+      })
+    })
+    
+    describe('with 0', function () {
+      it('should not animate the number', async function () {
+        const Story = composeStory(Stories.Zero, Meta)
+        render(<Story />)
+        expect(prefersReducedMotion()).to.be.true()
+        const number = document.querySelector('span')
+        expect(number.textContent).to.equal('0')
+        await waitFor(() => {
+          expect(number.textContent).to.equal('0')
+        })
+      })
+    })
+
+    describe('updating after the animation', function () {
+      it('should update the number', async function () {
+        const user = userEvent.setup()
+        const Story = composeStory(Stories.UpdateTheValue, Meta)
+        render(<Story />)
+        expect(prefersReducedMotion()).to.be.true()
+        const number = document.querySelector('span')
+        expect(number.textContent).to.equal('0')
+        await waitFor(() => {
+          expect(number.textContent).to.equal('10')
+        })
+        await user.click(document.querySelector('button'))
+        await waitFor(() => {
+          expect(number.textContent).to.equal('11')
+        })
+      })
+    })
+  
+    describe('with a deferred value', function () {
+      it('should animate the number', async function () {
+        const clock = sinon.useFakeTimers({
+          shouldClearNativeTimers: true
+        })
+        const Story = composeStory(Stories.DeferredAnimation, Meta)
+        render(<Story />)
+        expect(prefersReducedMotion()).to.be.true()
+        const number = document.querySelector('span')
+        expect(number.textContent).to.equal('0')
+        // wait 2000ms for the value prop to change
+        clock.tick(2000)
+        clock.restore()
+        expect(number.textContent).to.equal('0')
+        await waitFor(() => {
+          expect(number.textContent).to.equal('700,000,000')
+        })
+      })
+    })
+  })
+
+  describe('with animation', function() {
+    /*
+    * Override the slow test warning threshold
+    * as the d3 animations take ~1000ms to run.
+    */
+    this.slow(3000)
+
+    beforeEach(function() {
+      sinon.stub(window, 'matchMedia').returns({
+        matches: false
+      })
+    })
+
+    afterEach(function() {
+      window.matchMedia.restore()
+    })
+
+    describe('default behaviour', function () {
+      it('should animate the number', async function () {
+        const Story = composeStory(Stories.Default, Meta)
+        render(<Story />)
+        expect(prefersReducedMotion()).to.be.false()
+        const number = document.querySelector('span')
+        expect(number.textContent).to.equal('0')
+        await waitFor(() => {
+          expect(number.textContent).to.equal('123,456')
+        }, { timeout: 2000 })
+      })
+    })
+    
+    describe('with 0', function () {
+      it('should not animate the number', async function () {
+        const Story = composeStory(Stories.Zero, Meta)
+        render(<Story />)
+        expect(prefersReducedMotion()).to.be.false()
+        const number = document.querySelector('span')
+        expect(number.textContent).to.equal('0')
+        await waitFor(() => {
+          expect(number.textContent).to.equal('0')
+        })
+      })
+    })
+  
+    describe('updating after the animation', function () {
+      it('should update the number', async function () {
+        const user = userEvent.setup()
+        const Story = composeStory(Stories.UpdateTheValue, Meta)
+        render(<Story />)
+        expect(prefersReducedMotion()).to.be.false()
+        const number = document.querySelector('span')
+        expect(number.textContent).to.equal('0')
+        await waitFor(() => {
+          expect(number.textContent).to.equal('10')
+        })
+        await user.click(document.querySelector('button'))
+        await waitFor(() => {
+          expect(number.textContent).to.equal('11')
+        })
+      })
+    })
+
+    describe('with a deferred value', function () {
+      it('should animate the number', async function () {
+        const clock = sinon.useFakeTimers({
+          shouldClearNativeTimers: true
+        })
+        const Story = composeStory(Stories.DeferredAnimation, Meta)
+        render(<Story />)
+        expect(prefersReducedMotion()).to.be.false()
+        const number = document.querySelector('span')
+        expect(number.textContent).to.equal('0')
+        // wait 2000ms for the value prop to change
+        clock.tick(2000)
+        expect(number.textContent).to.equal('0')
+        clock.restore()
+        await waitFor(() => {
+          expect(number.textContent).to.equal('700,000,000')
+        }, { timeout: 2000 })
+      })
+    })
+  })
+})

--- a/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.spec.js
+++ b/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.spec.js
@@ -147,7 +147,7 @@ describe('AnimatedNumber', function () {
     })
   
     describe('updating after the animation', function () {
-      it('should update the number immediately', async function () {
+      it('should update the number when the animation completes', async function () {
         const user = userEvent.setup()
         const Story = composeStory(Stories.UpdateTheValue, Meta)
         render(<Story />)
@@ -158,7 +158,9 @@ describe('AnimatedNumber', function () {
           expect(number.textContent).to.equal('10')
         })
         await user.click(document.querySelector('button'))
-        expect(number.textContent).to.equal('11')
+        await waitFor(() => {
+          expect(number.textContent).to.equal('11')
+        })
       })
     })
 

--- a/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.spec.js
+++ b/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.spec.js
@@ -147,7 +147,7 @@ describe('AnimatedNumber', function () {
     })
   
     describe('updating after the animation', function () {
-      it('should update the number', async function () {
+      it('should update the number immediately', async function () {
         const user = userEvent.setup()
         const Story = composeStory(Stories.UpdateTheValue, Meta)
         render(<Story />)
@@ -158,9 +158,7 @@ describe('AnimatedNumber', function () {
           expect(number.textContent).to.equal('10')
         })
         await user.click(document.querySelector('button'))
-        await waitFor(() => {
-          expect(number.textContent).to.equal('11')
-        })
+        expect(number.textContent).to.equal('11')
       })
     })
 

--- a/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.stories.js
+++ b/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.stories.js
@@ -50,7 +50,7 @@ export const DeferredAnimation = () => {
   setTimeout(() => setValue(700000000), 2000)
   return (
     <Box pad={{ vertical: '120vh' }}>
-      <AnimatedNumber duration={4000} value={value} />
+      <AnimatedNumber value={value} />
     </Box>
   )
 }

--- a/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.stories.js
+++ b/packages/lib-react-components/src/AnimatedNumber/AnimatedNumber.stories.js
@@ -44,3 +44,13 @@ export const ScrollDown = () => {
     </Box>
   )
 }
+
+export const DeferredAnimation = () => {
+  const [value, setValue] = useState(0)
+  setTimeout(() => setValue(700000000), 2000)
+  return (
+    <Box pad={{ vertical: '120vh' }}>
+      <AnimatedNumber duration={4000} value={value} />
+    </Box>
+  )
+}


### PR DESCRIPTION
- Refactor `AnimatedNumber` to add missing `value` and `duration` effect dependencies. Declare `animateValue` as a pure function outside the component, so that it doesn’t generate a new function on every render.  Refactor the `useEffect` hook to minimise side effects.
- Check that the current and initial values are different before animating. Update the displayed value when animation is complete, so that a render always returns the latest value, not 0. Animate numbers with a delay when the displayed value is 0 and prefers reduced motion is off. Otherwise, display changes immediately eg. after submitting a classification and incrementing your counts.
- Add a `DeferredAnimation` story, which reproduces #6190.
- Add a status live region to the `YourStats` component, so that changes to your classification counts are announced in screenreaders.
- Add missing tests for the `AnimatedNumber` component.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-react-components

## Linked Issue and/or Talk Post
- fixes #6190.
- fixes https://github.com/zooniverse/front-end-monorepo/issues/5971.

## How to Review
The behaviour of `AnimatedNumber` isn't changed here, so the stories in the storybook should be unchanged. Values are animated with a delay when the component first loads, then updated without a delay thereafter. If a value loads asynchronously, eg. from an external API, the first animation waits for the value to be non-zero before running. You can use the new `DeferredAnimation` story to both reproduce that bug and verify the fix. If an animation is interrupted by a user action (eg. submitting a classification) then the animation completes before updating to show the new value. You can check that with the `UpdateTheValue` story (and its tests.)

Bootstrap the monorepo and run a production build of the project app to test this out in a Next.js app. The original bug triggers when your stats load from Zooniverse offscreen, so delete any user stats that are cached in session storage (to force user preferences to load from Zooniverse) and wait until stats and preferences have loaded before scrolling down to the Your Stats widget. The bug won't trigger if Your Stats is already in the viewport when stats load, or if stats and preferences are loaded from session storage.

`yarn dev` runs the Next.js app in strict mode, which breaks the intersection observer that handles animations. ~~I didn't investigate that, but~~ strict mode runs `useEffect` twice so it seems there's a bug in the `useEffect` hook, in `AnimatedNumber`, when it is run more than once (~~which isn't fixed here.~~) In dev mode, your personal classification stats are always displayed as 0 (see #6190.) I’ve added a check for the case where the component might try to animate from 0 to 0, when the displayed value is 0 but `value` hasn’t loaded yet. That should fix the stuck counter in both strict mode and in production. I've also added a story that reproduces #6190 by rendering a deferred value. 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [x] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [x] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [x] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [x] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [x] Can submit a classification
- [x] Can sign-in and sign-out
- [x] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed
- [x] Unit tests are added or updated
