### PR TITLE
fix(app-project): data-fetching for assigned workflow level

### DIFF
--- a/packages/app-project/src/hooks/useAssignedLevel.js
+++ b/packages/app-project/src/hooks/useAssignedLevel.js
@@ -3,8 +3,6 @@
   so we fetch the assigned workflow's config just in case.
   https://github.com/zooniverse/front-end-monorepo/issues/6198
 */
-
-import { useEffect, useState } from 'react'
 import { panoptes } from '@zooniverse/panoptes-js'
 import useSWR from 'swr'
 

--- a/packages/app-project/src/hooks/useAssignedLevel.js
+++ b/packages/app-project/src/hooks/useAssignedLevel.js
@@ -4,15 +4,7 @@
   https://github.com/zooniverse/front-end-monorepo/issues/6198
 */
 import { panoptes } from '@zooniverse/panoptes-js'
-import useSWR from 'swr'
-
-const SWRoptions = {
-  revalidateIfStale: false,
-  revalidateOnMount: false,
-  revalidateOnFocus: false,
-  revalidateOnReconnect: false,
-  refreshInterval: 0
-}
+import useSWRImmutable from 'swr/immutable'
 
 async function fetchAssignedWorkflow({
   fields = 'configuration',
@@ -38,7 +30,7 @@ function useAssignedLevel(assignedWorkflowID, workflows = []) {
   const key = !existingWorkflow && assignedWorkflowID
     ? { assignedWorkflowID }
     : null // skip data fetching when we already have the workflow level
-  const { data: fetchedWorkflowLevel } = useSWR(key, fetchAssignedWorkflow, SWRoptions)
+  const { data: fetchedWorkflowLevel } = useSWRImmutable(key, fetchAssignedWorkflow)
 
   return fetchedWorkflowLevel || defaultWorkflowLevel
 }

--- a/packages/app-project/src/hooks/useAssignedLevel.js
+++ b/packages/app-project/src/hooks/useAssignedLevel.js
@@ -18,8 +18,13 @@ const SWRoptions = {
 
 async function fetchAssignedWorkflow({
   fields = 'configuration',
-  assignedWorkflowID
+  assignedWorkflowID,
+  workflows = []
 }) {
+  const existingWorkflow = workflows.find(workflow => workflow.id === assignedWorkflowID)
+  if (existingWorkflow) {
+    return parseInt(existingWorkflow.configuration?.level, 10)
+  }
   const query = {
     fields,
     id: assignedWorkflowID
@@ -32,8 +37,8 @@ async function fetchAssignedWorkflow({
   return 1
 }
 
-function useAssignedLevel(assignedWorkflowID) {
-  const key = assignedWorkflowID ? { assignedWorkflowID } : null
+function useAssignedLevel(assignedWorkflowID, workflows = []) {
+  const key = assignedWorkflowID ? { assignedWorkflowID, workflows } : null
   const { data: assignedWorkflowLevel } = useSWR(key, fetchAssignedWorkflow, SWRoptions)
 
   return assignedWorkflowLevel || 1

--- a/packages/app-project/src/hooks/useAssignedLevel.js
+++ b/packages/app-project/src/hooks/useAssignedLevel.js
@@ -7,10 +7,10 @@ import { panoptes } from '@zooniverse/panoptes-js'
 import useSWR from 'swr'
 
 const SWRoptions = {
-  revalidateIfStale: true,
-  revalidateOnMount: true,
-  revalidateOnFocus: true,
-  revalidateOnReconnect: true,
+  revalidateIfStale: false,
+  revalidateOnMount: false,
+  revalidateOnFocus: false,
+  revalidateOnReconnect: false,
   refreshInterval: 0
 }
 

--- a/packages/app-project/src/hooks/useAssignedLevel.js
+++ b/packages/app-project/src/hooks/useAssignedLevel.js
@@ -4,7 +4,15 @@
   https://github.com/zooniverse/front-end-monorepo/issues/6198
 */
 import { panoptes } from '@zooniverse/panoptes-js'
-import useSWRImmutable from 'swr/immutable'
+import useSWR from 'swr'
+
+const SWRoptions = {
+  revalidateIfStale: false,
+  revalidateOnMount: false,
+  revalidateOnFocus: false,
+  revalidateOnReconnect: false,
+  refreshInterval: 0
+}
 
 async function fetchAssignedWorkflow({
   fields = 'configuration',
@@ -30,7 +38,7 @@ function useAssignedLevel(assignedWorkflowID, workflows = []) {
   const key = !existingWorkflow && assignedWorkflowID
     ? { assignedWorkflowID }
     : null // skip data fetching when we already have the workflow level
-  const { data: fetchedWorkflowLevel } = useSWRImmutable(key, fetchAssignedWorkflow)
+    const { data: fetchedWorkflowLevel } = useSWR(key, fetchAssignedWorkflow, SWRoptions)
 
   return fetchedWorkflowLevel || defaultWorkflowLevel
 }

--- a/packages/app-project/src/hooks/useAssignedLevel.js
+++ b/packages/app-project/src/hooks/useAssignedLevel.js
@@ -40,8 +40,12 @@ async function fetchAssignedWorkflow({
 function useAssignedLevel(assignedWorkflowID, workflows = []) {
   const key = assignedWorkflowID ? { assignedWorkflowID, workflows } : null
   const { data: assignedWorkflowLevel } = useSWR(key, fetchAssignedWorkflow, SWRoptions)
+  const existingWorkflow = workflows.find(workflow => workflow.id === assignedWorkflowID)
+  let defaultWorkflowLevel = existingWorkflow?.configuration?.level ?
+    parseInt(existingWorkflow.configuration?.level, 10) :
+    1
 
-  return assignedWorkflowLevel || 1
+  return assignedWorkflowLevel || defaultWorkflowLevel
 }
 
 export default useAssignedLevel

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageConnector.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageConnector.js
@@ -27,7 +27,7 @@ function ClassifyPageConnector(props) {
     workflowAssignmentEnabled = false
   } = useStore(store)
   const assignedWorkflowID = projectPreferences?.settings?.workflow_id
-  const assignedWorkflowLevel = useAssignedLevel(assignedWorkflowID)
+  const assignedWorkflowLevel = useAssignedLevel(assignedWorkflowID, props.workflows)
 
   return (
     <ClassifyPageContainer

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageConnector.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageConnector.js
@@ -1,5 +1,6 @@
 import { MobXProviderContext, observer } from 'mobx-react'
 import { useContext } from 'react'
+import useAssignedLevel from '@hooks/useAssignedLevel'
 import ClassifyPageContainer from './ClassifyPageContainer'
 
 function useStore(store) {
@@ -25,14 +26,16 @@ function ClassifyPageConnector(props) {
     projectPreferences,
     workflowAssignmentEnabled = false
   } = useStore(store)
+  const assignedWorkflowID = projectPreferences?.settings?.workflow_id
+  const assignedWorkflowLevel = useAssignedLevel(assignedWorkflowID)
 
   return (
     <ClassifyPageContainer
+      {...props}
       appLoadingState={appLoadingState}
-      assignedWorkflowID={projectPreferences?.settings?.workflow_id}
+      assignedWorkflowLevel={assignedWorkflowLevel}
       projectPreferences={projectPreferences}
       workflowAssignmentEnabled={workflowAssignmentEnabled}
-      {...props}
     />
   )
 }

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.js
@@ -2,10 +2,9 @@ import { useCallback, useEffect, useState } from 'react'
 import { array, bool, string } from 'prop-types'
 
 import ClassifyPage from './ClassifyPage'
-import useAssignedLevel from '@hooks/useAssignedLevel.js'
 
 function ClassifyPageContainer ({
-  assignedWorkflowID = '',
+  assignedWorkflowLevel = 1,
   subjectID,
   workflowAssignmentEnabled = false,
   workflowID,
@@ -16,7 +15,6 @@ function ClassifyPageContainer ({
   but can be reset by the Classifier component via onSubjectReset().
   This state does not change via components of the prioritized subjects UI (Next/Prev buttons) */
   const [selectedSubjectID, setSelectedSubjectID] = useState(subjectID)
-  const assignedWorkflowLevel = useAssignedLevel(assignedWorkflowID)
 
   let allowedWorkflows = workflows.slice()
   /* Double check that a volunteer navigating to url with workflowID is allowed to load that workflow */

--- a/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/ClassifyPageContainer.spec.js
@@ -235,7 +235,7 @@ describe('Component > ClassifyPageContainer', function () {
             <RouterContext.Provider value={mockRouter}>
               <Provider store={mockStoreWithAssignment}>
                 <ClassifyPageContainer
-                  assignedWorkflowID='5678'
+                  assignedWorkflowLevel={2}
                   workflowAssignmentEnabled
                   workflowID='1234'
                   workflows={workflows}
@@ -279,7 +279,7 @@ describe('Component > ClassifyPageContainer', function () {
             <RouterContext.Provider value={mockRouter}>
               <Provider store={mockStoreWithAssignment}>
                 <ClassifyPageContainer
-                  assignedWorkflowID='1234'
+                  assignedWorkflowLevel={1}
                   workflowAssignmentEnabled
                   workflowID='5678'
                   workflows={workflows}

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/LevelingUpButtons.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/LevelingUpButtons.js
@@ -8,7 +8,7 @@ import useAssignedLevel from '@hooks/useAssignedLevel.js'
 function LevelingUpButtons({ assignedWorkflowID = '', workflows = [] }) {
   const { t } = useTranslation('components')
 
-  const assignedWorkflowLevel = useAssignedLevel(assignedWorkflowID)
+  const assignedWorkflowLevel = useAssignedLevel(assignedWorkflowID, workflows)
   const filteredWorkflowsByLevel = { allowed: [], disallowed: [] }
 
   if (assignedWorkflowLevel) {

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.spec.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.spec.js
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { expect } from 'chai'
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime'
 import WorkflowSelectButtons from './WorkflowSelectButtons'
@@ -54,13 +54,13 @@ describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
 
   describe('when workflow assignment is enabled', function () {
     describe('when there is an assigned workflow', function () {
-      it('should only render links for unlocked workflows', async function () {
+      it('should only render links for unlocked workflows', function () {
         const { getAllByRole } = render(
           <RouterContext.Provider value={mockRouter}>
             <WorkflowSelectButtons assignedWorkflowID='2' workflowAssignmentEnabled workflows={workflows} />
           </RouterContext.Provider>
         )
-        await waitFor(() => expect(getAllByRole('link')).to.have.lengthOf(2))
+        expect(getAllByRole('link')).to.have.lengthOf(2)
       })
 
       it('should render other workflows as just text', function () {

--- a/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.spec.js
+++ b/packages/app-project/src/shared/components/WorkflowSelector/components/WorkflowSelectButtons/WorkflowSelectButtons.spec.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { expect } from 'chai'
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime'
 import WorkflowSelectButtons from './WorkflowSelectButtons'
@@ -52,16 +52,15 @@ describe('Component > WorkflowSelector > WorkflowSelectorButtons', function () {
     })
   })
 
-  /** Skipped because I added a custom hook to WorkflowSelectButtons > LevelingUpButtons */
   describe('when workflow assignment is enabled', function () {
-    describe.skip('when there is an assigned workflow', function () {
-      it('should only render links for unlocked workflows', function () {
+    describe('when there is an assigned workflow', function () {
+      it('should only render links for unlocked workflows', async function () {
         const { getAllByRole } = render(
           <RouterContext.Provider value={mockRouter}>
             <WorkflowSelectButtons assignedWorkflowID='2' workflowAssignmentEnabled workflows={workflows} />
           </RouterContext.Provider>
         )
-        expect(getAllByRole('link')).to.have.lengthOf(2)
+        await waitFor(() => expect(getAllByRole('link')).to.have.lengthOf(2))
       })
 
       it('should render other workflows as just text', function () {


### PR DESCRIPTION
Fix missing dependency errors in the `useAssignedLevel` hook by using `useSWR` to fetch and cache the assigned workflow level. SWR also adds revalidation of the Panoptes API request for cases where I might classify in the same tab over several days or weeks.* 

Adds conditional data-fetching, so that we only fetch a workflow configuration if we don’t already have it in the `workflows` page prop. 

Also fixes the workflow assignment tests in `ClassifyPageContainer` so that they test against the correct levels, and restores skipped tests to double check that nothing is broken.

~~Adds Mock Service Worker, for mocking API requests in stories.~~ I've moved the story for this into #6406. It sets up a test case where the assigned workflow, level 3, is complete and must be fetched from the Panoptes API.

*do workflow levels change over time? If not, the fetched value can be cached indefinitely.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project

## Linked Issue and/or Talk Post
- closes #6217.
- fixes an issue where the workflow API request can run more than once, when `useAssignedLevel` is used more than once in the page or the page is run in React Strict Mode.
- fixes a bug where the Classify page always renders twice, first with a level of 1 and then with your actual level. 

## How to Review
Testing for this should be the same as #6201. `useAssignedLevel` should only call the API once for a given workflow, even if it’s invoked from multiple components. 

If you load Gravity Spy with the workflow choice menu, you can check that the Classify page only makes one API request for any missing workflows, even though `useAssignedLevel` is used twice on the page. The assigned level should also be cached in the client-side project app for the duration of your session.
https://local.zooniverse.org:3000/projects/zooniverse/gravity-spy/classify?env=production

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
