### PR TITLE
feat(app-project): remember current workflow in a same-site session cookie

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.js
@@ -1,5 +1,6 @@
 import { SpacedText } from '@zooniverse/react-components'
 import { Anchor, Box } from 'grommet'
+import { observer } from 'mobx-react'
 import { useRouter } from 'next/router'
 import { bool } from 'prop-types'
 import styled, { css } from 'styled-components'
@@ -90,4 +91,4 @@ Nav.propTypes = {
   adminMode: bool
 }
 
-export default Nav
+export default observer(Nav)

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageConnector.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageConnector.js
@@ -7,7 +7,9 @@ function useStore(store) {
   const {
     appLoadingState,
     project: {
-      experimental_tools
+      experimental_tools,
+      defaultWorkflow,
+      setSelectedWorkflow
     },
     user: { personalization: { projectPreferences } }
   } = store
@@ -15,6 +17,8 @@ function useStore(store) {
   return {
     appLoadingState,
     projectPreferences,
+    defaultWorkflow,
+    setSelectedWorkflow,
     workflowAssignmentEnabled: experimental_tools.includes('workflow assignment')
   }
 }
@@ -24,10 +28,16 @@ function ClassifyPageConnector(props) {
   const {
     appLoadingState,
     projectPreferences,
+    defaultWorkflow,
+    setSelectedWorkflow,
     workflowAssignmentEnabled = false
   } = useStore(store)
   const assignedWorkflowID = projectPreferences?.settings?.workflow_id
   const assignedWorkflowLevel = useAssignedLevel(assignedWorkflowID, props.workflows)
+
+  if (props.workflowID && props.workflowID !== defaultWorkflow) {
+    setSelectedWorkflow(props.workflowID)
+  }
 
   return (
     <ClassifyPageContainer
@@ -36,6 +46,7 @@ function ClassifyPageConnector(props) {
       assignedWorkflowLevel={assignedWorkflowLevel}
       projectPreferences={projectPreferences}
       workflowAssignmentEnabled={workflowAssignmentEnabled}
+      workflowID={props.workflowID || defaultWorkflow}
     />
   )
 }

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageConnector.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageConnector.js
@@ -1,4 +1,5 @@
 import { MobXProviderContext, observer } from 'mobx-react'
+import { useRouter } from 'next/router'
 import { useContext } from 'react'
 import useAssignedLevel from '@hooks/useAssignedLevel'
 import ClassifyPageContainer from './ClassifyPageContainer'
@@ -23,7 +24,12 @@ function useStore(store) {
   }
 }
 
-function ClassifyPageConnector(props) {
+function ClassifyPageConnector({
+  // workflow ID from the page URL
+  workflowID,
+  ...props
+}) {
+  const router = useRouter()
   const { store } = useContext(MobXProviderContext)
   const {
     appLoadingState,
@@ -35,8 +41,15 @@ function ClassifyPageConnector(props) {
   const assignedWorkflowID = projectPreferences?.settings?.workflow_id
   const assignedWorkflowLevel = useAssignedLevel(assignedWorkflowID, props.workflows)
 
-  if (props.workflowID && props.workflowID !== defaultWorkflow) {
-    setSelectedWorkflow(props.workflowID)
+  // store the workflow from the URL, if it isn't already stored
+  if (workflowID && workflowID !== defaultWorkflow) {
+    setSelectedWorkflow(workflowID)
+  }
+
+  // client-side redirect if there's no workflow in the URL
+  if (!workflowID && defaultWorkflow) {
+    const newPath = router.asPath.replace('/classify', `/classify/workflow/${defaultWorkflow}`)
+    router.replace(newPath, newPath, { shallow: true })
   }
 
   return (
@@ -46,7 +59,7 @@ function ClassifyPageConnector(props) {
       assignedWorkflowLevel={assignedWorkflowLevel}
       projectPreferences={projectPreferences}
       workflowAssignmentEnabled={workflowAssignmentEnabled}
-      workflowID={props.workflowID || defaultWorkflow}
+      workflowID={workflowID || defaultWorkflow}
     />
   )
 }

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { MobXProviderContext, observer } from 'mobx-react'
 import { Button, Box, CheckBox } from 'grommet'
 import { Modal, PrimaryButton, SpacedText } from '@zooniverse/react-components'
-import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import Link from 'next/link'
 import addQueryParams from '@helpers/addQueryParams'
@@ -12,6 +11,8 @@ function useStore() {
   const { store } = useContext(MobXProviderContext)
 
   return {
+    /** the current project */
+    project: store.project,
     /** assignedWorkflowID is fetched every 5 classifications per user session */
     assignedWorkflowID: store.user.personalization.projectPreferences.settings?.workflow_id,
     /** This function determines if the user has an assigned workflow and verifies that workflow is active in panoptes */
@@ -20,13 +21,10 @@ function useStore() {
 }
 
 function WorkflowAssignmentModal({ currentWorkflowID = '' }) {
-  const { assignedWorkflowID, promptAssignment } = useStore()
+  const { project, assignedWorkflowID, promptAssignment } = useStore()
 
   const { t } = useTranslation('screens')
-  const router = useRouter()
-  const owner = router?.query?.owner
-  const project = router?.query?.project
-  const url = `/${owner}/${project}/classify/workflow/${assignedWorkflowID}`
+  const url = `/${project.slug}/classify/workflow/${assignedWorkflowID}`
 
   /** Check if user has dismissed the modal, but only in the browser */
   const isBrowser = typeof window !== 'undefined'
@@ -66,6 +64,10 @@ function WorkflowAssignmentModal({ currentWorkflowID = '' }) {
     setActive(false)
   }
 
+  function onClick() {
+    project.setSelectedWorkflow(assignedWorkflowID)
+  }
+
   return (
     <Modal
       active={active}
@@ -95,6 +97,7 @@ function WorkflowAssignmentModal({ currentWorkflowID = '' }) {
           as={Link}
           href={addQueryParams(url)}
           label={t('Classify.WorkflowAssignmentModal.confirm')}
+          onClick={onClick}
         />
       </Box>
     </Modal>

--- a/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.stories.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/WorkflowAssignmentModal/WorkflowAssignmentModal.stories.js
@@ -22,6 +22,7 @@ const mockRouter = {
 
 const snapshot = {
   project: {
+    slug: 'zooniverse/snapshot-serengeti',
     strings: {
       display_name: 'Snapshot Serengeti',
     },

--- a/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelector.spec.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/WorkflowSelector.spec.js
@@ -1,12 +1,16 @@
 import asyncStates from '@zooniverse/async-states'
 import { mount } from 'enzyme'
+import { Provider } from 'mobx-react'
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime'
 
+import initStore from '@stores'
 import WorkflowSelector from './WorkflowSelector'
 import WorkflowSelectButtons from './components/WorkflowSelectButtons'
 import { expect } from 'chai'
 
 describe('Component > WorkflowSelector', function () {
+  let store
+
   const mockRouter = {
     asPath: '/zooniverse/snapshot-serengeti/about/team',
     basePath: '/projects',
@@ -42,22 +46,13 @@ describe('Component > WorkflowSelector', function () {
   const DEFAULT_WORKFLOW_DESCRIPTION = 'WorkflowSelector.message'
   /** The translation function will simply return keys in a testing env */
 
-  it('should render without crashing', function () {
-    const wrapper = mount(
-      <RouterContext.Provider value={mockRouter}>
-        <WorkflowSelector
-          theme={THEME}
-          workflows={WORKFLOWS}
-          workflowDescription={WORKFLOW_DESCRIPTION}
-        />
-      </RouterContext.Provider>
-    )
-    expect(wrapper).to.be.ok()
+  this.beforeEach(function () {
+    store = initStore(true)
   })
 
-  describe('workflow description', function () {
-    it('should use the `workflowDescription` prop if available', function () {
-      const wrapper = mount(
+  it('should render without crashing', function () {
+    const wrapper = mount(
+      <Provider store={store}>
         <RouterContext.Provider value={mockRouter}>
           <WorkflowSelector
             theme={THEME}
@@ -65,31 +60,52 @@ describe('Component > WorkflowSelector', function () {
             workflowDescription={WORKFLOW_DESCRIPTION}
           />
         </RouterContext.Provider>
+      </Provider>
+    )
+    expect(wrapper).to.be.ok()
+  })
+
+  describe('workflow description', function () {
+    it('should use the `workflowDescription` prop if available', function () {
+      const wrapper = mount(
+        <Provider store={store}>
+          <RouterContext.Provider value={mockRouter}>
+            <WorkflowSelector
+              theme={THEME}
+              workflows={WORKFLOWS}
+              workflowDescription={WORKFLOW_DESCRIPTION}
+            />
+          </RouterContext.Provider>
+        </Provider>
       )
       expect(wrapper.contains(WORKFLOW_DESCRIPTION)).to.be.true()
     })
 
     it('should use the default message if the `workflowDescription` prop is unset', function () {
       const wrapper = mount(
-        <RouterContext.Provider value={mockRouter}>
-          <WorkflowSelector
-            theme={THEME}
-            workflows={WORKFLOWS}
-          />
-        </RouterContext.Provider>
+        <Provider store={store}>
+          <RouterContext.Provider value={mockRouter}>
+            <WorkflowSelector
+              theme={THEME}
+              workflows={WORKFLOWS}
+            />
+          </RouterContext.Provider>
+        </Provider>
       )
       expect(wrapper.contains(DEFAULT_WORKFLOW_DESCRIPTION)).to.be.true()
     })
 
     it('should use the default message if the `workflowDescription` prop is an empty string', function () {
       const wrapper = mount(
-        <RouterContext.Provider value={mockRouter}>
-          <WorkflowSelector
-            theme={THEME}
-            workflows={WORKFLOWS}
-            workflowDescription=''
-          />
-        </RouterContext.Provider>
+        <Provider store={store}>
+          <RouterContext.Provider value={mockRouter}>
+            <WorkflowSelector
+              theme={THEME}
+              workflows={WORKFLOWS}
+              workflowDescription=''
+            />
+          </RouterContext.Provider>
+        </Provider>
       )
       expect(wrapper.contains(DEFAULT_WORKFLOW_DESCRIPTION)).to.be.true()
     })
@@ -98,14 +114,16 @@ describe('Component > WorkflowSelector', function () {
   describe('when successfully loaded the user state and loaded the user project preferences', function () {
     it('should render workflow select buttons', function () {
       const wrapper = mount(
-        <RouterContext.Provider value={mockRouter}>
-          <WorkflowSelector
-            uppLoaded={true}
-            userReadyState={asyncStates.success}
-            theme={THEME}
-            workflows={WORKFLOWS}
-          />
-        </RouterContext.Provider>
+        <Provider store={store}>
+          <RouterContext.Provider value={mockRouter}>
+            <WorkflowSelector
+              uppLoaded={true}
+              userReadyState={asyncStates.success}
+              theme={THEME}
+              workflows={WORKFLOWS}
+            />
+          </RouterContext.Provider>
+        </Provider>
       )
       expect(wrapper.find(WorkflowSelectButtons)).to.have.lengthOf(1)
     })

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.js
@@ -3,28 +3,33 @@ import withThemeContext from '@zooniverse/react-components/helpers/withThemeCont
 import { Button } from 'grommet'
 import { Next } from 'grommet-icons'
 import Link from 'next/link'
-import { useRouter } from 'next/router'
 import { bool, number, object, shape, string } from 'prop-types'
 import { useTranslation } from 'next-i18next'
+import { useCallback, useContext } from 'react'
+import { MobXProviderContext } from 'mobx-react'
 
 import addQueryParams from '@helpers/addQueryParams'
 import theme from './theme'
 
 export const ThemedButton = withThemeContext(Button, theme)
 
+function useProject() {
+  const stores = useContext(MobXProviderContext)
+  const { project } = stores.store
+  return project
+}
 function WorkflowSelectButton ({
   disabled = false,
-  router,
   workflow,
   ...rest
 }) {
   const { t } = useTranslation('components')
-  const nextRouter = useRouter()
-  router = router || nextRouter
-  const owner = router?.query?.owner
-  const project = router?.query?.project
+  const project = useProject()
 
-  const url = `/${owner}/${project}/classify/workflow/${workflow.id}`
+  const url = `/${project.slug}/classify/workflow/${workflow.id}`
+  const onClick = useCallback(() => {
+    project.setSelectedWorkflow(workflow.id)
+  }, [project, workflow.id])
 
   const href = addQueryParams(url)
   const completeness = parseInt(workflow.completeness * 100, 10)
@@ -68,6 +73,7 @@ function WorkflowSelectButton ({
       icon={<Next size='15px' />}
       reverse
       label={label}
+      onClick={onClick}
       primary
       {...rest}
     />

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.spec.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButton/WorkflowSelectButton.spec.js
@@ -3,12 +3,17 @@ import { Grommet } from 'grommet'
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime'
 import sinon from 'sinon'
 import zooTheme from '@zooniverse/grommet-theme'
+import { Provider } from 'mobx-react'
+import { applySnapshot } from 'mobx-state-tree'
 
 import WorkflowSelectButton, { ThemedButton } from './WorkflowSelectButton'
+import initStore from '@stores'
 import Link from 'next/link'
 import { expect } from 'chai'
 
 describe('Component > WorkflowSelector > WorkflowSelectButton', function () {
+  let store
+
   const mockRouter = {
     asPath: '/zooniverse/snapshot-serengeti/about/team',
     basePath: '/projects',
@@ -36,24 +41,36 @@ describe('Component > WorkflowSelector > WorkflowSelectButton', function () {
     }
   }
 
+  beforeEach(function () {
+    store = initStore(true)
+    applySnapshot(store.project, {
+      id: '1',
+      slug: 'foo/bar'
+    })
+  })
+
   it('should render without crashing', function () {
     const wrapper = mount(
-      <RouterContext.Provider value={mockRouter}>
-        <Grommet theme={zooTheme}>
-          <WorkflowSelectButton router={router} theme={zooTheme} workflow={WORKFLOW} />
-        </Grommet>
-      </RouterContext.Provider>
+      <Provider store={store}>
+        <RouterContext.Provider value={mockRouter}>
+          <Grommet theme={zooTheme}>
+            <WorkflowSelectButton router={router} theme={zooTheme} workflow={WORKFLOW} />
+          </Grommet>
+        </RouterContext.Provider>
+      </Provider>
     )
     expect(wrapper).to.be.ok()
   })
 
   it('should not add "set selection" to the label', function () {
     const wrapper = mount(
-      <RouterContext.Provider value={mockRouter}>
-        <Grommet theme={zooTheme}>
-          <WorkflowSelectButton theme={zooTheme} workflow={WORKFLOW} />
-        </Grommet>
-      </RouterContext.Provider>
+      <Provider store={store}>
+        <RouterContext.Provider value={mockRouter}>
+          <Grommet theme={zooTheme}>
+            <WorkflowSelectButton theme={zooTheme} workflow={WORKFLOW} />
+          </Grommet>
+        </RouterContext.Provider>
+      </Provider>
     )
     const label = shallow(wrapper.find(ThemedButton).prop('label')).render()
     expect(label.text()).to.equal('WorkflowSelector.WorkflowSelectButton.completeWorkflow name')
@@ -63,18 +80,20 @@ describe('Component > WorkflowSelector > WorkflowSelectButton', function () {
   describe('when used with a default workflow', function () {
     it('should be a link pointing to `/classify/workflow/:workflow_id`', function () {
       const wrapper = mount(
-        <RouterContext.Provider value={mockRouter}>
-          <Grommet theme={zooTheme}>
-            <WorkflowSelectButton
-              router={router}
-              theme={zooTheme}
-              workflow={{
-                ...WORKFLOW,
-                default: true
-              }}
-            />
-          </Grommet>
-        </RouterContext.Provider>
+        <Provider store={store}>
+          <RouterContext.Provider value={mockRouter}>
+            <Grommet theme={zooTheme}>
+              <WorkflowSelectButton
+                router={router}
+                theme={zooTheme}
+                workflow={{
+                  ...WORKFLOW,
+                  default: true
+                }}
+              />
+            </Grommet>
+          </RouterContext.Provider>
+        </Provider>
       )
       expect(wrapper.find(Link).prop('href')).to.equal(`${router.asPath}/classify/workflow/${WORKFLOW.id}`)
     })
@@ -83,11 +102,13 @@ describe('Component > WorkflowSelector > WorkflowSelectButton', function () {
   describe('when used with a non-default workflow', function () {
     it('should be a link pointing to `/classify/workflow/:workflow_id`', function () {
       const wrapper = mount(
-        <RouterContext.Provider value={mockRouter}>
-          <Grommet theme={zooTheme}>
-            <WorkflowSelectButton router={router} theme={zooTheme} workflow={WORKFLOW} />
-          </Grommet>
-        </RouterContext.Provider>
+        <Provider store={store}>
+          <RouterContext.Provider value={mockRouter}>
+            <Grommet theme={zooTheme}>
+              <WorkflowSelectButton router={router} theme={zooTheme} workflow={WORKFLOW} />
+            </Grommet>
+          </RouterContext.Provider>
+        </Provider>
       ).find(WorkflowSelectButton)
       expect(wrapper.find(Link).prop('href')).to.equal(`${router.asPath}/classify/workflow/${WORKFLOW.id}`)
     })
@@ -102,11 +123,13 @@ describe('Component > WorkflowSelector > WorkflowSelectButton', function () {
         grouped: true
       }
       wrapper = mount(
-        <RouterContext.Provider value={mockRouter}>
-          <Grommet theme={zooTheme}>
-            <WorkflowSelectButton router={router} theme={zooTheme} workflow={groupedWorkflow} />
-          </Grommet>
-        </RouterContext.Provider>
+        <Provider store={store}>
+          <RouterContext.Provider value={mockRouter}>
+            <Grommet theme={zooTheme}>
+              <WorkflowSelectButton router={router} theme={zooTheme} workflow={groupedWorkflow} />
+            </Grommet>
+          </RouterContext.Provider>
+        </Provider>
       )
     })
 
@@ -120,22 +143,26 @@ describe('Component > WorkflowSelector > WorkflowSelectButton', function () {
   describe('when disabled', function () {
     it('should not have an href', function () {
       const wrapper = mount(
-        <RouterContext.Provider value={mockRouter}>
-          <Grommet theme={zooTheme}>
-            <WorkflowSelectButton disabled router={router} theme={zooTheme} workflow={WORKFLOW} />
-          </Grommet>
-        </RouterContext.Provider>
+        <Provider store={store}>
+          <RouterContext.Provider value={mockRouter}>
+            <Grommet theme={zooTheme}>
+              <WorkflowSelectButton disabled router={router} theme={zooTheme} workflow={WORKFLOW} />
+            </Grommet>
+          </RouterContext.Provider>
+        </Provider>
       ).find(WorkflowSelectButton)
       expect(wrapper.prop('href')).to.be.undefined()
     })
 
     it('should not wrap the button with Link', function () {
       const wrapper = mount(
-        <RouterContext.Provider value={mockRouter}>
-          <Grommet theme={zooTheme}>
-            <WorkflowSelectButton disabled router={router} theme={zooTheme} workflow={WORKFLOW} />
-          </Grommet>
-        </RouterContext.Provider>
+        <Provider store={store}>
+          <RouterContext.Provider value={mockRouter}>
+            <Grommet theme={zooTheme}>
+              <WorkflowSelectButton disabled router={router} theme={zooTheme} workflow={WORKFLOW} />
+            </Grommet>
+          </RouterContext.Provider>
+        </Provider>
       )
       expect(wrapper.find(Link)).to.have.lengthOf(0)
     })

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.spec.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.spec.js
@@ -1,9 +1,13 @@
 import { render } from '@testing-library/react'
 import { expect } from 'chai'
+import { Provider } from 'mobx-react'
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime'
+import initStore from '@stores'
 import WorkflowSelectButtons from './WorkflowSelectButtons'
 
 describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
+  let store
+
   const mockRouter = {
     asPath: '/zooniverse/snapshot-serengeti',
     basePath: '/projects',
@@ -41,12 +45,18 @@ describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
     }
   ]
 
+  this.beforeEach(function () {
+    store = initStore(true)
+  })
+
   describe('when workflow assignment is not enabled', function () {
     it('should render a workflow link for each workflow', function () {
       const { getAllByRole } = render(
-        <RouterContext.Provider value={mockRouter}>
-          <WorkflowSelectButtons workflows={workflows} />
-        </RouterContext.Provider>
+        <Provider store={store}>
+          <RouterContext.Provider value={mockRouter}>
+            <WorkflowSelectButtons workflows={workflows} />
+          </RouterContext.Provider>
+        </Provider>
       )
       expect(getAllByRole('link')).to.have.lengthOf(workflows.length)
     })
@@ -56,18 +66,22 @@ describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
     describe('when there is an assigned workflow', function () {
       it('should only render links for unlocked workflows', function () {
         const { getAllByRole } = render(
-          <RouterContext.Provider value={mockRouter}>
-            <WorkflowSelectButtons assignedWorkflowID='2' workflowAssignmentEnabled workflows={workflows} />
-          </RouterContext.Provider>
+          <Provider store={store}>
+            <RouterContext.Provider value={mockRouter}>
+              <WorkflowSelectButtons assignedWorkflowID='2' workflowAssignmentEnabled workflows={workflows} />
+            </RouterContext.Provider>
+          </Provider>
         )
         expect(getAllByRole('link')).to.have.lengthOf(2)
       })
 
       it('should render other workflows as just text', function () {
         const { getByText } = render(
-          <RouterContext.Provider value={mockRouter}>
-            <WorkflowSelectButtons assignedWorkflowID='2' workflowAssignmentEnabled workflows={workflows} />
-          </RouterContext.Provider>
+          <Provider store={store}>
+            <RouterContext.Provider value={mockRouter}>
+              <WorkflowSelectButtons assignedWorkflowID='2' workflowAssignmentEnabled workflows={workflows} />
+            </RouterContext.Provider>
+          </Provider>
         )
         expect(getByText('workflow 3')).to.exist()
       })
@@ -76,9 +90,11 @@ describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
     describe('when there is not an assigned workflow', function () {
       it('should only render the first level workflow as unlocked', function () {
         const { getAllByRole, getByRole } = render(
-          <RouterContext.Provider value={mockRouter}>
-            <WorkflowSelectButtons assignedWorkflowID='1' workflowAssignmentEnabled workflows={workflows} />
-          </RouterContext.Provider>
+          <Provider store={store}>
+            <RouterContext.Provider value={mockRouter}>
+              <WorkflowSelectButtons assignedWorkflowID='1' workflowAssignmentEnabled workflows={workflows} />
+            </RouterContext.Provider>
+          </Provider>
         )
         expect(getByRole('link', { href: '/projects/undefined/undefined/classify/workflow/1' })).to.exist()
         expect(getAllByRole('link')).to.have.lengthOf(1)
@@ -87,9 +103,11 @@ describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
 
       it('should render other workflows as just text', function () {
         const { getByText } = render(
-          <RouterContext.Provider value={mockRouter}>
-            <WorkflowSelectButtons assignedWorkflowID='1' workflowAssignmentEnabled workflows={workflows} />
-          </RouterContext.Provider>
+          <Provider store={store}>
+            <RouterContext.Provider value={mockRouter}>
+              <WorkflowSelectButtons assignedWorkflowID='1' workflowAssignmentEnabled workflows={workflows} />
+            </RouterContext.Provider>
+          </Provider>
         )
         expect(getByText('workflow 2')).to.exist()
         expect(getByText('workflow 3')).to.exist()

--- a/packages/app-project/stores/Project.spec.js
+++ b/packages/app-project/stores/Project.spec.js
@@ -147,8 +147,8 @@ describe('Stores > Project', function () {
         project = rootStore.project
       })
 
-      it('should be undefined', function () {
-        expect(project.defaultWorkflow).to.be.undefined()
+      it('should be empty', function () {
+        expect(project.defaultWorkflow).to.be.empty()
       })
     })
 
@@ -167,8 +167,8 @@ describe('Stores > Project', function () {
         project = rootStore.project
       })
 
-      it('should be undefined', function () {
-        expect(project.defaultWorkflow).to.be.undefined()
+      it('should be empty', function () {
+        expect(project.defaultWorkflow).to.be.empty()
       })
     })
   })


### PR DESCRIPTION
- Store your selected workflow in a `workflow_id` session cookie on the `zooniverse.org` domain, scoped to the current project.
- Set that cookie when you choose a workflow with the `WorkflowSelectButton` component, or when you level up by following a workflow link in Gravity Spy. 
- Read the cookie in the Project model, and store it as `project.selectedWorkflow`. Return the stored value from `project.defaultWorkflow`. 
- Use `project.defaultWorkflow` on the Classify page, if there's no workflow in the URL.
- Use `props.workflowID` on the Classify page, if there is a workflow in the URL.
- Add the project context to tests.

<img width=800 src="https://github.com/user-attachments/assets/45d4485c-9142-49e5-81fe-e18fd9c572c0" alt="Cookies for local.zooniverse.org in Firefox, showing 3 workflow_id cookies for 3 projects." >

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project

## Linked Issue and/or Talk Post

- fixes #6218.
- https://www.zooniverse.org/talk/2354/3326062?comment=5610483 (part of a much longer discussion but I think @yshish summarised all the main problems with the current navigation there.)
- Fixes an issue for Black Hole Hunters and Gravity Spy where you are asked to choose a workflow after using Done & Talk to leave a comment. 
- Black Hole Hunters Talk discussion: https://www.zooniverse.org/projects/cobalt-lensing/black-hole-hunters/talk/4564/3371395
- Gravity Spy discussions: 
  - https://www.zooniverse.org/projects/zooniverse/gravity-spy/talk/730/3206987
  - https://www.zooniverse.org/projects/zooniverse/gravity-spy/talk/329/2928875?comment=4968315&page=5

## How to Review
On a project with multiple workflows, clicking a link to choose a workflow should now set a project session cookie that remembers the workflow ID.
- when you leave the project to go to another Zooniverse page, and come back to `/classify`, it should use the cookie to load a workflow, then update the window location bar to show that workflow. 
- when you leave the project and come back to `/classify/workflow/[workflowID]`, it should respect the workflow in the URL.
- when you use client-side navigation within the project app, your selected workflow should be remembered when you go back to Classify.
- when you enter the project from outside the Zooniverse (eg. a link in an email), it should ignore the same-site cookie. 

https://local.zooniverse.org:3000/projects/abbsta/south-coast-threatened-fauna-recovery-project?env=production
The big change here is that the Classify link in the project navigation should now reflect your selected workflow (either 21967 or 21968.) That workflow should also be remembered in a session cookie, when you leave the React app and return to https://local.zooniverse.org:3000/projects/abbsta/south-coast-threatened-fauna-recovery-project/classify?env=production

If you shut down the browser, then 'restore previous session', the browser will probably restore the session cookie too. Otherwise, ending your browser session should clear session cookies for all projects, and you'll be asked to choose a workflow when you next classify on a project.

I’ve tested with Gravity Spy and South Coast Threatened Fauna, but any project with more than one workflow should work. 

Next.js turns off client-side navigation in development mode, so you’ll need to run the app in production mode to test the project navigation menu. 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)
