### PR TITLE
lib-user: Add max character group name validation to group form

### DIFF
--- a/packages/lib-user/src/components/shared/GroupForm/GroupForm.js
+++ b/packages/lib-user/src/components/shared/GroupForm/GroupForm.js
@@ -88,6 +88,7 @@ function GroupForm({
           validate={[
             (name) => {
               if (name && name.length < 4) return 'must be > 3 characters'
+              if (name && name.length > 60) return 'must be < 60 characters'
               return undefined
             }
           ]}

--- a/packages/lib-user/src/components/shared/GroupForm/GroupForm.spec.js
+++ b/packages/lib-user/src/components/shared/GroupForm/GroupForm.spec.js
@@ -89,7 +89,7 @@ describe('components > shared > GroupForm', function() {
       })
     })
   
-    describe('with an invalid display name', function() {
+    describe('with an invalid display name, below minimum characters', function() {
       it('should show display name is invalid', async function() {
         render(<CreateStory />)
   
@@ -99,6 +99,20 @@ describe('components > shared > GroupForm', function() {
         await user.click(submit)
   
         const error = screen.getByText('must be > 3 characters')
+        expect(error).to.be.ok()
+      })
+    })
+
+    describe('with an invalid display name, above maximum characters', function() {
+      it('should show display name is invalid', async function() {
+        render(<CreateStory />)
+  
+        const displayName = screen.getByRole('textbox', { name: 'Group Name' })
+        await user.type(displayName, 'a'.repeat(61))
+        const submit = screen.getByRole('button', { name: 'Create new group' })
+        await user.click(submit)
+  
+        const error = screen.getByText('must be < 60 characters')
         expect(error).to.be.ok()
       })
     })


### PR DESCRIPTION
## Package
- lib-user

## Describe your changes
- add 60 max character validation for group name in GroupForm

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a
- What user actions should my reviewer step through to review this PR?
  - create or edit a group locally (lib-user or app-root)
  - attempt to create a group name more than 60 characters, note error message
- Which storybook stories should be reviewed?
  - http://localhost:6008/?path=/story/components-shared-groupform--create
  - http://localhost:6008/?path=/story/components-shared-groupform--manage
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)