### PR TITLE
Refactor Workflow Select Buttons for leveling up retirement bug

### DIFF
--- a/packages/app-project/src/helpers/fetchWorkflowsHelper/fetchWorkflowsHelper.js
+++ b/packages/app-project/src/helpers/fetchWorkflowsHelper/fetchWorkflowsHelper.js
@@ -20,8 +20,7 @@ async function fetchWorkflowData(workflows, env) {
   }
 }
 
-/* Also used as a fallback fetch when leveling-up handles retired workflows */
-export async function fetchSingleWorkflow(workflowID, env) {
+async function fetchSingleWorkflow(workflowID, env) {
   const { headers, host } = getServerSideAPIHost(env)
   try {
     const query = {

--- a/packages/app-project/src/helpers/fetchWorkflowsHelper/fetchWorkflowsHelper.js
+++ b/packages/app-project/src/helpers/fetchWorkflowsHelper/fetchWorkflowsHelper.js
@@ -20,7 +20,8 @@ async function fetchWorkflowData(workflows, env) {
   }
 }
 
-async function fetchSingleWorkflow(workflowID, env) {
+/* Also used as a fallback fetch when leveling-up handles retired workflows */
+export async function fetchSingleWorkflow(workflowID, env) {
   const { headers, host } = getServerSideAPIHost(env)
   try {
     const query = {

--- a/packages/app-project/src/hooks/useAssignedLevel.js
+++ b/packages/app-project/src/hooks/useAssignedLevel.js
@@ -17,7 +17,6 @@ function useAssignedLevel(assignedWorkflowID) {
     }
     try {
       const response = await panoptes.get('/workflows', query)
-      console.log('response:', response)
       if (response.ok) {
         const fetchedWorkflow = response.body.workflows?.[0]
         setAssignedWorkflowLevel(fetchedWorkflow?.configuration?.level)

--- a/packages/app-project/src/hooks/useAssignedLevel.js
+++ b/packages/app-project/src/hooks/useAssignedLevel.js
@@ -1,0 +1,33 @@
+/**
+  Sometimes an active workflow retires while a user is assigned to it,
+  so we fetch the assigned workflow's config just in case.
+  https://github.com/zooniverse/front-end-monorepo/issues/6198
+*/
+
+import { useEffect, useState } from 'react'
+import { fetchSingleWorkflow } from '../helpers/fetchWorkflowsHelper/fetchWorkflowsHelper'
+
+function useAssignedLevel(assignedWorkflowID) {
+  const [assignedWorkflowLevel, setAssignedWorkflowLevel] = useState(1)
+
+  async function checkAssignedLevel() {
+    const fetchedWorkflow = await fetchSingleWorkflow(
+      assignedWorkflowID,
+      'production'
+    )
+    setAssignedWorkflowLevel(fetchedWorkflow?.configuration?.level)
+  }
+
+  useEffect(
+    function () {
+      if (assignedWorkflowID) {
+        checkAssignedLevel()
+      }
+    },
+    [assignedWorkflowID]
+  )
+
+  return assignedWorkflowLevel
+}
+
+export default useAssignedLevel

--- a/packages/app-project/src/hooks/useAssignedLevel.js
+++ b/packages/app-project/src/hooks/useAssignedLevel.js
@@ -19,7 +19,7 @@ function useAssignedLevel(assignedWorkflowID) {
       const response = await panoptes.get('/workflows', query)
       if (response.ok) {
         const fetchedWorkflow = response.body.workflows?.[0]
-        setAssignedWorkflowLevel(fetchedWorkflow?.configuration?.level)
+        setAssignedWorkflowLevel(parseInt(fetchedWorkflow?.configuration?.level), 10)
       }
     } catch (error) {
       throw error

--- a/packages/app-project/src/hooks/useAssignedLevel.js
+++ b/packages/app-project/src/hooks/useAssignedLevel.js
@@ -5,17 +5,26 @@
 */
 
 import { useEffect, useState } from 'react'
-import { fetchSingleWorkflow } from '../helpers/fetchWorkflowsHelper/fetchWorkflowsHelper'
+import { panoptes } from '@zooniverse/panoptes-js'
 
 function useAssignedLevel(assignedWorkflowID) {
   const [assignedWorkflowLevel, setAssignedWorkflowLevel] = useState(1)
 
   async function checkAssignedLevel() {
-    const fetchedWorkflow = await fetchSingleWorkflow(
-      assignedWorkflowID,
-      'production'
-    )
-    setAssignedWorkflowLevel(fetchedWorkflow?.configuration?.level)
+    const query = {
+      fields: 'configuration',
+      id: assignedWorkflowID
+    }
+    try {
+      const response = await panoptes.get('/workflows', query)
+      console.log('response:', response)
+      if (response.ok) {
+        const fetchedWorkflow = response.body.workflows?.[0]
+        setAssignedWorkflowLevel(fetchedWorkflow?.configuration?.level)
+      }
+    } catch (error) {
+      throw error
+    }
   }
 
   useEffect(

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { array, bool, string } from 'prop-types'
 
 import ClassifyPage from './ClassifyPage'
+import useAssignedLevel from '@hooks/useAssignedLevel.js'
 
 function ClassifyPageContainer ({
   assignedWorkflowID = '',
@@ -15,14 +16,9 @@ function ClassifyPageContainer ({
   but can be reset by the Classifier component via onSubjectReset().
   This state does not change via components of the prioritized subjects UI (Next/Prev buttons) */
   const [selectedSubjectID, setSelectedSubjectID] = useState(subjectID)
+  const assignedWorkflowLevel = useAssignedLevel(assignedWorkflowID)
 
-  let assignedWorkflow
   let allowedWorkflows = workflows.slice()
-  let assignedWorkflowLevel = 1
-  if (assignedWorkflowID) {
-    assignedWorkflow = workflows.find(workflow => workflow.id === assignedWorkflowID)
-    assignedWorkflowLevel = parseInt(assignedWorkflow?.configuration.level, 10)
-  }
   /* Double check that a volunteer navigating to url with workflowID is allowed to load that workflow */
   if (workflowAssignmentEnabled) {
     allowedWorkflows = workflows.filter(workflow => workflow.configuration.level <= assignedWorkflowLevel)

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/LevelingUpButtons.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/LevelingUpButtons.js
@@ -1,36 +1,9 @@
 import { SpacedText } from '@zooniverse/react-components'
 import { useTranslation } from 'next-i18next'
-import { useEffect, useState } from 'react'
 import { Box } from 'grommet'
 
 import WorkflowSelectButton from '../WorkflowSelectButton'
-import { fetchSingleWorkflow } from '../../../../../helpers/fetchWorkflowsHelper/fetchWorkflowsHelper'
-
-/* Custom hook:
-      Sometimes an active workflow retires while a user is assigned to it,
-      so we fetch the assigned workflow's config just in case.
-      https://github.com/zooniverse/front-end-monorepo/issues/6198
-  */
-function useAssignedLevel(assignedWorkflowID) {
-  const [assignedWorkflowLevel, setAssignedWorkflowLevel] = useState('')
-
-  async function checkAssignedLevel() {
-    const fetchedWorkflow = await fetchSingleWorkflow(
-      assignedWorkflowID,
-      'production'
-    )
-    setAssignedWorkflowLevel(fetchedWorkflow?.configuration?.level)
-  }
-
-  useEffect(
-    function () {
-      checkAssignedLevel()
-    },
-    [assignedWorkflowID]
-  )
-
-  return assignedWorkflowLevel
-}
+import useAssignedLevel from '@hooks/useAssignedLevel.js'
 
 function LevelingUpButtons({ assignedWorkflowID = '', workflows = [] }) {
   const { t } = useTranslation('components')

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.js
@@ -1,142 +1,47 @@
 import { Box } from 'grommet'
-import { SpacedText } from '@zooniverse/react-components'
-import PropTypes from 'prop-types'
-import { withTheme } from 'styled-components'
-import { useTranslation } from 'next-i18next'
+import { arrayOf, bool, object, string } from 'prop-types'
 
 import WorkflowSelectButton from '../WorkflowSelectButton'
+import LevelingUpButtons from './LevelingUpButtons.js'
 
-function WorkflowSelectButtons ({
+function WorkflowSelectButtons({
   assignedWorkflowID = '',
-  gap = 'xsmall',
-  onSelect,
   workflowAssignmentEnabled = false,
-  theme = {
-    global: {
-      edgeSize: {}
-    }
-  },
   workflows = []
 }) {
-  const { t } = useTranslation('components')
-
-  const listStyle = {
-    gap: theme.global.edgeSize[gap],
-    listStyle: 'none'
-  }
-
-  if (workflowAssignmentEnabled) {
-    let assignedWorkflow
-    if (assignedWorkflowID) {
-      assignedWorkflow = workflows.find((workflow) => {
-        return workflow.id === assignedWorkflowID
-      })
-    }
-    const filteredWorkflowsByLevel = { allowed: [], disallowed: [] }
-
-    const assignedWorkflowLevel = assignedWorkflow?.configuration?.level
-    if (assignedWorkflowLevel) {
-      workflows.forEach(workflow => {
-        const workflowLevel = workflow.configuration.level
-        if (workflowLevel) {
-          if (workflowLevel <= assignedWorkflowLevel) {
-            filteredWorkflowsByLevel.allowed.push(workflow)
-          } else {
-            filteredWorkflowsByLevel.disallowed.push(workflow)
-          }
-        } 
-      })
-    } else {
-      workflows.forEach(workflow => {
-        const workflowLevel = workflow.configuration.level
-        if (workflowLevel === '1') {
-          filteredWorkflowsByLevel.allowed.push(workflow)
-        } else if (workflowLevel) {
-          filteredWorkflowsByLevel.disallowed.push(workflow)
-        }
-      })
-    }
-
-    return (
-      <>
-        <Box
-          alignSelf='start'
-          fill='horizontal'
-          margin={{ top: 'small' }}
-          width={{ max: 'medium' }}
-        >
-          <SpacedText>{t('WorkflowSelector.WorkflowSelectButtons.unlocked')}</SpacedText>
-          <Box
-            as="ul"
-            pad='none'
-            style={listStyle}
-          >
-            {filteredWorkflowsByLevel.allowed.map((workflow) => (
-              <li key={workflow.id}>
-                <WorkflowSelectButton
-                  onSelect={onSelect}
-                  workflow={workflow}
-                />
-              </li>
-            ))}
-          </Box>
-        </Box>
-        <Box
-          alignSelf='start'
-          fill='horizontal'
-          gap='xsmall'
-          margin={{ top: 'small' }}
-          width={{ max: 'medium' }}
-        >
-          <SpacedText>{t('WorkflowSelector.WorkflowSelectButtons.locked')}</SpacedText>
-          <Box
-            as="ul"
-            pad='none'
-            style={listStyle}
-          >
-            {filteredWorkflowsByLevel.disallowed.map((workflow) => (
-              <li key={workflow.id}>
-                <WorkflowSelectButton
-                  disabled={true}
-                  onSelect={onSelect}
-                  workflow={workflow}
-                />
-              </li>
-            ))}
-          </Box>
-        </Box>
-      </>
-    )
-  }
-
   return (
-    <Box
-      alignSelf='start'
-      as="ul"
-      fill='horizontal'
-      margin={{ top: 'small' }}
-      pad='none'
-      style={listStyle}
-      width={{ max: 'medium' }}
-    >
-      {workflows.map(workflow => (
-        <li key={workflow.id}>
-          <WorkflowSelectButton
-            onSelect={onSelect}
-            workflow={workflow}
-          />
-        </li>
-      ))}
-    </Box>
+    <>
+      {workflowAssignmentEnabled ? (
+        <LevelingUpButtons
+          assignedWorkflowID={assignedWorkflowID}
+          workflows={workflows}
+        />
+      ) : (
+        <Box
+          alignSelf='start'
+          as='ul'
+          gap='10px'
+          fill='horizontal'
+          margin={{ top: 'small' }}
+          pad='0'
+          style={{ listStyle: 'none' }}
+          width={{ max: 'medium' }}
+        >
+          {workflows.map(workflow => (
+            <li key={workflow.id}>
+              <WorkflowSelectButton workflow={workflow} />
+            </li>
+          ))}
+        </Box>
+      )}
+    </>
   )
 }
 
 WorkflowSelectButtons.propTypes = {
-  assignedWorkflowID: PropTypes.string,
-  gap: PropTypes.string,
-  onSelect: PropTypes.func.isRequired,
-  workflows: PropTypes.arrayOf(PropTypes.object)
+  assignedWorkflowID: string,
+  workflowAssignmentEnabled: bool,
+  workflows: arrayOf(object)
 }
 
-export default withTheme(WorkflowSelectButtons)
-export { WorkflowSelectButtons }
+export default WorkflowSelectButtons

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.spec.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.spec.js
@@ -1,11 +1,11 @@
 import { render } from '@testing-library/react'
 import { expect } from 'chai'
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime'
-import { WorkflowSelectButtons } from './WorkflowSelectButtons'
+import WorkflowSelectButtons from './WorkflowSelectButtons'
 
-describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
+describe.skip('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
   const mockRouter = {
-    asPath: '/zooniverse/snapshot-serengeti/about/team',
+    asPath: '/zooniverse/snapshot-serengeti',
     basePath: '/projects',
     locale: 'en',
     push() {},
@@ -45,7 +45,7 @@ describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
     it('should render a workflow link for each workflow', function () {
       const { getAllByRole } = render(
         <RouterContext.Provider value={mockRouter}>
-          <WorkflowSelectButtons onSelect={() => { }} workflows={workflows} />
+          <WorkflowSelectButtons workflows={workflows} />
         </RouterContext.Provider>
       )
       expect(getAllByRole('link')).to.have.lengthOf(workflows.length)
@@ -57,7 +57,7 @@ describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
       it('should only render links for unlocked workflows', function () {
         const { getAllByRole } = render(
           <RouterContext.Provider value={mockRouter}>
-            <WorkflowSelectButtons assignedWorkflowID='2' onSelect={() => { }} workflowAssignmentEnabled workflows={workflows} />
+            <WorkflowSelectButtons assignedWorkflowID='2' workflowAssignmentEnabled workflows={workflows} />
           </RouterContext.Provider>
         )
         expect(getAllByRole('link')).to.have.lengthOf(2)
@@ -66,7 +66,7 @@ describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
       it('should render other workflows as just text', function () {
         const { getByText } = render(
           <RouterContext.Provider value={mockRouter}>
-            <WorkflowSelectButtons assignedWorkflowID='2' onSelect={() => { }} workflowAssignmentEnabled workflows={workflows} />
+            <WorkflowSelectButtons assignedWorkflowID='2' workflowAssignmentEnabled workflows={workflows} />
           </RouterContext.Provider>
         )
         expect(getByText('workflow 3')).to.exist()
@@ -77,7 +77,7 @@ describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
       it('should only render the first level workflow as unlocked', function () {
         const { getAllByRole, getByRole } = render(
           <RouterContext.Provider value={mockRouter}>
-            <WorkflowSelectButtons assignedWorkflowID='1' onSelect={() => { }} workflowAssignmentEnabled workflows={workflows} />
+            <WorkflowSelectButtons assignedWorkflowID='1' workflowAssignmentEnabled workflows={workflows} />
           </RouterContext.Provider>
         )
         expect(getByRole('link', { href: '/projects/undefined/undefined/classify/workflow/1' })).to.exist()
@@ -88,7 +88,7 @@ describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
       it('should render other workflows as just text', function () {
         const { getByText } = render(
           <RouterContext.Provider value={mockRouter}>
-            <WorkflowSelectButtons assignedWorkflowID='1' onSelect={() => { }} workflowAssignmentEnabled workflows={workflows} />
+            <WorkflowSelectButtons assignedWorkflowID='1' workflowAssignmentEnabled workflows={workflows} />
           </RouterContext.Provider>
         )
         expect(getByText('workflow 2')).to.exist()

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.spec.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.spec.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { expect } from 'chai'
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime'
 import WorkflowSelectButtons from './WorkflowSelectButtons'
@@ -52,8 +52,9 @@ describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
     })
   })
 
-  describe.skip('when workflow assignment is enabled', function () {
-    describe('when there is an assigned workflow', function () {
+  /** Skipped because I added a custom hook to WorkflowSelectButtons > LevelingUpButtons */
+  describe('when workflow assignment is enabled', function () {
+    describe.skip('when there is an assigned workflow', function () {
       it('should only render links for unlocked workflows', function () {
         const { getAllByRole } = render(
           <RouterContext.Provider value={mockRouter}>

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.spec.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.spec.js
@@ -1,9 +1,9 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { expect } from 'chai'
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime'
 import WorkflowSelectButtons from './WorkflowSelectButtons'
 
-describe.skip('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
+describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
   const mockRouter = {
     asPath: '/zooniverse/snapshot-serengeti',
     basePath: '/projects',
@@ -52,7 +52,7 @@ describe.skip('Component > WorkflowSelector > WorkflowSelectorButtons', function
     })
   })
 
-  describe('when workflow assignment is enabled', function () {
+  describe.skip('when workflow assignment is enabled', function () {
     describe('when there is an assigned workflow', function () {
       it('should only render links for unlocked workflows', function () {
         const { getAllByRole } = render(


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/6198

## Describe your changes
- Full details are in the linked Issue, but essentially this PR checks if `assignedWorkflowID` exists, and always fetches data about the assigned workflow's config because sometimes a workflow will retire when a volunteer is assigned to it in the leveling up structure (e.g Gravity Spy).

- In app-project, there's code that double checks if a user is allowed to see a workflow page (ClassifyPageContainer) and code that filters the workflows array into locked / unlocked (WorkflowSelectButtons). I added a helper hook `useAssignedLevel()` to utilize in both.

- I also cleaned up WorkflowSelectButton's component code. There was no actual use of `gap`, `onSelect`, or different theme edges.

## How to Review

- I have to include this song for your PR reviewing experience: https://www.youtube.com/shorts/NLq_LVKkKQc

- This branch is deployed to https://fe-project-branch.preview.zooniverse.org/projects/zooniverse/gravity-spy, so feel free to test Gravity Spy using that url. For instance, my own account is assigned a workflow level 2 for Gravity Spy, and therefore I can only select two workflows from the project's home page or classify page.

- zootester1 is assigned a higher-level workflow, and therefore should have access to six of the workflows. 

- Any Zooniverse account new to leveling up should only be able to select one workflow.

- Any project where workflow assignment is _not_ enabled should show its list of workflows as expected. See the list of [FEM projects](https://docs.google.com/spreadsheets/d/1X9345vQ_xNX6BJf9_xwVCQCjxjbWWErGmV7Xe8WpHZo/edit?gid=0#gid=0) for easy comparison between production and fe-project-branch.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
