### PR TITLE
test(app-project): run YourStats tests in a non-UTC timezone

### DIFF
--- a/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.js
+++ b/packages/app-project/src/screens/ClassifyPage/components/YourStats/components/DailyClassificationsChart/DailyClassificationsChartContainer.js
@@ -17,7 +17,7 @@ function DailyClassificationsChartContainer({
     const [year, monthIndex, date] = period.split('-')
     const utcDay = Date.UTC(year, monthIndex - 1, date)
     const day = new Date(utcDay)
-    const isToday = day.getUTCDay() === TODAY.getDay()
+    const isToday = day.getUTCDay() === TODAY.getUTCDay()
     const count = isToday ? counts.today : statsCount
     const longLabel = day.toLocaleDateString(locale, { timeZone: 'UTC', weekday: 'long' })
     const alt = `${longLabel}: ${count}`

--- a/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
+++ b/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
@@ -29,14 +29,14 @@ export const statsClient = {
 }
 
 // https://stackoverflow.com/a/51918448/10951669
-function firstDayOfWeek (dateObject, firstDayOfWeekIndex) {
-  const dayOfWeek = dateObject.getUTCDay()
-  const firstDayOfWeek = new Date(dateObject)
+function firstDayOfWeek (dateUTCObject, firstDayOfWeekIndex) {
+  const dayOfWeek = dateUTCObject.getUTCDay()
+  const firstDayOfWeek = new Date(dateUTCObject)
   const diff = dayOfWeek >= firstDayOfWeekIndex
     ? dayOfWeek - firstDayOfWeekIndex
     : 6 - dayOfWeek
 
-  firstDayOfWeek.setUTCDate(dateObject.getUTCDate() - diff)
+  firstDayOfWeek.setUTCDate(dateUTCObject.getUTCDate() - diff)
 
   return firstDayOfWeek
 }
@@ -65,9 +65,11 @@ const YourStats = types
       /*
       Calculate daily stats for this week, starting last Monday.
       */
-      const today = new Date()
+      const today = new Date().toUTCString()
+      // convert the local clock to UTC before finding the first day of the week.
+      const todayUTC = new Date(today)
       const weeklyStats = []
-      const monday = firstDayOfWeek(today, 1) // Monday is day number 1 in JavaScript
+      const monday = firstDayOfWeek(todayUTC, 1) // Monday is day number 1 in JavaScript
       for (let day = 0; day < 7; day++) {
         const weekDay = new Date(monday.toISOString())
         const newDate = monday.getUTCDate() + day

--- a/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
+++ b/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
@@ -31,18 +31,18 @@ export const statsClient = {
 /**
  * Find the first day matching a given weekday number, prior to a given UTC date.
  * https://stackoverflow.com/a/51918448/10951669
- * @param {Date} dateUTCObject search prior to this UTC datetime.
+ * @param {Date} dateObject search prior to this datetime.
  * @param {number} firstDayOfWeekIndex day of the week to find (Sunday is 0.)
  * @returns a UTC date object for the first day of the week
  */
-function firstDayOfWeek(dateUTCObject, firstDayOfWeekIndex) {
-  const dayOfWeek = dateUTCObject.getUTCDay()
-  const firstDayOfWeek = new Date(dateUTCObject)
+function firstDayOfWeek(dateObject, firstDayOfWeekIndex) {
+  const dayOfWeek = dateObject.getUTCDay()
+  const firstDayOfWeek = new Date(dateObject)
   const diff = dayOfWeek >= firstDayOfWeekIndex
     ? dayOfWeek - firstDayOfWeekIndex
     : 6 - dayOfWeek
 
-  firstDayOfWeek.setUTCDate(dateUTCObject.getUTCDate() - diff)
+  firstDayOfWeek.setUTCDate(dateObject.getUTCDate() - diff)
 
   return firstDayOfWeek
 }
@@ -71,11 +71,9 @@ const YourStats = types
       /*
       Calculate daily stats for this week, starting last Monday.
       */
-      const today = new Date().toUTCString()
-      // convert the local clock to UTC before finding the first day of the week.
-      const todayUTC = new Date(today)
+      const today = new Date()
       const weeklyStats = []
-      const monday = firstDayOfWeek(todayUTC, 1) // Monday is day number 1 in JavaScript
+      const monday = firstDayOfWeek(today, 1) // Monday is day number 1 in JavaScript
       for (let day = 0; day < 7; day++) {
         const weekDay = new Date(monday.toISOString())
         const newDate = monday.getUTCDate() + day

--- a/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
+++ b/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
@@ -28,8 +28,14 @@ export const statsClient = {
   }
 }
 
-// https://stackoverflow.com/a/51918448/10951669
-function firstDayOfWeek (dateUTCObject, firstDayOfWeekIndex) {
+/**
+ * Find the first day matching a given weekday number, prior to a given UTC date.
+ * https://stackoverflow.com/a/51918448/10951669
+ * @param {Date} dateUTCObject search prior to this UTC datetime.
+ * @param {number} firstDayOfWeekIndex day of the week to find (Sunday is 0.)
+ * @returns a UTC date object for the first day of the week
+ */
+function firstDayOfWeek(dateUTCObject, firstDayOfWeekIndex) {
   const dayOfWeek = dateUTCObject.getUTCDay()
   const firstDayOfWeek = new Date(dateUTCObject)
   const diff = dayOfWeek >= firstDayOfWeekIndex

--- a/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
+++ b/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.js
@@ -80,7 +80,7 @@ const YourStats = types
         weekDay.setUTCDate(newDate)
         const period = weekDay.toISOString().substring(0, 10)
         const { count } = dailyCounts.find(count => count.period.startsWith(period)) || { count: 0, period }
-        const dayNumber = weekDay.getDay()
+        const dayNumber = weekDay.getUTCDay()
         weeklyStats.push({
           count,
           dayNumber,

--- a/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.spec.js
@@ -20,14 +20,14 @@ describe('Stores > YourStats', function () {
     sinon.stub(console, 'error')
 
     const MOCK_DAILY_COUNTS = [
-      { count: 12, period: '2019-09-29' },
-      { count: 12, period: '2019-09-30' },
-      { count: 13, period: '2019-10-01' },
-      { count: 14, period: '2019-10-02' },
-      { count: 10, period: '2019-10-03' },
-      { count: 11, period: '2019-10-04' },
-      { count: 8, period: '2019-10-05' },
-      { count: 15, period: '2019-10-06' }
+      { count: 12, period: '2019-09-29T00:00:00.000Z' },
+      { count: 12, period: '2019-09-30T00:00:00.000Z' },
+      { count: 13, period: '2019-10-01T00:00:00.000Z' },
+      { count: 14, period: '2019-10-02T00:00:00.000Z' },
+      { count: 10, period: '2019-10-03T00:00:00.000Z' },
+      { count: 11, period: '2019-10-04T00:00:00.000Z' },
+      { count: 8, period: '2019-10-05T00:00:00.000Z' },
+      { count: 15, period: '2019-10-06T00:00:00.000Z' }
     ]
 
     nockScope = nock('https://panoptes-staging.zooniverse.org/api')
@@ -67,7 +67,9 @@ describe('Stores > YourStats', function () {
     let clock
 
     before(function () {
-      clock = sinon.useFakeTimers({ now: new Date(2019, 9, 1, 12), toFake: ['Date'] })
+      // Set the local clock to 1am on Tuesday 1 October 2019, UTC.
+      // Stats should be shown for Monday 30 September 2019, local time.
+      clock = sinon.useFakeTimers(new Date('2019-09-30T20:00:00-05:00'))
       const user = {
         id: '123',
         login: 'test.user'

--- a/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.spec.js
+++ b/packages/app-project/stores/User/UserPersonalization/YourStats/YourStats.spec.js
@@ -68,18 +68,20 @@ describe('Stores > YourStats', function () {
 
     before(function () {
       // Set the local clock to 1am on Tuesday 1 October 2019, UTC.
-      // Stats should be shown for Monday 30 September 2019, local time.
-      clock = sinon.useFakeTimers(new Date('2019-09-30T20:00:00-05:00'))
+      // Local time for this test will be 7pm, Monday 30 September 2019, CST.
+      clock = sinon.useFakeTimers(new Date('2019-10-01T01:00:00Z'))
       const user = {
         id: '123',
         login: 'test.user'
       }
 
+      process.env.TZ = 'America/Chicago'
       rootStore.user.set(user)
     })
 
     after(function () {
       clock.restore()
+      delete process.env.TZ
     })
 
     it('should request user statistics', function () {


### PR DESCRIPTION
A couple of small refactors for the `YourStats` tests:
- add missing timestamps to the mock ERAS data, to match real ERAS responses.
- ~~test the weekly stats in the `-05:00` timezone, to check for timezone bugs.~~ this doesn’t work. Tests always run in the OS time zone. 
- run the tests in the `-06:00:00` timezone by setting the Node `TZ` env var, to catch #2244.
- use `getUTCDay` to get the day number for daily stats, fixing #2244.

_Please request review from `@zooniverse/frontend` team or an individual member of that team._ 

## Package
- app-project

## Linked Issue and/or Talk Post
- #2244.

## How to Review
I'm not seeing any errors when I run this, but I'm running it on a computer that's set to UTC. I think it might need to be run in a different time zone, in order to test it. Whatever timezone it's run in, the stats chart should always start on Monday.

# Checklist
_PR Creator - Please cater the checklist to fit the review needed for your code changes._
_PR Reviewer - Use the checklist during your review. Each point should be checkmarked or discussed before PR approval._

## General
- [ ] Tests are passing locally and on Github
- [ ] Documentation is up to date and changelog has been updated if appropriate
- [ ] You can `yarn panic && yarn bootstrap` or `docker-compose up --build` and FEM works as expected
- [ ] FEM works in all major desktop browsers: Firefox, Chrome, Edge, Safari (Use Browserstack account as needed)
- [ ] FEM works in a mobile browser
