### PR TITLE
SubjectGroupComparison tool not allowing Annotating

### DIFF
--- a/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
+++ b/packages/lib-classifier/src/store/WorkflowStepStore/WorkflowStepStore.js
@@ -79,7 +79,7 @@ const WorkflowStepStore = types
     get hasAnnotateTask () {
       for (const key in self.workflow?.tasks) {
         const task = self.workflow.tasks[key]
-        if (task.type === 'drawing' || task.type === 'transcription' || task.type === 'dataVisAnnotation') {
+        if (task.type === 'drawing' || task.type === 'transcription' || task.type === 'dataVisAnnotation' || task.type === 'subjectGroupComparison') {
           return true
         }
       }


### PR DESCRIPTION
## Package
lib-classifier

## Linked Issue and/or Talk Post
Issue #6224 

## Describe your changes
Research team started creating a group subject selection for FEM and realized that the tool wouldn't allow "selecting" or "annotating" individual subjects within the group viewer. Found that the bug is related to a previous PR that has a list of tasks that enable the Annotate Button in the Classifier, specifically noting that the `subjectGroupComparison` task does not pass that filter.

## How to Review
Load up the Classifer locally and visit Mike Wallamsley's test project ["Not Galaxy Zoo FEM"](https://local.zooniverse.org:8081/?project=mikewalmsley%2Fnot-galaxy-zoo-fem&env=production&workflow=27251). You should be able to see the pencil icon to annotate and it should be selected by default. 

You can also view it on the [Deployed Branch Build](https://fe-project-branch.preview.zooniverse.org/projects/mikewalmsley/not-galaxy-zoo-fem/classify/workflow/27251).

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
