### PR TITLE
Homepages: Adjust mobile styling of Article in Community section

### DIFF
--- a/packages/app-root/src/app/page.js
+++ b/packages/app-root/src/app/page.js
@@ -15,7 +15,7 @@ function parseFeedPost(post) {
     excerpt: post.excerpt, // string but text is wrapped in <p></p>
     created_at: new Date(post.date), // string such as '2024-02-02T15:00:00+00:00'
     url: post.URL, // string
-    imageSrc: post.featured_image // ?? these are always '', might need to grab attached image instead
+    imageSrc: post.featured_image // src string
   }
 }
 
@@ -45,6 +45,8 @@ async function getBlogPosts(url) {
   }
   return posts
 }
+
+export const revalidate = 3600 // revalidate the data at most every hour
 
 export default async function HomePage() {
   const dailyZooPosts = await getBlogPosts(DAILY_ZOO_FEED)

--- a/packages/lib-content/src/components/Article/Article.js
+++ b/packages/lib-content/src/components/Article/Article.js
@@ -1,8 +1,9 @@
-import { Anchor, Box, Heading, Paragraph } from 'grommet'
+import { Anchor, Box, Heading, Paragraph, ResponsiveContext } from 'grommet'
 import { string } from 'prop-types'
 import { useTranslation } from '../../translations/i18n.js'
 import styled from 'styled-components'
 import { SpacedText } from '@zooniverse/react-components'
+import { useContext } from 'react'
 
 const StyledParagraph = styled(Paragraph)`
   line-height: 1.2;
@@ -16,6 +17,7 @@ export default function Article({
   url = ''
 }) {
   const { t } = useTranslation()
+  const size = useContext(ResponsiveContext)
 
   return (
     <Box
@@ -28,7 +30,7 @@ export default function Article({
       border={{ color: { light: 'light-5', dark: 'black' }, size: 'xsmall' }}
       data-testid='community-article'
     >
-      {imageSrc.length ? (
+      {imageSrc.length && size !== 'small' ? (
         <Box
           alignSelf='center'
           background={`url('${imageSrc}')`}
@@ -57,7 +59,7 @@ export default function Article({
           <Anchor href={url}>{title}</Anchor>
         </Heading>
         <StyledParagraph color={{ light: 'black', dark: 'white' }}>
-          {excerpt}
+          {size !== 'small' ? excerpt : excerpt.slice(0, 120) + '...'}
         </StyledParagraph>
         <Anchor
           href={url}

--- a/packages/lib-content/src/components/Article/Article.js
+++ b/packages/lib-content/src/components/Article/Article.js
@@ -59,7 +59,7 @@ export default function Article({
           <Anchor href={url}>{title}</Anchor>
         </Heading>
         <StyledParagraph color={{ light: 'black', dark: 'white' }}>
-          {size !== 'small' ? excerpt : excerpt.slice(0, 120) + '...'}
+          {size !== 'small' ? excerpt : excerpt.slice(0, 160) + '...'}
         </StyledParagraph>
         <Anchor
           href={url}


### PR DESCRIPTION
## Package
lib-content

## Describe your changes

This is a small change to the Article component for mobile widths. I noticed in the recent blog post, a long url runs off the screen and causes awkward shifting of the whole page. To solve, I hid featured images on mobile widths and also limited the excerpt to only 120 characters to show more articles on the screen at once.

I also realized I forgot to include a `revalidate` timeframe in the home page file, so I added a 1-hour revalidation similar to the Team and Publications pages (only affects blog post data because those are fetched server-side).

Before:
<img width="300" alt="runoff" src="https://github.com/user-attachments/assets/60d3e343-361e-4279-9bad-2ed733664156">


After:
<img width="300" alt="new" src="https://github.com/user-attachments/assets/c57ed4a5-d0c9-4c2e-a843-19598020f3f1">


## How to Review

@seanmiller26 please take a look at the screenshots above.

To review the code locally, run lib-content's Storybook and change the viewport size, or run app-root locally and view your homepage on mobile and desktop.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser
