### PR TITLE
lib-user: Fix Tip icon size

### DIFF
--- a/packages/lib-user/src/components/shared/Tip/Tip.js
+++ b/packages/lib-user/src/components/shared/Tip/Tip.js
@@ -30,7 +30,7 @@ function Tip({
       plain
     >
       <Button
-        icon={<CircleInformation size={buttonProps.iconSize} />}
+        icon={<CircleInformation size={buttonProps.iconSize || DEFAULT_BUTTON_PROPS.iconSize} />}
         plain
         {...buttonProps}
       />


### PR DESCRIPTION
## Package
- lib-user

## Linked Issue and/or Talk Post
- https://github.com/zooniverse/front-end-monorepo/pull/6191#issuecomment-2278803669

## Describe your changes
- Tip component has a `buttonProps` property for the tooltip button properties
- in #6191 an `iconSize` property was added to the `buttonProps` property and passed to the tooltip icon size
- this created a bug in the TopContributors component where `buttonProps` were defined, but not an `iconSize`
- this caused the tooltip icon size to be defined by the Grommet Icons default value when the desired default value should be `0.75rem`
- these changes set the icon size to the desired default value of `0.75rem` if the icon size is not defined by `buttonProps.iconSize`

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a
- What user actions should my reviewer step through to review this PR?
  - review a group stats page that shows member contributions (i.e. lib-user, `yarn dev`, https://local.zooniverse.org:8080/?groups=1326962)
- Which storybook stories should be reviewed?
  - https://zooniverse.github.io/front-end-monorepo/@zooniverse/user/index.html?path=/story/components-groupstats-topcontributors--default
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated