### PR TITLE
Add Google Tag Manager to app-root's layout

### DIFF
--- a/packages/app-root/package.json
+++ b/packages/app-root/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@next/bundle-analyzer": "~14.2.7",
+    "@next/third-parties": "~14.2.7",
     "@zooniverse/async-states": "~0.0.1",
     "@zooniverse/content": "~0.0.1",
     "@zooniverse/grommet-theme": "~3.2.0",

--- a/packages/app-root/src/app/layout.js
+++ b/packages/app-root/src/app/layout.js
@@ -1,5 +1,6 @@
 import RootLayout from '@/components/RootLayout'
 import StyledComponentsRegistry from './style-registry'
+import { GoogleTagManager } from '@next/third-parties/google'
 
 export const metadata = {
   title: {
@@ -21,9 +22,12 @@ export const metadata = {
   }
 }
 
+const isProduction = process.env.NODE_ENV === 'production'
+
 export default function NextLayout({ children }) {
   return (
     <html lang='en'>
+      {isProduction && <GoogleTagManager gtmId='GTM-WDW6V4' />}
       <StyledComponentsRegistry>
         <RootLayout>{children}</RootLayout>
       </StyledComponentsRegistry>


### PR DESCRIPTION
## Package
app-root

## Linked Issue and/or Talk Post
next/third-parties documentation: https://nextjs.org/docs/app/building-your-application/optimizing/third-party-libraries#google-tag-manager

## Describe your changes
- Add GoogleTagManager component to top level layout.js in app-root. It uses the same tag ID as PFE and app-project.

## How to Review
- When run locally, the tag html can be inspected when in production mode, but not in development mode.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)