### PR TITLE
app-root: Try same config as app-project in app-root middleware file

### DIFF
--- a/packages/app-root/src/middleware.js
+++ b/packages/app-root/src/middleware.js
@@ -4,15 +4,30 @@
 import { NextResponse } from 'next/server'
 
 export function middleware(req) {
+  /*
+    Bypass /assets.
+  */
+  if (pathname.startsWith('/assets')) {
+    return NextResponse.next()
+  }
+  /*
+        Bypass internal NextJS requests.
+      */
+  if (pathname.startsWith('/_next')) {
+    return NextResponse.next()
+  }
   /* This is a temporary mocked env */
   if (req.nextUrl.pathname.startsWith('/mock/wrong')) {
     return NextResponse.redirect(new URL('/mock', req.url))
   }
-  
+
   /*
     Redirect legacy PFE /about and /get-involved paths to new FEM paths
   */
-  if (req.nextUrl.pathname.startsWith('/about/acknowledgments') || req.nextUrl.pathname.startsWith('/about/acknowledgements')) {
+  if (
+    req.nextUrl.pathname.startsWith('/about/acknowledgments') ||
+    req.nextUrl.pathname.startsWith('/about/acknowledgements')
+  ) {
     return NextResponse.redirect(new URL('/about/resources', req.url))
   }
 

--- a/packages/app-root/src/middleware.js
+++ b/packages/app-root/src/middleware.js
@@ -7,13 +7,13 @@ export function middleware(req) {
   /*
     Bypass /assets.
   */
-  if (pathname.startsWith('/assets')) {
+  if (req.nextUrl.pathname.startsWith('/assets')) {
     return NextResponse.next()
   }
   /*
         Bypass internal NextJS requests.
       */
-  if (pathname.startsWith('/_next')) {
+  if (req.nextUrl.pathname.startsWith('/_next')) {
     return NextResponse.next()
   }
   /* This is a temporary mocked env */


### PR DESCRIPTION
## Package
app-root

## Linked Issue and/or Talk Post
Follows: https://github.com/zooniverse/front-end-monorepo/pull/6292

## Describe your changes
- Add rules to middleware.js to bypass Next.js internals. Middleware and basePath do not work well together for the `matcher` function.

## How to Review
I'll be self-reviewing this in collaboration with [@zach](https://zooniverse.slack.com/team/U11KL1NLW). These changes do not affect any public facing FEM pages.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
