### PR TITLE
Use ERAS for all user stats in YourStats component

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStats.mock.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStats.mock.js
@@ -4,65 +4,104 @@ const YourStatsStoreMock = {
 	},
 	user: {
 		personalization: {
-			counts: {
-				today: 97,
-				total: 100
-			},
 			stats: {
-				thisWeek: [
-					{
-						alt: 'Monday: 85',
-						count: 85,
+        counts: {
+          today: 97,
+          total: 147
+        },
+        thisWeek: [
+          {
+						count: 50,
+            dayNumber: 1,
 						period: '2019-09-30',
-						label: 'M',
-						longLabel: 'Monday'
 					},
-					{
-						alt: 'Tuesday: 97',
+          {
 						count: 97,
+            dayNumber: 2,
 						period: '2019-10-1',
-						label: 'T',
-						longLabel: 'Tuesday'
 					},
-					{
-						alt: 'Wednesday: 0',
+          {
 						count: 0,
+            dayNumber: 3,
 						period: '2019-10-2',
-						label: 'W',
-						longLabel: 'Wednesday'
 					},
 					{
-						alt: 'Thursday: 0',
 						count: 0,
+            dayNumber: 4,
 						period: '2019-10-3',
-						label: 'T',
-						longLabel: 'Thursday'
 					},
 					{
-						alt: 'Friday: 0',
+
 						count: 0,
+            dayNumber: 5,
 						period: '2019-10-4',
-						label: 'F',
-						longLabel: 'Friday'
 					},
 					{
-						alt: 'Saturday: 0',
 						count: 0,
+            dayNumber: 6,
 						period: '2019-10-5',
-						label: 'S',
-						longLabel: 'Saturday'
 					},
 					{
-						alt: 'Sunday: 0',
 						count: 0,
+            dayNumber: 7,
 						period: '2019-10-6',
-						label: 'S',
-						longLabel: 'Sunday'
 					}
-				]
+        ]
 			}
 		}
-	},
+	}
 }
 
-export { YourStatsStoreMock }
+const DailyClassificationsChartContainerMockStats = [
+  {
+    alt: 'Monday: 50',
+    count: 50,
+    period: '2019-09-30',
+    label: 'M',
+    longLabel: 'Monday'
+  },
+  {
+    alt: 'Tuesday: 97',
+    count: 97,
+    period: '2019-10-1',
+    label: 'T',
+    longLabel: 'Tuesday'
+  },
+  {
+    alt: 'Wednesday: 0',
+    count: 0,
+    period: '2019-10-2',
+    label: 'W',
+    longLabel: 'Wednesday'
+  },
+  {
+    alt: 'Thursday: 0',
+    count: 0,
+    period: '2019-10-3',
+    label: 'T',
+    longLabel: 'Thursday'
+  },
+  {
+    alt: 'Friday: 0',
+    count: 0,
+    period: '2019-10-4',
+    label: 'F',
+    longLabel: 'Friday'
+  },
+  {
+    alt: 'Saturday: 0',
+    count: 0,
+    period: '2019-10-5',
+    label: 'S',
+    longLabel: 'Saturday'
+  },
+  {
+    alt: 'Sunday: 0',
+    count: 0,
+    period: '2019-10-6',
+    label: 'S',
+    longLabel: 'Sunday'
+  }
+]
+
+export { DailyClassificationsChartContainerMockStats, YourStatsStoreMock }

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStats.spec.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStats.spec.js
@@ -3,11 +3,12 @@ import { composeStory } from '@storybook/react'
 import sinon from 'sinon'
 
 import Meta, { YourStats } from './YourStats.stories.js'
-import { YourStatsStoreMock } from './YourStats.mock'
+import { DailyClassificationsChartContainerMockStats, YourStatsStoreMock } from './YourStats.mock'
 
 describe('Component > YourStats', function () {
+  const YourStatsStory = composeStory(YourStats, Meta)
+
   beforeEach(function () {
-    const YourStatsStory = composeStory(YourStats, Meta)
     render(<YourStatsStory />)
   })
 
@@ -33,12 +34,13 @@ describe('Component > YourStats', function () {
 })
 
 describe('Component > YourStats > Daily bars', function () {
-  YourStatsStoreMock.user.personalization.stats.thisWeek.forEach(function (count, i) {
-    it(`should have an accessible description for ${count.longLabel}`, function () {
+  YourStatsStoreMock.user.personalization.stats.thisWeek.forEach(function (storeCount, i) {
+    it(`should have an accessible description`, function () {
       const clock = sinon.useFakeTimers(new Date('2019-10-01T19:00:00+06:00'))
       const YourStatsStory = composeStory(YourStats, Meta)
       render(<YourStatsStory />)
-      const bar = screen.getByRole('img', { name: count.alt })
+      const { alt } = DailyClassificationsChartContainerMockStats.find((stat) => stat.count === storeCount.count)
+      const bar = screen.getByRole('img', { name: alt })
       expect(bar).to.exist()
       clock.restore()
     })

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStats.stories.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStats.stories.js
@@ -1,8 +1,9 @@
 import { Provider } from 'mobx-react'
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime'
 import { Grommet, base } from 'grommet'
+
 import { YourStatsContainer } from './YourStatsContainer'
-import { YourStatsStoreMock } from './YourStats.mock'
+import { YourStatsStoreMock } from './YourStats.mock' // Used for DailyClassificationsChart's connector
 
 const mockedRouter = {
   asPath: '/projects/zooniverse/snapshot-serengeti/about/team',
@@ -25,6 +26,10 @@ export default {
 	component: YourStatsContainer,
   decorators: [NextRouterStory]
 }
+
+// Note: DailyClassificationsChart grabs YourStatsStoreMock, but the dates do not match
+// whatever "today" is when you run the storybook, so the visual stats bars will
+// not accurately display the mock `thisWeek` data
 
 export const YourStats = () => (
 	<Provider store={YourStatsStoreMock}>

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStatsContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStatsContainer.js
@@ -13,6 +13,8 @@ function useStores() {
       personalization: { counts }
     }
   } = store
+
+  console.log('COUNTS', counts)
   return {
     counts,
     projectName: project['display_name']

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStatsContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStatsContainer.js
@@ -10,7 +10,9 @@ function useStores() {
   const {
     project,
     user: {
-      personalization: { counts }
+      personalization: {
+        stats: { counts }
+      }
     }
   } = store
 

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStatsContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/YourStatsContainer.js
@@ -14,7 +14,6 @@ function useStores() {
     }
   } = store
 
-  console.log('COUNTS', counts)
   return {
     counts,
     projectName: project['display_name']

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChart.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChart.js
@@ -16,7 +16,7 @@ const StyledBarGroup = styled(Group)`
       font-size: ${props.theme.text.small.size}
     `}
   }
-  
+
   &:hover rect,
   &:focus rect {
     ${props => css`fill: ${props.theme.global.colors.brand};`}

--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartConnector.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartConnector.js
@@ -9,8 +9,8 @@ function storeMapper(store) {
     project,
     user: {
       personalization: {
-        counts,
         stats: {
+          counts,
           thisWeek
         }
       }

--- a/packages/app-project/stores/Store.spec.js
+++ b/packages/app-project/stores/Store.spec.js
@@ -64,10 +64,6 @@ describe('Stores > Store', function () {
           login: 'zootester',
           personalization: {
             projectPreferences: {
-              activity_count: 8,
-              activity_count_by_workflow: {
-                1234: 8,
-              },
               id: '5',
               links: { project: '5678', user: '1' },
               loadingState: asyncStates.success,
@@ -88,9 +84,9 @@ describe('Stores > Store', function () {
                 { count: 10, dayNumber: 5, period: '2019-10-03' },
                 { count: 11, dayNumber: 6, period: '2019-10-04' },
                 { count: 8, dayNumber: 0, period: '2019-10-05' }
-              ]
-            },
-            totalClassificationCount: 8
+              ],
+              total: 80
+            }
           }
         }
       }, placeholderEnv)

--- a/packages/app-project/stores/User/Collections/Collections.js
+++ b/packages/app-project/stores/User/Collections/Collections.js
@@ -1,5 +1,4 @@
-import { autorun } from 'mobx'
-import { addDisposer, flow, getRoot, types } from 'mobx-state-tree'
+import { flow, getRoot, types } from 'mobx-state-tree'
 import auth from 'panoptes-client/lib/auth'
 import asyncStates from '@zooniverse/async-states'
 

--- a/packages/app-project/stores/User/Recents/Recents.js
+++ b/packages/app-project/stores/User/Recents/Recents.js
@@ -1,5 +1,4 @@
-import { autorun } from 'mobx'
-import { addDisposer, flow, getParentOfType, getRoot, types } from 'mobx-state-tree'
+import { flow, getParentOfType, getRoot, types } from 'mobx-state-tree'
 import auth from 'panoptes-client/lib/auth'
 import asyncStates from '@zooniverse/async-states'
 

--- a/packages/app-project/stores/User/User.js
+++ b/packages/app-project/stores/User/User.js
@@ -1,6 +1,5 @@
 import asyncStates from '@zooniverse/async-states'
-import { applySnapshot, flow, getSnapshot, types } from 'mobx-state-tree'
-import auth from 'panoptes-client/lib/auth'
+import { applySnapshot, getSnapshot, types } from 'mobx-state-tree'
 
 import Collections from './Collections'
 import Recents from './Recents'
@@ -44,11 +43,6 @@ const User = types
         display_name: null,
         login: null,
         loadingState: asyncStates.success,
-        // personalization: {
-        //   projectPreferences: {
-        //     loadingState: asyncStates.success
-        //   }
-        // }
       }
       applySnapshot(self, loggedOutUser)
     },

--- a/packages/app-project/stores/User/User.js
+++ b/packages/app-project/stores/User/User.js
@@ -38,16 +38,17 @@ const User = types
 
   .actions(self => ({
     clear() {
+      self.personalization.reset()
       const loggedOutUser = {
         id: null,
         display_name: null,
         login: null,
         loadingState: asyncStates.success,
-        personalization: {
-          projectPreferences: {
-            loadingState: asyncStates.success
-          }
-        }
+        // personalization: {
+        //   projectPreferences: {
+        //     loadingState: asyncStates.success
+        //   }
+        // }
       }
       applySnapshot(self, loggedOutUser)
     },

--- a/packages/app-project/stores/User/User.spec.js
+++ b/packages/app-project/stores/User/User.spec.js
@@ -9,7 +9,7 @@ import { statsClient } from './UserPersonalization/YourStats'
 
 import Store from '@stores/Store'
 
-describe.only('stores > User', function () {
+describe('stores > User', function () {
   const user = {
     display_name: 'Jean-Luc Picard',
     id: '1',
@@ -37,19 +37,31 @@ describe.only('stores > User', function () {
     .get('/project_preferences?project_id=1&user_id=1&http_cache=true')
     .reply(200, {
       project_preferences: [
-        { id: '1' }
+        {
+          links: {
+            user: '1'
+          }
+        }
       ]
     })
     .get('/project_preferences?project_id=1&user_id=1&http_cache=true')
     .reply(200, {
       project_preferences: [
-        { id: '1' }
+        {
+          links: {
+            user: '1'
+          }
+        }
       ]
     })
     .get('/project_preferences?project_id=1&user_id=2&http_cache=true')
     .reply(200, {
       project_preferences: [
-        { id: '1' }
+        {
+          links: {
+            user: '2'
+          }
+        }
       ]
     })
 

--- a/packages/app-project/stores/User/User.spec.js
+++ b/packages/app-project/stores/User/User.spec.js
@@ -9,7 +9,7 @@ import { statsClient } from './UserPersonalization/YourStats'
 
 import Store from '@stores/Store'
 
-describe('stores > User', function () {
+describe.only('stores > User', function () {
   const user = {
     display_name: 'Jean-Luc Picard',
     id: '1',

--- a/packages/app-project/stores/User/User.spec.js
+++ b/packages/app-project/stores/User/User.spec.js
@@ -37,19 +37,19 @@ describe('stores > User', function () {
     .get('/project_preferences?project_id=1&user_id=1&http_cache=true')
     .reply(200, {
       project_preferences: [
-        { activity_count: 23 }
+        { id: '1' }
       ]
     })
     .get('/project_preferences?project_id=1&user_id=1&http_cache=true')
     .reply(200, {
       project_preferences: [
-        { activity_count: 25 }
+        { id: '1' }
       ]
     })
     .get('/project_preferences?project_id=1&user_id=2&http_cache=true')
     .reply(200, {
       project_preferences: [
-        { activity_count: 27 }
+        { id: '1' }
       ]
     })
 
@@ -105,7 +105,7 @@ describe('stores > User', function () {
   })
 
   describe('with an existing user session', function () {
-    
+
     it('should refresh project preferences for the same user', async function () {
       userStore.set(user)
       const { personalization } = userStore

--- a/packages/app-project/stores/User/UserPersonalization/UserPersonalization.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserPersonalization.js
@@ -16,10 +16,11 @@ const UserPersonalization = types
   .views(self => ({
     get counts() {
       const today = self.todaysCount
+      const total = self.stats.total
 
       return {
         today,
-        total: self.totalClassificationCount
+        total
       }
     },
 
@@ -43,10 +44,6 @@ const UserPersonalization = types
         return self.stats.thisWeek.find(stat => stat.dayNumber === todaysDate.getDay())
       }
       return null
-    },
-
-    get totalClassificationCount() {
-      return self.projectPreferences?.activity_count || 0
     }
   }))
   .actions(self => {
@@ -65,7 +62,7 @@ const UserPersonalization = types
       increment() {
         self.sessionCount = self.sessionCount + 1
         self.todaysStats?.increment()
-        self.projectPreferences?.incrementActivityCount()
+        self.stats.incrementTotal()
         const { user } = getRoot(self)
         if (user?.id && self.sessionCountIsDivisibleByFive) {
           self.projectPreferences.refreshSettings()

--- a/packages/app-project/stores/User/UserPersonalization/UserPersonalization.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserPersonalization.js
@@ -14,36 +14,8 @@ const UserPersonalization = types
     stats: types.optional(YourStats, {})
   })
   .views(self => ({
-    get counts() {
-      const today = self.todaysCount
-      const total = self.stats.total
-
-      return {
-        today,
-        total
-      }
-    },
-
     get sessionCountIsDivisibleByFive() {
       return self.sessionCount % 5 === 0
-    },
-
-    get todaysCount() {
-      let todaysCount = 0
-      try {
-        todaysCount = self.todaysStats.count
-      } catch (error) {
-        todaysCount = self.sessionCount
-      }
-      return todaysCount
-    },
-
-    get todaysStats() {
-      const todaysDate = new Date()
-      if (self.stats.thisWeek.length === 7) {
-        return self.stats.thisWeek.find(stat => stat.dayNumber === todaysDate.getDay())
-      }
-      return null
     }
   }))
   .actions(self => {
@@ -60,9 +32,11 @@ const UserPersonalization = types
       },
 
       increment() {
+        self.stats.incrementStats()
+
+        // Session count is separated from stats counts because it's used
+        // specifically for authentication invitation messaging
         self.sessionCount = self.sessionCount + 1
-        self.todaysStats?.increment()
-        self.stats.incrementTotal()
         const { user } = getRoot(self)
         if (user?.id && self.sessionCountIsDivisibleByFive) {
           self.projectPreferences.refreshSettings()

--- a/packages/app-project/stores/User/UserPersonalization/UserPersonalization.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserPersonalization.js
@@ -53,6 +53,17 @@ const UserPersonalization = types
         }
       },
 
+      refreshCounts() {
+        console.log('refreshing user counts/stats')
+        self.stats.reset()
+        self.sessionCount = 0
+
+        const user = getRoot(self).user
+        if (user?.isLoggedIn) {
+          self.stats.fetchDailyCounts()
+        }
+      },
+
       reset() {
         self.notifications.reset()
         self.projectPreferences.reset()

--- a/packages/app-project/stores/User/UserPersonalization/UserPersonalization.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserPersonalization.spec.js
@@ -123,23 +123,9 @@ describe('Stores > UserPersonalization', function () {
     })
 
     describe('incrementing your classification count', function () {
-      before(function () {
-        const user = {
-          id: '123',
-          login: 'test.user',
-          personalization: {
-            stats: {
-              thisWeek: [],
-              total: 23
-            }
-          }
-        }
-        rootStore = initStore(true, { project, user })
-        rootStore.user.personalization.increment()
-      })
-
       it('should add 1 to your total count', function () {
-        expect(rootStore.user.personalization.stats.total).to.equal(24)
+        rootStore.user.personalization.increment()
+        expect(rootStore.user.personalization.stats.total).to.equal(81) // +1 to sinon stub for statsClient above
       })
 
       it('should add 1 to your session count', function () {

--- a/packages/app-project/stores/User/UserPersonalization/UserPersonalization.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserPersonalization.spec.js
@@ -220,7 +220,7 @@ describe('Stores > UserPersonalization', function () {
       })
     })
 
-    describe('incrementing your classification count', function () {
+    describe('incrementing your session count', function () {
       before(function () {
         rootStore.user.personalization.increment()
       })
@@ -289,63 +289,6 @@ describe('Stores > UserPersonalization', function () {
 
     it('should count session classifications from 0', function () {
       expect(rootStore.user.personalization.sessionCount).to.equal(1)
-    })
-  })
-
-  describe('counts view', function () {
-    it('should return the expected counts with no user data', function () {
-      const personalizationStore = UserPersonalization.create()
-      expect(personalizationStore.counts).to.deep.equal({
-        today: 0,
-        total: 0
-      })
-    })
-
-    describe('total count', function () {
-      it('should get the total classification count from the store', function () {
-        const personalizationStore = UserPersonalization.create()
-        personalizationStore.increment()
-        personalizationStore.increment()
-        personalizationStore.increment()
-        personalizationStore.increment()
-        expect(personalizationStore.stats.total).to.equal(4)
-      })
-    })
-
-    describe('today\'s count', function () {
-      let clock
-
-      before(function () {
-        clock = sinon.useFakeTimers({ now: new Date(2019, 9, 1, 12), toFake: ['Date'] })
-      })
-
-      after(function () {
-        clock.restore()
-      })
-
-      it('should get today\'s count from the store\'s counts for this week', function () {
-        const MOCK_DAILY_COUNTS = [
-          { count: 12, dayNumber: 1, period: '2019-09-30T00:00:00Z' },
-          { count: 13, dayNumber: 2, period: '2019-10-01T00:00:00Z' },
-          { count: 14, dayNumber: 3, period: '2019-10-02T00:00:00Z' },
-          { count: 10, dayNumber: 4, period: '2019-10-03T00:00:00Z' },
-          { count: 11, dayNumber: 5, period: '2019-10-04T00:00:00Z' },
-          { count: 8, dayNumber: 6, period: '2019-10-05T00:00:00Z' },
-          { count: 15, dayNumber: 0, period: '2019-10-06T00:00:00Z' }
-        ]
-        const personalizationStore = UserPersonalization.create({ stats: { thisWeek: MOCK_DAILY_COUNTS, total: 80 } })
-        expect(personalizationStore.counts.today).to.equal(MOCK_DAILY_COUNTS[1].count)
-      })
-
-      it('should be `0` if there are no classifications today', function () {
-        const MOCK_DAILY_COUNTS = [
-          { count: 12, dayNumber: 2, period: '2019-01-03T00:00:00Z' },
-          { count: 13, dayNumber: 1, period: '2019-01-02T00:00:00Z' },
-          { count: 14, dayNumber: 0, period: '2019-01-01T00:00:00Z' }
-        ]
-        const personalizationStore = UserPersonalization.create({ stats: { thisWeek: MOCK_DAILY_COUNTS, total: 80 } })
-        expect(personalizationStore.counts.today).to.equal(0)
-      })
     })
   })
 

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.js
@@ -29,8 +29,6 @@ export const Settings = types
 
 const UserProjectPreferences = types
   .model('UserProjectPreferences', {
-    activity_count: types.optional(types.number, 0),
-    activity_count_by_workflow: types.maybe(types.frozen()),
     error: types.maybeNull(types.frozen({})),
     id: types.maybe(numberString),
     links: types.maybe(
@@ -81,8 +79,6 @@ const UserProjectPreferences = types
     return {
       reset() {
         const resetSnapshot = {
-          activity_count: 0,
-          activity_count_by_workflow: undefined,
           error: undefined,
           id: undefined,
           links: undefined,
@@ -129,11 +125,7 @@ const UserProjectPreferences = types
         } catch (error) {
           console.error(error)
         }
-      }),
-
-      incrementActivityCount() {
-        self.activity_count = self.activity_count + 1
-      }
+      })
     }
   })
 

--- a/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/UserProjectPreferences/UserProjectPreferences.spec.js
@@ -30,8 +30,6 @@ describe('Stores > UserProjectPreferences', function () {
     }
   }
   const initialState = {
-    activity_count: 0,
-    activity_count_by_workflow: undefined,
     error: undefined,
     id: undefined,
     links: undefined,
@@ -40,8 +38,6 @@ describe('Stores > UserProjectPreferences', function () {
     settings: undefined
   }
   const upp = {
-    activity_count: 23,
-    activity_count_by_workflow: {},
     id: '555',
     links: {
       project: '2',
@@ -152,10 +148,6 @@ describe('Stores > UserProjectPreferences', function () {
         const storedUPP = Object.assign({}, upp, { error: undefined, loadingState: asyncStates.success })
         expect(getSnapshot(projectPreferences)).to.deep.equal(storedUPP)
       })
-
-      it('should set the total classification count on the parent node', function () {
-        expect(rootStore.user.personalization.totalClassificationCount).to.equal(23)
-      })
     })
 
     describe('when there are no user project preferences in the response', function () {
@@ -187,10 +179,6 @@ describe('Stores > UserProjectPreferences', function () {
         await rootStore.user.personalization.projectPreferences.fetchResource()
         expect(projectPreferences.loadingState).to.equal(asyncStates.success)
         expect(projectPreferences.id).to.be.undefined()
-      })
-
-      it('should not set the total classification count on the parent node', function () {
-        expect(rootStore.user.personalization.totalClassificationCount).to.equal(0)
       })
     })
 
@@ -269,8 +257,6 @@ describe('Stores > UserProjectPreferences', function () {
     beforeEach(function () {
       const personalization = {
         projectPreferences: {
-          activity_count: 28,
-          activity_count_by_workflow: {},
           id: '555',
           loadingState: asyncStates.success
         }
@@ -292,13 +278,6 @@ describe('Stores > UserProjectPreferences', function () {
       })
       const { projectPreferences } = rootStore.user.personalization
       projectPreferences.refreshSettings()
-    })
-
-    it('should not change your total classification count', async function () {
-      expect(rootStore.user.personalization.totalClassificationCount).to.equal(28)
-      const { projectPreferences } = rootStore.user.personalization
-      await when(() => projectPreferences.assignedWorkflowID)
-      expect(rootStore.user.personalization.totalClassificationCount).to.equal(28)
     })
 
     it('should not change the app loading state', function () {

--- a/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
+++ b/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
@@ -71,12 +71,13 @@ const YourStats = types
         total
       }
     },
+
     get todaysCount() {
       let todaysCount = 0
       try {
         todaysCount = self.todaysStats.count
       } catch (error) {
-        todaysCount = self.sessionCount
+        todaysCount = 0
       }
       return todaysCount
     },

--- a/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
+++ b/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
@@ -4,7 +4,6 @@ import auth from 'panoptes-client/lib/auth'
 import { env } from '@zooniverse/panoptes-js'
 
 function statsHost(env) {
-  console.log('ENV', env)
   switch (env) {
     case 'production':
       return 'https://eras.zooniverse.org'

--- a/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.spec.js
@@ -32,13 +32,6 @@ describe('Stores > YourStats', function () {
 
     nockScope = nock('https://panoptes-staging.zooniverse.org/api')
       .persist()
-      .get('/project_preferences')
-      .query(true)
-      .reply(200, {
-        project_preferences: [
-          { activity_count: 23 }
-        ]
-      })
       .get('/collections')
       .query(true)
       .reply(200)
@@ -47,7 +40,7 @@ describe('Stores > YourStats', function () {
       .reply(200)
     rootStore = initStore(true, { project })
     sinon.stub(statsClient, 'fetchDailyStats').callsFake(({ projectId, userId }) => (projectId === '2' && userId === '123') ?
-      Promise.resolve({ data: MOCK_DAILY_COUNTS }) :
+      Promise.resolve({ data: MOCK_DAILY_COUNTS, total_count: 80 }) :
       Promise.reject(new Error(`Unable to fetch stats for project ${projectId} and user ${userId}`)))
     sinon.stub(talkAPI, 'get')
   })
@@ -82,6 +75,12 @@ describe('Stores > YourStats', function () {
 
     it('should request user statistics', function () {
       expect(statsClient.fetchDailyStats).to.have.been.calledOnceWith({ projectId: '2', userId: '123' })
+    })
+
+    describe('total classification count', function () {
+      it('should be created', function () {
+        expect(getSnapshot(rootStore.user.personalization.stats).total).to.equal(80)
+      })
     })
 
     describe('weekly classification stats', function () {
@@ -120,7 +119,8 @@ describe('Stores > YourStats', function () {
       ]
       const yourStatsStore = YourStats.create({
         loadingState: asyncStates.success,
-        thisWeek: MOCK_DAILY_COUNTS
+        thisWeek: MOCK_DAILY_COUNTS,
+        total: 80
       })
       const signedInStats = yourStatsStore.toJSON()
       yourStatsStore.reset()

--- a/packages/lib-classifier/src/components/Classifier/ClassifierContainer.spec.js
+++ b/packages/lib-classifier/src/components/Classifier/ClassifierContainer.spec.js
@@ -172,7 +172,7 @@ describe('components > ClassifierContainer', function () {
         .get('/project_preferences')
         .query(true)
         .reply(200, { project_preferences: [{
-          activity_count: 24
+          id: '123'
         }] })
         .get('/project_roles')
         .query(true)
@@ -262,7 +262,7 @@ describe('components > ClassifierContainer', function () {
         .get('/project_preferences')
         .query(true)
         .reply(200, { project_preferences: [{
-          activity_count: 24
+          id: '123'
         }] })
         .get('/project_roles')
         .query(true)
@@ -358,7 +358,7 @@ describe('components > ClassifierContainer', function () {
         .get('/project_preferences')
         .query(true)
         .reply(200, { project_preferences: [{
-          activity_count: 24
+          id: '123'
         }] })
         .get('/project_roles')
         .query(true)
@@ -454,7 +454,7 @@ describe('components > ClassifierContainer', function () {
         .get('/project_preferences')
         .query(true)
         .reply(200, { project_preferences: [{
-          activity_count: 24
+          id: '123'
         }] })
         .get('/project_roles')
         .query(true)
@@ -550,7 +550,7 @@ describe('components > ClassifierContainer', function () {
         .get('/project_preferences')
         .query(true)
         .reply(200, { project_preferences: [{
-          activity_count: 24
+          id: '123'
         }] })
         .get('/project_roles')
         .query(true)
@@ -646,7 +646,7 @@ describe('components > ClassifierContainer', function () {
         .get('/project_preferences')
         .query(true)
         .reply(200, { project_preferences: [{
-          activity_count: 24
+          id: '123'
         }] })
         .get('/project_roles')
         .query(true)
@@ -753,7 +753,7 @@ describe('components > ClassifierContainer', function () {
         .get('/project_preferences')
         .query(true)
         .reply(200, { project_preferences: [{
-          activity_count: 24
+          id: '123'
         }] })
         .get('/project_roles')
         .query(true)

--- a/packages/lib-classifier/src/store/UserProjectPreferencesStore/UserProjectPreferences/UserProjectPreferences.js
+++ b/packages/lib-classifier/src/store/UserProjectPreferencesStore/UserProjectPreferences/UserProjectPreferences.js
@@ -10,8 +10,6 @@ const Preferences = types
 
 const UserProjectPreferences = types
   .model('UserProjectPreferences', {
-    activity_count: types.maybe(types.number),
-    activity_count_by_workflow: types.maybe(types.frozen()),
     links: types.maybe(
       types.frozen({
         project: types.string,

--- a/packages/lib-classifier/src/store/UserProjectPreferencesStore/UserProjectPreferencesStore.js
+++ b/packages/lib-classifier/src/store/UserProjectPreferencesStore/UserProjectPreferencesStore.js
@@ -1,6 +1,5 @@
 import merge from 'lodash/merge'
-import { autorun } from 'mobx'
-import { addDisposer, getRoot, getSnapshot, isValidReference, tryReference, types, flow } from 'mobx-state-tree'
+import { getRoot, getSnapshot, tryReference, types, flow } from 'mobx-state-tree'
 import asyncStates from '@zooniverse/async-states'
 
 import ResourceStore from '@store/ResourceStore'

--- a/packages/lib-classifier/test/factories/UPPFactory.js
+++ b/packages/lib-classifier/test/factories/UPPFactory.js
@@ -2,8 +2,6 @@ import { Factory } from 'rosie'
 
 export default new Factory()
   .sequence('id', (id) => { return id.toString() })
-  .attr('activity_count', 100)
-  .attr('activity_count_by_workflow', {})
   .attr('links', {})
   .attr('preferences', {
     minicourses: {},

--- a/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.stories.js
+++ b/packages/lib-user/src/components/UserHome/components/RecentProjects/RecentProjects.stories.js
@@ -1,10 +1,12 @@
 import RecentProjects from './RecentProjects.js'
 import { PROJECTS } from '../../../../../test/mocks/panoptes/projects.js'
 
-const mockProjectPreferencesWithProjectObj = PROJECTS.map(project => ({
-  activity_count: Math.floor(Math.random() * 100),
-  project
-}))
+const mockRecentProjects = PROJECTS.map(project => {
+  return {
+    count: Math.floor(Math.random() * 100),
+    ...project
+  }
+})
 
 export default {
   title: 'Components / UserHome / RecentProjects',
@@ -13,19 +15,19 @@ export default {
 
 export const Default = {
   args: {
-    projectPreferences: mockProjectPreferencesWithProjectObj
+    recentProjects: mockRecentProjects
   }
 }
 
 export const NoProjects = {
   args: {
-    projectPreferences: []
+    recentProjects: []
   }
 }
 
 export const Error = {
   args: {
-    projectPreferences: [],
+    recentProjects: [],
     error: { message: `Couldn't fetch recent projects` }
   }
 }


### PR DESCRIPTION
## Package
app-project
lib-classifier

## Linked Issue and/or Talk Post
Closes: https://github.com/zooniverse/front-end-monorepo/issues/6400
Closes: https://github.com/zooniverse/front-end-monorepo/issues/5964
Closes: https://github.com/zooniverse/front-end-monorepo/issues/5134

## Describe your changes
- Remove `activity_count` everywhere in FEM so user stats are no longer using `/project_preferences` for calculating classification count.
- Untangle the spaghetti code of UPP > YourStats MST files.
- Add a disposer function with autorun to Store.js so that UserPersonalization refreshes every time the project id changes. This ensures the YourStats component displays correct stats data if you keep the same tab open and switch between FEM projects.

## How to Review

- View any project's classify page and YourStats total classification count should match the total classification count displayed on your stats and homepage.
- When you make a classification, the YourStats component should increment as expected.
- See more comments below about removing legacy code.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)

## General UX
Example Staging Project: [i-fancy-cats](https://local.zooniverse.org:3000/projects/brooke/i-fancy-cats)
- [ ] All pages of a FEM project load: Home Page, Classify Page, and About Pages
- [ ] Can submit a classification
- [ ] Can sign-in and sign-out

## Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

## Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
