### PR TITLE
fix(classifier): focus management for consensus lines

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/InteractionLayer/components/TranscribedLines/TranscribedLines.js
@@ -1,11 +1,12 @@
 import { observer } from 'mobx-react'
 import { array, arrayOf, bool, number, object, shape, string } from 'prop-types'
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import styled, { css, useTheme } from 'styled-components'
 import { Tooltip } from '@zooniverse/react-components'
 
 import { useTranscriptionReductions } from '@hooks'
 import { TranscriptionLine } from '@plugins/drawingTools/components'
+import { focusMark } from '@plugins/drawingTools/components/Mark/Mark'
 import { useTranslation } from '@translations/i18n'
 
 import TooltipIcon from './components/TooltipIcon'
@@ -77,6 +78,7 @@ function TranscribedLines({
   const [ bounds, setBounds ] = useState({})
   const [ line, setLine ] = useState(defaultLine)
   const [ show, setShow ] = useState(false)
+  const activeLine = useRef()
 
   const { t } = useTranslation('components')
 
@@ -127,12 +129,14 @@ function TranscribedLines({
     setBounds(bounds)
     setLine(line)
     setShow(true)
+    activeLine.current = document.activeElement
   }
 
   function close() {
     setBounds({})
     setLine(defaultLine)
     setShow(false)
+    focusMark(activeLine.current)
   }
 
   return (

--- a/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
+++ b/packages/lib-classifier/src/plugins/drawingTools/components/Mark/Mark.js
@@ -31,7 +31,7 @@ const StyledGroup = styled.g`
   }
 `
 
-function focusMark(markNode) {
+export function focusMark(markNode) {
   const hasFocus = markNode === document.activeElement
   if (!hasFocus) {
     const x = scrollX


### PR DESCRIPTION
Manually focus the current consensus line when the consensus popup is closed, for the transcription task. This fixes an issue in Firefox, where keyboard focus switches to the document body when the popup is closed.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-classifier

## Linked Issue and/or Talk Post
- closes #6271.
- https://github.com/zooniverse/Panoptes-Front-End/pull/4125
- https://github.com/zooniverse/Panoptes-Front-End/issues/4123

## How to Review
Window scroll position shouldn't change now, after closing the consensus transcriptions popup. Remember to test opening/closing the popup with both the keyboard and a mouse/trackpad.

Dev classifier: https://localhost:8080/?project=printmigrationnetwork/print&workflow=20199&subjectSet=111064&subject=84319115&env=production


https://github.com/user-attachments/assets/58d56035-404f-46b7-bf51-52e2c24386a1



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
