### PR TITLE
fix(a11y): style user tabs label text with CSS

### DIFF
--- a/packages/lib-user/src/components/UserHome/components/Dashboard/components/StatsTabs/StatsTabs.js
+++ b/packages/lib-user/src/components/UserHome/components/Dashboard/components/StatsTabs/StatsTabs.js
@@ -8,10 +8,15 @@ import {
 } from 'grommet'
 import { number, shape } from 'prop-types'
 import { useContext } from 'react'
+import styled from 'styled-components'
 
 import { Tip } from '@components/shared'
 
 import tabsTheme from './tabsTheme.js'
+
+const StyledTab = styled(Tab)`
+  text-transform: uppercase;
+`
 
 function Stat({ stats }) {
   return (
@@ -54,12 +59,12 @@ export default function StatsTabs({ statsPreview }) {
     <ThemeContext.Extend value={tabsTheme}>
       <Box width={size !== 'small' ? { min: '480px' } : { min: '350px'}}>
         <GrommetTabs gap='small' size={size}>
-          <Tab title='THIS WEEK'>
+          <StyledTab title='This Week'>
             {statsPreview?.thisWeek && <Stat stats={statsPreview.thisWeek} />}
-          </Tab>
-          <Tab title='ALL TIME'>
+          </StyledTab>
+          <StyledTab title='All Time'>
             {statsPreview?.allTime && <Stat stats={statsPreview.allTime} />}
-          </Tab>
+          </StyledTab>
         </GrommetTabs>
       </Box>
     </ThemeContext.Extend>


### PR DESCRIPTION
A small accessibility fix. Style the home page user tabs with `text-transform: uppercase;` so that they aren't read as all capitals (letter by letter) in screen readers.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-user

## Additional context
>Always type words with appropriate capitalization (capitals for the beginning of a sentence and proper nouns, etc., lowercase for other words). Then apply a style or text effect to create the appearance of all caps. Screen-reading devices will then announce the words correctly (as opposed to, e.g., trying to treat them as an initialism or acronym and reading out each word letter by letter). Other assistive technologies or conversions will also work correctly because they have the option to override your style to remove the all-caps style or effect. This puts the power exactly where we want it—in the hands of readers.

https://apastyle.apa.org/style-grammar-guidelines/paper-format/accessibility/typography#myth2

## How to Review
Visually, the home page shouldn't have changed at all. In the DOM inspector, the  labels of the tabs should now be title case. A screen reader should read "This Week" rather than "T H I S W E E K".

<img width=800 alt="One of the tabs selected in the DOM inspector, to show that the label is: This Week." src="https://github.com/user-attachments/assets/8e827deb-7899-46f6-bb7b-b91299fa79aa">


# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
