### PR TITLE
PanoptesJS: remove superagent

### DIFF
--- a/packages/lib-panoptes-js/src/panoptes.js
+++ b/packages/lib-panoptes-js/src/panoptes.js
@@ -40,6 +40,7 @@ function parseHeaders(headers = {}) {
   return httpHeaders
 }
 
+// Note: if it makes the code more readable, we can merge getQueryParams into getQueryString.
 function getQueryParams (query) {
   const defaultParams = { admin: checkForAdminFlag(), http_cache: true }
 
@@ -50,6 +51,18 @@ function getQueryParams (query) {
   } else {
     return defaultParams
   }
+}
+
+/*
+Converts a query object (e.g. { foo: 'bar', img: 'http://foo.bar/baz.jpg' })
+into a query string (e.g. "foo=bar&img=http%3A%2F%2Ffoo.bar%")
+ */
+function getQueryString (query) {
+  const queryParams = getQueryParams(query)
+  let queryString = Object.entries(queryParams)
+    .map(([key, val]) => `${encodeURIComponent(key)}=${encodeURIComponent(val)}`)
+    .join('&')
+  return queryString.length > 0 ? `?${queryString}` : ''
 }
 
 // TODO: Consider how to integrate a GraphQL option


### PR DESCRIPTION
## PR Overview

Package: panoptes-js

This PR attempts to remove `superagent` from the PanoptesJS client

- Reason: `superagent` is a dependency that we don't technically need anymore, since the standard `fetch` API works fine, while maintaining superagent can be a bit of a faff.
- Observation: superagent() is _only_ used in the get(), post(), put(), and del() (i.e. delete) functions of `panoptes.js`, so replacing the dependency should be very easy.
  - _(Spoiler: it wasn't)_
- Priority: low priority, _for now._ Removing superagent is a "nice to have" item that will eventually escalate to "gotta get it done" once the maintenance cost gets too high in the future (or the library stops getting updates, whichever comes first).

### Dev Notes

As of 12 Sep 2024, this PR is in an experimental stage. The biggest lessons we've learnt are:
1. it's actually easy to replace the `superagent()` calls in `panoptes.js`, as initially observed.
2. however, there are MULTIPLE places in the FEM code that expects _a very specific superagent-shaped response_ from `panoptes.get()/panoptes.put()/panoptes.post()/panoptes.del()`, 

<details>
<summary>Comparison of the default response data we get from superagent vs the default response data we get from fetch().</summary>

Superagent response:

<img width="432" alt="Screenshot 2024-09-12 at 15 56 50" src="https://github.com/user-attachments/assets/fd7ff73c-4aae-42fe-aae6-a5722a443e68">

Fetch API response:

<img width="423" alt="Screenshot 2024-09-12 at 16 00 18" src="https://github.com/user-attachments/assets/92bfe195-dec7-400f-8a4e-23abbed1dbaf">
</details>

So in practice, we either need to...
1. accept the cost of going through the hundred(s?) instances in the FEM code ([and any other project that uses PanoptesJS](https://github.com/zooniverse/community-catalog)) that expects a superagent response and make changes there, OR
2. create a transformer/adapter that transform Fetch API responses into superagent-compatible responses.

### Status

Experimental. Put on pause as of 12 Sep 2024 while higher priority items in PanoptesJS is addressed.

As of commit [96096e: panoptes.get experimental: replace superagent with fetch](https://github.com/zooniverse/front-end-monorepo/commit/96096edae89583059e950d7a8a3d97497360fee5), the get() function has superagent() successfully replaced with fetch(), with a very rudimentary fetch-response-to-superagent-response transformer in place. You can run `lib-classifier > yarn dev` and [load a local test project,](https://local.zooniverse.org:8080/?env=staging&project=darkeshard%2Ftest-project-2022&workflow=3581) and the data will be fetched fine _for this instance._