### PR TITLE
app-root: Remove revalidate param from home page

### DIFF
--- a/packages/app-root/src/app/page.js
+++ b/packages/app-root/src/app/page.js
@@ -46,8 +46,6 @@ async function getBlogPosts(url) {
   return posts
 }
 
-export const revalidate = 3600 // revalidate the data at most every hour
-
 export default async function HomePage() {
   const dailyZooPosts = await getBlogPosts(DAILY_ZOO_FEED)
   const zooBlogPosts = await getBlogPosts(ZOO_BLOG_FEED)


### PR DESCRIPTION
## Package
app-root

## Linked Issue and/or Talk Post

As stated in Slack, there’s something strange going on with https://fe-root.preview.zooniverse.org/ where sometimes I see the content and other times it’s blank 🤔 Zach observed the same behavior today, so we're testing the reversion of `revalidate` for the home page file.


## How to Review

I don't think this can be replicated locally, but when app-root is run locally it's https://local.zooniverse.org:3000.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)