### PR TITLE
Fix Finished Announcement banner results link

### DIFF
--- a/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncement.stories.js
+++ b/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncement.stories.js
@@ -22,7 +22,7 @@ function NextRouterStory(Story) {
 
 const mockStore = {
   project: {
-    baseUrl: '/projects/zookeeper/galaxy-zoo',
+    baseUrl: '/zookeeper/galaxy-zoo',
     hasResultsPage: true,
     isComplete: true
   }
@@ -49,7 +49,7 @@ export const Default = () => (
 
 const mockStoreNoResults = {
   project: {
-    baseUrl: '/projects/zookeeper/galaxy-zoo',
+    baseUrl: '/zookeeper/galaxy-zoo',
     hasResultsPage: false,
     isComplete: true
   }

--- a/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.js
+++ b/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.js
@@ -23,7 +23,7 @@ function FinishedAnnouncementConnector() {
 
   const announcement = t('Announcements.FinishedAnnouncement.announcement')
   const link = {
-    href: `${baseUrl}/about/results`,
+    href: `/projects${baseUrl}/about/results`,
     text: t('Announcements.FinishedAnnouncement.seeResults')
   }
 

--- a/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.spec.js
+++ b/packages/app-project/src/components/Announcements/components/FinishedAnnouncement/FinishedAnnouncementConnector.spec.js
@@ -7,7 +7,7 @@ describe('Component > FinishedAnnouncementConnector', function () {
 
   it('should show a results link if results page exists', function () {
     render(<DefaultStory />)
-    const link = screen.findByLabelText('Announcements.FinishedAnnouncement.seeResults')
-    expect(link).exists()
+    const link = screen.getByRole('link')
+    expect(link?.getAttribute('href')).to.equal('/projects/zookeeper/galaxy-zoo/about/results')
   })
 })


### PR DESCRIPTION
## PR Overview

Package: app-project
Fixes #6370 

This PR fixes the Finished Announcement banner's "See Results" link.

- Prior to this fix, the "See Results" link failed to add a "/projects" to the URL.
- Storybook Story has been fixed: 'baseUrl' now matches the 'baseUrl' returned by the Project store (which _doesn't_ automagically prepend a "/projects" to the project slug). 
- Tests have been fixed: prior to this, the tests would always return _incorrect passes_ due to the use of ".findBy..." returning a Promise that always `.exists()`.

### Testing

Test on app-project, on localhost

- Open any paused project with a results page, e.g. https://local.zooniverse.org:3000/projects/alexfitzpatrick/bradfords-industrial-heritage-in-photographs?env=production
- Examine the "See Results" link. It should be a valid link to a results page.

### Status

Ready for review.

Note: if this gets approved while I'm on vacation, please go ahead and merge+deploy this.