### PR TITLE
Add fe-root resources to production k8s template

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -206,3 +206,96 @@ spec:
   minReplicas: 1
   maxReplicas: 6
   targetCPUUtilizationPercentage: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zooniverse-org-root-production
+spec:
+  selector:
+    app: zooniverse-org-root-production
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3000
+  type: NodePort
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zooniverse-org-root-production
+  labels:
+    app: zooniverse-org-root-production
+spec:
+  selector:
+    matchLabels:
+      app: zooniverse-org-root-production
+  template:
+    metadata:
+      labels:
+        app: zooniverse-org-root-production
+    spec:
+      containers:
+        - name: fe-root-production
+          image: ghcr.io/zooniverse/front-end-monorepo-production:__IMAGE_TAG__
+          command: ["yarn", "workspace", "@zooniverse/fe-root"]
+          args: ["start"]
+          resources:
+            requests:
+              memory: "500Mi"
+              cpu: "250m"
+            limits:
+              memory: "1000Mi"
+              cpu: "1000m"
+          startupProbe:
+            httpGet:
+              path: /users
+              port: 3000
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /users
+              port: 3000
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /users
+              port: 3000
+            initialDelaySeconds: 20
+            timeoutSeconds: 10
+          ports:
+            - containerPort: 3000
+          env:
+            - name: COMMIT_ID
+              value: __IMAGE_TAG__
+            - name: CONTENTFUL_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: contentful-conf
+                  key: CONTENTFUL_ACCESS_TOKEN
+            - name: CONTENTFUL_SPACE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: contentful-conf
+                  key: CONTENTFUL_SPACE_ID
+            - name: NODE_ENV
+              value: production
+            - name: PANOPTES_ENV
+              value: production
+            - name: APP_ENV
+              value: production
+            - name: ENABLE_CACHE_HEADERS
+              value: "true"
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: zooniverse-org-root-production
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: zooniverse-org-root-production
+  minReplicas: 2
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
Includes the service, deployment, and autoscaler for the production instance of the fe-root app. Gave it the same resources & scaler config as the fe-project app, but I'll keep an eye on it and scale it up if necessary.

This will create the new resources when the template is applied during the production deploy, but will have no other effect until routing changes in a static PR starts pointing traffic at the new service.

## How to Review
_Helpful explanations that will make your reviewer happy:_
- What Zooniverse project should my reviewer use to review UX?
- What user actions should my reviewer step through to review this PR?
- Which storybook stories should be reviewed?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## New Feature
- [ ] The PR creator has listed user actions to use when testing the new feature
- [ ] Unit tests are included for the new feature
- [ ] A storybook story has been created or updated
  - Example of SlideTutorial [component](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/components/Classifier/components/SlideTutorial/SlideTutorial.js) with docgen comments, and its [story](https://zooniverse.github.io/front-end-monorepo/@zooniverse/classifier/index.html?path=/docs/other-slidetutorial--default)

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

## Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)

## Post-merge
- [ ] This PR adds translations keys to English dictionary(s). See guidance for pulling new keys to Lokalise [here](https://github.com/zooniverse/how-to-zooniverse/blob/master/Translations/lokalise.md#lokalise-and-fem).