### PR TITLE
app-content-pages: change liveness probe url

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -151,17 +151,17 @@ spec:
               cpu: "1000m"
           startupProbe:
             httpGet:
-              path: /about/Index
+              path: /about
               port: 3000
             failureThreshold: 6
           livenessProbe:
             httpGet:
-              path: /about/Index
+              path: /about
               port: 3000
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /about/Index
+              path: /about
               port: 3000
             initialDelaySeconds: 20
             timeoutSeconds: 10

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -131,17 +131,17 @@ spec:
               cpu: "1000m"
           startupProbe:
             httpGet:
-              path: /about/Index
+              path: /about
               port: 3000
             failureThreshold: 6
           livenessProbe:
             httpGet:
-              path: /about/Index
+              path: /about
               port: 3000
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /about/Index
+              path: /about
               port: 3000
             initialDelaySeconds: 20
             timeoutSeconds: 10


### PR DESCRIPTION
## Package
app-content-pages

## Linked Issue and/or Talk Post
Similar to https://github.com/zooniverse/front-end-monorepo/pull/6046 which was changed for fe-root.

## Describe your changes

- Change the liveness probe to `/about` because `/about/Index` does not exist have adding the Get Involved routes to the Pages Router.

## How to Review

- Will need to be double check after deployment.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
