### PR TITLE
Content pages copy and link updates

### DIFF
--- a/packages/lib-content/src/screens/Collaborate/Collaborate.js
+++ b/packages/lib-content/src/screens/Collaborate/Collaborate.js
@@ -10,7 +10,7 @@ import {
   MobileHeading,
   StyledHeading
 } from '../../components/SharedStyledComponents/SharedStyledComponents.js'
-import { Supporters, SelectedCollaborators} from './Logos.js'
+import { Supporters, SelectedCollaborators } from './Logos.js'
 
 function Collaborate() {
   const { t } = useTranslation()
@@ -38,13 +38,16 @@ function Collaborate() {
           >
             {t('Collaborate.subheadings.one')}
           </SpacedHeading>
-          <Paragraph margin={{ top: '0' }}>{t('Collaborate.paragraphs.one')}</Paragraph>
+          <Paragraph margin={{ top: '0' }}>
+            {t('Collaborate.paragraphs.one')}
+          </Paragraph>
           <Paragraph margin='0'>{t('Collaborate.paragraphs.two')}</Paragraph>
           <Paragraph>
             <Trans
               i18nKey='Collaborate.paragraphs.three'
               t={t}
               components={[
+                <Anchor key='lab' href='https://www.zooniverse.org/lab' />,
                 <Anchor
                   key='best-practices'
                   href='https://docs.google.com/document/d/1SJmOdGmpzYGyKpSnFt_tEe_BZIc2Bzmc3kKlWw-gX68'
@@ -52,7 +55,15 @@ function Collaborate() {
               ]}
             />
           </Paragraph>
-          <Paragraph margin='0'>{t('Collaborate.paragraphs.four')}</Paragraph>
+          <Paragraph margin='0'>
+            <Trans
+              i18nKey='Collaborate.paragraphs.four'
+              t={t}
+              components={[
+                <Anchor key='lab' href='https://www.zooniverse.org/lab' />
+              ]}
+            />
+          </Paragraph>
           <Paragraph margin={{ bottom: 'medium' }}>
             <Trans
               i18nKey='Collaborate.paragraphs.five'
@@ -62,33 +73,18 @@ function Collaborate() {
           </Paragraph>
 
           {/** Our Supporters */}
-          <SpacedHeading
-            level={3}
-            size='1.5rem'
-            textAlign='center'
-            fill
-          >
+          <SpacedHeading level={3} size='1.5rem' textAlign='center' fill>
             {t('Collaborate.subheadings.two')}
           </SpacedHeading>
           <Supporters />
 
           {/** Selected Collaborators */}
-          <SpacedHeading
-            level={3}
-            size='1.5rem'
-            textAlign='center'
-            fill
-          >
+          <SpacedHeading level={3} size='1.5rem' textAlign='center' fill>
             {t('Collaborate.subheadings.three')}
           </SpacedHeading>
           <SelectedCollaborators />
 
-          <SpacedHeading
-            level={3}
-            size='1.5rem'
-            textAlign='center'
-            fill
-          >
+          <SpacedHeading level={3} size='1.5rem' textAlign='center' fill>
             {t('Collaborate.subheadings.four')}
           </SpacedHeading>
           <Paragraph>{t('Collaborate.paragraphs.six')}</Paragraph>
@@ -98,17 +94,15 @@ function Collaborate() {
               i18nKey='Collaborate.paragraphs.eight'
               t={t}
               components={[
-                <Anchor key='direct-email-cliff' href='mailto:cliff@zooniverse.org' />
+                <Anchor
+                  key='direct-email-cliff'
+                  href='mailto:cliff@zooniverse.org'
+                />
               ]}
             />
           </Paragraph>
 
-          <SpacedHeading
-            level={3}
-            size='1.5rem'
-            textAlign='center'
-            fill
-          >
+          <SpacedHeading level={3} size='1.5rem' textAlign='center' fill>
             {t('Collaborate.subheadings.five')}
           </SpacedHeading>
           <Paragraph>

--- a/packages/lib-content/src/screens/Educate/Educate.js
+++ b/packages/lib-content/src/screens/Educate/Educate.js
@@ -152,7 +152,8 @@ function Educate() {
                     components={[
                       <Anchor
                         key='group-stats-announcement'
-                        href='' // Need url after blog post
+                        href='' // Need url after blog post,
+                        // Add the sentence "Read our annoucement for more details, and tag <0>annoucement</0>"
                       />
                     ]}
                   />
@@ -197,6 +198,8 @@ function Educate() {
                   <Trans
                     i18nKey='Educate.forEducators.paragraphs.three'
                     t={t}
+                    // Updated blog post text coming in October
+                    // "See this <0>blog post</0> for details."
                     components={[
                       <Anchor
                         key='group-stats-announcement'
@@ -236,7 +239,7 @@ function Educate() {
                 '...'
               }
               title={t('Educate.articles.two.title')}
-              url='https://astroedjournal.org/index.php/ijae/article/view/43'
+              url='https://blog.zooniverse.org/2019/08/14/uscientist-and-the-galaxy-zoo-touch-table-at-adler-planetarium'
             />
             <Article
               date={t('Educate.articles.three.datePublished')}
@@ -247,7 +250,7 @@ function Educate() {
                 ) + '...'
               }
               title={t('Educate.articles.three.title')}
-              url='https://astroedjournal.org/index.php/ijae/article/view/43'
+              url='https://www.bpl.org/blogs/post/8th-graders-in-missouri-transcribe-anti-slavery-documents-and-learn-about-the-abolitionist-movement'
             />
             <Article
               date={t('Educate.articles.four.datePublished')}
@@ -258,7 +261,7 @@ function Educate() {
                 ) + '...'
               }
               title={t('Educate.articles.four.title')}
-              url='https://astroedjournal.org/index.php/ijae/article/view/43'
+              url='https://blog.zooniverse.org/2015/04/29/floating-forests-teaching-young-children-about-kelp'
             />
           </Box>
 

--- a/packages/lib-content/src/screens/FAQ/FAQ.js
+++ b/packages/lib-content/src/screens/FAQ/FAQ.js
@@ -39,7 +39,11 @@ function FAQPage() {
         </MobileHeading>
         <Box pad={{ horizontal: 'medium' }} align='center'>
           <MaxWidthContent>
-            <StyledHeading color={{ light: 'neutral-1', dark: 'accent-1' }} level='1' size='small'>
+            <StyledHeading
+              color={{ light: 'neutral-1', dark: 'accent-1' }}
+              level='1'
+              size='small'
+            >
               {t('FAQ.title')}
             </StyledHeading>
             <Paragraph margin={{ vertical: 'medium' }}>
@@ -55,10 +59,7 @@ function FAQPage() {
                     key='talk-page'
                     href='https://www.zooniverse.org/talk'
                   />,
-                  <Anchor
-                    key='contact-us'
-                    href='/about#contact'
-                  />
+                  <Anchor key='contact-us' href='/about#contact' />
                 ]}
               />
             </Paragraph>
@@ -73,24 +74,24 @@ function FAQPage() {
               </Box>
               <Box as='li'>
                 <Question>{t('FAQ.item2.question')}</Question>
-                <Answer>
-                  <Trans
-                    i18nKey='FAQ.item2.answer'
-                    t={t}
-                    components={[
-                      <Anchor
-                        key='privacy-page'
-                        href='https://www.zooniverse.org/privacy'
-                      />
-                    ]}
-                  />
-                </Answer>
+                <Answer>{t('FAQ.item2.answer')}</Answer>
               </Box>
-              <Box as='li'>
+              {/** Okay to enable with launch of new homepage */}
+              {/* <Box as='li'>
                 <Question>{t('FAQ.item3.question')}</Question>
                 <Answer>
                   <Trans
                     i18nKey='FAQ.item3.answer'
+                    t={t}
+                    components={[<Anchor key='stats-blog-post' href='' />]}
+                  />
+                </Answer>
+              </Box> */}
+              <Box as='li'>
+                <Question>{t('FAQ.item4.question')}</Question>
+                <Answer>
+                  <Trans
+                    i18nKey='FAQ.item4.answer'
                     t={t}
                     components={[
                       <Anchor
@@ -106,10 +107,10 @@ function FAQPage() {
                 </Answer>
               </Box>
               <Box as='li'>
-                <Question>{t('FAQ.item4.question')}</Question>
+                <Question>{t('FAQ.item5.question')}</Question>
                 <Answer>
                   <Trans
-                    i18nKey='FAQ.item4.answer'
+                    i18nKey='FAQ.item5.answer'
                     t={t}
                     components={[
                       <Anchor
@@ -118,17 +119,17 @@ function FAQPage() {
                       />,
                       <Anchor
                         key='FEM-github-issues'
-                        href='https://github.com/zooniverse/front-end-monorepo/issues'
+                        href='https://github.com/zooniverse'
                       />
                     ]}
                   />
                 </Answer>
               </Box>
               <Box as='li'>
-                <Question>{t('FAQ.item5.question')}</Question>
+                <Question>{t('FAQ.item6.question')}</Question>
                 <Answer>
                   <Trans
-                    i18nKey='FAQ.item5.answer'
+                    i18nKey='FAQ.item6.answer'
                     t={t}
                     components={[
                       <Anchor
@@ -140,41 +141,46 @@ function FAQPage() {
                 </Answer>
               </Box>
               <Box as='li'>
-                <Question>{t('FAQ.item6.question')}</Question>
-                <Answer>{t('FAQ.item6.answer0')}</Answer>
-                <Paragraph margin='0'>{t('FAQ.item6.answer1')}</Paragraph>
-                <Answer>
+                <Question>{t('FAQ.item7.question')}</Question>
+                <Answer>{t('FAQ.item7.answer0')}</Answer>
+                <Paragraph margin='0'>
                   <Trans
-                    i18nKey='FAQ.item6.answer2'
+                    i18nKey='FAQ.item7.answer1'
                     t={t}
                     components={[
                       <Anchor
-                        key='donate-link'
-                        href='/get-involved/donate'
+                        key='503c'
+                        href='https://drive.google.com/file/d/108Ocx76oQLCJ8H_g9ZlF5wl4wa75mHyB/view'
                       />
                     ]}
                   />
-                </Answer>
-              </Box>
-              <Box as='li'>
-                <Question>{t('FAQ.item7.question')}</Question>
+                </Paragraph>
                 <Answer>
                   <Trans
-                    i18nKey='FAQ.item7.answer'
+                    i18nKey='FAQ.item7.answer2'
                     t={t}
                     components={[
-                      <Anchor
-                        key='resources-page'
-                        href='/about/resources'
-                      />
+                      <Anchor key='donate-link' href='/get-involved/donate' />
                     ]}
                   />
                 </Answer>
               </Box>
               <Box as='li'>
                 <Question>{t('FAQ.item8.question')}</Question>
+                <Answer>
+                  <Trans
+                    i18nKey='FAQ.item8.answer'
+                    t={t}
+                    components={[
+                      <Anchor key='resources-page' href='/about/resources' />
+                    ]}
+                  />
+                </Answer>
+              </Box>
+              <Box as='li'>
+                <Question>{t('FAQ.item9.question')}</Question>
                 <Paragraph margin={{ top: 'small', bottom: 'medium' }}>
-                  {t('FAQ.item8.answer')}
+                  {t('FAQ.item9.answer')}
                 </Paragraph>
               </Box>
             </StyledList>

--- a/packages/lib-content/src/translations/en.json
+++ b/packages/lib-content/src/translations/en.json
@@ -127,8 +127,8 @@
     "paragraphs": {
       "one": "Would your research benefit from the involvement of thousands of volunteers? The Zooniverse is the world’s largest and most successful online platform for crowd-sourced research; we have millions of registered volunteers working in collaboration with professional researchers on research projects across a range of disciplines, from astronomy to the humanities.",
       "two": "Research teams can build Zooniverse projects in two ways.",
-      "three": "Teams can use our free-to-use Project Builder tool to create their very own Zooniverse project. In order to launch publicly and be featured on our projects page, teams must go through our review process to ensure the project is appropriate for the platform and ready to be launched. This is the quickest and most straightforward option for creating a Zooniverse project. For more information on this process, including estimated timelines for review, please see our <0>Project Review Best Practices & Flowchart</0>. ",
-      "four": "In cases where the tools available in the Project Builder aren’t quite right for the research goals of a particular team, researchers may want to consider partnering with the Zooniverse to create new, custom tools. We work with these teams to apply for funding to support the research, design, and development process. Those who have applied for grant funding before will know that this process can take a long time. Once we’ve applied for a grant, it can take 6 months or more to hear back about whether or not our efforts were successful. Funded projects typically require at least 6 months to design, build, and test, depending on the complexity of the features being created. We then need additional time to generalize (and often revise) them for inclusion in the Project Builder toolkit. ",
+      "three": "Teams can use our free-to-use <0>Project Builder</0> tool to create their very own Zooniverse project. In order to launch publicly and be featured on our projects page, teams must go through our review process to ensure the project is appropriate for the platform and ready to be launched. This is the quickest and most straightforward option for creating a Zooniverse project. For more information on this process, including estimated timelines for review, please see our <1>Project Review Best Practices & Flowchart</1>. ",
+      "four": "In cases where the tools available in the <0>Project Builder</0> aren’t quite right for the research goals of a particular team, researchers may want to consider partnering with the Zooniverse to create new, custom tools. We work with these teams to apply for funding to support the research, design, and development process. Those who have applied for grant funding before will know that this process can take a long time. Once we’ve applied for a grant, it can take 6 months or more to hear back about whether or not our efforts were successful. Funded projects typically require at least 6 months to design, build, and test, depending on the complexity of the features being created. We then need additional time to generalize (and often revise) them for inclusion in the Project Builder toolkit. ",
       "five": "If you are interested in partnering with us to create custom project tools or infrastructure, please <0>contact us</0>.",
       "six": "Are you a researcher working on a project relevant to one of NASA’s Science Mission Directorate divisions (Astrophysics, Biological and Physical Sciences, Heliophysics, and the Planetary Science) who would benefit from contributions from Zooniverse volunteers? As part of an on-going partnership with NASA, the Zooniverse seeks to build on its current support of NASA research teams and encourage the development of new projects on our platform.",
       "seven": "Whether you are already building workflows using the Project Builder or you are just starting to consider how crowdsourced contributions could advance your research, the Zooniverse team has dedicated effort to support teams during development and implementation of NASA-focused projects. We are happy to discuss and support proposals to NASA citizen science funding calls (including the Citizen Science Seed Funding Program, the Citizen Science for Earth Systems Program, and other NASA ROSES funding opportunities) for projects interested in using the Zooniverse platform.",
@@ -192,9 +192,9 @@
         "three": "Volunteer certificate"
       },
       "paragraphs": {
-        "one": "Set classification milestones, track effort, and celebrate collective impact. Read our <0>announcement</0> for more details.",
+        "one": "Set classification milestones, track effort, and celebrate collective impact.",
         "two": "Each project team can share additional educator resources including lesson plans, video tutorials, research links, and more. Be sure to check a project’s <0>Education</0> tab.",
-        "three": "Support for students fulfilling student service hours for scholarships, graduation requirements, and more. See this <0>blog post</0> for details."
+        "three": "Support for students fulfilling student service hours for scholarships, graduation requirements, and more."
       }
     },
     "introduction": "Are you an educator interested in using Zooniverse in the classroom? Great! Millions of people around the world participate in about 100 active projects, each with a supportive and welcoming discussion forum in which researchers engage with the public around the research and broader interests. The Zooniverse is a wonderful place for students.",
@@ -218,32 +218,36 @@
       "question": "How do I know if I'm doing this right?"
     },
     "item2": {
-      "answer": "Your classifications are stored in the Zooniverse's secure online database. Later on a project's research team accesses and combines the multiple volunteer assessments stored for each subject, including your classifications, together. Once you have submitted your response for a given subject image, graph, or video, you can't go back and edit it. Further information can be found on the <0>Zooniverse User Agreement and Privacy Policy page.</0>",
+      "answer": "Your classifications are stored in the Zooniverse's secure online database. Project research teams download their project’s classification data and combine the multiple submissions together to create a ‘final’ response for each subject.",
       "question": "What happens to my classification after I submit it?"
     },
     "item3": {
+      "answer": "Yes. Go to zooniverse.org, log in, click ‘More Stats’, and then click the ‘Generate Volunteer Certificate’ button to the bottom-right of the stats bar chart. Then save or print your certificate! Read more <0>here</0>.",
+      "question": "Can I download a volunteer Certificate? Can I use Zooniverse to fulfill Service Learning requirements?"
+    },
+    "item4": {
       "answer": "The Zooniverse takes very seriously the task of protecting our volunteer's personal information and classification data. Details about these efforts can be found on the <0>Zooniverse User Agreement and Privacy Policy page</0> and the <1>Zooniverse Security page.</1>",
       "question": "What does the Zooniverse do with my account information?"
     },
-    "item4": {
+    "item5": {
       "answer": "You can post your suggestions for new features and report bugs via the <0>Zooniverse Talk</0> or through the <1>Github repository.</1>",
       "question": "I have a feature request or found a bug; who should I talk to/how do I report it?"
     },
-    "item5": {
+    "item6": {
       "answer": "The Zooniverse is a collaboration between institutions from the United Kingdom and the United States; all of our team are employed by one or the other of these partner institutions. Check out the <0>Zooniverse jobs page</0> to find out more about employment opportunities within the Zooniverse.",
       "question": "Is the Zooniverse hiring?"
     },
-    "item6": {
+    "item7": {
       "answer0": "The Zooniverse is a platform for people-powered research, not an entity, company, or non-profit. We are a multi-institutional collaboration.",
-      "answer1": "The Adler Planetarium in Chicago, one of the host institutions for the Zooniverse team, is a 501(c)(3). Individuals or organizations that need to link explicitly to a 501(c)(3) for their volunteering efforts use the Adler Planetarium as the reference. Documentation of the Adler Planetarium's 501(c)(3) status is provided here, and the Adler Planetarium EIN number is 36-6210902. When inputting the organization name, please use “Adler Planetarium - Zooniverse” if possible. If not possible, please use “Adler Planetarium” (which matches the EIN number). In all cases, you'll volunteer through Zooniverse.org.",
+      "answer1": "The Adler Planetarium in Chicago, one of the host institutions for the Zooniverse team, is a 501(c)(3). Individuals or organizations that need to link explicitly to a 501(c)(3) for their volunteering efforts use the Adler Planetarium as the reference. Documentation of the Adler Planetarium's 501(c)(3) status is provided <0>here</0>, and the Adler Planetarium EIN number is 36-6210902. When inputting the organization name, please use “Adler Planetarium - Zooniverse” if possible. If not possible, please use “Adler Planetarium” (which matches the EIN number). In all cases, you'll volunteer through Zooniverse.org.",
       "answer2": "For information on how to donate, please visit our <0>donation page.</0>",
       "question": "Is the Zooniverse a non-profit organization?"
     },
-    "item7": {
+    "item8": {
       "answer": "You can find more details on how to cite the Zooniverse in research publications using data derived from use of the Zooniverse Project Builder on our <0>Resources page</0>.",
       "question": "I'm a project owner/research team member, how do I acknowledge the Zooniverse and the Project Builder Platform in my paper, talk abstract, etc.?"
     },
-    "item8": {
+    "item9": {
       "answer": "We support major browsers up to the second to last version.",
       "question": "What browser version does Zooniverse support?"
     }

--- a/packages/lib-user/src/components/UserHome/components/Dashboard/Dashboard.js
+++ b/packages/lib-user/src/components/UserHome/components/Dashboard/Dashboard.js
@@ -15,7 +15,6 @@ import { SpacedHeading, SpacedText } from '@zooniverse/react-components'
 import DashboardLink from './components/DashboardLink.js'
 import StatsTabsContainer from './components/StatsTabs/StatsTabsContainer.js'
 
-// Enable this component below to show the link to "About your new homepage" blog post
 const LinkToBlogPost = styled(Anchor)`
   position: absolute;
   top: 15px;
@@ -164,16 +163,15 @@ export default function Dashboard({ user, userLoading }) {
         }
         round={size === 'small' ? false : '16px 16px 0 0'}
       >
-        {/** Update this link with blog post url */}
-        {/* <LinkToBlogPost
-          href='https://www.zooniverse.org'
+        <LinkToBlogPost
+          href='https://blog.zooniverse.org/2024/09/10/coming-soon-freshening-up-the-zooniverse-homepage'
           target='_blank'
           label={
             <SpacedText size='0.8rem' color='dark-5' weight='bold'>
               {blogLinkLabel} <Share size='0.7rem' />
             </SpacedText>
           }
-        /> */}
+        />
 
         <StyledAvatar
           background='brand'

--- a/packages/lib-user/src/components/UserHome/components/WelcomeModal/WelcomeModal.js
+++ b/packages/lib-user/src/components/UserHome/components/WelcomeModal/WelcomeModal.js
@@ -144,8 +144,7 @@ function WelcomeModal() {
               </Paragraph>
             </Box>
             <Box direction='row' pad={{ top: 'large' }} gap='small'>
-              {/* Needs update with link to blog post when published */}
-              <StyledAnchor href=''>
+              <StyledAnchor href='https://blog.zooniverse.org/2024/09/10/coming-soon-freshening-up-the-zooniverse-homepage'>
                 Read about the changes
               </StyledAnchor>
               <StyledDismiss


### PR DESCRIPTION
## Package
lib-content
lib-user

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/6177
Details in https://docs.google.com/spreadsheets/d/10k8yyZsRjaJens7BdffD6VUpoInZNLEPNQNgKSSTgpM

## Describe your changes

Details are in the above Google doc, but this PR makes minor edits to the copy and a couple of links on the content pages. I'll note below where I plan to follow-up with a few more changes upon launch of the user groups pages.

## How to Review

This just needs a quick glance, but I double checked all edited copy and links appear as expected in Storybook.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
