### PR TITLE
app-root: Add morgan for logging on production server

### DIFF
--- a/packages/app-root/package.json
+++ b/packages/app-root/package.json
@@ -25,6 +25,7 @@
     "grommet": "~2.35.0",
     "grommet-icons": "~4.12.0",
     "lodash": "~4.17.21",
+    "morgan": "~1.10.0",
     "newrelic": "~12.3.1",
     "next": "~14.2.6",
     "panoptes-client": "~5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12866,6 +12866,17 @@ morgan@^1.10.0:
     on-finished "~2.3.0"
     on-headers "~1.0.2"
 
+morgan@~1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"
+  integrity sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==
+  dependencies:
+    basic-auth "~2.0.1"
+    debug "2.6.9"
+    depd "~2.0.0"
+    on-finished "~2.3.0"
+    on-headers "~1.0.2"
+
 mrmime@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-2.0.0.tgz#151082a6e06e59a9a39b46b3e14d5cfe92b3abb4"


### PR DESCRIPTION
## Package
app-root

## Linked Issue and/or Talk Post

This is a feature request by @zwolf 

## Describe your changes

Install `morgan` and setup logging in the same manner as app-project.

## How to Review

Run the app locally in production mode `yarn start` instead of dev mode `yarn dev`. Visit any app-root url such as https://local.zooniverse.org:3000 and the page requests are logged to the terminal.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)