### PR TITLE
test(lib-user): broken date range tests

### DIFF
--- a/packages/lib-user/src/components/shared/MainContent/helpers/getDateRangeSelectOptions.spec.js
+++ b/packages/lib-user/src/components/shared/MainContent/helpers/getDateRangeSelectOptions.spec.js
@@ -154,7 +154,7 @@ describe('components > MainContent > getDateRangeSelectOptions', function () {
   describe('with a custom date range', function () {
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(new Date('2023-04-15T00:00:00'))
+      clock = sinon.useFakeTimers(new Date('2023-04-15T00:00:00Z'))
     })
 
     afterEach(function () {
@@ -223,7 +223,7 @@ describe('components > MainContent > getDateRangeSelectOptions', function () {
   describe('with a source created_at date', function () {
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(new Date('2023-04-15T00:00:00'))
+      clock = sinon.useFakeTimers(new Date('2023-04-15T00:00:00Z'))
     })
 
     afterEach(function () {


### PR DESCRIPTION
Add missing time zones to the date range tests, so that they pass in all time zones.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- lib-user

## Linked Issue and/or Talk Post
- fixes #6354

## How to Review
Tests are passing now when I run them in a UK time zone (UTC + 1.) I'm not sure how to test this outside the UK. Maybe run it in a CST or CDT time zone in the US?

<img width=744 alt="Screenshot of the test suite running in a MacBook terminal. All packages pass." src="https://github.com/user-attachments/assets/5a3f85ef-f175-48e7-a9aa-ac36a740eac1">



# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

