### PR TITLE
fix(lib-user): use next/link for internal app routes

### DIFF
--- a/packages/lib-user/src/components/MyGroups/components/PreviewLayout/PreviewLayout.js
+++ b/packages/lib-user/src/components/MyGroups/components/PreviewLayout/PreviewLayout.js
@@ -1,6 +1,7 @@
 import { Loader, SpacedText } from '@zooniverse/react-components'
 import { Anchor, Box, Paragraph } from 'grommet'
 import { arrayOf, bool, func, shape, string } from 'prop-types'
+import Link from 'next/link'
 
 import { ContentBox } from '@components/shared'
 import GroupCardContainer from '../GroupCard/GroupCardContainer.js'
@@ -17,7 +18,7 @@ export default function PreviewLayout({
   return (
     <ContentBox
       linkLabel='See all'
-      linkProps={{ href: `/users/${authUser?.login}/groups` }}
+      linkProps={{ as: Link, href: `/users/${authUser?.login}/groups` }}
       title='My Groups'
     >
       {loading && (

--- a/packages/lib-user/src/components/UserHome/components/Dashboard/Dashboard.js
+++ b/packages/lib-user/src/components/UserHome/components/Dashboard/Dashboard.js
@@ -14,6 +14,7 @@ import { SpacedHeading, SpacedText } from '@zooniverse/react-components'
 
 import DashboardLink from './components/DashboardLink.js'
 import StatsTabsContainer from './components/StatsTabs/StatsTabsContainer.js'
+import Link from 'next/link'
 
 const LinkToBlogPost = styled(Anchor)`
   position: absolute;
@@ -253,6 +254,7 @@ export default function Dashboard({ user, userLoading }) {
           <Relative fill>
             <StyledStatsLink
               alignSelf={size === 'small' ? 'center' : 'end'}
+              forwardedAs={Link}
               href={`/users/${user?.login}/stats`}
               label={<SpacedText>More Stats</SpacedText>}
               icon={<FormNext />}

--- a/packages/lib-user/src/components/shared/HeaderLink/HeaderLink.js
+++ b/packages/lib-user/src/components/shared/HeaderLink/HeaderLink.js
@@ -2,6 +2,7 @@ import { Previous } from 'grommet-icons'
 import { string } from 'prop-types'
 
 import { HeaderButton } from '@components/shared'
+import Link from 'next/link'
 
 function HeaderLink({
   href,
@@ -10,6 +11,7 @@ function HeaderLink({
 }) {
   return (
     <HeaderButton
+      forwardedAs={Link}
       href={href}
       icon={<Previous color='white' size='small' />}
       label={label}

--- a/packages/lib-user/src/components/shared/MainContent/MainContent.js
+++ b/packages/lib-user/src/components/shared/MainContent/MainContent.js
@@ -22,6 +22,7 @@ import {
   StyledTab
 } from './components'
 import { getDateRangeSelectOptions, getProjectSelectOptions } from './helpers'
+import Link from 'next/link'
 
 const DEFAULT_HANDLER = () => true
 const DEFAULT_DATE_RANGE = {
@@ -291,7 +292,7 @@ function MainContent({
             margin={{ top: 'small' }}
           >
             <StyledCertificateButton
-              forwardedAs='a'
+              forwardedAs={Link}
               color='neutral-1'
               href={`/users/${source.login}/stats/certificate${window.location.search}`}
               label='Generate Volunteer Certificate'


### PR DESCRIPTION
Use `next/link` for the home page link to user stats, the link to your stats certificate, and the Back link at the top of each page.

Also fix the `lib-user` peer dependencies, which were still requiring Next.js 13.5.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-user

## Linked Issue and/or Talk Post
- fixes #6350.

## How to Review
'More stats', on the home page, and 'View certificate', on the user stats page, and the Back link on each of those pages, should now use client-side routing in the root Next.js app.

Build the user library with these changes, then build and run the root app with `yarn build && yarn start`, to verify that those links are now using client-side routing (ie. the page doesn't reload, and `app-root` doesn't unmount and remount in the browser, when moving between views.)

This should also lower the load on the Next.js app server, since it doesn't have to serve the whole app on every page transition. Locally, you'll probably see that as faster page transitions with a production build. 

NB. Next.js development mode disables client-side routing, so I don't think this PR can be checked with `yarn dev`.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated
