### PR TITLE
build: ignore post-install scripts

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -15,24 +15,28 @@ set -ev
 ROOT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && cd .. && pwd)"
 cd $ROOT_DIR
 
+printf 'Installing dependencies...\n'
+yarn install --frozen-lockfile --ignore-scripts
+printf '\n'
+
 printf 'Building `lib-react-components`...\n'
-yarn workspace @zooniverse/react-components install --frozen-lockfile
+yarn workspace @zooniverse/react-components build
 printf '\n'
 
 printf 'Building `lib-content`...\n'
-yarn workspace @zooniverse/content install --frozen-lockfile
+yarn workspace @zooniverse/content build
 printf '\n'
 
 printf 'Building `lib-user`...\n'
-yarn workspace @zooniverse/user install --frozen-lockfile
+yarn workspace @zooniverse/user build
 printf '\n'
 
 printf 'Building `lib-subject-viewers`...\n'
-yarn workspace @zooniverse/subject-viewers install --frozen-lockfile
+yarn workspace @zooniverse/subject-viewers build
 printf '\n'
 
 printf 'Building `lib-classifier`...\n'
-yarn workspace @zooniverse/classifier install --frozen-lockfile
+yarn workspace @zooniverse/classifier build
 printf '\n'
 
 printf 'Building `fe-project`...\n'

--- a/bin/bootstrap:es6.sh
+++ b/bin/bootstrap:es6.sh
@@ -16,7 +16,7 @@ ROOT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && cd .. && pwd)"
 cd $ROOT_DIR
 
 printf 'Installing dependencies...\n'
-yarn install --frozen-lockfile
+yarn install --frozen-lockfile --ignore-scripts
 printf '\n'
 
 printf 'Building `lib-react-components`...\n'

--- a/bin/clean-install.sh
+++ b/bin/clean-install.sh
@@ -17,5 +17,5 @@ for DIR in $(find $ROOT_DIR/packages -mindepth 1 -maxdepth 1 -type d) ; do
   printf " done!\n"
 done
 
-yarn install --frozen-lockfile
+yarn install --frozen-lockfile --ignore-scripts
 echo "Finished!"


### PR DESCRIPTION
The GitHub CI workflows and the Docker builds already run `yarn install` with the `--ignore-scripts` flag. This PR makes the same change to the bootstrap scripts for local development.

I've also tidied up `bin/bootstrap.sh` so that it only runs the install once, then builds the various packages in order.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Linked Issue and/or Talk Post
- closes #6391.

## How to Review
`yarn bootstrap` should build the various packages as usual. Tests should still run, and the Next.js apps should still run.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser
