### PR TITLE
lib-classifier: Fix survey task Confusion drop positioning

### DIFF
--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
@@ -73,7 +73,7 @@ function ConfusedWith({
                 />
               }
               dropProps={{
-                elevation: 'xlarge',
+                elevation: 'none',
                 overflow: 'visible',
                 responsive: false
               }}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
@@ -73,8 +73,9 @@ function ConfusedWith({
                 />
               }
               dropProps={{
+                elevation: 'xlarge',
                 overflow: 'visible',
-                responsive: false,
+                responsive: false
               }}
               label={strings.get(`choices.${confusionId}.label`)}
               open={open === confusionId}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/ConfusedWith.js
@@ -59,7 +59,7 @@ function ConfusedWith({
               autoFocus={hasFocus && index === 0}
               backgroundColor={backgroundColor}
               dropAlign={{
-                bottom: 'top'
+                top: 'bottom'
               }}
               dropContent={
                 <Confusion
@@ -73,7 +73,8 @@ function ConfusedWith({
                 />
               }
               dropProps={{
-                overflow: 'visible'
+                overflow: 'visible',
+                responsive: false,
               }}
               label={strings.get(`choices.${confusionId}.label`)}
               open={open === confusionId}

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/components/Confusion.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Choice/components/ConfusedWith/components/Confusion.js
@@ -21,6 +21,7 @@ export default function Confusion({
         dark: 'dark-3',
         light: 'neutral-6'
       }}
+      elevation='xlarge'
       flex={false}
       pad={{
         bottom: 'small',

--- a/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/components/CharacteristicSection.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/components/components/Chooser/components/CharacteristicsFilter/Characteristics/components/CharacteristicSection.js
@@ -100,12 +100,7 @@ export default function CharacteristicSection({
 CharacteristicSection.propTypes = {
   characteristic: PropTypes.shape({
     label: PropTypes.string,
-    values: PropTypes.objectOf(
-      PropTypes.shape({
-        image: PropTypes.string,
-        label: PropTypes.string
-      })
-    ),
+    values: MobXPropTypes.observableMap,
     valuesOrder: PropTypes.arrayOf(PropTypes.string)
   }),
   characteristicId: PropTypes.string,

--- a/packages/lib-classifier/src/plugins/tasks/survey/models/SurveyTask.js
+++ b/packages/lib-classifier/src/plugins/tasks/survey/models/SurveyTask.js
@@ -40,7 +40,7 @@ const Survey = types.model('Survey', {
   // alwaysShowThumbnails is deprecated in favor of the `thumbnails` property
   alwaysShowThumbnails: types.maybe(types.boolean),
   annotation: types.safeReference(SurveyAnnotation),
-  characteristics: types.optional(types.map(Characteristic), {}),
+  characteristics: types.map(Characteristic),
   characteristicsOrder: types.array(types.string),
   choices: types.map(Choice),
   choicesOrder: types.array(types.string),


### PR DESCRIPTION
## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #5112 

## Describe your changes
- positions Confusion drop below ConfusedWith button
- prevents repositioning Confusion drop per browser view height, affixes Confusion drop below ConfusedWith button
- fix `characteristic.values` type warning, similar to #6087 

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
  - https://local.zooniverse.org:8080/?project=1634&env=staging&workflow=2434
- What user actions should my reviewer step through to review this PR?
  - in [an existing survey task](https://frontend.preview.zooniverse.org/projects/markb-panoptes/survey-task-test-project/classify/workflow/2434?env=staging) and locally, compare:
  - click a survey task choice confusion, note the confusion drop positioning
  - with the confusion drop open, scroll up and down
- Which storybook stories should be reviewed?
  - http://localhost:6006/?path=/story/tasks-survey-choice--default
- Are there plans for follow up PR’s to further fix this bug or develop this feature? no

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated