### PR TITLE
Update platform-wide classification and user count offsets

### DIFF
--- a/packages/app-content-pages/src/screens/About/components/Stats/Stats.js
+++ b/packages/app-content-pages/src/screens/About/components/Stats/Stats.js
@@ -45,12 +45,10 @@ const Stat = styled(Box)`
   We have to manually add some legacy (static) stats to the UI.
   These numbers are not included in the fetch response for
   total volunteers or classifications.
-  https://github.com/zooniverse/Panoptes-Front-End/pull/4511
+  https://github.com/zooniverse/Panoptes-Front-End/pull/7167
 */
-const GZ123_COUNT = 98989226 // classifications
-const OUROBOROS_COUNT = 142800311 // classifications
-const OTHERS_COUNT = 8680290 // classifications
-const OUROBOROS_USER_COUNT = 124921 // volunteers
+const PREPANOPTES_COUNT = 25284786 // classifications
+const OUROBOROS_USER_COUNT = 114576 // volunteers
 
 export default function Stats() {
   const { t } = useTranslation()
@@ -62,7 +60,7 @@ export default function Stats() {
   const { data: volunteers } = useTotalVolunteerCount()
 
   const totalClassifications =
-    classifications + GZ123_COUNT + OUROBOROS_COUNT + OTHERS_COUNT
+    classifications + PREPANOPTES_COUNT
   const totalVolunteers = volunteers + OUROBOROS_USER_COUNT
 
   return (

--- a/packages/app-content-pages/src/screens/About/components/Stats/Stats.js
+++ b/packages/app-content-pages/src/screens/About/components/Stats/Stats.js
@@ -59,8 +59,7 @@ export default function Stats() {
 
   const { data: volunteers } = useTotalVolunteerCount()
 
-  const totalClassifications =
-    classifications + PREPANOPTES_COUNT
+  const totalClassifications = classifications + PREPANOPTES_COUNT
   const totalVolunteers = volunteers + OUROBOROS_USER_COUNT
 
   return (

--- a/packages/lib-content/src/components/Stats/Stats.js
+++ b/packages/lib-content/src/components/Stats/Stats.js
@@ -43,12 +43,10 @@ const Stat = styled(Box)`
   We have to manually add some legacy (static) stats to the UI.
   These numbers are not included in the fetch response for
   total volunteers or classifications.
-  https://github.com/zooniverse/Panoptes-Front-End/pull/4511
+  https://github.com/zooniverse/Panoptes-Front-End/pull/7167
 */
-const GZ123_COUNT = 98989226 // classifications
-const OUROBOROS_COUNT = 142800311 // classifications
-const OTHERS_COUNT = 8680290 // classifications
-const OUROBOROS_USER_COUNT = 124921 // volunteers
+const PREPANOPTES_COUNT = 25284786 // classifications
+const OUROBOROS_USER_COUNT = 114576 // volunteers
 
 export default function Stats() {
   const { t } = useTranslation()
@@ -60,7 +58,7 @@ export default function Stats() {
   const { data: volunteers } = useTotalVolunteerCount()
 
   const totalClassifications =
-    classifications + GZ123_COUNT + OUROBOROS_COUNT + OTHERS_COUNT
+    classifications + PREPANOPTES_COUNT
   const totalVolunteers = volunteers + OUROBOROS_USER_COUNT
 
   return (

--- a/packages/lib-content/src/components/Stats/Stats.js
+++ b/packages/lib-content/src/components/Stats/Stats.js
@@ -57,8 +57,7 @@ export default function Stats() {
 
   const { data: volunteers } = useTotalVolunteerCount()
 
-  const totalClassifications =
-    classifications + PREPANOPTES_COUNT
+  const totalClassifications = classifications + PREPANOPTES_COUNT
   const totalVolunteers = volunteers + OUROBOROS_USER_COUNT
 
   return (


### PR DESCRIPTION
## Packages
app-content-pages
lib-content

## Describe your changes
Updating static offsets for platform-wide classification and user counts.  Parallels changes in https://github.com/zooniverse/Panoptes-Front-End/pull/7167.

## How to Review
1. Visit the not-logged-in homepage (equiv to https://fe-root.preview.zooniverse.org/) and the new About page (equiv to https://fe-root.preview.zooniverse.org/about).
2. Check that new classification and user count values appear. Current approx values: classifications = 832,512,123; users = 2,757,137 (as of Fri Sept 6).

# Checklist
- [ ] Tests are passing locally and on Github
- [ ] New values appear correctly on not-logged-in homepage
- [ ] New values appear on About page