### PR TITLE
lib-user: Add MainContent tooltip about hours stats calculation

### DIFF
--- a/packages/lib-user/src/components/shared/MainContent/MainContent.js
+++ b/packages/lib-user/src/components/shared/MainContent/MainContent.js
@@ -13,7 +13,8 @@ import {
   BarChart,
   ContentBox,
   ProfileHeader,
-  Select
+  Select,
+  Tip
 } from '@components/shared'
 
 import {
@@ -154,31 +155,40 @@ function MainContent({
           gap={size === 'small' ? 'small' : 'none'}
         >
           <Box
-            role='tablist'
+            align='baseline'
             basis='1/2'
             direction='row'
-            fill={size === 'small' ? 'horizontal' : false}
-            gap='medium'
+            gap='xsmall'
           >
-            <StyledTab
-              role='tab'
-              aria-expanded={activeTab === 0}
-              aria-selected={activeTab === 0}
-              active={activeTab === 0}
-              label='CLASSIFICATIONS'
-              onClick={() => handleActiveTab(0)}
-              plain
+            <Box
+              role='tablist'
+              direction='row'
               fill={size === 'small' ? 'horizontal' : false}
-            />
-            <StyledTab
-              role='tab'
-              aria-expanded={activeTab === 1}
-              aria-selected={activeTab === 1}
-              active={activeTab === 1}
-              label='HOURS'
-              onClick={() => handleActiveTab(1)}
-              plain
-              fill={size === 'small' ? 'horizontal' : false}
+              gap='medium'
+            >
+              <StyledTab
+                role='tab'
+                aria-expanded={activeTab === 0}
+                aria-selected={activeTab === 0}
+                active={activeTab === 0}
+                label='CLASSIFICATIONS'
+                onClick={() => handleActiveTab(0)}
+                plain
+                fill={size === 'small' ? 'horizontal' : false}
+              />
+              <StyledTab
+                role='tab'
+                aria-expanded={activeTab === 1}
+                aria-selected={activeTab === 1}
+                active={activeTab === 1}
+                label='HOURS'
+                onClick={() => handleActiveTab(1)}
+                plain
+                fill={size === 'small' ? 'horizontal' : false}
+              />
+            </Box>
+            <Tip
+              contentText='Hours are calculated based on the start and end times of your classification efforts. Hours do not reflect your time spent on Talk.'
             />
           </Box>
           <Box


### PR DESCRIPTION
## Package
- lib-user

## Linked Issue and/or Talk Post
- [Figma link](https://www.figma.com/design/qbqbmR3t5XV6eKcpuRj7mG/Group-Stats?node-id=658-15872&m=dev)

## Describe your changes
- originally added [here](https://github.com/zooniverse/front-end-monorepo/pull/6132/files#diff-7ddb94740b3bf0fbefeac7e9a8e7958177ff669c0007e21939ae1484ad261f37R114-R122), but I must have removed it by mistake in a rebase at some point...
- add Tip about hours stats calculation to MainContent "Hours" tab

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a
- What user actions should my reviewer step through to review this PR?
  - review your user stats or a group stats page
- Which storybook stories should be reviewed?
  - http://localhost:6008/?path=/story/components-shared-maincontent--default
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)