### PR TITLE
fix(classifier): proportional height for subject images

### DIFF
--- a/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
+++ b/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/SingleImageViewer/SingleImageViewer.js
@@ -54,7 +54,7 @@ function SingleImageViewer({
       >
         <PlaceholderSVG
           focusable
-          maxHeight={svgMaxHeight}
+          height={svgMaxHeight}
           maxWidth={limitSubjectHeight ? `${width}px` : '100%'}
           onKeyDown={onKeyDown}
           tabIndex={0}


### PR DESCRIPTION
When 'limit subject height' is enabled, style subject images with a proportional height of 90% of the viewport height, up to a maximum size of the original image height.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package

## Linked Issue and/or Talk Post
- closes #6275.

## How to Review
Subject height should now be fixed during all workflow tasks, but never larger than the viewport.

https://local.zooniverse.org:3000/projects/chloezycheng/science-scribbler-synapse-safari/classify/workflow/26732

https://github.com/user-attachments/assets/bb7f1df2-0ba5-487b-bed6-02bce9637440



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

