### PR TITLE
Revert "Homepages: Revalidate wordpress fetch every hour"

### DIFF
--- a/packages/app-root/src/app/page.js
+++ b/packages/app-root/src/app/page.js
@@ -21,7 +21,7 @@ function parseFeedPost(post) {
 
 async function fetchBlogFeed(url) {
   try {
-    const response = await fetch(url, { next: { revalidate: 3600 } }) // revalidate at most every hour
+    const response = await fetch(url)
     if (response.ok) {
       const feed = await response.json()
       return feed.posts


### PR DESCRIPTION
Reverts zooniverse/front-end-monorepo#6221

Closes: https://github.com/zooniverse/front-end-monorepo/issues/6231

I'm going to self-review and merge this reversion to close the above Issue.