### PR TITLE
Use relative paths for any links with /about or /get-involved or sharing groups

### DIFF
--- a/packages/lib-content/src/screens/About/components/Contact.js
+++ b/packages/lib-content/src/screens/About/components/Contact.js
@@ -98,7 +98,13 @@ export default function Contact({ widgetLoaded = false }) {
           {t('AboutPage.contact.heading')}
         </StyledButton>
         <Paragraph margin={{ top: 'medium' }}>
-          {t('AboutPage.contact.paragraphs.three')}
+          <Trans
+            i18nKey='AboutPage.contact.paragraphs.three'
+            t={t}
+            components={[
+              <Anchor key='direct-email-contact' href='mailto:contact@zooniverse.org' />
+            ]}
+          />
         </Paragraph>
       </Box>
     </Box>

--- a/packages/lib-content/src/screens/About/components/Contact.js
+++ b/packages/lib-content/src/screens/About/components/Contact.js
@@ -82,8 +82,8 @@ export default function Contact({ widgetLoaded = false }) {
           t={t}
           components={[
             <Anchor
-              key='publications-page'
-              href='/publications' // after switch to app-root, this will need to be /about/publications
+              key='faq-page'
+              href='/about/faq'
             />,
             <Anchor
               key='freshdesk-page'

--- a/packages/lib-content/src/screens/About/components/Highlights.js
+++ b/packages/lib-content/src/screens/About/components/Highlights.js
@@ -28,7 +28,7 @@ export default function Highlights() {
           components={[
             <Anchor
               key='publications-page'
-              href='/publications' // after switch to app-root, this will need to be /about/publications
+              href='/about/publications'
             />
           ]}
         />

--- a/packages/lib-content/src/screens/Collaborate/Collaborate.js
+++ b/packages/lib-content/src/screens/Collaborate/Collaborate.js
@@ -98,11 +98,7 @@ function Collaborate() {
               i18nKey='Collaborate.paragraphs.eight'
               t={t}
               components={[
-                <Text
-                  weight='bold'
-                  size='1rem'
-                  color={{ light: 'neutral-1', dark: 'accent-1' }}
-                />
+                <Anchor key='direct-email-cliff' href='mailto:cliff@zooniverse.org' />
               ]}
             />
           </Paragraph>

--- a/packages/lib-content/src/screens/Collaborate/Logos.js
+++ b/packages/lib-content/src/screens/Collaborate/Logos.js
@@ -19,7 +19,7 @@ export function Supporters() {
   return (
     <Box
       gap={size !== 'small' ? '40px' : '15px'}
-      margin={{ top: 'small', bottom: 'large' }}
+      margin={{ top: 'small', bottom: 'xlarge' }}
     >
       <Grid columns={['1fr 1fr 1fr']} rows='auto' gap={gap}>
         <LogoImage

--- a/packages/lib-content/src/screens/FAQ/FAQ.js
+++ b/packages/lib-content/src/screens/FAQ/FAQ.js
@@ -57,7 +57,7 @@ function FAQPage() {
                   />,
                   <Anchor
                     key='contact-us'
-                    href='https://www.zooniverse.org/about#contact'
+                    href='/about#contact'
                   />
                 ]}
               />
@@ -150,7 +150,7 @@ function FAQPage() {
                     components={[
                       <Anchor
                         key='donate-link'
-                        href='https://www.zooniverse.org/about/donate' // Will link to a get-involved section once those pages are built
+                        href='/get-involved/donate'
                       />
                     ]}
                   />
@@ -165,7 +165,7 @@ function FAQPage() {
                     components={[
                       <Anchor
                         key='resources-page'
-                        href='https://www.zooniverse.org/about/resources'
+                        href='/about/resources'
                       />
                     ]}
                   />

--- a/packages/lib-content/src/screens/Resources/Resources.js
+++ b/packages/lib-content/src/screens/Resources/Resources.js
@@ -125,7 +125,7 @@ function Resources() {
                   />,
                   <Anchor
                     key='publications-page'
-                    href='https://www.zooniverse.org/about/publications'
+                    href='/about/publications'
                   />
                 ]}
               />
@@ -137,7 +137,7 @@ function Resources() {
                 components={[
                   <Anchor
                     key='contact-us'
-                    href='https://www.zooniverse.org/about#contact'
+                    href='/about#contact'
                   />
                 ]}
               />
@@ -164,7 +164,7 @@ function Resources() {
                 components={[
                   <Anchor
                     key='contact-us'
-                    href='https://www.zooniverse.org/about#contact'
+                    href='/about#contact'
                   />
                 ]}
               />

--- a/packages/lib-content/src/translations/en.json
+++ b/packages/lib-content/src/translations/en.json
@@ -37,7 +37,7 @@
       "paragraphs": {
         "one": "Please read through our <0>FAQ page</0> and the <1>Zooniverse Solutions webpage</1>.",
         "two": "Do you have an issue related to a specific project? We recommend reaching out directly to the research team on their Talk page.",
-        "three": "Can't access the Contact Us button? Email us directly at contact@zooniverse.org."
+        "three": "Can't access the Contact Us button? Email us directly at <0>contact@zooniverse.org</0>."
       }
     },
     "description": "",

--- a/packages/lib-user/src/components/GroupStats/helpers/getHeaderItems.js
+++ b/packages/lib-user/src/components/GroupStats/helpers/getHeaderItems.js
@@ -7,8 +7,6 @@ import {
   HeaderToast
 } from '@components/shared'
 
-const BASE_URL = 'https://fe-root.preview.zooniverse.org'
-
 const DEFAULT_HANDLER = () => true
 
 function getHeaderItems({
@@ -26,7 +24,7 @@ function getHeaderItems({
 
   const publicGroup = group.stats_visibility.startsWith('public')
   const role = membership?.roles?.[0]
-  const shareGroupUrl = new URL(`${BASE_URL}/groups/${group.id}`)
+  const shareGroupUrl = new URL(`${window.location.origin}/groups/${group.id}`)
   shareGroupUrl.search = window.location.search
   const shareGroupUrlString = shareGroupUrl.toString()
 
@@ -79,7 +77,7 @@ function getHeaderItems({
         icon={<Link color='white' size='small' />}
         label='Copy Join Link'
         message='Join Link Copied!'
-        textToCopy={`${BASE_URL}/groups/${group.id}?join_token=${group.join_token}`}
+        textToCopy={`${window.location.origin}/groups/${group.id}?join_token=${group.join_token}`}
       />,
       <HeaderToast
         key='share-group-toast'

--- a/packages/lib-user/src/components/UserHome/components/WelcomeModal/WelcomeModal.js
+++ b/packages/lib-user/src/components/UserHome/components/WelcomeModal/WelcomeModal.js
@@ -144,7 +144,8 @@ function WelcomeModal() {
               </Paragraph>
             </Box>
             <Box direction='row' pad={{ top: 'large' }} gap='small'>
-              <StyledAnchor href='https://www.zooniverse.org'>
+              {/* Needs update with link to blog post when published */}
+              <StyledAnchor href=''>
                 Read about the changes
               </StyledAnchor>
               <StyledDismiss


### PR DESCRIPTION
## Package
lib-content
lib-user

## Describe your changes

- All of the Get Involved and About pages are built into lib-content for use in app-root, so links to their pages can be relative paths.
- I refactored `BASE_URL` in getHeaderItems() so that on launch of those pages it will equal zooniverse.org.

## How to Review

- Links edited in this PR should work as expected with app-root run locally. There's one case where I corrected a link to the FAQ page, and I'll comment on it below.
- When you click "share a group" or "copy join link", the base of the url should be your local host, and when deployed it will be etc.zooniverse.org.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)