### PR TITLE
Refactor homepage recent projects to use ERAS

### DIFF
--- a/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.js
@@ -1,5 +1,5 @@
 import { Anchor, Box, ResponsiveContext, Text } from 'grommet'
-import { arrayOf, bool, shape, string } from 'prop-types'
+import { arrayOf, bool, number, shape, string } from 'prop-types'
 import { useContext } from 'react'
 import { Loader, ProjectCard, SpacedText } from '@zooniverse/react-components'
 
@@ -44,14 +44,14 @@ export default function RecentProjects({
           style={{ listStyle: 'none' }}
           margin='0'
         >
-          {recentProjectsStats.map(project => (
-            <li key={project?.id}>
+          {recentProjectsStats.map(stat => (
+            <li key={stat.project_id}>
               <ProjectCard
-                badge={project?.userContributions}
-                description={project?.description}
-                displayName={project?.display_name}
-                href={`https://www.zooniverse.org/projects/${project?.slug}`}
-                imageSrc={project?.avatar_src}
+                badge={stat.count}
+                description={stat.projectInfo?.description}
+                displayName={stat.projectInfo?.display_name}
+                href={`https://www.zooniverse.org/projects/${stat.projectInfo?.slug}`}
+                imageSrc={stat.projectInfo?.avatar_src}
                 size={size}
               />
             </li>
@@ -66,7 +66,15 @@ RecentProjects.propTypes = {
   isLoading: bool,
   recentProjectsStats: arrayOf(
     shape({
-      id: string
+      count: number,
+      project_id: number,
+      projectInfo: shape({
+        avatar_src: string,
+        description: string,
+        display_name: string,
+        id: string,
+        slug: string
+      })
     })
   )
 }

--- a/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.js
@@ -7,26 +7,23 @@ import { ContentBox } from '@components/shared'
 
 export default function RecentProjects({
   isLoading = false,
-  projectPreferences = [],
+  recentProjectsStats = [],
   error = undefined
 }) {
   const size = useContext(ResponsiveContext)
-
   return (
     <ContentBox title='Continue Classifying' screenSize={size}>
-      {isLoading && (
+      {isLoading ? (
         <Box fill justify='center' align='center'>
           <Loader />
         </Box>
-      )}
-      {!isLoading && error && (
+      ) : error ? (
         <Box fill justify='center' align='center' pad='medium'>
           <SpacedText>
             There was an error fetching your recent projects
           </SpacedText>
         </Box>
-      )}
-      {!isLoading && !projectPreferences.length && !error && (
+      ) : !recentProjectsStats.length ? (
         <Box fill justify='center' align='center' pad='medium'>
           <SpacedText>No Recent Projects found</SpacedText>
           <Text>
@@ -37,39 +34,37 @@ export default function RecentProjects({
             .
           </Text>
         </Box>
+      ) : (
+        <Box
+          as='ul'
+          direction='row'
+          gap='small'
+          pad={{ horizontal: 'xxsmall', bottom: 'xsmall', top: 'xxsmall' }}
+          overflow={{ horizontal: 'auto' }}
+          style={{ listStyle: 'none' }}
+          margin='0'
+        >
+          {recentProjectsStats.map(project => (
+            <li key={project?.id}>
+              <ProjectCard
+                badge={project?.userContributions}
+                description={project?.description}
+                displayName={project?.display_name}
+                href={`https://www.zooniverse.org/projects/${project?.slug}`}
+                imageSrc={project?.avatar_src}
+                size={size}
+              />
+            </li>
+          ))}
+        </Box>
       )}
-      {!isLoading &&
-        projectPreferences?.length ? (
-          <Box
-            as='ul'
-            direction='row'
-            gap='small'
-            pad={{ horizontal: 'xxsmall', bottom: 'xsmall', top: 'xxsmall' }}
-            overflow={{ horizontal: 'auto' }}
-            style={{ listStyle: 'none' }}
-            margin='0'
-          >
-            {projectPreferences.map(preference => (
-              <li key={preference?.project?.id}>
-                <ProjectCard
-                  badge={preference?.activity_count}
-                  description={preference?.project?.description}
-                  displayName={preference?.project?.display_name}
-                  href={`https://www.zooniverse.org/projects/${preference?.project?.slug}`}
-                  imageSrc={preference?.project?.avatar_src}
-                  size={size}
-                />
-              </li>
-            ))}
-          </Box>
-        ) : null}
     </ContentBox>
   )
 }
 
 RecentProjects.propTypes = {
   isLoading: bool,
-  projectPreferences: arrayOf(
+  recentProjectsStats: arrayOf(
     shape({
       id: string
     })

--- a/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.js
@@ -7,10 +7,11 @@ import { ContentBox } from '@components/shared'
 
 export default function RecentProjects({
   isLoading = false,
-  recentProjectsStats = [],
+  recentProjects = [],
   error = undefined
 }) {
   const size = useContext(ResponsiveContext)
+
   return (
     <ContentBox title='Continue Classifying' screenSize={size}>
       {isLoading ? (
@@ -23,7 +24,7 @@ export default function RecentProjects({
             There was an error fetching your recent projects
           </SpacedText>
         </Box>
-      ) : !recentProjectsStats.length ? (
+      ) : !recentProjects.length ? (
         <Box fill justify='center' align='center' pad='medium'>
           <SpacedText>No Recent Projects found</SpacedText>
           <Text>
@@ -44,14 +45,14 @@ export default function RecentProjects({
           style={{ listStyle: 'none' }}
           margin='0'
         >
-          {recentProjectsStats.map(stat => (
-            <li key={stat.project_id}>
+          {recentProjects.map(project => (
+            <li key={project.id}>
               <ProjectCard
-                badge={stat.count}
-                description={stat.projectInfo?.description}
-                displayName={stat.projectInfo?.display_name}
-                href={`https://www.zooniverse.org/projects/${stat.projectInfo?.slug}`}
-                imageSrc={stat.projectInfo?.avatar_src}
+                badge={project.count}
+                description={project?.description}
+                displayName={project?.display_name}
+                href={`https://www.zooniverse.org/projects/${project?.slug}`}
+                imageSrc={project?.avatar_src}
                 size={size}
               />
             </li>
@@ -64,17 +65,14 @@ export default function RecentProjects({
 
 RecentProjects.propTypes = {
   isLoading: bool,
-  recentProjectsStats: arrayOf(
+  recentProjects: arrayOf(
     shape({
+      avatar_src: string,
       count: number,
-      project_id: number,
-      projectInfo: shape({
-        avatar_src: string,
-        description: string,
-        display_name: string,
-        id: string,
-        slug: string
-      })
+      description: string,
+      display_name: string,
+      id: string,
+      slug: string
     })
   )
 }

--- a/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjectsContainer.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjectsContainer.js
@@ -15,28 +15,27 @@ function RecentProjectsContainer({ authUser }) {
     error: statsError
   } = useStats({ sourceId: authUser?.id, query: recentProjectsQuery })
 
-  // Get more info about each project
-  const projectIds = stats?.project_contributions?.map(
-    project => project.project_id
-  )
+  // limit to 20 projects fetched from panoptes
+  const contributionStats = stats?.project_contributions.slice(0, 20)
+  const projectIds = contributionStats?.map(project => project.project_id)
 
+  // Get more info about each project
   const {
     data: projects,
     isLoading: projectsLoading,
     error: projectsError
   } = usePanoptesProjects({
     cards: true,
-    id: projectIds?.join(','),
-    page_size: 20
+    id: projectIds?.join(',')
   })
 
-  // Attach contributions to each project
-  if (projects?.length && stats.project_contributions.length) {
-    projects.forEach(project => {
-      const projectStat = stats.project_contributions.find(
-        stat => stat.project_id === parseInt(project.id)
+  // Attach project info to each contribution stat
+  if (projects?.length && contributionStats?.length) {
+    contributionStats.forEach(stat => {
+      const projectObj = projects.find(
+        project => parseInt(project.id) === stat.project_id
       )
-      project.userContributions = projectStat.count
+      stat.projectInfo = projectObj
     })
   }
 
@@ -44,7 +43,7 @@ function RecentProjectsContainer({ authUser }) {
     <RecentProjects
       error={statsError || projectsError}
       isLoading={statsLoading || projectsLoading}
-      recentProjectsStats={projects}
+      recentProjectsStats={contributionStats}
     />
   )
 }

--- a/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjectsContainer.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjectsContainer.js
@@ -16,8 +16,8 @@ function RecentProjectsContainer({ authUser }) {
   } = useStats({ sourceId: authUser?.id, query: recentProjectsQuery })
 
   // limit to 20 projects fetched from panoptes
-  const contributionStats = stats?.project_contributions.slice(0, 20)
-  const projectIds = contributionStats?.map(project => project.project_id)
+  const contributions = stats?.project_contributions.slice(0, 20)
+  const projectIds = contributions?.map(project => project.project_id)
 
   // Get more info about each project
   const {
@@ -29,21 +29,28 @@ function RecentProjectsContainer({ authUser }) {
     id: projectIds?.join(',')
   })
 
-  // Attach project info to each contribution stat
-  if (projects?.length && contributionStats?.length) {
-    contributionStats.forEach(stat => {
-      const projectObj = projects.find(
-        project => parseInt(project.id) === stat.project_id
-      )
-      stat.projectInfo = projectObj
-    })
+  // Attach project info to each contribution stat (see similar behavior in TopProjects)
+  let recentProjects = []
+
+  if (projects?.length && contributions?.length) {
+    recentProjects = contributions
+      .map(projectContribution => {
+        const projectData = projects?.find(
+          project => project.id === projectContribution.project_id.toString()
+        )
+        return {
+          count: projectContribution.count,
+          ...projectData
+        }
+      })
+      .filter(project => project?.id) // exclude private or deleted projects
   }
 
   return (
     <RecentProjects
       error={statsError || projectsError}
       isLoading={statsLoading || projectsLoading}
-      recentProjectsStats={contributionStats}
+      recentProjects={recentProjects}
     />
   )
 }

--- a/packages/lib-user/src/components/shared/ContentBox/components/ContentLink.js
+++ b/packages/lib-user/src/components/shared/ContentBox/components/ContentLink.js
@@ -1,10 +1,10 @@
 import { SpacedText } from '@zooniverse/react-components'
 import { Anchor } from 'grommet'
-import { shape, string } from 'prop-types'
+import { object, oneOfType, shape, string } from 'prop-types'
 import styled from 'styled-components'
 
 const StyledAnchor = styled(Anchor)`
-  font-family: 'Karla', Arial, sans-serif; 
+  font-family: 'Karla', Arial, sans-serif;
   font-size: 1rem;
   line-height: normal;
   background: none;
@@ -45,7 +45,7 @@ function ContentLink({
 
 ContentLink.propTypes = {
   link: shape({
-    as: string,
+    as: oneOfType([object, string]),
     href: string,
     text: string
   })


### PR DESCRIPTION
## Package
lib-user

## Linked Issue and/or Talk Post
Follows: https://github.com/zooniverse/eras/pull/76
Might fix: https://github.com/zooniverse/front-end-monorepo/issues/6332

## Describe your changes
- Use eras instead of `/project_preferences` to fetch contribution count per project on the homepage and sort the Recent Projects section.

## How to Review

- Looking at the Recent Projects section, compare your signed-in homepage at https://www.zooniverse.org to app-root run locally. The order and classification count might vary a little bit because we're migrating to ERAS from `/project_preferences`.
- With the changes in this PR, the stats count on each Recent Projects badge should match the stats count on your stats page. For instance, eras says I made 123 classifications on i-fancy-cats which is displayed on my homepage and in the Top Projects of my all-time stats page.
- Note: do _not_ compare Recent Projects on app-root's homepage to Recent Projects on the old PFE page. They intentionally use two completely different API requests.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out