### PR TITLE
fix(lib-user): pixelated home page subject cards

### DIFF
--- a/packages/lib-user/src/components/UserHome/components/SubjectCard/SubjectCard.js
+++ b/packages/lib-user/src/components/UserHome/components/SubjectCard/SubjectCard.js
@@ -78,7 +78,7 @@ export default function SubjectCard({
         alt={`subject ${subjectID}`}
         controls={false}
         src={mediaSrc}
-        width={cardWidth(size)}
+        width={cardWidth(size) * 2}
       />
       <Gradient fill />
       <StyledSpacedText color='white' weight='bold'>


### PR DESCRIPTION
Double the size of subject card images, so that they are not pixelated on the home page.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-user

## Linked Issue and/or Talk Post
- fixes #6333.

## How to Review
Your personal subject card images are blurred on the main branch, but sharp here.

This branch:

<img width=800 alt="Sharp subject card images on this branch." src="https://github.com/user-attachments/assets/5e45b6df-74c0-41c5-b3a2-890f4d3e05c9">

zooniverse.org:

<img width=800 alt="Blurred subject cards on the live home page." src="https://github.com/user-attachments/assets/5d3be3c6-0950-4d23-aa2c-e87a7860b01d">


## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

