### PR TITLE
Signed-out homepage Hero video - autoplay only once screen size is detected

### DIFF
--- a/packages/lib-content/src/screens/Home/DefaultHome/components/Hero.js
+++ b/packages/lib-content/src/screens/Home/DefaultHome/components/Hero.js
@@ -2,7 +2,7 @@ import { Anchor, Box, Heading, Paragraph, ResponsiveContext } from 'grommet'
 import styled from 'styled-components'
 import { SpacedText, ZooniverseLogotype } from '@zooniverse/react-components'
 import { useHasMounted } from '@zooniverse/react-components/hooks'
-import { useContext } from 'react'
+import { useContext, useRef } from 'react'
 
 import { useTranslation } from '../../../../translations/i18n.js'
 
@@ -10,11 +10,16 @@ const Relative = styled(Box)`
   position: relative;
   overflow: hidden;
   background: ${props => props.theme.global.colors['neutral-1']};
+  min-height: 60vh;
 `
 
-const MobileHeroImage = styled(Box)`
+const HeroImage = styled(Box)`
   width: 100%;
   height: 60vh;
+
+  @media (width > 768px) {
+    height: 90vh;
+  }
 `
 
 const HeroCopy = styled(Box)`
@@ -64,6 +69,7 @@ const StyledLink = styled(Anchor)`
 `
 
 export default function Hero() {
+  const videoRef = useRef(null)
   const { t } = useTranslation()
   const size = useContext(ResponsiveContext)
   const hasMounted = useHasMounted()
@@ -74,25 +80,22 @@ export default function Hero() {
     prefersReducedMotion = reducedMotionQuery?.matches
   }
 
+  // Only autoplay a video element if desktop width and device does not prefer reduced motion
+   if (size !== 'small' && !prefersReducedMotion && hasMounted && videoRef.current) {
+    videoRef.current.play()
+   }
+
   return (
     <Relative width='100%'>
       {size !== 'small' && !prefersReducedMotion ? (
         <Box fill>
-          {hasMounted && (
-            <video
-              autoPlay
-              loop
-              disablePictureInPicture
-              muted
-              preload='metadata'
-            >
-              <source type='video/webm' src='/assets/home-video.webm' />
-              <source type='video/mp4' src='/assets/home-video.mp4' />
-            </video>
-          )}
+          <video loop disablePictureInPicture muted preload='metadata' ref={videoRef}>
+            <source type='video/webm' src='/assets/home-video.webm' />
+            <source type='video/mp4' src='/assets/home-video.mp4' />
+          </video>
         </Box>
       ) : (
-        <MobileHeroImage
+        <HeroImage
           background={`url(${'/assets/home-video-placeholder.jpg'})`}
         />
       )}

--- a/packages/lib-content/src/screens/Home/DefaultHome/components/Hero.js
+++ b/packages/lib-content/src/screens/Home/DefaultHome/components/Hero.js
@@ -1,10 +1,10 @@
 import { Anchor, Box, Heading, Paragraph, ResponsiveContext } from 'grommet'
 import styled from 'styled-components'
 import { SpacedText, ZooniverseLogotype } from '@zooniverse/react-components'
+import { useHasMounted } from '@zooniverse/react-components/hooks'
 import { useContext } from 'react'
 
 import { useTranslation } from '../../../../translations/i18n.js'
-import { mobileBreakpoint } from '../../../../components/SharedStyledComponents/SharedStyledComponents.js'
 
 const Relative = styled(Box)`
   position: relative;
@@ -12,25 +12,9 @@ const Relative = styled(Box)`
   background: ${props => props.theme.global.colors['neutral-1']};
 `
 
-const VideoContainer = styled(Box)`
-  width: 100%;
-
-  @media (width <= ${mobileBreakpoint}) {
-    display: none;
-  }
-
-  @media (prefers-reduced-motion) {
-    display: none;
-  }
-`
-
 const MobileHeroImage = styled(Box)`
   width: 100%;
   height: 60vh;
-
-  @media (width > ${mobileBreakpoint}) {
-    display: none;
-  }
 `
 
 const HeroCopy = styled(Box)`
@@ -82,18 +66,36 @@ const StyledLink = styled(Anchor)`
 export default function Hero() {
   const { t } = useTranslation()
   const size = useContext(ResponsiveContext)
+  const hasMounted = useHasMounted()
+
+  let prefersReducedMotion
+  if (hasMounted) {
+    const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+    prefersReducedMotion = reducedMotionQuery?.matches
+  }
 
   return (
     <Relative width='100%'>
-      <VideoContainer>
-        <video autoPlay loop disablePictureInPicture muted preload='metadata'>
-          <source type='video/webm' src='/assets/home-video.webm' />
-          <source type='video/mp4' src='/assets/home-video.mp4' />
-        </video>
-      </VideoContainer>
-      <MobileHeroImage
-        background={`url(${'/assets/home-video-placeholder.jpg'})`}
-      />
+      {size !== 'small' && !prefersReducedMotion ? (
+        <Box fill>
+          {hasMounted && (
+            <video
+              autoPlay
+              loop
+              disablePictureInPicture
+              muted
+              preload='metadata'
+            >
+              <source type='video/webm' src='/assets/home-video.webm' />
+              <source type='video/mp4' src='/assets/home-video.mp4' />
+            </video>
+          )}
+        </Box>
+      ) : (
+        <MobileHeroImage
+          background={`url(${'/assets/home-video-placeholder.jpg'})`}
+        />
+      )}
       <HeroCopy justify='center' align='center' pad='medium'>
         <StyledHeading level={1} margin='0'>
           <SpacedText

--- a/packages/lib-react-components/src/hooks/Readme.md
+++ b/packages/lib-react-components/src/hooks/Readme.md
@@ -5,7 +5,7 @@
 When a component needs to be deferred until client-side rendering. See [https://www.joshwcomeau.com/react/the-perils-of-rehydration/](https://www.joshwcomeau.com/react/the-perils-of-rehydration) for a detailed mental model.
 
 ```js
-const hasMounted = useHadMounted()
+const hasMounted = useHasMounted()
 
 return (
   <>


### PR DESCRIPTION
## Package
lib-content

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/6229

## Describe your changes
- In the Hero component, detect if the component has mounted, the screen is not small, and the device does not prefer reduced motion before autoplaying the Hero video.

## How to Review
- Run app-root locally and load the signed-out homepage on desktop and a mobile device. For instance, you can see these changes on your mobile device by using https://xxx.xxx.x.x:3000 with your IP address.
- Change your local device settings for [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) and the video will not display if accessibility settings are set to reduce motion. On macOS this is in Settings > Accessibility > Display.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [x] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [x] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [x] The PR creator has listed user actions to use when testing if bug is fixed
- [x] The bug is fixed