### PR TITLE
fix(lib-content): accessible sidebar links for screenreaders and keyboard users

### DIFF
--- a/packages/lib-content/src/components/DropdownNav/DropdownNav.js
+++ b/packages/lib-content/src/components/DropdownNav/DropdownNav.js
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import Link from 'next/link'
 import { arrayOf, bool, func, number, shape, string } from 'prop-types'
 import styled, { css } from 'styled-components'
 import { Box, Button, DropButton, Nav } from 'grommet'
@@ -115,7 +114,6 @@ function DropdownNav({
         {sections.map((section, index) => (
           <StyledLi key={section.name}>
             <StyledButton
-              as={Link}
               aria-current={index === activeSection ? 'true' : 'false'}
               href={section.slug ? `#${section.slug}` : ''}
               onClick={() => handleSectionSelect(index)}

--- a/packages/lib-content/src/components/Sidebar/Sidebar.js
+++ b/packages/lib-content/src/components/Sidebar/Sidebar.js
@@ -1,4 +1,3 @@
-import Link from 'next/link'
 import { arrayOf, func, number, shape, string } from 'prop-types'
 import styled, { css } from 'styled-components'
 import { Button, Nav } from 'grommet'
@@ -49,7 +48,6 @@ function Sidebar({
         {sections.map((section, index) => (
           <StyledLi key={section.name}>
             <StyledButton
-              as={Link}
               aria-current={index === activeSection ? 'true' : 'false'}
               href={section.slug ? `#${section.slug}` : ''}
               onClick={() => setActiveSection(index)}

--- a/packages/lib-content/src/screens/About/About.js
+++ b/packages/lib-content/src/screens/About/About.js
@@ -43,7 +43,7 @@ function AboutPage() {
   const [activeSection, setActiveSection] = useState(0)
 
   const sidebarSections = [
-    { name: t('AboutPage.ourMission.heading'), slug: '' },
+    { name: t('AboutPage.ourMission.heading'), slug: 'our-mission' },
     { name: t('AboutPage.howItWorks.heading'), slug: 'how-it-works' },
     { name: t('AboutPage.mobile.sidebar'), slug: 'mobile' },
     { name: t('AboutPage.highlights.sidebar'), slug: 'highlights' },


### PR DESCRIPTION
- Remove `next/link` from sidebar links, so that the browser focuses the linked heading when you follow an in-page link on one of the About pages.
- Link the 'Our Mission' link to its corresponding heading on the About page, so that readers aren't sent back to the top of the page body.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-content

## Linked Issue and/or Talk Post
- closes #6289.

## How to Review
In a screenreader, like NVDA or VoiceOver, reading focus should now move to the linked heading when you follow a sidebar link. Similarly, focus should move logically through the page when you tab through the page and follow sidebar links from the keyboard. See [WCAG 2.4.3: Focus order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html).

Testing this PR revealed some other WCAG failures on the About page. They aren't addressed here, so will also need to be fixed:
- no clear focus indicator on links within the How It Works section ([WCAG 2.4.7: Focus visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html)).
- the Contact Us button opens a popup form that isn't accessible via the keyboard or with a screenreader ([WCAG 2.1.1: Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard)).

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
