### PR TITLE
app-project: add /projects to useProjectNavigation external links

### DIFF
--- a/packages/app-project/src/components/ProjectHeader/ProjectHeader.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/ProjectHeader.spec.js
@@ -82,7 +82,7 @@ describe('Component > ProjectHeader', function () {
       expect(navLinks.length).to.be.above(0)
       expect(navLinks[0].href).to.equal('https://localhost/zooniverse/snapshot-serengeti/about/research')
       expect(navLinks[navLinks.length - 1].href).to.equal(
-        'https://localhost/zooniverse/snapshot-serengeti/collections'
+        'https://localhost/projects/zooniverse/snapshot-serengeti/collections'
       )
     })
   })
@@ -95,7 +95,7 @@ describe('Component > ProjectHeader', function () {
 
       expect(navLinks.length).to.be.above(0)
       expect(navLinks[0].href).to.equal('https://localhost/zooniverse/snapshot-serengeti/about/research')
-      expect(navLinks[navLinks.length - 1].href).to.equal('https://localhost/zooniverse/snapshot-serengeti/recents')
+      expect(navLinks[navLinks.length - 1].href).to.equal('https://localhost/projects/zooniverse/snapshot-serengeti/recents')
     })
   })
 

--- a/packages/app-project/src/components/ProjectHeader/components/DropdownNav/DropdownNav.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/DropdownNav/DropdownNav.spec.js
@@ -47,7 +47,7 @@ describe('Component > ProjectHeader > Dropdown Nav', function () {
       expect(navLinks.length).to.be.above(0)
       expect(navLinks[0].href).to.equal('https://localhost/zooniverse/snapshot-serengeti/about/research')
       expect(navLinks[navLinks.length - 1].href).to.equal(
-        'https://localhost/zooniverse/snapshot-serengeti/collections'
+        'https://localhost/projects/zooniverse/snapshot-serengeti/collections'
       )
     })
   })
@@ -75,7 +75,7 @@ describe('Component > ProjectHeader > Dropdown Nav', function () {
       const navLinks = within(navMenu).getAllByRole('link')
       expect(navLinks.length).to.be.above(0)
       expect(navLinks[0].href).to.equal('https://localhost/zooniverse/snapshot-serengeti/about/research')
-      expect(navLinks[navLinks.length - 1].href).to.equal('https://localhost/zooniverse/snapshot-serengeti/recents')
+      expect(navLinks[navLinks.length - 1].href).to.equal('https://localhost/projects/zooniverse/snapshot-serengeti/recents')
     })
   })
 

--- a/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.spec.js
+++ b/packages/app-project/src/components/ProjectHeader/components/Nav/Nav.spec.js
@@ -39,7 +39,7 @@ describe('Component > ProjectHeader > Nav', function () {
       expect(navLinks.length).to.be.above(0)
       expect(navLinks[0].href).to.equal('https://localhost/zooniverse/snapshot-serengeti/about/research')
       expect(navLinks[navLinks.length - 1].href).to.equal(
-        'https://localhost/zooniverse/snapshot-serengeti/collections'
+        'https://localhost/projects/zooniverse/snapshot-serengeti/collections'
       )
     })
   })
@@ -60,7 +60,7 @@ describe('Component > ProjectHeader > Nav', function () {
       const navLinks = within(navMenu).getAllByRole('link')
       expect(navLinks.length).to.be.above(0)
       expect(navLinks[0].href).to.equal('https://localhost/zooniverse/snapshot-serengeti/about/research')
-      expect(navLinks[navLinks.length - 1].href).to.equal('https://localhost/zooniverse/snapshot-serengeti/recents')
+      expect(navLinks[navLinks.length - 1].href).to.equal('https://localhost/projects/zooniverse/snapshot-serengeti/recents')
     })
   })
 

--- a/packages/app-project/src/components/ProjectHeader/hooks/useProjectNavigation.js
+++ b/packages/app-project/src/components/ProjectHeader/hooks/useProjectNavigation.js
@@ -16,12 +16,12 @@ export default function useProjectNavigation(adminMode) {
       text: t('ProjectHeader.classify')
     },
     {
-      href: `/${slug}/talk`,
+      href: `/projects/${slug}/talk`,
       text: t('ProjectHeader.talk'),
       externalLink: true // code is in PFE
     },
     {
-      href: `/${slug}/collections`,
+      href: `/projects/${slug}/collections`,
       text: t('ProjectHeader.collect'),
       externalLink: true // code is in PFE
     }
@@ -29,7 +29,7 @@ export default function useProjectNavigation(adminMode) {
 
   if (isLoggedIn) {
     links.push({
-      href: `/${slug}/recents`,
+      href: `/projects/${slug}/recents`,
       text: t('ProjectHeader.recents'),
       externalLink: true // code is in PFE
     })


### PR DESCRIPTION
## Package
app-project

## Linked Issue and/or Talk Post
Follow-up to https://github.com/zooniverse/front-end-monorepo/pull/6320

## Describe your changes
- Links in the ProjectHeader that do not use next/link need the `/projects` path manually added.

## How to Review

- Run any project locally and the Talk, Collect, and Recents links in the project header should form the correct urls.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out