### PR TITLE
fix(lib-react-components): project card badge width in Safari

### DIFF
--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - refactor `AnimatedNumber` to fix a bug where deferred values are displayed as 0.
 - Style RegisterForm as one column for `small` screensize.
+- Project card badges are now circular in Safari.
 
 ## [1.13.0] 2024-05-17
 

--- a/packages/lib-react-components/src/ProjectCard/ProjectCard.js
+++ b/packages/lib-react-components/src/ProjectCard/ProjectCard.js
@@ -52,6 +52,8 @@ const StyledBadge = styled(Text)`
   text-align: center;
   align-items: center;
   justify-content: center;
+  min-width: 1rem;
+  height: auto;
 `
 
 function cardWidth(size) {


### PR DESCRIPTION
Add a minimum width and a height to the project card badge.

>At least one of the box's sizes needs to be automatic in order for aspect-ratio to have any effect. If neither the width nor height is an automatic size, then the provided aspect ratio has no effect on the box's preferred sizes.

https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-react-components

## Linked Issue and/or Talk Post
- fixes #6313.

## How to Review
You can use the `ProjectCard` stories to test this. The badge should now be circular in Safari, even when the number is small.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
