### PR TITLE
Increase dependabot PR limit to 15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,4 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 15


### PR DESCRIPTION
## Linked Issue and/or Talk Post
Dependabot Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit

## Describe your changes
Change `open-pull-requests-limit` in dependabot.yml. As noted in Slack, right now the limit is 5, but several dependabot PRs are left open/un-merged due to failing CI (needs dev work to upgrade). Rather than close and forget about dependabot PRs, I’m going to self-approve a PR that increases the limit, and hopefully that’ll help us keep third party libraries up to date.