### PR TITLE
fix(app-project): test the daily stats chart

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStats.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStats.js
@@ -6,8 +6,15 @@ import DailyClassificationsChart from './components/DailyClassificationsChart'
 import ContentBox from '@shared/components/ContentBox'
 import Stat from '@shared/components/Stat'
 
-function YourStats(props) {
-  const { counts, projectName } = props
+const defaultCounts = {
+  today: 0,
+  total: 0
+}
+
+function YourStats({
+  counts = defaultCounts,
+  projectName = ''
+}) {
   const { t } = useTranslation('screens')
 
   return (
@@ -38,7 +45,7 @@ function YourStats(props) {
         <DailyClassificationsChart />
       </Box>
     </ContentBox>
-  );
+  )
 }
 
 YourStats.propTypes = {
@@ -47,13 +54,6 @@ YourStats.propTypes = {
     total: number
   }),
   projectName: string
-}
-
-YourStats.defaultProps = {
-  counts: {
-    today: 0,
-    total: 0
-  }
 }
 
 export default YourStats

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStats.mock.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStats.mock.js
@@ -5,45 +5,17 @@ const YourStatsStoreMock = {
 	user: {
 		personalization: {
 			counts: {
-				today: 10,
+				today: 97,
 				total: 100
 			},
 			stats: {
 				thisWeek: [
 					{
-						alt: 'Sunday: 0',
-						count: 0,
-						period: '2019-10-6',
-						label: 'S',
-						longLabel: 'Sunday'
-					},
-					{
-						alt: 'Saturday: 0',
-						count: 0,
-						period: '2019-10-5',
-						label: 'S',
-						longLabel: 'Saturday'
-					},
-					{
-						alt: 'Friday: 0',
-						count: 0,
-						period: '2019-10-4',
-						label: 'F',
-						longLabel: 'Friday'
-					},
-					{
-						alt: 'Thursday: 0',
-						count: 0,
-						period: '2019-10-3',
-						label: 'T',
-						longLabel: 'Thursday'
-					},
-					{
-						alt: 'Wednesday: 0',
-						count: 0,
-						period: '2019-10-2',
-						label: 'W',
-						longLabel: 'Wednesday'
+						alt: 'Monday: 85',
+						count: 85,
+						period: '2019-09-30',
+						label: 'M',
+						longLabel: 'Monday'
 					},
 					{
 						alt: 'Tuesday: 97',
@@ -53,11 +25,39 @@ const YourStatsStoreMock = {
 						longLabel: 'Tuesday'
 					},
 					{
-						alt: 'Monday: 85',
-						count: 85,
-						period: '2019-09-30',
-						label: 'M',
-						longLabel: 'Monday'
+						alt: 'Wednesday: 0',
+						count: 0,
+						period: '2019-10-2',
+						label: 'W',
+						longLabel: 'Wednesday'
+					},
+					{
+						alt: 'Thursday: 0',
+						count: 0,
+						period: '2019-10-3',
+						label: 'T',
+						longLabel: 'Thursday'
+					},
+					{
+						alt: 'Friday: 0',
+						count: 0,
+						period: '2019-10-4',
+						label: 'F',
+						longLabel: 'Friday'
+					},
+					{
+						alt: 'Saturday: 0',
+						count: 0,
+						period: '2019-10-5',
+						label: 'S',
+						longLabel: 'Saturday'
+					},
+					{
+						alt: 'Sunday: 0',
+						count: 0,
+						period: '2019-10-6',
+						label: 'S',
+						longLabel: 'Sunday'
 					}
 				]
 			}

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStats.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStats.spec.js
@@ -1,14 +1,14 @@
 import { render, screen } from '@testing-library/react'
 import { composeStory } from '@storybook/react'
+import sinon from 'sinon'
+
 import Meta, { YourStats } from './YourStats.stories.js'
 import { YourStatsStoreMock } from './YourStats.mock'
 
 describe('Component > YourStats', function () {
-  let rendered;
-
   beforeEach(function () {
     const YourStatsStory = composeStory(YourStats, Meta)
-    rendered = render(<YourStatsStory />)
+    render(<YourStatsStory />)
   })
 
   it('should have a heading', function () {
@@ -30,12 +30,17 @@ describe('Component > YourStats', function () {
   it('should have 7 bars and each bar should be an image', function () {
     expect(screen.getAllByRole('img').length).to.equal(7)
   })
+})
 
-  describe('Daily bars', function () {
-    YourStatsStoreMock.user.personalization.stats.thisWeek.forEach(function (count, i) {
-      it(`should have an accessible description for ${count.longLabel}`, function () {
-        expect(screen.findByLabelText(count.alt)).to.be.ok()
-      })
+describe('Component > YourStats > Daily bars', function () {
+  YourStatsStoreMock.user.personalization.stats.thisWeek.forEach(function (count, i) {
+    it(`should have an accessible description for ${count.longLabel}`, function () {
+      const clock = sinon.useFakeTimers(new Date('2019-10-01T19:00:00+06:00'))
+      const YourStatsStory = composeStory(YourStats, Meta)
+      render(<YourStatsStory />)
+      const bar = screen.getByRole('img', { name: count.alt })
+      expect(bar).to.exist()
+      clock.restore()
     })
   })
 })

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStatsContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStatsContainer.js
@@ -4,9 +4,9 @@ import { useContext } from 'react'
 import YourStats from './YourStats'
 import withRequireUser from '@shared/components/withRequireUser'
 
-function useStores(mockStore) {
+function useStores() {
   const stores = useContext(MobXProviderContext)
-  const store = mockStore || stores.store
+  const store = stores.store
   const {
     project,
     user: {
@@ -19,8 +19,8 @@ function useStores(mockStore) {
   }
 }
 
-function YourStatsContainer({ mockStore }) {
-  const { counts, projectName } = useStores(mockStore)
+function YourStatsContainer() {
+  const { counts, projectName } = useStores()
   return <YourStats counts={counts} projectName={projectName} />
 }
 

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.js
@@ -14,7 +14,9 @@ function DailyClassificationsChartContainer({
 }) {
   const TODAY = new Date()
   const stats = thisWeek.map(({ count: statsCount, period }) => {
-    const day = new Date(period)
+    const [year, monthIndex, date] = period.split('-')
+    const utcDay = Date.UTC(year, monthIndex - 1, date)
+    const day = new Date(utcDay)
     const isToday = day.getUTCDay() === TODAY.getDay()
     const count = isToday ? counts.today : statsCount
     const longLabel = day.toLocaleDateString(locale, { timeZone: 'UTC', weekday: 'long' })


### PR DESCRIPTION
- test the daily stats chart, on the Classify page. Check that each bar has the expected day and classification count.
- fix a bug thrown up by those tests, where the bar date wasn't correctly calculated as UTC.
- fix a bug in the mocks, so that the current daily count matches the count for the current day.
- fix a bug in the storybook, where the mocks were in reverse order.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project

## Linked Issue and/or Talk Post
- closes #2244.
- closes #6324.
- #6383.

## How to Review
This started out as replacing some tests that were removed in #5210, but those tests failed, because of bugs in the `YourStats` component. So this now:
- tests the stats component to check that each day has the correct day name and classification count.
- fixes the stats calculation so that those tests pass.

To properly test this, you should look at a project that you've classified on in the last week, preferably on more than one day, and check that the daily classification counts are assigned to the correct day.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out
- [ ] The component is accessible
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
  - It is passing accessibility checks in the storybook


## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

