### PR TITLE
app-root: Use /mock for liveness rather than /users

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -249,17 +249,17 @@ spec:
               cpu: "1000m"
           startupProbe:
             httpGet:
-              path: /users
+              path: /mock
               port: 3000
             failureThreshold: 6
           livenessProbe:
             httpGet:
-              path: /users
+              path: /mock
               port: 3000
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /users
+              path: /mock
               port: 3000
             initialDelaySeconds: 20
             timeoutSeconds: 10

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -229,17 +229,17 @@ spec:
               cpu: "1000m"
           startupProbe:
             httpGet:
-              path: /users
+              path: /mock
               port: 3000
             failureThreshold: 6
           livenessProbe:
             httpGet:
-              path: /users
+              path: /mock
               port: 3000
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /users
+              path: /mock
               port: 3000
             initialDelaySeconds: 20
             timeoutSeconds: 10


### PR DESCRIPTION
## Package
app-root

## Linked Issue and/or Talk Post
Follows: https://github.com/zooniverse/front-end-monorepo/pull/6294

## Describe your changes

- With basePath, use /mock for the liveness probe.

## How to Review
I'll be self-reviewing this in collaboration with [@zach](https://zooniverse.slack.com/team/U11KL1NLW). These changes do not affect any public facing FEM pages.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
