### PR TITLE
Re-arrange open-pull-requests-limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 15
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 15


### PR DESCRIPTION
## Linked Issue and/or Talk Post
As mentioned in [Slack](https://zooniverse.slack.com/archives/CANKLB50E/p1730822483375389?thread_ts=1730325928.928729&cid=CANKLB50E), dependabot is still hitting a limit of 5 open PRs 🤔 

## Describe your changes
- Place `open-pull-requests-limit` near the "npm" section in dependabot.yml to try triggering more dependabot PRs.

## How to Review
I'll be self-reviewing and merging this PR as it has no effect on any builds, components, staged apps, storybook, etc.