### PR TITLE
app-root: Refactor setting stats startDate param with router.replace

### DIFF
--- a/packages/app-root/src/app/groups/[groupId]/GroupStatsContainer.js
+++ b/packages/app-root/src/app/groups/[groupId]/GroupStatsContainer.js
@@ -50,7 +50,7 @@ function GroupStatsContainer({
   useEffect(function updateStartDateParam() {
     if (selectedStartDate && (startDate === undefined)) {
       const newQueryParams = updateQueryParams([['start_date', selectedStartDate]])
-      router.push(`${window.location.pathname}?${newQueryParams.toString()}`)
+      router.replace(`${window.location.pathname}?${newQueryParams.toString()}`)
     }
   }, [selectedStartDate, startDate, router])
 

--- a/packages/app-root/src/app/users/[login]/stats/UserStatsContainer.js
+++ b/packages/app-root/src/app/users/[login]/stats/UserStatsContainer.js
@@ -48,7 +48,7 @@ function UserStatsContainer({
   useEffect(function updateStartDateParam() {
     if (selectedStartDate && (startDate === undefined)) {
       const newQueryParams = updateQueryParams([['start_date', selectedStartDate]])
-      router.push(`${window.location.pathname}?${newQueryParams.toString()}`)
+      router.replace(`${window.location.pathname}?${newQueryParams.toString()}`)
     }
   }, [selectedStartDate, startDate, router])
 

--- a/packages/app-root/src/app/users/[login]/stats/certificate/CertificateContainer.js
+++ b/packages/app-root/src/app/users/[login]/stats/certificate/CertificateContainer.js
@@ -57,7 +57,7 @@ function CertificateContainer({
   useEffect(function updateStartDateParam() {
     if (selectedStartDate && (startDate === undefined)) {
       const newQueryParams = updateQueryParams([['start_date', selectedStartDate]])
-      router.push(`${window.location.pathname}?${newQueryParams.toString()}`)
+      router.replace(`${window.location.pathname}?${newQueryParams.toString()}`)
     }
   }, [selectedStartDate, startDate, router])
 


### PR DESCRIPTION
## Package
- app-root

## Describe your changes
- refactor updateStartDateParam with `router.replace` instead of `router.push`
- related [Next useRouter docs](https://nextjs.org/docs/app/api-reference/functions/use-router#userouter)
- updateStartDateParam runs when the start_date param is undefined, and sets the start_date param as the default value (7 days ago for user and group stats, all time for certificate page), with router.push this was creating a new entry to the browser history stack, with router.replace it does not add a new entry

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX? n/a
- What user actions should my reviewer step through to review this PR?
  - confirm bug:
    - start from your MyGroups page, i.e. https://fe-root.preview.zooniverse.org/users/markbouslog/groups
    - click a group
    - click browser back button
    - 🐛 note bug - don't go back to MyGroups page
  - confirm same bug, only Firefox:
    - start from your logged-in homepage
    - click "More Stats" button
    - click browser back button
    - 🐛 note bug - don't go back to logged-in homepage
  - confirm fixes locally, same steps as noted above, but clicking browser back button should go back a page
- Which storybook stories should be reviewed? n/a
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated