### PR TITLE
fix(app-root): wait for login to complete before fetching authenticated user data

### DIFF
--- a/packages/lib-react-components/CHANGELOG.md
+++ b/packages/lib-react-components/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Style RegisterForm as one column for `small` screensize.
 - Project card badges are now circular in Safari.
 - Inconsistent text sizes for Markdown tables and lists.
+- `useUnreadNotifications` and `useUnreadMessages` now wait for Panoptes auth to complete before fetching data.
 
 ## [1.13.0] 2024-05-17
 

--- a/packages/lib-react-components/src/hooks/useUnreadMessages.js
+++ b/packages/lib-react-components/src/hooks/useUnreadMessages.js
@@ -17,6 +17,7 @@ if (isBrowser) {
 }
 
 async function fetchUnreadMessageCount({ endpoint = '/conversations' }) {
+  await auth.checkCurrent()
   const token = await auth.checkBearerToken()
   const authorization = `Bearer ${token}`
   if (!token) return 0

--- a/packages/lib-react-components/src/hooks/useUnreadNotifications.js
+++ b/packages/lib-react-components/src/hooks/useUnreadNotifications.js
@@ -17,6 +17,7 @@ if (isBrowser) {
 }
 
 async function fetchUnreadNotificationsCount({ endpoint = '/notifications' }) {
+  await auth.checkCurrent()
   const token = await auth.checkBearerToken()
   const authorization = `Bearer ${token}`
   if (!token) return 0

--- a/packages/lib-user/src/hooks/usePanoptesAuthToken.js
+++ b/packages/lib-user/src/hooks/usePanoptesAuthToken.js
@@ -1,23 +1,23 @@
-import auth from 'panoptes-client/lib/auth'
-import { useState } from 'react'
+import auth from "panoptes-client/lib/auth";
+import { useState } from "react";
 
-const isBrowser = typeof window !== 'undefined'
+const isBrowser = typeof window !== "undefined";
 
 if (isBrowser) {
-    auth.checkCurrent()
+  auth.checkCurrent();
 }
 
 export default function usePanoptesAuthToken() {
-    const [token, setToken] = useState(null)
+  const [token, setToken] = useState(null);
 
-    async function fetchPanoptesAuthToken() {
-        await auth.checkCurrent()
-        const newToken = await auth.checkBearerToken()
-        if (newToken !== token) {
-            setToken(newToken)
-        }   
+  async function fetchPanoptesAuthToken() {
+    await auth.checkCurrent();
+    const newToken = await auth.checkBearerToken();
+    if (newToken !== token) {
+      setToken(newToken);
     }
+  }
 
-    fetchPanoptesAuthToken()
-    return token
+  fetchPanoptesAuthToken();
+  return token;
 }

--- a/packages/lib-user/src/hooks/usePanoptesAuthToken.js
+++ b/packages/lib-user/src/hooks/usePanoptesAuthToken.js
@@ -1,23 +1,35 @@
-import auth from "panoptes-client/lib/auth";
-import { useState } from "react";
+import auth from "panoptes-client/lib/auth"
+import { useState } from "react"
 
-const isBrowser = typeof window !== "undefined";
+const isBrowser = typeof window !== "undefined"
 
-if (isBrowser) {
-  auth.checkCurrent();
-}
+let defaultToken
+/*
+  Top-level await in modules has been supported in Node
+  and in all browsers since 2021. However, ES modules are still
+  not supported in the monorepo. An immediately-invoked async
+  function is a workaround when top-level await is not supported.
+  https://v8.dev/features/top-level-await
+*/
+(async function getDefaultToken() {
+  defaultToken = null
+  if (isBrowser) {
+    await auth.checkCurrent()
+    defaultToken = await auth.checkBearerToken()
+  }
+})()
 
 export default function usePanoptesAuthToken() {
-  const [token, setToken] = useState(null);
+  const [token, setToken] = useState(defaultToken)
 
   async function fetchPanoptesAuthToken() {
-    await auth.checkCurrent();
-    const newToken = await auth.checkBearerToken();
+    await auth.checkCurrent()
+    const newToken = await auth.checkBearerToken()
     if (newToken !== token) {
-      setToken(newToken);
+      setToken(newToken)
     }
   }
 
-  fetchPanoptesAuthToken();
-  return token;
+  fetchPanoptesAuthToken()
+  return token
 }

--- a/packages/lib-user/src/hooks/usePanoptesAuthToken.js
+++ b/packages/lib-user/src/hooks/usePanoptesAuthToken.js
@@ -5,6 +5,7 @@ const isBrowser = typeof window !== "undefined"
 
 let defaultToken
 /*
+  See comments in https://github.com/zooniverse/front-end-monorepo/pull/6345
   Top-level await in modules has been supported in Node
   and in all browsers since 2021. However, ES modules are still
   not supported in the monorepo. An immediately-invoked async

--- a/packages/lib-user/src/hooks/usePanoptesAuthToken.js
+++ b/packages/lib-user/src/hooks/usePanoptesAuthToken.js
@@ -1,0 +1,23 @@
+import auth from 'panoptes-client/lib/auth'
+import { useState } from 'react'
+
+const isBrowser = typeof window !== 'undefined'
+
+if (isBrowser) {
+    auth.checkCurrent()
+}
+
+export default function usePanoptesAuthToken() {
+    const [token, setToken] = useState(null)
+
+    async function fetchPanoptesAuthToken() {
+        await auth.checkCurrent()
+        const newToken = await auth.checkBearerToken()
+        if (newToken !== token) {
+            setToken(newToken)
+        }   
+    }
+
+    fetchPanoptesAuthToken()
+    return token
+}

--- a/packages/lib-user/src/hooks/usePanoptesMemberships.js
+++ b/packages/lib-user/src/hooks/usePanoptesMemberships.js
@@ -1,10 +1,7 @@
 import { panoptes } from '@zooniverse/panoptes-js'
-import auth from 'panoptes-client/lib/auth'
 import useSWR from 'swr'
 
 import usePanoptesAuthToken from './usePanoptesAuthToken'
-
-const isBrowser = typeof window !== 'undefined'
 
 const SWROptions = {
   revalidateIfStale: true,
@@ -12,10 +9,6 @@ const SWROptions = {
   revalidateOnFocus: true,
   revalidateOnReconnect: true,
   refreshInterval: 0
-}
-
-if (isBrowser) {
-  auth.checkCurrent()
 }
 
 async function fetchMemberships({ query, token }) {

--- a/packages/lib-user/src/hooks/usePanoptesMemberships.js
+++ b/packages/lib-user/src/hooks/usePanoptesMemberships.js
@@ -2,6 +2,8 @@ import { panoptes } from '@zooniverse/panoptes-js'
 import auth from 'panoptes-client/lib/auth'
 import useSWR from 'swr'
 
+import usePanoptesAuthToken from './usePanoptesAuthToken'
+
 const isBrowser = typeof window !== 'undefined'
 
 const SWROptions = {
@@ -16,9 +18,7 @@ if (isBrowser) {
   auth.checkCurrent()
 }
 
-async function fetchMemberships({ query }) {
-  await auth.checkCurrent()
-  const token = await auth.checkBearerToken()
+async function fetchMemberships({ query, token }) {
   const authorization = `Bearer ${token}`
   if (!token) return null 
 
@@ -31,8 +31,9 @@ async function fetchMemberships({ query }) {
   }
 }
 
-export function usePanoptesMemberships({ authUserId, query, swrOptions = {} }) {
-  const key = (query.user_id || query.user_group_id) && authUserId ? { query } : null
+export function usePanoptesMemberships({ authUserId, query, swrOptions = SWROptions }) {
+  const token = usePanoptesAuthToken()
+  const key = token && (query.user_id || query.user_group_id) && authUserId ? { query, token } : null
   const options = { ...SWROptions, ...swrOptions }
   return useSWR(key, fetchMemberships, options)
 }

--- a/packages/lib-user/src/hooks/usePanoptesMemberships.js
+++ b/packages/lib-user/src/hooks/usePanoptesMemberships.js
@@ -17,6 +17,7 @@ if (isBrowser) {
 }
 
 async function fetchMemberships({ query }) {
+  await auth.checkCurrent()
   const token = await auth.checkBearerToken()
   const authorization = `Bearer ${token}`
   if (!token) return null 

--- a/packages/lib-user/src/hooks/usePanoptesProjects.js
+++ b/packages/lib-user/src/hooks/usePanoptesProjects.js
@@ -2,6 +2,8 @@ import { projects as panoptesProjects } from '@zooniverse/panoptes-js'
 import auth from 'panoptes-client/lib/auth'
 import useSWR from 'swr'
 
+import usePanoptesAuthToken from './usePanoptesAuthToken'
+
 const isBrowser = typeof window !== 'undefined'
 
 const SWROptions = {
@@ -16,9 +18,7 @@ if (isBrowser) {
   auth.checkCurrent()
 }
 
-async function fetchProjects(query) {
-  await auth.checkCurrent()
-  const token = await auth.checkBearerToken()
+async function fetchProjects({ query, token }) {
   const authorization = token ? `Bearer ${token}` : undefined
 
   let projectsAccumulator = []
@@ -60,9 +60,10 @@ async function fetchProjects(query) {
 }
 
 export function usePanoptesProjects(query) {
+  const token = usePanoptesAuthToken()
   let key = null
-  if (query?.id) {
-    key = query
+  if (token && query?.id) {
+    key = { query, token }
   }
   return useSWR(key, fetchProjects, SWROptions)
 }

--- a/packages/lib-user/src/hooks/usePanoptesProjects.js
+++ b/packages/lib-user/src/hooks/usePanoptesProjects.js
@@ -17,11 +17,8 @@ if (isBrowser) {
 }
 
 async function fetchProjects(query) {
-  let token = await auth.checkBearerToken()
-  if (!token) {
-    await auth.checkCurrent()
-    token = await auth.checkBearerToken()
-  }
+  await auth.checkCurrent()
+  const token = await auth.checkBearerToken()
   const authorization = token ? `Bearer ${token}` : undefined
 
   let projectsAccumulator = []

--- a/packages/lib-user/src/hooks/usePanoptesProjects.js
+++ b/packages/lib-user/src/hooks/usePanoptesProjects.js
@@ -1,10 +1,7 @@
 import { projects as panoptesProjects } from '@zooniverse/panoptes-js'
-import auth from 'panoptes-client/lib/auth'
 import useSWR from 'swr'
 
 import usePanoptesAuthToken from './usePanoptesAuthToken'
-
-const isBrowser = typeof window !== 'undefined'
 
 const SWROptions = {
   revalidateIfStale: true,
@@ -12,10 +9,6 @@ const SWROptions = {
   revalidateOnFocus: true,
   revalidateOnReconnect: true,
   refreshInterval: 0
-}
-
-if (isBrowser) {
-  auth.checkCurrent()
 }
 
 async function fetchProjects({ query, token }) {

--- a/packages/lib-user/src/hooks/usePanoptesUser.js
+++ b/packages/lib-user/src/hooks/usePanoptesUser.js
@@ -17,6 +17,7 @@ if (isBrowser) {
 }
 
 async function getUser({ query }) {
+  await auth.checkCurrent()
   const token = await auth.checkBearerToken()
   const authorization = `Bearer ${token}`
   

--- a/packages/lib-user/src/hooks/usePanoptesUser.js
+++ b/packages/lib-user/src/hooks/usePanoptesUser.js
@@ -4,18 +4,12 @@ import useSWR from 'swr'
 
 import usePanoptesAuthToken from './usePanoptesAuthToken'
 
-const isBrowser = typeof window !== 'undefined'
-
 const SWROptions = {
   revalidateIfStale: true,
   revalidateOnMount: true,
   revalidateOnFocus: true,
   revalidateOnReconnect: true,
   refreshInterval: 0
-}
-
-if (isBrowser) {
-  auth.checkCurrent()
 }
 
 async function getUser({ query, token }) {

--- a/packages/lib-user/src/hooks/usePanoptesUserGroup.js
+++ b/packages/lib-user/src/hooks/usePanoptesUserGroup.js
@@ -2,6 +2,8 @@ import { panoptes } from '@zooniverse/panoptes-js'
 import auth from 'panoptes-client/lib/auth'
 import useSWR from 'swr'
 
+import usePanoptesAuthToken from './usePanoptesAuthToken'
+
 const isBrowser = typeof window !== 'undefined'
 
 const SWROptions = {
@@ -16,9 +18,7 @@ if (isBrowser) {
   auth.checkCurrent()
 }
 
-async function fetchPanoptesUserGroup({ groupId }) {
-  await auth.checkCurrent()
-  const token = await auth.checkBearerToken()
+async function fetchPanoptesUserGroup({ groupId, token }) {
   const authorization = token ? `Bearer ${token}` : undefined
 
   const endpoint = `/user_groups/${groupId}`
@@ -35,6 +35,7 @@ async function fetchPanoptesUserGroup({ groupId }) {
 }
 
 export function usePanoptesUserGroup({ adminMode, authUserId, groupId, membershipId }) {
-  const key = groupId ? { adminMode, authUserId, groupId, membershipId } : null
+  const token = usePanoptesAuthToken()
+  const key = token && groupId ? { groupId, token } : null
   return useSWR(key, fetchPanoptesUserGroup, SWROptions)
 }

--- a/packages/lib-user/src/hooks/usePanoptesUserGroup.js
+++ b/packages/lib-user/src/hooks/usePanoptesUserGroup.js
@@ -1,10 +1,7 @@
 import { panoptes } from '@zooniverse/panoptes-js'
-import auth from 'panoptes-client/lib/auth'
 import useSWR from 'swr'
 
 import usePanoptesAuthToken from './usePanoptesAuthToken'
-
-const isBrowser = typeof window !== 'undefined'
 
 const SWROptions = {
   revalidateIfStale: true,
@@ -12,10 +9,6 @@ const SWROptions = {
   revalidateOnFocus: true,
   revalidateOnReconnect: true,
   refreshInterval: 0
-}
-
-if (isBrowser) {
-  auth.checkCurrent()
 }
 
 async function fetchPanoptesUserGroup({ groupId, token }) {

--- a/packages/lib-user/src/hooks/usePanoptesUserGroup.js
+++ b/packages/lib-user/src/hooks/usePanoptesUserGroup.js
@@ -17,11 +17,8 @@ if (isBrowser) {
 }
 
 async function fetchPanoptesUserGroup({ groupId }) {
-  let token = await auth.checkBearerToken()
-  if (!token) {
-    await auth.checkCurrent()
-    token = await auth.checkBearerToken()
-  }
+  await auth.checkCurrent()
+  const token = await auth.checkBearerToken()
   const authorization = token ? `Bearer ${token}` : undefined
 
   const endpoint = `/user_groups/${groupId}`

--- a/packages/lib-user/src/hooks/useStats.js
+++ b/packages/lib-user/src/hooks/useStats.js
@@ -1,11 +1,8 @@
 import { env } from '@zooniverse/panoptes-js'
-import auth from 'panoptes-client/lib/auth'
 import useSWR from 'swr'
 import usePanoptesAuthToken from './usePanoptesAuthToken'
 
 const defaultEndpoint = '/classifications/users'
-
-const isBrowser = typeof window !== 'undefined'
 
 const SWROptions = {
   revalidateIfStale: true,
@@ -13,10 +10,6 @@ const SWROptions = {
   revalidateOnFocus: true,
   revalidateOnReconnect: true,
   refreshInterval: 0
-}
-
-if (isBrowser) {
-  auth.checkCurrent()
 }
 
 function statsHost(env) {

--- a/packages/lib-user/src/hooks/useStats.js
+++ b/packages/lib-user/src/hooks/useStats.js
@@ -1,6 +1,7 @@
 import { env } from '@zooniverse/panoptes-js'
 import auth from 'panoptes-client/lib/auth'
 import useSWR from 'swr'
+import usePanoptesAuthToken from './usePanoptesAuthToken'
 
 const defaultEndpoint = '/classifications/users'
 
@@ -30,10 +31,9 @@ function statsHost(env) {
 async function fetchStats({
   endpoint,
   query,
-  sourceId
+  sourceId,
+  token
 }) {
-  await auth.checkCurrent()
-  const token = await auth.checkBearerToken()
   const authorization = `Bearer ${token}`
   const headers = { authorization }
 
@@ -55,6 +55,7 @@ export function useStats({
   query = {},
   sourceId
 }) {
-  const key = sourceId ? { endpoint, query, sourceId } : null
+  const token = usePanoptesAuthToken()
+  const key = token && sourceId ? { endpoint, query, sourceId, token } : null
   return useSWR(key, fetchStats, SWROptions)
 }

--- a/packages/lib-user/src/hooks/useStats.js
+++ b/packages/lib-user/src/hooks/useStats.js
@@ -32,6 +32,7 @@ async function fetchStats({
   query,
   sourceId
 }) {
+  await auth.checkCurrent()
   const token = await auth.checkBearerToken()
   const authorization = `Bearer ${token}`
   const headers = { authorization }


### PR DESCRIPTION
Wait for the current Panoptes user to be signed-in before fetching unread messages and notifications. See https://zooniverse.github.io/panoptes-javascript-client/#panoptes-javascript-client-auth-authcheckbearertoken

Update user hooks that had the same race condition. Move token fetching code into a hook.

I've moved token fetching into a hook so that the auth token can be used in the SWR cache key, invalidating cached values when auth state changes. See the example in [the SWR docs for multiple fetcher arguments](https://swr.vercel.app/docs/arguments#multiple-arguments).

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-react-components
- lib-user

## Linked Issue and/or Talk Post
- fixes #6337.
- #6336.

## How to Review
Unread notifications should now be fetched with your bearer token. In production, the bearer token can be an empty string when you first fetch notifications, so they come back as 0 when `app-root` loads in the browser, and the SWR cache then returns 0 until it expires and refreshes from Panoptes.

`lib-user` hasn’t changed at all, except that auth’ed requests now wait until you have a refresh token from Panoptes. Previously, `auth.checkBearerToken()` could run before `auth.checkCurrent()` had received your refresh token. In that case, auth’ed requests would fail. 

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
