### PR TITLE
Fix homepage dashboard links and minor logged-out copy update

### DIFF
--- a/packages/lib-content/src/translations/en.json
+++ b/packages/lib-content/src/translations/en.json
@@ -169,7 +169,7 @@
       "seeAll": "See all posts"
     },
     "DefaultHome": {
-      "heroText": "Join millions of people who help to advance real research, real science, and real knowledge.",
+      "heroText": "Join millions of people who help to advance real research, science, and knowledge.",
       "mainHeading": "People-powered research",
       "projects": "Explore projects",
       "headings": {

--- a/packages/lib-react-components/src/PlainButton/PlainButton.js
+++ b/packages/lib-react-components/src/PlainButton/PlainButton.js
@@ -39,10 +39,10 @@ function PlainButton({
       disabled={disabled}
       href={disabled ? '' : href}
       gap='xxsmall'
-      label={
+      label={text ?
         <SpacedText color={color} size={labelSize}>
           {text}
-        </SpacedText>
+        </SpacedText> : null
       }
       onClick={onClick}
       plain

--- a/packages/lib-react-components/src/PlainButton/PlainButton.js
+++ b/packages/lib-react-components/src/PlainButton/PlainButton.js
@@ -30,7 +30,7 @@ function PlainButton({
   labelSize = 'medium',
   text = '',
   color = defaultColor,
-  ...rest
+  ...rest // rest can include an icon
 }) {
   return (
     <StyledPlainButton

--- a/packages/lib-user/src/components/UserHome/components/Dashboard/components/DashboardLink.js
+++ b/packages/lib-user/src/components/UserHome/components/Dashboard/components/DashboardLink.js
@@ -6,7 +6,12 @@ import { Blank } from 'grommet-icons'
 
 function Icon({ icon, text = '', size = 'medium' }) {
   return (
-    <Blank role='img' aria-label={text} aria-hidden='false' size={size === 'small' ? '1.5rem' : '1rem'}>
+    <Blank
+      role='img'
+      aria-label={text}
+      aria-hidden='false'
+      size={size === 'small' ? '1.5rem' : '1rem'}
+    >
       {icon}
     </Blank>
   )
@@ -15,13 +20,11 @@ function Icon({ icon, text = '', size = 'medium' }) {
 export default function DashboardLink({ href = '', icon, text = '' }) {
   const size = useContext(ResponsiveContext)
   return (
-    <>
-      {size !== 'small' ? (
-        <PlainButton href={href} text={text} icon={icon} />
-      ) : (
-        <Icon text={text} icon={icon} size={size} />
-      )}
-    </>
+    <PlainButton
+      href={href}
+      icon={<Icon text={text} icon={icon} size={size} />}
+      text={size !== 'small' ? text : null}
+    />
   )
 }
 


### PR DESCRIPTION
## Package
lib-user
lib-content
lib-react-components

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/6181
Closes: https://github.com/zooniverse/front-end-monorepo/issues/6183

## Describe your changes

This PR makes minor changes to the logged-in and logged-out homepage components to close the above Issues. I also add a small change to the `label` in PlainButton so it can be a button that renders an aria-labeled icon without a string label. If `text` is an empty string, then we don't want to render SpacedText in PlainButton.

## How to Review

Run lib-user locally to see the logged-in homepage, and the change to lib-content is only two words in a translation string, but it can be run via Storybook or via app-root to review the logged-out homepage.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser